### PR TITLE
feat(output-store): add training output persistence with libsql

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokenizers = "0.22"
 minijinja = { version = "2.5", features = ["json"] }
 uuid = { version = "1.11", features = ["v4"] }
 regex = "1.11"
+libsql = { version = "0.9", features = ["replication"] }
 
 # NAPI-RS
 napi = { version = "3", features = ["napi10", "async", "tokio_fs", "serde-json"] }

--- a/__test__/models/qwen3-chat.test.ts
+++ b/__test__/models/qwen3-chat.test.ts
@@ -117,6 +117,7 @@ describe.sequential('Qwen3 Chat API', () => {
         arguments: { key: 'value' },
         status: 'ok',
         error: undefined,
+        rawContent: '<tool_call>{"name": "test_function", "arguments": {"key": "value"}}</tool_call>',
       };
 
       expect(mockToolCall.id).toMatch(/^call_/);
@@ -132,6 +133,7 @@ describe.sequential('Qwen3 Chat API', () => {
         arguments: {},
         status: 'missing_name',
         error: 'Tool call missing name',
+        rawContent: '<tool_call>{"arguments": {}}</tool_call>',
       };
 
       expect(errorCall.status).toBe('missing_name');

--- a/__test__/tools/chat.test.ts
+++ b/__test__/tools/chat.test.ts
@@ -25,6 +25,8 @@ describe('chat() API Types', () => {
         arguments: { key: 'value', nested: { a: 1 } },
         status: 'ok',
         error: undefined,
+        rawContent:
+          '<tool_call>{"name": "test_function", "arguments": {"key": "value", "nested": {"a": 1}}}</tool_call>',
       };
 
       expect(mockToolCall.id).toBe('call_abc123');
@@ -41,6 +43,7 @@ describe('chat() API Types', () => {
         arguments: {},
         status: 'invalid_json',
         error: 'Failed to parse arguments JSON',
+        rawContent: '<tool_call>{"name": "broken_function", "arguments": {invalid}}</tool_call>',
       };
 
       expect(errorToolCall.status).toBe('invalid_json');
@@ -54,6 +57,7 @@ describe('chat() API Types', () => {
         arguments: {},
         status: 'missing_name',
         error: 'Tool call missing name',
+        rawContent: '<tool_call>{"arguments": {}}</tool_call>',
       };
 
       expect(missingNameCall.status).toBe('missing_name');
@@ -118,6 +122,8 @@ describe('Tool Arguments as Native Objects', () => {
       name: 'get_weather',
       arguments: { location: 'Paris', units: 'celsius' },
       status: 'ok',
+      rawContent:
+        '<tool_call>{"name": "get_weather", "arguments": {"location": "Paris", "units": "celsius"}}</tool_call>',
     };
 
     // Direct property access - no JSON.parse needed!
@@ -144,6 +150,8 @@ describe('Tool Arguments as Native Objects', () => {
         },
       },
       status: 'ok',
+      rawContent:
+        '<tool_call>{"name": "complex_tool", "arguments": {"config": {"setting1": true, "setting2": [1, 2, 3]}, "data": {"nested": {"deep": "value"}}}}</tool_call>',
     };
 
     const config = toolCall.arguments.config as { setting1: boolean; setting2: number[] };

--- a/__test__/trainers/output-store.test.ts
+++ b/__test__/trainers/output-store.test.ts
@@ -1,0 +1,513 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { OutputStore } from '@mlx-node/core';
+
+describe('OutputStore', () => {
+  let testDbPath: string;
+  let store: OutputStore;
+
+  beforeEach(async () => {
+    // Create a unique temp file for each test
+    testDbPath = join(tmpdir(), `output-store-test-${Date.now()}.db`);
+    store = await OutputStore.local(testDbPath);
+  });
+
+  afterEach(async () => {
+    // Clean up test database
+    if (existsSync(testDbPath)) {
+      try {
+        unlinkSync(testDbPath);
+      } catch {
+        // Ignore errors
+      }
+    }
+    // Also clean up WAL files if they exist
+    if (existsSync(`${testDbPath}-wal`)) {
+      try {
+        unlinkSync(`${testDbPath}-wal`);
+      } catch {
+        // Ignore errors
+      }
+    }
+    if (existsSync(`${testDbPath}-shm`)) {
+      try {
+        unlinkSync(`${testDbPath}-shm`);
+      } catch {
+        // Ignore errors
+      }
+    }
+  });
+
+  describe('local store creation', () => {
+    it('should create a local database file', async () => {
+      expect(existsSync(testDbPath)).toBe(true);
+    });
+  });
+
+  describe('training run lifecycle', () => {
+    it('should start and end a training run', async () => {
+      const runId = await store.startRun('test-model', './models/test', '{"test": true}');
+      expect(runId).toBeTruthy();
+      expect(typeof runId).toBe('string');
+      expect(runId.length).toBeGreaterThan(0);
+
+      const currentRunId = await store.currentRunId();
+      expect(currentRunId).toBe(runId);
+
+      await store.endRun('completed');
+      const afterEnd = await store.currentRunId();
+      expect(afterEnd).toBeNull();
+    });
+
+    it('should list training runs', async () => {
+      // Start a run
+      const runId = await store.startRun('test-model-2', undefined, '{}');
+      await store.endRun('completed');
+
+      // List runs
+      const runs = await store.listRuns(10, undefined);
+      expect(runs.length).toBeGreaterThanOrEqual(1);
+
+      const run = runs.find((r) => r.id === runId);
+      expect(run).toBeTruthy();
+      expect(run?.modelName).toBe('test-model-2');
+      expect(run?.status).toBe('completed');
+    });
+
+    it('should get a specific run', async () => {
+      const runId = await store.startRun('test-model-3', './path', '{"lr": 0.001}');
+      await store.endRun('completed');
+
+      const run = await store.getRun(runId);
+      expect(run).toBeTruthy();
+      expect(run?.id).toBe(runId);
+      expect(run?.modelName).toBe('test-model-3');
+      expect(run?.modelPath).toBe('./path');
+      expect(run?.config).toBe('{"lr": 0.001}');
+    });
+  });
+
+  describe('step recording', () => {
+    it('should record a training step with generations', async () => {
+      const runId = await store.startRun('test-model', undefined, '{}');
+
+      const stepRecord = {
+        runId,
+        step: 1,
+        epoch: undefined,
+        loss: 0.5,
+        meanReward: 0.7,
+        stdReward: 0.1,
+        meanAdvantage: 0.3,
+        totalTokens: 100,
+        generationTimeMs: 500.0,
+        trainingTimeMs: 200.0,
+        gradientsApplied: true,
+      };
+
+      const generations = [
+        {
+          batchIndex: 0,
+          groupIndex: 0,
+          prompt: 'Test prompt 1',
+          expectedAnswer: '42',
+          completionText: 'The answer is 42',
+          completionRaw: 'The answer is 42',
+          thinking: undefined,
+          numTokens: 10,
+          finishReason: 'eos',
+          reward: 1.0,
+        },
+        {
+          batchIndex: 0,
+          groupIndex: 1,
+          prompt: 'Test prompt 1',
+          expectedAnswer: '42',
+          completionText: 'I think it is 41',
+          completionRaw: 'I think it is 41',
+          thinking: undefined,
+          numTokens: 8,
+          finishReason: 'eos',
+          reward: 0.0,
+        },
+      ];
+
+      const stepId = await store.recordStep(stepRecord, generations, []);
+      expect(stepId).toBeGreaterThan(0);
+
+      await store.endRun('completed');
+    });
+  });
+
+  describe('querying', () => {
+    it('should query step summaries', async () => {
+      const runId = await store.startRun('query-test', undefined, '{}');
+
+      // Record a step
+      const stepRecord = {
+        runId,
+        step: 1,
+        epoch: undefined,
+        loss: 0.5,
+        meanReward: 0.8,
+        stdReward: 0.1,
+        meanAdvantage: 0.2,
+        totalTokens: 50,
+        generationTimeMs: 100.0,
+        trainingTimeMs: 50.0,
+        gradientsApplied: true,
+      };
+
+      await store.recordStep(
+        stepRecord,
+        [
+          {
+            batchIndex: 0,
+            groupIndex: 0,
+            prompt: 'Q',
+            expectedAnswer: 'A',
+            completionText: 'A',
+            completionRaw: 'A',
+            thinking: undefined,
+            numTokens: 5,
+            finishReason: 'eos',
+            reward: 0.8,
+          },
+        ],
+        [],
+      );
+
+      await store.endRun('completed');
+
+      // Query summaries
+      const summaries = await store.getStepSummaries(runId, undefined, undefined);
+      expect(summaries.length).toBe(1);
+      expect(summaries[0].step).toBe(1);
+      expect(summaries[0].loss).toBeCloseTo(0.5);
+      expect(summaries[0].meanReward).toBeCloseTo(0.8);
+    });
+
+    it('should get generations for a step', async () => {
+      const runId = await store.startRun('gen-test', undefined, '{}');
+
+      const stepRecord = {
+        runId,
+        step: 1,
+        epoch: undefined,
+        loss: 0.5,
+        meanReward: 0.5,
+        stdReward: 0.1,
+        meanAdvantage: 0.0,
+        totalTokens: 20,
+        generationTimeMs: 100.0,
+        trainingTimeMs: 50.0,
+        gradientsApplied: true,
+      };
+
+      await store.recordStep(
+        stepRecord,
+        [
+          {
+            batchIndex: 0,
+            groupIndex: 0,
+            prompt: 'Hello',
+            expectedAnswer: 'World',
+            completionText: 'World',
+            completionRaw: 'World',
+            thinking: 'Let me think...',
+            numTokens: 10,
+            finishReason: 'eos',
+            reward: 1.0,
+          },
+        ],
+        [],
+      );
+
+      await store.endRun('completed');
+
+      const gens = await store.getGenerations(runId, 1);
+      expect(gens.length).toBe(1);
+      expect(gens[0].generation.prompt).toBe('Hello');
+      expect(gens[0].generation.thinking).toBe('Let me think...');
+      expect(gens[0].generation.reward).toBe(1.0);
+    });
+
+    it('should get reward statistics', async () => {
+      const runId = await store.startRun('stats-test', undefined, '{}');
+
+      const stepRecord = {
+        runId,
+        step: 1,
+        epoch: undefined,
+        loss: 0.5,
+        meanReward: 0.5,
+        stdReward: 0.3,
+        meanAdvantage: 0.0,
+        totalTokens: 30,
+        generationTimeMs: 100.0,
+        trainingTimeMs: 50.0,
+        gradientsApplied: true,
+      };
+
+      await store.recordStep(
+        stepRecord,
+        [
+          {
+            batchIndex: 0,
+            groupIndex: 0,
+            prompt: 'P1',
+            expectedAnswer: undefined,
+            completionText: 'C1',
+            completionRaw: 'C1',
+            thinking: undefined,
+            numTokens: 10,
+            finishReason: 'eos',
+            reward: 0.0,
+          },
+          {
+            batchIndex: 0,
+            groupIndex: 1,
+            prompt: 'P1',
+            expectedAnswer: undefined,
+            completionText: 'C2',
+            completionRaw: 'C2',
+            thinking: undefined,
+            numTokens: 10,
+            finishReason: 'eos',
+            reward: 0.5,
+          },
+          {
+            batchIndex: 0,
+            groupIndex: 2,
+            prompt: 'P1',
+            expectedAnswer: undefined,
+            completionText: 'C3',
+            completionRaw: 'C3',
+            thinking: undefined,
+            numTokens: 10,
+            finishReason: 'eos',
+            reward: 1.0,
+          },
+        ],
+        [],
+      );
+
+      await store.endRun('completed');
+
+      const stats = await store.getRewardStats(runId, undefined);
+      expect(stats.count).toBe(3);
+      expect(stats.min).toBe(0.0);
+      expect(stats.max).toBe(1.0);
+      expect(stats.mean).toBeCloseTo(0.5);
+    });
+  });
+
+  describe('SQL parameter binding edge cases', () => {
+    it('getStepSummaries with only endStep should work', async () => {
+      const runId = await store.startRun('binding-test', undefined, '{}');
+
+      // Record a step
+      const stepRecord = {
+        runId,
+        step: 5,
+        epoch: undefined,
+        loss: 0.5,
+        meanReward: 0.7,
+        stdReward: 0.1,
+        meanAdvantage: 0.2,
+        totalTokens: 50,
+        generationTimeMs: 100.0,
+        trainingTimeMs: 50.0,
+        gradientsApplied: true,
+      };
+
+      await store.recordStep(
+        stepRecord,
+        [
+          {
+            batchIndex: 0,
+            groupIndex: 0,
+            prompt: 'Q',
+            expectedAnswer: 'A',
+            completionText: 'A',
+            completionRaw: 'A',
+            thinking: undefined,
+            numTokens: 5,
+            finishReason: 'eos',
+            reward: 0.8,
+          },
+        ],
+        [],
+      );
+
+      await store.endRun('completed');
+
+      // Query with only endStep (start_step is undefined)
+      // This tests the SQL binding fix for dynamic placeholder numbering
+      const summaries = await store.getStepSummaries(runId, undefined, 10);
+      expect(summaries.length).toBe(1);
+      expect(summaries[0].step).toBe(5);
+    });
+
+    it('getGenerationsWithToolCalls with only status should work', async () => {
+      const runId = await store.startRun('status-filter-test', undefined, '{}');
+
+      // Record a step with tool calls
+      const stepRecord = {
+        runId,
+        step: 1,
+        epoch: undefined,
+        loss: 0.5,
+        meanReward: 0.7,
+        stdReward: 0.1,
+        meanAdvantage: 0.2,
+        totalTokens: 50,
+        generationTimeMs: 100.0,
+        trainingTimeMs: 50.0,
+        gradientsApplied: true,
+      };
+
+      await store.recordStep(
+        stepRecord,
+        [
+          {
+            batchIndex: 0,
+            groupIndex: 0,
+            prompt: 'Use a tool',
+            expectedAnswer: undefined,
+            completionText: 'I used a tool',
+            completionRaw: '<tool_call>{"name": "test"}</tool_call>',
+            thinking: undefined,
+            numTokens: 5,
+            finishReason: 'eos',
+            reward: 1.0,
+          },
+        ],
+        [
+          [
+            {
+              callIndex: 0,
+              status: 'ok',
+              toolName: 'test_tool',
+              arguments: '{}',
+              rawContent: '<tool_call>{"name": "test"}</tool_call>',
+              errorMessage: undefined,
+            },
+          ],
+        ],
+      );
+
+      await store.endRun('completed');
+
+      // Query with only status (tool_name is undefined)
+      // This tests the SQL binding fix for dynamic placeholder numbering
+      const results = await store.getGenerationsWithToolCalls(runId, undefined, 'ok', 10);
+      expect(results.length).toBe(1);
+    });
+  });
+
+  describe('input validation', () => {
+    it('recordStepFromOutputs should reject group_size=0', async () => {
+      await store.startRun('validation-test', undefined, '{}');
+
+      const metrics = {
+        step: 1,
+        loss: 0.5,
+        meanReward: 0.7,
+        stdReward: 0.1,
+        meanAdvantage: 0.2,
+        totalTokens: 50,
+        generationTimeMs: 100.0,
+        trainingTimeMs: 50.0,
+        gradientsApplied: true,
+      };
+
+      const outputsJson = JSON.stringify([
+        {
+          prompt: 'test',
+          completion: {
+            text: 'response',
+            raw_text: 'response',
+            tool_calls: [],
+            thinking: null,
+            num_tokens: 5,
+            finish_reason: 'eos',
+          },
+          expected_answer: null,
+        },
+      ]);
+
+      // This should throw because group_size=0 would cause division by zero
+      await expect(store.recordStepFromOutputs(1, metrics, outputsJson, [0.5], 0)).rejects.toThrow(
+        /group_size must be positive/,
+      );
+
+      await store.endRun('failed');
+    });
+  });
+
+  describe('search', () => {
+    it('should search generations by text', async () => {
+      const runId = await store.startRun('search-test', undefined, '{}');
+
+      const stepRecord = {
+        runId,
+        step: 1,
+        epoch: undefined,
+        loss: 0.5,
+        meanReward: 0.5,
+        stdReward: 0.1,
+        meanAdvantage: 0.0,
+        totalTokens: 20,
+        generationTimeMs: 100.0,
+        trainingTimeMs: 50.0,
+        gradientsApplied: true,
+      };
+
+      await store.recordStep(
+        stepRecord,
+        [
+          {
+            batchIndex: 0,
+            groupIndex: 0,
+            prompt: 'apple banana',
+            expectedAnswer: undefined,
+            completionText: 'fruit salad',
+            completionRaw: 'fruit salad',
+            thinking: undefined,
+            numTokens: 5,
+            finishReason: 'eos',
+            reward: 0.5,
+          },
+          {
+            batchIndex: 0,
+            groupIndex: 1,
+            prompt: 'orange grape',
+            expectedAnswer: undefined,
+            completionText: 'citrus blend',
+            completionRaw: 'citrus blend',
+            thinking: undefined,
+            numTokens: 5,
+            finishReason: 'eos',
+            reward: 0.5,
+          },
+        ],
+        [],
+      );
+
+      await store.endRun('completed');
+
+      // Search for "banana" in prompts
+      const results = await store.searchGenerations(runId, 'banana', 'prompt', 10);
+      expect(results.length).toBe(1);
+      expect(results[0].generation.prompt).toContain('banana');
+
+      // Search for "citrus" in completions
+      const citrusResults = await store.searchGenerations(runId, 'citrus', 'completion', 10);
+      expect(citrusResults.length).toBe(1);
+      expect(citrusResults[0].generation.completionText).toContain('citrus');
+    });
+  });
+});

--- a/crates/mlx-core/Cargo.toml
+++ b/crates/mlx-core/Cargo.toml
@@ -24,6 +24,7 @@ regex = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 mlx-paged-attn = { workspace = true }
+libsql = { workspace = true }
 
 [dependencies.mimalloc-safe]
 workspace = true

--- a/crates/mlx-core/src/lib.rs
+++ b/crates/mlx-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod grpo;
 pub mod models;
 pub mod nn;
 pub mod optimizers;
+pub mod output_store;
 pub mod param_manager;
 pub mod sampling;
 pub mod sft;

--- a/crates/mlx-core/src/output_store/mod.rs
+++ b/crates/mlx-core/src/output_store/mod.rs
@@ -1,0 +1,47 @@
+//! Output Store - Persistence layer for training outputs
+//!
+//! This module provides a database-backed storage system for recording
+//! all model outputs during GRPO training. It supports:
+//!
+//! - Local SQLite file storage
+//! - Remote Turso cloud database
+//! - Embedded replica mode (local cache + remote sync)
+//!
+//! ## Usage
+//!
+//! ```typescript
+//! // Create local store
+//! const store = await OutputStore.local('./training_outputs.db');
+//!
+//! // Or with Turso cloud sync
+//! const store = await OutputStore.embeddedReplica(
+//!     './local_cache.db',
+//!     'libsql://your-db.turso.io',
+//!     'your-token',
+//!     60 // sync interval in seconds
+//! );
+//!
+//! // Start a training run
+//! const runId = await store.startRun('qwen3-0.6b', './models/qwen3', JSON.stringify(config));
+//!
+//! // Record steps during training (called automatically by GRPOTrainer)
+//! await store.recordStepFromOutputs(step, metrics, outputsJson, rewards, groupSize);
+//!
+//! // End the run
+//! await store.endRun('completed');
+//!
+//! // Query recorded data
+//! const runs = await store.listRuns();
+//! const topGens = await store.getGenerationsByReward(runId, 10, 10);
+//! const stats = await store.getRewardStats(runId);
+//! await store.exportJsonl(runId, './analysis.jsonl');
+//! ```
+
+mod reader;
+mod schema;
+mod store;
+mod types;
+mod writer;
+
+pub use store::OutputStore;
+pub use types::*;

--- a/crates/mlx-core/src/output_store/reader.rs
+++ b/crates/mlx-core/src/output_store/reader.rs
@@ -1,0 +1,728 @@
+//! Reader operations for the output store
+//!
+//! Handles querying training runs, steps, generations, and tool calls.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+use libsql::Connection;
+use napi::bindgen_prelude::*;
+use serde_json::json;
+
+use super::types::*;
+
+/// List all training runs
+pub async fn list_runs(
+    conn: &Connection,
+    limit: Option<i64>,
+    status: Option<String>,
+) -> Result<Vec<TrainingRunRecord>> {
+    let mut sql = "SELECT id, model_name, model_path, config, started_at, ended_at, total_steps, status FROM training_runs".to_string();
+
+    if status.is_some() {
+        sql.push_str(" WHERE status = ?1");
+    }
+
+    sql.push_str(" ORDER BY started_at DESC");
+
+    if let Some(lim) = limit {
+        sql.push_str(&format!(" LIMIT {}", lim));
+    }
+
+    let mut rows = if let Some(ref st) = status {
+        conn.query(&sql, libsql::params![st.clone()]).await
+    } else {
+        conn.query(&sql, ()).await
+    }
+    .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut runs = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        runs.push(TrainingRunRecord {
+            id: row.get::<String>(0).unwrap_or_default(),
+            model_name: row.get::<String>(1).unwrap_or_default(),
+            model_path: row.get::<Option<String>>(2).ok().flatten(),
+            config: row.get::<String>(3).unwrap_or_default(),
+            started_at: row.get::<i64>(4).unwrap_or(0),
+            ended_at: row.get::<Option<i64>>(5).ok().flatten(),
+            total_steps: row.get::<i64>(6).unwrap_or(0),
+            status: row.get::<String>(7).unwrap_or_default(),
+        });
+    }
+
+    Ok(runs)
+}
+
+/// Get a specific run
+pub async fn get_run(conn: &Connection, run_id: &str) -> Result<Option<TrainingRunRecord>> {
+    let mut rows = conn
+        .query(
+            "SELECT id, model_name, model_path, config, started_at, ended_at, total_steps, status FROM training_runs WHERE id = ?1",
+            libsql::params![run_id.to_string()],
+        )
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    if let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        Ok(Some(TrainingRunRecord {
+            id: row.get::<String>(0).unwrap_or_default(),
+            model_name: row.get::<String>(1).unwrap_or_default(),
+            model_path: row.get::<Option<String>>(2).ok().flatten(),
+            config: row.get::<String>(3).unwrap_or_default(),
+            started_at: row.get::<i64>(4).unwrap_or(0),
+            ended_at: row.get::<Option<i64>>(5).ok().flatten(),
+            total_steps: row.get::<i64>(6).unwrap_or(0),
+            status: row.get::<String>(7).unwrap_or_default(),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Get step summaries for a run
+pub async fn get_step_summaries(
+    conn: &Connection,
+    run_id: &str,
+    start_step: Option<i64>,
+    end_step: Option<i64>,
+) -> Result<Vec<StepSummary>> {
+    let mut sql = r#"
+        SELECT
+            ts.step,
+            ts.loss,
+            ts.mean_reward,
+            COUNT(g.id) as num_generations,
+            (SELECT COUNT(*) FROM tool_calls tc WHERE tc.generation_id IN (SELECT id FROM generations WHERE step_id = ts.id)) as num_tool_calls,
+            SUM(CASE WHEN g.finish_reason = 'eos' THEN 1 ELSE 0 END) as eos_count,
+            SUM(CASE WHEN g.finish_reason = 'length' THEN 1 ELSE 0 END) as length_count
+        FROM training_steps ts
+        LEFT JOIN generations g ON g.step_id = ts.id
+        WHERE ts.run_id = ?1
+    "#.to_string();
+
+    let mut param_idx = 2;
+    if start_step.is_some() {
+        sql.push_str(&format!(" AND ts.step >= ?{}", param_idx));
+        param_idx += 1;
+    }
+    if end_step.is_some() {
+        sql.push_str(&format!(" AND ts.step <= ?{}", param_idx));
+    }
+
+    sql.push_str(" GROUP BY ts.id ORDER BY ts.step");
+
+    let mut rows = match (start_step, end_step) {
+        (Some(s), Some(e)) => {
+            conn.query(&sql, libsql::params![run_id.to_string(), s, e])
+                .await
+        }
+        (Some(s), None) => {
+            conn.query(&sql, libsql::params![run_id.to_string(), s])
+                .await
+        }
+        (None, Some(e)) => {
+            conn.query(&sql, libsql::params![run_id.to_string(), e])
+                .await
+        }
+        (None, None) => conn.query(&sql, libsql::params![run_id.to_string()]).await,
+    }
+    .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut summaries = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        summaries.push(StepSummary {
+            step: row.get::<i64>(0).unwrap_or(0),
+            loss: row.get::<f64>(1).unwrap_or(0.0),
+            mean_reward: row.get::<f64>(2).unwrap_or(0.0),
+            num_generations: row.get::<i64>(3).unwrap_or(0),
+            num_tool_calls: row.get::<i64>(4).unwrap_or(0),
+            eos_count: row.get::<i64>(5).unwrap_or(0),
+            length_count: row.get::<i64>(6).unwrap_or(0),
+        });
+    }
+
+    Ok(summaries)
+}
+
+/// Get all generations for a step
+pub async fn get_generations(
+    conn: &Connection,
+    run_id: &str,
+    step: i64,
+) -> Result<Vec<GenerationWithToolCalls>> {
+    let mut rows = conn
+        .query(
+            r#"SELECT g.id, g.batch_index, g.group_index, g.prompt, g.expected_answer,
+                      g.completion_text, g.completion_raw, g.thinking, g.num_tokens, g.finish_reason, g.reward
+               FROM generations g
+               JOIN training_steps ts ON g.step_id = ts.id
+               WHERE ts.run_id = ?1 AND ts.step = ?2
+               ORDER BY g.batch_index, g.group_index"#,
+            libsql::params![run_id.to_string(), step],
+        )
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut results = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        let gen_id: i64 = row.get(0).unwrap_or(0);
+        let generation = GenerationRecord {
+            batch_index: row.get::<i64>(1).unwrap_or(0),
+            group_index: row.get::<i64>(2).unwrap_or(0),
+            prompt: row.get::<String>(3).unwrap_or_default(),
+            expected_answer: row.get::<Option<String>>(4).ok().flatten(),
+            completion_text: row.get::<String>(5).unwrap_or_default(),
+            completion_raw: row.get::<String>(6).unwrap_or_default(),
+            thinking: row.get::<Option<String>>(7).ok().flatten(),
+            num_tokens: row.get::<i64>(8).unwrap_or(0),
+            finish_reason: row.get::<String>(9).unwrap_or_default(),
+            reward: row.get::<f64>(10).unwrap_or(0.0),
+        };
+
+        let tool_calls = get_tool_calls_for_generation(conn, gen_id).await?;
+        results.push(GenerationWithToolCalls {
+            generation,
+            tool_calls,
+        });
+    }
+
+    Ok(results)
+}
+
+/// Get top/bottom generations by reward
+pub async fn get_generations_by_reward(
+    conn: &Connection,
+    run_id: &str,
+    top_n: Option<i64>,
+    bottom_n: Option<i64>,
+    step_range: Option<Vec<i64>>,
+) -> Result<Vec<GenerationWithToolCalls>> {
+    let mut results = Vec::new();
+
+    let step_filter = if let Some(ref range) = step_range {
+        if range.len() >= 2 {
+            format!(" AND ts.step >= {} AND ts.step <= {}", range[0], range[1])
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
+
+    // Get top N
+    if let Some(n) = top_n {
+        let sql = format!(
+            r#"SELECT g.id, g.batch_index, g.group_index, g.prompt, g.expected_answer,
+                      g.completion_text, g.completion_raw, g.thinking, g.num_tokens, g.finish_reason, g.reward
+               FROM generations g
+               JOIN training_steps ts ON g.step_id = ts.id
+               WHERE ts.run_id = ?1{}
+               ORDER BY g.reward DESC
+               LIMIT ?2"#,
+            step_filter
+        );
+
+        let mut rows = conn
+            .query(&sql, libsql::params![run_id.to_string(), n])
+            .await
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+        {
+            let gen_id: i64 = row.get(0).unwrap_or(0);
+            let generation = parse_generation_row(&row)?;
+            let tool_calls = get_tool_calls_for_generation(conn, gen_id).await?;
+            results.push(GenerationWithToolCalls {
+                generation,
+                tool_calls,
+            });
+        }
+    }
+
+    // Get bottom N
+    if let Some(n) = bottom_n {
+        let sql = format!(
+            r#"SELECT g.id, g.batch_index, g.group_index, g.prompt, g.expected_answer,
+                      g.completion_text, g.completion_raw, g.thinking, g.num_tokens, g.finish_reason, g.reward
+               FROM generations g
+               JOIN training_steps ts ON g.step_id = ts.id
+               WHERE ts.run_id = ?1{}
+               ORDER BY g.reward ASC
+               LIMIT ?2"#,
+            step_filter
+        );
+
+        let mut rows = conn
+            .query(&sql, libsql::params![run_id.to_string(), n])
+            .await
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+        {
+            let gen_id: i64 = row.get(0).unwrap_or(0);
+            let generation = parse_generation_row(&row)?;
+            let tool_calls = get_tool_calls_for_generation(conn, gen_id).await?;
+            results.push(GenerationWithToolCalls {
+                generation,
+                tool_calls,
+            });
+        }
+    }
+
+    Ok(results)
+}
+
+/// Get generations with specific finish reason
+pub async fn get_generations_by_finish_reason(
+    conn: &Connection,
+    run_id: &str,
+    finish_reason: &str,
+    limit: Option<i64>,
+) -> Result<Vec<GenerationWithToolCalls>> {
+    let limit_clause = limit.map(|n| format!(" LIMIT {}", n)).unwrap_or_default();
+
+    let sql = format!(
+        r#"SELECT g.id, g.batch_index, g.group_index, g.prompt, g.expected_answer,
+                  g.completion_text, g.completion_raw, g.thinking, g.num_tokens, g.finish_reason, g.reward
+           FROM generations g
+           JOIN training_steps ts ON g.step_id = ts.id
+           WHERE ts.run_id = ?1 AND g.finish_reason = ?2
+           ORDER BY ts.step DESC{}"#,
+        limit_clause
+    );
+
+    let mut rows = conn
+        .query(
+            &sql,
+            libsql::params![run_id.to_string(), finish_reason.to_string()],
+        )
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut results = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        let gen_id: i64 = row.get(0).unwrap_or(0);
+        let generation = parse_generation_row(&row)?;
+        let tool_calls = get_tool_calls_for_generation(conn, gen_id).await?;
+        results.push(GenerationWithToolCalls {
+            generation,
+            tool_calls,
+        });
+    }
+
+    Ok(results)
+}
+
+/// Get generations containing tool calls
+pub async fn get_generations_with_tool_calls(
+    conn: &Connection,
+    run_id: &str,
+    tool_name: Option<String>,
+    status: Option<String>,
+    limit: Option<i64>,
+) -> Result<Vec<GenerationWithToolCalls>> {
+    let limit_clause = limit.map(|n| format!(" LIMIT {}", n)).unwrap_or_default();
+
+    let mut sql = r#"SELECT DISTINCT g.id, g.batch_index, g.group_index, g.prompt, g.expected_answer,
+                  g.completion_text, g.completion_raw, g.thinking, g.num_tokens, g.finish_reason, g.reward
+           FROM generations g
+           JOIN training_steps ts ON g.step_id = ts.id
+           JOIN tool_calls tc ON tc.generation_id = g.id
+           WHERE ts.run_id = ?1"#.to_string();
+
+    let mut param_idx = 2;
+    if tool_name.is_some() {
+        sql.push_str(&format!(" AND tc.tool_name = ?{}", param_idx));
+        param_idx += 1;
+    }
+    if status.is_some() {
+        sql.push_str(&format!(" AND tc.status = ?{}", param_idx));
+    }
+
+    sql.push_str(&format!(" ORDER BY ts.step DESC{}", limit_clause));
+
+    let mut rows = match (&tool_name, &status) {
+        (Some(t), Some(s)) => {
+            conn.query(
+                &sql,
+                libsql::params![run_id.to_string(), t.clone(), s.clone()],
+            )
+            .await
+        }
+        (Some(t), None) => {
+            conn.query(&sql, libsql::params![run_id.to_string(), t.clone()])
+                .await
+        }
+        (None, Some(s)) => {
+            conn.query(&sql, libsql::params![run_id.to_string(), s.clone()])
+                .await
+        }
+        (None, None) => conn.query(&sql, libsql::params![run_id.to_string()]).await,
+    }
+    .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut results = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        let gen_id: i64 = row.get(0).unwrap_or(0);
+        let generation = parse_generation_row(&row)?;
+        let tool_calls = get_tool_calls_for_generation(conn, gen_id).await?;
+        results.push(GenerationWithToolCalls {
+            generation,
+            tool_calls,
+        });
+    }
+
+    Ok(results)
+}
+
+/// Search generations by text content
+pub async fn search_generations(
+    conn: &Connection,
+    run_id: &str,
+    query: &str,
+    search_in: Option<String>,
+    limit: Option<i64>,
+) -> Result<Vec<GenerationWithToolCalls>> {
+    let search_pattern = format!("%{}%", query);
+    let limit_clause = limit.map(|n| format!(" LIMIT {}", n)).unwrap_or_default();
+
+    let where_clause = match search_in.as_deref() {
+        Some("prompt") => "g.prompt LIKE ?2",
+        Some("completion") => "g.completion_text LIKE ?2",
+        Some("thinking") => "g.thinking LIKE ?2",
+        _ => "(g.prompt LIKE ?2 OR g.completion_text LIKE ?2 OR g.thinking LIKE ?2)",
+    };
+
+    let sql = format!(
+        r#"SELECT g.id, g.batch_index, g.group_index, g.prompt, g.expected_answer,
+                  g.completion_text, g.completion_raw, g.thinking, g.num_tokens, g.finish_reason, g.reward
+           FROM generations g
+           JOIN training_steps ts ON g.step_id = ts.id
+           WHERE ts.run_id = ?1 AND {}
+           ORDER BY ts.step DESC{}"#,
+        where_clause, limit_clause
+    );
+
+    let mut rows = conn
+        .query(
+            &sql,
+            libsql::params![run_id.to_string(), search_pattern.clone()],
+        )
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut results = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        let gen_id: i64 = row.get(0).unwrap_or(0);
+        let generation = parse_generation_row(&row)?;
+        let tool_calls = get_tool_calls_for_generation(conn, gen_id).await?;
+        results.push(GenerationWithToolCalls {
+            generation,
+            tool_calls,
+        });
+    }
+
+    Ok(results)
+}
+
+/// Get reward distribution statistics
+pub async fn get_reward_stats(
+    conn: &Connection,
+    run_id: &str,
+    step_range: Option<Vec<i64>>,
+) -> Result<RewardStats> {
+    let step_filter = if let Some(ref range) = step_range {
+        if range.len() >= 2 {
+            format!(" AND ts.step >= {} AND ts.step <= {}", range[0], range[1])
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
+
+    // Get basic stats
+    let sql = format!(
+        r#"SELECT
+            COUNT(*) as count,
+            AVG(g.reward) as mean,
+            MIN(g.reward) as min,
+            MAX(g.reward) as max
+           FROM generations g
+           JOIN training_steps ts ON g.step_id = ts.id
+           WHERE ts.run_id = ?1{}"#,
+        step_filter
+    );
+
+    let mut rows = conn
+        .query(&sql, libsql::params![run_id.to_string()])
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let row = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+        .ok_or_else(|| Error::new(Status::GenericFailure, "No stats returned"))?;
+
+    let count: i64 = row.get(0).unwrap_or(0);
+    let mean: f64 = row.get(1).unwrap_or(0.0);
+    let min: f64 = row.get(2).unwrap_or(0.0);
+    let max: f64 = row.get(3).unwrap_or(0.0);
+
+    if count == 0 {
+        return Ok(RewardStats::default());
+    }
+
+    // Get all rewards for std dev and percentiles
+    let sql = format!(
+        r#"SELECT g.reward FROM generations g
+           JOIN training_steps ts ON g.step_id = ts.id
+           WHERE ts.run_id = ?1{}
+           ORDER BY g.reward"#,
+        step_filter
+    );
+
+    let mut rows = conn
+        .query(&sql, libsql::params![run_id.to_string()])
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut rewards = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        rewards.push(row.get::<f64>(0).unwrap_or(0.0));
+    }
+
+    // Calculate std dev
+    let variance: f64 = rewards.iter().map(|&r| (r - mean).powi(2)).sum::<f64>() / count as f64;
+    let std = variance.sqrt();
+
+    // Calculate percentiles
+    let n = rewards.len();
+    let p25 = if n > 0 { rewards[n / 4] } else { 0.0 };
+    let median = if n > 0 { rewards[n / 2] } else { 0.0 };
+    let p75 = if n > 0 { rewards[3 * n / 4] } else { 0.0 };
+
+    Ok(RewardStats {
+        count,
+        mean,
+        std,
+        min,
+        max,
+        median,
+        p25,
+        p75,
+    })
+}
+
+/// Export to JSONL file
+pub async fn export_jsonl(
+    conn: &Connection,
+    run_id: &str,
+    output_path: &str,
+    include_tool_calls: bool,
+) -> Result<i64> {
+    let file = File::create(output_path).map_err(|e| {
+        Error::new(
+            Status::GenericFailure,
+            format!("Failed to create file: {}", e),
+        )
+    })?;
+    let mut writer = BufWriter::new(file);
+
+    let mut rows = conn
+        .query(
+            r#"SELECT g.id, g.batch_index, g.group_index, g.prompt, g.expected_answer,
+                      g.completion_text, g.completion_raw, g.thinking, g.num_tokens, g.finish_reason, g.reward,
+                      ts.step, ts.loss
+               FROM generations g
+               JOIN training_steps ts ON g.step_id = ts.id
+               WHERE ts.run_id = ?1
+               ORDER BY ts.step, g.batch_index, g.group_index"#,
+            libsql::params![run_id.to_string()],
+        )
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut count = 0i64;
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        let gen_id: i64 = row.get(0).unwrap_or(0);
+
+        let mut record = json!({
+            "step": row.get::<i64>(11).unwrap_or(0),
+            "loss": row.get::<f64>(12).unwrap_or(0.0),
+            "batch_index": row.get::<i64>(1).unwrap_or(0),
+            "group_index": row.get::<i64>(2).unwrap_or(0),
+            "prompt": row.get::<String>(3).unwrap_or_default(),
+            "expected_answer": row.get::<Option<String>>(4).ok().flatten(),
+            "completion_text": row.get::<String>(5).unwrap_or_default(),
+            "completion_raw": row.get::<String>(6).unwrap_or_default(),
+            "thinking": row.get::<Option<String>>(7).ok().flatten(),
+            "num_tokens": row.get::<i64>(8).unwrap_or(0),
+            "finish_reason": row.get::<String>(9).unwrap_or_default(),
+            "reward": row.get::<f64>(10).unwrap_or(0.0),
+        });
+
+        if include_tool_calls {
+            let tool_calls = get_tool_calls_for_generation(conn, gen_id).await?;
+            record["tool_calls"] = json!(
+                tool_calls
+                    .iter()
+                    .map(|tc| {
+                        json!({
+                            "status": tc.status,
+                            "tool_name": tc.tool_name,
+                            "arguments": tc.arguments,
+                            "raw_content": tc.raw_content,
+                            "error_message": tc.error_message,
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        let line = serde_json::to_string(&record).map_err(|e| {
+            Error::new(
+                Status::GenericFailure,
+                format!("JSON serialize failed: {}", e),
+            )
+        })?;
+        writeln!(writer, "{}", line)
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Write failed: {}", e)))?;
+        count += 1;
+    }
+
+    writer
+        .flush()
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Flush failed: {}", e)))?;
+
+    Ok(count)
+}
+
+/// Execute raw SQL query
+pub async fn query_raw(conn: &Connection, sql: &str) -> Result<String> {
+    let mut rows = conn
+        .query(sql, ())
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut results = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        // Get column count from the row
+        let mut row_data = serde_json::Map::new();
+        // Note: libsql doesn't provide column count directly, so we try to read columns 0-20
+        for i in 0..20 {
+            if let Ok(val) = row.get::<String>(i) {
+                row_data.insert(format!("col{}", i), json!(val));
+            } else if let Ok(val) = row.get::<i64>(i) {
+                row_data.insert(format!("col{}", i), json!(val));
+            } else if let Ok(val) = row.get::<f64>(i) {
+                row_data.insert(format!("col{}", i), json!(val));
+            } else {
+                break;
+            }
+        }
+        results.push(serde_json::Value::Object(row_data));
+    }
+
+    serde_json::to_string(&results).map_err(|e| {
+        Error::new(
+            Status::GenericFailure,
+            format!("JSON serialize failed: {}", e),
+        )
+    })
+}
+
+// === Helper functions ===
+
+async fn get_tool_calls_for_generation(
+    conn: &Connection,
+    gen_id: i64,
+) -> Result<Vec<ToolCallRecord>> {
+    let mut rows = conn
+        .query(
+            "SELECT call_index, status, tool_name, arguments, raw_content, error_message FROM tool_calls WHERE generation_id = ?1 ORDER BY call_index",
+            libsql::params![gen_id],
+        )
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Query failed: {}", e)))?;
+
+    let mut tool_calls = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Row read failed: {}", e)))?
+    {
+        tool_calls.push(ToolCallRecord {
+            call_index: row.get::<i64>(0).unwrap_or(0),
+            status: row.get::<String>(1).unwrap_or_default(),
+            tool_name: row.get::<Option<String>>(2).ok().flatten(),
+            arguments: row.get::<Option<String>>(3).ok().flatten(),
+            raw_content: row.get::<String>(4).unwrap_or_default(),
+            error_message: row.get::<Option<String>>(5).ok().flatten(),
+        });
+    }
+
+    Ok(tool_calls)
+}
+
+fn parse_generation_row(row: &libsql::Row) -> Result<GenerationRecord> {
+    Ok(GenerationRecord {
+        batch_index: row.get::<i64>(1).unwrap_or(0),
+        group_index: row.get::<i64>(2).unwrap_or(0),
+        prompt: row.get::<String>(3).unwrap_or_default(),
+        expected_answer: row.get::<Option<String>>(4).ok().flatten(),
+        completion_text: row.get::<String>(5).unwrap_or_default(),
+        completion_raw: row.get::<String>(6).unwrap_or_default(),
+        thinking: row.get::<Option<String>>(7).ok().flatten(),
+        num_tokens: row.get::<i64>(8).unwrap_or(0),
+        finish_reason: row.get::<String>(9).unwrap_or_default(),
+        reward: row.get::<f64>(10).unwrap_or(0.0),
+    })
+}

--- a/crates/mlx-core/src/output_store/schema.rs
+++ b/crates/mlx-core/src/output_store/schema.rs
@@ -1,0 +1,115 @@
+//! Database schema for the output store
+//!
+//! Defines tables for storing training runs, steps, generations, and tool calls.
+
+use libsql::Connection;
+use napi::bindgen_prelude::*;
+
+/// SQL statements for creating the schema
+pub const CREATE_TABLES_SQL: &str = r#"
+-- Training runs (one per training session)
+CREATE TABLE IF NOT EXISTS training_runs (
+    id TEXT PRIMARY KEY,
+    model_name TEXT NOT NULL,
+    model_path TEXT,
+    config TEXT NOT NULL,
+    started_at INTEGER NOT NULL,
+    ended_at INTEGER,
+    total_steps INTEGER DEFAULT 0,
+    status TEXT DEFAULT 'running'
+);
+
+-- Individual training steps
+CREATE TABLE IF NOT EXISTS training_steps (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL REFERENCES training_runs(id),
+    step INTEGER NOT NULL,
+    epoch INTEGER,
+    loss REAL NOT NULL,
+    mean_reward REAL NOT NULL,
+    std_reward REAL NOT NULL,
+    mean_advantage REAL,
+    total_tokens INTEGER,
+    generation_time_ms REAL,
+    training_time_ms REAL,
+    gradients_applied INTEGER,
+    created_at INTEGER NOT NULL,
+    UNIQUE(run_id, step)
+);
+
+-- All generations (group_size * batch_size per step)
+CREATE TABLE IF NOT EXISTS generations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL REFERENCES training_runs(id),
+    step_id INTEGER NOT NULL REFERENCES training_steps(id),
+    batch_index INTEGER NOT NULL,
+    group_index INTEGER NOT NULL,
+    prompt TEXT NOT NULL,
+    expected_answer TEXT,
+    completion_text TEXT NOT NULL,
+    completion_raw TEXT NOT NULL,
+    thinking TEXT,
+    num_tokens INTEGER NOT NULL,
+    finish_reason TEXT NOT NULL,
+    reward REAL NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+-- Parsed tool calls (0-N per generation)
+CREATE TABLE IF NOT EXISTS tool_calls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    generation_id INTEGER NOT NULL REFERENCES generations(id),
+    call_index INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    tool_name TEXT,
+    arguments TEXT,
+    raw_content TEXT NOT NULL,
+    error_message TEXT
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_steps_run ON training_steps(run_id, step);
+CREATE INDEX IF NOT EXISTS idx_gens_step ON generations(step_id);
+CREATE INDEX IF NOT EXISTS idx_gens_run_reward ON generations(run_id, reward);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_gen ON tool_calls(generation_id);
+CREATE INDEX IF NOT EXISTS idx_gens_finish ON generations(run_id, finish_reason);
+"#;
+
+/// Initialize the database schema
+pub async fn init_schema(conn: &Connection) -> Result<()> {
+    // Split SQL into individual statements and execute each
+    for statement in CREATE_TABLES_SQL.split(';') {
+        // Remove comment lines and trim
+        let cleaned: String = statement
+            .lines()
+            .filter(|line| !line.trim().starts_with("--"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let cleaned = cleaned.trim();
+
+        if !cleaned.is_empty() {
+            conn.execute(cleaned, ()).await.map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to execute schema statement: {}", e),
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_tables_sql_is_valid() {
+        // Basic validation that the SQL string is well-formed
+        assert!(CREATE_TABLES_SQL.contains("CREATE TABLE IF NOT EXISTS training_runs"));
+        assert!(CREATE_TABLES_SQL.contains("CREATE TABLE IF NOT EXISTS training_steps"));
+        assert!(CREATE_TABLES_SQL.contains("CREATE TABLE IF NOT EXISTS generations"));
+        assert!(CREATE_TABLES_SQL.contains("CREATE TABLE IF NOT EXISTS tool_calls"));
+        assert!(CREATE_TABLES_SQL.contains("CREATE INDEX IF NOT EXISTS"));
+    }
+}

--- a/crates/mlx-core/src/output_store/store.rs
+++ b/crates/mlx-core/src/output_store/store.rs
@@ -1,0 +1,453 @@
+//! OutputStore - Main storage interface for training outputs
+//!
+//! Provides connection management and high-level API for recording
+//! and querying training data.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use libsql::{Builder, Connection, Database};
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use super::reader;
+use super::schema::init_schema;
+use super::types::*;
+use super::writer;
+use crate::grpo::engine::EngineStepMetrics;
+
+/// OutputStore - Persistence layer for training outputs
+///
+/// Stores all model outputs during GRPO training for debugging and research.
+/// Supports local SQLite files and remote Turso cloud databases.
+#[napi]
+pub struct OutputStore {
+    db: Arc<Database>,
+    conn: Arc<RwLock<Connection>>,
+    config: OutputStoreConfig,
+    current_run_id: Arc<RwLock<Option<String>>>,
+}
+
+#[napi]
+impl OutputStore {
+    /// Create a new output store with local SQLite file
+    #[napi(factory)]
+    pub async fn local(path: String) -> Result<Self> {
+        let db = Builder::new_local(&path).build().await.map_err(|e| {
+            Error::new(
+                Status::GenericFailure,
+                format!("Failed to open local db: {}", e),
+            )
+        })?;
+
+        let conn = db
+            .connect()
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to connect: {}", e)))?;
+
+        // Initialize schema
+        init_schema(&conn).await?;
+
+        Ok(Self {
+            db: Arc::new(db),
+            conn: Arc::new(RwLock::new(conn)),
+            config: OutputStoreConfig {
+                local_path: Some(path),
+                ..Default::default()
+            },
+            current_run_id: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// Create a new output store with remote Turso database
+    #[napi(factory)]
+    pub async fn remote(url: String, token: String) -> Result<Self> {
+        let db = Builder::new_remote(url.clone(), token.clone())
+            .build()
+            .await
+            .map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to connect to remote db: {}", e),
+                )
+            })?;
+
+        let conn = db
+            .connect()
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to connect: {}", e)))?;
+
+        // Initialize schema
+        init_schema(&conn).await?;
+
+        Ok(Self {
+            db: Arc::new(db),
+            conn: Arc::new(RwLock::new(conn)),
+            config: OutputStoreConfig {
+                remote_url: Some(url),
+                auth_token: Some(token),
+                ..Default::default()
+            },
+            current_run_id: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// Create embedded replica (local cache + remote sync)
+    #[napi(factory)]
+    pub async fn embedded_replica(
+        local_path: String,
+        remote_url: String,
+        token: String,
+        sync_interval_secs: Option<u32>,
+    ) -> Result<Self> {
+        let interval = sync_interval_secs.unwrap_or(60);
+
+        let db = Builder::new_remote_replica(&local_path, remote_url.clone(), token.clone())
+            .sync_interval(Duration::from_secs(interval as u64))
+            .build()
+            .await
+            .map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to create replica: {}", e),
+                )
+            })?;
+
+        let conn = db
+            .connect()
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to connect: {}", e)))?;
+
+        // Initialize schema
+        init_schema(&conn).await?;
+
+        // Initial sync
+        db.sync().await.map_err(|e| {
+            Error::new(
+                Status::GenericFailure,
+                format!("Initial sync failed: {}", e),
+            )
+        })?;
+
+        Ok(Self {
+            db: Arc::new(db),
+            conn: Arc::new(RwLock::new(conn)),
+            config: OutputStoreConfig {
+                local_path: Some(local_path),
+                remote_url: Some(remote_url),
+                auth_token: Some(token),
+                sync_interval_secs: Some(interval),
+                ..Default::default()
+            },
+            current_run_id: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// Create from config object
+    #[napi(factory)]
+    pub async fn from_config(config: OutputStoreConfig) -> Result<Self> {
+        if let (Some(local), Some(remote), Some(token)) =
+            (&config.local_path, &config.remote_url, &config.auth_token)
+        {
+            // Embedded replica mode
+            Self::embedded_replica(
+                local.clone(),
+                remote.clone(),
+                token.clone(),
+                config.sync_interval_secs,
+            )
+            .await
+        } else if let (Some(remote), Some(token)) = (&config.remote_url, &config.auth_token) {
+            // Remote only
+            Self::remote(remote.clone(), token.clone()).await
+        } else if let Some(local) = &config.local_path {
+            // Local only
+            Self::local(local.clone()).await
+        } else {
+            Err(Error::new(
+                Status::InvalidArg,
+                "OutputStoreConfig must specify either local_path or remote_url + auth_token",
+            ))
+        }
+    }
+
+    // === Training Run Management ===
+
+    /// Start a new training run
+    #[napi]
+    pub async fn start_run(
+        &self,
+        model_name: String,
+        model_path: Option<String>,
+        config: String,
+    ) -> Result<String> {
+        let run_id = Uuid::new_v4().to_string();
+        let started_at = chrono_now_ms();
+
+        let conn = self.conn.write().await;
+        conn.execute(
+            "INSERT INTO training_runs (id, model_name, model_path, config, started_at, status) VALUES (?1, ?2, ?3, ?4, ?5, 'running')",
+            libsql::params![run_id.clone(), model_name, model_path, config, started_at],
+        )
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to insert run: {}", e)))?;
+
+        // Store current run ID
+        let mut current = self.current_run_id.write().await;
+        *current = Some(run_id.clone());
+
+        Ok(run_id)
+    }
+
+    /// End the current training run
+    #[napi]
+    pub async fn end_run(&self, status: String) -> Result<()> {
+        let run_id = {
+            let current = self.current_run_id.read().await;
+            current
+                .clone()
+                .ok_or_else(|| Error::new(Status::GenericFailure, "No active training run"))?
+        };
+
+        let ended_at = chrono_now_ms();
+
+        let conn = self.conn.write().await;
+        conn.execute(
+            "UPDATE training_runs SET ended_at = ?1, status = ?2 WHERE id = ?3",
+            libsql::params![ended_at, status, run_id.clone()],
+        )
+        .await
+        .map_err(|e| {
+            Error::new(
+                Status::GenericFailure,
+                format!("Failed to update run: {}", e),
+            )
+        })?;
+
+        // Update step count
+        conn.execute(
+            "UPDATE training_runs SET total_steps = (SELECT COUNT(*) FROM training_steps WHERE run_id = ?1) WHERE id = ?1",
+            libsql::params![run_id],
+        )
+        .await
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to update step count: {}", e)))?;
+
+        // Clear current run ID
+        let mut current = self.current_run_id.write().await;
+        *current = None;
+
+        Ok(())
+    }
+
+    /// Get current run ID
+    #[napi]
+    pub async fn current_run_id(&self) -> Option<String> {
+        let current = self.current_run_id.read().await;
+        current.clone()
+    }
+
+    /// Get store configuration
+    #[napi(getter)]
+    pub fn config(&self) -> OutputStoreConfig {
+        self.config.clone()
+    }
+
+    // === Recording ===
+
+    /// Record a complete training step with all generations
+    #[napi]
+    pub async fn record_step(
+        &self,
+        step: StepRecord,
+        generations: Vec<GenerationRecord>,
+        tool_calls: Vec<Vec<ToolCallRecord>>,
+    ) -> Result<i64> {
+        let conn = self.conn.write().await;
+        writer::record_step(&conn, step, generations, tool_calls).await
+    }
+
+    /// Record from RewardOutput JSON (direct integration with training engine)
+    #[napi]
+    pub async fn record_step_from_outputs(
+        &self,
+        step: i64,
+        metrics: EngineStepMetrics,
+        outputs_json: String,
+        rewards: Vec<f64>,
+        group_size: i64,
+    ) -> Result<i64> {
+        let run_id = {
+            let current = self.current_run_id.read().await;
+            current
+                .clone()
+                .ok_or_else(|| Error::new(Status::GenericFailure, "No active training run"))?
+        };
+
+        let conn = self.conn.write().await;
+        writer::record_step_from_outputs(
+            &conn,
+            &run_id,
+            step,
+            metrics,
+            &outputs_json,
+            &rewards,
+            group_size,
+        )
+        .await
+    }
+
+    /// Flush any pending writes
+    #[napi]
+    pub async fn flush(&self) -> Result<()> {
+        // For now, all writes are immediate
+        // Future: implement batched writes
+        Ok(())
+    }
+
+    /// Sync with remote (for embedded replica mode)
+    #[napi]
+    pub async fn sync(&self) -> Result<()> {
+        self.db
+            .sync()
+            .await
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Sync failed: {}", e)))?;
+        Ok(())
+    }
+
+    // === Query API ===
+
+    /// List all training runs
+    #[napi]
+    pub async fn list_runs(
+        &self,
+        limit: Option<i64>,
+        status: Option<String>,
+    ) -> Result<Vec<TrainingRunRecord>> {
+        let conn = self.conn.read().await;
+        reader::list_runs(&conn, limit, status).await
+    }
+
+    /// Get a specific run
+    #[napi]
+    pub async fn get_run(&self, run_id: String) -> Result<Option<TrainingRunRecord>> {
+        let conn = self.conn.read().await;
+        reader::get_run(&conn, &run_id).await
+    }
+
+    /// Get step summaries for a run
+    #[napi]
+    pub async fn get_step_summaries(
+        &self,
+        run_id: String,
+        start_step: Option<i64>,
+        end_step: Option<i64>,
+    ) -> Result<Vec<StepSummary>> {
+        let conn = self.conn.read().await;
+        reader::get_step_summaries(&conn, &run_id, start_step, end_step).await
+    }
+
+    /// Get all generations for a step
+    #[napi]
+    pub async fn get_generations(
+        &self,
+        run_id: String,
+        step: i64,
+    ) -> Result<Vec<GenerationWithToolCalls>> {
+        let conn = self.conn.read().await;
+        reader::get_generations(&conn, &run_id, step).await
+    }
+
+    /// Get top/bottom generations by reward
+    #[napi]
+    pub async fn get_generations_by_reward(
+        &self,
+        run_id: String,
+        top_n: Option<i64>,
+        bottom_n: Option<i64>,
+        step_range: Option<Vec<i64>>,
+    ) -> Result<Vec<GenerationWithToolCalls>> {
+        let conn = self.conn.read().await;
+        reader::get_generations_by_reward(&conn, &run_id, top_n, bottom_n, step_range).await
+    }
+
+    /// Get generations with specific finish reason
+    #[napi]
+    pub async fn get_generations_by_finish_reason(
+        &self,
+        run_id: String,
+        finish_reason: String,
+        limit: Option<i64>,
+    ) -> Result<Vec<GenerationWithToolCalls>> {
+        let conn = self.conn.read().await;
+        reader::get_generations_by_finish_reason(&conn, &run_id, &finish_reason, limit).await
+    }
+
+    /// Get generations containing tool calls
+    #[napi]
+    pub async fn get_generations_with_tool_calls(
+        &self,
+        run_id: String,
+        tool_name: Option<String>,
+        status: Option<String>,
+        limit: Option<i64>,
+    ) -> Result<Vec<GenerationWithToolCalls>> {
+        let conn = self.conn.read().await;
+        reader::get_generations_with_tool_calls(&conn, &run_id, tool_name, status, limit).await
+    }
+
+    /// Search generations by text content
+    #[napi]
+    pub async fn search_generations(
+        &self,
+        run_id: String,
+        query: String,
+        search_in: Option<String>,
+        limit: Option<i64>,
+    ) -> Result<Vec<GenerationWithToolCalls>> {
+        let conn = self.conn.read().await;
+        reader::search_generations(&conn, &run_id, &query, search_in, limit).await
+    }
+
+    /// Get reward distribution statistics
+    #[napi]
+    pub async fn get_reward_stats(
+        &self,
+        run_id: String,
+        step_range: Option<Vec<i64>>,
+    ) -> Result<RewardStats> {
+        let conn = self.conn.read().await;
+        reader::get_reward_stats(&conn, &run_id, step_range).await
+    }
+
+    /// Export to JSONL file
+    #[napi]
+    pub async fn export_jsonl(
+        &self,
+        run_id: String,
+        output_path: String,
+        include_tool_calls: Option<bool>,
+    ) -> Result<i64> {
+        let conn = self.conn.read().await;
+        reader::export_jsonl(
+            &conn,
+            &run_id,
+            &output_path,
+            include_tool_calls.unwrap_or(true),
+        )
+        .await
+    }
+
+    /// Execute raw SQL query (for advanced users)
+    #[napi]
+    pub async fn query_raw(&self, sql: String) -> Result<String> {
+        let conn = self.conn.read().await;
+        reader::query_raw(&conn, &sql).await
+    }
+}
+
+/// Get current timestamp in milliseconds
+fn chrono_now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock is set before UNIX_EPOCH")
+        .as_millis() as i64
+}

--- a/crates/mlx-core/src/output_store/types.rs
+++ b/crates/mlx-core/src/output_store/types.rs
@@ -1,0 +1,183 @@
+//! Data types for the output store module
+//!
+//! These types are exposed via NAPI and used for recording and querying
+//! training outputs.
+
+use napi_derive::napi;
+
+/// Configuration for creating an OutputStore connection
+#[napi(object)]
+#[derive(Clone, Default)]
+pub struct OutputStoreConfig {
+    /// Local SQLite file path (e.g., "training_outputs.db")
+    pub local_path: Option<String>,
+    /// Remote Turso URL (e.g., "libsql://db-name.turso.io")
+    pub remote_url: Option<String>,
+    /// Turso auth token
+    pub auth_token: Option<String>,
+    /// Sync interval in seconds for embedded replica mode (default: 60)
+    pub sync_interval_secs: Option<u32>,
+    /// Batch size for buffered inserts (default: 100)
+    pub batch_size: Option<u32>,
+}
+
+/// A training run record
+#[napi(object)]
+#[derive(Clone)]
+pub struct TrainingRunRecord {
+    /// Unique run ID (UUID)
+    pub id: String,
+    /// Model name
+    pub model_name: String,
+    /// Path to model weights
+    pub model_path: Option<String>,
+    /// Serialized training config (JSON)
+    pub config: String,
+    /// Unix timestamp (milliseconds) when training started
+    pub started_at: i64,
+    /// Unix timestamp (milliseconds) when training ended
+    pub ended_at: Option<i64>,
+    /// Total number of training steps completed
+    pub total_steps: i64,
+    /// Run status: "running", "completed", "failed", "paused"
+    pub status: String,
+}
+
+/// A training step record
+#[napi(object)]
+#[derive(Clone)]
+pub struct StepRecord {
+    /// Run ID this step belongs to
+    pub run_id: String,
+    /// Step number
+    pub step: i64,
+    /// Epoch number
+    pub epoch: Option<i64>,
+    /// GRPO loss value
+    pub loss: f64,
+    /// Mean reward across completions
+    pub mean_reward: f64,
+    /// Standard deviation of rewards
+    pub std_reward: f64,
+    /// Mean advantage value
+    pub mean_advantage: Option<f64>,
+    /// Total tokens generated this step
+    pub total_tokens: Option<i64>,
+    /// Time for generation phase (milliseconds)
+    pub generation_time_ms: Option<f64>,
+    /// Time for training phase (milliseconds)
+    pub training_time_ms: Option<f64>,
+    /// Whether gradients were applied this step
+    pub gradients_applied: bool,
+}
+
+/// A generation record (one completion)
+#[napi(object)]
+#[derive(Clone)]
+pub struct GenerationRecord {
+    /// Index within the batch
+    pub batch_index: i64,
+    /// Index within the group (0 to group_size-1)
+    pub group_index: i64,
+    /// The prompt text
+    pub prompt: String,
+    /// Expected answer (if available)
+    pub expected_answer: Option<String>,
+    /// Cleaned completion text (tags removed)
+    pub completion_text: String,
+    /// Raw completion text (with <think>/<tool_call> tags)
+    pub completion_raw: String,
+    /// Extracted thinking content from <think> tags
+    pub thinking: Option<String>,
+    /// Number of tokens in the completion
+    pub num_tokens: i64,
+    /// Finish reason: "eos", "length", or "repetition"
+    pub finish_reason: String,
+    /// Reward value for this completion
+    pub reward: f64,
+}
+
+/// A tool call record
+#[napi(object)]
+#[derive(Clone)]
+pub struct ToolCallRecord {
+    /// Index of this call within the generation
+    pub call_index: i64,
+    /// Parse status: "ok", "parse_error", "json_error"
+    pub status: String,
+    /// Tool name (null if parse failed)
+    pub tool_name: Option<String>,
+    /// Tool arguments as JSON (null if parse failed)
+    pub arguments: Option<String>,
+    /// Raw content from <tool_call> tag
+    pub raw_content: String,
+    /// Error message if parsing failed
+    pub error_message: Option<String>,
+}
+
+/// A generation with its associated tool calls
+#[napi(object)]
+#[derive(Clone)]
+pub struct GenerationWithToolCalls {
+    /// The generation record
+    pub generation: GenerationRecord,
+    /// Tool calls made in this generation
+    pub tool_calls: Vec<ToolCallRecord>,
+}
+
+/// Summary of a training step
+#[napi(object)]
+#[derive(Clone)]
+pub struct StepSummary {
+    /// Step number
+    pub step: i64,
+    /// Loss value
+    pub loss: f64,
+    /// Mean reward
+    pub mean_reward: f64,
+    /// Number of generations in this step
+    pub num_generations: i64,
+    /// Number of tool calls across all generations
+    pub num_tool_calls: i64,
+    /// Count of completions that ended with EOS
+    pub eos_count: i64,
+    /// Count of completions that hit token limit
+    pub length_count: i64,
+}
+
+/// Reward distribution statistics
+#[napi(object)]
+#[derive(Clone)]
+pub struct RewardStats {
+    /// Total count of generations
+    pub count: i64,
+    /// Mean reward
+    pub mean: f64,
+    /// Standard deviation
+    pub std: f64,
+    /// Minimum reward
+    pub min: f64,
+    /// Maximum reward
+    pub max: f64,
+    /// Median (50th percentile)
+    pub median: f64,
+    /// 25th percentile
+    pub p25: f64,
+    /// 75th percentile
+    pub p75: f64,
+}
+
+impl Default for RewardStats {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            mean: 0.0,
+            std: 0.0,
+            min: 0.0,
+            max: 0.0,
+            median: 0.0,
+            p25: 0.0,
+            p75: 0.0,
+        }
+    }
+}

--- a/crates/mlx-core/src/output_store/writer.rs
+++ b/crates/mlx-core/src/output_store/writer.rs
@@ -1,0 +1,241 @@
+//! Writer operations for the output store
+//!
+//! Handles inserting training steps, generations, and tool calls.
+
+use libsql::Connection;
+use napi::bindgen_prelude::*;
+
+use super::types::*;
+use crate::grpo::engine::EngineStepMetrics;
+use crate::tools::RewardOutput;
+
+/// Record a complete training step with all generations
+///
+/// Uses a transaction to ensure atomicity - all inserts succeed or none do.
+pub async fn record_step(
+    conn: &Connection,
+    step: StepRecord,
+    generations: Vec<GenerationRecord>,
+    tool_calls: Vec<Vec<ToolCallRecord>>,
+) -> Result<i64> {
+    let created_at = chrono_now_ms();
+
+    // Start transaction for atomicity
+    let tx = conn.transaction().await.map_err(|e| {
+        Error::new(
+            Status::GenericFailure,
+            format!("Failed to begin transaction: {}", e),
+        )
+    })?;
+
+    // Insert step record and get ID atomically using RETURNING clause
+    let step_id = tx
+        .query(
+            r#"INSERT INTO training_steps
+               (run_id, step, epoch, loss, mean_reward, std_reward, mean_advantage,
+                total_tokens, generation_time_ms, training_time_ms, gradients_applied, created_at)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+               RETURNING id"#,
+            libsql::params![
+                step.run_id.clone(),
+                step.step,
+                step.epoch,
+                step.loss,
+                step.mean_reward,
+                step.std_reward,
+                step.mean_advantage,
+                step.total_tokens,
+                step.generation_time_ms,
+                step.training_time_ms,
+                step.gradients_applied as i32,
+                created_at
+            ],
+        )
+        .await
+        .map_err(|e| {
+            Error::new(
+                Status::GenericFailure,
+                format!("Failed to insert step: {}", e),
+            )
+        })?
+        .next()
+        .await
+        .map_err(|e| {
+            Error::new(
+                Status::GenericFailure,
+                format!("Failed to read step id: {}", e),
+            )
+        })?
+        .ok_or_else(|| Error::new(Status::GenericFailure, "No step id returned"))?
+        .get::<i64>(0)
+        .map_err(|e| {
+            Error::new(
+                Status::GenericFailure,
+                format!("Failed to parse step id: {}", e),
+            )
+        })?;
+
+    // Insert generations
+    for (idx, generation) in generations.iter().enumerate() {
+        // Insert generation and get ID atomically using RETURNING clause
+        let gen_id = tx
+            .query(
+                r#"INSERT INTO generations
+                   (run_id, step_id, batch_index, group_index, prompt, expected_answer,
+                    completion_text, completion_raw, thinking, num_tokens, finish_reason, reward, created_at)
+                   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+                   RETURNING id"#,
+                libsql::params![
+                    step.run_id.clone(),
+                    step_id,
+                    generation.batch_index,
+                    generation.group_index,
+                    generation.prompt.clone(),
+                    generation.expected_answer.clone(),
+                    generation.completion_text.clone(),
+                    generation.completion_raw.clone(),
+                    generation.thinking.clone(),
+                    generation.num_tokens,
+                    generation.finish_reason.clone(),
+                    generation.reward,
+                    created_at
+                ],
+            )
+            .await
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to insert generation: {}", e)))?
+            .next()
+            .await
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to read gen id: {}", e)))?
+            .ok_or_else(|| Error::new(Status::GenericFailure, "No gen id returned"))?
+            .get::<i64>(0)
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to parse gen id: {}", e)))?;
+
+        // Insert tool calls for this generation
+        if idx < tool_calls.len() {
+            for tc in &tool_calls[idx] {
+                tx.execute(
+                    r#"INSERT INTO tool_calls
+                       (generation_id, call_index, status, tool_name, arguments, raw_content, error_message)
+                       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)"#,
+                    libsql::params![
+                        gen_id,
+                        tc.call_index,
+                        tc.status.clone(),
+                        tc.tool_name.clone(),
+                        tc.arguments.clone(),
+                        tc.raw_content.clone(),
+                        tc.error_message.clone()
+                    ],
+                )
+                .await
+                .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to insert tool call: {}", e)))?;
+            }
+        }
+    }
+
+    // Commit transaction - all inserts succeeded
+    tx.commit().await.map_err(|e| {
+        Error::new(
+            Status::GenericFailure,
+            format!("Failed to commit transaction: {}", e),
+        )
+    })?;
+
+    Ok(step_id)
+}
+
+/// Record step from RewardOutput JSON (direct integration)
+pub async fn record_step_from_outputs(
+    conn: &Connection,
+    run_id: &str,
+    step: i64,
+    metrics: EngineStepMetrics,
+    outputs_json: &str,
+    rewards: &[f64],
+    group_size: i64,
+) -> Result<i64> {
+    // Validate group_size to prevent division by zero
+    if group_size <= 0 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!("group_size must be positive, got {}", group_size),
+        ));
+    }
+
+    // Parse RewardOutput JSON
+    let outputs: Vec<RewardOutput> = serde_json::from_str(outputs_json).map_err(|e| {
+        Error::new(
+            Status::GenericFailure,
+            format!("Failed to parse outputs JSON: {}", e),
+        )
+    })?;
+
+    // Build step record
+    let step_record = StepRecord {
+        run_id: run_id.to_string(),
+        step,
+        epoch: None,
+        loss: metrics.loss,
+        mean_reward: metrics.mean_reward,
+        std_reward: metrics.std_reward,
+        mean_advantage: Some(metrics.mean_advantage),
+        total_tokens: Some(metrics.total_tokens as i64),
+        generation_time_ms: Some(metrics.generation_time_ms),
+        training_time_ms: Some(metrics.training_time_ms),
+        gradients_applied: metrics.gradients_applied,
+    };
+
+    // Build generation records and tool calls
+    let mut generations = Vec::with_capacity(outputs.len());
+    let mut all_tool_calls = Vec::with_capacity(outputs.len());
+
+    for (idx, output) in outputs.iter().enumerate() {
+        let batch_index = (idx / group_size as usize) as i64;
+        let group_index = (idx % group_size as usize) as i64;
+
+        let generation = GenerationRecord {
+            batch_index,
+            group_index,
+            prompt: output.prompt.clone(),
+            expected_answer: output.expected_answer.clone(),
+            completion_text: output.completion.text.clone(),
+            completion_raw: output.completion.raw_text.clone(),
+            thinking: output.completion.thinking.clone(),
+            num_tokens: output.completion.num_tokens as i64,
+            finish_reason: output.completion.finish_reason.clone(),
+            reward: if idx < rewards.len() {
+                rewards[idx]
+            } else {
+                0.0
+            },
+        };
+        generations.push(generation);
+
+        // Convert tool calls
+        let tool_calls: Vec<ToolCallRecord> = output
+            .completion
+            .tool_calls
+            .iter()
+            .enumerate()
+            .map(|(call_idx, tc)| ToolCallRecord {
+                call_index: call_idx as i64,
+                status: tc.status.clone(),
+                tool_name: Some(tc.name.clone()),
+                arguments: Some(serde_json::to_string(&tc.arguments).unwrap_or_default()),
+                raw_content: tc.raw_content.clone(),
+                error_message: tc.error.clone(),
+            })
+            .collect();
+        all_tool_calls.push(tool_calls);
+    }
+
+    record_step(conn, step_record, generations, all_tool_calls).await
+}
+
+/// Get current timestamp in milliseconds
+fn chrono_now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock is set before UNIX_EPOCH")
+        .as_millis() as i64
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@oxc-node/core": "^0.0.35",
     "@std/toml": "npm:@jsr/std__toml@^1.0.11",
     "@types/node": "^25.0.2",
+    "oxc-parser": "^0.105.0",
     "oxfmt": "^0.18.0",
     "oxlint": "^1.33.0",
     "typescript": "^5.9.3",

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -594,6 +594,7 @@ module.exports.LRScheduler = nativeBinding.LRScheduler
 module.exports.MLP = nativeBinding.MLP
 module.exports.MxArray = nativeBinding.MxArray
 module.exports.NativeRewardRegistry = nativeBinding.NativeRewardRegistry
+module.exports.OutputStore = nativeBinding.OutputStore
 module.exports.PaddedSequences = nativeBinding.PaddedSequences
 module.exports.Qwen3Model = nativeBinding.Qwen3Model
 module.exports.Qwen3Tokenizer = nativeBinding.Qwen3Tokenizer

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,7 +1064,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.0.3, @napi-rs/wasm-runtime@npm:^1.0.7":
+"@napi-rs/wasm-runtime@npm:^1.0.3, @napi-rs/wasm-runtime@npm:^1.0.7, @napi-rs/wasm-runtime@npm:^1.1.0":
   version: 1.1.0
   resolution: "@napi-rs/wasm-runtime@npm:1.1.0"
   dependencies:
@@ -1552,6 +1552,120 @@ __metadata:
     "@oxc-node/core-win32-x64-msvc":
       optional: true
   checksum: 10c0/6328427d833c99b498f41b8dc58ed3503d17aabe66172a5aacce06c7e85377649aa6ac602dfa5dd8f8f01167b5fe428a65d751c40386eced495acbe9eb414e10
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-android-arm64@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-android-arm64@npm:0.105.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-darwin-arm64@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-darwin-arm64@npm:0.105.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-darwin-x64@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-darwin-x64@npm:0.105.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-freebsd-x64@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-freebsd-x64@npm:0.105.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm-gnueabihf@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-linux-arm-gnueabihf@npm:0.105.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm64-gnu@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-linux-arm64-gnu@npm:0.105.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-arm64-musl@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-linux-arm64-musl@npm:0.105.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-riscv64-gnu@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-linux-riscv64-gnu@npm:0.105.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-s390x-gnu@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-linux-s390x-gnu@npm:0.105.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-x64-gnu@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-linux-x64-gnu@npm:0.105.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-linux-x64-musl@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-linux-x64-musl@npm:0.105.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-openharmony-arm64@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-openharmony-arm64@npm:0.105.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-wasm32-wasi@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-wasm32-wasi@npm:0.105.0"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:^1.1.0"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-win32-arm64-msvc@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-win32-arm64-msvc@npm:0.105.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxc-parser/binding-win32-x64-msvc@npm:0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-parser/binding-win32-x64-msvc@npm:0.105.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:^0.105.0":
+  version: 0.105.0
+  resolution: "@oxc-project/types@npm:0.105.0"
+  checksum: 10c0/6c9cb733e0bd7579709411517f773ed8305f9f545fe8e6686bb82f41f6e2add6650a4f315ea4ec9e50f2432027c2900abf1e73c533f5e60e3e05f601ae73e67f
   languageName: node
   linkType: hard
 
@@ -2570,6 +2684,7 @@ __metadata:
     "@oxc-node/core": "npm:^0.0.35"
     "@std/toml": "npm:@jsr/std__toml@^1.0.11"
     "@types/node": "npm:^25.0.2"
+    oxc-parser: "npm:^0.105.0"
     oxfmt: "npm:^0.18.0"
     oxlint: "npm:^1.33.0"
     typescript: "npm:^5.9.3"
@@ -2642,6 +2757,61 @@ __metadata:
   version: 2.1.1
   resolution: "obug@npm:2.1.1"
   checksum: 10c0/59dccd7de72a047e08f8649e94c1015ec72f94eefb6ddb57fb4812c4b425a813bc7e7cd30c9aca20db3c59abc3c85cc7a62bb656a968741d770f4e8e02bc2e78
+  languageName: node
+  linkType: hard
+
+"oxc-parser@npm:^0.105.0":
+  version: 0.105.0
+  resolution: "oxc-parser@npm:0.105.0"
+  dependencies:
+    "@oxc-parser/binding-android-arm64": "npm:0.105.0"
+    "@oxc-parser/binding-darwin-arm64": "npm:0.105.0"
+    "@oxc-parser/binding-darwin-x64": "npm:0.105.0"
+    "@oxc-parser/binding-freebsd-x64": "npm:0.105.0"
+    "@oxc-parser/binding-linux-arm-gnueabihf": "npm:0.105.0"
+    "@oxc-parser/binding-linux-arm64-gnu": "npm:0.105.0"
+    "@oxc-parser/binding-linux-arm64-musl": "npm:0.105.0"
+    "@oxc-parser/binding-linux-riscv64-gnu": "npm:0.105.0"
+    "@oxc-parser/binding-linux-s390x-gnu": "npm:0.105.0"
+    "@oxc-parser/binding-linux-x64-gnu": "npm:0.105.0"
+    "@oxc-parser/binding-linux-x64-musl": "npm:0.105.0"
+    "@oxc-parser/binding-openharmony-arm64": "npm:0.105.0"
+    "@oxc-parser/binding-wasm32-wasi": "npm:0.105.0"
+    "@oxc-parser/binding-win32-arm64-msvc": "npm:0.105.0"
+    "@oxc-parser/binding-win32-x64-msvc": "npm:0.105.0"
+    "@oxc-project/types": "npm:^0.105.0"
+  dependenciesMeta:
+    "@oxc-parser/binding-android-arm64":
+      optional: true
+    "@oxc-parser/binding-darwin-arm64":
+      optional: true
+    "@oxc-parser/binding-darwin-x64":
+      optional: true
+    "@oxc-parser/binding-freebsd-x64":
+      optional: true
+    "@oxc-parser/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxc-parser/binding-linux-arm64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-arm64-musl":
+      optional: true
+    "@oxc-parser/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-s390x-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-x64-gnu":
+      optional: true
+    "@oxc-parser/binding-linux-x64-musl":
+      optional: true
+    "@oxc-parser/binding-openharmony-arm64":
+      optional: true
+    "@oxc-parser/binding-wasm32-wasi":
+      optional: true
+    "@oxc-parser/binding-win32-arm64-msvc":
+      optional: true
+    "@oxc-parser/binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/e21317911933dcd80b636f6bb8c403843343957b1b1f54c3faad85c03ab967ff87b2a171a97b003d2c75dde3d13fd55e60c2db9bc80fc86e26d2955c6e5bfe7b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add OutputStore for recording training outputs to SQLite (local) or Turso (remote).

Features:
- Record training steps with generations, tool calls, and metrics
- Query by step range, reward thresholds, tool usage patterns
- Embedded replica mode for local cache + remote sync
- Automatic run tracking with model/config metadata

Fixes from review:
- Add transaction wrapper in record_step for atomicity
- Add #[serde(default)] for raw_content backward compatibility
- Fix lazy init race with promise mutex pattern
- Fix toolCalls snake_case → camelCase conversion
- Fix status type narrowing (ok|invalid_json|missing_name)
- Ensure outputDir exists before DB open in lazy init

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a persistent output store and wires it into training for recording and analysis.
> 
> - New `mlx-core/output_store` module (schema, reader, writer, NAPI `OutputStore`) with local/remote/embedded-replica support via `libsql`; queries for runs/steps/generations/tool-calls/reward stats; JSONL export
> - Engine: new `train_step_auto_with_recording` returning optional `outputs_json` for zero-copy persistence; `ToolCallResult`/`CompletionInfo`/`RewardOutput` now deserializable and include `raw_content` (with `#[serde(default)]`); parser preserves raw tool-call content
> - Trainer: integrates `OutputStore` (lazy init with promise mutex, start/end run, `recordStepFromOutputs`, optional cloud sync); new `outputStore` config block
> - Tests: extensive `OutputStore` lifecycle/query/edge-case tests; chat/tool tests updated for `rawContent`
> - Packaging: export `OutputStore` and types in `packages/core`, add workspace `libsql` dep and dev `oxc-parser`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db3196ab37782ca6e93dc3ff6ebb1d0c341adcd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Output Store: persistent storage for training runs (local, remote, embedded replica) with start/end/run lifecycle, recording, search, filtering, export, and reward stats.
  * Optional training-step recording that can capture full reward outputs alongside extended training results.
  * Tool-call tracking now preserves raw tool-call content for improved debugging and analysis.
* **Tests**
  * Added end-to-end tests covering Output Store lifecycle, recording, querying, search, and edge cases.
* **Chores**
  * Dependency and public export updates to enable the new persistence surface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->