### PR TITLE
feat(paged-attn): complete P0 integration with FP8 scales and MxArray…

### DIFF
--- a/crates/mlx-core/src/transformer/paged_attention.rs
+++ b/crates/mlx-core/src/transformer/paged_attention.rs
@@ -9,12 +9,21 @@
 //! - `reshape_and_cache` - Updates KV cache with new tokens
 //! - `paged_attention` - Computes attention using paged KV cache
 //!
-//! Currently, operations use the C++ software fallback in `mlx-sys`.
-//! Full Metal kernel dispatch requires extracting MTLBuffer from MLX arrays,
-//! which is not yet supported by the MLX public API.
+//! Operations use the C++ implementation in `mlx-sys`. For direct Metal
+//! kernel dispatch, use `PagedKVCache` from `mlx-paged-attn` directly:
 //!
-//! The Metal dispatch infrastructure is ready in `mlx_paged_attn::metal` and
-//! can be enabled once buffer extraction is available.
+//! ```ignore
+//! use mlx_paged_attn::{PagedKVCache, PagedAttentionConfig};
+//!
+//! let mut cache = PagedKVCache::new(config)?;
+//! cache.initialize()?;  // Allocate Metal buffers
+//!
+//! // Direct Metal kernel dispatch
+//! unsafe {
+//!     cache.update(layer_idx, keys_ptr, values_ptr, slot_mapping_ptr)?;
+//!     let output = cache.attention(layer_idx, queries_ptr, &seq_ids, num_heads, scale)?;
+//! }
+//! ```
 
 use crate::array::MxArray;
 use mlx_sys as sys;

