### PR TITLE
feat(sft): add SFT trainer infrastructure

### DIFF
--- a/__test__/trainers/sft-config.test.ts
+++ b/__test__/trainers/sft-config.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { getDefaultSFTConfig, mergeSFTConfig, applySFTOverrides, SFTConfigError } from '@mlx-node/trl';
+
+describe('SFT configuration', () => {
+  it('returns a mutable copy of the default configuration', () => {
+    const defaultsA = getDefaultSFTConfig();
+    const defaultsB = getDefaultSFTConfig();
+
+    expect(defaultsA).not.toBe(defaultsB);
+    expect(defaultsA.learning_rate).toBeCloseTo(2e-5);
+    expect(defaultsA.batch_size).toBe(4);
+    expect(defaultsA.num_epochs).toBe(3);
+    expect(defaultsA.max_seq_length).toBe(2048);
+    expect(defaultsA.completion_only).toBe(false); // default is false for TRL parity
+    expect(defaultsA.label_smoothing).toBe(0.0);
+  });
+
+  it('merges partial config with defaults', () => {
+    const defaults = getDefaultSFTConfig();
+    const partial = {
+      learning_rate: 1e-4,
+      batch_size: 8,
+      num_epochs: 5,
+    };
+    const merged = mergeSFTConfig(defaults, partial);
+
+    expect(merged.learning_rate).toBeCloseTo(1e-4);
+    expect(merged.batch_size).toBe(8);
+    expect(merged.num_epochs).toBe(5);
+    // Unchanged defaults
+    expect(merged.max_seq_length).toBe(2048);
+    expect(merged.completion_only).toBe(false); // default is false for TRL parity
+  });
+
+  it('applies CLI-style overrides without mutating the base config', () => {
+    const base = getDefaultSFTConfig();
+    const overrides = ['learning_rate=1e-4', 'run_name=my-sft-run', 'completion_only=true', 'seed=42'];
+    const updated = applySFTOverrides(base, overrides);
+
+    expect(updated.learning_rate).toBeCloseTo(1e-4);
+    expect(updated.run_name).toBe('my-sft-run');
+    expect(updated.completion_only).toBe(true);
+    expect(updated.seed).toBe(42);
+
+    // Ensure original remains unchanged
+    expect(base.run_name).toBe('sft-run');
+    expect(base.completion_only).toBe(false); // default is false for TRL parity
+  });
+
+  it('throws when an override uses an unknown key', () => {
+    const base = getDefaultSFTConfig();
+    expect(() => applySFTOverrides(base, ['unknown_key=1'])).toThrow(SFTConfigError);
+  });
+
+  it('throws when an override value is invalid', () => {
+    const base = getDefaultSFTConfig();
+    expect(() => applySFTOverrides(base, ['batch_size=not-a-number'])).toThrow(SFTConfigError);
+  });
+
+  it('throws when batch_size is not an integer', () => {
+    const base = getDefaultSFTConfig();
+    expect(() => applySFTOverrides(base, ['batch_size=2.5'])).toThrow(SFTConfigError);
+  });
+});