--- a/crates/mlx-paged-attn/src/attention_layer.rs
+++ b/crates/mlx-paged-attn/src/attention_layer.rs
@@ -1,0 +1,547 @@
+//! PagedAttentionLayer - High-level attention layer with paged KV cache
+//!
+//! This module provides `PagedAttentionLayer`, a drop-in replacement for standard
+//! attention layers that uses paged KV cache for memory-efficient inference.
+
+use crate::config::PagedAttentionConfig;
+use crate::input_metadata::PagedAttentionInputMetadata;
+use crate::paged_kv_cache::PagedKVCache;
+
+#[cfg(target_os = "macos")]
+use crate::metal::{
+    MetalDtype, MetalState, MlxMetalBuffer, PagedAttentionParams, RawBufferInfo,
+    ReshapeAndCacheParams, dispatch_paged_attention_auto, dispatch_reshape_and_cache_raw,
+};
+
+#[cfg(target_os = "macos")]
+use metal::MTLResourceOptions;
+
+/// PagedAttentionLayer - Attention layer with paged KV cache
+///
+/// This layer handles:
+/// 1. Updating the KV cache with new key/value pairs (reshape_and_cache)
+/// 2. Computing attention using the paged cache (paged_attention)
+/// 3. Automatic prefill vs decode handling
+///
+/// # Example
+///
+/// ```typescript
+/// // Create layer
+/// const layer = new PagedAttentionLayer({
+///   layerIdx: 0,
+///   numHeads: 32,
+///   numKvHeads: 8,
+///   headSize: 128,
+///   scale: 1.0 / Math.sqrt(128),
+/// });
+///
+/// // Forward pass
+/// const output = layer.forward(queries, keys, values, inputMetadata);
+/// ```
+pub struct PagedAttentionLayer {
+    /// Layer index in the transformer stack
+    layer_idx: u32,
+
+    /// Number of query heads
+    num_heads: u32,
+
+    /// Number of KV heads (for GQA, may be < num_heads)
+    num_kv_heads: u32,
+
+    /// Head dimension
+    head_size: u32,
+
+    /// Attention scale factor (typically 1/sqrt(head_size))
+    scale: f32,
+
+    /// Block size for paged attention
+    block_size: u32,
+
+    /// Softcapping value (1.0 = no softcapping)
+    softcap: f32,
+
+    /// ALiBi slopes (optional, for ALiBi attention)
+    /// TODO: Implement ALiBi support in paged_attention kernel
+    #[allow(dead_code)]
+    #[cfg(target_os = "macos")]
+    alibi_slopes: Option<Vec<f32>>,
+
+    /// K scale for FP8 quantization (1.0 for non-FP8)
+    k_scale: f32,
+
+    /// V scale for FP8 quantization (1.0 for non-FP8)
+    v_scale: f32,
+
+    /// Whether to use FP8 cache
+    use_fp8: bool,
+}
+
+/// Parameters for creating a PagedAttentionLayer
+#[derive(Clone, Debug)]
+pub struct PagedAttentionLayerParams {
+    /// Layer index in the transformer stack
+    pub layer_idx: u32,
+
+    /// Number of query heads
+    pub num_heads: u32,
+
+    /// Number of KV heads
+    pub num_kv_heads: u32,
+
+    /// Head dimension
+    pub head_size: u32,
+
+    /// Attention scale (default: 1/sqrt(head_size))
+    pub scale: Option<f32>,
+
+    /// Block size for paging (default: 16)
+    pub block_size: u32,
+
+    /// Softcapping value (default: 1.0 = no softcapping)
+    pub softcap: Option<f32>,
+
+    /// ALiBi slopes (optional)
+    pub alibi_slopes: Option<Vec<f32>>,
+
+    /// Whether to use FP8 cache (default: false)
+    pub use_fp8: bool,
+
+    /// K scale for FP8 quantization (default: 1.0)
+    pub k_scale: Option<f32>,
+
+    /// V scale for FP8 quantization (default: 1.0)
+    pub v_scale: Option<f32>,
+}
+
+impl PagedAttentionLayer {
+    /// Create a new PagedAttentionLayer
+    pub fn new(params: PagedAttentionLayerParams) -> Self {
+        let scale = params
+            .scale
+            .unwrap_or(1.0 / (params.head_size as f32).sqrt());
+        let softcap = params.softcap.unwrap_or(1.0);
+        let k_scale = params.k_scale.unwrap_or(1.0);
+        let v_scale = params.v_scale.unwrap_or(1.0);
+
+        Self {
+            layer_idx: params.layer_idx,
+            num_heads: params.num_heads,
+            num_kv_heads: params.num_kv_heads,
+            head_size: params.head_size,
+            scale,
+            block_size: params.block_size,
+            softcap,
+            #[cfg(target_os = "macos")]
+            alibi_slopes: params.alibi_slopes,
+            k_scale,
+            v_scale,
+            use_fp8: params.use_fp8,
+        }
+    }
+
+    /// Create from PagedKVCache config
+    pub fn from_cache_config(
+        layer_idx: u32,
+        num_heads: u32,
+        config: &PagedAttentionConfig,
+    ) -> Self {
+        Self::new(PagedAttentionLayerParams {
+            layer_idx,
+            num_heads,
+            num_kv_heads: config.num_kv_heads,
+            head_size: config.head_size,
+            scale: None,
+            block_size: config.block_size,
+            softcap: None,
+            alibi_slopes: None,
+            use_fp8: config.use_fp8(),
+            k_scale: None, // TODO: Get from config when calibrated
+            v_scale: None,
+        })
+    }
+
+    /// Get the layer index
+    pub fn layer_idx(&self) -> u32 {
+        self.layer_idx
+    }
+
+    /// Get the number of query heads
+    pub fn num_heads(&self) -> u32 {
+        self.num_heads
+    }
+
+    /// Get the number of KV heads
+    pub fn num_kv_heads(&self) -> u32 {
+        self.num_kv_heads
+    }
+
+    /// Get the head size
+    pub fn head_size(&self) -> u32 {
+        self.head_size
+    }
+
+    /// Get the attention scale
+    pub fn scale(&self) -> f32 {
+        self.scale
+    }
+
+    /// Set K/V scales for FP8 quantization
+    pub fn set_kv_scales(&mut self, k_scale: f32, v_scale: f32) {
+        self.k_scale = k_scale;
+        self.v_scale = v_scale;
+    }
+
+    /// Forward pass with paged attention
+    ///
+    /// This method:
+    /// 1. Updates the KV cache with new keys/values using reshape_and_cache
+    /// 2. For prefill: returns early (caller should use standard attention)
+    /// 3. For decode: computes attention using the paged_attention kernel
+    ///
+    /// # Arguments
+    /// * `cache` - The PagedKVCache instance
+    /// * `queries` - Query tensor [num_tokens, num_heads, head_size]
+    /// * `keys` - Key tensor [num_tokens, num_kv_heads, head_size]
+    /// * `values` - Value tensor [num_tokens, num_kv_heads, head_size]
+    /// * `metadata` - Input metadata (block tables, context lens, etc.)
+    ///
+    /// # Returns
+    /// * `Ok(Some(output))` - Attention output for decode phase
+    /// * `Ok(None)` - For prefill, caller should use standard attention
+    /// * `Err(...)` - On error
+    ///
+    /// # Safety
+    /// * queries, keys, values must be valid MLX array pointers
+    /// * cache must be initialized
+    #[cfg(target_os = "macos")]
+    pub unsafe fn forward(
+        &self,
+        cache: &PagedKVCache,
+        queries: *mut mlx_sys::mlx_array,
+        keys: *mut mlx_sys::mlx_array,
+        values: *mut mlx_sys::mlx_array,
+        metadata: &mut PagedAttentionInputMetadata,
+    ) -> Result<Option<crate::metal::PagedAttentionOutput>, String> {
+        use crate::metal::synchronize_mlx;
+
+        // Synchronize MLX before accessing arrays
+        synchronize_mlx();
+
+        // Get the cache engine for this layer
+        let engine = cache
+            .engine_manager()
+            .get_engine(self.layer_idx)
+            .ok_or_else(|| format!("Layer {} not found", self.layer_idx))?;
+
+        if !engine.is_initialized() {
+            return Err(format!(
+                "Layer {} cache not initialized. Call cache.initialize() first.",
+                self.layer_idx
+            ));
+        }
+
+        let key_cache = engine
+            .key_cache()
+            .ok_or_else(|| "Key cache buffer not initialized".to_string())?;
+        let value_cache = engine
+            .value_cache()
+            .ok_or_else(|| "Value cache buffer not initialized".to_string())?;
+
+        // Extract Metal buffer info from MLX arrays
+        let key_info = unsafe { MlxMetalBuffer::from_mlx_array(keys) }
+            .ok_or_else(|| "Failed to extract Metal buffer from keys".to_string())?;
+        let value_info = unsafe { MlxMetalBuffer::from_mlx_array(values) }
+            .ok_or_else(|| "Failed to extract Metal buffer from values".to_string())?;
+
+        // Create slot mapping buffer from metadata
+        let state = MetalState::get()?;
+        let slot_buffer = state.device.new_buffer_with_data(
+            metadata.slot_mappings.as_ptr() as *const _,
+            (metadata.slot_mappings.len() * std::mem::size_of::<i64>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        let num_tokens = metadata.num_tokens() as u32;
+
+        // Step 1: Update KV cache with reshape_and_cache
+        // x = 16 / sizeof(dtype): 8 for FP16, 16 for FP8
+        let x = if self.use_fp8 { 16i32 } else { 8i32 };
+        let stride = (self.num_kv_heads * self.head_size) as i32;
+
+        let reshape_params = ReshapeAndCacheParams {
+            num_tokens,
+            num_heads: self.num_kv_heads,
+            head_size: self.head_size,
+            block_size: self.block_size,
+            key_stride: stride,
+            value_stride: stride,
+            x,
+            k_scale: self.k_scale,
+            v_scale: self.v_scale,
+        };
+
+        let key_raw = RawBufferInfo {
+            ptr: key_info.buffer_ptr,
+            offset: key_info.offset,
+        };
+        let value_raw = RawBufferInfo {
+            ptr: value_info.buffer_ptr,
+            offset: value_info.offset,
+        };
+
+        use metal::foreign_types::ForeignType;
+        let slot_raw = RawBufferInfo {
+            ptr: slot_buffer.as_ptr() as *mut _,
+            offset: 0,
+        };
+
+        // Determine dtype based on FP8 config
+        let dtype = if self.use_fp8 {
+            MetalDtype::UChar
+        } else {
+            MetalDtype::Float16
+        };
+
+        // Dispatch reshape_and_cache
+        unsafe {
+            dispatch_reshape_and_cache_raw(
+                &key_raw,
+                &value_raw,
+                key_cache,
+                value_cache,
+                &slot_raw,
+                &reshape_params,
+                dtype,
+            )?;
+        }
+
+        // Step 2: For prefill, return None (caller uses standard attention)
+        if metadata.is_prefill() {
+            return Ok(None);
+        }
+
+        // Step 3: For decode, compute paged attention
+        let query_info = unsafe { MlxMetalBuffer::from_mlx_array(queries) }
+            .ok_or_else(|| "Failed to extract Metal buffer from queries".to_string())?;
+
+        // Extract values from metadata before mutable borrow
+        let num_seqs = metadata.num_seqs();
+        let max_context_len = metadata.max_context_len;
+        let max_blocks_per_seq = metadata.max_blocks_per_seq;
+
+        // Get Metal buffers from metadata (mutable borrow for lazy buffer creation)
+        let (block_tables_buffer, context_lens_buffer, _) = metadata.get_metal_buffers()?;
+
+        // Calculate strides
+        let q_stride = (self.num_heads * self.head_size) as i32;
+        let kv_block_stride = (self.num_kv_heads * self.head_size * self.block_size) as i32;
+        let kv_head_stride = (self.head_size * self.block_size) as i32;
+
+        let attn_params = PagedAttentionParams {
+            num_seqs,
+            num_heads: self.num_heads,
+            num_kv_heads: self.num_kv_heads,
+            head_size: self.head_size,
+            block_size: self.block_size,
+            max_seq_len: max_context_len,
+            max_num_blocks_per_seq: max_blocks_per_seq,
+            scale: self.scale,
+            softcapping: self.softcap,
+            q_stride,
+            kv_block_stride,
+            kv_head_stride,
+            k_scale: self.k_scale,
+            v_scale: self.v_scale,
+        };
+
+        let query_raw = RawBufferInfo {
+            ptr: query_info.buffer_ptr,
+            offset: query_info.offset,
+        };
+
+        // Determine dtype based on FP8 config
+        let dtype = if self.use_fp8 {
+            MetalDtype::UChar
+        } else {
+            MetalDtype::Float16
+        };
+
+        // Dispatch paged attention
+        let output = unsafe {
+            dispatch_paged_attention_auto(
+                &query_raw,
+                key_cache,
+                value_cache,
+                block_tables_buffer,
+                context_lens_buffer,
+                max_context_len,
+                &attn_params,
+                dtype,
+            )?
+        };
+
+        Ok(Some(output))
+    }
+
+    /// Forward pass for decode-only (simplified API)
+    ///
+    /// Use this when you know you're in decode phase and want paged attention output.
+    /// Unlike `forward()`, this always returns an output (errors if in prefill phase).
+    ///
+    /// # Safety
+    /// - `queries`, `keys`, and `values` must be valid MLX array pointers
+    /// - Arrays must remain valid until this function returns
+    /// - Cache must be initialized before calling
+    #[cfg(target_os = "macos")]
+    pub unsafe fn forward_decode(
+        &self,
+        cache: &PagedKVCache,
+        queries: *mut mlx_sys::mlx_array,
+        keys: *mut mlx_sys::mlx_array,
+        values: *mut mlx_sys::mlx_array,
+        metadata: &mut PagedAttentionInputMetadata,
+    ) -> Result<crate::metal::PagedAttentionOutput, String> {
+        if metadata.is_prefill() {
+            return Err(
+                "forward_decode called during prefill phase. Use forward() instead.".to_string(),
+            );
+        }
+
+        // SAFETY: Caller guarantees all array pointers are valid
+        unsafe { self.forward(cache, queries, keys, values, metadata) }?
+            .ok_or_else(|| "Expected output for decode phase".to_string())
+    }
+}
+
+/// Collection of PagedAttentionLayers for all transformer layers
+pub struct PagedAttentionLayers {
+    layers: Vec<PagedAttentionLayer>,
+}
+
+impl PagedAttentionLayers {
+    /// Create layers for all transformer layers
+    pub fn new(
+        num_layers: u32,
+        num_heads: u32,
+        num_kv_heads: u32,
+        head_size: u32,
+        block_size: u32,
+        use_fp8: bool,
+    ) -> Self {
+        let layers = (0..num_layers)
+            .map(|layer_idx| {
+                PagedAttentionLayer::new(PagedAttentionLayerParams {
+                    layer_idx,
+                    num_heads,
+                    num_kv_heads,
+                    head_size,
+                    scale: None,
+                    block_size,
+                    softcap: None,
+                    alibi_slopes: None,
+                    use_fp8,
+                    k_scale: None,
+                    v_scale: None,
+                })
+            })
+            .collect();
+
+        Self { layers }
+    }
+
+    /// Create from PagedKVCache config
+    pub fn from_cache_config(num_heads: u32, config: &PagedAttentionConfig) -> Self {
+        Self::new(
+            config.num_layers,
+            num_heads,
+            config.num_kv_heads,
+            config.head_size,
+            config.block_size,
+            config.use_fp8(),
+        )
+    }
+
+    /// Get a specific layer
+    pub fn get(&self, layer_idx: u32) -> Option<&PagedAttentionLayer> {
+        self.layers.get(layer_idx as usize)
+    }
+
+    /// Get number of layers
+    pub fn num_layers(&self) -> u32 {
+        self.layers.len() as u32
+    }
+
+    /// Iterate over layers
+    pub fn iter(&self) -> impl Iterator<Item = &PagedAttentionLayer> {
+        self.layers.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layer_creation() {
+        let layer = PagedAttentionLayer::new(PagedAttentionLayerParams {
+            layer_idx: 0,
+            num_heads: 32,
+            num_kv_heads: 8,
+            head_size: 128,
+            scale: None,
+            block_size: 16,
+            softcap: None,
+            alibi_slopes: None,
+            use_fp8: false,
+            k_scale: None,
+            v_scale: None,
+        });
+
+        assert_eq!(layer.layer_idx(), 0);
+        assert_eq!(layer.num_heads(), 32);
+        assert_eq!(layer.num_kv_heads(), 8);
+        assert_eq!(layer.head_size(), 128);
+        // Scale should be 1/sqrt(128) ≈ 0.0884
+        assert!((layer.scale() - 0.0884).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_layers_collection() {
+        let layers = PagedAttentionLayers::new(
+            28,    // num_layers
+            32,    // num_heads
+            8,     // num_kv_heads
+            128,   // head_size
+            16,    // block_size
+            false, // use_fp8
+        );
+
+        assert_eq!(layers.num_layers(), 28);
+        assert!(layers.get(0).is_some());
+        assert!(layers.get(27).is_some());
+        assert!(layers.get(28).is_none());
+
+        // Check each layer has correct index
+        for (i, layer) in layers.iter().enumerate() {
+            assert_eq!(layer.layer_idx(), i as u32);
+        }
+    }
+
+    #[test]
+    fn test_from_cache_config() {
+        let config = PagedAttentionConfig {
+            block_size: 32,
+            gpu_memory_mb: 4096,
+            head_size: 128,
+            num_kv_heads: 4,
+            num_layers: 28,
+            ..Default::default()
+        };
+
+        let layer = PagedAttentionLayer::from_cache_config(5, 32, &config);
+        assert_eq!(layer.layer_idx(), 5);
+        assert_eq!(layer.num_heads(), 32);
+        assert_eq!(layer.num_kv_heads(), 4);
+        assert_eq!(layer.head_size(), 128);
+    }
+}

--- a/crates/mlx-paged-attn/src/block_table.rs
+++ b/crates/mlx-paged-attn/src/block_table.rs
@@ -39,6 +39,13 @@ impl SequenceBlockTable {
         self.blocks.push(block);
     }
 
+    /// Replace a block at the given index (for copy-on-write)
+    pub fn replace_block(&mut self, index: usize, block: Arc<PhysicalBlock>) {
+        if index < self.blocks.len() {
+            self.blocks[index] = block;
+        }
+    }
+
     /// Get the number of blocks
     pub fn num_blocks(&self) -> usize {
         self.blocks.len()

--- a/crates/mlx-paged-attn/src/input_metadata.rs
+++ b/crates/mlx-paged-attn/src/input_metadata.rs
@@ -1,0 +1,322 @@
+//! Input metadata for paged attention operations
+//!
+//! This module provides the `PagedAttentionInputMetadata` struct which encapsulates
+//! all the information needed to perform paged attention: block tables, context lengths,
+//! slot mappings, and phase information (prefill vs decode).
+
+#[cfg(target_os = "macos")]
+use metal::Buffer;
+
+/// Input metadata for paged attention operations
+///
+/// Contains all the information needed by the paged attention kernel to locate
+/// KV cache blocks and compute attention correctly.
+///
+/// # Usage
+///
+/// ```typescript
+/// // Build metadata for a batch of sequences
+/// const metadata = pagedKVCache.buildInputMetadata(
+///   seqIds,
+///   inputLens,
+///   isPrefill
+/// );
+///
+/// // Use for attention
+/// const output = pagedAttnLayer.forward(queries, keys, values, metadata);
+/// ```
+#[derive(Clone, Debug)]
+pub struct PagedAttentionInputMetadata {
+    /// Block tables for each sequence: [num_seqs, max_blocks_per_seq]
+    /// Maps sequence positions to physical cache block IDs.
+    pub block_tables: Vec<i32>,
+
+    /// Context length for each sequence (total tokens in KV cache)
+    pub context_lens: Vec<i32>,
+
+    /// Slot mapping: maps each input token to its cache slot
+    /// Shape: [total_num_tokens]
+    pub slot_mappings: Vec<i64>,
+
+    /// Maximum context length across all sequences in the batch
+    pub max_context_len: u32,
+
+    /// Whether this is the first chunk of a prompt (prefill phase)
+    /// During prefill, we use standard attention; during decode, we use paged attention.
+    pub is_prefill: bool,
+
+    /// Number of sequences in the batch
+    pub num_seqs: u32,
+
+    /// Maximum blocks per sequence (for array indexing)
+    pub max_blocks_per_seq: u32,
+
+    // Metal buffers (cached for kernel dispatch)
+    #[cfg(target_os = "macos")]
+    block_tables_buffer: Option<Buffer>,
+
+    #[cfg(target_os = "macos")]
+    context_lens_buffer: Option<Buffer>,
+
+    #[cfg(target_os = "macos")]
+    slot_mappings_buffer: Option<Buffer>,
+}
+
+impl PagedAttentionInputMetadata {
+    /// Create new input metadata
+    ///
+    /// # Arguments
+    /// * `block_tables` - Flattened block tables [num_seqs * max_blocks_per_seq]
+    /// * `context_lens` - Context length for each sequence
+    /// * `slot_mappings` - Slot indices for input tokens
+    /// * `max_context_len` - Maximum context length
+    /// * `is_prefill` - Whether in prefill phase
+    /// * `max_blocks_per_seq` - Maximum blocks per sequence
+    pub fn new(
+        block_tables: Vec<i32>,
+        context_lens: Vec<i32>,
+        slot_mappings: Vec<i64>,
+        max_context_len: u32,
+        is_prefill: bool,
+        max_blocks_per_seq: u32,
+    ) -> Self {
+        let num_seqs = context_lens.len() as u32;
+        Self {
+            block_tables,
+            context_lens,
+            slot_mappings,
+            max_context_len,
+            is_prefill,
+            num_seqs,
+            max_blocks_per_seq,
+            #[cfg(target_os = "macos")]
+            block_tables_buffer: None,
+            #[cfg(target_os = "macos")]
+            context_lens_buffer: None,
+            #[cfg(target_os = "macos")]
+            slot_mappings_buffer: None,
+        }
+    }
+
+    /// Create a dummy metadata for testing/profiling
+    ///
+    /// This creates minimal metadata that won't be used for actual decoding.
+    pub fn dummy() -> Self {
+        Self {
+            block_tables: vec![0],
+            context_lens: vec![1],
+            slot_mappings: vec![0],
+            max_context_len: 1,
+            is_prefill: true,
+            num_seqs: 1,
+            max_blocks_per_seq: 1,
+            #[cfg(target_os = "macos")]
+            block_tables_buffer: None,
+            #[cfg(target_os = "macos")]
+            context_lens_buffer: None,
+            #[cfg(target_os = "macos")]
+            slot_mappings_buffer: None,
+        }
+    }
+
+    /// Get the number of sequences
+    pub fn num_seqs(&self) -> u32 {
+        self.num_seqs
+    }
+
+    /// Get the total number of input tokens
+    pub fn num_tokens(&self) -> usize {
+        self.slot_mappings.len()
+    }
+
+    /// Check if this is a prefill phase
+    pub fn is_prefill(&self) -> bool {
+        self.is_prefill
+    }
+
+    /// Get block tables as slice
+    pub fn block_tables(&self) -> &[i32] {
+        &self.block_tables
+    }
+
+    /// Get context lengths as slice
+    pub fn context_lens(&self) -> &[i32] {
+        &self.context_lens
+    }
+
+    /// Get slot mappings as slice
+    pub fn slot_mappings(&self) -> &[i64] {
+        &self.slot_mappings
+    }
+
+    /// Ensure Metal buffers are created and return them
+    ///
+    /// This lazily creates Metal buffers from the CPU data.
+    /// The buffers are cached for reuse.
+    #[cfg(target_os = "macos")]
+    pub fn get_metal_buffers(&mut self) -> Result<(&Buffer, &Buffer, &Buffer), String> {
+        use crate::metal::MetalState;
+        use metal::MTLResourceOptions;
+
+        // Create block tables buffer if not exists
+        if self.block_tables_buffer.is_none() {
+            let state = MetalState::get()?;
+            let buffer = state.device.new_buffer_with_data(
+                self.block_tables.as_ptr() as *const _,
+                (self.block_tables.len() * std::mem::size_of::<i32>()) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+            self.block_tables_buffer = Some(buffer);
+        }
+
+        // Create context lens buffer if not exists
+        if self.context_lens_buffer.is_none() {
+            let state = MetalState::get()?;
+            let buffer = state.device.new_buffer_with_data(
+                self.context_lens.as_ptr() as *const _,
+                (self.context_lens.len() * std::mem::size_of::<i32>()) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+            self.context_lens_buffer = Some(buffer);
+        }
+
+        // Create slot mappings buffer if not exists
+        if self.slot_mappings_buffer.is_none() {
+            let state = MetalState::get()?;
+            let buffer = state.device.new_buffer_with_data(
+                self.slot_mappings.as_ptr() as *const _,
+                (self.slot_mappings.len() * std::mem::size_of::<i64>()) as u64,
+                MTLResourceOptions::StorageModeShared,
+            );
+            self.slot_mappings_buffer = Some(buffer);
+        }
+
+        Ok((
+            self.block_tables_buffer.as_ref().unwrap(),
+            self.context_lens_buffer.as_ref().unwrap(),
+            self.slot_mappings_buffer.as_ref().unwrap(),
+        ))
+    }
+
+    /// Invalidate cached Metal buffers
+    ///
+    /// Call this when the underlying data changes.
+    #[cfg(target_os = "macos")]
+    pub fn invalidate_buffers(&mut self) {
+        self.block_tables_buffer = None;
+        self.context_lens_buffer = None;
+        self.slot_mappings_buffer = None;
+    }
+}
+
+/// Builder for PagedAttentionInputMetadata
+///
+/// Provides a fluent API for constructing input metadata.
+#[derive(Default)]
+pub struct PagedAttentionInputMetadataBuilder {
+    block_tables: Vec<i32>,
+    context_lens: Vec<i32>,
+    slot_mappings: Vec<i64>,
+    max_context_len: u32,
+    is_prefill: bool,
+    max_blocks_per_seq: u32,
+}
+
+impl PagedAttentionInputMetadataBuilder {
+    /// Create a new builder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set block tables
+    pub fn block_tables(mut self, tables: Vec<i32>) -> Self {
+        self.block_tables = tables;
+        self
+    }
+
+    /// Set context lengths
+    pub fn context_lens(mut self, lens: Vec<i32>) -> Self {
+        self.context_lens = lens;
+        self
+    }
+
+    /// Set slot mappings
+    pub fn slot_mappings(mut self, mappings: Vec<i64>) -> Self {
+        self.slot_mappings = mappings;
+        self
+    }
+
+    /// Set maximum context length
+    pub fn max_context_len(mut self, len: u32) -> Self {
+        self.max_context_len = len;
+        self
+    }
+
+    /// Set prefill flag
+    pub fn is_prefill(mut self, is_prefill: bool) -> Self {
+        self.is_prefill = is_prefill;
+        self
+    }
+
+    /// Set maximum blocks per sequence
+    pub fn max_blocks_per_seq(mut self, max_blocks: u32) -> Self {
+        self.max_blocks_per_seq = max_blocks;
+        self
+    }
+
+    /// Build the metadata
+    pub fn build(self) -> PagedAttentionInputMetadata {
+        PagedAttentionInputMetadata::new(
+            self.block_tables,
+            self.context_lens,
+            self.slot_mappings,
+            self.max_context_len,
+            self.is_prefill,
+            self.max_blocks_per_seq,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_input_metadata_creation() {
+        let metadata = PagedAttentionInputMetadata::new(
+            vec![0, 1, 2, 3], // block tables
+            vec![32, 64],     // context lens
+            vec![0, 1, 2],    // slot mappings
+            64,               // max context len
+            false,            // is_prefill
+            2,                // max_blocks_per_seq
+        );
+
+        assert_eq!(metadata.num_seqs(), 2);
+        assert_eq!(metadata.num_tokens(), 3);
+        assert!(!metadata.is_prefill());
+        assert_eq!(metadata.max_context_len, 64);
+    }
+
+    #[test]
+    fn test_builder() {
+        let metadata = PagedAttentionInputMetadataBuilder::new()
+            .block_tables(vec![0, 1])
+            .context_lens(vec![16])
+            .slot_mappings(vec![0])
+            .max_context_len(16)
+            .is_prefill(true)
+            .max_blocks_per_seq(2)
+            .build();
+
+        assert_eq!(metadata.num_seqs(), 1);
+        assert!(metadata.is_prefill());
+    }
+
+    #[test]
+    fn test_dummy() {
+        let metadata = PagedAttentionInputMetadata::dummy();
+        assert_eq!(metadata.num_seqs(), 1);
+        assert!(metadata.is_prefill());
+    }
+}

--- a/crates/mlx-paged-attn/src/lib.rs
+++ b/crates/mlx-paged-attn/src/lib.rs
@@ -18,22 +18,28 @@
 //! - [PagedAttention Paper](https://arxiv.org/abs/2309.06180)
 //! - [HuggingFace kernels-community](https://huggingface.co/kernels-community/paged-attention)
 
+mod attention_layer;
 mod block_allocator;
 mod block_table;
 mod cache_engine;
 mod config;
+mod input_metadata;
 mod paged_kv_cache;
 mod scheduler;
+mod token_tracker;
 
 #[cfg(target_os = "macos")]
 pub mod metal;
 
+pub use attention_layer::*;
 pub use block_allocator::*;
 pub use block_table::*;
 pub use cache_engine::*;
 pub use config::*;
+pub use input_metadata::*;
 pub use paged_kv_cache::*;
 pub use scheduler::*;
+pub use token_tracker::*;
 
 /// Path to the compiled Metal library (set at build time)
 /// Only valid on macOS; empty string on other platforms

--- a/crates/mlx-paged-attn/src/metal/copy_blocks.rs
+++ b/crates/mlx-paged-attn/src/metal/copy_blocks.rs
@@ -1,0 +1,224 @@
+//! copy_blocks Metal kernel dispatch
+//!
+//! This kernel copies blocks for copy-on-write semantics (used in beam search).
+
+use super::state::{MetalDtype, MetalState};
+use metal::foreign_types::ForeignTypeRef;
+use metal::{Buffer, BufferRef, MTLSize};
+use std::ffi::c_void;
+
+/// Parameters for copy_blocks kernel
+#[derive(Debug, Clone)]
+pub struct CopyBlocksParams {
+    /// Number of block pairs to copy
+    pub num_pairs: u32,
+    /// Number of elements per block (num_kv_heads * head_size * block_size)
+    pub numel_per_block: u32,
+}
+
+impl CopyBlocksParams {
+    /// Create params from cache config
+    pub fn from_config(num_pairs: u32, num_kv_heads: u32, head_size: u32, block_size: u32) -> Self {
+        Self {
+            num_pairs,
+            numel_per_block: num_kv_heads * head_size * block_size,
+        }
+    }
+}
+
+impl MetalState {
+    /// Get the copy_blocks kernel name for a dtype
+    ///
+    /// # Arguments
+    /// * `dtype` - Data type for cache elements
+    pub fn copy_blocks_kernel_name(dtype: MetalDtype) -> String {
+        let type_str = dtype.type_string();
+        format!("copy_blocks_{}", type_str)
+    }
+}
+
+/// Dispatch the copy_blocks kernel
+///
+/// Copies blocks from source to destination for copy-on-write semantics.
+/// This is used during beam search when a sequence branches.
+///
+/// # Buffer Layout
+/// - buffer(0): key_cache [num_blocks, num_kv_heads, head_size/x, block_size, x]
+/// - buffer(1): value_cache [num_blocks, num_kv_heads, head_size, block_size]
+/// - buffer(2): block_mapping [num_pairs, 2] - int64 pairs of (src_block, dst_block)
+/// - buffer(3): numel_per_block - int32
+///
+/// # Arguments
+/// * `key_cache` - Key cache buffer
+/// * `value_cache` - Value cache buffer
+/// * `block_mapping` - Buffer containing (src, dst) block pairs
+/// * `params` - Copy parameters
+/// * `dtype` - Data type of cache elements
+pub fn dispatch_copy_blocks(
+    key_cache: &Buffer,
+    value_cache: &Buffer,
+    block_mapping: &Buffer,
+    params: &CopyBlocksParams,
+    dtype: MetalDtype,
+) -> Result<(), String> {
+    if params.num_pairs == 0 {
+        return Ok(()); // Nothing to copy
+    }
+
+    let state = MetalState::get()?;
+
+    // Get pipeline for this dtype
+    let kernel_name = MetalState::copy_blocks_kernel_name(dtype);
+    let pipeline = state.get_pipeline(&kernel_name)?;
+
+    // Create command buffer and encoder
+    let command_queue = state.device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+    let encoder = command_buffer.new_compute_command_encoder();
+
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    // Set buffers
+    encoder.set_buffer(0, Some(key_cache), 0);
+    encoder.set_buffer(1, Some(value_cache), 0);
+    encoder.set_buffer(2, Some(block_mapping), 0);
+
+    // Set numel_per_block constant
+    let numel = params.numel_per_block as i32;
+    let numel_buffer = state.device.new_buffer_with_data(
+        &numel as *const i32 as *const _,
+        std::mem::size_of::<i32>() as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+    encoder.set_buffer(3, Some(&numel_buffer), 0);
+
+    // Dispatch: 1 threadgroup per block pair, 256 threads per threadgroup
+    let threads_per_threadgroup = MTLSize::new(256, 1, 1);
+    let threadgroups = MTLSize::new(params.num_pairs as u64, 1, 1);
+
+    encoder.dispatch_thread_groups(threadgroups, threads_per_threadgroup);
+    encoder.end_encoding();
+
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    Ok(())
+}
+
+/// Raw buffer info for copy_blocks dispatch
+#[derive(Debug)]
+pub struct RawCopyBlocksBuffers {
+    /// Key cache raw pointer
+    pub key_cache_ptr: *mut c_void,
+    /// Value cache raw pointer
+    pub value_cache_ptr: *mut c_void,
+}
+
+/// Dispatch copy_blocks kernel with raw buffer pointers
+///
+/// # Safety
+///
+/// - All buffer pointers must be valid MTLBuffer* pointers
+/// - key_cache and value_cache must be properly sized
+/// - block_mapping must have num_pairs * 2 elements of i64
+/// - All buffers must remain valid until the kernel completes
+pub unsafe fn dispatch_copy_blocks_raw(
+    caches: &RawCopyBlocksBuffers,
+    block_mapping: &Buffer,
+    params: &CopyBlocksParams,
+    dtype: MetalDtype,
+) -> Result<(), String> {
+    if params.num_pairs == 0 {
+        return Ok(()); // Nothing to copy
+    }
+
+    let state = MetalState::get()?;
+
+    // Get pipeline for this dtype
+    let kernel_name = MetalState::copy_blocks_kernel_name(dtype);
+    let pipeline = state.get_pipeline(&kernel_name)?;
+
+    // Create command buffer and encoder
+    let command_queue = state.device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+    let encoder = command_buffer.new_compute_command_encoder();
+
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    // Set buffers - convert raw pointers to BufferRef
+    // SAFETY: Caller guarantees these are valid MTLBuffer* pointers
+    let key_cache_ref: &BufferRef =
+        unsafe { ForeignTypeRef::from_ptr(caches.key_cache_ptr as *mut _) };
+    let value_cache_ref: &BufferRef =
+        unsafe { ForeignTypeRef::from_ptr(caches.value_cache_ptr as *mut _) };
+
+    encoder.set_buffer(0, Some(key_cache_ref), 0);
+    encoder.set_buffer(1, Some(value_cache_ref), 0);
+    encoder.set_buffer(2, Some(block_mapping), 0);
+
+    // Set numel_per_block constant
+    let numel = params.numel_per_block as i32;
+    let numel_buffer = state.device.new_buffer_with_data(
+        &numel as *const i32 as *const _,
+        std::mem::size_of::<i32>() as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+    encoder.set_buffer(3, Some(&numel_buffer), 0);
+
+    // Dispatch: 1 threadgroup per block pair, 256 threads per threadgroup
+    let threads_per_threadgroup = MTLSize::new(256, 1, 1);
+    let threadgroups = MTLSize::new(params.num_pairs as u64, 1, 1);
+
+    encoder.dispatch_thread_groups(threadgroups, threads_per_threadgroup);
+    encoder.end_encoding();
+
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_copy_blocks_params() {
+        let params = CopyBlocksParams::from_config(
+            2,   // num_pairs
+            4,   // num_kv_heads
+            128, // head_size
+            16,  // block_size
+        );
+        assert_eq!(params.num_pairs, 2);
+        assert_eq!(params.numel_per_block, 4 * 128 * 16);
+    }
+
+    #[test]
+    fn test_copy_blocks_kernel_name() {
+        assert_eq!(
+            MetalState::copy_blocks_kernel_name(MetalDtype::Float16),
+            "copy_blocks_half"
+        );
+        assert_eq!(
+            MetalState::copy_blocks_kernel_name(MetalDtype::Float32),
+            "copy_blocks_float"
+        );
+        assert_eq!(
+            MetalState::copy_blocks_kernel_name(MetalDtype::BFloat16),
+            "copy_blocks_bfloat16_t"
+        );
+    }
+
+    #[test]
+    fn test_get_copy_blocks_pipeline() {
+        let state = MetalState::get().expect("Failed to init Metal state");
+        let kernel_name = MetalState::copy_blocks_kernel_name(MetalDtype::Float16);
+        let pipeline = state.get_pipeline(&kernel_name);
+        assert!(
+            pipeline.is_ok(),
+            "Failed to get copy_blocks pipeline: {:?}",
+            pipeline.err()
+        );
+    }
+}

--- a/crates/mlx-paged-attn/src/metal/kv_scale.rs
+++ b/crates/mlx-paged-attn/src/metal/kv_scale.rs
@@ -1,0 +1,449 @@
+//! KV Scale calibration for FP8 quantization
+//!
+//! This module provides scale calibration for FP8 KV cache quantization.
+//! Proper scale calibration is critical for FP8 to work well - without it,
+//! values will either overflow (scale too small) or lose precision (scale too large).
+//!
+//! ## FP8 E4M3 Format
+//! - 1 sign bit, 4 exponent bits, 3 mantissa bits
+//! - Range: [-448, 448] with special values for inf/nan
+//! - We use 448.0 as the max representable value for scale computation
+//!
+//! ## Calibration Modes
+//! - **One-shot**: Compute scales from a single calibration batch
+//! - **Running EMA**: Exponential moving average for online calibration
+
+use std::collections::HashMap;
+
+/// Maximum representable value in FP8 E4M3 format
+const FP8_E4M3_MAX: f32 = 448.0;
+
+/// Minimum scale to prevent division by zero
+const MIN_SCALE: f32 = 1e-12;
+
+/// Default EMA smoothing factor
+const DEFAULT_ALPHA: f32 = 0.1;
+
+/// KV scale manager for FP8 quantization
+///
+/// Manages per-layer quantization scales for keys and values.
+/// Scales are computed as: scale = FP8_MAX / max(abs(tensor))
+///
+/// During inference:
+/// - Quantization: fp8_value = fp32_value * scale
+/// - Dequantization: fp32_value = fp8_value / scale
+#[derive(Debug, Clone)]
+pub struct KvScaleManager {
+    /// Per-layer key scales
+    k_scales: HashMap<u32, f32>,
+
+    /// Per-layer value scales
+    v_scales: HashMap<u32, f32>,
+
+    /// Number of layers
+    num_layers: u32,
+
+    /// EMA smoothing factor for running calibration
+    alpha: f32,
+
+    /// Whether calibration has been performed
+    calibrated: bool,
+
+    /// Running max values for EMA (per layer)
+    k_running_max: HashMap<u32, f32>,
+    v_running_max: HashMap<u32, f32>,
+}
+
+impl KvScaleManager {
+    /// Create a new KV scale manager
+    ///
+    /// # Arguments
+    /// * `num_layers` - Number of transformer layers
+    pub fn new(num_layers: u32) -> Self {
+        Self {
+            k_scales: HashMap::new(),
+            v_scales: HashMap::new(),
+            num_layers,
+            alpha: DEFAULT_ALPHA,
+            calibrated: false,
+            k_running_max: HashMap::new(),
+            v_running_max: HashMap::new(),
+        }
+    }
+
+    /// Create with custom EMA alpha
+    pub fn with_alpha(num_layers: u32, alpha: f32) -> Self {
+        let mut manager = Self::new(num_layers);
+        manager.alpha = alpha.clamp(0.0, 1.0);
+        manager
+    }
+
+    /// Initialize all scales to 1.0 (no quantization effect)
+    pub fn init_default_scales(&mut self) {
+        for layer_idx in 0..self.num_layers {
+            self.k_scales.insert(layer_idx, 1.0);
+            self.v_scales.insert(layer_idx, 1.0);
+        }
+    }
+
+    /// Get the key scale for a layer
+    pub fn k_scale(&self, layer_idx: u32) -> f32 {
+        *self.k_scales.get(&layer_idx).unwrap_or(&1.0)
+    }
+
+    /// Get the value scale for a layer
+    pub fn v_scale(&self, layer_idx: u32) -> f32 {
+        *self.v_scales.get(&layer_idx).unwrap_or(&1.0)
+    }
+
+    /// Check if calibration has been performed
+    pub fn is_calibrated(&self) -> bool {
+        self.calibrated
+    }
+
+    /// Calibrate scales for a single layer from observed KV tensors
+    ///
+    /// Computes optimal scales based on the maximum absolute values in the tensors.
+    /// Uses MLX operations for GPU-accelerated computation.
+    ///
+    /// # Arguments
+    /// * `layer_idx` - Layer index
+    /// * `keys` - Key tensor (any shape)
+    /// * `values` - Value tensor (any shape)
+    ///
+    /// # Safety
+    /// The key and value pointers must be valid MLX array handles.
+    #[cfg(target_os = "macos")]
+    pub unsafe fn calibrate_layer(
+        &mut self,
+        layer_idx: u32,
+        keys: *mut mlx_sys::mlx_array,
+        values: *mut mlx_sys::mlx_array,
+    ) -> Result<(f32, f32), String> {
+        // Compute max absolute values using MLX ops
+        // SAFETY: compute_max_abs is unsafe, caller guarantees valid pointers
+        let k_max = unsafe { Self::compute_max_abs(keys)? };
+        let v_max = unsafe { Self::compute_max_abs(values)? };
+
+        // Compute scales: scale = FP8_MAX / max_abs
+        // Higher max_abs -> lower scale (to fit in FP8 range)
+        let k_scale = Self::compute_scale(k_max);
+        let v_scale = Self::compute_scale(v_max);
+
+        // Store scales
+        self.k_scales.insert(layer_idx, k_scale);
+        self.v_scales.insert(layer_idx, v_scale);
+        self.calibrated = true;
+
+        Ok((k_scale, v_scale))
+    }
+
+    /// Update scales using exponential moving average
+    ///
+    /// This is useful for online calibration during inference.
+    /// The scale is updated as: new_scale = alpha * observed_scale + (1-alpha) * old_scale
+    ///
+    /// # Arguments
+    /// * `layer_idx` - Layer index
+    /// * `keys` - Key tensor
+    /// * `values` - Value tensor
+    ///
+    /// # Safety
+    /// - `keys` and `values` must be valid MLX array pointers
+    /// - Arrays must remain valid until this function returns
+    #[cfg(target_os = "macos")]
+    pub unsafe fn update_layer_ema(
+        &mut self,
+        layer_idx: u32,
+        keys: *mut mlx_sys::mlx_array,
+        values: *mut mlx_sys::mlx_array,
+    ) -> Result<(f32, f32), String> {
+        // Compute current max absolute values
+        // SAFETY: compute_max_abs is unsafe, caller guarantees valid pointers
+        let k_max = unsafe { Self::compute_max_abs(keys)? };
+        let v_max = unsafe { Self::compute_max_abs(values)? };
+
+        // Update running max using EMA
+        let k_running = self.k_running_max.entry(layer_idx).or_insert(k_max);
+        *k_running = self.alpha * k_max + (1.0 - self.alpha) * *k_running;
+
+        let v_running = self.v_running_max.entry(layer_idx).or_insert(v_max);
+        *v_running = self.alpha * v_max + (1.0 - self.alpha) * *v_running;
+
+        // Compute scales from running max
+        let k_scale = Self::compute_scale(*k_running);
+        let v_scale = Self::compute_scale(*v_running);
+
+        // Store scales
+        self.k_scales.insert(layer_idx, k_scale);
+        self.v_scales.insert(layer_idx, v_scale);
+        self.calibrated = true;
+
+        Ok((k_scale, v_scale))
+    }
+
+    /// Compute max absolute value of a tensor using MLX ops
+    #[cfg(target_os = "macos")]
+    unsafe fn compute_max_abs(tensor: *mut mlx_sys::mlx_array) -> Result<f32, String> {
+        use mlx_sys::{
+            mlx_array_abs, mlx_array_delete, mlx_array_eval, mlx_array_item_at_float32,
+            mlx_array_max,
+        };
+
+        if tensor.is_null() {
+            return Err("Null tensor pointer".to_string());
+        }
+
+        // Compute abs(tensor)
+        let abs_tensor = unsafe { mlx_array_abs(tensor) };
+        if abs_tensor.is_null() {
+            return Err("Failed to compute abs".to_string());
+        }
+
+        // Compute max over all dimensions (pass null for axes = all axes)
+        let max_tensor = unsafe { mlx_array_max(abs_tensor, std::ptr::null(), 0, false) };
+        if max_tensor.is_null() {
+            // Clean up abs_tensor before returning error
+            unsafe { mlx_array_delete(abs_tensor) };
+            return Err("Failed to compute max".to_string());
+        }
+
+        // Evaluate to get the result
+        unsafe { mlx_array_eval(max_tensor) };
+
+        // Extract scalar value (index 0 for scalar result)
+        let mut max_val: f32 = 0.0;
+        let ok = unsafe { mlx_array_item_at_float32(max_tensor, 0, &mut max_val) };
+
+        // Clean up intermediate arrays
+        unsafe {
+            mlx_array_delete(abs_tensor);
+            mlx_array_delete(max_tensor);
+        }
+
+        if !ok {
+            return Err("Failed to extract max value".to_string());
+        }
+
+        Ok(max_val)
+    }
+
+    /// Compute scale from max absolute value
+    fn compute_scale(max_abs: f32) -> f32 {
+        if max_abs < MIN_SCALE {
+            // Tensor is essentially zero, use default scale
+            1.0
+        } else {
+            // scale = FP8_MAX / max_abs
+            // This ensures max_abs * scale = FP8_MAX (fits exactly in FP8 range)
+            FP8_E4M3_MAX / max_abs
+        }
+    }
+
+    /// Set scales directly (useful for loading pre-calibrated values)
+    pub fn set_scales(&mut self, layer_idx: u32, k_scale: f32, v_scale: f32) {
+        self.k_scales.insert(layer_idx, k_scale);
+        self.v_scales.insert(layer_idx, v_scale);
+        self.calibrated = true;
+    }
+
+    /// Get all scales as vectors (for serialization)
+    pub fn get_all_scales(&self) -> (Vec<f32>, Vec<f32>) {
+        let mut k_scales = vec![1.0; self.num_layers as usize];
+        let mut v_scales = vec![1.0; self.num_layers as usize];
+
+        for (&layer_idx, &scale) in &self.k_scales {
+            if (layer_idx as usize) < k_scales.len() {
+                k_scales[layer_idx as usize] = scale;
+            }
+        }
+
+        for (&layer_idx, &scale) in &self.v_scales {
+            if (layer_idx as usize) < v_scales.len() {
+                v_scales[layer_idx as usize] = scale;
+            }
+        }
+
+        (k_scales, v_scales)
+    }
+
+    /// Load scales from vectors (for deserialization)
+    pub fn load_scales(&mut self, k_scales: &[f32], v_scales: &[f32]) {
+        for (layer_idx, &scale) in k_scales.iter().enumerate() {
+            self.k_scales.insert(layer_idx as u32, scale);
+        }
+
+        for (layer_idx, &scale) in v_scales.iter().enumerate() {
+            self.v_scales.insert(layer_idx as u32, scale);
+        }
+
+        self.calibrated = true;
+    }
+
+    /// Reset calibration state
+    pub fn reset(&mut self) {
+        self.k_scales.clear();
+        self.v_scales.clear();
+        self.k_running_max.clear();
+        self.v_running_max.clear();
+        self.calibrated = false;
+    }
+
+    /// Get statistics about the scales
+    pub fn stats(&self) -> KvScaleStats {
+        let k_scales: Vec<f32> = self.k_scales.values().copied().collect();
+        let v_scales: Vec<f32> = self.v_scales.values().copied().collect();
+
+        KvScaleStats {
+            num_layers_calibrated: self.k_scales.len() as u32,
+            k_scale_min: k_scales.iter().copied().fold(f32::INFINITY, f32::min),
+            k_scale_max: k_scales.iter().copied().fold(f32::NEG_INFINITY, f32::max),
+            k_scale_mean: if k_scales.is_empty() {
+                0.0
+            } else {
+                k_scales.iter().sum::<f32>() / k_scales.len() as f32
+            },
+            v_scale_min: v_scales.iter().copied().fold(f32::INFINITY, f32::min),
+            v_scale_max: v_scales.iter().copied().fold(f32::NEG_INFINITY, f32::max),
+            v_scale_mean: if v_scales.is_empty() {
+                0.0
+            } else {
+                v_scales.iter().sum::<f32>() / v_scales.len() as f32
+            },
+        }
+    }
+}
+
+/// Statistics about KV scales
+#[derive(Debug, Clone)]
+pub struct KvScaleStats {
+    /// Number of layers with calibrated scales
+    pub num_layers_calibrated: u32,
+    /// Minimum key scale
+    pub k_scale_min: f32,
+    /// Maximum key scale
+    pub k_scale_max: f32,
+    /// Mean key scale
+    pub k_scale_mean: f32,
+    /// Minimum value scale
+    pub v_scale_min: f32,
+    /// Maximum value scale
+    pub v_scale_max: f32,
+    /// Mean value scale
+    pub v_scale_mean: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scale_manager_creation() {
+        let manager = KvScaleManager::new(28);
+        assert_eq!(manager.num_layers, 28);
+        assert!(!manager.is_calibrated());
+        assert_eq!(manager.k_scale(0), 1.0);
+        assert_eq!(manager.v_scale(0), 1.0);
+    }
+
+    #[test]
+    fn test_default_scales() {
+        let mut manager = KvScaleManager::new(4);
+        manager.init_default_scales();
+
+        for i in 0..4 {
+            assert_eq!(manager.k_scale(i), 1.0);
+            assert_eq!(manager.v_scale(i), 1.0);
+        }
+    }
+
+    #[test]
+    fn test_set_scales() {
+        let mut manager = KvScaleManager::new(4);
+        manager.set_scales(0, 0.5, 0.25);
+        manager.set_scales(1, 2.0, 1.5);
+
+        assert_eq!(manager.k_scale(0), 0.5);
+        assert_eq!(manager.v_scale(0), 0.25);
+        assert_eq!(manager.k_scale(1), 2.0);
+        assert_eq!(manager.v_scale(1), 1.5);
+        assert!(manager.is_calibrated());
+    }
+
+    #[test]
+    fn test_compute_scale() {
+        // max_abs = 448 -> scale = 1.0
+        assert!((KvScaleManager::compute_scale(448.0) - 1.0).abs() < 1e-6);
+
+        // max_abs = 224 -> scale = 2.0
+        assert!((KvScaleManager::compute_scale(224.0) - 2.0).abs() < 1e-6);
+
+        // max_abs = 896 -> scale = 0.5
+        assert!((KvScaleManager::compute_scale(896.0) - 0.5).abs() < 1e-6);
+
+        // Very small max_abs -> scale = 1.0 (default)
+        assert_eq!(KvScaleManager::compute_scale(0.0), 1.0);
+    }
+
+    #[test]
+    fn test_serialization() {
+        let mut manager = KvScaleManager::new(4);
+        manager.set_scales(0, 0.5, 0.25);
+        manager.set_scales(1, 2.0, 1.5);
+        manager.set_scales(2, 1.0, 1.0);
+        manager.set_scales(3, 0.8, 0.9);
+
+        let (k_scales, v_scales) = manager.get_all_scales();
+
+        assert_eq!(k_scales, vec![0.5, 2.0, 1.0, 0.8]);
+        assert_eq!(v_scales, vec![0.25, 1.5, 1.0, 0.9]);
+
+        // Test loading
+        let mut new_manager = KvScaleManager::new(4);
+        new_manager.load_scales(&k_scales, &v_scales);
+
+        for i in 0..4 {
+            assert_eq!(new_manager.k_scale(i), manager.k_scale(i));
+            assert_eq!(new_manager.v_scale(i), manager.v_scale(i));
+        }
+    }
+
+    #[test]
+    fn test_stats() {
+        let mut manager = KvScaleManager::new(4);
+        manager.set_scales(0, 0.5, 0.25);
+        manager.set_scales(1, 2.0, 1.5);
+        manager.set_scales(2, 1.0, 1.0);
+        manager.set_scales(3, 0.5, 0.25);
+
+        let stats = manager.stats();
+        assert_eq!(stats.num_layers_calibrated, 4);
+        assert_eq!(stats.k_scale_min, 0.5);
+        assert_eq!(stats.k_scale_max, 2.0);
+        assert!((stats.k_scale_mean - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut manager = KvScaleManager::new(4);
+        manager.set_scales(0, 0.5, 0.25);
+        assert!(manager.is_calibrated());
+
+        manager.reset();
+        assert!(!manager.is_calibrated());
+        assert_eq!(manager.k_scale(0), 1.0);
+    }
+
+    #[test]
+    fn test_with_alpha() {
+        let manager = KvScaleManager::with_alpha(4, 0.5);
+        assert_eq!(manager.alpha, 0.5);
+
+        // Test clamping
+        let manager = KvScaleManager::with_alpha(4, -0.5);
+        assert_eq!(manager.alpha, 0.0);
+
+        let manager = KvScaleManager::with_alpha(4, 1.5);
+        assert_eq!(manager.alpha, 1.0);
+    }
+}

--- a/crates/mlx-paged-attn/src/metal/mod.rs
+++ b/crates/mlx-paged-attn/src/metal/mod.rs
@@ -18,14 +18,27 @@
 //! - `reshape_and_cache_kv_{type}_cache_{type}[_fp8]`
 //! - `paged_attention_{type}_cache_{type}_hs{head}_bs{block}_nt256_nsl32_ps{partition}[_alibi]`
 
+mod copy_blocks;
+mod kv_scale;
 mod mlx_integration;
 mod paged_attention;
 mod reshape_and_cache;
 mod state;
+mod swap_blocks;
 
+pub use copy_blocks::{
+    CopyBlocksParams, RawCopyBlocksBuffers, dispatch_copy_blocks, dispatch_copy_blocks_raw,
+};
+pub use kv_scale::{KvScaleManager, KvScaleStats};
 pub use mlx_integration::{MlxMetalBuffer, is_metal_extraction_supported, synchronize_mlx};
 pub use paged_attention::{
-    PagedAttentionParams, dispatch_paged_attention_v1, dispatch_paged_attention_v2,
+    PagedAttentionOutput, PagedAttentionParams, dispatch_paged_attention_auto,
+    dispatch_paged_attention_v1, dispatch_paged_attention_v1_raw, dispatch_paged_attention_v2,
+    dispatch_paged_attention_v2_raw,
 };
-pub use reshape_and_cache::{ReshapeAndCacheParams, dispatch_reshape_and_cache};
+pub use reshape_and_cache::{
+    RawBufferInfo, ReshapeAndCacheParams, dispatch_reshape_and_cache,
+    dispatch_reshape_and_cache_raw,
+};
 pub use state::{MetalDtype, MetalState};
+pub use swap_blocks::{CpuBlockCache, SwapBlocksParams, swap_in, swap_out};

--- a/crates/mlx-paged-attn/src/metal/paged_attention.rs
+++ b/crates/mlx-paged-attn/src/metal/paged_attention.rs
@@ -3,8 +3,51 @@
 //! This kernel computes attention using the paged KV cache.
 //! Supports both V1 (no partitioning) and V2 (with partitioning) modes.
 
+use super::reshape_and_cache::RawBufferInfo;
 use super::state::{MetalDtype, MetalState};
-use metal::{Buffer, MTLSize};
+use metal::foreign_types::ForeignTypeRef;
+use metal::{Buffer, BufferRef, MTLSize};
+use std::ffi::c_void;
+
+/// Convert IEEE 754 half-precision (f16) to single-precision (f32)
+#[inline]
+fn f16_to_f32(bits: u16) -> f32 {
+    let sign = ((bits >> 15) & 0x1) as u32;
+    let exp = ((bits >> 10) & 0x1F) as u32;
+    let mant = (bits & 0x3FF) as u32;
+
+    if exp == 0 {
+        if mant == 0 {
+            // Zero
+            f32::from_bits(sign << 31)
+        } else {
+            // Subnormal - convert to normalized f32
+            let mut m = mant;
+            let mut e = 0i32;
+            while (m & 0x400) == 0 {
+                m <<= 1;
+                e -= 1;
+            }
+            m &= 0x3FF;
+            let f32_exp = ((127 - 15 + 1 + e) as u32) << 23;
+            f32::from_bits((sign << 31) | f32_exp | (m << 13))
+        }
+    } else if exp == 31 {
+        // Inf or NaN
+        f32::from_bits((sign << 31) | 0x7F800000 | (mant << 13))
+    } else {
+        // Normalized
+        let f32_exp = ((exp as i32 - 15 + 127) as u32) << 23;
+        f32::from_bits((sign << 31) | f32_exp | (mant << 13))
+    }
+}
+
+/// Convert bfloat16 (bf16) to single-precision (f32)
+#[inline]
+fn bf16_to_f32(bits: u16) -> f32 {
+    // bf16 is just the upper 16 bits of f32
+    f32::from_bits((bits as u32) << 16)
+}
 
 /// Parameters for paged_attention kernel
 pub struct PagedAttentionParams {
@@ -32,6 +75,31 @@ pub struct PagedAttentionParams {
     pub kv_block_stride: i32,
     /// KV head stride
     pub kv_head_stride: i32,
+    /// K scale for FP8 quantization (1.0 for non-FP8)
+    pub k_scale: f32,
+    /// V scale for FP8 quantization (1.0 for non-FP8)
+    pub v_scale: f32,
+}
+
+impl Default for PagedAttentionParams {
+    fn default() -> Self {
+        Self {
+            num_seqs: 0,
+            num_heads: 0,
+            num_kv_heads: 0,
+            head_size: 128,
+            block_size: 16,
+            max_seq_len: 0,
+            max_num_blocks_per_seq: 0,
+            scale: 1.0,
+            softcapping: 1.0,
+            q_stride: 0,
+            kv_block_stride: 0,
+            kv_head_stride: 0,
+            k_scale: 1.0,
+            v_scale: 1.0,
+        }
+    }
 }
 
 /// Partition size for V2 kernel
@@ -96,15 +164,19 @@ pub fn dispatch_paged_attention_v1(
     encoder.set_buffer(4, Some(key_cache), 0);
     encoder.set_buffer(5, Some(value_cache), 0);
 
-    // k_scale and v_scale (unused for non-FP8)
-    let one_f32: f32 = 1.0;
-    let scale_buffer = state.device.new_buffer_with_data(
-        &one_f32 as *const f32 as *const _,
+    // k_scale and v_scale - use params values for FP8 support
+    let k_scale_buffer = state.device.new_buffer_with_data(
+        &params.k_scale as *const f32 as *const _,
         std::mem::size_of::<f32>() as u64,
         metal::MTLResourceOptions::StorageModeShared,
     );
-    encoder.set_buffer(6, Some(&scale_buffer), 0);
-    encoder.set_buffer(7, Some(&scale_buffer), 0);
+    let v_scale_buffer = state.device.new_buffer_with_data(
+        &params.v_scale as *const f32 as *const _,
+        std::mem::size_of::<f32>() as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+    encoder.set_buffer(6, Some(&k_scale_buffer), 0);
+    encoder.set_buffer(7, Some(&v_scale_buffer), 0);
 
     // Set constant buffers
     let create_int_buffer = |value: i32| {
@@ -236,15 +308,19 @@ pub fn dispatch_paged_attention_v2(
         encoder.set_buffer(4, Some(key_cache), 0);
         encoder.set_buffer(5, Some(value_cache), 0);
 
-        // k_scale and v_scale
-        let one_f32: f32 = 1.0;
-        let scale_buffer = state.device.new_buffer_with_data(
-            &one_f32 as *const f32 as *const _,
+        // k_scale and v_scale - use params values for FP8 support
+        let k_scale_buffer = state.device.new_buffer_with_data(
+            &params.k_scale as *const f32 as *const _,
             std::mem::size_of::<f32>() as u64,
             metal::MTLResourceOptions::StorageModeShared,
         );
-        encoder.set_buffer(6, Some(&scale_buffer), 0);
-        encoder.set_buffer(7, Some(&scale_buffer), 0);
+        let v_scale_buffer = state.device.new_buffer_with_data(
+            &params.v_scale as *const f32 as *const _,
+            std::mem::size_of::<f32>() as u64,
+            metal::MTLResourceOptions::StorageModeShared,
+        );
+        encoder.set_buffer(6, Some(&k_scale_buffer), 0);
+        encoder.set_buffer(7, Some(&v_scale_buffer), 0);
 
         // Set constant buffers
         let create_int_buffer = |value: i32| {
@@ -352,6 +428,562 @@ pub fn dispatch_paged_attention_v2(
     Ok(())
 }
 
+/// Output from paged attention dispatch
+///
+/// Contains the output buffer and metadata for creating an MLX array.
+pub struct PagedAttentionOutput {
+    /// Output buffer [num_seqs, num_heads, head_size]
+    pub buffer: Buffer,
+    /// Number of sequences
+    pub num_seqs: u32,
+    /// Number of query heads
+    pub num_heads: u32,
+    /// Head size
+    pub head_size: u32,
+    /// Data type
+    pub dtype: MetalDtype,
+}
+
+impl PagedAttentionOutput {
+    /// Get the raw buffer pointer
+    pub fn buffer_ptr(&self) -> *mut c_void {
+        use metal::foreign_types::ForeignType;
+        self.buffer.as_ptr() as *mut c_void
+    }
+
+    /// Get the total number of elements
+    pub fn num_elements(&self) -> usize {
+        (self.num_seqs * self.num_heads * self.head_size) as usize
+    }
+
+    /// Get the buffer size in bytes
+    pub fn size_bytes(&self) -> usize {
+        self.num_elements() * self.dtype.size()
+    }
+
+    /// Get output shape as [num_seqs, num_heads, head_size]
+    pub fn shape(&self) -> [i64; 3] {
+        [
+            self.num_seqs as i64,
+            self.num_heads as i64,
+            self.head_size as i64,
+        ]
+    }
+
+    /// Copy output data to host memory as f32
+    ///
+    /// This copies the GPU-private buffer to CPU-accessible memory and converts to f32.
+    /// Use this to create an MLX array from the attention output.
+    ///
+    /// # Performance Note
+    /// This involves a GPU->CPU copy. For best performance, consider batching
+    /// multiple layers' attention outputs before copying to host.
+    ///
+    /// # Returns
+    /// Vector of f32 values with shape [num_seqs, num_heads, head_size]
+    pub fn to_host_f32(&self) -> Result<Vec<f32>, String> {
+        let state = MetalState::get()?;
+        let size_bytes = self.size_bytes();
+
+        // Create shared (CPU-accessible) buffer
+        let shared_buffer = state.device.new_buffer(
+            size_bytes as u64,
+            metal::MTLResourceOptions::StorageModeShared,
+        );
+
+        // Blit copy from private to shared
+        let command_queue = state.device.new_command_queue();
+        let command_buffer = command_queue.new_command_buffer();
+        let blit_encoder = command_buffer.new_blit_command_encoder();
+
+        blit_encoder.copy_from_buffer(&self.buffer, 0, &shared_buffer, 0, size_bytes as u64);
+        blit_encoder.end_encoding();
+
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+
+        // Read data from shared buffer
+        let num_elements = self.num_elements();
+        let mut result = vec![0.0f32; num_elements];
+
+        match self.dtype {
+            MetalDtype::Float32 => {
+                // Direct copy for f32
+                let ptr = shared_buffer.contents() as *const f32;
+                unsafe {
+                    std::ptr::copy_nonoverlapping(ptr, result.as_mut_ptr(), num_elements);
+                }
+            }
+            MetalDtype::Float16 => {
+                // Convert f16 to f32
+                let ptr = shared_buffer.contents() as *const u16;
+                let src = unsafe { std::slice::from_raw_parts(ptr, num_elements) };
+                for (dst, &bits) in result.iter_mut().zip(src.iter()) {
+                    *dst = f16_to_f32(bits);
+                }
+            }
+            MetalDtype::BFloat16 => {
+                // Convert bf16 to f32
+                let ptr = shared_buffer.contents() as *const u16;
+                let src = unsafe { std::slice::from_raw_parts(ptr, num_elements) };
+                for (dst, &bits) in result.iter_mut().zip(src.iter()) {
+                    *dst = bf16_to_f32(bits);
+                }
+            }
+            MetalDtype::UChar => {
+                // FP8 E4M3 format cannot be correctly converted to f32 without the quantization scales.
+                // The raw byte cast (byte as f32) produces completely wrong values because FP8 E4M3
+                // has a different bit layout (1 sign, 4 exponent, 3 mantissa bits).
+                // Proper dequantization requires: f32_value = fp8_to_f32(byte) / scale
+                // where scale was used during quantization.
+                return Err(
+                    "FP8 (UChar) to f32 conversion not yet implemented. \
+                    FP8 dequantization requires k_scale/v_scale values which are not available here. \
+                    Use the raw buffer directly or implement to_host_f32_with_scales() for FP8 data."
+                        .to_string(),
+                );
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Convert output to an MLX array
+    ///
+    /// Creates a new MLX array from the attention output data.
+    /// This involves copying data from GPU to CPU and back to MLX.
+    ///
+    /// # Safety
+    /// The returned pointer must be managed by the caller (typically wrapped in MxArray).
+    ///
+    /// # Performance Note
+    /// This involves GPU->CPU->GPU copies. For zero-copy integration,
+    /// use the raw buffer pointer with MLX's metal operations directly.
+    pub unsafe fn to_mlx_array(&self) -> Result<*mut mlx_sys::mlx_array, String> {
+        let data = self.to_host_f32()?;
+        let shape = self.shape();
+
+        // SAFETY: data and shape are valid pointers with correct length
+        let arr = unsafe {
+            mlx_sys::mlx_array_from_float32(
+                data.as_ptr(),
+                shape.as_ptr(),
+                3, // ndim
+            )
+        };
+
+        if arr.is_null() {
+            return Err("Failed to create MLX array from attention output".to_string());
+        }
+
+        Ok(arr)
+    }
+}
+
+/// Dispatch paged_attention V1 with raw buffer pointers
+///
+/// This variant is used when integrating with MLX arrays.
+///
+/// # Safety
+///
+/// - queries must be a valid MTLBuffer* with shape [num_seqs, num_heads, head_size]
+/// - key_cache and value_cache must be valid cache buffers
+/// - block_tables must have shape [num_seqs, max_blocks_per_seq]
+/// - context_lens must have shape [num_seqs]
+///
+/// # Returns
+///
+/// A new buffer containing the attention output [num_seqs, num_heads, head_size]
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn dispatch_paged_attention_v1_raw(
+    queries: &RawBufferInfo,
+    key_cache: &Buffer,
+    value_cache: &Buffer,
+    block_tables: &Buffer,
+    context_lens: &Buffer,
+    params: &PagedAttentionParams,
+    dtype: MetalDtype,
+) -> Result<PagedAttentionOutput, String> {
+    let state = MetalState::get()?;
+
+    // Allocate output buffer
+    let output_size =
+        (params.num_seqs * params.num_heads * params.head_size) as u64 * dtype.size() as u64;
+    let output = state
+        .device
+        .new_buffer(output_size, metal::MTLResourceOptions::StorageModePrivate);
+
+    // Get V1 pipeline (partition_size = 0)
+    let kernel_name = MetalState::paged_attention_v1_kernel_name(
+        dtype,
+        params.head_size,
+        params.block_size,
+        false, // use_alibi
+    );
+    let pipeline = state.get_pipeline(&kernel_name)?;
+
+    // Create command buffer and encoder
+    let command_queue = state.device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+    let encoder = command_buffer.new_compute_command_encoder();
+
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    // Create dummy buffers for exp_sums/max_logits (unused in V1)
+    let dummy_float: f32 = 0.0;
+    let dummy_buffer = state.device.new_buffer_with_data(
+        &dummy_float as *const f32 as *const _,
+        std::mem::size_of::<f32>() as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+
+    // Convert queries raw pointer to BufferRef
+    // SAFETY: Caller guarantees queries.ptr is a valid MTLBuffer*
+    let queries_ref: &BufferRef = unsafe { ForeignTypeRef::from_ptr(queries.ptr as *mut _) };
+
+    // Set buffers
+    encoder.set_buffer(0, Some(&dummy_buffer), 0); // exp_sums (unused)
+    encoder.set_buffer(1, Some(&dummy_buffer), 0); // max_logits (unused)
+    encoder.set_buffer(2, Some(&output), 0);
+    encoder.set_buffer(3, Some(queries_ref), queries.offset as u64);
+    encoder.set_buffer(4, Some(key_cache), 0);
+    encoder.set_buffer(5, Some(value_cache), 0);
+
+    // k_scale and v_scale - use params values for FP8 support
+    let k_scale_buffer = state.device.new_buffer_with_data(
+        &params.k_scale as *const f32 as *const _,
+        std::mem::size_of::<f32>() as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+    let v_scale_buffer = state.device.new_buffer_with_data(
+        &params.v_scale as *const f32 as *const _,
+        std::mem::size_of::<f32>() as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+    encoder.set_buffer(6, Some(&k_scale_buffer), 0);
+    encoder.set_buffer(7, Some(&v_scale_buffer), 0);
+
+    // Set constant buffers
+    let create_int_buffer = |value: i32| {
+        state.device.new_buffer_with_data(
+            &value as *const i32 as *const _,
+            std::mem::size_of::<i32>() as u64,
+            metal::MTLResourceOptions::StorageModeShared,
+        )
+    };
+
+    let create_float_buffer = |value: f32| {
+        state.device.new_buffer_with_data(
+            &value as *const f32 as *const _,
+            std::mem::size_of::<f32>() as u64,
+            metal::MTLResourceOptions::StorageModeShared,
+        )
+    };
+
+    let num_kv_heads_buf = create_int_buffer(params.num_kv_heads as i32);
+    let scale_buf = create_float_buffer(params.scale);
+    let softcapping_buf = create_float_buffer(params.softcapping);
+    let max_num_blocks_buf = create_int_buffer(params.max_num_blocks_per_seq as i32);
+    let q_stride_buf = create_int_buffer(params.q_stride);
+    let kv_block_stride_buf = create_int_buffer(params.kv_block_stride);
+    let kv_head_stride_buf = create_int_buffer(params.kv_head_stride);
+
+    encoder.set_buffer(8, Some(&num_kv_heads_buf), 0);
+    encoder.set_buffer(9, Some(&scale_buf), 0);
+    encoder.set_buffer(10, Some(&softcapping_buf), 0);
+    encoder.set_buffer(11, Some(block_tables), 0);
+    encoder.set_buffer(12, Some(context_lens), 0);
+    encoder.set_buffer(13, Some(&max_num_blocks_buf), 0);
+
+    // alibi_slopes (unused, set to dummy)
+    encoder.set_buffer(14, Some(&dummy_buffer), 0);
+
+    encoder.set_buffer(15, Some(&q_stride_buf), 0);
+    encoder.set_buffer(16, Some(&kv_block_stride_buf), 0);
+    encoder.set_buffer(17, Some(&kv_head_stride_buf), 0);
+
+    // Calculate threadgroup memory size
+    let threadgroup_mem_size = (params.max_seq_len as usize * std::mem::size_of::<f32>())
+        + (2 * 8 * std::mem::size_of::<f32>()); // 2 * NUM_WARPS * sizeof(float)
+    encoder.set_threadgroup_memory_length(0, threadgroup_mem_size as u64);
+
+    // Dispatch: (num_heads, num_seqs, 1) threadgroups, 256 threads each
+    let threads_per_threadgroup = MTLSize::new(256, 1, 1);
+    let threadgroups = MTLSize::new(
+        params.num_heads as u64,
+        params.num_seqs as u64,
+        1, // No partitioning in V1
+    );
+
+    encoder.dispatch_thread_groups(threadgroups, threads_per_threadgroup);
+    encoder.end_encoding();
+
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    Ok(PagedAttentionOutput {
+        buffer: output,
+        num_seqs: params.num_seqs,
+        num_heads: params.num_heads,
+        head_size: params.head_size,
+        dtype,
+    })
+}
+
+/// Dispatch paged_attention V2 with raw buffer pointers (for long sequences)
+///
+/// This variant uses partitioning for sequences longer than PARTITION_SIZE tokens.
+///
+/// # Safety
+///
+/// Same requirements as V1.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn dispatch_paged_attention_v2_raw(
+    queries: &RawBufferInfo,
+    key_cache: &Buffer,
+    value_cache: &Buffer,
+    block_tables: &Buffer,
+    context_lens: &Buffer,
+    params: &PagedAttentionParams,
+    dtype: MetalDtype,
+) -> Result<PagedAttentionOutput, String> {
+    let state = MetalState::get()?;
+
+    // Allocate output buffer
+    let output_size =
+        (params.num_seqs * params.num_heads * params.head_size) as u64 * dtype.size() as u64;
+    let output = state
+        .device
+        .new_buffer(output_size, metal::MTLResourceOptions::StorageModePrivate);
+
+    // Calculate number of partitions
+    let max_num_partitions = params.max_seq_len.div_ceil(PARTITION_SIZE);
+
+    // Allocate temporary buffers
+    let exp_sums_size = (params.num_seqs * params.num_heads * max_num_partitions) as usize
+        * std::mem::size_of::<f32>();
+    let max_logits_size = exp_sums_size;
+    let tmp_out_size = (params.num_seqs * params.num_heads * max_num_partitions * params.head_size)
+        as usize
+        * dtype.size();
+
+    let exp_sums = state.device.new_buffer(
+        exp_sums_size as u64,
+        metal::MTLResourceOptions::StorageModePrivate,
+    );
+    let max_logits = state.device.new_buffer(
+        max_logits_size as u64,
+        metal::MTLResourceOptions::StorageModePrivate,
+    );
+    let tmp_out = state.device.new_buffer(
+        tmp_out_size as u64,
+        metal::MTLResourceOptions::StorageModePrivate,
+    );
+
+    // Convert queries raw pointer to BufferRef
+    // SAFETY: Caller guarantees queries.ptr is a valid MTLBuffer*
+    let queries_ref: &BufferRef = unsafe { ForeignTypeRef::from_ptr(queries.ptr as *mut _) };
+
+    // Phase 1: Compute partitioned attention
+    {
+        let kernel_name = MetalState::paged_attention_v2_kernel_name(
+            dtype,
+            params.head_size,
+            params.block_size,
+            false,
+        );
+        let pipeline = state.get_pipeline(&kernel_name)?;
+
+        let command_queue = state.device.new_command_queue();
+        let command_buffer = command_queue.new_command_buffer();
+        let encoder = command_buffer.new_compute_command_encoder();
+
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        // Set buffers
+        encoder.set_buffer(0, Some(&exp_sums), 0);
+        encoder.set_buffer(1, Some(&max_logits), 0);
+        encoder.set_buffer(2, Some(&tmp_out), 0);
+        encoder.set_buffer(3, Some(queries_ref), queries.offset as u64);
+        encoder.set_buffer(4, Some(key_cache), 0);
+        encoder.set_buffer(5, Some(value_cache), 0);
+
+        // k_scale and v_scale - use params values for FP8 support
+        let k_scale_buffer = state.device.new_buffer_with_data(
+            &params.k_scale as *const f32 as *const _,
+            std::mem::size_of::<f32>() as u64,
+            metal::MTLResourceOptions::StorageModeShared,
+        );
+        let v_scale_buffer = state.device.new_buffer_with_data(
+            &params.v_scale as *const f32 as *const _,
+            std::mem::size_of::<f32>() as u64,
+            metal::MTLResourceOptions::StorageModeShared,
+        );
+        encoder.set_buffer(6, Some(&k_scale_buffer), 0);
+        encoder.set_buffer(7, Some(&v_scale_buffer), 0);
+
+        // Set constant buffers
+        let create_int_buffer = |value: i32| {
+            state.device.new_buffer_with_data(
+                &value as *const i32 as *const _,
+                std::mem::size_of::<i32>() as u64,
+                metal::MTLResourceOptions::StorageModeShared,
+            )
+        };
+
+        let create_float_buffer = |value: f32| {
+            state.device.new_buffer_with_data(
+                &value as *const f32 as *const _,
+                std::mem::size_of::<f32>() as u64,
+                metal::MTLResourceOptions::StorageModeShared,
+            )
+        };
+
+        let num_kv_heads_buf = create_int_buffer(params.num_kv_heads as i32);
+        let scale_buf = create_float_buffer(params.scale);
+        let softcapping_buf = create_float_buffer(params.softcapping);
+        let max_num_blocks_buf = create_int_buffer(params.max_num_blocks_per_seq as i32);
+        let q_stride_buf = create_int_buffer(params.q_stride);
+        let kv_block_stride_buf = create_int_buffer(params.kv_block_stride);
+        let kv_head_stride_buf = create_int_buffer(params.kv_head_stride);
+
+        let dummy_float: f32 = 0.0;
+        let dummy_buffer = state.device.new_buffer_with_data(
+            &dummy_float as *const f32 as *const _,
+            std::mem::size_of::<f32>() as u64,
+            metal::MTLResourceOptions::StorageModeShared,
+        );
+
+        encoder.set_buffer(8, Some(&num_kv_heads_buf), 0);
+        encoder.set_buffer(9, Some(&scale_buf), 0);
+        encoder.set_buffer(10, Some(&softcapping_buf), 0);
+        encoder.set_buffer(11, Some(block_tables), 0);
+        encoder.set_buffer(12, Some(context_lens), 0);
+        encoder.set_buffer(13, Some(&max_num_blocks_buf), 0);
+        encoder.set_buffer(14, Some(&dummy_buffer), 0); // alibi_slopes
+        encoder.set_buffer(15, Some(&q_stride_buf), 0);
+        encoder.set_buffer(16, Some(&kv_block_stride_buf), 0);
+        encoder.set_buffer(17, Some(&kv_head_stride_buf), 0);
+
+        // Threadgroup memory
+        let threadgroup_mem_size = (PARTITION_SIZE as usize * std::mem::size_of::<f32>())
+            + (2 * 8 * std::mem::size_of::<f32>());
+        encoder.set_threadgroup_memory_length(0, threadgroup_mem_size as u64);
+
+        // Dispatch: (num_heads, num_seqs, max_num_partitions)
+        let threads_per_threadgroup = MTLSize::new(256, 1, 1);
+        let threadgroups = MTLSize::new(
+            params.num_heads as u64,
+            params.num_seqs as u64,
+            max_num_partitions as u64,
+        );
+
+        encoder.dispatch_thread_groups(threadgroups, threads_per_threadgroup);
+        encoder.end_encoding();
+
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+    }
+
+    // Phase 2: Reduce partitions
+    {
+        let kernel_name =
+            MetalState::paged_attention_v2_reduce_kernel_name(dtype, params.head_size);
+        let pipeline = state.get_pipeline(&kernel_name)?;
+
+        let command_queue = state.device.new_command_queue();
+        let command_buffer = command_queue.new_command_buffer();
+        let encoder = command_buffer.new_compute_command_encoder();
+
+        encoder.set_compute_pipeline_state(&pipeline);
+
+        encoder.set_buffer(0, Some(&output), 0);
+        encoder.set_buffer(1, Some(&exp_sums), 0);
+        encoder.set_buffer(2, Some(&max_logits), 0);
+        encoder.set_buffer(3, Some(&tmp_out), 0);
+        encoder.set_buffer(4, Some(context_lens), 0);
+
+        let max_num_partitions_buf = state.device.new_buffer_with_data(
+            &(max_num_partitions as i32) as *const i32 as *const _,
+            std::mem::size_of::<i32>() as u64,
+            metal::MTLResourceOptions::StorageModeShared,
+        );
+        encoder.set_buffer(5, Some(&max_num_partitions_buf), 0);
+
+        // Threadgroup memory for reduce
+        let threadgroup_mem_size = 2 * (max_num_partitions as usize) * std::mem::size_of::<f32>();
+        encoder.set_threadgroup_memory_length(0, threadgroup_mem_size as u64);
+
+        // Dispatch: (num_heads, num_seqs, 1)
+        let threads_per_threadgroup = MTLSize::new(256, 1, 1);
+        let threadgroups = MTLSize::new(params.num_heads as u64, params.num_seqs as u64, 1);
+
+        encoder.dispatch_thread_groups(threadgroups, threads_per_threadgroup);
+        encoder.end_encoding();
+
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+    }
+
+    Ok(PagedAttentionOutput {
+        buffer: output,
+        num_seqs: params.num_seqs,
+        num_heads: params.num_heads,
+        head_size: params.head_size,
+        dtype,
+    })
+}
+
+/// Automatically dispatch V1 or V2 based on max context length
+///
+/// Uses V1 for short sequences (< PARTITION_SIZE tokens), V2 for longer.
+///
+/// # Safety
+/// - `queries` must contain a valid MTLBuffer pointer
+/// - `key_cache` and `value_cache` must be valid cache buffers
+/// - `block_tables` must have shape [num_seqs, max_blocks_per_seq]
+/// - `context_lens` must have shape [num_seqs]
+/// - All buffers must remain valid until the kernel completes
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn dispatch_paged_attention_auto(
+    queries: &RawBufferInfo,
+    key_cache: &Buffer,
+    value_cache: &Buffer,
+    block_tables: &Buffer,
+    context_lens: &Buffer,
+    max_context_len: u32,
+    params: &PagedAttentionParams,
+    dtype: MetalDtype,
+) -> Result<PagedAttentionOutput, String> {
+    if max_context_len <= PARTITION_SIZE {
+        // SAFETY: Caller guarantees all buffer pointers are valid
+        unsafe {
+            dispatch_paged_attention_v1_raw(
+                queries,
+                key_cache,
+                value_cache,
+                block_tables,
+                context_lens,
+                params,
+                dtype,
+            )
+        }
+    } else {
+        // SAFETY: Caller guarantees all buffer pointers are valid
+        unsafe {
+            dispatch_paged_attention_v2_raw(
+                queries,
+                key_cache,
+                value_cache,
+                block_tables,
+                context_lens,
+                params,
+                dtype,
+            )
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -371,7 +1003,20 @@ mod tests {
             q_stride: 1536, // 12 * 128
             kv_block_stride: 32768,
             kv_head_stride: 16384,
+            k_scale: 1.0,
+            v_scale: 1.0,
         };
         assert_eq!(params.num_heads / params.num_kv_heads, 6); // GQA ratio
+    }
+
+    #[test]
+    fn test_fp8_params() {
+        let params = PagedAttentionParams {
+            k_scale: 0.5,  // FP8 quantization scale
+            v_scale: 0.25, // FP8 quantization scale
+            ..Default::default()
+        };
+        assert_eq!(params.k_scale, 0.5);
+        assert_eq!(params.v_scale, 0.25);
     }
 }

--- a/crates/mlx-paged-attn/src/metal/reshape_and_cache.rs
+++ b/crates/mlx-paged-attn/src/metal/reshape_and_cache.rs
@@ -3,7 +3,9 @@
 //! This kernel writes new KV pairs into the paged KV cache.
 
 use super::state::{MetalDtype, MetalState};
-use metal::{Buffer, MTLSize};
+use metal::foreign_types::ForeignTypeRef;
+use metal::{Buffer, BufferRef, MTLSize};
+use std::ffi::c_void;
 
 /// Parameters for reshape_and_cache kernel
 pub struct ReshapeAndCacheParams {
@@ -21,6 +23,26 @@ pub struct ReshapeAndCacheParams {
     pub value_stride: i32,
     /// X factor for key cache layout (typically 16 / sizeof(dtype))
     pub x: i32,
+    /// K scale for FP8 quantization (1.0 for non-FP8)
+    pub k_scale: f32,
+    /// V scale for FP8 quantization (1.0 for non-FP8)
+    pub v_scale: f32,
+}
+
+impl Default for ReshapeAndCacheParams {
+    fn default() -> Self {
+        Self {
+            num_tokens: 0,
+            num_heads: 0,
+            head_size: 0,
+            block_size: 0,
+            key_stride: 0,
+            value_stride: 0,
+            x: 8,
+            k_scale: 1.0,
+            v_scale: 1.0,
+        }
+    }
 }
 
 /// Dispatch the reshape_and_cache kernel
@@ -48,9 +70,11 @@ pub fn dispatch_reshape_and_cache(
 ) -> Result<(), String> {
     let state = MetalState::get()?;
 
+    // Determine if using FP8 based on cache dtype
+    let use_fp8 = dtype.is_fp8();
+
     // Get pipeline for this dtype
-    // FORKED: Pass use_fp8=false since we don't support FP8 yet
-    let kernel_name = MetalState::reshape_and_cache_kernel_name(dtype, false);
+    let kernel_name = MetalState::reshape_and_cache_kernel_name(dtype, use_fp8);
     let pipeline = state.get_pipeline(&kernel_name)?;
 
     // Create command buffer and encoder
@@ -67,16 +91,19 @@ pub fn dispatch_reshape_and_cache(
     encoder.set_buffer(3, Some(value_cache), 0);
     encoder.set_buffer(4, Some(slot_mapping), 0);
 
-    // k_scale and v_scale (unused for non-FP8, but must be set)
-    // Create dummy scale buffers with value 1.0
-    let one_f32: f32 = 1.0;
-    let scale_buffer = state.device.new_buffer_with_data(
-        &one_f32 as *const f32 as *const _,
+    // k_scale and v_scale - use params values for FP8
+    let k_scale_buffer = state.device.new_buffer_with_data(
+        &params.k_scale as *const f32 as *const _,
         std::mem::size_of::<f32>() as u64,
         metal::MTLResourceOptions::StorageModeShared,
     );
-    encoder.set_buffer(5, Some(&scale_buffer), 0);
-    encoder.set_buffer(6, Some(&scale_buffer), 0);
+    let v_scale_buffer = state.device.new_buffer_with_data(
+        &params.v_scale as *const f32 as *const _,
+        std::mem::size_of::<f32>() as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+    encoder.set_buffer(5, Some(&k_scale_buffer), 0);
+    encoder.set_buffer(6, Some(&v_scale_buffer), 0);
 
     // Set dimension constants as buffers (Metal kernel expects device buffers)
     let key_stride = params.key_stride;
@@ -87,6 +114,126 @@ pub fn dispatch_reshape_and_cache(
     let x = params.x;
 
     // Create constant buffers
+    let create_const_buffer = |value: i32| {
+        state.device.new_buffer_with_data(
+            &value as *const i32 as *const _,
+            std::mem::size_of::<i32>() as u64,
+            metal::MTLResourceOptions::StorageModeShared,
+        )
+    };
+
+    let key_stride_buf = create_const_buffer(key_stride);
+    let value_stride_buf = create_const_buffer(value_stride);
+    let num_heads_buf = create_const_buffer(num_heads);
+    let head_size_buf = create_const_buffer(head_size);
+    let block_size_buf = create_const_buffer(block_size);
+    let x_buf = create_const_buffer(x);
+
+    encoder.set_buffer(7, Some(&key_stride_buf), 0);
+    encoder.set_buffer(8, Some(&value_stride_buf), 0);
+    encoder.set_buffer(9, Some(&num_heads_buf), 0);
+    encoder.set_buffer(10, Some(&head_size_buf), 0);
+    encoder.set_buffer(11, Some(&block_size_buf), 0);
+    encoder.set_buffer(12, Some(&x_buf), 0);
+
+    // Dispatch: 1 threadgroup per token, 256 threads per threadgroup
+    let threads_per_threadgroup = MTLSize::new(256, 1, 1);
+    let threadgroups = MTLSize::new(params.num_tokens as u64, 1, 1);
+
+    encoder.dispatch_thread_groups(threadgroups, threads_per_threadgroup);
+    encoder.end_encoding();
+
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    Ok(())
+}
+
+/// Raw buffer pointers for reshape_and_cache dispatch
+///
+/// Used when working with MLX arrays where we extract raw Metal buffer pointers.
+#[derive(Debug)]
+pub struct RawBufferInfo {
+    /// Raw MTLBuffer pointer (as void*)
+    pub ptr: *mut c_void,
+    /// Byte offset into the buffer
+    pub offset: usize,
+}
+
+/// Dispatch reshape_and_cache kernel with raw buffer pointers
+///
+/// This variant is used when integrating with MLX arrays, where we extract
+/// raw Metal buffer pointers instead of having owned `Buffer` references.
+///
+/// # Safety
+///
+/// - All buffer pointers must be valid MTLBuffer* pointers
+/// - key and value buffers must have shape [num_tokens, num_heads, head_size]
+/// - key_cache must have shape [num_blocks, num_heads, head_size/x, block_size, x]
+/// - value_cache must have shape [num_blocks, num_heads, head_size, block_size]
+/// - slot_mapping must have num_tokens elements of i64
+/// - All buffers must remain valid until the kernel completes
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn dispatch_reshape_and_cache_raw(
+    key: &RawBufferInfo,
+    value: &RawBufferInfo,
+    key_cache: &Buffer,
+    value_cache: &Buffer,
+    slot_mapping: &RawBufferInfo,
+    params: &ReshapeAndCacheParams,
+    dtype: MetalDtype,
+) -> Result<(), String> {
+    let state = MetalState::get()?;
+
+    // Determine if using FP8 based on cache dtype
+    let use_fp8 = dtype.is_fp8();
+
+    // Get pipeline for this dtype
+    let kernel_name = MetalState::reshape_and_cache_kernel_name(dtype, use_fp8);
+    let pipeline = state.get_pipeline(&kernel_name)?;
+
+    // Create command buffer and encoder
+    let command_queue = state.device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+    let encoder = command_buffer.new_compute_command_encoder();
+
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    // Set buffers - convert raw pointers to BufferRef
+    // SAFETY: Caller guarantees these are valid MTLBuffer* pointers
+    let key_buffer_ref: &BufferRef = unsafe { ForeignTypeRef::from_ptr(key.ptr as *mut _) };
+    let value_buffer_ref: &BufferRef = unsafe { ForeignTypeRef::from_ptr(value.ptr as *mut _) };
+    let slot_buffer_ref: &BufferRef =
+        unsafe { ForeignTypeRef::from_ptr(slot_mapping.ptr as *mut _) };
+
+    encoder.set_buffer(0, Some(key_buffer_ref), key.offset as u64);
+    encoder.set_buffer(1, Some(value_buffer_ref), value.offset as u64);
+    encoder.set_buffer(2, Some(key_cache), 0);
+    encoder.set_buffer(3, Some(value_cache), 0);
+    encoder.set_buffer(4, Some(slot_buffer_ref), slot_mapping.offset as u64);
+
+    // k_scale and v_scale - use params values for FP8
+    let k_scale_buffer = state.device.new_buffer_with_data(
+        &params.k_scale as *const f32 as *const _,
+        std::mem::size_of::<f32>() as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+    let v_scale_buffer = state.device.new_buffer_with_data(
+        &params.v_scale as *const f32 as *const _,
+        std::mem::size_of::<f32>() as u64,
+        metal::MTLResourceOptions::StorageModeShared,
+    );
+    encoder.set_buffer(5, Some(&k_scale_buffer), 0);
+    encoder.set_buffer(6, Some(&v_scale_buffer), 0);
+
+    // Set dimension constants as buffers
+    let key_stride = params.key_stride;
+    let value_stride = params.value_stride;
+    let num_heads = params.num_heads as i32;
+    let head_size = params.head_size as i32;
+    let block_size = params.block_size as i32;
+    let x = params.x;
+
     let create_const_buffer = |value: i32| {
         state.device.new_buffer_with_data(
             &value as *const i32 as *const _,
@@ -136,7 +283,27 @@ mod tests {
             key_stride: 512, // 4 * 128
             value_stride: 512,
             x: 8, // 16 / sizeof(half)
+            k_scale: 1.0,
+            v_scale: 1.0,
         };
         assert_eq!(params.num_tokens, 1);
+    }
+
+    #[test]
+    fn test_fp8_params() {
+        let params = ReshapeAndCacheParams {
+            num_tokens: 1,
+            num_heads: 4,
+            head_size: 128,
+            block_size: 16,
+            key_stride: 512,
+            value_stride: 512,
+            x: 16,         // 16 / sizeof(uchar) for FP8
+            k_scale: 0.5,  // Example FP8 scale
+            v_scale: 0.25, // Example FP8 scale
+        };
+        assert_eq!(params.x, 16);
+        assert_eq!(params.k_scale, 0.5);
+        assert_eq!(params.v_scale, 0.25);
     }
 }

--- a/crates/mlx-paged-attn/src/metal/state.rs
+++ b/crates/mlx-paged-attn/src/metal/state.rs
@@ -183,6 +183,8 @@ pub enum MetalDtype {
     Float32,
     Float16,
     BFloat16,
+    /// FP8 E4M3 format (1 byte per element)
+    UChar,
 }
 
 impl MetalDtype {
@@ -192,6 +194,7 @@ impl MetalDtype {
             MetalDtype::Float32 => "float",
             MetalDtype::Float16 => "half",
             MetalDtype::BFloat16 => "bfloat16_t",
+            MetalDtype::UChar => "uchar",
         }
     }
 
@@ -200,7 +203,13 @@ impl MetalDtype {
         match self {
             MetalDtype::Float32 => 4,
             MetalDtype::Float16 | MetalDtype::BFloat16 => 2,
+            MetalDtype::UChar => 1,
         }
+    }
+
+    /// Check if this is an FP8 type
+    pub fn is_fp8(&self) -> bool {
+        matches!(self, MetalDtype::UChar)
     }
 }
 

--- a/crates/mlx-paged-attn/src/metal/swap_blocks.rs
+++ b/crates/mlx-paged-attn/src/metal/swap_blocks.rs
@@ -1,0 +1,313 @@
+//! swap_blocks - CPU offload support for paged attention
+//!
+//! This module provides infrastructure for swapping KV cache blocks
+//! between GPU and CPU memory when GPU memory is constrained.
+//! Uses Metal blit commands for efficient async copy.
+
+use super::state::MetalState;
+use metal::{Buffer, MTLResourceOptions};
+use std::collections::HashMap;
+
+/// CPU cache for swapped-out blocks
+///
+/// Provides a CPU-side storage for KV cache blocks that have been
+/// swapped out from GPU memory to make room for other sequences.
+pub struct CpuBlockCache {
+    /// CPU buffers for swapped key blocks
+    /// Maps block_id -> (key_buffer, value_buffer)
+    swapped_blocks: HashMap<u32, (Buffer, Buffer)>,
+
+    /// Block size (tokens per block)
+    block_size: u32,
+}
+
+impl CpuBlockCache {
+    /// Create a new CPU block cache
+    ///
+    /// # Arguments
+    /// * `num_kv_heads` - Number of KV heads (unused, kept for API compatibility)
+    /// * `head_size` - Size of each head (unused, kept for API compatibility)
+    /// * `block_size` - Block size (tokens per block)
+    pub fn new(_num_kv_heads: u32, _head_size: u32, block_size: u32) -> Self {
+        Self {
+            swapped_blocks: HashMap::new(),
+            block_size,
+        }
+    }
+
+    /// Check if a block is currently swapped out
+    pub fn is_swapped(&self, block_id: u32) -> bool {
+        self.swapped_blocks.contains_key(&block_id)
+    }
+
+    /// Get the number of swapped blocks
+    pub fn num_swapped(&self) -> usize {
+        self.swapped_blocks.len()
+    }
+
+    /// Get swapped block buffers
+    pub fn get_swapped(&self, block_id: u32) -> Option<(&Buffer, &Buffer)> {
+        self.swapped_blocks.get(&block_id).map(|(k, v)| (k, v))
+    }
+
+    /// Remove a swapped block (after swap-in)
+    pub fn remove_swapped(&mut self, block_id: u32) -> Option<(Buffer, Buffer)> {
+        self.swapped_blocks.remove(&block_id)
+    }
+
+    /// Get block size configuration
+    pub fn block_size(&self) -> u32 {
+        self.block_size
+    }
+}
+
+/// Parameters for swap operations
+#[derive(Debug, Clone)]
+pub struct SwapBlocksParams {
+    /// Number of KV heads
+    pub num_kv_heads: u32,
+    /// Size of each head
+    pub head_size: u32,
+    /// Block size (tokens per block)
+    pub block_size: u32,
+    /// Whether to use FP8 cache (affects element size)
+    pub use_fp8: bool,
+}
+
+impl SwapBlocksParams {
+    /// Get element size in bytes based on dtype
+    fn element_size(&self) -> u64 {
+        if self.use_fp8 { 1 } else { 2 }
+    }
+
+    /// Get x value (16 bytes / element_size) for key cache layout
+    fn x(&self) -> u32 {
+        if self.use_fp8 { 16 } else { 8 }
+    }
+
+    /// Calculate key block offset in bytes
+    pub fn key_block_offset(&self, block_id: u32) -> u64 {
+        let x = self.x();
+        let element_size = self.element_size();
+        let block_elements = self.num_kv_heads as u64
+            * (self.head_size as u64 / x as u64)
+            * self.block_size as u64
+            * x as u64;
+        block_id as u64 * block_elements * element_size
+    }
+
+    /// Calculate value block offset in bytes
+    pub fn value_block_offset(&self, block_id: u32) -> u64 {
+        let element_size = self.element_size();
+        let block_elements =
+            self.num_kv_heads as u64 * self.head_size as u64 * self.block_size as u64;
+        block_id as u64 * block_elements * element_size
+    }
+
+    /// Calculate key block size in bytes
+    pub fn key_block_size(&self) -> u64 {
+        let x = self.x();
+        let element_size = self.element_size();
+        self.num_kv_heads as u64
+            * (self.head_size as u64 / x as u64)
+            * self.block_size as u64
+            * x as u64
+            * element_size
+    }
+
+    /// Calculate value block size in bytes
+    pub fn value_block_size(&self) -> u64 {
+        let element_size = self.element_size();
+        self.num_kv_heads as u64 * self.head_size as u64 * self.block_size as u64 * element_size
+    }
+}
+
+/// Swap blocks from GPU to CPU (swap out)
+///
+/// Copies the specified blocks from GPU key/value caches to CPU memory.
+/// The blocks are stored in the cpu_cache for later swap-in.
+///
+/// # Arguments
+/// * `key_cache` - GPU key cache buffer
+/// * `value_cache` - GPU value cache buffer
+/// * `block_ids` - Block IDs to swap out
+/// * `cpu_cache` - CPU cache to store swapped blocks
+/// * `params` - Swap parameters
+///
+/// # Returns
+/// * Ok(()) on success
+pub fn swap_out(
+    key_cache: &Buffer,
+    value_cache: &Buffer,
+    block_ids: &[u32],
+    cpu_cache: &mut CpuBlockCache,
+    params: &SwapBlocksParams,
+) -> Result<(), String> {
+    if block_ids.is_empty() {
+        return Ok(());
+    }
+
+    let state = MetalState::get()?;
+
+    // Create command buffer for blit operations
+    let command_queue = state.device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+    let blit_encoder = command_buffer.new_blit_command_encoder();
+
+    let key_block_size = params.key_block_size();
+    let value_block_size = params.value_block_size();
+
+    for &block_id in block_ids {
+        if cpu_cache.is_swapped(block_id) {
+            continue; // Already swapped out
+        }
+
+        // Allocate CPU buffers for this block
+        let cpu_key = state
+            .device
+            .new_buffer(key_block_size, MTLResourceOptions::StorageModeShared);
+        let cpu_value = state
+            .device
+            .new_buffer(value_block_size, MTLResourceOptions::StorageModeShared);
+
+        // Copy key block from GPU to CPU
+        let key_offset = params.key_block_offset(block_id);
+        blit_encoder.copy_from_buffer(key_cache, key_offset, &cpu_key, 0, key_block_size);
+
+        // Copy value block from GPU to CPU
+        let value_offset = params.value_block_offset(block_id);
+        blit_encoder.copy_from_buffer(value_cache, value_offset, &cpu_value, 0, value_block_size);
+
+        cpu_cache
+            .swapped_blocks
+            .insert(block_id, (cpu_key, cpu_value));
+    }
+
+    blit_encoder.end_encoding();
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    Ok(())
+}
+
+/// Swap blocks from CPU back to GPU (swap in)
+///
+/// Copies the specified blocks from CPU memory back to GPU key/value caches.
+/// The blocks are removed from the cpu_cache after swap-in.
+///
+/// # Arguments
+/// * `key_cache` - GPU key cache buffer
+/// * `value_cache` - GPU value cache buffer
+/// * `block_ids` - Block IDs to swap in
+/// * `cpu_cache` - CPU cache containing swapped blocks
+/// * `params` - Swap parameters
+///
+/// # Returns
+/// * Ok(()) on success
+pub fn swap_in(
+    key_cache: &Buffer,
+    value_cache: &Buffer,
+    block_ids: &[u32],
+    cpu_cache: &mut CpuBlockCache,
+    params: &SwapBlocksParams,
+) -> Result<(), String> {
+    if block_ids.is_empty() {
+        return Ok(());
+    }
+
+    let state = MetalState::get()?;
+
+    // Create command buffer for blit operations
+    let command_queue = state.device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+    let blit_encoder = command_buffer.new_blit_command_encoder();
+
+    let key_block_size = params.key_block_size();
+    let value_block_size = params.value_block_size();
+
+    for &block_id in block_ids {
+        let (cpu_key, cpu_value) = cpu_cache
+            .get_swapped(block_id)
+            .ok_or_else(|| format!("Block {} not found in CPU cache", block_id))?;
+
+        // Copy key block from CPU to GPU
+        let key_offset = params.key_block_offset(block_id);
+        blit_encoder.copy_from_buffer(cpu_key, 0, key_cache, key_offset, key_block_size);
+
+        // Copy value block from CPU to GPU
+        let value_offset = params.value_block_offset(block_id);
+        blit_encoder.copy_from_buffer(cpu_value, 0, value_cache, value_offset, value_block_size);
+    }
+
+    blit_encoder.end_encoding();
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    // Remove swapped blocks from CPU cache
+    for &block_id in block_ids {
+        cpu_cache.remove_swapped(block_id);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cpu_block_cache() {
+        let cache = CpuBlockCache::new(4, 128, 16);
+        assert_eq!(cache.num_swapped(), 0);
+        assert!(!cache.is_swapped(0));
+    }
+
+    #[test]
+    fn test_swap_params_fp16() {
+        let params = SwapBlocksParams {
+            num_kv_heads: 4,
+            head_size: 128,
+            block_size: 16,
+            use_fp8: false,
+        };
+
+        // Key block size: 4 * (128/8) * 16 * 8 * 2 = 4 * 16 * 16 * 8 * 2 = 16384
+        assert_eq!(params.key_block_size(), 16384);
+
+        // Value block size: 4 * 128 * 16 * 2 = 16384
+        assert_eq!(params.value_block_size(), 16384);
+
+        // Block 0 offset should be 0
+        assert_eq!(params.key_block_offset(0), 0);
+        assert_eq!(params.value_block_offset(0), 0);
+
+        // Block 1 offset
+        assert_eq!(params.key_block_offset(1), 16384);
+        assert_eq!(params.value_block_offset(1), 16384);
+    }
+
+    #[test]
+    fn test_swap_params_fp8() {
+        let params = SwapBlocksParams {
+            num_kv_heads: 4,
+            head_size: 128,
+            block_size: 16,
+            use_fp8: true,
+        };
+
+        // FP8: element_size = 1, x = 16
+        // Key block size: 4 * (128/16) * 16 * 16 * 1 = 4 * 8 * 16 * 16 * 1 = 8192
+        assert_eq!(params.key_block_size(), 8192);
+
+        // Value block size: 4 * 128 * 16 * 1 = 8192
+        assert_eq!(params.value_block_size(), 8192);
+
+        // Block 0 offset should be 0
+        assert_eq!(params.key_block_offset(0), 0);
+        assert_eq!(params.value_block_offset(0), 0);
+
+        // Block 1 offset (half of FP16 due to 1 byte elements)
+        assert_eq!(params.key_block_offset(1), 8192);
+        assert_eq!(params.value_block_offset(1), 8192);
+    }
+}

--- a/crates/mlx-paged-attn/src/paged_kv_cache.rs
+++ b/crates/mlx-paged-attn/src/paged_kv_cache.rs
@@ -45,6 +45,13 @@ pub struct PagedKVCache {
 
     /// Configuration
     config: PagedAttentionConfig,
+
+    /// KV scale manager for FP8 quantization (only used when use_fp8 is enabled)
+    #[cfg(target_os = "macos")]
+    scale_manager: Option<crate::metal::KvScaleManager>,
+
+    /// Token tracker for logical block management
+    token_tracker: crate::token_tracker::TokenTracker,
 }
 
 impl PagedKVCache {
@@ -57,10 +64,26 @@ impl PagedKVCache {
 
         let block_table = BlockTable::new(config.block_size);
 
+        // Create scale manager for FP8 mode
+        #[cfg(target_os = "macos")]
+        let scale_manager = if config.use_fp8() {
+            let mut manager = crate::metal::KvScaleManager::new(config.num_layers);
+            manager.init_default_scales();
+            Some(manager)
+        } else {
+            None
+        };
+
+        // Create token tracker for prefix caching
+        let token_tracker = crate::token_tracker::TokenTracker::new(config.block_size);
+
         Ok(Self {
             block_table,
             engine_manager,
             config,
+            #[cfg(target_os = "macos")]
+            scale_manager,
+            token_tracker,
         })
     }
 
@@ -103,7 +126,7 @@ impl PagedKVCache {
 
     /// Remove a sequence from the cache
     ///
-    /// Frees all blocks associated with the sequence.
+    /// Frees all blocks associated with the sequence and cleans up token tracking data.
     ///
     /// # Arguments
     /// * `seq_id` - Sequence ID to remove
@@ -113,8 +136,11 @@ impl PagedKVCache {
             .remove_sequence(seq_id)
             .ok_or_else(|| format!("Sequence {} not found", seq_id))?;
 
-        // Free all blocks
+        // Free all blocks and clean up token tracking
         for block in table.blocks().iter() {
+            // Clean up token tracking data for this block
+            self.token_tracker.remove_block(block.block_id);
+            // Free the physical block
             self.engine_manager.allocator_mut().free(block.clone());
         }
 
@@ -176,6 +202,253 @@ impl PagedKVCache {
         self.block_table
             .build_block_tables_array(max_blocks_per_seq)
     }
+
+    // ========== FP8 Scale Calibration Methods ==========
+
+    /// Calibrate FP8 scales for a specific layer from observed KV tensors
+    ///
+    /// This computes optimal quantization scales based on the maximum absolute
+    /// values in the key and value tensors. Should be called during a calibration
+    /// pass before FP8 inference.
+    ///
+    /// # Arguments
+    /// * `layer_idx` - Layer index (0 to num_layers-1)
+    /// * `keys` - Key tensor for scale computation
+    /// * `values` - Value tensor for scale computation
+    ///
+    /// # Returns
+    /// * (k_scale, v_scale) tuple on success
+    ///
+    /// # Safety
+    /// The key and value pointers must be valid MLX array handles.
+    #[cfg(target_os = "macos")]
+    pub unsafe fn calibrate_layer_scales(
+        &mut self,
+        layer_idx: u32,
+        keys: *mut mlx_sys::mlx_array,
+        values: *mut mlx_sys::mlx_array,
+    ) -> Result<(f32, f32), String> {
+        let manager = self.scale_manager.as_mut().ok_or_else(|| {
+            "FP8 scale calibration requires use_fp8 to be enabled in config".to_string()
+        })?;
+
+        unsafe { manager.calibrate_layer(layer_idx, keys, values) }
+    }
+
+    /// Update FP8 scales using exponential moving average
+    ///
+    /// This is useful for online calibration during inference. The scale is
+    /// updated as: new_scale = alpha * observed_scale + (1-alpha) * old_scale
+    ///
+    /// # Safety
+    /// The key and value pointers must be valid MLX array handles.
+    #[cfg(target_os = "macos")]
+    pub unsafe fn update_layer_scales_ema(
+        &mut self,
+        layer_idx: u32,
+        keys: *mut mlx_sys::mlx_array,
+        values: *mut mlx_sys::mlx_array,
+    ) -> Result<(f32, f32), String> {
+        let manager = self.scale_manager.as_mut().ok_or_else(|| {
+            "FP8 scale update requires use_fp8 to be enabled in config".to_string()
+        })?;
+
+        unsafe { manager.update_layer_ema(layer_idx, keys, values) }
+    }
+
+    /// Get the FP8 scales for a specific layer
+    ///
+    /// Returns (k_scale, v_scale) for use in kernel dispatch.
+    /// Returns (1.0, 1.0) if FP8 is not enabled or layer not calibrated.
+    #[cfg(target_os = "macos")]
+    pub fn get_layer_scales(&self, layer_idx: u32) -> (f32, f32) {
+        match &self.scale_manager {
+            Some(manager) => (manager.k_scale(layer_idx), manager.v_scale(layer_idx)),
+            None => (1.0, 1.0),
+        }
+    }
+
+    /// Check if FP8 calibration has been performed
+    #[cfg(target_os = "macos")]
+    pub fn is_fp8_calibrated(&self) -> bool {
+        self.scale_manager
+            .as_ref()
+            .map(|m| m.is_calibrated())
+            .unwrap_or(false)
+    }
+
+    /// Get FP8 scale statistics
+    #[cfg(target_os = "macos")]
+    pub fn get_scale_stats(&self) -> Option<crate::metal::KvScaleStats> {
+        self.scale_manager.as_ref().map(|m| m.stats())
+    }
+
+    /// Set FP8 scales directly (useful for loading pre-calibrated values)
+    #[cfg(target_os = "macos")]
+    pub fn set_layer_scales(&mut self, layer_idx: u32, k_scale: f32, v_scale: f32) {
+        if let Some(manager) = &mut self.scale_manager {
+            manager.set_scales(layer_idx, k_scale, v_scale);
+        }
+    }
+
+    /// Load all FP8 scales from vectors (for checkpoint loading)
+    #[cfg(target_os = "macos")]
+    pub fn load_scales(&mut self, k_scales: &[f32], v_scales: &[f32]) {
+        if let Some(manager) = &mut self.scale_manager {
+            manager.load_scales(k_scales, v_scales);
+        }
+    }
+
+    /// Get all FP8 scales as vectors (for checkpoint saving)
+    #[cfg(target_os = "macos")]
+    pub fn get_all_scales(&self) -> Option<(Vec<f32>, Vec<f32>)> {
+        self.scale_manager.as_ref().map(|m| m.get_all_scales())
+    }
+
+    // ========== End FP8 Scale Methods ==========
+
+    // ========== Token Tracking Methods ==========
+
+    /// Track tokens being stored in a block
+    ///
+    /// This should be called when new tokens are added to the cache to enable
+    /// prefix caching and debugging capabilities.
+    ///
+    /// # Arguments
+    /// * `block_id` - Physical block ID
+    /// * `tokens` - Token IDs being stored
+    /// * `start_offset` - Starting position within the block
+    ///
+    /// # Returns
+    /// * Hash of the block's tokens (for prefix cache integration)
+    pub fn track_tokens(&mut self, block_id: u32, tokens: &[u32], start_offset: u32) -> u64 {
+        self.token_tracker
+            .track_tokens(block_id, tokens, start_offset)
+    }
+
+    /// Track tokens for a sequence at the current position
+    ///
+    /// Convenience method that computes block assignments automatically.
+    ///
+    /// # Arguments
+    /// * `seq_id` - Sequence ID
+    /// * `tokens` - Token IDs being added
+    /// * `start_pos` - Starting position in the sequence
+    pub fn track_sequence_tokens(
+        &mut self,
+        seq_id: u32,
+        tokens: &[u32],
+        start_pos: u32,
+    ) -> Result<(), String> {
+        let table = self
+            .block_table
+            .get(seq_id)
+            .ok_or_else(|| format!("Sequence {} not found", seq_id))?;
+
+        let block_size = self.config.block_size;
+        let blocks = table.blocks();
+
+        for (i, &token) in tokens.iter().enumerate() {
+            let pos = start_pos + i as u32;
+            let block_idx = (pos / block_size) as usize;
+            let offset_in_block = pos % block_size;
+
+            if block_idx < blocks.len() {
+                let block_id = blocks[block_idx].block_id;
+                self.token_tracker
+                    .track_tokens(block_id, &[token], offset_in_block);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get tokens stored in a specific block
+    ///
+    /// # Arguments
+    /// * `block_id` - Physical block ID
+    ///
+    /// # Returns
+    /// * Token IDs in the block
+    pub fn get_block_tokens(&self, block_id: u32) -> &[u32] {
+        self.token_tracker.get_block_tokens(block_id)
+    }
+
+    /// Get all tokens for a sequence
+    ///
+    /// # Arguments
+    /// * `seq_id` - Sequence ID
+    ///
+    /// # Returns
+    /// * Vector of all token IDs in the sequence's blocks
+    pub fn get_sequence_tokens(&self, seq_id: u32) -> Result<Vec<u32>, String> {
+        let table = self
+            .block_table
+            .get(seq_id)
+            .ok_or_else(|| format!("Sequence {} not found", seq_id))?;
+
+        let num_tokens = table.num_tokens() as usize;
+        let mut tokens = Vec::with_capacity(num_tokens);
+
+        for block in table.blocks() {
+            let block_tokens = self.token_tracker.get_block_tokens(block.block_id);
+            tokens.extend_from_slice(block_tokens);
+        }
+
+        // Truncate to actual token count (last block may not be full)
+        tokens.truncate(num_tokens);
+
+        Ok(tokens)
+    }
+
+    /// Find blocks matching a token prefix
+    ///
+    /// Searches for cached blocks that contain the given token sequence.
+    /// Useful for prefix caching - reuse KV cache for shared prompts.
+    ///
+    /// # Arguments
+    /// * `tokens` - Token sequence to match
+    ///
+    /// # Returns
+    /// * Vector of (block_id, match_length) for matching blocks
+    pub fn find_prefix_matches(&self, tokens: &[u32]) -> Vec<(u32, u32)> {
+        self.token_tracker.find_prefix_matches(tokens)
+    }
+
+    /// Find the longest matching prefix in the cache
+    ///
+    /// # Arguments
+    /// * `tokens` - Token sequence to match
+    ///
+    /// # Returns
+    /// * (matched_block_ids, total_matched_tokens)
+    pub fn find_longest_prefix(&self, tokens: &[u32]) -> (Vec<u32>, u32) {
+        self.token_tracker.find_longest_prefix(tokens)
+    }
+
+    /// Remove token tracking for a block
+    ///
+    /// Call this when a block is freed.
+    pub fn untrack_block(&mut self, block_id: u32) {
+        self.token_tracker.remove_block(block_id);
+    }
+
+    /// Get token tracking statistics
+    pub fn get_token_tracker_stats(&self) -> crate::token_tracker::TokenTrackerStats {
+        self.token_tracker.stats()
+    }
+
+    /// Get memory usage of token tracker in bytes
+    pub fn get_token_tracker_memory(&self) -> usize {
+        self.token_tracker.memory_usage()
+    }
+
+    /// Check if token tracking is enabled
+    pub fn is_token_tracking_enabled(&self) -> bool {
+        self.token_tracker.is_enabled()
+    }
+
+    // ========== End Token Tracking Methods ==========
 
     /// Extend a sequence with additional tokens
     /// Allocates new blocks if needed
@@ -345,9 +618,1023 @@ impl PagedKVCache {
         }
     }
 
-    // TODO: Implement Metal kernel integration
-    // - update() - calls reshape_and_cache kernel
-    // - attention() - calls paged_attention kernel
+    /// Get the configuration
+    pub fn config(&self) -> &PagedAttentionConfig {
+        &self.config
+    }
+
+    /// Get access to the engine manager (for PagedAttentionLayer)
+    pub fn engine_manager(&self) -> &CacheEngineManager {
+        &self.engine_manager
+    }
+
+    /// Build PagedAttentionInputMetadata for a batch of sequences
+    ///
+    /// This creates all the metadata needed for paged attention operations:
+    /// block tables, context lengths, slot mappings, etc.
+    ///
+    /// # Arguments
+    /// * `seq_ids` - Sequence IDs in the batch
+    /// * `input_lens` - Number of input tokens per sequence (prompt len for prefill, 1 for decode)
+    /// * `is_prefill` - Whether each sequence is in prefill phase
+    ///
+    /// # Returns
+    /// * `PagedAttentionInputMetadata` ready for use with PagedAttentionLayer
+    pub fn build_input_metadata(
+        &self,
+        seq_ids: &[u32],
+        input_lens: &[u32],
+        is_prefill: &[bool],
+    ) -> Result<crate::input_metadata::PagedAttentionInputMetadata, String> {
+        use crate::input_metadata::PagedAttentionInputMetadata;
+
+        // Get context lengths
+        let context_lens: Vec<i32> = seq_ids
+            .iter()
+            .map(|&id| {
+                self.block_table
+                    .get(id)
+                    .map(|t| t.num_tokens() as i32)
+                    .unwrap_or(0)
+            })
+            .collect();
+
+        let max_context_len = context_lens.iter().copied().max().unwrap_or(0) as u32;
+
+        // Build slot mappings
+        let slot_mappings = self.get_slot_mapping_batch(
+            seq_ids,
+            &context_lens.iter().map(|&x| x as u32).collect::<Vec<_>>(),
+            is_prefill,
+            input_lens,
+        )?;
+
+        // Build block tables
+        let block_tables = self.build_block_tables_batch(seq_ids)?;
+        let max_blocks_per_seq = self.get_max_blocks_per_seq() as usize;
+
+        // Flatten block tables
+        let mut flat_block_tables: Vec<i32> =
+            Vec::with_capacity(seq_ids.len() * max_blocks_per_seq);
+        for table in &block_tables {
+            for &block_id in table {
+                flat_block_tables.push(block_id as i32);
+            }
+            // Pad to max_blocks_per_seq
+            let pad_count = max_blocks_per_seq - table.len();
+            flat_block_tables.extend(std::iter::repeat_n(0i32, pad_count));
+        }
+
+        // Determine if this is a prefill batch (all sequences in prefill)
+        let batch_is_prefill = is_prefill.iter().all(|&p| p);
+
+        Ok(PagedAttentionInputMetadata::new(
+            flat_block_tables,
+            context_lens,
+            slot_mappings,
+            max_context_len,
+            batch_is_prefill,
+            max_blocks_per_seq as u32,
+        ))
+    }
+
+    /// Build input metadata for decode-only (simplified API)
+    ///
+    /// All sequences are assumed to be in decode phase (1 new token each).
+    pub fn build_decode_metadata(
+        &self,
+        seq_ids: &[u32],
+    ) -> Result<crate::input_metadata::PagedAttentionInputMetadata, String> {
+        let input_lens = vec![1u32; seq_ids.len()];
+        let is_prefill = vec![false; seq_ids.len()];
+        self.build_input_metadata(seq_ids, &input_lens, &is_prefill)
+    }
+
+    /// Build input metadata for prefill (simplified API)
+    ///
+    /// All sequences are assumed to be in prefill phase.
+    pub fn build_prefill_metadata(
+        &self,
+        seq_ids: &[u32],
+        prompt_lens: &[u32],
+    ) -> Result<crate::input_metadata::PagedAttentionInputMetadata, String> {
+        let is_prefill = vec![true; seq_ids.len()];
+        self.build_input_metadata(seq_ids, prompt_lens, &is_prefill)
+    }
+
+    /// Initialize the GPU cache buffers
+    ///
+    /// Must be called before using update() or attention().
+    /// This allocates GPU memory for all layers' KV caches.
+    #[cfg(target_os = "macos")]
+    pub fn initialize(&mut self) -> Result<(), String> {
+        self.engine_manager.initialize()
+    }
+
+    /// Update the KV cache with new keys and values
+    ///
+    /// This is the core operation that writes new K/V pairs into the paged cache.
+    /// Uses the `reshape_and_cache` Metal kernel for GPU-accelerated updates.
+    ///
+    /// # Arguments
+    /// * `layer_idx` - The transformer layer index (0 to num_layers-1)
+    /// * `keys` - MLX array handle for keys [num_tokens, num_kv_heads, head_size]
+    /// * `values` - MLX array handle for values [num_tokens, num_kv_heads, head_size]
+    /// * `slot_mapping` - Slot indices for each token [num_tokens], i64
+    ///
+    /// # Safety
+    /// - keys, values, slot_mapping must be valid MLX array pointers
+    /// - Arrays must remain valid until this function returns
+    /// - Cache must be initialized via initialize() before calling
+    #[cfg(target_os = "macos")]
+    pub unsafe fn update(
+        &self,
+        layer_idx: u32,
+        keys: *mut mlx_sys::mlx_array,
+        values: *mut mlx_sys::mlx_array,
+        slot_mapping: *mut mlx_sys::mlx_array,
+    ) -> Result<(), String> {
+        use crate::metal::{
+            MetalDtype, MlxMetalBuffer, RawBufferInfo, ReshapeAndCacheParams,
+            dispatch_reshape_and_cache_raw, is_metal_extraction_supported, synchronize_mlx,
+        };
+
+        // Check Metal availability
+        if !is_metal_extraction_supported() {
+            return Err("Metal GPU not available".to_string());
+        }
+
+        // Get the cache engine for this layer
+        let engine = self
+            .engine_manager
+            .get_engine(layer_idx)
+            .ok_or_else(|| format!("Layer {} not found", layer_idx))?;
+
+        if !engine.is_initialized() {
+            return Err(format!(
+                "Layer {} cache not initialized. Call initialize() first.",
+                layer_idx
+            ));
+        }
+
+        let key_cache = engine
+            .key_cache()
+            .ok_or_else(|| "Key cache buffer not initialized".to_string())?;
+        let value_cache = engine
+            .value_cache()
+            .ok_or_else(|| "Value cache buffer not initialized".to_string())?;
+
+        // Synchronize MLX to ensure all operations are complete
+        synchronize_mlx();
+
+        // Extract Metal buffer info from MLX arrays
+        // SAFETY: Caller guarantees these are valid MLX array pointers
+        let key_info = unsafe { MlxMetalBuffer::from_mlx_array(keys) }
+            .ok_or_else(|| "Failed to extract Metal buffer from keys".to_string())?;
+        let value_info = unsafe { MlxMetalBuffer::from_mlx_array(values) }
+            .ok_or_else(|| "Failed to extract Metal buffer from values".to_string())?;
+        let slot_info = unsafe { MlxMetalBuffer::from_mlx_array(slot_mapping) }
+            .ok_or_else(|| "Failed to extract Metal buffer from slot_mapping".to_string())?;
+
+        // Calculate number of tokens from the key array
+        let num_tokens = key_info.data_size
+            / (self.config.num_kv_heads as usize * self.config.head_size as usize);
+
+        // Prepare kernel parameters
+        // x = 16 / sizeof(dtype): 8 for FP16, 16 for FP8
+        let use_fp8 = self.config.use_fp8();
+        let x = if use_fp8 { 16i32 } else { 8i32 };
+        let stride = (self.config.num_kv_heads * self.config.head_size) as i32;
+
+        // Get FP8 scales from scale_manager if enabled
+        let (k_scale, v_scale) = if use_fp8 {
+            self.scale_manager
+                .as_ref()
+                .map(|sm| (sm.k_scale(layer_idx), sm.v_scale(layer_idx)))
+                .unwrap_or((1.0, 1.0))
+        } else {
+            (1.0, 1.0)
+        };
+
+        let params = ReshapeAndCacheParams {
+            num_tokens: num_tokens as u32,
+            num_heads: self.config.num_kv_heads,
+            head_size: self.config.head_size,
+            block_size: self.config.block_size,
+            key_stride: stride,
+            value_stride: stride,
+            x,
+            k_scale,
+            v_scale,
+        };
+
+        // Prepare raw buffer info
+        let key_raw = RawBufferInfo {
+            ptr: key_info.buffer_ptr,
+            offset: key_info.offset,
+        };
+        let value_raw = RawBufferInfo {
+            ptr: value_info.buffer_ptr,
+            offset: value_info.offset,
+        };
+        let slot_raw = RawBufferInfo {
+            ptr: slot_info.buffer_ptr,
+            offset: slot_info.offset,
+        };
+
+        // Determine dtype based on FP8 mode
+        let dtype = if use_fp8 {
+            MetalDtype::UChar
+        } else {
+            MetalDtype::Float16
+        };
+
+        // Dispatch the kernel
+        // SAFETY: Buffer pointers are valid (extracted from MLX arrays above)
+        unsafe {
+            dispatch_reshape_and_cache_raw(
+                &key_raw,
+                &value_raw,
+                key_cache,
+                value_cache,
+                &slot_raw,
+                &params,
+                dtype,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Update the KV cache using slot mapping slice (convenience method)
+    ///
+    /// This variant creates the slot_mapping MLX array internally from a Rust slice.
+    ///
+    /// # Arguments
+    /// * `layer_idx` - The transformer layer index
+    /// * `keys` - MLX array handle for keys [num_tokens, num_kv_heads, head_size]
+    /// * `values` - MLX array handle for values [num_tokens, num_kv_heads, head_size]
+    /// * `slot_mapping` - Slot indices as a Rust slice
+    ///
+    /// # Safety
+    /// - `keys` and `values` must be valid MLX array pointers
+    /// - Arrays must remain valid until this function returns
+    /// - Cache must be initialized via `initialize()` before calling
+    #[cfg(target_os = "macos")]
+    pub unsafe fn update_with_slots(
+        &self,
+        layer_idx: u32,
+        keys: *mut mlx_sys::mlx_array,
+        values: *mut mlx_sys::mlx_array,
+        slot_mapping: &[i64],
+    ) -> Result<(), String> {
+        use crate::metal::{
+            MetalDtype, MetalState, MlxMetalBuffer, RawBufferInfo, ReshapeAndCacheParams,
+            dispatch_reshape_and_cache_raw, is_metal_extraction_supported, synchronize_mlx,
+        };
+        use metal::MTLResourceOptions;
+
+        // Check Metal availability
+        if !is_metal_extraction_supported() {
+            return Err("Metal GPU not available".to_string());
+        }
+
+        // Get the cache engine for this layer
+        let engine = self
+            .engine_manager
+            .get_engine(layer_idx)
+            .ok_or_else(|| format!("Layer {} not found", layer_idx))?;
+
+        if !engine.is_initialized() {
+            return Err(format!(
+                "Layer {} cache not initialized. Call initialize() first.",
+                layer_idx
+            ));
+        }
+
+        let key_cache = engine
+            .key_cache()
+            .ok_or_else(|| "Key cache buffer not initialized".to_string())?;
+        let value_cache = engine
+            .value_cache()
+            .ok_or_else(|| "Value cache buffer not initialized".to_string())?;
+
+        // Synchronize MLX
+        synchronize_mlx();
+
+        // Extract Metal buffer info from MLX arrays
+        // SAFETY: Caller guarantees these are valid MLX array pointers
+        let key_info = unsafe { MlxMetalBuffer::from_mlx_array(keys) }
+            .ok_or_else(|| "Failed to extract Metal buffer from keys".to_string())?;
+        let value_info = unsafe { MlxMetalBuffer::from_mlx_array(values) }
+            .ok_or_else(|| "Failed to extract Metal buffer from values".to_string())?;
+
+        // Create slot_mapping Metal buffer from slice
+        let state = MetalState::get()?;
+        let slot_buffer = state.device.new_buffer_with_data(
+            slot_mapping.as_ptr() as *const _,
+            std::mem::size_of_val(slot_mapping) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        let num_tokens = slot_mapping.len();
+
+        // Prepare kernel parameters
+        // x = 16 / sizeof(dtype): 8 for FP16, 16 for FP8
+        let use_fp8 = self.config.use_fp8();
+        let x = if use_fp8 { 16i32 } else { 8i32 };
+        let stride = (self.config.num_kv_heads * self.config.head_size) as i32;
+
+        // Get FP8 scales from scale_manager if enabled
+        let (k_scale, v_scale) = if use_fp8 {
+            self.scale_manager
+                .as_ref()
+                .map(|sm| (sm.k_scale(layer_idx), sm.v_scale(layer_idx)))
+                .unwrap_or((1.0, 1.0))
+        } else {
+            (1.0, 1.0)
+        };
+
+        let params = ReshapeAndCacheParams {
+            num_tokens: num_tokens as u32,
+            num_heads: self.config.num_kv_heads,
+            head_size: self.config.head_size,
+            block_size: self.config.block_size,
+            key_stride: stride,
+            value_stride: stride,
+            x,
+            k_scale,
+            v_scale,
+        };
+
+        // Prepare raw buffer info
+        let key_raw = RawBufferInfo {
+            ptr: key_info.buffer_ptr,
+            offset: key_info.offset,
+        };
+        let value_raw = RawBufferInfo {
+            ptr: value_info.buffer_ptr,
+            offset: value_info.offset,
+        };
+
+        // For slot buffer, we need to get the raw pointer
+        use metal::foreign_types::ForeignType;
+        let slot_raw = RawBufferInfo {
+            ptr: slot_buffer.as_ptr() as *mut _,
+            offset: 0,
+        };
+
+        // Determine dtype based on FP8 mode
+        let dtype = if use_fp8 {
+            MetalDtype::UChar
+        } else {
+            MetalDtype::Float16
+        };
+
+        // Dispatch the kernel
+        // SAFETY: Buffer pointers are valid (extracted from MLX arrays and created above)
+        unsafe {
+            dispatch_reshape_and_cache_raw(
+                &key_raw,
+                &value_raw,
+                key_cache,
+                value_cache,
+                &slot_raw,
+                &params,
+                dtype,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Run paged attention forward pass
+    ///
+    /// Computes attention using the paged KV cache. Automatically selects V1 or V2
+    /// kernel based on the maximum context length.
+    ///
+    /// # Arguments
+    /// * `layer_idx` - The transformer layer index (0 to num_layers-1)
+    /// * `queries` - MLX array handle for queries [num_seqs, num_heads, head_size]
+    /// * `seq_ids` - Sequence IDs in the batch
+    /// * `num_query_heads` - Number of query heads (for GQA, >= num_kv_heads)
+    /// * `scale` - Attention scale factor (typically 1/sqrt(head_size))
+    ///
+    /// # Returns
+    /// * `PagedAttentionOutput` containing the output buffer and metadata
+    ///
+    /// # Safety
+    /// - queries must be a valid MLX array pointer
+    /// - Cache must be initialized via initialize() before calling
+    /// - All seq_ids must be valid (added via add_sequence)
+    #[cfg(target_os = "macos")]
+    pub unsafe fn attention(
+        &self,
+        layer_idx: u32,
+        queries: *mut mlx_sys::mlx_array,
+        seq_ids: &[u32],
+        num_query_heads: u32,
+        scale: f32,
+    ) -> Result<crate::metal::PagedAttentionOutput, String> {
+        use crate::metal::{
+            MetalDtype, MetalState, MlxMetalBuffer, PagedAttentionParams, RawBufferInfo,
+            dispatch_paged_attention_auto, is_metal_extraction_supported, synchronize_mlx,
+        };
+        use metal::MTLResourceOptions;
+
+        // Check Metal availability
+        if !is_metal_extraction_supported() {
+            return Err("Metal GPU not available".to_string());
+        }
+
+        // Get the cache engine for this layer
+        let engine = self
+            .engine_manager
+            .get_engine(layer_idx)
+            .ok_or_else(|| format!("Layer {} not found", layer_idx))?;
+
+        if !engine.is_initialized() {
+            return Err(format!(
+                "Layer {} cache not initialized. Call initialize() first.",
+                layer_idx
+            ));
+        }
+
+        let key_cache = engine
+            .key_cache()
+            .ok_or_else(|| "Key cache buffer not initialized".to_string())?;
+        let value_cache = engine
+            .value_cache()
+            .ok_or_else(|| "Value cache buffer not initialized".to_string())?;
+
+        // Synchronize MLX
+        synchronize_mlx();
+
+        // Extract query buffer
+        let query_info = unsafe { MlxMetalBuffer::from_mlx_array(queries) }
+            .ok_or_else(|| "Failed to extract Metal buffer from queries".to_string())?;
+
+        // Get context lengths for the batch
+        let context_lens: Vec<u32> = seq_ids
+            .iter()
+            .map(|&id| {
+                self.block_table
+                    .get(id)
+                    .map(|t| t.num_tokens())
+                    .unwrap_or(0)
+            })
+            .collect();
+
+        let max_context_len = context_lens.iter().copied().max().unwrap_or(0);
+
+        // Build block tables for the batch
+        let block_tables = self.build_block_tables_batch(seq_ids)?;
+        let max_blocks_per_seq = self.get_max_blocks_per_seq() as usize;
+
+        // Flatten block tables into 2D array [num_seqs, max_blocks_per_seq]
+        let mut flat_block_tables: Vec<i32> =
+            Vec::with_capacity(seq_ids.len() * max_blocks_per_seq);
+        for table in &block_tables {
+            for &block_id in table {
+                flat_block_tables.push(block_id as i32);
+            }
+            // Pad to max_blocks_per_seq
+            let pad_count = max_blocks_per_seq - table.len();
+            flat_block_tables.extend(std::iter::repeat_n(0i32, pad_count));
+        }
+
+        // Convert context_lens to i32
+        let context_lens_i32: Vec<i32> = context_lens.iter().map(|&x| x as i32).collect();
+
+        // Create Metal buffers for block_tables and context_lens
+        let state = MetalState::get()?;
+
+        let block_tables_buffer = state.device.new_buffer_with_data(
+            flat_block_tables.as_ptr() as *const _,
+            (flat_block_tables.len() * std::mem::size_of::<i32>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        let context_lens_buffer = state.device.new_buffer_with_data(
+            context_lens_i32.as_ptr() as *const _,
+            (context_lens_i32.len() * std::mem::size_of::<i32>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        // Calculate strides for kernel
+        let num_seqs = seq_ids.len() as u32;
+        let q_stride = (num_query_heads * self.config.head_size) as i32;
+
+        // KV cache layout: [num_blocks, num_kv_heads, head_size/x, block_size, x] for keys
+        // kv_block_stride = num_kv_heads * head_size * block_size (elements per block per layer)
+        // x = 16 / sizeof(half) = 8 for FP16
+        let kv_block_stride =
+            (self.config.num_kv_heads * self.config.head_size * self.config.block_size) as i32;
+        let kv_head_stride = (self.config.head_size * self.config.block_size) as i32;
+
+        // Get FP8 scales from scale_manager if enabled
+        let use_fp8 = self.config.use_fp8();
+        let (k_scale, v_scale) = if use_fp8 {
+            self.scale_manager
+                .as_ref()
+                .map(|sm| (sm.k_scale(layer_idx), sm.v_scale(layer_idx)))
+                .unwrap_or((1.0, 1.0))
+        } else {
+            (1.0, 1.0)
+        };
+
+        let params = PagedAttentionParams {
+            num_seqs,
+            num_heads: num_query_heads,
+            num_kv_heads: self.config.num_kv_heads,
+            head_size: self.config.head_size,
+            block_size: self.config.block_size,
+            max_seq_len: max_context_len,
+            max_num_blocks_per_seq: max_blocks_per_seq as u32,
+            scale,
+            softcapping: 1.0, // No softcapping
+            q_stride,
+            kv_block_stride,
+            kv_head_stride,
+            k_scale,
+            v_scale,
+        };
+
+        let query_raw = RawBufferInfo {
+            ptr: query_info.buffer_ptr,
+            offset: query_info.offset,
+        };
+
+        // Determine dtype based on config
+        let dtype = if self.config.use_fp8() {
+            MetalDtype::UChar
+        } else {
+            MetalDtype::Float16
+        };
+
+        // Dispatch the kernel
+        let output = unsafe {
+            dispatch_paged_attention_auto(
+                &query_raw,
+                key_cache,
+                value_cache,
+                &block_tables_buffer,
+                &context_lens_buffer,
+                max_context_len,
+                &params,
+                dtype,
+            )?
+        };
+
+        Ok(output)
+    }
+
+    /// Run paged attention with explicit context lengths (convenience method)
+    ///
+    /// Use this when you already have context lengths computed.
+    ///
+    /// # Safety
+    /// - `queries` must be a valid MLX array pointer
+    /// - Cache must be initialized via `initialize()` before calling
+    /// - All `seq_ids` must be valid (added via `add_sequence`)
+    #[cfg(target_os = "macos")]
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn attention_with_context(
+        &self,
+        layer_idx: u32,
+        queries: *mut mlx_sys::mlx_array,
+        seq_ids: &[u32],
+        context_lens: &[u32],
+        num_query_heads: u32,
+        scale: f32,
+    ) -> Result<crate::metal::PagedAttentionOutput, String> {
+        use crate::metal::{
+            MetalDtype, MetalState, MlxMetalBuffer, PagedAttentionParams, RawBufferInfo,
+            dispatch_paged_attention_auto, is_metal_extraction_supported, synchronize_mlx,
+        };
+        use metal::MTLResourceOptions;
+
+        // Check Metal availability
+        if !is_metal_extraction_supported() {
+            return Err("Metal GPU not available".to_string());
+        }
+
+        // Get the cache engine for this layer
+        let engine = self
+            .engine_manager
+            .get_engine(layer_idx)
+            .ok_or_else(|| format!("Layer {} not found", layer_idx))?;
+
+        if !engine.is_initialized() {
+            return Err(format!(
+                "Layer {} cache not initialized. Call initialize() first.",
+                layer_idx
+            ));
+        }
+
+        let key_cache = engine
+            .key_cache()
+            .ok_or_else(|| "Key cache buffer not initialized".to_string())?;
+        let value_cache = engine
+            .value_cache()
+            .ok_or_else(|| "Value cache buffer not initialized".to_string())?;
+
+        // Synchronize MLX
+        synchronize_mlx();
+
+        // Extract query buffer
+        let query_info = unsafe { MlxMetalBuffer::from_mlx_array(queries) }
+            .ok_or_else(|| "Failed to extract Metal buffer from queries".to_string())?;
+
+        let max_context_len = context_lens.iter().copied().max().unwrap_or(0);
+
+        // Build block tables for the batch
+        let block_tables = self.build_block_tables_batch(seq_ids)?;
+        let max_blocks_per_seq = self.get_max_blocks_per_seq() as usize;
+
+        // Flatten block tables
+        let mut flat_block_tables: Vec<i32> =
+            Vec::with_capacity(seq_ids.len() * max_blocks_per_seq);
+        for table in &block_tables {
+            for &block_id in table {
+                flat_block_tables.push(block_id as i32);
+            }
+            let pad_count = max_blocks_per_seq - table.len();
+            flat_block_tables.extend(std::iter::repeat_n(0i32, pad_count));
+        }
+
+        let context_lens_i32: Vec<i32> = context_lens.iter().map(|&x| x as i32).collect();
+
+        // Create Metal buffers
+        let state = MetalState::get()?;
+
+        let block_tables_buffer = state.device.new_buffer_with_data(
+            flat_block_tables.as_ptr() as *const _,
+            (flat_block_tables.len() * std::mem::size_of::<i32>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        let context_lens_buffer = state.device.new_buffer_with_data(
+            context_lens_i32.as_ptr() as *const _,
+            (context_lens_i32.len() * std::mem::size_of::<i32>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        // Calculate strides
+        let num_seqs = seq_ids.len() as u32;
+        let q_stride = (num_query_heads * self.config.head_size) as i32;
+        let kv_block_stride =
+            (self.config.num_kv_heads * self.config.head_size * self.config.block_size) as i32;
+        let kv_head_stride = (self.config.head_size * self.config.block_size) as i32;
+
+        // Get FP8 scales from scale_manager if enabled
+        let use_fp8 = self.config.use_fp8();
+        let (k_scale, v_scale) = if use_fp8 {
+            self.scale_manager
+                .as_ref()
+                .map(|sm| (sm.k_scale(layer_idx), sm.v_scale(layer_idx)))
+                .unwrap_or((1.0, 1.0))
+        } else {
+            (1.0, 1.0)
+        };
+
+        let params = PagedAttentionParams {
+            num_seqs,
+            num_heads: num_query_heads,
+            num_kv_heads: self.config.num_kv_heads,
+            head_size: self.config.head_size,
+            block_size: self.config.block_size,
+            max_seq_len: max_context_len,
+            max_num_blocks_per_seq: max_blocks_per_seq as u32,
+            scale,
+            softcapping: 1.0,
+            q_stride,
+            kv_block_stride,
+            kv_head_stride,
+            k_scale,
+            v_scale,
+        };
+
+        let query_raw = RawBufferInfo {
+            ptr: query_info.buffer_ptr,
+            offset: query_info.offset,
+        };
+
+        // Determine dtype based on config
+        let dtype = if self.config.use_fp8() {
+            MetalDtype::UChar
+        } else {
+            MetalDtype::Float16
+        };
+
+        let output = unsafe {
+            dispatch_paged_attention_auto(
+                &query_raw,
+                key_cache,
+                value_cache,
+                &block_tables_buffer,
+                &context_lens_buffer,
+                max_context_len,
+                &params,
+                dtype,
+            )?
+        };
+
+        Ok(output)
+    }
+
+    /// Copy blocks for copy-on-write semantics (used in beam search)
+    ///
+    /// Copies data from source blocks to destination blocks using the Metal
+    /// copy_blocks kernel. This is used during beam search when a sequence
+    /// branches and we need to make independent copies of shared blocks.
+    ///
+    /// # Arguments
+    /// * `layer_idx` - Layer index to copy blocks for
+    /// * `block_mapping` - Pairs of (src_block_id, dst_block_id)
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// // Copy block 5 to block 10, and block 6 to block 11
+    /// cache.copy_blocks(0, &[(5, 10), (6, 11)])?;
+    /// ```
+    #[cfg(target_os = "macos")]
+    pub fn copy_blocks(&self, layer_idx: u32, block_mapping: &[(u32, u32)]) -> Result<(), String> {
+        use crate::metal::{CopyBlocksParams, MetalDtype, MetalState, dispatch_copy_blocks};
+        use metal::MTLResourceOptions;
+
+        if block_mapping.is_empty() {
+            return Ok(());
+        }
+
+        let engine = self
+            .engine_manager
+            .get_engine(layer_idx)
+            .ok_or_else(|| format!("Layer {} not found", layer_idx))?;
+
+        if !engine.is_initialized() {
+            return Err(format!("Layer {} cache not initialized", layer_idx));
+        }
+
+        let key_cache = engine
+            .key_cache()
+            .ok_or_else(|| "Key cache not initialized".to_string())?;
+        let value_cache = engine
+            .value_cache()
+            .ok_or_else(|| "Value cache not initialized".to_string())?;
+
+        // Create block mapping buffer (flattened pairs as i64)
+        let state = MetalState::get()?;
+        let mapping_flat: Vec<i64> = block_mapping
+            .iter()
+            .flat_map(|(src, dst)| [*src as i64, *dst as i64])
+            .collect();
+
+        let mapping_buffer = state.device.new_buffer_with_data(
+            mapping_flat.as_ptr() as *const _,
+            (mapping_flat.len() * std::mem::size_of::<i64>()) as u64,
+            MTLResourceOptions::StorageModeShared,
+        );
+
+        let params = CopyBlocksParams::from_config(
+            block_mapping.len() as u32,
+            self.config.num_kv_heads,
+            self.config.head_size,
+            self.config.block_size,
+        );
+
+        // Determine dtype based on FP8 config
+        let dtype = if self.config.use_fp8() {
+            MetalDtype::UChar
+        } else {
+            MetalDtype::Float16
+        };
+
+        dispatch_copy_blocks(key_cache, value_cache, &mapping_buffer, &params, dtype)
+    }
+
+    /// Fork a sequence for beam search
+    ///
+    /// Creates a new sequence that shares all blocks with the parent sequence.
+    /// When either sequence is modified, copy-on-write semantics are used to
+    /// create independent copies of modified blocks.
+    ///
+    /// # Arguments
+    /// * `parent_seq_id` - Sequence ID to fork from
+    ///
+    /// # Returns
+    /// * New sequence ID for the forked sequence
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// // During beam search, fork the best sequence
+    /// let beam1_id = cache.fork_sequence(parent_id)?;
+    /// let beam2_id = cache.fork_sequence(parent_id)?;
+    /// ```
+    pub fn fork_sequence(&mut self, parent_seq_id: u32) -> Result<u32, String> {
+        // Get parent's block info - extract data before mutating
+        let (parent_blocks, parent_tokens) = {
+            let parent_table = self
+                .block_table
+                .get(parent_seq_id)
+                .ok_or_else(|| format!("Parent sequence {} not found", parent_seq_id))?;
+
+            (parent_table.blocks().to_vec(), parent_table.num_tokens())
+        };
+
+        // Create new sequence
+        let child_id = self.block_table.add_sequence();
+
+        // Share all blocks (increment reference counts)
+        let child_table = self.block_table.get_mut(child_id).unwrap();
+        for block in parent_blocks.iter() {
+            block.incref();
+            child_table.add_block(block.clone());
+        }
+        child_table.set_num_tokens(parent_tokens);
+
+        Ok(child_id)
+    }
+
+    /// Handle copy-on-write for a sequence before writing to a block
+    ///
+    /// If the block at the given position is shared, allocates a new block
+    /// and copies the data. Returns the block mapping for the Metal kernel.
+    ///
+    /// # Arguments
+    /// * `seq_id` - Sequence ID
+    /// * `layer_idx` - Layer to copy
+    /// * `block_idx` - Index of block in the sequence's block table
+    ///
+    /// # Returns
+    /// * Some((src_block_id, dst_block_id)) if copy was needed
+    /// * None if the block is not shared
+    #[cfg(target_os = "macos")]
+    pub fn handle_cow(
+        &mut self,
+        seq_id: u32,
+        layer_idx: u32,
+        block_idx: usize,
+    ) -> Result<Option<(u32, u32)>, String> {
+        // Check if block is shared
+        let table = self
+            .block_table
+            .get(seq_id)
+            .ok_or_else(|| format!("Sequence {} not found", seq_id))?;
+
+        let blocks = table.blocks();
+        if block_idx >= blocks.len() {
+            return Err(format!("Block index {} out of range", block_idx));
+        }
+
+        let block = &blocks[block_idx];
+        if !block.is_shared() {
+            return Ok(None);
+        }
+
+        // Block is shared, need to copy
+        let src_block_id = block.block_id;
+
+        // Allocate new block via copy_on_write
+        let new_block = self
+            .engine_manager
+            .allocator_mut()
+            .copy_on_write(block)
+            .ok_or_else(|| "Failed to allocate block for copy-on-write".to_string())?;
+
+        let dst_block_id = new_block.block_id;
+
+        // Copy the data using Metal kernel
+        self.copy_blocks(layer_idx, &[(src_block_id, dst_block_id)])?;
+
+        // Update block table with new block
+        let table = self.block_table.get_mut(seq_id).unwrap();
+        table.replace_block(block_idx, new_block);
+
+        Ok(Some((src_block_id, dst_block_id)))
+    }
+
+    /// Swap blocks out to CPU memory
+    ///
+    /// Copies the specified blocks from GPU to CPU memory to free up
+    /// GPU memory for other sequences. The blocks can be swapped back
+    /// in later with `swap_in`.
+    ///
+    /// # Arguments
+    /// * `layer_idx` - Layer to swap blocks from
+    /// * `block_ids` - Block IDs to swap out
+    /// * `cpu_cache` - CPU cache to store swapped blocks
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// // Swap out blocks 10, 11, 12 from layer 0
+    /// cache.swap_out(0, &[10, 11, 12], &mut cpu_cache)?;
+    /// ```
+    #[cfg(target_os = "macos")]
+    pub fn swap_out(
+        &self,
+        layer_idx: u32,
+        block_ids: &[u32],
+        cpu_cache: &mut crate::metal::CpuBlockCache,
+    ) -> Result<(), String> {
+        use crate::metal::{SwapBlocksParams, swap_out as metal_swap_out};
+
+        if block_ids.is_empty() {
+            return Ok(());
+        }
+
+        let engine = self
+            .engine_manager
+            .get_engine(layer_idx)
+            .ok_or_else(|| format!("Layer {} not found", layer_idx))?;
+
+        if !engine.is_initialized() {
+            return Err(format!("Layer {} cache not initialized", layer_idx));
+        }
+
+        let key_cache = engine
+            .key_cache()
+            .ok_or_else(|| "Key cache not initialized".to_string())?;
+        let value_cache = engine
+            .value_cache()
+            .ok_or_else(|| "Value cache not initialized".to_string())?;
+
+        let params = SwapBlocksParams {
+            num_kv_heads: self.config.num_kv_heads,
+            head_size: self.config.head_size,
+            block_size: self.config.block_size,
+            use_fp8: self.config.use_fp8(),
+        };
+
+        metal_swap_out(key_cache, value_cache, block_ids, cpu_cache, &params)
+    }
+
+    /// Swap blocks back in from CPU memory
+    ///
+    /// Copies the specified blocks from CPU back to GPU memory.
+    /// The blocks are removed from the cpu_cache after swap-in.
+    ///
+    /// # Arguments
+    /// * `layer_idx` - Layer to swap blocks into
+    /// * `block_ids` - Block IDs to swap in
+    /// * `cpu_cache` - CPU cache containing swapped blocks
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// // Swap in blocks 10, 11, 12 to layer 0
+    /// cache.swap_in(0, &[10, 11, 12], &mut cpu_cache)?;
+    /// ```
+    #[cfg(target_os = "macos")]
+    pub fn swap_in(
+        &self,
+        layer_idx: u32,
+        block_ids: &[u32],
+        cpu_cache: &mut crate::metal::CpuBlockCache,
+    ) -> Result<(), String> {
+        use crate::metal::{SwapBlocksParams, swap_in as metal_swap_in};
+
+        if block_ids.is_empty() {
+            return Ok(());
+        }
+
+        let engine = self
+            .engine_manager
+            .get_engine(layer_idx)
+            .ok_or_else(|| format!("Layer {} not found", layer_idx))?;
+
+        if !engine.is_initialized() {
+            return Err(format!("Layer {} cache not initialized", layer_idx));
+        }
+
+        let key_cache = engine
+            .key_cache()
+            .ok_or_else(|| "Key cache not initialized".to_string())?;
+        let value_cache = engine
+            .value_cache()
+            .ok_or_else(|| "Value cache not initialized".to_string())?;
+
+        let params = SwapBlocksParams {
+            num_kv_heads: self.config.num_kv_heads,
+            head_size: self.config.head_size,
+            block_size: self.config.block_size,
+            use_fp8: self.config.use_fp8(),
+        };
+
+        metal_swap_in(key_cache, value_cache, block_ids, cpu_cache, &params)
+    }
+
+    /// Create a new CPU block cache for swap operations
+    ///
+    /// # Returns
+    /// * A new `CpuBlockCache` configured for this cache's block size
+    #[cfg(target_os = "macos")]
+    pub fn create_cpu_cache(&self) -> crate::metal::CpuBlockCache {
+        crate::metal::CpuBlockCache::new(
+            self.config.num_kv_heads,
+            self.config.head_size,
+            self.config.block_size,
+        )
+    }
 }
 
 /// Memory usage statistics
@@ -505,5 +1792,226 @@ mod tests {
 
         cache.remove_sequence(seq1).unwrap();
         cache.remove_sequence(seq2).unwrap();
+    }
+
+    #[test]
+    fn test_fork_sequence() {
+        let config = PagedAttentionConfig {
+            block_size: 32,
+            gpu_memory_mb: 1024,
+            head_size: 128,
+            num_kv_heads: 4,
+            num_layers: 28,
+            ..Default::default()
+        };
+
+        let mut cache = PagedKVCache::new(config).unwrap();
+
+        // Add a parent sequence with 64 tokens (2 blocks)
+        let parent_id = cache.add_sequence(64).unwrap();
+        assert_eq!(cache.num_sequences(), 1);
+        assert_eq!(cache.get_memory_stats().allocated_blocks, 2);
+
+        // Fork the sequence
+        let child_id = cache.fork_sequence(parent_id).unwrap();
+        assert_eq!(cache.num_sequences(), 2);
+
+        // Still only 2 blocks allocated (shared)
+        assert_eq!(cache.get_memory_stats().allocated_blocks, 2);
+
+        // Both sequences should have same context length
+        let context_lens = cache.get_context_lens();
+        assert_eq!(context_lens.len(), 2);
+        assert_eq!(context_lens[0], context_lens[1]);
+
+        // Remove parent - blocks should still be allocated (child has refs)
+        cache.remove_sequence(parent_id).unwrap();
+        assert_eq!(cache.num_sequences(), 1);
+        assert_eq!(cache.get_memory_stats().allocated_blocks, 2);
+
+        // Remove child - blocks should be freed
+        cache.remove_sequence(child_id).unwrap();
+        assert_eq!(cache.num_sequences(), 0);
+        assert_eq!(cache.get_memory_stats().allocated_blocks, 0);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_fp8_scale_integration() {
+        // Test with FP8 disabled - scale manager should be None
+        let config_fp16 = PagedAttentionConfig {
+            block_size: 16,
+            gpu_memory_mb: 1024,
+            head_size: 128,
+            num_kv_heads: 4,
+            num_layers: 4,
+            use_fp8_cache: Some(false),
+            ..Default::default()
+        };
+
+        let cache_fp16 = PagedKVCache::new(config_fp16).unwrap();
+        assert!(!cache_fp16.is_fp8_calibrated());
+        assert_eq!(cache_fp16.get_layer_scales(0), (1.0, 1.0));
+        assert!(cache_fp16.get_scale_stats().is_none());
+
+        // Test with FP8 enabled - scale manager should be initialized
+        let config_fp8 = PagedAttentionConfig {
+            block_size: 16,
+            gpu_memory_mb: 1024,
+            head_size: 128,
+            num_kv_heads: 4,
+            num_layers: 4,
+            use_fp8_cache: Some(true),
+            ..Default::default()
+        };
+
+        let mut cache_fp8 = PagedKVCache::new(config_fp8).unwrap();
+
+        // Default scales should be 1.0
+        assert_eq!(cache_fp8.get_layer_scales(0), (1.0, 1.0));
+        assert_eq!(cache_fp8.get_layer_scales(1), (1.0, 1.0));
+        assert_eq!(cache_fp8.get_layer_scales(2), (1.0, 1.0));
+        assert_eq!(cache_fp8.get_layer_scales(3), (1.0, 1.0));
+
+        // Set scales manually
+        cache_fp8.set_layer_scales(0, 0.5, 0.25);
+        cache_fp8.set_layer_scales(1, 2.0, 1.5);
+
+        assert_eq!(cache_fp8.get_layer_scales(0), (0.5, 0.25));
+        assert_eq!(cache_fp8.get_layer_scales(1), (2.0, 1.5));
+
+        // Check stats - all 4 layers have scales (init_default_scales + 2 overwritten)
+        let stats = cache_fp8.get_scale_stats().unwrap();
+        assert_eq!(stats.num_layers_calibrated, 4);
+
+        // Test load/save scales
+        let (k_scales, v_scales) = cache_fp8.get_all_scales().unwrap();
+        assert_eq!(k_scales.len(), 4);
+        assert_eq!(v_scales.len(), 4);
+        assert_eq!(k_scales[0], 0.5);
+        assert_eq!(v_scales[0], 0.25);
+        assert_eq!(k_scales[1], 2.0);
+        assert_eq!(v_scales[1], 1.5);
+    }
+
+    #[test]
+    fn test_token_tracking_integration() {
+        let config = PagedAttentionConfig {
+            block_size: 8, // Must be 8, 16, or 32
+            gpu_memory_mb: 1024,
+            head_size: 128,
+            num_kv_heads: 4,
+            num_layers: 2,
+            ..Default::default()
+        };
+
+        let mut cache = PagedKVCache::new(config).unwrap();
+        assert!(cache.is_token_tracking_enabled());
+
+        // Add a sequence with 24 tokens (allocates 3 blocks of size 8)
+        let tokens: Vec<u32> = vec![
+            100, 101, 102, 103, 104, 105, 106, 107, // Block 0
+            200, 201, 202, 203, 204, 205, 206, 207, // Block 1
+            300, 301, 302, 303, 304, 305, 306, 307, // Block 2
+        ];
+        let seq_id = cache.add_sequence(tokens.len() as u32).unwrap();
+
+        // Track tokens for the sequence
+        cache.track_sequence_tokens(seq_id, &tokens, 0).unwrap();
+
+        // Verify tokens are tracked
+        let seq_tokens = cache.get_sequence_tokens(seq_id).unwrap();
+        assert_eq!(seq_tokens, tokens);
+
+        // Add another sequence with 16 tokens and same first block
+        let tokens2: Vec<u32> = vec![
+            100, 101, 102, 103, 104, 105, 106, 107, // Same as seq1 block 0
+            500, 501, 502, 503, 504, 505, 506, 507, // Different block
+        ];
+        let seq_id2 = cache.add_sequence(tokens2.len() as u32).unwrap();
+
+        // Track tokens with same first block
+        cache.track_sequence_tokens(seq_id2, &tokens2, 0).unwrap();
+
+        // Find prefix matches for the common prefix (first block)
+        // Note: prefix_index stores only one block per hash, so we get the most recent one
+        let matches = cache.find_prefix_matches(&[100, 101, 102, 103, 104, 105, 106, 107]);
+        assert_eq!(matches.len(), 1); // Returns the most recently tracked block with this hash
+
+        // Find longest prefix for a new sequence
+        let test_tokens: Vec<u32> = vec![
+            100, 101, 102, 103, 104, 105, 106, 107, // Match block 0
+            200, 201, 202, 203, 204, 205, 206, 207, // Match block 1
+            999, 999, 999, 999, 999, 999, 999, 999, // No match
+        ];
+        let (matching_blocks, matched_tokens) = cache.find_longest_prefix(&test_tokens);
+        assert_eq!(matched_tokens, 16); // First 2 blocks match seq1
+        assert_eq!(matching_blocks.len(), 2);
+
+        // Check memory usage
+        let memory = cache.get_token_tracker_memory();
+        assert!(memory > 0);
+
+        // Check stats
+        let stats = cache.get_token_tracker_stats();
+        assert!(stats.num_tracked_blocks > 0);
+        assert!(stats.total_tracked_tokens >= 40); // 24 + 16 tokens
+
+        // Remove a sequence and verify untracking works
+        cache.remove_sequence(seq_id).unwrap();
+
+        // seq1's unique blocks should be untracked, but shared prefix block remains
+        let seq2_tokens = cache.get_sequence_tokens(seq_id2).unwrap();
+        assert_eq!(seq2_tokens, tokens2);
+    }
+
+    #[test]
+    fn test_token_tracking_prefix_caching_workflow() {
+        let config = PagedAttentionConfig {
+            block_size: 8, // Must be 8, 16, or 32
+            gpu_memory_mb: 1024,
+            head_size: 128,
+            num_kv_heads: 4,
+            num_layers: 2,
+            ..Default::default()
+        };
+
+        let mut cache = PagedKVCache::new(config).unwrap();
+
+        // Simulate a system prompt that many requests will share (24 tokens = 3 blocks)
+        let system_prompt_tokens: Vec<u32> = vec![
+            1, 2, 3, 4, 5, 6, 7, 8, // Block 0
+            9, 10, 11, 12, 13, 14, 15, 16, // Block 1
+            17, 18, 19, 20, 21, 22, 23, 24, // Block 2
+        ];
+
+        // First request with system prompt + user message (32 tokens = 4 blocks)
+        let request1_tokens: Vec<u32> = system_prompt_tokens
+            .iter()
+            .chain(&[100, 101, 102, 103, 104, 105, 106, 107]) // User message (8 tokens)
+            .copied()
+            .collect();
+        let seq1 = cache.add_sequence(request1_tokens.len() as u32).unwrap();
+        cache
+            .track_sequence_tokens(seq1, &request1_tokens, 0)
+            .unwrap();
+
+        // Second request comes in - check for prefix cache hit
+        let request2_prefix = &system_prompt_tokens;
+        let (matching_blocks, num_matched_tokens) = cache.find_longest_prefix(request2_prefix);
+
+        // Should find all 3 system prompt blocks
+        assert_eq!(num_matched_tokens, 24);
+        assert_eq!(matching_blocks.len(), 3);
+
+        // In a real implementation, we could now:
+        // 1. Copy the matching blocks to the new sequence (using copy_blocks)
+        // 2. Only compute attention for the non-matched tokens
+
+        // Verify the matching blocks contain the right tokens
+        for &block_id in &matching_blocks {
+            let block_tokens = cache.get_block_tokens(block_id);
+            assert!(!block_tokens.is_empty());
+        }
     }
 }

--- a/crates/mlx-paged-attn/src/token_tracker.rs
+++ b/crates/mlx-paged-attn/src/token_tracker.rs
@@ -1,0 +1,544 @@
+//! Token tracking for logical block management
+//!
+//! This module tracks which tokens are stored in each block of the KV cache.
+//! This enables:
+//! - **Prefix Caching**: Match incoming prompts against cached token sequences
+//! - **Debugging**: Inspect what tokens are in each block
+//! - **Eviction Decisions**: Make informed decisions based on block content
+//!
+//! ## Architecture
+//!
+//! The `TokenTracker` maintains:
+//! - Per-block token ID storage
+//! - Hash-based prefix index for O(1) lookups
+//! - Sequence-to-block mapping for efficient queries
+//!
+//! ## Memory Overhead
+//!
+//! For each block, we store `block_size` token IDs (4 bytes each).
+//! Example: 32 block size × 10K blocks = 1.28 MB overhead.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+/// Token tracker for logical block management
+///
+/// Tracks token IDs stored in each physical block and provides
+/// efficient prefix matching for cache reuse.
+#[derive(Debug)]
+pub struct TokenTracker {
+    /// Token IDs per block: block_id -> Vec<token_id>
+    block_tokens: HashMap<u32, Vec<u32>>,
+
+    /// Prefix hash index: hash -> (block_id, num_tokens)
+    /// Maps a hash of tokens to the block containing them
+    prefix_index: HashMap<u64, (u32, u32)>,
+
+    /// Block size (max tokens per block)
+    block_size: u32,
+
+    /// Whether tracking is enabled
+    enabled: bool,
+}
+
+impl TokenTracker {
+    /// Create a new token tracker
+    ///
+    /// # Arguments
+    /// * `block_size` - Maximum tokens per block
+    pub fn new(block_size: u32) -> Self {
+        Self {
+            block_tokens: HashMap::new(),
+            prefix_index: HashMap::new(),
+            block_size,
+            enabled: true,
+        }
+    }
+
+    /// Create a disabled token tracker (no-op)
+    pub fn disabled() -> Self {
+        Self {
+            block_tokens: HashMap::new(),
+            prefix_index: HashMap::new(),
+            block_size: 0,
+            enabled: false,
+        }
+    }
+
+    /// Check if tracking is enabled
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Record tokens being stored in a block
+    ///
+    /// # Arguments
+    /// * `block_id` - Physical block ID
+    /// * `tokens` - Token IDs being stored
+    /// * `start_offset` - Starting position within the block
+    ///
+    /// # Returns
+    /// * Hash of the block's tokens (for prefix caching integration)
+    pub fn track_tokens(&mut self, block_id: u32, tokens: &[u32], start_offset: u32) -> u64 {
+        if !self.enabled {
+            return 0;
+        }
+
+        // Get or create token vector for this block
+        let block_tokens = self
+            .block_tokens
+            .entry(block_id)
+            .or_insert_with(|| Vec::with_capacity(self.block_size as usize));
+
+        // Ensure vector is long enough for the offset
+        if block_tokens.len() < start_offset as usize {
+            block_tokens.resize(start_offset as usize, 0);
+        }
+
+        // Insert or extend tokens
+        for (i, &token) in tokens.iter().enumerate() {
+            let pos = start_offset as usize + i;
+            if pos < block_tokens.len() {
+                block_tokens[pos] = token;
+            } else {
+                block_tokens.push(token);
+            }
+        }
+
+        // Compute hash and num_tokens while we have the borrow
+        let hash = Self::hash_tokens(block_tokens);
+        let num_tokens = block_tokens.len() as u32;
+
+        // Update prefix index
+        self.prefix_index.insert(hash, (block_id, num_tokens));
+
+        hash
+    }
+
+    /// Get tokens stored in a block
+    ///
+    /// # Arguments
+    /// * `block_id` - Physical block ID
+    ///
+    /// # Returns
+    /// * Token IDs in the block, or empty slice if not tracked
+    pub fn get_block_tokens(&self, block_id: u32) -> &[u32] {
+        self.block_tokens
+            .get(&block_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Get the number of tokens in a block
+    pub fn get_block_token_count(&self, block_id: u32) -> u32 {
+        self.block_tokens
+            .get(&block_id)
+            .map(|v| v.len() as u32)
+            .unwrap_or(0)
+    }
+
+    /// Remove tracking for a block
+    ///
+    /// Call this when a block is freed.
+    pub fn remove_block(&mut self, block_id: u32) {
+        if !self.enabled {
+            return;
+        }
+
+        // Compute hash before removing (for prefix index cleanup)
+        if self.block_tokens.contains_key(&block_id) {
+            let hash = self.compute_block_hash(block_id);
+            self.prefix_index.remove(&hash);
+        }
+
+        self.block_tokens.remove(&block_id);
+    }
+
+    /// Copy tokens from one block to another
+    ///
+    /// Used during copy-on-write operations.
+    pub fn copy_block(&mut self, src_block_id: u32, dst_block_id: u32) {
+        if !self.enabled {
+            return;
+        }
+
+        if let Some(src_tokens) = self.block_tokens.get(&src_block_id) {
+            let tokens = src_tokens.clone();
+            let hash = Self::hash_tokens(&tokens);
+            let num_tokens = tokens.len() as u32;
+
+            self.block_tokens.insert(dst_block_id, tokens);
+            self.prefix_index.insert(hash, (dst_block_id, num_tokens));
+        }
+    }
+
+    /// Find blocks that match a token prefix
+    ///
+    /// # Arguments
+    /// * `tokens` - Token sequence to match
+    ///
+    /// # Returns
+    /// * Vector of (block_id, match_length) for blocks matching the prefix
+    pub fn find_prefix_matches(&self, tokens: &[u32]) -> Vec<(u32, u32)> {
+        if !self.enabled || tokens.is_empty() {
+            return Vec::new();
+        }
+
+        let mut matches = Vec::new();
+
+        // Try matching full blocks first
+        let full_blocks = tokens.len() / self.block_size as usize;
+
+        for block_idx in 0..=full_blocks {
+            let start = block_idx * self.block_size as usize;
+            let end = std::cmp::min(start + self.block_size as usize, tokens.len());
+
+            if start >= tokens.len() {
+                break;
+            }
+
+            let block_tokens = &tokens[start..end];
+            let hash = Self::hash_tokens(block_tokens);
+
+            if let Some(&(block_id, num_tokens)) = self.prefix_index.get(&hash) {
+                // Verify the match (hash collision protection)
+                if let Some(stored) = self.block_tokens.get(&block_id)
+                    && stored.len() >= block_tokens.len()
+                    && &stored[..block_tokens.len()] == block_tokens
+                {
+                    matches.push((block_id, num_tokens));
+                }
+            }
+        }
+
+        matches
+    }
+
+    /// Find the longest matching prefix
+    ///
+    /// # Arguments
+    /// * `tokens` - Token sequence to match
+    ///
+    /// # Returns
+    /// * (matched_blocks, total_matched_tokens) - Blocks and total tokens matched
+    pub fn find_longest_prefix(&self, tokens: &[u32]) -> (Vec<u32>, u32) {
+        if !self.enabled || tokens.is_empty() {
+            return (Vec::new(), 0);
+        }
+
+        let mut matched_blocks = Vec::new();
+        let mut total_matched = 0u32;
+        let mut pos = 0usize;
+
+        while pos < tokens.len() {
+            let remaining = tokens.len() - pos;
+            let block_len = std::cmp::min(self.block_size as usize, remaining);
+            let block_tokens = &tokens[pos..pos + block_len];
+            let hash = Self::hash_tokens(block_tokens);
+
+            match self.prefix_index.get(&hash) {
+                Some(&(block_id, num_tokens)) => {
+                    // Verify match
+                    if let Some(stored) = self.block_tokens.get(&block_id)
+                        && stored.len() >= block_tokens.len()
+                        && &stored[..block_tokens.len()] == block_tokens
+                    {
+                        matched_blocks.push(block_id);
+                        total_matched += num_tokens;
+                        pos += num_tokens as usize;
+                        continue;
+                    }
+                    // No match, stop searching
+                    break;
+                }
+                None => break,
+            }
+        }
+
+        (matched_blocks, total_matched)
+    }
+
+    /// Compute hash for a block's tokens
+    fn compute_block_hash(&self, block_id: u32) -> u64 {
+        match self.block_tokens.get(&block_id) {
+            Some(tokens) => Self::hash_tokens(tokens),
+            None => 0,
+        }
+    }
+
+    /// Hash a token sequence using FNV-1a
+    fn hash_tokens(tokens: &[u32]) -> u64 {
+        let mut hasher = FnvHasher::new();
+        for &token in tokens {
+            token.hash(&mut hasher);
+        }
+        hasher.finish()
+    }
+
+    /// Get statistics about tracked blocks
+    pub fn stats(&self) -> TokenTrackerStats {
+        let num_blocks = self.block_tokens.len() as u32;
+        let total_tokens: usize = self.block_tokens.values().map(|v| v.len()).sum();
+        let avg_tokens_per_block = if num_blocks > 0 {
+            total_tokens as f32 / num_blocks as f32
+        } else {
+            0.0
+        };
+
+        TokenTrackerStats {
+            num_tracked_blocks: num_blocks,
+            total_tracked_tokens: total_tokens as u32,
+            avg_tokens_per_block,
+            prefix_index_size: self.prefix_index.len() as u32,
+        }
+    }
+
+    /// Clear all tracking data
+    pub fn clear(&mut self) {
+        self.block_tokens.clear();
+        self.prefix_index.clear();
+    }
+
+    /// Get memory usage in bytes
+    pub fn memory_usage(&self) -> usize {
+        let tokens_mem: usize = self
+            .block_tokens
+            .values()
+            .map(|v| v.capacity() * std::mem::size_of::<u32>())
+            .sum();
+        let index_mem = self.prefix_index.capacity()
+            * (std::mem::size_of::<u64>() + std::mem::size_of::<(u32, u32)>());
+
+        tokens_mem + index_mem
+    }
+}
+
+/// Statistics about token tracking
+#[derive(Debug, Clone)]
+pub struct TokenTrackerStats {
+    /// Number of blocks being tracked
+    pub num_tracked_blocks: u32,
+    /// Total tokens tracked across all blocks
+    pub total_tracked_tokens: u32,
+    /// Average tokens per block
+    pub avg_tokens_per_block: f32,
+    /// Size of prefix index
+    pub prefix_index_size: u32,
+}
+
+/// FNV-1a hasher for token sequences
+///
+/// Chosen for its simplicity and good distribution for integer sequences.
+struct FnvHasher {
+    state: u64,
+}
+
+impl FnvHasher {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+
+    fn new() -> Self {
+        Self {
+            state: Self::FNV_OFFSET,
+        }
+    }
+}
+
+impl Hasher for FnvHasher {
+    fn finish(&self) -> u64 {
+        self.state
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.state ^= byte as u64;
+            self.state = self.state.wrapping_mul(Self::FNV_PRIME);
+        }
+    }
+}
+
+/// Compute hash for a sequence of token IDs
+///
+/// This is a standalone function for use with the existing BlockAllocator prefix cache.
+pub fn compute_token_hash(tokens: &[u32]) -> u64 {
+    let mut hasher = FnvHasher::new();
+    for &token in tokens {
+        token.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_token_tracker_creation() {
+        let tracker = TokenTracker::new(32);
+        assert!(tracker.is_enabled());
+        assert_eq!(tracker.block_size, 32);
+
+        let disabled = TokenTracker::disabled();
+        assert!(!disabled.is_enabled());
+    }
+
+    #[test]
+    fn test_track_tokens() {
+        let mut tracker = TokenTracker::new(32);
+
+        // Track some tokens
+        let tokens = vec![1, 2, 3, 4, 5];
+        let hash = tracker.track_tokens(0, &tokens, 0);
+
+        assert!(hash != 0);
+        assert_eq!(tracker.get_block_tokens(0), &[1, 2, 3, 4, 5]);
+        assert_eq!(tracker.get_block_token_count(0), 5);
+    }
+
+    #[test]
+    fn test_track_tokens_with_offset() {
+        let mut tracker = TokenTracker::new(32);
+
+        // Track initial tokens
+        tracker.track_tokens(0, &[1, 2, 3], 0);
+
+        // Track more tokens at offset
+        tracker.track_tokens(0, &[4, 5], 3);
+
+        assert_eq!(tracker.get_block_tokens(0), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_remove_block() {
+        let mut tracker = TokenTracker::new(32);
+
+        tracker.track_tokens(0, &[1, 2, 3], 0);
+        tracker.track_tokens(1, &[4, 5, 6], 0);
+
+        assert_eq!(tracker.get_block_token_count(0), 3);
+        assert_eq!(tracker.get_block_token_count(1), 3);
+
+        tracker.remove_block(0);
+
+        assert_eq!(tracker.get_block_token_count(0), 0);
+        assert_eq!(tracker.get_block_token_count(1), 3);
+    }
+
+    #[test]
+    fn test_copy_block() {
+        let mut tracker = TokenTracker::new(32);
+
+        tracker.track_tokens(0, &[1, 2, 3, 4, 5], 0);
+        tracker.copy_block(0, 1);
+
+        assert_eq!(tracker.get_block_tokens(0), &[1, 2, 3, 4, 5]);
+        assert_eq!(tracker.get_block_tokens(1), &[1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_find_prefix_matches() {
+        let mut tracker = TokenTracker::new(4);
+
+        // Track blocks with different tokens
+        tracker.track_tokens(0, &[1, 2, 3, 4], 0);
+        tracker.track_tokens(1, &[5, 6, 7, 8], 0);
+        tracker.track_tokens(2, &[1, 2, 3, 4], 0); // Duplicate content
+
+        // Find match for first block's content
+        let matches = tracker.find_prefix_matches(&[1, 2, 3, 4]);
+        // Should find block 2 (last one with this content in prefix_index)
+        assert!(!matches.is_empty());
+        assert_eq!(matches[0].1, 4); // 4 tokens matched
+    }
+
+    #[test]
+    fn test_find_longest_prefix() {
+        let mut tracker = TokenTracker::new(4);
+
+        // Track a sequence of blocks
+        tracker.track_tokens(0, &[1, 2, 3, 4], 0);
+        tracker.track_tokens(1, &[5, 6, 7, 8], 0);
+
+        // Find longest prefix for a sequence that matches both blocks
+        let (blocks, total) = tracker.find_longest_prefix(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        // Should match both blocks (8 tokens total)
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(total, 8);
+
+        // Test partial match - only first block matches
+        let (blocks2, total2) = tracker.find_longest_prefix(&[1, 2, 3, 4, 99, 99, 99, 99]);
+        assert_eq!(blocks2.len(), 1);
+        assert_eq!(total2, 4);
+
+        // Test no match
+        let (blocks3, total3) = tracker.find_longest_prefix(&[99, 98, 97, 96]);
+        assert_eq!(blocks3.len(), 0);
+        assert_eq!(total3, 0);
+    }
+
+    #[test]
+    fn test_stats() {
+        let mut tracker = TokenTracker::new(32);
+
+        tracker.track_tokens(0, &[1, 2, 3], 0);
+        tracker.track_tokens(1, &[4, 5, 6, 7], 0);
+
+        let stats = tracker.stats();
+        assert_eq!(stats.num_tracked_blocks, 2);
+        assert_eq!(stats.total_tracked_tokens, 7);
+        assert!((stats.avg_tokens_per_block - 3.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_disabled_tracker() {
+        let mut tracker = TokenTracker::disabled();
+
+        // All operations should be no-ops
+        let hash = tracker.track_tokens(0, &[1, 2, 3], 0);
+        assert_eq!(hash, 0);
+        assert_eq!(tracker.get_block_token_count(0), 0);
+
+        let matches = tracker.find_prefix_matches(&[1, 2, 3]);
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_hash_consistency() {
+        // Same tokens should produce same hash
+        let tokens = vec![1, 2, 3, 4, 5];
+        let hash1 = compute_token_hash(&tokens);
+        let hash2 = compute_token_hash(&tokens);
+        assert_eq!(hash1, hash2);
+
+        // Different tokens should produce different hash
+        let tokens2 = vec![1, 2, 3, 4, 6];
+        let hash3 = compute_token_hash(&tokens2);
+        assert_ne!(hash1, hash3);
+    }
+
+    #[test]
+    fn test_memory_usage() {
+        let mut tracker = TokenTracker::new(32);
+
+        let initial = tracker.memory_usage();
+        tracker.track_tokens(0, &[1, 2, 3, 4, 5], 0);
+        let after = tracker.memory_usage();
+
+        assert!(after >= initial);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut tracker = TokenTracker::new(32);
+
+        tracker.track_tokens(0, &[1, 2, 3], 0);
+        tracker.track_tokens(1, &[4, 5, 6], 0);
+
+        assert_eq!(tracker.stats().num_tracked_blocks, 2);
+
+        tracker.clear();
+
+        assert_eq!(tracker.stats().num_tracked_blocks, 0);
+    }
+}


### PR DESCRIPTION
… conversion

Implements critical missing integration pieces from gap analysis:

- Wire FP8 scales from KvScaleManager to update() and attention() methods
- Fix hard-coded Float16 dtype to use UChar for FP8 mode
- Add PagedAttentionOutput.to_mlx_array() for converting output to MLX arrays
- Add token tracking cleanup in remove_sequence()

- PagedAttentionLayer: Model-level wrapper for paged attention
- PagedAttentionInputMetadata: Unified struct for kernel metadata
- TokenTracker: Content-based prefix caching with hash matching
- KvScaleManager: FP8 scale calibration with EMA updates
- copy_blocks, swap_blocks: Block management kernels

- Replace same_item_push loops with extend(repeat_n())
- Add # Safety docs to all unsafe functions
- Use iterator zip instead of index loops for conversions

Tests: 74 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Completes end-to-end paged attention integration on macOS with GPU kernels, FP8 support, and higher-level APIs.
> 
> - New `PagedAttentionLayer`, `PagedAttentionLayers`, and `PagedAttentionInputMetadata` for model-level usage and unified kernel metadata
> - Metal dispatch expanded: raw-buffer variants for `reshape_and_cache` and `paged_attention` (V1/V2/auto), plus `PagedAttentionOutput` (host copy and `to_mlx_array()`)
> - FP8 enablement: `MetalDtype::UChar`, FP8 paths in kernels, and `KvScaleManager` (one-shot/EMA calibration) wired into `update()` and `attention()`; config validation updated (allow FP8 with block_size 16/32)
> - Cache engines: GPU buffer allocation per-layer; manager init across layers
> - Block ops: `copy_blocks` kernel and CPU offload `swap_out`/`swap_in` with `CpuBlockCache`
> - Token-aware infra: `TokenTracker` for per-block tokens, prefix matching, and cleanup in `remove_sequence()`
> - `mlx-core` integration docs updated to direct users to `PagedKVCache` for direct Metal dispatch; re-exports added
> - Tests added/updated across new modules
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4627afc6dd29ac99f64f2bcac95f0a1e9f8f835e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FP8 quantization for KV caches with per-layer calibration and scale management
  * Token-tracking with prefix/longest-prefix matching to accelerate reuse
  * CPU↔GPU block swap and copy-on-write support for larger contexts and beam search
  * Configurable paged attention layers and end-to-end paged-attention outputs, including raw-buffer dispatch paths

* **Improvements**
  * FP8-aware kernels and parameter propagation for improved memory/compute efficiency
  * Expanded metadata builders for batch/prefill/decode workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->