--- a/__test__/trainers/sft-dataset.test.ts
+++ b/__test__/trainers/sft-dataset.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { resolve } from 'node:path';
+import {
+  SFTDataset,
+  createSFTDataset,
+  type SFTPromptCompletionExample,
+  type SFTConversationExample,
+} from '@mlx-node/trl';
+import { Qwen3Tokenizer } from '@mlx-node/core';
+
+describe('SFT Dataset', () => {
+  let tokenizer: Qwen3Tokenizer;
+
+  beforeAll(async () => {
+    // Load tokenizer from cached model
+    const tokenizerPath = resolve(process.cwd(), '.cache/models/qwen3-0.6b-mlx-bf16/tokenizer.json');
+    tokenizer = await Qwen3Tokenizer.fromPretrained(tokenizerPath);
+  });
+
+  describe('prompt-completion format', () => {
+    it('creates dataset from prompt-completion examples', () => {
+      const examples: SFTPromptCompletionExample[] = [
+        {
+          prompt: [
+            { role: 'system', content: 'You are a helpful assistant.' },
+            { role: 'user', content: 'What is 2 + 2?' },
+          ],
+          completion: { role: 'assistant', content: '4' },
+        },
+        {
+          prompt: [{ role: 'user', content: 'Hello!' }],
+          completion: { role: 'assistant', content: 'Hi there!' },
+        },
+      ];
+
+      const dataset = createSFTDataset(examples, tokenizer);
+      expect(dataset.length).toBe(2);
+    });
+
+    it('collates batch correctly with tokenization', async () => {
+      const examples: SFTPromptCompletionExample[] = [
+        {
+          prompt: [{ role: 'user', content: 'Hi' }],
+          completion: { role: 'assistant', content: 'Hello!' },
+        },
+      ];
+
+      const dataset = createSFTDataset(examples, tokenizer, { maxSeqLength: 512 });
+      const batch = await dataset.collateBatch([0]);
+
+      expect(batch.shape[0]).toBe(1); // batch size
+      expect(batch.shape[1]).toBeGreaterThan(0); // seq length
+      expect(batch.inputIds.length).toBe(batch.shape[0] * batch.shape[1]);
+      expect(batch.labels.length).toBe(batch.shape[0] * batch.shape[1]);
+    });
+
+    it('masks prompt tokens with -100 when completionOnly=true', async () => {
+      const examples: SFTPromptCompletionExample[] = [
+        {
+          prompt: [{ role: 'user', content: 'Hi' }],
+          completion: { role: 'assistant', content: 'Hello!' },
+        },
+      ];
+
+      const dataset = createSFTDataset(examples, tokenizer, {
+        maxSeqLength: 512,
+        completionOnly: true,
+      });
+      const batch = await dataset.collateBatch([0]);
+
+      // At least some tokens should be -100 (masked)
+      const maskedCount = Array.from(batch.labels).filter((l) => l === -100).length;
+      expect(maskedCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('conversation format', () => {
+    it('creates dataset from conversation examples', () => {
+      const examples: SFTConversationExample[] = [
+        {
+          messages: [
+            { role: 'system', content: 'You are a helpful assistant.' },
+            { role: 'user', content: 'Hello!' },
+            { role: 'assistant', content: 'Hi! How can I help you today?' },
+            { role: 'user', content: 'What time is it?' },
+            { role: 'assistant', content: 'I cannot tell the exact time.' },
+          ],
+        },
+      ];
+
+      const dataset = createSFTDataset(examples, tokenizer);
+      expect(dataset.length).toBe(1);
+    });
+
+    it('throws for conversation without assistant messages', () => {
+      const examples = [
+        {
+          messages: [
+            { role: 'system', content: 'System prompt' },
+            { role: 'user', content: 'User message' },
+          ],
+        },
+      ] as SFTConversationExample[];
+
+      // This should fail validation since there's no assistant message
+      expect(() => createSFTDataset(examples, tokenizer)).not.toThrow();
+      // The validation happens in loadSFTDataset, not createSFTDataset
+    });
+  });
+
+  describe('batching', () => {
+    it('generates correct number of batches', async () => {
+      const examples: SFTPromptCompletionExample[] = Array(10)
+        .fill(null)
+        .map((_, i) => ({
+          prompt: [{ role: 'user', content: `Question ${i}` }],
+          completion: { role: 'assistant', content: `Answer ${i}` },
+        }));
+
+      const dataset = createSFTDataset(examples, tokenizer);
+
+      expect(dataset.numBatches(4)).toBe(3); // 10 / 4 = 2.5 -> 3 batches
+      expect(dataset.numBatches(5)).toBe(2); // 10 / 5 = 2 batches
+      expect(dataset.numBatches(10)).toBe(1); // 10 / 10 = 1 batch
+    });
+
+    it('shuffles dataset', () => {
+      const examples: SFTPromptCompletionExample[] = Array(5)
+        .fill(null)
+        .map((_, i) => ({
+          prompt: [{ role: 'user', content: `Question ${i}` }],
+          completion: { role: 'assistant', content: `Answer ${i}` },
+        }));
+
+      const dataset = createSFTDataset(examples, tokenizer);
+
+      // Get initial order by iterating
+      const batches1: SFTDataset['length'][] = [];
+      for (let i = 0; i < dataset.length; i++) {
+        batches1.push(i);
+      }
+
+      // Shuffle for epoch 0 and verify it doesn't throw
+      dataset.shuffleForEpoch(0);
+      expect(dataset.length).toBe(5);
+
+      // Shuffle for epoch 1 should give different order
+      dataset.shuffleForEpoch(1);
+      expect(dataset.length).toBe(5);
+    });
+  });
+
+  describe('truncation', () => {
+    it('truncates sequences longer than maxSeqLength', async () => {
+      const longContent = 'word '.repeat(1000); // Very long content
+      const examples: SFTPromptCompletionExample[] = [
+        {
+          prompt: [{ role: 'user', content: longContent }],
+          completion: { role: 'assistant', content: longContent },
+        },
+      ];
+
+      const maxSeqLength = 256;
+      const dataset = createSFTDataset(examples, tokenizer, { maxSeqLength });
+      const batch = await dataset.collateBatch([0]);
+
+      expect(batch.shape[1]).toBe(maxSeqLength);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws for empty dataset', () => {
+      expect(() => createSFTDataset([], tokenizer)).toThrow('at least one example');
+    });
+
+    it('throws for mixed format examples', () => {
+      const mixedExamples = [
+        {
+          prompt: [{ role: 'user', content: 'Hi' }],
+          completion: { role: 'assistant', content: 'Hello' },
+        },
+        {
+          messages: [
+            { role: 'user', content: 'Hi' },
+            { role: 'assistant', content: 'Hello' },
+          ],
+        },
+      ] as unknown as SFTPromptCompletionExample[];
+
+      expect(() => createSFTDataset(mixedExamples, tokenizer)).toThrow('Inconsistent SFT data format');
+    });
+  });
+});

--- a/crates/mlx-core/src/lib.rs
+++ b/crates/mlx-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod nn;
 pub mod optimizers;
 pub mod param_manager;
 pub mod sampling;
+pub mod sft;
 pub mod stream;
 pub mod tensor;
 pub mod tokenizer;

--- a/crates/mlx-core/src/sft/autograd.rs
+++ b/crates/mlx-core/src/sft/autograd.rs
@@ -1,0 +1,262 @@
+// SFT Training with MLX Autograd
+//
+// This module provides autograd-based training for Supervised Fine-Tuning (SFT).
+// Much simpler than GRPO - just forward pass + cross-entropy loss on completions.
+//
+// ## Architecture
+//
+// 1. Extract trainable parameters into flat Vec<MxArray>
+// 2. Create loss closure that:
+//    - Maps params to structured dictionary
+//    - Runs functional forward pass
+//    - Computes cross-entropy loss on completion tokens
+//    - Returns scalar loss
+// 3. Call autograd::value_and_grad
+// 4. Map gradients back to parameter names
+
+use std::collections::HashMap;
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::autograd;
+use crate::models::qwen3::Qwen3Config;
+use crate::nn::Losses;
+use crate::param_manager;
+use crate::utils::functional;
+
+use super::SftLossConfig;
+
+/// Compute SFT loss and gradients using autograd
+///
+/// This is much simpler than GRPO autograd:
+/// - No importance sampling or policy ratios
+/// - No advantage computation
+/// - Just cross-entropy loss on completion tokens
+///
+/// # Arguments
+/// * `model_config` - Model configuration (for functional forward pass)
+/// * `model_params` - Current model parameters (will not be modified)
+/// * `input_ids` - Full input sequences [batch, seq_len] (prompts + completions)
+/// * `labels` - Target labels [batch, seq_len] with -100 for prompt/padding tokens
+/// * `loss_config` - SFT loss configuration
+///
+/// # Returns
+/// * `(loss_value, gradients)` - Scalar loss and gradients for each parameter
+pub fn compute_sft_loss_and_gradients(
+    model_config: &Qwen3Config,
+    model_params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+    labels: &MxArray,
+    loss_config: SftLossConfig,
+) -> Result<(f64, HashMap<String, MxArray>)> {
+    // 1. Flatten parameters into ordered list (keep native dtype - bfloat16)
+    let mut param_names: Vec<String> = model_params.keys().cloned().collect();
+    param_names.sort(); // Ensure consistent ordering
+
+    let param_arrays: Vec<&MxArray> = param_names
+        .iter()
+        .map(|name| {
+            model_params
+                .get(name)
+                .ok_or_else(|| Error::from_reason(format!("Parameter not found: {}", name)))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // 2. Clone data needed by closure
+    let param_names_clone = param_names.clone();
+    let input_ids_clone = input_ids.clone();
+    let labels_clone = labels.clone();
+    let config_clone = model_config.clone();
+    let loss_config_clone = loss_config.clone();
+
+    // 3. Define loss function for autograd
+    let loss_fn = move |params: &[MxArray]| -> Result<MxArray> {
+        // Map params to structured dictionary
+        let param_dict = param_manager::map_params_to_dict(params, &param_names_clone)?;
+
+        // Forward pass using functional implementation
+        let logits =
+            functional::qwen3_forward_functional(&config_clone, &param_dict, &input_ids_clone)?;
+
+        // Get shapes
+        let batch_size = logits.shape_at(0)?;
+        let seq_len = logits.shape_at(1)?;
+        let vocab_size = logits.shape_at(2)?;
+
+        // For autograd-compatible cross-entropy, we need to:
+        // 1. Shift logits and labels for next-token prediction
+        // 2. Reshape for cross_entropy
+        // 3. Apply ignore_index masking
+
+        // Shift: logits[:-1] predicts labels[1:]
+        // This is standard causal LM training
+        let shift_logits = logits.slice(&[0, 0, 0], &[batch_size, seq_len - 1, vocab_size])?;
+        let shift_labels = labels_clone.slice(&[0, 1], &[batch_size, seq_len])?;
+
+        // Reshape for cross_entropy
+        let logits_flat = shift_logits.reshape(&[(batch_size) * (seq_len - 1), vocab_size])?;
+        let labels_flat = shift_labels.reshape(&[(batch_size) * (seq_len - 1)])?;
+
+        // Compute cross-entropy loss
+        // The Losses::cross_entropy handles:
+        // - Numerical stability via logsumexp
+        // - ignore_index masking
+        // - Label smoothing
+        let ignore_idx = loss_config_clone.ignore_index.unwrap_or(-100);
+        let label_smoothing = loss_config_clone.label_smoothing.unwrap_or(0.0);
+
+        Losses::cross_entropy(
+            &logits_flat,
+            &labels_flat,
+            None,
+            Some(ignore_idx),
+            Some(label_smoothing),
+        )
+    };
+
+    // 4. Compute value and gradients using MLX autograd
+    let (loss_array, grad_arrays) = autograd::value_and_grad(param_arrays, loss_fn)?;
+
+    // 5. Eval all outputs and cleanup
+    loss_array.eval();
+    for grad in &grad_arrays {
+        grad.eval();
+    }
+    crate::array::heavy_cleanup();
+
+    // 6. Extract loss value
+    let loss_value = loss_array.item_at_float32(0)? as f64;
+
+    // 7. Map gradients back to parameter names
+    let gradients = param_names
+        .into_iter()
+        .enumerate()
+        .map(|(i, param_name)| (param_name, grad_arrays[i].clone()))
+        .collect::<HashMap<_, _>>();
+
+    Ok((loss_value, gradients))
+}
+
+/// Compute token-level accuracy for SFT training
+///
+/// Returns the fraction of correctly predicted tokens (excluding ignored tokens).
+/// This requires an extra forward pass but provides useful training metrics.
+///
+/// # Arguments
+/// * `model_config` - Model configuration
+/// * `model_params` - Current model parameters
+/// * `input_ids` - Input sequences [batch, seq_len]
+/// * `labels` - Target labels [batch, seq_len] with -100 for ignored tokens
+///
+/// # Returns
+/// * Accuracy value between 0.0 and 1.0
+pub fn compute_token_accuracy(
+    model_config: &Qwen3Config,
+    model_params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+    labels: &MxArray,
+) -> Result<f64> {
+    // Forward pass
+    let logits = functional::qwen3_forward_functional(model_config, model_params, input_ids)?;
+
+    // Get shapes
+    let batch_size = logits.shape_at(0)?;
+    let seq_len = logits.shape_at(1)?;
+    let vocab_size = logits.shape_at(2)?;
+
+    // Shift for next-token prediction (same as loss computation)
+    let shift_logits = logits.slice(&[0, 0, 0], &[batch_size, seq_len - 1, vocab_size])?;
+    let shift_labels = labels.slice(&[0, 1], &[batch_size, seq_len])?;
+
+    // Get predictions (argmax over vocab)
+    let predictions = shift_logits.argmax(-1, Some(false))?;
+    let labels_flat = shift_labels.reshape(&[(batch_size) * (seq_len - 1)])?;
+    let preds_flat = predictions.reshape(&[(batch_size) * (seq_len - 1)])?;
+
+    // Create mask for valid (non-ignored) tokens
+    let ignore_val = MxArray::scalar_int(-100)?;
+    let valid_mask = labels_flat.not_equal(&ignore_val)?;
+
+    // Compute correct predictions (where pred == label AND label != -100)
+    let correct = preds_flat.equal(&labels_flat)?;
+    let correct_and_valid = correct.logical_and(&valid_mask)?;
+
+    // Sum correct and total valid
+    let num_correct = correct_and_valid.sum(None, Some(false))?;
+    let num_valid = valid_mask.sum(None, Some(false))?;
+
+    num_correct.eval();
+    num_valid.eval();
+
+    let correct_val = num_correct.item_at_float32(0)? as f64;
+    let valid_val = num_valid.item_at_float32(0)? as f64;
+
+    if valid_val == 0.0 {
+        Ok(0.0)
+    } else {
+        Ok(correct_val / valid_val)
+    }
+}
+
+/// Compute SFT loss only (no gradients)
+///
+/// Useful for evaluation/validation without the overhead of gradient computation.
+pub fn compute_sft_loss_only(
+    model_config: &Qwen3Config,
+    model_params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+    labels: &MxArray,
+    loss_config: SftLossConfig,
+) -> Result<f64> {
+    // Build param dict
+    let param_dict: HashMap<String, MxArray> = model_params.clone();
+
+    // Forward pass
+    let logits = functional::qwen3_forward_functional(model_config, &param_dict, input_ids)?;
+
+    // Get shapes
+    let batch_size = logits.shape_at(0)?;
+    let seq_len = logits.shape_at(1)?;
+    let vocab_size = logits.shape_at(2)?;
+
+    // Shift for next-token prediction
+    let shift_logits = logits.slice(&[0, 0, 0], &[batch_size, seq_len - 1, vocab_size])?;
+    let shift_labels = labels.slice(&[0, 1], &[batch_size, seq_len])?;
+
+    // Reshape
+    let logits_flat = shift_logits.reshape(&[(batch_size) * (seq_len - 1), vocab_size])?;
+    let labels_flat = shift_labels.reshape(&[(batch_size) * (seq_len - 1)])?;
+
+    // Compute loss
+    let ignore_idx = loss_config.ignore_index.unwrap_or(-100);
+    let label_smoothing = loss_config.label_smoothing.unwrap_or(0.0);
+
+    let loss = Losses::cross_entropy(
+        &logits_flat,
+        &labels_flat,
+        None,
+        Some(ignore_idx),
+        Some(label_smoothing),
+    )?;
+
+    loss.eval();
+    let loss_value = loss.item_at_float32(0)? as f64;
+
+    Ok(loss_value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: Full autograd tests require a model, which is tested at integration level
+    // Here we just verify the function signatures compile correctly
+
+    #[test]
+    fn test_loss_config_default() {
+        let config = SftLossConfig::default();
+        assert_eq!(config.ignore_index, Some(-100));
+        assert_eq!(config.label_smoothing, Some(0.0));
+    }
+}

--- a/crates/mlx-core/src/sft/engine.rs
+++ b/crates/mlx-core/src/sft/engine.rs
@@ -1,0 +1,720 @@
+/// SFT Training Engine - Rust-native Training Loop
+///
+/// This module provides a complete Supervised Fine-Tuning (SFT) engine that runs
+/// entirely in Rust, eliminating FFI overhead for the core training loop.
+///
+/// ## Key Features
+/// - Simple cross-entropy loss on completion tokens
+/// - Gradient accumulation and clipping
+/// - Memory management with heavy cleanup
+/// - NaN gradient protection
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use tracing::{debug, info, warn};
+
+use crate::array::{MxArray, heavy_cleanup, synchronize_and_clear_cache};
+use crate::models::qwen3::{Qwen3Config, Qwen3Model};
+use crate::optimizers::GradientUtils;
+use crate::sft::SftLossConfig;
+use crate::sft::autograd::{compute_sft_loss_and_gradients, compute_token_accuracy};
+
+/// Configuration for the SFT training engine
+#[napi(object)]
+#[derive(Clone)]
+pub struct SftEngineConfig {
+    /// Learning rate (default: 2e-5)
+    pub learning_rate: Option<f64>,
+    /// Gradient accumulation steps (default: 1)
+    pub gradient_accumulation_steps: Option<i32>,
+    /// Maximum gradient norm for clipping (default: 1.0)
+    pub gradient_clip_norm: Option<f64>,
+    /// Maximum gradient value for element-wise clipping (optional)
+    pub gradient_clip_value: Option<f64>,
+    /// Weight decay (L2 regularization) (default: 0.01)
+    pub weight_decay: Option<f64>,
+    /// Label smoothing factor (default: 0.0)
+    pub label_smoothing: Option<f64>,
+    /// Steps between heavy cleanup (default: 25)
+    pub heavy_cleanup_interval: Option<i32>,
+    /// Maximum allowed NaN gradient occurrences (default: 100)
+    pub max_nan_gradients: Option<i64>,
+    /// Consecutive NaN gradients that trigger emergency checkpoint (default: 5)
+    pub emergency_save_threshold: Option<i32>,
+    /// Compute token accuracy (requires extra forward pass) (default: false)
+    pub compute_accuracy: Option<bool>,
+}
+
+impl Default for SftEngineConfig {
+    fn default() -> Self {
+        Self {
+            learning_rate: Some(2e-5),
+            gradient_accumulation_steps: Some(1),
+            gradient_clip_norm: Some(1.0),
+            gradient_clip_value: None,
+            weight_decay: Some(0.01),
+            label_smoothing: Some(0.0),
+            heavy_cleanup_interval: Some(25),
+            max_nan_gradients: Some(100),
+            emergency_save_threshold: Some(5),
+            compute_accuracy: Some(false),
+        }
+    }
+}
+
+/// Metrics from a single training step
+#[napi(object)]
+#[derive(Clone)]
+pub struct SftStepMetrics {
+    /// Current step number
+    pub step: i64,
+    /// Cross-entropy loss value
+    pub loss: f64,
+    /// Total tokens processed this step (non-ignored)
+    pub total_tokens: i32,
+    /// Token-level accuracy (if compute_accuracy enabled)
+    pub token_accuracy: Option<f64>,
+    /// Whether gradients were applied (vs accumulated)
+    pub gradients_applied: bool,
+    /// Time for training step (ms)
+    pub training_time_ms: f64,
+}
+
+/// Metrics from a training epoch
+#[napi(object)]
+#[derive(Clone)]
+pub struct SftEpochMetrics {
+    /// Epoch number
+    pub epoch: i32,
+    /// Average loss for the epoch
+    pub avg_loss: f64,
+    /// Total steps in the epoch
+    pub total_steps: i64,
+    /// Total tokens processed
+    pub total_tokens: i64,
+    /// Time for the epoch (seconds)
+    pub epoch_time_secs: f64,
+}
+
+/// Result of resume position computation
+#[napi(object)]
+#[derive(Clone)]
+pub struct ResumePosition {
+    /// Epoch to start from (0-indexed)
+    pub start_epoch: i32,
+    /// Batch index within epoch to start from
+    pub start_batch_idx: i32,
+    /// Whether we're at an epoch boundary
+    pub is_epoch_boundary: bool,
+}
+
+/// Internal training state
+struct EngineState {
+    accumulated_gradients: Option<HashMap<String, MxArray>>,
+    micro_step: i32,
+    step: i64,
+    epoch: i32,
+    epoch_loss_sum: f64,
+    epoch_steps: i64,
+    epoch_tokens: i64,
+    last_heavy_cleanup_step: i64,
+    nan_gradient_count: u64,
+    consecutive_nan_count: u32,
+    needs_emergency_save: bool,
+}
+
+impl Default for EngineState {
+    fn default() -> Self {
+        Self {
+            accumulated_gradients: None,
+            micro_step: 0,
+            step: 0,
+            epoch: 0,
+            epoch_loss_sum: 0.0,
+            epoch_steps: 0,
+            epoch_tokens: 0,
+            last_heavy_cleanup_step: 0,
+            nan_gradient_count: 0,
+            consecutive_nan_count: 0,
+            needs_emergency_save: false,
+        }
+    }
+}
+
+/// SFT Training Engine
+#[napi]
+pub struct SftTrainingEngine {
+    model: Arc<RwLock<Qwen3Model>>,
+    model_config: Qwen3Config,
+    config: SftEngineConfig,
+    state: Arc<RwLock<EngineState>>,
+}
+
+#[napi]
+impl SftTrainingEngine {
+    /// Create a new SFT training engine
+    #[napi(constructor)]
+    pub fn new(model: &Qwen3Model, config: SftEngineConfig) -> Result<Self> {
+        let model_config = model.get_config();
+
+        info!(
+            "Creating SFT training engine: {} layers, {} hidden, lr={}",
+            model_config.num_layers,
+            model_config.hidden_size,
+            config.learning_rate.unwrap_or(2e-5)
+        );
+
+        Ok(Self {
+            model: Arc::new(RwLock::new(model.clone_for_session()?)),
+            model_config,
+            config,
+            state: Arc::new(RwLock::new(EngineState::default())),
+        })
+    }
+
+    /// Run a single training step
+    #[napi]
+    pub async fn train_step(
+        &self,
+        input_ids: &MxArray,
+        labels: &MxArray,
+    ) -> Result<SftStepMetrics> {
+        let training_start = std::time::Instant::now();
+
+        // Clone Arcs for the blocking task
+        let model_arc = Arc::clone(&self.model);
+        let state_arc = Arc::clone(&self.state);
+        let model_config = self.model_config.clone();
+        let config = self.config.clone();
+        let input_ids = input_ids.clone();
+        let labels = labels.clone();
+
+        // Run in spawn_blocking to avoid blocking the async runtime
+        let result: std::result::Result<SftStepMetrics, Error> =
+            tokio::task::spawn_blocking(move || {
+                // Get model parameters
+                let params = {
+                    let model = model_arc.read().map_err(|_| {
+                        Error::new(Status::GenericFailure, "Failed to acquire model read lock")
+                    })?;
+                    model.get_parameters()
+                };
+
+                // Build loss config
+                let loss_config = SftLossConfig {
+                    ignore_index: Some(-100),
+                    label_smoothing: config.label_smoothing,
+                };
+
+                // Compute loss and gradients
+                let (loss_value, gradients) = compute_sft_loss_and_gradients(
+                    &model_config,
+                    &params,
+                    &input_ids,
+                    &labels,
+                    loss_config,
+                )?;
+
+                // Check for NaN loss
+                if loss_value.is_nan() || loss_value.is_infinite() {
+                    let mut state = state_arc.write().map_err(|_| {
+                        Error::new(Status::GenericFailure, "Failed to acquire state write lock")
+                    })?;
+                    state.nan_gradient_count += 1;
+                    state.consecutive_nan_count += 1;
+
+                    let emergency_threshold = config.emergency_save_threshold.unwrap_or(5) as u32;
+                    if state.consecutive_nan_count >= emergency_threshold {
+                        state.needs_emergency_save = true;
+                        warn!(
+                            "Emergency save triggered: {} consecutive NaN losses",
+                            state.consecutive_nan_count
+                        );
+                    }
+
+                    let max_nan = config.max_nan_gradients.unwrap_or(100) as u64;
+                    if state.nan_gradient_count >= max_nan {
+                        return Err(Error::new(
+                            Status::GenericFailure,
+                            format!("Training stopped: exceeded {} NaN gradient limit", max_nan),
+                        ));
+                    }
+
+                    warn!(
+                        "NaN loss detected, skipping step (count: {})",
+                        state.nan_gradient_count
+                    );
+
+                    return Ok(SftStepMetrics {
+                        step: state.step,
+                        loss: 0.0,
+                        total_tokens: 0,
+                        token_accuracy: None,
+                        gradients_applied: false,
+                        training_time_ms: training_start.elapsed().as_secs_f64() * 1000.0,
+                    });
+                }
+
+                // Reset consecutive NaN count on successful step
+                {
+                    let mut state = state_arc.write().map_err(|_| {
+                        Error::new(Status::GenericFailure, "Failed to acquire state write lock")
+                    })?;
+                    state.consecutive_nan_count = 0;
+                }
+
+                // Count non-ignored tokens
+                let total_tokens = count_valid_tokens(&labels)?;
+
+                // Gradient accumulation
+                let gradient_accumulation_steps = config.gradient_accumulation_steps.unwrap_or(1);
+                let gradients_applied;
+                let current_step;
+
+                {
+                    let mut state = state_arc.write().map_err(|_| {
+                        Error::new(Status::GenericFailure, "Failed to acquire state write lock")
+                    })?;
+
+                    // Accumulate gradients
+                    if let Some(ref mut acc) = state.accumulated_gradients {
+                        for (name, grad) in &gradients {
+                            if let Some(acc_grad) = acc.get_mut(name) {
+                                *acc_grad = acc_grad.add(grad)?;
+                            }
+                        }
+                    } else {
+                        state.accumulated_gradients = Some(gradients.clone());
+                    }
+
+                    state.micro_step += 1;
+
+                    // Apply gradients if we've accumulated enough
+                    if state.micro_step >= gradient_accumulation_steps {
+                        let accumulated = state.accumulated_gradients.take().unwrap();
+
+                        // Average gradients
+                        let scale = 1.0 / gradient_accumulation_steps as f64;
+                        let averaged: HashMap<String, MxArray> = accumulated
+                            .into_iter()
+                            .map(|(name, grad)| {
+                                let scaled = grad.mul_scalar(scale).unwrap_or(grad);
+                                (name, scaled)
+                            })
+                            .collect();
+
+                        // Clip gradients by global norm
+                        let clipped = if let Some(clip_norm) = config.gradient_clip_norm {
+                            let grad_refs: HashMap<String, &MxArray> =
+                                averaged.iter().map(|(k, v)| (k.clone(), v)).collect();
+                            GradientUtils::clip_grad_norm(grad_refs, clip_norm)?
+                        } else {
+                            averaged
+                        };
+
+                        // Apply element-wise clipping if configured
+                        let final_grads = if let Some(clip_val) = config.gradient_clip_value {
+                            clipped
+                                .into_iter()
+                                .map(|(name, grad)| {
+                                    let clipped_grad =
+                                        grad.clip(Some(-clip_val), Some(clip_val)).unwrap_or(grad);
+                                    (name, clipped_grad)
+                                })
+                                .collect()
+                        } else {
+                            clipped
+                        };
+
+                        // Apply gradients with weight decay
+                        let lr = config.learning_rate.unwrap_or(2e-5);
+                        let weight_decay = config.weight_decay.unwrap_or(0.0);
+
+                        // Update model parameters
+                        {
+                            let mut model = model_arc.write().map_err(|_| {
+                                Error::new(
+                                    Status::GenericFailure,
+                                    "Failed to acquire model write lock",
+                                )
+                            })?;
+
+                            // Apply weight decay to gradients if configured
+                            let grads_with_decay = if weight_decay > 0.0 {
+                                let current_params = model.get_parameters();
+                                final_grads
+                                    .into_iter()
+                                    .map(|(name, grad)| {
+                                        if let Some(param) = current_params.get(&name) {
+                                            // grad_with_decay = grad + weight_decay * param
+                                            if let Ok(decay_term) = param.mul_scalar(weight_decay)
+                                                && let Ok(new_grad) = grad.add(&decay_term)
+                                            {
+                                                return (name, new_grad);
+                                            }
+                                            (name, grad)
+                                        } else {
+                                            (name, grad)
+                                        }
+                                    })
+                                    .collect::<HashMap<_, _>>()
+                            } else {
+                                final_grads
+                            };
+
+                            let grads_refs: HashMap<String, &MxArray> = grads_with_decay
+                                .iter()
+                                .map(|(k, v)| (k.clone(), v))
+                                .collect();
+                            model.apply_gradients(grads_refs, lr)?;
+                        }
+
+                        state.step += 1;
+                        state.micro_step = 0;
+                        gradients_applied = true;
+
+                        // Memory management
+                        let cleanup_interval = config.heavy_cleanup_interval.unwrap_or(25) as i64;
+                        if state.step - state.last_heavy_cleanup_step >= cleanup_interval {
+                            debug!("Heavy cleanup at step {}", state.step);
+                            heavy_cleanup();
+                            state.last_heavy_cleanup_step = state.step;
+                        } else {
+                            synchronize_and_clear_cache();
+                        }
+                    } else {
+                        gradients_applied = false;
+                        synchronize_and_clear_cache();
+                    }
+
+                    // Update epoch metrics
+                    state.epoch_loss_sum += loss_value;
+                    state.epoch_steps += 1;
+                    state.epoch_tokens += total_tokens as i64;
+                    current_step = state.step;
+                }
+
+                // Compute token accuracy if enabled (requires extra forward pass)
+                let token_accuracy = if config.compute_accuracy.unwrap_or(false) {
+                    let model = model_arc.read().map_err(|_| {
+                        Error::new(Status::GenericFailure, "Failed to acquire model read lock")
+                    })?;
+                    let params = model.get_parameters();
+                    match compute_token_accuracy(&model_config, &params, &input_ids, &labels) {
+                        Ok(acc) => Some(acc),
+                        Err(e) => {
+                            warn!("Failed to compute accuracy: {}", e);
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                let training_time_ms = training_start.elapsed().as_secs_f64() * 1000.0;
+
+                Ok(SftStepMetrics {
+                    step: current_step,
+                    loss: loss_value,
+                    total_tokens,
+                    token_accuracy,
+                    gradients_applied,
+                    training_time_ms,
+                })
+            })
+            .await
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Task join error: {}", e)))?;
+
+        result
+    }
+
+    /// Get current step number
+    #[napi]
+    pub fn get_step(&self) -> Result<i64> {
+        let state = self
+            .state
+            .read()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+        Ok(state.step)
+    }
+
+    /// Get current epoch
+    #[napi]
+    pub fn get_epoch(&self) -> Result<i32> {
+        let state = self
+            .state
+            .read()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+        Ok(state.epoch)
+    }
+
+    /// Flush any accumulated gradients at epoch end
+    ///
+    /// When stepsPerEpoch % gradient_accumulation_steps != 0, there may be
+    /// leftover gradients from the final micro-batches. This method applies
+    /// them with proper averaging, matching TRL behavior.
+    #[napi]
+    pub fn flush_gradients(&self) -> Result<bool> {
+        let model_arc = Arc::clone(&self.model);
+        let config = self.config.clone();
+
+        let mut state = self.state.write().map_err(|_| {
+            Error::new(Status::GenericFailure, "Failed to acquire state write lock")
+        })?;
+
+        // Nothing to flush if no accumulated gradients
+        if state.micro_step == 0 || state.accumulated_gradients.is_none() {
+            return Ok(false);
+        }
+
+        let accumulated = state.accumulated_gradients.take().unwrap();
+        let actual_micro_steps = state.micro_step;
+
+        // Average gradients by ACTUAL micro-step count (not configured accumulation steps)
+        let scale = 1.0 / actual_micro_steps as f64;
+        let averaged: HashMap<String, MxArray> = accumulated
+            .into_iter()
+            .map(|(name, grad)| {
+                let scaled = grad.mul_scalar(scale).unwrap_or(grad);
+                (name, scaled)
+            })
+            .collect();
+
+        // Apply same clipping and weight decay as regular train_step
+        let clipped = if let Some(clip_norm) = config.gradient_clip_norm {
+            let grad_refs: HashMap<String, &MxArray> =
+                averaged.iter().map(|(k, v)| (k.clone(), v)).collect();
+            GradientUtils::clip_grad_norm(grad_refs, clip_norm)?
+        } else {
+            averaged
+        };
+
+        let final_grads = if let Some(clip_val) = config.gradient_clip_value {
+            clipped
+                .into_iter()
+                .map(|(name, grad)| {
+                    let clipped_grad = grad.clip(Some(-clip_val), Some(clip_val)).unwrap_or(grad);
+                    (name, clipped_grad)
+                })
+                .collect()
+        } else {
+            clipped
+        };
+
+        // Apply gradients
+        let lr = config.learning_rate.unwrap_or(2e-5);
+        let weight_decay = config.weight_decay.unwrap_or(0.0);
+
+        {
+            let mut model = model_arc.write().map_err(|_| {
+                Error::new(Status::GenericFailure, "Failed to acquire model write lock")
+            })?;
+
+            let grads_with_decay = if weight_decay > 0.0 {
+                let current_params = model.get_parameters();
+                final_grads
+                    .into_iter()
+                    .map(|(name, grad)| {
+                        if let Some(param) = current_params.get(&name) {
+                            if let Ok(decay_term) = param.mul_scalar(weight_decay)
+                                && let Ok(new_grad) = grad.add(&decay_term)
+                            {
+                                return (name, new_grad);
+                            }
+                            (name, grad)
+                        } else {
+                            (name, grad)
+                        }
+                    })
+                    .collect::<HashMap<_, _>>()
+            } else {
+                final_grads
+            };
+
+            let grads_refs: HashMap<String, &MxArray> = grads_with_decay
+                .iter()
+                .map(|(k, v)| (k.clone(), v))
+                .collect();
+            model.apply_gradients(grads_refs, lr)?;
+        }
+
+        state.step += 1;
+        state.micro_step = 0;
+
+        info!(
+            "Flushed {} micro-batches at epoch end, step now {}",
+            actual_micro_steps, state.step
+        );
+
+        synchronize_and_clear_cache();
+        Ok(true)
+    }
+
+    /// Compute the resume position given current state and dataset info
+    ///
+    /// This centralizes all resume logic in Rust for correctness.
+    /// Uses i64 math internally to avoid overflow on long runs.
+    #[napi]
+    pub fn compute_resume_position(&self, steps_per_epoch: i32) -> Result<ResumePosition> {
+        let state = self
+            .state
+            .read()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+
+        // Use i64 throughout to avoid overflow on long runs
+        let steps_per_epoch = steps_per_epoch as i64;
+        let grad_accum = self.config.gradient_accumulation_steps.unwrap_or(1) as i64;
+
+        // With flushGradients(), each epoch has ceil(steps_per_epoch / grad_accum) optimizer steps
+        let steps_per_epoch_applied = (steps_per_epoch + grad_accum - 1) / grad_accum; // ceil division
+
+        let current_step = state.step;
+        let current_epoch = state.epoch as i64;
+
+        // Compute within-epoch position
+        let within_epoch_steps = current_step - current_epoch * steps_per_epoch_applied;
+
+        // Epoch boundary: completed all optimizer steps for current epoch
+        let is_epoch_boundary = current_step > 0 && within_epoch_steps >= steps_per_epoch_applied;
+
+        let start_epoch = if is_epoch_boundary {
+            current_epoch + 1
+        } else {
+            current_epoch
+        };
+        let effective_within = if is_epoch_boundary {
+            0
+        } else {
+            within_epoch_steps
+        };
+        let start_batch_idx = effective_within * grad_accum;
+
+        // Clamp to i32 for return (batch_idx is bounded by steps_per_epoch which fits in i32)
+        Ok(ResumePosition {
+            start_epoch: start_epoch as i32,
+            start_batch_idx: start_batch_idx as i32,
+            is_epoch_boundary,
+        })
+    }
+
+    /// Check if emergency save is needed
+    #[napi]
+    pub fn needs_emergency_save(&self) -> Result<bool> {
+        let state = self
+            .state
+            .read()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+        Ok(state.needs_emergency_save)
+    }
+
+    /// Clear emergency save flag
+    #[napi]
+    pub fn clear_emergency_save(&self) -> Result<()> {
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+        state.needs_emergency_save = false;
+        Ok(())
+    }
+
+    /// Signal start of a new epoch
+    ///
+    /// Takes the epoch number directly from TypeScript to ensure synchronization.
+    /// The epoch is 0-indexed to match the TypeScript training loop.
+    #[napi]
+    pub fn start_epoch(&self, epoch: i32) -> Result<()> {
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+        state.epoch = epoch;
+        state.epoch_loss_sum = 0.0;
+        state.epoch_steps = 0;
+        state.epoch_tokens = 0;
+        info!("Starting epoch {}", state.epoch);
+        Ok(())
+    }
+
+    /// End current epoch and return metrics
+    #[napi]
+    pub fn end_epoch(&self, epoch_time_secs: f64) -> Result<SftEpochMetrics> {
+        let state = self
+            .state
+            .read()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+
+        let avg_loss = if state.epoch_steps > 0 {
+            state.epoch_loss_sum / state.epoch_steps as f64
+        } else {
+            0.0
+        };
+
+        info!(
+            "Epoch {} complete: avg_loss={:.4}, steps={}, tokens={}",
+            state.epoch, avg_loss, state.epoch_steps, state.epoch_tokens
+        );
+
+        Ok(SftEpochMetrics {
+            epoch: state.epoch,
+            avg_loss,
+            total_steps: state.epoch_steps,
+            total_tokens: state.epoch_tokens,
+            epoch_time_secs,
+        })
+    }
+
+    /// Reset training state (for new training run)
+    #[napi]
+    pub fn reset(&self) -> Result<()> {
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+        *state = EngineState::default();
+        info!("Training state reset");
+        Ok(())
+    }
+
+    /// Restore training state (for resuming from checkpoint)
+    #[napi]
+    pub fn restore_state(&self, step: i64, epoch: i32) -> Result<()> {
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+        state.step = step;
+        state.epoch = epoch;
+        info!("Restored training state: step={}, epoch={}", step, epoch);
+        Ok(())
+    }
+
+    /// Get the underlying model for checkpointing
+    #[napi]
+    pub fn get_model(&self) -> Result<Qwen3Model> {
+        let model = self
+            .model
+            .read()
+            .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
+        model.clone_for_session()
+    }
+}
+
+/// Count tokens that are not ignored (label != -100)
+fn count_valid_tokens(labels: &MxArray) -> Result<i32> {
+    let shape = labels.shape()?;
+    let total: i64 = shape.iter().product();
+
+    // Create mask for non-ignored tokens
+    let ignore_val = MxArray::scalar_int(-100)?;
+    let valid_mask = labels.not_equal(&ignore_val)?;
+
+    // Sum to count valid tokens
+    let count = valid_mask.sum(None, Some(false))?;
+    count.eval();
+
+    let count_val = count.item_at_int32(0).unwrap_or(total as i32);
+    Ok(count_val)
+}

--- a/crates/mlx-core/src/sft/loss.rs
+++ b/crates/mlx-core/src/sft/loss.rs
@@ -1,0 +1,23 @@
+// SFT Loss Configuration
+//
+// Configuration for supervised fine-tuning loss computation.
+// Used by autograd.rs which handles the actual loss computation
+// including token shifting for next-token prediction.
+
+/// Configuration for SFT loss computation
+#[derive(Clone, Debug)]
+pub struct SftLossConfig {
+    /// Ignore tokens with this label (default: -100)
+    pub ignore_index: Option<i32>,
+    /// Label smoothing factor (default: 0.0)
+    pub label_smoothing: Option<f64>,
+}
+
+impl Default for SftLossConfig {
+    fn default() -> Self {
+        Self {
+            ignore_index: Some(-100),
+            label_smoothing: Some(0.0),
+        }
+    }
+}

--- a/crates/mlx-core/src/sft/mod.rs
+++ b/crates/mlx-core/src/sft/mod.rs
@@ -1,0 +1,18 @@
+// SFT (Supervised Fine-Tuning) Module
+//
+// This module contains all SFT-related components for training models
+// on fixed prompt-completion pairs using cross-entropy loss.
+//
+// Components:
+// - loss: Cross-entropy loss with completion masking
+// - autograd: Autograd-based loss and gradient computation
+// - engine: Complete Rust-native training engine
+
+pub mod autograd;
+pub mod engine;
+pub mod loss;
+
+// Re-export all public items
+pub use autograd::*;
+pub use engine::*;
+pub use loss::*;

--- a/examples/grpo/compare-models.ts
+++ b/examples/grpo/compare-models.ts
@@ -78,7 +78,11 @@ CRITICAL: The tool_call MUST contain valid JSON with "name" and "arguments" keys
 // ============================================================================
 
 function getLang(language: string): Lang {
-  return language === 'typescript' ? Lang.TypeScript : Lang.JavaScript;
+  const normalized = language.toLowerCase();
+  if (normalized === 'typescript' || normalized === 'ts') return Lang.TypeScript;
+  if (normalized === 'tsx') return Lang.Tsx;
+  if (normalized === 'jsx') return Lang.JavaScript;
+  return Lang.JavaScript;
 }
 
 interface EvalResult {
@@ -321,10 +325,12 @@ ${pattern.codeContext}
 
       const evalResult = evaluateCompletion(
         {
+          prompt: messages[1].content,
           completion: {
+            text: result.text,
             rawText: result.rawText,
             toolCalls: result.toolCalls,
-            thinking: result.thinking,
+            thinking: result.thinking ?? undefined,
             numTokens: result.numTokens,
             finishReason: result.finishReason,
           },

--- a/examples/grpo/train-tool-use.ts
+++ b/examples/grpo/train-tool-use.ts
@@ -35,7 +35,7 @@ import {
 } from '@mlx-node/trl';
 import { generateCurriculumDataset, type AstGrepPattern } from './ast-grep-dataset';
 
-const DEFAULT_MODEL_PATH = resolve(process.cwd(), '.cache', 'models', 'qwen3-0.6b-mlx-bf16');
+const DEFAULT_MODEL_PATH = resolve(process.cwd(), 'outputs/sft-ast-grep/final-bf16');
 const DEFAULT_NUM_EXAMPLES = 100;
 const DEFAULT_OUTPUT_DIR = resolve(process.cwd(), 'outputs', 'grpo-tool-use');
 
@@ -134,7 +134,11 @@ ${pattern.codeContext}
  * Get the language enum for ast-grep
  */
 function getLang(language: string): Lang {
-  return language === 'typescript' ? Lang.TypeScript : Lang.JavaScript;
+  const normalized = language.toLowerCase();
+  if (normalized === 'typescript' || normalized === 'ts') return Lang.TypeScript;
+  if (normalized === 'tsx') return Lang.Tsx;
+  if (normalized === 'jsx') return Lang.JavaScript;
+  return Lang.JavaScript;
 }
 
 /**

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -601,6 +601,7 @@ module.exports.RMSNorm = nativeBinding.RMSNorm
 module.exports.RMSprop = nativeBinding.RMSprop
 module.exports.RoPE = nativeBinding.RoPE
 module.exports.RotatingKVCache = nativeBinding.RotatingKVCache
+module.exports.SftTrainingEngine = nativeBinding.SftTrainingEngine
 module.exports.SGD = nativeBinding.SGD
 module.exports.Tensor = nativeBinding.Tensor
 module.exports.TransformerBlock = nativeBinding.TransformerBlock

--- a/packages/trl/src/data/sft-dataset.ts
+++ b/packages/trl/src/data/sft-dataset.ts
@@ -1,0 +1,497 @@
+/**
+ * SFT Dataset handling for Supervised Fine-Tuning
+ *
+ * Supports two data formats (auto-detected):
+ * 1. Prompt-Completion: { prompt: ChatMessage[], completion: ChatMessage }
+ * 2. Full Conversation: { messages: ChatMessage[] }
+ *
+ * Both formats produce tokenized batches with labels masked appropriately.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
+import type { Qwen3Tokenizer } from '@mlx-node/core';
+import type { ChatMessage } from '../types';
+
+// -100 is the standard ignore index for cross-entropy loss
+const IGNORE_INDEX = -100;
+
+/**
+ * Prompt-Completion format for tool-use training
+ */
+export interface SFTPromptCompletionExample {
+  prompt: ChatMessage[];
+  completion: ChatMessage;
+}
+
+/**
+ * Full conversation format for multi-turn dialogue
+ */
+export interface SFTConversationExample {
+  messages: ChatMessage[];
+}
+
+/**
+ * Union type for SFT examples
+ */
+export type SFTExample = SFTPromptCompletionExample | SFTConversationExample;
+
+/**
+ * A tokenized batch ready for SFT training
+ */
+export interface SFTBatch {
+  inputIds: Int32Array;
+  labels: Int32Array;
+  shape: [number, number]; // [batch_size, seq_len]
+}
+
+/**
+ * Configuration for SFT dataset
+ */
+export interface SFTDatasetConfig {
+  maxSeqLength?: number;
+  completionOnly?: boolean; // If true, only train on completion tokens (default: false for TRL parity)
+  enableThinking?: boolean; // Enable thinking mode for tokenizer
+  seed?: number; // Random seed for reproducible shuffling (default: 42)
+}
+
+/**
+ * Detect the format of an SFT example
+ */
+function detectFormat(example: SFTExample): 'prompt-completion' | 'conversation' {
+  if ('prompt' in example && 'completion' in example) {
+    return 'prompt-completion';
+  }
+  if ('messages' in example) {
+    return 'conversation';
+  }
+  throw new Error('Invalid SFT example format. Expected either {prompt, completion} or {messages}');
+}
+
+/**
+ * Check if a message is from an assistant
+ */
+function isAssistantMessage(message: ChatMessage): boolean {
+  return message.role === 'assistant';
+}
+
+/**
+ * SFT Dataset class for handling SFT training data
+ */
+export class SFTDataset {
+  private examples: SFTExample[];
+  private tokenizer: Qwen3Tokenizer;
+  private config: Required<Omit<SFTDatasetConfig, 'seed'>> & { seed: number };
+  private format: 'prompt-completion' | 'conversation';
+  private shuffledIndices: number[];
+  private rng: () => number;
+
+  constructor(examples: SFTExample[], tokenizer: Qwen3Tokenizer, config: SFTDatasetConfig = {}) {
+    if (examples.length === 0) {
+      throw new Error('SFT dataset must contain at least one example');
+    }
+
+    this.examples = examples;
+    this.tokenizer = tokenizer;
+    this.config = {
+      maxSeqLength: config.maxSeqLength ?? 2048,
+      completionOnly: config.completionOnly ?? false, // Changed to false for TRL parity
+      enableThinking: config.enableThinking ?? false,
+      seed: config.seed ?? 42,
+    };
+    this.rng = this.createSeededRandom(this.config.seed);
+
+    // Detect format from first example
+    this.format = detectFormat(examples[0]);
+
+    // Validate all examples have the same format
+    for (let i = 1; i < examples.length; i++) {
+      const fmt = detectFormat(examples[i]);
+      if (fmt !== this.format) {
+        throw new Error(`Inconsistent SFT data format: example 0 is ${this.format}, example ${i} is ${fmt}`);
+      }
+    }
+
+    // Initialize indices
+    this.shuffledIndices = Array.from({ length: examples.length }, (_, i) => i);
+  }
+
+  /**
+   * Get the number of examples in the dataset
+   */
+  get length(): number {
+    return this.examples.length;
+  }
+
+  /**
+   * Shuffle dataset for a specific epoch using epoch-based seeding.
+   * This ensures reproducible shuffles across training resumes.
+   * Each epoch gets a deterministic shuffle based on (baseSeed + epoch).
+   *
+   * @param epoch - The epoch number (used as seed offset)
+   */
+  shuffleForEpoch(epoch: number): void {
+    // Reset RNG with epoch-specific seed for reproducibility
+    this.rng = this.createSeededRandom(this.config.seed + epoch);
+    // Reset indices to original order
+    this.shuffledIndices = Array.from({ length: this.examples.length }, (_, i) => i);
+    // Fisher-Yates shuffle
+    for (let i = this.shuffledIndices.length - 1; i > 0; i--) {
+      const j = Math.floor(this.rng() * (i + 1));
+      [this.shuffledIndices[i], this.shuffledIndices[j]] = [this.shuffledIndices[j], this.shuffledIndices[i]];
+    }
+  }
+
+  /**
+   * Create a seeded pseudo-random number generator (Linear Congruential Generator)
+   */
+  private createSeededRandom(seed: number): () => number {
+    let s = seed;
+    return () => {
+      s = (s * 1103515245 + 12345) & 0x7fffffff;
+      return s / 0x7fffffff;
+    };
+  }
+
+  /**
+   * Find length of common prefix between two token arrays
+   * Handles chat template quirks where prompt tokens may not be exact prefix of full tokens
+   */
+  private findCommonPrefixLength(prompt: number[], full: number[]): number {
+    let i = 0;
+    const maxLen = Math.min(prompt.length, full.length);
+    while (i < maxLen && prompt[i] === full[i]) {
+      i++;
+    }
+    return i;
+  }
+
+  /**
+   * Tokenize a prompt-completion example
+   */
+  private async tokenizePromptCompletion(
+    example: SFTPromptCompletionExample,
+  ): Promise<{ inputIds: number[]; labels: number[] }> {
+    // Tokenize prompt with generation prompt (so the model learns to continue)
+    const promptTokens = await this.tokenizer.applyChatTemplate(
+      example.prompt,
+      true, // add generation prompt
+      null,
+      this.config.enableThinking,
+    );
+
+    // Create full messages for tokenization
+    const fullMessages = [...example.prompt, example.completion];
+    const fullTokens = await this.tokenizer.applyChatTemplate(
+      fullMessages,
+      false, // no generation prompt at the end
+      null,
+      this.config.enableThinking,
+    );
+
+    // Convert to regular arrays for manipulation
+    const promptArr = Array.from(promptTokens).map((t) => Number(t));
+    const inputIds = Array.from(fullTokens).map((t) => Number(t));
+
+    // Use common prefix detection to handle chat template quirks
+    // (some templates may not produce prompt tokens as exact prefix of full tokens)
+    const promptLen = this.findCommonPrefixLength(promptArr, inputIds);
+
+    if (promptLen !== promptArr.length) {
+      console.warn(
+        `[SFT Dataset] Prompt tokens differ from prefix of full sequence ` +
+          `(${promptArr.length} vs ${promptLen}). Using common prefix for masking.`,
+      );
+    }
+
+    // Create labels: -100 for prompt tokens, actual tokens for completion
+    const labels = inputIds.map((id, i) => {
+      if (this.config.completionOnly && i < promptLen) {
+        return IGNORE_INDEX;
+      }
+      return id;
+    });
+
+    return { inputIds, labels };
+  }
+
+  /**
+   * Tokenize a conversation example
+   *
+   * For conversations, we train on all assistant turns.
+   * Non-assistant tokens (system, user) are masked with -100.
+   *
+   * Complexity: O(k) where k is the number of assistant messages,
+   * instead of O(n) for all messages.
+   */
+  private async tokenizeConversation(
+    example: SFTConversationExample,
+  ): Promise<{ inputIds: number[]; labels: number[] }> {
+    const messages = example.messages;
+
+    // Tokenize full conversation once
+    const fullTokens = await this.tokenizer.applyChatTemplate(
+      messages,
+      false, // no generation prompt
+      null,
+      this.config.enableThinking,
+    );
+
+    const inputIds = Array.from(fullTokens).map((t) => Number(t));
+
+    // If not masking prompts, all tokens are trainable
+    if (!this.config.completionOnly) {
+      return { inputIds, labels: [...inputIds] };
+    }
+
+    // Find assistant message indices
+    const assistantIndices = messages.map((m, i) => (isAssistantMessage(m) ? i : -1)).filter((i) => i >= 0);
+
+    if (assistantIndices.length === 0) {
+      // No assistant messages - mask everything
+      const labels = inputIds.map(() => IGNORE_INDEX);
+      return { inputIds, labels };
+    }
+
+    // Only tokenize at assistant boundaries - O(k) where k = # assistant messages
+    // Instead of O(n) for every message
+    const boundaries: Array<{ start: number; end: number; isAssistant: boolean }> = [];
+    let prevEnd = 0;
+
+    for (const assistantIdx of assistantIndices) {
+      // Tokenize up to but not including this assistant message
+      if (assistantIdx > 0) {
+        const beforeAssistant = await this.tokenizer.applyChatTemplate(
+          messages.slice(0, assistantIdx),
+          false,
+          null,
+          this.config.enableThinking,
+        );
+        const start = beforeAssistant.length;
+        if (start > prevEnd) {
+          boundaries.push({ start: prevEnd, end: start, isAssistant: false });
+        }
+        prevEnd = start;
+      }
+
+      // Tokenize including this assistant message
+      const afterAssistant = await this.tokenizer.applyChatTemplate(
+        messages.slice(0, assistantIdx + 1),
+        false,
+        null,
+        this.config.enableThinking,
+      );
+      const end = afterAssistant.length;
+      if (end > prevEnd) {
+        boundaries.push({ start: prevEnd, end, isAssistant: true });
+      }
+      prevEnd = end;
+    }
+
+    // Handle any trailing non-assistant messages
+    if (prevEnd < fullTokens.length) {
+      boundaries.push({ start: prevEnd, end: fullTokens.length, isAssistant: false });
+    }
+
+    // Build labels based on boundaries
+    const labels = Array.from({ length: inputIds.length }, () => IGNORE_INDEX);
+    for (const { start, end, isAssistant } of boundaries) {
+      if (isAssistant) {
+        for (let i = start; i < end; i++) {
+          labels[i] = inputIds[i];
+        }
+      }
+    }
+
+    return { inputIds, labels };
+  }
+
+  /**
+   * Tokenize a single example based on its format
+   */
+  private async tokenizeExample(example: SFTExample): Promise<{ inputIds: number[]; labels: number[] }> {
+    if (this.format === 'prompt-completion') {
+      return this.tokenizePromptCompletion(example as SFTPromptCompletionExample);
+    } else {
+      return this.tokenizeConversation(example as SFTConversationExample);
+    }
+  }
+
+  /**
+   * Collate multiple examples into a padded batch
+   */
+  async collateBatch(indices: number[]): Promise<SFTBatch> {
+    const examples = indices.map((i) => this.examples[this.shuffledIndices[i]]);
+
+    // Tokenize all examples
+    const tokenized = await Promise.all(examples.map((example) => this.tokenizeExample(example)));
+
+    // Find max length (capped at maxSeqLength)
+    const maxLen = Math.min(this.config.maxSeqLength, Math.max(...tokenized.map((t) => t.inputIds.length)));
+
+    // Pad and truncate
+    const batchSize = examples.length;
+    const paddedInputIds = new Int32Array(batchSize * maxLen);
+    const paddedLabels = new Int32Array(batchSize * maxLen);
+
+    const padTokenId = this.tokenizer.getPadTokenId();
+
+    for (let b = 0; b < batchSize; b++) {
+      const { inputIds, labels } = tokenized[b];
+      const seqLen = Math.min(inputIds.length, maxLen);
+
+      // Truncate from the left if necessary (keep the end of the sequence)
+      const startIdx = Math.max(0, inputIds.length - maxLen);
+
+      for (let s = 0; s < maxLen; s++) {
+        const offset = b * maxLen + s;
+        if (s < seqLen) {
+          paddedInputIds[offset] = inputIds[startIdx + s];
+          paddedLabels[offset] = labels[startIdx + s];
+        } else {
+          // Pad
+          paddedInputIds[offset] = padTokenId;
+          paddedLabels[offset] = IGNORE_INDEX;
+        }
+      }
+    }
+
+    return {
+      inputIds: paddedInputIds,
+      labels: paddedLabels,
+      shape: [batchSize, maxLen],
+    };
+  }
+
+  /**
+   * Generate batches for training
+   */
+  async *batches(batchSize: number): AsyncGenerator<SFTBatch> {
+    for (let i = 0; i < this.examples.length; i += batchSize) {
+      const end = Math.min(i + batchSize, this.examples.length);
+      const indices = Array.from({ length: end - i }, (_, j) => i + j);
+      yield await this.collateBatch(indices);
+    }
+  }
+
+  /**
+   * Get total number of batches for a given batch size
+   */
+  numBatches(batchSize: number): number {
+    return Math.ceil(this.examples.length / batchSize);
+  }
+}
+
+/**
+ * Read JSONL file and parse into records
+ */
+function readJsonl<T>(path: string, limit?: number): T[] {
+  let fileContents: string;
+  try {
+    fileContents = readFileSync(path, 'utf8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read SFT dataset at ${path}: ${message}`);
+  }
+
+  const lines = fileContents.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const records: T[] = [];
+  const max = typeof limit === 'number' && limit > 0 ? limit : Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < lines.length && records.length < max; i++) {
+    const line = lines[i];
+    try {
+      const parsed = JSON.parse(line) as T;
+      records.push(parsed);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to parse JSONL at ${path}:${i + 1} - ${message}`);
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Validate an SFT example
+ */
+function validateSFTExample(example: unknown, index: number): SFTExample {
+  if (typeof example !== 'object' || example === null) {
+    throw new Error(`SFT example ${index} must be an object`);
+  }
+
+  const obj = example as Record<string, unknown>;
+
+  // Check for prompt-completion format
+  if ('prompt' in obj && 'completion' in obj) {
+    if (!Array.isArray(obj.prompt)) {
+      throw new Error(`SFT example ${index}: prompt must be an array of messages`);
+    }
+    if (typeof obj.completion !== 'object' || obj.completion === null) {
+      throw new Error(`SFT example ${index}: completion must be a message object`);
+    }
+    const completion = obj.completion as Record<string, unknown>;
+    if (completion.role !== 'assistant') {
+      throw new Error(`SFT example ${index}: completion.role must be 'assistant'`);
+    }
+    if (typeof completion.content !== 'string') {
+      throw new Error(`SFT example ${index}: completion.content must be a string`);
+    }
+    return {
+      prompt: obj.prompt as ChatMessage[],
+      completion: obj.completion as ChatMessage,
+    };
+  }
+
+  // Check for conversation format
+  if ('messages' in obj) {
+    if (!Array.isArray(obj.messages)) {
+      throw new Error(`SFT example ${index}: messages must be an array`);
+    }
+    if (obj.messages.length === 0) {
+      throw new Error(`SFT example ${index}: messages cannot be empty`);
+    }
+    // Check that at least one message is from assistant
+    const hasAssistant = obj.messages.some(
+      (m: unknown) => typeof m === 'object' && m !== null && (m as Record<string, unknown>).role === 'assistant',
+    );
+    if (!hasAssistant) {
+      throw new Error(`SFT example ${index}: messages must contain at least one assistant message`);
+    }
+    return { messages: obj.messages as ChatMessage[] };
+  }
+
+  throw new Error(`SFT example ${index}: must have either {prompt, completion} or {messages}`);
+}
+
+/**
+ * Load SFT dataset from a JSONL file
+ *
+ * Supports two formats:
+ * 1. Prompt-Completion: {"prompt": [...], "completion": {...}}
+ * 2. Conversation: {"messages": [...]}
+ */
+export async function loadSFTDataset(
+  path: string,
+  tokenizer: Qwen3Tokenizer,
+  config?: SFTDatasetConfig & { limit?: number },
+): Promise<SFTDataset> {
+  const absolutePath = resolvePath(path);
+  const rawRecords = readJsonl<unknown>(absolutePath, config?.limit);
+
+  // Validate and convert
+  const examples: SFTExample[] = rawRecords.map((record, i) => validateSFTExample(record, i));
+
+  return new SFTDataset(examples, tokenizer, config);
+}
+
+/**
+ * Create SFT dataset from examples directly
+ */
+export function createSFTDataset(
+  examples: SFTExample[],
+  tokenizer: Qwen3Tokenizer,
+  config?: SFTDatasetConfig,
+): SFTDataset {
+  return new SFTDataset(examples, tokenizer, config);
+}

--- a/packages/trl/src/index.ts
+++ b/packages/trl/src/index.ts
@@ -105,8 +105,39 @@ export {
 // Entropy configuration
 export { type EntropyFilteringConfig, DEFAULT_ENTROPY_CONFIG } from './trainers/grpo-entropy';
 
+// SFT Trainer
+export {
+  SFTTrainer,
+  SftTrainingEngine,
+  type SFTTrainStepResult,
+  type SFTTrainingState,
+  type SftEngineConfig,
+  type SftStepMetrics,
+  type SftEpochMetrics,
+} from './trainers/sft-trainer';
+
+export {
+  type SFTTrainerConfig,
+  SFTConfigError,
+  getDefaultSFTConfig,
+  mergeSFTConfig,
+  loadSFTTomlConfig,
+  applySFTOverrides,
+  DEFAULT_SFT_CONFIG,
+} from './trainers/sft-config';
+
 // Data
 export * from './data/dataset';
+export {
+  SFTDataset,
+  loadSFTDataset,
+  createSFTDataset,
+  type SFTExample,
+  type SFTPromptCompletionExample,
+  type SFTConversationExample,
+  type SFTBatch,
+  type SFTDatasetConfig,
+} from './data/sft-dataset';
 
 // Utils
 export * from './utils/xml-parser';

--- a/packages/trl/src/trainers/sft-config.ts
+++ b/packages/trl/src/trainers/sft-config.ts
@@ -1,0 +1,238 @@
+import { parse as parseToml } from '@std/toml';
+import { readFileSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
+
+export class SFTConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SFTConfigError';
+  }
+}
+
+export interface SFTTrainerConfig {
+  // Model
+  model_name: string;
+  output_dir: string;
+  run_name: string;
+
+  // Training hyperparameters
+  learning_rate: number;
+  batch_size: number;
+  gradient_accumulation_steps: number;
+  num_epochs: number;
+  max_train_samples: number;
+  max_grad_norm: number;
+  weight_decay: number;
+
+  // SFT-specific
+  max_seq_length: number;
+  completion_only: boolean;
+  label_smoothing: number;
+
+  // Logging & checkpointing
+  logging_steps: number;
+  save_steps: number;
+  max_checkpoints: number;
+  log_jsonl: boolean;
+  tui_mode: boolean;
+
+  // Misc
+  seed: number;
+  resume_from_checkpoint: string;
+}
+
+const DEFAULT_SFT_CONFIG: SFTTrainerConfig = Object.freeze({
+  model_name: 'Qwen/Qwen3-0.6B',
+  output_dir: 'outputs/sft',
+  run_name: 'sft-run',
+
+  learning_rate: 2e-5,
+  batch_size: 4,
+  gradient_accumulation_steps: 1,
+  num_epochs: 3,
+  max_train_samples: 0,
+  max_grad_norm: 1.0,
+  weight_decay: 0.01,
+
+  max_seq_length: 2048,
+  completion_only: false, // Changed to false for TRL parity
+  label_smoothing: 0.0,
+
+  logging_steps: 10,
+  save_steps: 100,
+  max_checkpoints: 3,
+  log_jsonl: true,
+  tui_mode: false,
+
+  seed: 42,
+  resume_from_checkpoint: '',
+});
+
+type SFTConfigKey = keyof SFTTrainerConfig;
+
+const SFT_CONFIG_VALUE_TYPES: Record<SFTConfigKey, 'number' | 'boolean' | 'string'> = {
+  model_name: 'string',
+  output_dir: 'string',
+  run_name: 'string',
+  learning_rate: 'number',
+  batch_size: 'number',
+  gradient_accumulation_steps: 'number',
+  num_epochs: 'number',
+  max_train_samples: 'number',
+  max_grad_norm: 'number',
+  weight_decay: 'number',
+  max_seq_length: 'number',
+  completion_only: 'boolean',
+  label_smoothing: 'number',
+  logging_steps: 'number',
+  save_steps: 'number',
+  max_checkpoints: 'number',
+  log_jsonl: 'boolean',
+  tui_mode: 'boolean',
+  seed: 'number',
+  resume_from_checkpoint: 'string',
+};
+
+const SFT_INTEGER_KEYS: ReadonlySet<SFTConfigKey> = new Set([
+  'batch_size',
+  'gradient_accumulation_steps',
+  'num_epochs',
+  'max_train_samples',
+  'max_seq_length',
+  'logging_steps',
+  'save_steps',
+  'max_checkpoints',
+  'seed',
+]);
+
+function cloneDefaults(): SFTTrainerConfig {
+  return { ...DEFAULT_SFT_CONFIG };
+}
+
+function isConfigKey(value: string): value is SFTConfigKey {
+  return Object.prototype.hasOwnProperty.call(SFT_CONFIG_VALUE_TYPES, value);
+}
+
+function coerceBoolean(value: unknown, key: SFTConfigKey): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+    if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+  }
+  throw new SFTConfigError(`Invalid boolean for ${key}: ${String(value)}`);
+}
+
+function coerceNumber(value: unknown, key: SFTConfigKey): number {
+  if (typeof value === 'string' && value.trim() === '') {
+    throw new SFTConfigError(`Invalid number for ${key}: empty string`);
+  }
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new SFTConfigError(`Invalid number for ${key}: ${String(value)}`);
+  }
+  if (SFT_INTEGER_KEYS.has(key) && !Number.isInteger(parsed)) {
+    throw new SFTConfigError(`Expected integer for ${key}, received ${parsed}`);
+  }
+  return parsed;
+}
+
+function coerceString(value: unknown, key: SFTConfigKey): string {
+  if (typeof value === 'string') return value;
+  throw new SFTConfigError(`Invalid string for ${key}: ${String(value)}`);
+}
+
+function coerceValue(key: SFTConfigKey, value: unknown): SFTTrainerConfig[SFTConfigKey] {
+  const expected = SFT_CONFIG_VALUE_TYPES[key];
+  if (expected === 'boolean') {
+    return coerceBoolean(value, key) as SFTTrainerConfig[SFTConfigKey];
+  }
+  if (expected === 'number') {
+    return coerceNumber(value, key) as SFTTrainerConfig[SFTConfigKey];
+  }
+  return coerceString(value, key) as SFTTrainerConfig[SFTConfigKey];
+}
+
+function setConfigValue<T extends Partial<SFTTrainerConfig>>(
+  config: T,
+  key: SFTConfigKey,
+  value: SFTTrainerConfig[SFTConfigKey],
+): void {
+  (config as Record<SFTConfigKey, SFTTrainerConfig[SFTConfigKey]>)[key] = value;
+}
+
+function normalizeTomlRecord(record: Record<string, unknown>): Partial<SFTTrainerConfig> {
+  const normalized: Partial<SFTTrainerConfig> = {};
+  for (const [rawKey, rawValue] of Object.entries(record)) {
+    if (!isConfigKey(rawKey)) {
+      continue;
+    }
+    setConfigValue(normalized, rawKey, coerceValue(rawKey, rawValue));
+  }
+  return normalized;
+}
+
+export function getDefaultSFTConfig(): SFTTrainerConfig {
+  return cloneDefaults();
+}
+
+export function mergeSFTConfig(base: SFTTrainerConfig, update: Partial<SFTTrainerConfig>): SFTTrainerConfig {
+  if (!update) {
+    return { ...base };
+  }
+  const result: SFTTrainerConfig = { ...base };
+  for (const [key, value] of Object.entries(update) as [SFTConfigKey, SFTTrainerConfig[SFTConfigKey]][]) {
+    if (value === undefined) continue;
+    if (!isConfigKey(key)) {
+      throw new SFTConfigError(`Unknown configuration key: ${key}`);
+    }
+    setConfigValue(result, key, value);
+  }
+  return result;
+}
+
+export function loadSFTTomlConfig(filePath: string): SFTTrainerConfig {
+  const absolutePath = resolvePath(filePath);
+  let fileContents: string;
+  try {
+    fileContents = readFileSync(absolutePath, 'utf8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new SFTConfigError(`Failed to read config at ${absolutePath}: ${message}`);
+  }
+  let parsedRaw: unknown;
+  try {
+    parsedRaw = parseToml(fileContents);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new SFTConfigError(`Failed to parse TOML at ${absolutePath}: ${message}`);
+  }
+  if (parsedRaw === null || typeof parsedRaw !== 'object' || Array.isArray(parsedRaw)) {
+    throw new SFTConfigError(`Expected table at ${absolutePath}`);
+  }
+  const parsed = parsedRaw as Record<string, unknown>;
+  const normalized = normalizeTomlRecord(parsed);
+  return mergeSFTConfig(getDefaultSFTConfig(), normalized);
+}
+
+export function applySFTOverrides(config: SFTTrainerConfig, overrides: string[]): SFTTrainerConfig {
+  if (!overrides.length) {
+    return { ...config };
+  }
+  const accumulated: Partial<SFTTrainerConfig> = {};
+  for (const entry of overrides) {
+    const idx = entry.indexOf('=');
+    if (idx === -1) {
+      throw new SFTConfigError(`Invalid override "${entry}", expected key=value format`);
+    }
+    const key = entry.slice(0, idx).trim();
+    const rawValue = entry.slice(idx + 1).trim();
+    if (!isConfigKey(key)) {
+      throw new SFTConfigError(`Unknown configuration key in override: ${key}`);
+    }
+    setConfigValue(accumulated, key, coerceValue(key, rawValue));
+  }
+  return mergeSFTConfig(config, accumulated);
+}
+
+export { DEFAULT_SFT_CONFIG };

--- a/packages/trl/src/trainers/sft-trainer.ts
+++ b/packages/trl/src/trainers/sft-trainer.ts
@@ -1,0 +1,605 @@
+/**
+ * SFT (Supervised Fine-Tuning) Trainer
+ *
+ * This module provides a Rust-native SFT training engine for training
+ * models on fixed prompt-completion pairs using cross-entropy loss.
+ *
+ * ## Key Features
+ * - Training loop runs in Rust (eliminates FFI overhead)
+ * - Cross-entropy loss with completion masking (ignore_index=-100)
+ * - Label smoothing support
+ * - Gradient accumulation and clipping
+ * - High-level train() method for full training runs
+ * - Low-level trainStep() for custom training loops
+ *
+ * ## Usage
+ * ```typescript
+ * const trainer = await SFTTrainer.create({
+ *   modelPath: './model',
+ *   learningRate: 2e-5,
+ *   numEpochs: 3,
+ * });
+ * await trainer.train(dataset);
+ * ```
+ */
+
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, copyFileSync, rmSync } from 'node:fs';
+import { join, parse } from 'node:path';
+import * as readline from 'node:readline';
+
+import {
+  SftTrainingEngine,
+  Qwen3Model,
+  Qwen3Tokenizer,
+  MxArray,
+  type SftEngineConfig,
+  type SftStepMetrics,
+  type SftEpochMetrics,
+} from '@mlx-node/core';
+
+import type { SFTTrainerConfig } from './sft-config';
+import { getDefaultSFTConfig, mergeSFTConfig } from './sft-config';
+import { SFTDataset, loadSFTDataset, type SFTBatch } from '../data/sft-dataset';
+import { createTrainingLogger, type TrainingLogger } from './training-logger';
+
+// Re-export types
+export { SftTrainingEngine } from '@mlx-node/core';
+export type { SftEngineConfig, SftStepMetrics, SftEpochMetrics } from '@mlx-node/core';
+
+/**
+ * Training state saved with checkpoints for resumption
+ */
+export interface SFTTrainingState {
+  step: number;
+  epoch: number;
+  timestamp: string;
+  trainerType: 'sft';
+}
+
+/**
+ * Training step result
+ */
+export interface SFTTrainStepResult {
+  /** Step metrics */
+  metrics: SftStepMetrics;
+  /** Current epoch */
+  epoch: number;
+}
+
+/**
+ * SFT Trainer - Rust-Native Training Engine
+ *
+ * Provides a TypeScript-friendly interface to the Rust SFT training engine.
+ */
+export class SFTTrainer {
+  private engine: SftTrainingEngine;
+  private model: Qwen3Model;
+  private tokenizer: Qwen3Tokenizer;
+  private config: SFTTrainerConfig;
+  private currentEpoch: number = 0;
+  private currentStep: number = 0;
+  /** Original model path (for tokenizer files when saving checkpoints) */
+  private originalModelPath?: string;
+
+  // TUI state
+  private paused: boolean = false;
+  private stopRequested: boolean = false;
+  private stdinInterface?: readline.Interface;
+  private logger: TrainingLogger;
+
+  /**
+   * Create a new SFT trainer from a model
+   *
+   * @param model - Pre-loaded Qwen3 model
+   * @param tokenizer - Pre-loaded tokenizer
+   * @param config - Training configuration
+   * @param logger - Optional custom logger
+   */
+  constructor(
+    model: Qwen3Model,
+    tokenizer: Qwen3Tokenizer,
+    config: Partial<SFTTrainerConfig> = {},
+    logger?: TrainingLogger,
+  ) {
+    // Auto-detect TUI mode from environment variable
+    const tuiModeFromEnv = process.env.MLX_TUI_MODE === '1';
+    if (tuiModeFromEnv && config.tui_mode === undefined) {
+      config.tui_mode = true;
+    }
+
+    this.config = mergeSFTConfig(getDefaultSFTConfig(), config);
+    this.model = model;
+    this.tokenizer = tokenizer;
+
+    // Create or use provided logger
+    this.logger =
+      logger ??
+      createTrainingLogger({
+        logConsole: !this.config.tui_mode,
+        logJsonl: this.config.log_jsonl,
+        outputDir: this.config.output_dir,
+        runName: this.config.run_name,
+        logInterval: this.config.logging_steps,
+      });
+
+    // Convert to native config
+    const engineConfig: SftEngineConfig = {
+      learningRate: this.config.learning_rate,
+      gradientAccumulationSteps: this.config.gradient_accumulation_steps,
+      gradientClipNorm: this.config.max_grad_norm,
+      weightDecay: this.config.weight_decay,
+      labelSmoothing: this.config.label_smoothing,
+    };
+
+    this.engine = new SftTrainingEngine(model, engineConfig);
+
+    // Setup stdin handler if TUI mode
+    if (this.config.tui_mode) {
+      this.setupStdinHandler();
+    }
+  }
+
+  /**
+   * Setup stdin handler for TUI control commands
+   */
+  private setupStdinHandler(): void {
+    if (!this.config.tui_mode) return;
+
+    this.stdinInterface = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+
+    this.stdinInterface.on('line', (line: string) => {
+      const cmd = line.trim();
+      this.handleStdinCommand(cmd);
+    });
+  }
+
+  /**
+   * Handle a command received from stdin
+   */
+  private handleStdinCommand(cmd: string): void {
+    switch (cmd) {
+      case 'PAUSE':
+        this.paused = true;
+        this.logger.paused(this.currentStep);
+        break;
+      case 'RESUME':
+        this.paused = false;
+        this.logger.resumed(this.currentStep);
+        break;
+      case 'SAVE_CHECKPOINT':
+        this.saveCheckpoint().catch(() => {});
+        break;
+      case 'STOP':
+        this.stopRequested = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Wait for resume if paused
+   */
+  private async waitForResume(): Promise<void> {
+    while (this.paused && !this.stopRequested) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  /**
+   * Create a trainer by loading a model from disk
+   *
+   * @param config - Configuration including modelPath
+   * @returns Promise<SFTTrainer>
+   */
+  static async create(config: Partial<SFTTrainerConfig>): Promise<SFTTrainer> {
+    if (!config.model_name) {
+      throw new Error('model_name is required when using SFTTrainer.create()');
+    }
+
+    // Create logger early
+    const logger = createTrainingLogger({
+      logConsole: !config.tui_mode,
+      logJsonl: config.log_jsonl ?? true,
+      outputDir: config.output_dir,
+      runName: config.run_name,
+      logInterval: config.logging_steps ?? 10,
+    });
+
+    let modelPath = config.model_name;
+    let resumedState: SFTTrainingState | null = null;
+
+    // Handle checkpoint resumption
+    if (config.resume_from_checkpoint) {
+      const checkpointPath =
+        config.resume_from_checkpoint === 'latest'
+          ? SFTTrainer.findLatestCheckpoint(config.output_dir)
+          : config.resume_from_checkpoint;
+
+      if (checkpointPath) {
+        const statePath = join(checkpointPath, 'training_state.json');
+        if (existsSync(statePath)) {
+          resumedState = JSON.parse(readFileSync(statePath, 'utf-8'));
+          logger.info(
+            `Resuming from checkpoint: ${checkpointPath} (step ${resumedState?.step}, epoch ${resumedState?.epoch})`,
+          );
+        }
+        modelPath = checkpointPath;
+      } else if (config.resume_from_checkpoint === 'latest') {
+        logger.info('No checkpoint found, starting fresh training');
+      }
+    }
+
+    // Get model name for display
+    const modelName = parse(modelPath).base || 'Unknown';
+    logger.status('loading', `Loading ${modelName}...`);
+
+    // Load model and tokenizer
+    const model = await Qwen3Model.loadPretrained(modelPath);
+    const tokenizer = await Qwen3Tokenizer.fromPretrained(join(modelPath, 'tokenizer.json'));
+
+    logger.status('loading', `${modelName} loaded`);
+
+    // Create trainer
+    const trainer = new SFTTrainer(model, tokenizer, config, logger);
+    trainer.originalModelPath = config.model_name;
+
+    // Restore training state if resuming
+    if (resumedState) {
+      trainer.currentStep = resumedState.step;
+      trainer.currentEpoch = resumedState.epoch;
+      // Also restore engine state to sync step/epoch accounting
+      trainer.engine.restoreState(resumedState.step, resumedState.epoch);
+    }
+
+    return trainer;
+  }
+
+  /**
+   * Find the latest checkpoint in the output directory
+   */
+  static findLatestCheckpoint(outputDir?: string): string | null {
+    if (!outputDir || !existsSync(outputDir)) {
+      return null;
+    }
+
+    const entries = readdirSync(outputDir, { withFileTypes: true });
+    const checkpoints = entries
+      .filter((e) => e.isDirectory() && e.name.startsWith('checkpoint-'))
+      .map((e) => ({
+        name: e.name,
+        step: parseInt(e.name.replace('checkpoint-', ''), 10),
+        path: join(outputDir, e.name),
+      }))
+      .filter((c) => !isNaN(c.step))
+      .sort((a, b) => b.step - a.step);
+
+    return checkpoints.length > 0 ? checkpoints[0].path : null;
+  }
+
+  /**
+   * Run a single training step
+   *
+   * @param batch - Tokenized batch with input_ids and labels
+   * @returns Training step metrics
+   */
+  async trainStep(batch: SFTBatch): Promise<SFTTrainStepResult> {
+    // Convert Int32Array to MxArray
+    const inputIds = MxArray.fromInt32(batch.inputIds, BigInt64Array.from(batch.shape.map(BigInt)));
+    const labels = MxArray.fromInt32(batch.labels, BigInt64Array.from(batch.shape.map(BigInt)));
+
+    // Call native engine
+    const metrics = await this.engine.trainStep(inputIds, labels);
+
+    // Sync step with engine when gradients are applied (fixes gradient accumulation accounting)
+    // Note: metrics.step is i64 from Rust; JS number may lose precision beyond 2^53-1,
+    // but such step counts are unrealistic for any practical training run.
+    if (metrics.gradientsApplied) {
+      this.currentStep = Number(metrics.step);
+    }
+
+    return {
+      metrics,
+      epoch: this.currentEpoch,
+    };
+  }
+
+  /**
+   * Run a full training loop over a dataset
+   *
+   * @param dataset - SFT dataset or path to JSONL file
+   */
+  async train(dataset: SFTDataset | string): Promise<void> {
+    // Load dataset if path provided
+    let sftDataset: SFTDataset;
+    if (typeof dataset === 'string') {
+      sftDataset = await loadSFTDataset(dataset, this.tokenizer, {
+        maxSeqLength: this.config.max_seq_length,
+        completionOnly: this.config.completion_only,
+        seed: this.config.seed,
+        limit: this.config.max_train_samples > 0 ? this.config.max_train_samples : undefined,
+      });
+    } else {
+      sftDataset = dataset;
+    }
+
+    if (sftDataset.length === 0) {
+      return;
+    }
+
+    const numEpochs = this.config.num_epochs;
+    const batchSize = this.config.batch_size;
+    const saveInterval = this.config.save_steps;
+
+    // Create output directory
+    if (this.config.output_dir && !existsSync(this.config.output_dir)) {
+      mkdirSync(this.config.output_dir, { recursive: true });
+    }
+
+    // Calculate steps per epoch (in batches)
+    const stepsPerEpoch = sftDataset.numBatches(batchSize);
+
+    // Compute resume position (all logic centralized in Rust)
+    const resumePos = this.engine.computeResumePosition(stepsPerEpoch);
+    const effectiveStartEpoch = resumePos.startEpoch;
+    const effectiveStartBatchIdx = resumePos.startBatchIdx;
+
+    // Get model name
+    const modelName =
+      (this.originalModelPath ? parse(this.originalModelPath).base : null) ??
+      (this.config.model_name ? parse(this.config.model_name).base : null) ??
+      'Unknown';
+
+    // Log training start
+    this.logger.init(
+      modelName,
+      {
+        numEpochs,
+        batchSize,
+        groupSize: 1, // SFT doesn't use groups, but logger requires this field
+        learningRate: this.config.learning_rate,
+      },
+      sftDataset.length,
+    );
+
+    if (this.currentStep > 0) {
+      if (resumePos.isEpochBoundary) {
+        this.logger.info(`Resuming at epoch boundary, advancing to epoch ${effectiveStartEpoch + 1}`);
+      } else {
+        this.logger.info(
+          `Resuming from step ${this.currentStep} (epoch ${effectiveStartEpoch + 1}, batch ${effectiveStartBatchIdx + 1}/${stepsPerEpoch})`,
+        );
+      }
+    }
+
+    for (let epoch = effectiveStartEpoch; epoch < numEpochs; epoch++) {
+      if (this.stopRequested) break;
+
+      this.currentEpoch = epoch;
+      this.engine.startEpoch(epoch);
+      const epochStartTime = Date.now();
+
+      // Use epoch-based shuffle (deterministic, reproducible via seed + epoch)
+      sftDataset.shuffleForEpoch(epoch);
+
+      // Log epoch start
+      this.logger.epochStart(epoch, numEpochs, stepsPerEpoch);
+
+      // Determine batch start position for this epoch
+      const batchStart = epoch === effectiveStartEpoch ? effectiveStartBatchIdx : 0;
+
+      // Iterate through batches
+      let batchIdx = 0;
+      for await (const batch of sftDataset.batches(batchSize)) {
+        if (this.stopRequested) break;
+
+        // Skip batches if resuming mid-epoch
+        if (batchIdx < batchStart) {
+          batchIdx++;
+          continue;
+        }
+
+        // Wait if paused
+        if (this.paused) {
+          await this.waitForResume();
+          if (this.stopRequested) break;
+        }
+
+        // Run training step
+        const { metrics } = await this.trainStep(batch);
+
+        // Log step metrics (only when gradients are applied to avoid duplicate logs during accumulation)
+        if (metrics.gradientsApplied) {
+          this.logger.step(
+            {
+              step: this.currentStep,
+              loss: metrics.loss,
+              totalTokens: metrics.totalTokens,
+              meanReward: 0, // SFT doesn't use rewards
+              stdReward: 0,
+              meanAdvantage: 0,
+              trainingTimeMs: metrics.trainingTimeMs,
+            },
+            batchIdx,
+            stepsPerEpoch,
+          );
+
+          // Save checkpoint periodically
+          if (this.config.output_dir && this.currentStep > 0 && this.currentStep % saveInterval === 0) {
+            const path = await this.saveCheckpoint();
+            if (path) {
+              this.logger.checkpoint(path, this.currentStep);
+            }
+          }
+        }
+
+        // Check for emergency checkpoint
+        if (this.config.output_dir && this.engine.needsEmergencySave()) {
+          this.logger.warn(`[EMERGENCY] Saving emergency checkpoint at step ${this.currentStep} due to NaN gradients`);
+          await this.saveCheckpoint(`emergency-checkpoint-${this.currentStep}`);
+          this.engine.clearEmergencySave();
+        }
+
+        batchIdx++;
+      }
+
+      // Flush any remaining accumulated gradients (TRL parity)
+      const flushed = this.engine.flushGradients();
+      if (flushed) {
+        this.currentStep = this.engine.getStep();
+
+        // Check if flush step aligns with save interval
+        if (this.config.output_dir && this.currentStep > 0 && this.currentStep % saveInterval === 0) {
+          const path = await this.saveCheckpoint();
+          if (path) {
+            this.logger.checkpoint(path, this.currentStep);
+          }
+        }
+      }
+
+      const epochEndTime = Date.now();
+      const epochTimeSecs = (epochEndTime - epochStartTime) / 1000;
+      this.engine.endEpoch(epochTimeSecs);
+
+      this.logger.epochEnd(epoch, numEpochs, epochTimeSecs);
+    }
+
+    // Save final checkpoint
+    if (this.config.output_dir && !this.stopRequested) {
+      const path = await this.saveCheckpoint('final');
+      if (path) {
+        this.logger.checkpoint(path, this.currentStep);
+      }
+    }
+
+    // Log completion
+    this.logger.complete(this.currentStep);
+
+    // Cleanup
+    if (this.stdinInterface) {
+      this.stdinInterface.close();
+    }
+  }
+
+  /**
+   * Save a checkpoint with model weights and training state
+   *
+   * @param name - Checkpoint name (default: "checkpoint-{step}")
+   * @returns Path to saved checkpoint
+   */
+  async saveCheckpoint(name?: string): Promise<string> {
+    const checkpointName = name ?? `checkpoint-${this.currentStep}`;
+    const outputDir = this.config.output_dir ?? './outputs';
+    const checkpointPath = join(outputDir, checkpointName);
+
+    // Create checkpoint directory
+    if (!existsSync(checkpointPath)) {
+      mkdirSync(checkpointPath, { recursive: true });
+    }
+
+    // Save training state
+    const state: SFTTrainingState = {
+      step: this.currentStep,
+      epoch: this.currentEpoch,
+      timestamp: new Date().toISOString(),
+      trainerType: 'sft',
+    };
+    const statePath = join(checkpointPath, 'training_state.json');
+    writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+    // Save model weights (use trained model from engine, not original)
+    const trainedModel = this.engine.getModel();
+    await trainedModel.saveModel(checkpointPath);
+
+    // Copy tokenizer files
+    const tokenizerSource = this.originalModelPath ?? this.config.model_name;
+    if (tokenizerSource) {
+      const tokenizerFiles = ['tokenizer.json', 'tokenizer_config.json', 'vocab.json', 'merges.txt'];
+      for (const file of tokenizerFiles) {
+        const srcPath = join(tokenizerSource, file);
+        const destPath = join(checkpointPath, file);
+        if (existsSync(srcPath) && !existsSync(destPath)) {
+          copyFileSync(srcPath, destPath);
+        }
+      }
+    }
+
+    this.logger.info(`Checkpoint saved: ${checkpointPath}`);
+
+    // Clean up old checkpoints
+    const maxCheckpoints = this.config.max_checkpoints;
+    if (maxCheckpoints > 0) {
+      this.cleanupOldCheckpoints(outputDir, maxCheckpoints);
+    }
+
+    return checkpointPath;
+  }
+
+  /**
+   * Remove old checkpoints, keeping only the most recent ones
+   */
+  private cleanupOldCheckpoints(outputDir: string, maxToKeep: number): void {
+    try {
+      const entries = readdirSync(outputDir, { withFileTypes: true });
+
+      const checkpoints: { name: string; step: number }[] = [];
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name === 'final' || entry.name.startsWith('emergency-')) continue;
+
+        const match = entry.name.match(/^checkpoint-(\d+)$/);
+        if (match) {
+          checkpoints.push({
+            name: entry.name,
+            step: parseInt(match[1], 10),
+          });
+        }
+      }
+
+      checkpoints.sort((a, b) => b.step - a.step);
+
+      if (checkpoints.length > maxToKeep) {
+        const toRemove = checkpoints.slice(maxToKeep);
+        for (const checkpoint of toRemove) {
+          const checkpointPath = join(outputDir, checkpoint.name);
+          rmSync(checkpointPath, { recursive: true, force: true });
+          this.logger.debug(`Removed old checkpoint: ${checkpoint.name}`);
+        }
+      }
+    } catch (error) {
+      this.logger.warn(`Failed to cleanup old checkpoints: ${error}`);
+    }
+  }
+
+  /**
+   * Get current training step
+   */
+  get step(): number {
+    return this.engine.getStep();
+  }
+
+  /**
+   * Get current epoch
+   */
+  get epoch(): number {
+    return this.engine.getEpoch();
+  }
+
+  /**
+   * Get the underlying model for inference
+   */
+  getModel(): Qwen3Model {
+    return this.engine.getModel();
+  }
+
+  /**
+   * Get the tokenizer
+   */
+  getTokenizer(): Qwen3Tokenizer {
+    return this.tokenizer;
+  }
+}


### PR DESCRIPTION
- Add SFTConfig for training configuration
- Add SFTDataset for chat-format dataset handling
- Add SFTTrainer with training loop, checkpointing, logging
- Extend cross-entropy loss with label smoothing and ignore_index
- Add Qwen3 model sft_forward for training forward pass
- Export SFT components from @mlx-node/trl
- Add comprehensive tests for config and dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce end-to-end SFT training stack (Rust engine + TS trainer/dataset/config), fix cross-entropy ignore_index normalization and dtype-safe updates, adjust Qwen3 params export behavior, and add tests/examples.
> 
> - **Core (Rust)**:
>   - **SFT Module**: Add `sft/{loss,autograd,engine}.rs` implementing cross-entropy SFT training with autograd, gradient accumulation/clipping, metrics, resume logic, and emergency checkpoint signaling.
>   - **Losses**: Update `Losses::cross_entropy` to mask ignored labels and normalize by valid-token count; guard divide-by-zero (all-ignored => 0); keep label smoothing; resource cleanup.
>   - **Qwen3 Model**: `apply_gradients` now preserves param dtype by casting LR; only expose `lm_head.weight` when `tie_word_embeddings` is false.
> - **JS/TS Packages**:
>   - **TRL**: Add `SFTTrainer` (Rust-native loop wrapper), `SFTDataset` (prompt-completion & conversation formats with masking/truncation/shuffle), and `SFT` config utilities (defaults, TOML loader, CLI overrides). Export new SFT APIs from `@mlx-node/trl`.
>   - **Core bindings/typings**: Export `SftTrainingEngine` and related types (`SftEngineConfig`, step/epoch metrics, `ResumePosition`).
>   - **Tests**: New tests for extended losses, SFT config, and SFT dataset; update Qwen3 parameter access expectations.
> - **Examples**:
>   - Improve language detection and completion wiring in GRPO examples; point tool-use training to SFT output model path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce3dd3ab069bcf53a021f0f8699f2aeb0744d8a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->