### PR TITLE
feat: add PP-StructureV3 document understanding pipeline with PP-OCRv5 text detection and recognition

### DIFF
--- a/crates/mlx-core/src/models/mod.rs
+++ b/crates/mlx-core/src/models/mod.rs
@@ -4,4 +4,7 @@
  * Contains all model implementations.
  */
 pub mod paddleocr_vl;
+pub mod pp_doclayout_v3;
+pub mod pp_text_det;
+pub mod pp_text_rec;
 pub mod qwen3;

--- a/crates/mlx-core/src/models/paddleocr_vl/chat.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/chat.rs
@@ -122,6 +122,16 @@ impl VLMChatResult {
     }
 }
 
+/// A batch item for VLM batch inference
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct VLMBatchItem {
+    /// Chat messages for this item
+    pub messages: Vec<VLMChatMessage>,
+    /// Image paths for this item (one image per item for OCR)
+    pub image_paths: Option<Vec<String>>,
+}
+
 /// Default PaddleOCR-VL chat template
 ///
 /// PaddleOCR-VL uses the following format:

--- a/crates/mlx-core/src/models/paddleocr_vl/language.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/language.rs
@@ -974,6 +974,183 @@ impl ERNIELanguageModel {
 
         MxArray::from_handle(out_logits, "paddleocr_vl_forward_fused")
     }
+
+    /// Run fused forward pass and extract KV cache arrays for batch merging.
+    ///
+    /// Runs prefill through the existing single-item FFI, then clones out the
+    /// per-layer KV cache arrays and resets cache state for the next item.
+    ///
+    /// # Returns
+    /// * (logits, kv_keys, kv_values, cache_idx) where kv_keys/values are per-layer
+    pub fn forward_fused_extract_kv(
+        &mut self,
+        input_embeds: &MxArray,
+        position_ids: &MxArray,
+    ) -> Result<(MxArray, Vec<MxArray>, Vec<MxArray>, i32)> {
+        let logits = self.forward_fused(input_embeds, position_ids)?;
+
+        // Eval KV caches to materialize them before cloning
+        self.eval_fused_kv_caches();
+
+        // Clone out KV arrays
+        let num_layers = self.layers.len();
+        let mut kv_keys = Vec::with_capacity(num_layers);
+        let mut kv_values = Vec::with_capacity(num_layers);
+        for i in 0..num_layers {
+            kv_keys.push(
+                self.fused_kv_keys[i]
+                    .as_ref()
+                    .ok_or_else(|| {
+                        Error::new(
+                            Status::GenericFailure,
+                            format!("KV key cache missing for layer {}", i),
+                        )
+                    })?
+                    .clone(),
+            );
+            kv_values.push(
+                self.fused_kv_values[i]
+                    .as_ref()
+                    .ok_or_else(|| {
+                        Error::new(
+                            Status::GenericFailure,
+                            format!("KV value cache missing for layer {}", i),
+                        )
+                    })?
+                    .clone(),
+            );
+        }
+
+        let cache_idx = self.fused_cache_idx;
+
+        // Reset cache state for next item
+        self.reset_fused_kv_caches();
+
+        Ok((logits, kv_keys, kv_values, cache_idx))
+    }
+
+    /// Batched fused forward pass through C++ with left-padding-aware attention.
+    ///
+    /// Like forward_fused but takes external KV cache arrays and left_padding
+    /// for batched decode. Does NOT update internal cache state.
+    ///
+    /// # Arguments
+    /// * `input_embeds` - Input embeddings [batch, seq_len, hidden_size]
+    /// * `position_ids` - Position IDs [3, batch, seq_len] for mRoPE
+    /// * `left_padding` - Left padding amounts [batch]
+    /// * `kv_keys` - Per-layer KV keys [batch, heads, seq, dim]
+    /// * `kv_values` - Per-layer KV values [batch, heads, seq, dim]
+    /// * `cache_idx` - Current cache write position
+    ///
+    /// # Returns
+    /// * (logits, updated_kv_keys, updated_kv_values, new_cache_idx)
+    pub fn forward_fused_batched(
+        &self,
+        input_embeds: &MxArray,
+        position_ids: &MxArray,
+        left_padding: &MxArray,
+        kv_keys: &[Option<MxArray>],
+        kv_values: &[Option<MxArray>],
+        cache_idx: i32,
+    ) -> Result<(MxArray, Vec<Option<MxArray>>, Vec<Option<MxArray>>, i32)> {
+        let num_layers = self.layers.len() as i32;
+
+        // Collect layer weight pointers
+        let mut all_weight_ptrs: Vec<*mut sys::mlx_array> =
+            Vec::with_capacity(num_layers as usize * 9);
+        for layer in &self.layers {
+            let ptrs = layer.get_weight_ptrs();
+            all_weight_ptrs.extend_from_slice(&ptrs);
+        }
+
+        let final_norm_ptr = self.norm.get_weight().handle.0;
+        let lm_head_ptr = self.lm_head.get_weight().handle.0;
+        let inv_freq_ptr = self.rotary_emb.get_inv_freq_ptr();
+        let mrope_section = self.rotary_emb.mrope_section_arr();
+
+        // KV cache input pointers
+        let kv_keys_ptrs: Vec<*mut sys::mlx_array> = kv_keys
+            .iter()
+            .map(|k| {
+                k.as_ref()
+                    .map(|a| a.handle.0)
+                    .unwrap_or(std::ptr::null_mut())
+            })
+            .collect();
+        let kv_values_ptrs: Vec<*mut sys::mlx_array> = kv_values
+            .iter()
+            .map(|v| {
+                v.as_ref()
+                    .map(|a| a.handle.0)
+                    .unwrap_or(std::ptr::null_mut())
+            })
+            .collect();
+
+        // Output buffers
+        let mut out_logits: *mut sys::mlx_array = std::ptr::null_mut();
+        let mut out_kv_keys: Vec<*mut sys::mlx_array> =
+            vec![std::ptr::null_mut(); num_layers as usize];
+        let mut out_kv_values: Vec<*mut sys::mlx_array> =
+            vec![std::ptr::null_mut(); num_layers as usize];
+        let mut out_cache_idx: i32 = 0;
+
+        let config = &self.config;
+
+        unsafe {
+            sys::mlx_paddleocr_vl_forward_step_batched(
+                input_embeds.handle.0,
+                all_weight_ptrs.as_ptr(),
+                num_layers,
+                final_norm_ptr,
+                lm_head_ptr,
+                inv_freq_ptr,
+                position_ids.handle.0,
+                mrope_section.as_ptr(),
+                config.hidden_size,
+                config.num_attention_heads,
+                config.num_key_value_heads,
+                config.head_dim,
+                config.rms_norm_eps as f32,
+                left_padding.handle.0,
+                kv_keys_ptrs.as_ptr(),
+                kv_values_ptrs.as_ptr(),
+                cache_idx,
+                &mut out_logits,
+                out_kv_keys.as_mut_ptr(),
+                out_kv_values.as_mut_ptr(),
+                &mut out_cache_idx,
+            );
+        }
+
+        // Convert output pointers to MxArrays
+        let mut new_kv_keys: Vec<Option<MxArray>> = Vec::with_capacity(num_layers as usize);
+        let mut new_kv_values: Vec<Option<MxArray>> = Vec::with_capacity(num_layers as usize);
+        for i in 0..num_layers as usize {
+            new_kv_keys.push(if !out_kv_keys[i].is_null() {
+                Some(MxArray::from_handle(out_kv_keys[i], "batched_kv_key")?)
+            } else {
+                None
+            });
+            new_kv_values.push(if !out_kv_values[i].is_null() {
+                Some(MxArray::from_handle(out_kv_values[i], "batched_kv_value")?)
+            } else {
+                None
+            });
+        }
+
+        let logits = MxArray::from_handle(out_logits, "paddleocr_vl_forward_batched")?;
+        Ok((logits, new_kv_keys, new_kv_values, out_cache_idx))
+    }
+
+    /// Get number of layers (needed for batch KV cache setup)
+    pub fn num_layers_usize(&self) -> usize {
+        self.layers.len()
+    }
+
+    /// Get the embedding layer (for external use during batch generation)
+    pub fn get_embedding_layer(&self) -> &Embedding {
+        &self.embed_tokens
+    }
 }
 
 impl Clone for ERNIELanguageModel {

--- a/crates/mlx-core/src/models/paddleocr_vl/mod.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/mod.rs
@@ -13,7 +13,9 @@ pub mod processing;
 pub mod vision;
 
 // Re-export public items
-pub use chat::{ChatRole, VLMChatConfig, VLMChatMessage, VLMChatResult, format_vlm_chat};
+pub use chat::{
+    ChatRole, VLMBatchItem, VLMChatConfig, VLMChatMessage, VLMChatResult, format_vlm_chat,
+};
 pub use config::{ModelConfig, TextConfig, VisionConfig};
 pub use language::{ERNIELanguageModel, MultimodalRoPE, PaddleOCRAttention, PaddleOCRDecoderLayer};
 pub use model::VLModel;

--- a/crates/mlx-core/src/models/paddleocr_vl/model.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/model.rs
@@ -1253,6 +1253,11 @@ impl VLModel {
         config: Option<GenerationConfig>,
     ) -> Result<Vec<GenerationResult>> {
         let config = config.unwrap_or_default();
+
+        if all_input_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let batch_size = all_input_ids.len();
         let max_new_tokens = config.max_new_tokens.unwrap_or(256);
         let temperature = config.temperature.unwrap_or(0.0);

--- a/crates/mlx-core/src/models/paddleocr_vl/model.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/model.rs
@@ -4,7 +4,9 @@
  * Combines vision encoder and language model for vision-language tasks.
  */
 use crate::array::{MxArray, clear_cache};
-use crate::models::paddleocr_vl::chat::{ChatRole, VLMChatConfig, VLMChatMessage, VLMChatResult};
+use crate::models::paddleocr_vl::chat::{
+    ChatRole, VLMBatchItem, VLMChatConfig, VLMChatMessage, VLMChatResult,
+};
 use crate::models::paddleocr_vl::config::{ModelConfig, TextConfig, VisionConfig};
 use crate::models::paddleocr_vl::language::{ERNIELanguageModel, PaddleOCRDecoderLayer};
 use crate::models::paddleocr_vl::persistence::load_paddleocr_vl_weights;
@@ -1019,6 +1021,676 @@ impl VLModel {
         })
     }
 
+    /// Batch OCR: extract text from multiple images simultaneously
+    ///
+    /// Processes N images with sequential prefill + batched decode for ~N× decode throughput.
+    ///
+    /// # Arguments
+    /// * `image_paths` - Paths to image files
+    /// * `config` - Optional chat configuration (shared across all items)
+    ///
+    /// # Returns
+    /// * Vec of extracted text strings, one per image
+    ///
+    /// # Example
+    /// ```typescript
+    /// const texts = model.ocrBatch(['page1.jpg', 'page2.jpg', 'page3.jpg']);
+    /// ```
+    #[napi]
+    pub fn ocr_batch(
+        &self,
+        image_paths: Vec<String>,
+        config: Option<VLMChatConfig>,
+    ) -> Result<Vec<String>> {
+        let prompt = "Extract all text from this image.".to_string();
+
+        let batch: Vec<VLMBatchItem> = image_paths
+            .into_iter()
+            .map(|path| VLMBatchItem {
+                messages: vec![VLMChatMessage {
+                    role: ChatRole::User,
+                    content: prompt.clone(),
+                }],
+                image_paths: Some(vec![path]),
+            })
+            .collect();
+
+        let results = self.batch(batch, config)?;
+
+        Ok(results
+            .into_iter()
+            .map(|r| {
+                let text = r.text;
+                text.strip_prefix("\\(\\text{")
+                    .and_then(|s| s.strip_suffix("}\\)"))
+                    .map(|s| s.to_string())
+                    .unwrap_or(text)
+            })
+            .collect())
+    }
+
+    /// Batch chat: process multiple items simultaneously
+    ///
+    /// Sequential prefill + batched decode. Each item can have different images/prompts.
+    ///
+    /// # Arguments
+    /// * `batch` - Batch items, each with messages and optional image_paths
+    /// * `config` - Optional shared chat configuration
+    ///
+    /// # Returns
+    /// * Vec of VLMChatResult, one per batch item
+    #[napi]
+    pub fn batch(
+        &self,
+        batch: Vec<VLMBatchItem>,
+        config: Option<VLMChatConfig>,
+    ) -> Result<Vec<VLMChatResult>> {
+        let tokenizer = self.tokenizer.as_ref().ok_or_else(|| {
+            Error::new(
+                Status::GenericFailure,
+                "Tokenizer not set. Use set_tokenizer() first.",
+            )
+        })?;
+
+        if batch.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Fall back to sequential for batch_size == 1
+        if batch.len() == 1 {
+            let item = &batch[0];
+            let c = match &config {
+                Some(c) => Some(VLMChatConfig {
+                    image_paths: item.image_paths.clone(),
+                    ..c.clone()
+                }),
+                None => Some(VLMChatConfig {
+                    image_paths: item.image_paths.clone(),
+                    ..Default::default()
+                }),
+            };
+            let result = self.chat(item.messages.clone(), c)?;
+            return Ok(vec![result]);
+        }
+
+        let default_config = VLMChatConfig::default();
+        let config = match config {
+            Some(c) => VLMChatConfig {
+                image_paths: None, // Per-item
+                max_new_tokens: c.max_new_tokens.or(default_config.max_new_tokens),
+                temperature: c.temperature.or(default_config.temperature),
+                top_k: c.top_k.or(default_config.top_k),
+                top_p: c.top_p.or(default_config.top_p),
+                repetition_penalty: c.repetition_penalty.or(default_config.repetition_penalty),
+                return_logprobs: c.return_logprobs.or(default_config.return_logprobs),
+            },
+            None => default_config,
+        };
+
+        let gen_config = GenerationConfig {
+            max_new_tokens: config.max_new_tokens,
+            temperature: config.temperature,
+            top_k: config.top_k,
+            top_p: config.top_p,
+            min_p: None,
+            repetition_penalty: config.repetition_penalty,
+            repetition_context_size: None,
+            max_consecutive_tokens: None,
+            max_ngram_repeats: None,
+            ngram_size: None,
+            eos_token_id: Some(self.config.eos_token_id),
+            return_logprobs: config.return_logprobs,
+            prefill_step_size: None,
+            kv_cache_bits: None,
+            kv_cache_group_size: None,
+            num_draft_tokens: None,
+        };
+
+        // Prepare per-item inputs
+        let batch_size = batch.len();
+        let mut all_input_ids = Vec::with_capacity(batch_size);
+        let mut all_pixel_values = Vec::with_capacity(batch_size);
+        let mut all_grid_thws = Vec::with_capacity(batch_size);
+
+        for item in &batch {
+            // Process images
+            let (pixel_values, grid_thw) = if let Some(paths) = &item.image_paths {
+                if paths.is_empty() {
+                    (None, None)
+                } else {
+                    let processor_config = ImageProcessorConfig {
+                        patch_size: self.config.vision_config.patch_size,
+                        merge_size: self.config.vision_config.spatial_merge_size,
+                        ..ImageProcessorConfig::default()
+                    };
+                    let processor = ImageProcessor::new(Some(processor_config));
+                    let processed = processor.process_files(paths.clone())?;
+                    let pv = processed.pixel_values();
+                    let pv_shape = pv.shape()?;
+                    let new_shape = BigInt64Array::from(vec![
+                        1i64,
+                        pv_shape[0],
+                        pv_shape[1],
+                        pv_shape[2],
+                        pv_shape[3],
+                    ]);
+                    let pixel_values = pv.reshape(&new_shape)?;
+                    let grid_thw = processed.grid_thw();
+                    (Some(pixel_values), Some(grid_thw))
+                }
+            } else {
+                (None, None)
+            };
+
+            // Count image tokens
+            let num_image_tokens = if let Some(ref grid) = grid_thw {
+                grid.eval();
+                let grid_data = grid.to_int32()?;
+                let spatial_merge_size = self.config.vision_config.spatial_merge_size;
+                let merge_factor = spatial_merge_size * spatial_merge_size;
+                let mut total = 0i32;
+                for i in 0..(grid_data.len() / 3) {
+                    let t = grid_data[i * 3];
+                    let h = grid_data[i * 3 + 1];
+                    let w = grid_data[i * 3 + 2];
+                    total += (t * h * w) / merge_factor;
+                }
+                Some(total as usize)
+            } else {
+                None
+            };
+
+            // Format and tokenize
+            let formatted = crate::models::paddleocr_vl::chat::format_vlm_chat(
+                &item.messages,
+                num_image_tokens,
+            );
+            let token_ids = tokenizer.encode_sync(&formatted, None)?;
+            let input_ids = MxArray::from_uint32(&token_ids, &[1, token_ids.len() as i64])?;
+
+            all_input_ids.push(input_ids);
+            all_pixel_values.push(pixel_values);
+            all_grid_thws.push(grid_thw);
+        }
+
+        // Run batch generation
+        let results = self.generate_batch(
+            &all_input_ids,
+            &all_pixel_values,
+            &all_grid_thws,
+            Some(gen_config),
+        )?;
+
+        // Decode results
+        let mut chat_results = Vec::with_capacity(batch_size);
+        for result in results {
+            result.tokens.eval();
+            let tokens_vec = result.tokens.to_uint32()?;
+            let text = tokenizer.decode_sync(&tokens_vec, true)?;
+            let text = text.replace("<|im_end|>", "").trim().to_string();
+
+            chat_results.push(VLMChatResult {
+                text,
+                tokens: result.tokens,
+                logprobs: result.logprobs,
+                finish_reason: result.finish_reason,
+                num_tokens: result.num_tokens,
+            });
+        }
+
+        Ok(chat_results)
+    }
+
+    /// Batch generate: sequential prefill + batched decode
+    ///
+    /// Each item is prefilled independently (different image sizes → different vision tokens),
+    /// then KV caches are merged and decode runs in batch for ~N× throughput.
+    fn generate_batch(
+        &self,
+        all_input_ids: &[MxArray],
+        all_pixel_values: &[Option<MxArray>],
+        all_grid_thws: &[Option<MxArray>],
+        config: Option<GenerationConfig>,
+    ) -> Result<Vec<GenerationResult>> {
+        let config = config.unwrap_or_default();
+        let batch_size = all_input_ids.len();
+        let max_new_tokens = config.max_new_tokens.unwrap_or(256);
+        let temperature = config.temperature.unwrap_or(0.0);
+        let top_k = config.top_k.unwrap_or(0);
+        let top_p = config.top_p.unwrap_or(1.0);
+        let min_p = config.min_p.unwrap_or(0.0);
+        let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
+        let repetition_context_size = config.repetition_context_size.unwrap_or(20);
+        let eos_token_id = config.eos_token_id.unwrap_or(self.config.eos_token_id);
+        let return_logprobs = config.return_logprobs.unwrap_or(false);
+
+        let sampling_config = SamplingConfig {
+            temperature: Some(temperature),
+            top_k: Some(top_k),
+            top_p: Some(top_p),
+            min_p: Some(min_p),
+        };
+
+        let generation_stream = Stream::new(DeviceType::Gpu);
+
+        let lm = self
+            .language_model
+            .as_ref()
+            .ok_or_else(|| Error::new(Status::GenericFailure, "Language model not set"))?;
+        let visual = self.visual.as_ref();
+
+        let num_layers = {
+            let lm_guard = lm.read().map_err(|_| {
+                Error::new(Status::GenericFailure, "Failed to acquire LM read lock")
+            })?;
+            lm_guard.num_layers_usize()
+        };
+
+        // === STEP 1: Sequential per-item prefill ===
+        let mut item_kv_keys: Vec<Vec<MxArray>> = Vec::with_capacity(batch_size);
+        let mut item_kv_values: Vec<Vec<MxArray>> = Vec::with_capacity(batch_size);
+        let mut item_rope_deltas: Vec<i64> = Vec::with_capacity(batch_size);
+        let mut item_cache_idxs: Vec<i32> = Vec::with_capacity(batch_size);
+        let mut item_first_tokens: Vec<MxArray> = Vec::with_capacity(batch_size);
+        let mut item_first_logprobs: Vec<Option<MxArray>> = Vec::with_capacity(batch_size);
+        let mut item_all_tokens: Vec<Vec<u32>> = Vec::with_capacity(batch_size);
+
+        for i in 0..batch_size {
+            let input_ids = &all_input_ids[i];
+            let pixel_values = all_pixel_values[i].as_ref();
+            let grid_thw = all_grid_thws[i].as_ref();
+
+            let mut lm_guard = lm.write().map_err(|_| {
+                Error::new(Status::GenericFailure, "Failed to acquire LM write lock")
+            })?;
+
+            lm_guard.init_fused_kv_caches();
+            lm_guard.reset_position_state();
+
+            // Vision features
+            let vision_features = {
+                let _stream_ctx = StreamContext::new(generation_stream);
+                if let (Some(pv), Some(grid)) = (pixel_values, grid_thw) {
+                    let v = visual.ok_or_else(|| {
+                        Error::new(Status::GenericFailure, "Vision model not set")
+                    })?;
+                    Some(v.forward(pv, grid)?)
+                } else {
+                    None
+                }
+            };
+
+            // Position IDs with mRoPE
+            let (position_ids, rope_deltas) = self.get_rope_index(input_ids, grid_thw)?;
+
+            // Merge embeddings
+            let inputs_embeds = {
+                let _stream_ctx = StreamContext::new(generation_stream);
+                let embeds = lm_guard.get_embeddings(input_ids)?;
+                if let Some(ref vf) = vision_features {
+                    let embed_dtype = embeds.dtype()?;
+                    let vf_cast = if vf.dtype()? != embed_dtype {
+                        vf.astype(embed_dtype)?
+                    } else {
+                        vf.clone()
+                    };
+                    self.merge_input_ids_with_image_features(
+                        self.config.image_token_id,
+                        &vf_cast,
+                        &embeds,
+                        input_ids,
+                    )?
+                } else {
+                    embeds
+                }
+            };
+
+            // Prefill and extract KV
+            let (logits, kv_keys, kv_values, cache_idx) = {
+                let _stream_ctx = StreamContext::new(generation_stream);
+                lm_guard.forward_fused_extract_kv(&inputs_embeds, &position_ids)?
+            };
+
+            clear_cache();
+
+            // Sample first token (with logprobs if requested)
+            let seq_len = logits.shape_at(1)?;
+            let mut last_logits = logits
+                .slice_axis(1, seq_len - 1, seq_len)?
+                .squeeze(Some(&[0, 1]))?;
+
+            // Apply repetition penalty to first token (matches single-item generate())
+            let input_tokens = input_ids.to_uint32()?;
+            if repetition_penalty != 1.0 {
+                let all_tokens: Vec<u32> = input_tokens.to_vec();
+                last_logits = apply_repetition_penalty(
+                    &last_logits,
+                    &all_tokens,
+                    repetition_penalty,
+                    Some(repetition_context_size),
+                )?;
+            }
+
+            let (first_token, first_logprobs) = if return_logprobs {
+                let (tok, lp) = sample_and_logprobs(&last_logits, Some(sampling_config))?;
+                (tok, Some(lp))
+            } else {
+                (sample(&last_logits, Some(sampling_config))?, None)
+            };
+            first_token.eval();
+
+            item_kv_keys.push(kv_keys);
+            item_kv_values.push(kv_values);
+            item_rope_deltas.push(rope_deltas);
+            item_cache_idxs.push(cache_idx);
+            item_first_tokens.push(first_token);
+            item_first_logprobs.push(first_logprobs);
+            item_all_tokens.push(input_tokens.to_vec());
+        }
+
+        // === STEP 2: Merge KV caches into batch ===
+        let max_cache_idx = *item_cache_idxs.iter().max().unwrap();
+        let mut left_padding_values: Vec<i32> = Vec::with_capacity(batch_size);
+
+        for &cache_idx in &item_cache_idxs {
+            left_padding_values.push(max_cache_idx - cache_idx);
+        }
+
+        // Left-pad and stack KV caches per layer
+        let mut batch_kv_keys: Vec<Option<MxArray>> = Vec::with_capacity(num_layers);
+        let mut batch_kv_values: Vec<Option<MxArray>> = Vec::with_capacity(num_layers);
+
+        for layer in 0..num_layers {
+            let mut padded_keys: Vec<MxArray> = Vec::with_capacity(batch_size);
+            let mut padded_values: Vec<MxArray> = Vec::with_capacity(batch_size);
+
+            for i in 0..batch_size {
+                let k = &item_kv_keys[i][layer];
+                let v = &item_kv_values[i][layer];
+                let pad_amount = left_padding_values[i];
+
+                if pad_amount > 0 {
+                    // KV shape: [1, heads, seq, dim] - pad along axis 2
+                    let k_shape = k.shape()?;
+                    let heads = k_shape[1];
+                    let dim = k_shape[3];
+                    let pad_zeros =
+                        MxArray::zeros(&[1, heads, pad_amount as i64, dim], Some(k.dtype()?))?;
+                    let padded_k = MxArray::concatenate_many(vec![&pad_zeros, k], Some(2))?;
+                    let padded_v = MxArray::concatenate_many(vec![&pad_zeros, v], Some(2))?;
+                    // Slice to max_cache_idx to ensure uniform size
+                    let padded_k = padded_k.slice_axis(2, 0, max_cache_idx as i64)?;
+                    let padded_v = padded_v.slice_axis(2, 0, max_cache_idx as i64)?;
+                    padded_keys.push(padded_k);
+                    padded_values.push(padded_v);
+                } else {
+                    // Slice to max_cache_idx
+                    let k_trimmed = k.slice_axis(2, 0, max_cache_idx as i64)?;
+                    let v_trimmed = v.slice_axis(2, 0, max_cache_idx as i64)?;
+                    padded_keys.push(k_trimmed);
+                    padded_values.push(v_trimmed);
+                }
+            }
+
+            // Stack along batch dim: [batch, heads, max_cache_idx, dim]
+            let key_refs: Vec<&MxArray> = padded_keys.iter().collect();
+            let value_refs: Vec<&MxArray> = padded_values.iter().collect();
+            let stacked_keys = MxArray::concatenate_many(key_refs, Some(0))?;
+            let stacked_values = MxArray::concatenate_many(value_refs, Some(0))?;
+
+            batch_kv_keys.push(Some(stacked_keys));
+            batch_kv_values.push(Some(stacked_values));
+        }
+
+        // Eval merged KV caches
+        for k in batch_kv_keys.iter().flatten() {
+            k.eval();
+        }
+        for v in batch_kv_values.iter().flatten() {
+            v.eval();
+        }
+        clear_cache();
+
+        // === STEP 3: Batched decode loop ===
+        let mut generated_tokens: Vec<Vec<u32>> =
+            vec![Vec::with_capacity(max_new_tokens as usize); batch_size];
+        let mut generated_logprobs: Vec<Vec<f32>> = vec![Vec::new(); batch_size];
+        let mut finish_reasons: Vec<Option<String>> = vec![None; batch_size];
+
+        // Track active batch items
+        let mut active_indices: Vec<usize> = (0..batch_size).collect();
+        let mut current_cache_idx = max_cache_idx;
+
+        // Build initial token + logprobs arrays from prefill results
+        let first_token_refs: Vec<&MxArray> = item_first_tokens.iter().collect();
+        let mut current_tokens = MxArray::stack(first_token_refs, Some(0))?;
+
+        // Build initial logprobs: stack per-item logprob distributions [batch, vocab]
+        let mut current_logprobs: Option<Vec<Option<MxArray>>> = if return_logprobs {
+            Some(item_first_logprobs)
+        } else {
+            None
+        };
+
+        // Get read lock for batched decode
+        let lm_guard = lm
+            .read()
+            .map_err(|_| Error::new(Status::GenericFailure, "Failed to acquire LM read lock"))?;
+
+        for step in 0..max_new_tokens {
+            if active_indices.is_empty() {
+                break;
+            }
+
+            // --- Phase 1: Build next step's graph ---
+            // Embed current tokens and run forward pass to get next logits
+            let active_batch_size = active_indices.len() as i64;
+
+            let embed_tokens: Vec<u32> = {
+                current_tokens.eval();
+                let tok_vals = current_tokens.to_int32()?;
+                active_indices
+                    .iter()
+                    .enumerate()
+                    .map(|(local_idx, _)| tok_vals[local_idx] as u32)
+                    .collect()
+            };
+            let embed_input = MxArray::from_uint32(&embed_tokens, &[active_batch_size, 1])?;
+            let token_embeds = lm_guard.get_embedding_layer().forward(&embed_input)?;
+
+            // Build position_ids [3, active_batch, 1] for mRoPE decode
+            let mut pos_data: Vec<f32> = Vec::with_capacity(3 * active_indices.len());
+            for &global_idx in &active_indices {
+                let pos = (current_cache_idx as i64 - left_padding_values[global_idx] as i64
+                    + item_rope_deltas[global_idx]) as f32;
+                pos_data.push(pos);
+            }
+            let pos_1d = MxArray::from_float32(&pos_data, &[1, active_batch_size, 1])?;
+            let position_ids = MxArray::tile(&pos_1d, &[3, 1, 1])?;
+
+            // Build left_padding for active items
+            let active_left_padding: Vec<i32> = active_indices
+                .iter()
+                .map(|&idx| left_padding_values[idx])
+                .collect();
+            let left_padding_active =
+                MxArray::from_int32(&active_left_padding, &[active_batch_size])?;
+
+            // Batched forward
+            let (logits, new_kv_keys, new_kv_values, new_cache_idx) = {
+                let _stream_ctx = StreamContext::new(generation_stream);
+                lm_guard.forward_fused_batched(
+                    &token_embeds,
+                    &position_ids,
+                    &left_padding_active,
+                    &batch_kv_keys,
+                    &batch_kv_values,
+                    current_cache_idx,
+                )?
+            };
+
+            batch_kv_keys = new_kv_keys;
+            batch_kv_values = new_kv_values;
+            current_cache_idx = new_cache_idx;
+
+            // Sample next tokens [active_batch, 1, vocab] -> [active_batch, vocab]
+            let next_logits = logits.squeeze(Some(&[1]))?;
+
+            // Apply repetition penalty per item
+            let next_logits = if repetition_penalty != 1.0 {
+                let mut rows = Vec::with_capacity(active_indices.len());
+                for (local_idx, &global_idx) in active_indices.iter().enumerate() {
+                    let row = next_logits.slice_axis(0, local_idx as i64, local_idx as i64 + 1)?;
+                    let row = row.squeeze(Some(&[0]))?;
+                    let penalized = apply_repetition_penalty(
+                        &row,
+                        &item_all_tokens[global_idx],
+                        repetition_penalty,
+                        Some(repetition_context_size),
+                    )?;
+                    rows.push(penalized);
+                }
+                let row_refs: Vec<&MxArray> = rows.iter().collect();
+                MxArray::stack(row_refs, Some(0))?
+            } else {
+                next_logits
+            };
+
+            // Sample next tokens (with logprobs if requested)
+            let (mut next_tokens, mut next_logprobs) = if return_logprobs {
+                let (tok, lp) = sample_and_logprobs(&next_logits, Some(sampling_config))?;
+                (tok, Some(lp))
+            } else {
+                (sample(&next_logits, Some(sampling_config))?, None)
+            };
+
+            // --- Phase 2: Extract CURRENT tokens and CURRENT logprobs (aligned pair) ---
+            current_tokens.eval();
+            let token_values = current_tokens.to_int32()?;
+
+            // Extract logprobs for current tokens
+            if return_logprobs && let Some(ref lp_vec) = current_logprobs {
+                for (local_idx, &global_idx) in active_indices.iter().enumerate() {
+                    let token_value = token_values[local_idx] as u32;
+                    if let Some(ref lp) = lp_vec[global_idx] {
+                        lp.eval();
+                        let token_logprob = lp.item_at_float32(token_value as usize)?;
+                        generated_logprobs[global_idx].push(token_logprob);
+                    }
+                }
+            }
+
+            // Track deactivations
+            let mut to_deactivate: Vec<(usize, String)> = Vec::new();
+
+            for (local_idx, &global_idx) in active_indices.iter().enumerate() {
+                let token_value = token_values[local_idx] as u32;
+                generated_tokens[global_idx].push(token_value);
+                item_all_tokens[global_idx].push(token_value);
+
+                // Check EOS
+                if token_value == eos_token_id as u32 {
+                    to_deactivate.push((local_idx, "stop".to_string()));
+                }
+            }
+
+            // Build filter indices
+            let positions_to_remove: std::collections::HashSet<usize> =
+                to_deactivate.iter().map(|(idx, _)| *idx).collect();
+            let old_batch_size = active_indices.len();
+            let filter_indices: Vec<i32> = (0..old_batch_size)
+                .filter(|i| !positions_to_remove.contains(i))
+                .map(|i| i as i32)
+                .collect();
+
+            // Apply deactivations (reverse order)
+            to_deactivate.sort_by(|a, b| b.0.cmp(&a.0));
+            for (local_idx, reason) in to_deactivate {
+                let global_idx = active_indices[local_idx];
+                finish_reasons[global_idx] = Some(reason);
+                active_indices.remove(local_idx);
+            }
+
+            if active_indices.is_empty() {
+                break;
+            }
+
+            // Filter KV caches, tokens, and logprobs if batch shrank
+            if filter_indices.len() < old_batch_size {
+                let indices_array =
+                    MxArray::from_int32(&filter_indices, &[filter_indices.len() as i64])?;
+                for layer in 0..num_layers {
+                    if let Some(ref keys) = batch_kv_keys[layer] {
+                        batch_kv_keys[layer] = Some(keys.take(&indices_array, 0)?);
+                    }
+                    if let Some(ref values) = batch_kv_values[layer] {
+                        batch_kv_values[layer] = Some(values.take(&indices_array, 0)?);
+                    }
+                }
+                // Filter next_tokens to match the shrunken active set.
+                // Without this, tok_vals[local_idx] on the next iteration reads
+                // tokens from deactivated items, corrupting remaining outputs.
+                next_tokens = next_tokens.take(&indices_array, 0)?;
+                if let Some(ref lp) = next_logprobs {
+                    next_logprobs = Some(lp.take(&indices_array, 0)?);
+                }
+            }
+
+            // Advance: next becomes current
+            current_tokens = next_tokens;
+
+            // Update per-item logprobs for next iteration
+            if return_logprobs && let Some(ref next_lp) = next_logprobs {
+                let mut new_lp_vec: Vec<Option<MxArray>> = vec![None; batch_size];
+                for (local_idx, &global_idx) in active_indices.iter().enumerate() {
+                    let row = next_lp.slice_axis(0, local_idx as i64, local_idx as i64 + 1)?;
+                    let row = row.squeeze(Some(&[0]))?;
+                    new_lp_vec[global_idx] = Some(row);
+                }
+                current_logprobs = Some(new_lp_vec);
+            }
+
+            // Periodic cleanup
+            if step > 0 && step % 256 == 0 {
+                clear_cache();
+            }
+        }
+
+        // Set finish reason for items still active
+        for &global_idx in &active_indices {
+            if finish_reasons[global_idx].is_none() {
+                finish_reasons[global_idx] = Some("length".to_string());
+            }
+        }
+
+        // Build results
+        let mut results = Vec::with_capacity(batch_size);
+        for i in 0..batch_size {
+            let tokens = &generated_tokens[i];
+            let tokens_array = MxArray::from_uint32(tokens, &[tokens.len() as i64])?;
+            let logprobs_array = if return_logprobs {
+                MxArray::from_float32(
+                    &generated_logprobs[i],
+                    &[generated_logprobs[i].len() as i64],
+                )?
+            } else {
+                MxArray::from_float32(&[], &[0])?
+            };
+
+            results.push(GenerationResult {
+                text: String::new(),
+                tokens: tokens_array,
+                logprobs: logprobs_array,
+                finish_reason: finish_reasons[i]
+                    .clone()
+                    .unwrap_or_else(|| "length".to_string()),
+                num_tokens: tokens.len(),
+            });
+        }
+
+        Ok(results)
+    }
+
     /// Get model configuration
     #[napi(getter)]
     pub fn config(&self) -> ModelConfig {
@@ -1707,5 +2379,89 @@ mod tests {
         assert_eq!(config.text_config.num_hidden_layers, 18);
         assert_eq!(config.text_config.num_attention_heads, 16);
         assert_eq!(config.text_config.head_dim, 128);
+    }
+
+    /// Regression test: batch decode must filter next_tokens when items are deactivated.
+    ///
+    /// Before the fix, after EOS filtering removed batch items from active_indices
+    /// and KV caches, next_tokens was NOT filtered. On the next iteration,
+    /// tok_vals[local_idx] would read tokens from deactivated items, causing
+    /// cross-item contamination.
+    ///
+    /// This test simulates the exact control flow from generate_batch's decode loop:
+    ///   1. Start with 3 active items producing tokens [10, 20, 30]
+    ///   2. Item 1 (middle) hits EOS → deactivated
+    ///   3. Verify remaining items [0, 2] read correct tokens [10, 30] not [10, 20]
+    #[test]
+    fn test_batch_decode_eos_filter_tokens() {
+        // Simulate next_tokens = [tok_A, tok_B, tok_C] from batch of 3
+        let next_tokens = MxArray::from_int32(&[10, 20, 30], &[3]).unwrap();
+
+        // Item B (local_idx=1) hits EOS. filter_indices keeps items 0 and 2.
+        let filter_indices = MxArray::from_int32(&[0, 2], &[2]).unwrap();
+
+        // The fix: filter next_tokens before assigning to current_tokens
+        let filtered = next_tokens.take(&filter_indices, 0).unwrap();
+        filtered.eval();
+        let vals = filtered.to_int32().unwrap();
+
+        // After filtering, position 0 should be tok_A (10), position 1 should be tok_C (30)
+        assert_eq!(vals.len(), 2);
+        assert_eq!(vals[0], 10, "local_idx=0 should map to item A's token");
+        assert_eq!(
+            vals[1], 30,
+            "local_idx=1 should map to item C's token (not B's)"
+        );
+    }
+
+    /// Regression test: KV cache filtering must stay aligned with token filtering.
+    ///
+    /// Simulates the batch decode scenario where KV caches [batch, heads, seq, dim]
+    /// and next_tokens [batch] must both be filtered by the same indices when
+    /// items are deactivated.
+    #[test]
+    fn test_batch_decode_kv_and_token_alignment() {
+        // Simulate KV cache: [3 items, 2 heads, 4 seq positions, 2 dim]
+        // Each item has distinguishable values: item0=1.0, item1=2.0, item2=3.0
+        let kv = MxArray::from_float32(
+            &[
+                // item 0: all 1s
+                1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                // item 1: all 2s
+                2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                // item 2: all 3s
+                3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,
+            ],
+            &[3, 2, 4, 2],
+        )
+        .unwrap();
+        let tokens = MxArray::from_int32(&[100, 200, 300], &[3]).unwrap();
+
+        // Remove item 1 (middle)
+        let filter = MxArray::from_int32(&[0, 2], &[2]).unwrap();
+        let filtered_kv = kv.take(&filter, 0).unwrap();
+        let filtered_tokens = tokens.take(&filter, 0).unwrap();
+
+        filtered_kv.eval();
+        filtered_tokens.eval();
+
+        let kv_shape: Vec<i64> = filtered_kv.shape().unwrap().to_vec();
+        assert_eq!(
+            kv_shape,
+            vec![2, 2, 4, 2],
+            "KV batch dim should shrink to 2"
+        );
+
+        let tok_vals: Vec<i32> = filtered_tokens.to_int32().unwrap().to_vec();
+        assert_eq!(
+            tok_vals,
+            vec![100, 300],
+            "tokens should match filtered KV rows"
+        );
+
+        // Verify KV content: row 0 should be item 0 (1.0), row 1 should be item 2 (3.0)
+        let kv_data = filtered_kv.to_float32().unwrap();
+        assert_eq!(kv_data[0], 1.0, "KV row 0 should be item 0");
+        assert_eq!(kv_data[16], 3.0, "KV row 1 should be item 2 (not item 1)");
     }
 }

--- a/crates/mlx-core/src/models/pp_doclayout_v3/backbone.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/backbone.rs
@@ -1,0 +1,928 @@
+//! HGNetV2 Backbone for PP-DocLayoutV3
+//!
+//! Convolutional backbone implementing the HGNetV2-L architecture.
+//! Ported from the HuggingFace Transformers HGNetV2 implementation.
+//!
+//! Architecture overview:
+//! - HGNetV2Embeddings (Stem): Initial convolutions + MaxPool to downsample 4x
+//! - HGNetV2Stage x4: Each stage contains HGBlocks with feature aggregation
+//! - Output: Feature maps at 4 scales [stage1, stage2, stage3, stage4]
+//!
+//! All operations use NHWC format (MLX native).
+//! Weight tensors follow MLX conventions:
+//! - Conv2d weights: [out_channels, kernel_h, kernel_w, in_channels/groups]
+//! - BatchNorm params: [channels]
+
+use crate::array::MxArray;
+use mlx_sys as sys;
+use napi::bindgen_prelude::*;
+use std::sync::Arc;
+
+use super::config::HGNetV2Config;
+
+// ============================================================================
+// Frozen Batch Normalization
+// ============================================================================
+
+/// Frozen Batch Normalization layer (inference only).
+///
+/// Uses fixed running_mean and running_var statistics.
+/// Equivalent to PyTorch's FrozenBatchNorm2d or BatchNorm2d in eval mode.
+///
+/// Formula: output = (input - mean) / sqrt(var + eps) * weight + bias
+///
+/// All tensors are 1D with shape [channels].
+/// In NHWC format, normalization is applied to the last dimension.
+pub struct FrozenBatchNorm2d {
+    /// Scale parameter (gamma) [channels]
+    weight: Arc<MxArray>,
+    /// Shift parameter (beta) [channels]
+    bias: Arc<MxArray>,
+    /// Running mean [channels]
+    running_mean: Arc<MxArray>,
+    /// Running variance [channels]
+    running_var: Arc<MxArray>,
+    /// Epsilon for numerical stability
+    eps: f64,
+}
+
+impl FrozenBatchNorm2d {
+    /// Create a new FrozenBatchNorm2d layer.
+    ///
+    /// # Arguments
+    /// * `weight` - Scale parameter (gamma) [channels]
+    /// * `bias` - Shift parameter (beta) [channels]
+    /// * `running_mean` - Running mean [channels]
+    /// * `running_var` - Running variance [channels]
+    /// * `eps` - Epsilon for numerical stability
+    pub fn new(
+        weight: &MxArray,
+        bias: &MxArray,
+        running_mean: &MxArray,
+        running_var: &MxArray,
+        eps: f64,
+    ) -> Self {
+        Self {
+            weight: Arc::new(weight.clone()),
+            bias: Arc::new(bias.clone()),
+            running_mean: Arc::new(running_mean.clone()),
+            running_var: Arc::new(running_var.clone()),
+            eps,
+        }
+    }
+
+    /// Forward pass: normalize input using frozen statistics.
+    ///
+    /// Input shape: [batch, height, width, channels] (NHWC)
+    /// Output shape: [batch, height, width, channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        // Compute: (input - mean) / sqrt(var + eps) * weight + bias
+        // In NHWC, the channel dimension is the last dimension, so
+        // broadcasting of 1D tensors [C] over [N,H,W,C] works correctly
+        // since they broadcast on the last dimension.
+
+        // (input - running_mean)
+        let centered = input.sub(&self.running_mean)?;
+
+        // sqrt(running_var + eps)
+        let var_plus_eps = self.running_var.add_scalar(self.eps)?;
+        let std_dev = var_plus_eps.sqrt()?;
+
+        // (input - mean) / std
+        let normalized = centered.div(&std_dev)?;
+
+        // normalized * weight + bias
+        let scaled = normalized.mul(&self.weight)?;
+        scaled.add(&self.bias)
+    }
+}
+
+// ============================================================================
+// Conv2d (native MLX)
+// ============================================================================
+
+/// 2D Convolution layer using MLX's native conv2d.
+///
+/// Uses `mlx::core::conv2d` which operates in NHWC format.
+/// Weight shape: [out_channels, kernel_h, kernel_w, in_channels/groups]
+pub struct NativeConv2d {
+    /// Convolution weights [out_channels, kH, kW, in_channels/groups]
+    weight: Arc<MxArray>,
+    /// Optional bias [out_channels]
+    bias: Option<Arc<MxArray>>,
+    /// Stride (h, w)
+    stride: (i32, i32),
+    /// Padding (h, w)
+    padding: (i32, i32),
+    /// Dilation (h, w)
+    dilation: (i32, i32),
+    /// Groups for grouped/depthwise convolution
+    groups: i32,
+}
+
+impl NativeConv2d {
+    /// Create a new NativeConv2d layer.
+    ///
+    /// # Arguments
+    /// * `weight` - Convolution weights [out_channels, kH, kW, in_channels/groups]
+    /// * `bias` - Optional bias [out_channels]
+    /// * `stride` - Stride as (stride_h, stride_w)
+    /// * `padding` - Padding as (pad_h, pad_w)
+    /// * `dilation` - Dilation as (dilation_h, dilation_w)
+    /// * `groups` - Number of groups (1 for standard, out_channels for depthwise)
+    pub fn new(
+        weight: &MxArray,
+        bias: Option<&MxArray>,
+        stride: (i32, i32),
+        padding: (i32, i32),
+        dilation: (i32, i32),
+        groups: i32,
+    ) -> Self {
+        Self {
+            weight: Arc::new(weight.clone()),
+            bias: bias.map(|b| Arc::new(b.clone())),
+            stride,
+            padding,
+            dilation,
+            groups,
+        }
+    }
+
+    /// Forward pass: apply convolution.
+    ///
+    /// Input shape: [batch, height, width, in_channels] (NHWC)
+    /// Output shape: [batch, out_h, out_w, out_channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let handle = unsafe {
+            sys::mlx_conv2d(
+                input.handle.0,
+                self.weight.handle.0,
+                self.stride.0,
+                self.stride.1,
+                self.padding.0,
+                self.padding.1,
+                self.dilation.0,
+                self.dilation.1,
+                self.groups,
+            )
+        };
+        let mut output = MxArray::from_handle(handle, "conv2d")?;
+
+        // Add bias if present
+        if let Some(ref bias) = self.bias {
+            output = output.add(bias)?;
+        }
+
+        Ok(output)
+    }
+}
+
+// ============================================================================
+// ConvTranspose2d (native MLX)
+// ============================================================================
+
+/// 2D Transposed Convolution layer using MLX's native conv_transpose2d.
+///
+/// Uses `mlx::core::conv_transpose2d` which operates in NHWC format.
+/// Weight shape: [out_channels, kernel_h, kernel_w, in_channels/groups]
+/// Transposed convolution layer with frozen batch norm.
+///
+/// **Note on output_padding**: The underlying FFI binding (`mlx_conv_transpose2d`) hardcodes
+/// output_padding to (0, 0). This is correct for the current use case (DBHead upsampling
+/// with kernel=2, stride=2, padding=0), which produces exact 2x upsampling. For future
+/// use cases requiring non-zero output_padding, the C++ FFI and this struct must be updated
+/// to expose it as a parameter.
+pub struct NativeConvTranspose2d {
+    /// Convolution weights [out_channels, kH, kW, in_channels/groups]
+    weight: Arc<MxArray>,
+    /// Optional bias [out_channels]
+    bias: Option<Arc<MxArray>>,
+    /// Stride (h, w)
+    stride: (i32, i32),
+    /// Padding (h, w)
+    padding: (i32, i32),
+    /// Dilation (h, w)
+    dilation: (i32, i32),
+    /// Groups for grouped/depthwise convolution
+    groups: i32,
+}
+
+impl NativeConvTranspose2d {
+    /// Create a new NativeConvTranspose2d layer.
+    ///
+    /// # Arguments
+    /// * `weight` - Convolution weights [out_channels, kH, kW, in_channels/groups]
+    /// * `bias` - Optional bias [out_channels]
+    /// * `stride` - Stride as (stride_h, stride_w)
+    /// * `padding` - Padding as (pad_h, pad_w)
+    /// * `dilation` - Dilation as (dilation_h, dilation_w)
+    /// * `groups` - Number of groups
+    pub fn new(
+        weight: &MxArray,
+        bias: Option<&MxArray>,
+        stride: (i32, i32),
+        padding: (i32, i32),
+        dilation: (i32, i32),
+        groups: i32,
+    ) -> Self {
+        Self {
+            weight: Arc::new(weight.clone()),
+            bias: bias.map(|b| Arc::new(b.clone())),
+            stride,
+            padding,
+            dilation,
+            groups,
+        }
+    }
+
+    /// Forward pass: apply transposed convolution.
+    ///
+    /// Input shape: [batch, height, width, in_channels] (NHWC)
+    /// Output shape: [batch, out_h, out_w, out_channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let handle = unsafe {
+            sys::mlx_conv_transpose2d(
+                input.handle.0,
+                self.weight.handle.0,
+                self.stride.0,
+                self.stride.1,
+                self.padding.0,
+                self.padding.1,
+                self.dilation.0,
+                self.dilation.1,
+                self.groups,
+            )
+        };
+        let mut output = MxArray::from_handle(handle, "conv_transpose2d")?;
+
+        // Add bias if present
+        if let Some(ref bias) = self.bias {
+            output = output.add(bias)?;
+        }
+
+        Ok(output)
+    }
+}
+
+// ============================================================================
+// Learnable Affine Block
+// ============================================================================
+
+/// Learnable Affine Block: output = scale * input + bias
+///
+/// Adds learnable per-element scale and bias after activation.
+/// Scale is initialized to 1.0, bias to 0.0.
+pub struct LearnableAffineBlock {
+    /// Scale parameter [1]
+    scale: Arc<MxArray>,
+    /// Bias parameter [1]
+    bias: Arc<MxArray>,
+}
+
+impl LearnableAffineBlock {
+    /// Create a new LearnableAffineBlock.
+    pub fn new(scale: &MxArray, bias: &MxArray) -> Self {
+        Self {
+            scale: Arc::new(scale.clone()),
+            bias: Arc::new(bias.clone()),
+        }
+    }
+
+    /// Forward pass: scale * input + bias
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let scaled = input.mul(&self.scale)?;
+        scaled.add(&self.bias)
+    }
+}
+
+// ============================================================================
+// ConvBNAct: Conv2d + BatchNorm + Activation (+ optional LAB)
+// ============================================================================
+
+/// Convolution + Batch Normalization + Activation layer.
+///
+/// Corresponds to HGNetV2ConvLayer in the reference implementation.
+/// Optionally includes a LearnableAffineBlock after activation.
+pub struct ConvBNAct {
+    /// Convolution layer
+    conv: NativeConv2d,
+    /// Frozen batch normalization
+    norm: FrozenBatchNorm2d,
+    /// Activation function name ("relu", "silu", "none")
+    activation: String,
+    /// Optional learnable affine block
+    lab: Option<LearnableAffineBlock>,
+}
+
+impl ConvBNAct {
+    /// Create a new ConvBNAct layer.
+    ///
+    /// # Arguments
+    /// * `conv` - NativeConv2d layer
+    /// * `norm` - FrozenBatchNorm2d layer
+    /// * `activation` - Activation name ("relu", "silu", "none"/identity)
+    /// * `lab` - Optional LearnableAffineBlock
+    pub fn new(
+        conv: NativeConv2d,
+        norm: FrozenBatchNorm2d,
+        activation: &str,
+        lab: Option<LearnableAffineBlock>,
+    ) -> Self {
+        Self {
+            conv,
+            norm,
+            activation: activation.to_string(),
+            lab,
+        }
+    }
+
+    /// Forward pass: Conv -> BN -> Activation -> (optional LAB)
+    ///
+    /// Input/Output: [batch, height, width, channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let mut x = self.conv.forward(input)?;
+        x = self.norm.forward(&x)?;
+        x = super::apply_activation(&x, &self.activation)?;
+        if let Some(ref lab) = self.lab {
+            x = lab.forward(&x)?;
+        }
+        Ok(x)
+    }
+}
+
+// ============================================================================
+// ConvBNActLight: Depthwise separable convolution
+// ============================================================================
+
+/// Light (depthwise separable) convolution block.
+///
+/// Corresponds to HGNetV2ConvLayerLight in the reference implementation.
+/// Consists of:
+/// 1. 1x1 pointwise convolution (no activation)
+/// 2. kxk depthwise convolution (groups=out_channels) with activation
+pub struct ConvBNActLight {
+    /// 1x1 pointwise convolution (activation=None)
+    conv1: ConvBNAct,
+    /// kxk depthwise convolution (groups=out_channels)
+    conv2: ConvBNAct,
+}
+
+impl ConvBNActLight {
+    /// Create a new ConvBNActLight layer.
+    pub fn new(conv1: ConvBNAct, conv2: ConvBNAct) -> Self {
+        Self { conv1, conv2 }
+    }
+
+    /// Forward pass: pointwise conv -> depthwise conv
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let x = self.conv1.forward(input)?;
+        self.conv2.forward(&x)
+    }
+}
+
+// ============================================================================
+// HGBlock: Basic building block with feature aggregation
+// ============================================================================
+
+/// A single convolutional layer within an HGBlock, which can be either
+/// a standard ConvBNAct or a light (depthwise separable) ConvBNActLight.
+pub enum HGBlockLayer {
+    Standard(ConvBNAct),
+    Light(ConvBNActLight),
+}
+
+impl HGBlockLayer {
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        match self {
+            HGBlockLayer::Standard(layer) => layer.forward(input),
+            HGBlockLayer::Light(layer) => layer.forward(input),
+        }
+    }
+}
+
+/// HGBlock: Feature aggregation block.
+///
+/// Corresponds to HGNetV2BasicLayer in the reference implementation.
+///
+/// Architecture:
+/// 1. Sequential conv layers, each taking the previous output
+/// 2. Concatenate all intermediate outputs (including input) along channel dim
+/// 3. Aggregation: squeeze (1x1 conv to out/2) -> excitation (1x1 conv to out)
+/// 4. Optional residual connection (for non-first blocks)
+pub struct HGBlock {
+    /// Sequential conv layers (standard or light)
+    layers: Vec<HGBlockLayer>,
+    /// Aggregation squeeze conv (total_channels -> out_channels/2)
+    agg_squeeze: ConvBNAct,
+    /// Aggregation excitation conv (out_channels/2 -> out_channels)
+    agg_excitation: ConvBNAct,
+    /// Whether to use residual connection
+    residual: bool,
+}
+
+impl HGBlock {
+    /// Create a new HGBlock.
+    ///
+    /// # Arguments
+    /// * `layers` - Sequential conv layers
+    /// * `agg_squeeze` - Aggregation squeeze conv
+    /// * `agg_excitation` - Aggregation excitation conv
+    /// * `residual` - Whether to add input as residual
+    pub fn new(
+        layers: Vec<HGBlockLayer>,
+        agg_squeeze: ConvBNAct,
+        agg_excitation: ConvBNAct,
+        residual: bool,
+    ) -> Self {
+        Self {
+            layers,
+            agg_squeeze,
+            agg_excitation,
+            residual,
+        }
+    }
+
+    /// Forward pass with feature aggregation.
+    ///
+    /// Input/Output: [batch, height, width, channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let identity = input.clone();
+        let mut outputs: Vec<MxArray> = vec![input.clone()];
+
+        let mut hidden = input.clone();
+        for layer in &self.layers {
+            hidden = layer.forward(&hidden)?;
+            outputs.push(hidden.clone());
+        }
+
+        // Concatenate all intermediate outputs along channel axis (last dim in NHWC)
+        // NHWC: axis=3 (channels) or axis=-1
+        let output_refs: Vec<&MxArray> = outputs.iter().collect();
+        let concatenated = MxArray::concatenate_many(output_refs, Some(3))?;
+
+        // Aggregation: squeeze -> excitation
+        let mut aggregated = self.agg_squeeze.forward(&concatenated)?;
+        aggregated = self.agg_excitation.forward(&aggregated)?;
+
+        // Residual connection
+        if self.residual {
+            aggregated = aggregated.add(&identity)?;
+        }
+
+        Ok(aggregated)
+    }
+}
+
+// ============================================================================
+// MaxPool2d (pure Rust implementation for MLX NHWC)
+// ============================================================================
+
+/// Max pooling implementation for NHWC format.
+///
+/// Since MLX does not have a native max_pool2d FFI binding, we implement
+/// it using slicing and element-wise maximum operations.
+///
+/// For the specific case used in HGNetV2 (kernel=2, stride=1, ceil_mode=true),
+/// this pads the input by (0,1) on height and width, then takes the maximum
+/// of 4 overlapping positions.
+pub struct MaxPool2d {
+    kernel_size: i32,
+    stride: i32,
+    /// Whether to use ceil mode for output size calculation
+    ceil_mode: bool,
+}
+
+impl MaxPool2d {
+    pub fn new(kernel_size: i32, stride: i32, ceil_mode: bool) -> Self {
+        Self {
+            kernel_size,
+            stride,
+            ceil_mode,
+        }
+    }
+
+    /// Forward pass: apply max pooling.
+    ///
+    /// Input: [batch, height, width, channels] (NHWC)
+    /// Output: [batch, out_h, out_w, channels] (NHWC)
+    ///
+    /// For kernel=2, stride=1, ceil_mode=true:
+    /// - Pads input with -inf on H,W dimensions
+    /// - Takes max over 2x2 windows with stride 1
+    /// - Output size = input size (due to ceil_mode + padding)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let shape = input.shape()?;
+        let shape: Vec<i64> = shape.as_ref().to_vec();
+        if shape.len() != 4 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("MaxPool2d input must be 4D [N,H,W,C], got {}D", shape.len()),
+            ));
+        }
+
+        let batch = shape[0];
+        let in_h = shape[1];
+        let in_w = shape[2];
+        let channels = shape[3];
+
+        let k = self.kernel_size as i64;
+        let s = self.stride as i64;
+
+        // Calculate output dimensions
+        let out_h = if self.ceil_mode {
+            (in_h - k + s - 1) / s + 1
+        } else {
+            (in_h - k) / s + 1
+        };
+        let out_w = if self.ceil_mode {
+            (in_w - k + s - 1) / s + 1
+        } else {
+            (in_w - k) / s + 1
+        };
+
+        // Pad input with -inf so that padded elements don't affect max
+        // We need to pad H and W dimensions to ensure we can take k-sized windows
+        // at all valid output positions.
+        let pad_h = (out_h - 1) * s + k - in_h;
+        let pad_w = (out_w - 1) * s + k - in_w;
+
+        let padded = if pad_h > 0 || pad_w > 0 {
+            // NHWC pad_width: [batch_before, batch_after, h_before, h_after, w_before, w_after, c_before, c_after]
+            let pad_width = vec![0i32, 0, 0, pad_h as i32, 0, pad_w as i32, 0, 0];
+            input.pad(&pad_width, f64::NEG_INFINITY)?
+        } else {
+            input.clone()
+        };
+
+        // For the common case of kernel_size=2, stride=1, we can implement
+        // this efficiently using element-wise maximum of shifted windows.
+        if k == 2 && s == 1 {
+            // max(input[h:h+2, w:w+2]) for each output position
+            // = max(max(padded[:, :out_h, :out_w, :],
+            //          padded[:, 1:out_h+1, :out_w, :]),
+            //       max(padded[:, :out_h, 1:out_w+1, :],
+            //          padded[:, 1:out_h+1, 1:out_w+1, :]))
+
+            let tl = padded.slice(&[0, 0, 0, 0], &[batch, out_h, out_w, channels])?;
+            let tr = padded.slice(&[0, 0, 1, 0], &[batch, out_h, out_w + 1, channels])?;
+            let bl = padded.slice(&[0, 1, 0, 0], &[batch, out_h + 1, out_w, channels])?;
+            let br = padded.slice(&[0, 1, 1, 0], &[batch, out_h + 1, out_w + 1, channels])?;
+
+            let max_top = tl.maximum(&tr)?;
+            let max_bot = bl.maximum(&br)?;
+            let result = max_top.maximum(&max_bot)?;
+
+            return Ok(result);
+        }
+
+        // General case: use nested loops of slicing and max
+        // For each (kh, kw) position in the kernel, slice the padded input
+        // and accumulate the element-wise maximum.
+        let mut result: Option<MxArray> = None;
+        for kh in 0..k {
+            for kw in 0..k {
+                let window = padded.slice(
+                    &[0, kh, kw, 0],
+                    &[batch, kh + out_h * s, kw + out_w * s, channels],
+                )?;
+
+                // If stride > 1, we need to take every s-th element
+                // For stride=1, the slice already gives us the right output
+                if s > 1 {
+                    return Err(Error::new(
+                        Status::GenericFailure,
+                        "MaxPool2d with stride > 1 and kernel > 2 not yet optimized",
+                    ));
+                }
+
+                result = Some(match result {
+                    None => window,
+                    Some(prev) => prev.maximum(&window)?,
+                });
+            }
+        }
+
+        result.ok_or_else(|| Error::new(Status::GenericFailure, "Empty max pool kernel"))
+    }
+}
+
+// ============================================================================
+// HGNetV2Embeddings (Stem)
+// ============================================================================
+
+/// HGNetV2 Stem (Embeddings) layer.
+///
+/// Corresponds to HGNetV2Embeddings in the reference implementation.
+///
+/// Architecture:
+/// 1. stem1: Conv(3->32, k=3, s=2) - initial 2x downsample
+/// 2. Pad(0,1,0,1) + stem2a: Conv(32->16, k=2, s=1)
+/// 3. Pad(0,1,0,1) + stem2b: Conv(16->32, k=2, s=1)
+/// 4. MaxPool2d(k=2, s=1, ceil_mode=True) on output of stem1+pad
+/// 5. Cat(pooled, stem2b) along channels -> 64 channels
+/// 6. stem3: Conv(64->32, k=3, s=2) - second 2x downsample
+/// 7. stem4: Conv(32->48, k=1, s=1) - channel projection
+///
+/// Total downsample: 4x (stride 2 * stride 2)
+/// Output: [batch, H/4, W/4, stem_channels[2]]
+pub struct HGNetV2Embeddings {
+    stem1: ConvBNAct,
+    stem2a: ConvBNAct,
+    stem2b: ConvBNAct,
+    stem3: ConvBNAct,
+    stem4: ConvBNAct,
+    pool: MaxPool2d,
+}
+
+impl HGNetV2Embeddings {
+    /// Create a new HGNetV2Embeddings layer.
+    pub fn new(
+        stem1: ConvBNAct,
+        stem2a: ConvBNAct,
+        stem2b: ConvBNAct,
+        stem3: ConvBNAct,
+        stem4: ConvBNAct,
+    ) -> Self {
+        Self {
+            stem1,
+            stem2a,
+            stem2b,
+            stem3,
+            stem4,
+            pool: MaxPool2d::new(2, 1, true),
+        }
+    }
+
+    /// Forward pass through the stem.
+    ///
+    /// Input: [batch, H, W, 3] (NHWC, RGB image)
+    /// Output: [batch, H/4, W/4, stem_channels[2]] (NHWC)
+    pub fn forward(&self, pixel_values: &MxArray) -> Result<MxArray> {
+        // stem1: 3->32, k=3, s=2
+        let embedding = self.stem1.forward(pixel_values)?;
+
+        // Pad H and W by (0,1) each for the k=2 convolutions
+        // In PyTorch NCHW: F.pad(x, (0, 1, 0, 1)) pads W_right=1, H_bottom=1
+        // In MLX NHWC pad_width: [N_before, N_after, H_before, H_after, W_before, W_after, C_before, C_after]
+        let padded = embedding.pad(&[0, 0, 0, 1, 0, 1, 0, 0], 0.0)?;
+
+        // stem2a: 32->16, k=2, s=1
+        let emb_stem_2a = self.stem2a.forward(&padded)?;
+
+        // Pad again for stem2b
+        let emb_stem_2a_padded = emb_stem_2a.pad(&[0, 0, 0, 1, 0, 1, 0, 0], 0.0)?;
+
+        // stem2b: 16->32, k=2, s=1
+        let emb_stem_2b = self.stem2b.forward(&emb_stem_2a_padded)?;
+
+        // MaxPool on the first padded embedding (after stem1 + pad)
+        let pooled_emb = self.pool.forward(&padded)?;
+
+        // Concatenate pooled and stem2b along channel axis (axis=3 in NHWC)
+        let concatenated = MxArray::concatenate(&pooled_emb, &emb_stem_2b, 3)?;
+
+        // stem3: 64->32, k=3, s=2 (second 2x downsample)
+        let embedding = self.stem3.forward(&concatenated)?;
+
+        // stem4: 32->48, k=1, s=1 (channel projection)
+        self.stem4.forward(&embedding)
+    }
+}
+
+// ============================================================================
+// HGNetV2Stage
+// ============================================================================
+
+/// HGNetV2 Stage: optional downsample + stack of HGBlocks.
+///
+/// Corresponds to HGNetV2Stage in the reference implementation.
+///
+/// If downsample is true, applies a depthwise Conv(k=3, s=2, groups=in_channels)
+/// before the HGBlocks.
+pub struct HGNetV2Stage {
+    /// Optional downsample layer (depthwise conv with stride 2)
+    downsample: Option<ConvBNAct>,
+    /// Stack of HGBlocks
+    blocks: Vec<HGBlock>,
+}
+
+impl HGNetV2Stage {
+    /// Create a new HGNetV2Stage.
+    pub fn new(downsample: Option<ConvBNAct>, blocks: Vec<HGBlock>) -> Self {
+        Self { downsample, blocks }
+    }
+
+    /// Forward pass: downsample (if any) -> sequential HGBlocks.
+    ///
+    /// Input/Output: [batch, height, width, channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let mut x = if let Some(ref ds) = self.downsample {
+            ds.forward(input)?
+        } else {
+            input.clone()
+        };
+
+        for block in &self.blocks {
+            x = block.forward(&x)?;
+        }
+
+        Ok(x)
+    }
+}
+
+// ============================================================================
+// HGNetV2Encoder
+// ============================================================================
+
+/// HGNetV2 Encoder: sequence of stages.
+///
+/// Corresponds to HGNetV2Encoder in the reference implementation.
+pub struct HGNetV2Encoder {
+    /// The 4 stages
+    stages: Vec<HGNetV2Stage>,
+}
+
+impl HGNetV2Encoder {
+    pub fn new(stages: Vec<HGNetV2Stage>) -> Self {
+        Self { stages }
+    }
+
+    /// Forward pass: run through all stages, collecting hidden states.
+    ///
+    /// Input: [batch, H/4, W/4, stem_out_channels] (output of embeddings)
+    /// Returns: Vec of hidden states - one before each stage plus the final output.
+    ///          Index 0 = input to stage 0 (stem output)
+    ///          Index i = output of stage i-1 (for i > 0)
+    ///          Index num_stages = output of last stage
+    pub fn forward(&self, input: &MxArray) -> Result<Vec<MxArray>> {
+        let mut hidden_states: Vec<MxArray> = Vec::with_capacity(self.stages.len() + 1);
+        hidden_states.push(input.clone());
+
+        let mut x = input.clone();
+        for stage in &self.stages {
+            x = stage.forward(&x)?;
+            hidden_states.push(x.clone());
+        }
+
+        Ok(hidden_states)
+    }
+}
+
+// ============================================================================
+// HGNetV2Backbone
+// ============================================================================
+
+/// HGNetV2 Backbone: Embeddings + Encoder + feature selection.
+///
+/// Corresponds to HGNetV2Backbone in the reference implementation.
+/// Returns feature maps for the requested output stages.
+pub struct HGNetV2Backbone {
+    /// Stem / embeddings layer
+    embedder: HGNetV2Embeddings,
+    /// Encoder with all stages
+    encoder: HGNetV2Encoder,
+    /// Which features to output (indices into hidden_states)
+    /// stage_names: ["stem", "stage1", "stage2", "stage3", "stage4"]
+    /// out_features selects from these. "stage1" = hidden_states[1], etc.
+    out_feature_indices: Vec<usize>,
+    /// Channel sizes for the output features
+    pub channels: Vec<i32>,
+}
+
+impl HGNetV2Backbone {
+    /// Create a new HGNetV2Backbone.
+    ///
+    /// # Arguments
+    /// * `embedder` - The stem/embeddings layer
+    /// * `encoder` - The encoder with all stages
+    /// * `config` - Configuration to determine output features
+    pub fn new(
+        embedder: HGNetV2Embeddings,
+        encoder: HGNetV2Encoder,
+        config: &HGNetV2Config,
+    ) -> Self {
+        // Map out_features names to indices in the hidden_states array
+        // hidden_states[0] = "stem" output
+        // hidden_states[1] = "stage1" output
+        // hidden_states[2] = "stage2" output, etc.
+        let stage_names: Vec<String> = std::iter::once("stem".to_string())
+            .chain((1..=config.num_stages()).map(|i| format!("stage{i}")))
+            .collect();
+
+        let out_feature_indices: Vec<usize> = config
+            .out_features
+            .iter()
+            .filter_map(|name| stage_names.iter().position(|s| s == name))
+            .collect();
+
+        // Compute channel sizes for output features
+        let all_channels: Vec<i32> = std::iter::once(config.embedding_size)
+            .chain(config.stage_out_channels.iter().copied())
+            .collect();
+
+        let channels: Vec<i32> = out_feature_indices
+            .iter()
+            .map(|&idx| all_channels[idx])
+            .collect();
+
+        Self {
+            embedder,
+            encoder,
+            out_feature_indices,
+            channels,
+        }
+    }
+
+    /// Forward pass: extract feature maps from the backbone.
+    ///
+    /// Input: [batch, H, W, 3] (NHWC, RGB image)
+    /// Returns: Vec of feature maps at requested scales.
+    ///
+    /// For default config (out_features = ["stage1", "stage2", "stage3", "stage4"]):
+    /// - feature_maps[0]: [batch, H/4, W/4, 128]   (stage1)
+    /// - feature_maps[1]: [batch, H/8, W/8, 512]   (stage2)
+    /// - feature_maps[2]: [batch, H/16, W/16, 1024] (stage3)
+    /// - feature_maps[3]: [batch, H/32, W/32, 2048] (stage4)
+    pub fn forward(&self, pixel_values: &MxArray) -> Result<Vec<MxArray>> {
+        let embedding_output = self.embedder.forward(pixel_values)?;
+        let hidden_states = self.encoder.forward(&embedding_output)?;
+
+        let feature_maps: Vec<MxArray> = self
+            .out_feature_indices
+            .iter()
+            .map(|&idx| hidden_states[idx].clone())
+            .collect();
+
+        Ok(feature_maps)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_frozen_batch_norm() {
+        // Create simple 1D tensors for a 4-channel batch norm
+        let weight = MxArray::from_float32(&[1.0, 1.0, 1.0, 1.0], &[4]).unwrap();
+        let bias = MxArray::from_float32(&[0.0, 0.0, 0.0, 0.0], &[4]).unwrap();
+        let running_mean = MxArray::from_float32(&[0.0, 0.0, 0.0, 0.0], &[4]).unwrap();
+        let running_var = MxArray::from_float32(&[1.0, 1.0, 1.0, 1.0], &[4]).unwrap();
+
+        let bn = FrozenBatchNorm2d::new(&weight, &bias, &running_mean, &running_var, 1e-5);
+
+        // Input: [1, 2, 2, 4] - identity normalization should pass through
+        let input = MxArray::from_float32(
+            &[
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                16.0,
+            ],
+            &[1, 2, 2, 4],
+        )
+        .unwrap();
+
+        let output = bn.forward(&input).unwrap();
+        let output_shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(output_shape, vec![1, 2, 2, 4]);
+    }
+
+    #[test]
+    fn test_max_pool_2d_k2_s1_ceil() {
+        let pool = MaxPool2d::new(2, 1, true);
+
+        // Input: [1, 3, 3, 1] - simple 3x3 with 1 channel
+        let input = MxArray::from_float32(
+            &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+            &[1, 3, 3, 1],
+        )
+        .unwrap();
+
+        let output = pool.forward(&input).unwrap();
+        let output_shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+
+        // With k=2, s=1, ceil_mode=true:
+        // out_h = ceil((3 - 2) / 1) + 1 = 2
+        assert_eq!(output_shape, vec![1, 2, 2, 1]);
+
+        // Check values: max of 2x2 windows
+        output.eval();
+        let data = output.to_float32().unwrap();
+        let data: Vec<f32> = data.to_vec();
+        // Position (0,0): max(1,2,4,5) = 5
+        assert_eq!(data[0], 5.0);
+        // Position (0,1): max(2,3,5,6) = 6
+        assert_eq!(data[1], 6.0);
+        // Position (1,0): max(4,5,7,8) = 8
+        assert_eq!(data[2], 8.0);
+        // Position (1,1): max(5,6,8,9) = 9
+        assert_eq!(data[3], 9.0);
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = HGNetV2Config::default();
+        assert_eq!(config.num_stages(), 4);
+        assert_eq!(config.stem_channels, vec![3, 32, 48]);
+        assert_eq!(config.output_channels(), vec![128, 512, 1024, 2048]);
+    }
+}

--- a/crates/mlx-core/src/models/pp_doclayout_v3/config.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/config.rs
@@ -1,0 +1,790 @@
+//! PP-DocLayoutV3 Configuration
+//!
+//! Model configuration for PP-DocLayoutV3 document layout analysis models.
+//! Based on the HuggingFace Transformers PPDocLayoutV3Config and HGNetV2Config.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+
+// ============================================================================
+// HGNetV2 Backbone Configuration
+// ============================================================================
+
+/// Configuration for the HGNetV2 backbone used in PP-DocLayoutV3.
+///
+/// The HGNetV2 architecture consists of:
+/// - A stem (embedding) layer that downsamples the input
+/// - 4 stages of HGBlocks with increasing channel dimensions
+///
+/// Default values correspond to the HGNetV2-L architecture.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HGNetV2Config {
+    /// Model type identifier
+    #[serde(default = "default_hgnet_v2_model_type")]
+    pub model_type: String,
+
+    /// Number of input image channels (default: 3 for RGB)
+    #[serde(default = "default_num_channels")]
+    pub num_channels: i32,
+
+    /// Dimensionality of the embedding (stem output) layer
+    #[serde(default = "default_embedding_size")]
+    pub embedding_size: i32,
+
+    /// Depth (number of layers) for each stage
+    #[serde(default = "default_depths")]
+    pub depths: Vec<i32>,
+
+    /// Hidden sizes (output channels) at each stage
+    #[serde(default = "default_hidden_sizes")]
+    pub hidden_sizes: Vec<i32>,
+
+    /// Activation function: "relu" or "silu"
+    #[serde(default = "default_hidden_act")]
+    pub hidden_act: String,
+
+    /// Channel dimensions for the stem layers: [input, intermediate, output]
+    #[serde(default = "default_stem_channels")]
+    pub stem_channels: Vec<i32>,
+
+    /// Input channel dimensions for each stage
+    #[serde(default = "default_stage_in_channels")]
+    pub stage_in_channels: Vec<i32>,
+
+    /// Mid-channel dimensions for each stage
+    #[serde(default = "default_stage_mid_channels")]
+    pub stage_mid_channels: Vec<i32>,
+
+    /// Output channel dimensions for each stage
+    #[serde(default = "default_stage_out_channels")]
+    pub stage_out_channels: Vec<i32>,
+
+    /// Number of HGBlocks in each stage
+    #[serde(default = "default_stage_num_blocks")]
+    pub stage_num_blocks: Vec<i32>,
+
+    /// Whether to downsample at each stage
+    #[serde(default = "default_stage_downsample")]
+    pub stage_downsample: Vec<bool>,
+
+    /// Whether to use light (depthwise separable) blocks in each stage
+    #[serde(default = "default_stage_light_block")]
+    pub stage_light_block: Vec<bool>,
+
+    /// Kernel sizes for convolutions in each stage
+    #[serde(default = "default_stage_kernel_size")]
+    pub stage_kernel_size: Vec<i32>,
+
+    /// Number of conv layers within each HGBlock per stage
+    #[serde(default = "default_stage_numb_of_layers")]
+    pub stage_numb_of_layers: Vec<i32>,
+
+    /// Whether to use Learnable Affine Blocks after activations
+    #[serde(default)]
+    pub use_learnable_affine_block: bool,
+
+    /// Per-stage downsample strides as (stride_h, stride_w).
+    /// Default: all (2,2). Text recognition uses asymmetric strides like [(2,1),(1,2),(2,1),(2,1)].
+    #[serde(default = "default_stage_strides")]
+    pub stage_strides: Vec<(i32, i32)>,
+
+    /// Stride for stem3 layer. Default: (2,2). Text recognition may use (2,1).
+    #[serde(default = "default_stem3_stride")]
+    pub stem3_stride: (i32, i32),
+
+    /// Which stage outputs to return (e.g., ["stage1", "stage2", "stage3", "stage4"])
+    #[serde(default = "default_out_features")]
+    pub out_features: Vec<String>,
+
+    /// Indices of output stages
+    #[serde(default)]
+    pub out_indices: Option<Vec<i32>>,
+
+    /// Standard deviation for weight initialization
+    #[serde(default = "default_initializer_range_backbone")]
+    pub initializer_range: f64,
+}
+
+impl Default for HGNetV2Config {
+    fn default() -> Self {
+        Self {
+            model_type: default_hgnet_v2_model_type(),
+            num_channels: default_num_channels(),
+            embedding_size: default_embedding_size(),
+            depths: default_depths(),
+            hidden_sizes: default_hidden_sizes(),
+            hidden_act: default_hidden_act(),
+            stem_channels: default_stem_channels(),
+            stage_in_channels: default_stage_in_channels(),
+            stage_mid_channels: default_stage_mid_channels(),
+            stage_out_channels: default_stage_out_channels(),
+            stage_num_blocks: default_stage_num_blocks(),
+            stage_downsample: default_stage_downsample(),
+            stage_light_block: default_stage_light_block(),
+            stage_kernel_size: default_stage_kernel_size(),
+            stage_numb_of_layers: default_stage_numb_of_layers(),
+            use_learnable_affine_block: false,
+            stage_strides: default_stage_strides(),
+            stem3_stride: default_stem3_stride(),
+            out_features: default_out_features(),
+            out_indices: None,
+            initializer_range: default_initializer_range_backbone(),
+        }
+    }
+}
+
+impl HGNetV2Config {
+    /// Get the number of stages
+    pub fn num_stages(&self) -> usize {
+        self.stage_in_channels.len()
+    }
+
+    /// Get the output channel sizes for the stages that are in out_features.
+    /// Returns all 4 stage output channels (the backbone always runs all 4 stages
+    /// and returns the requested features).
+    pub fn output_channels(&self) -> Vec<i32> {
+        self.out_features
+            .iter()
+            .filter_map(|name| {
+                if let Some(idx_str) = name.strip_prefix("stage")
+                    && let Ok(idx) = idx_str.parse::<usize>()
+                {
+                    // stage1 = index 0, stage2 = index 1, etc.
+                    return self.stage_out_channels.get(idx.saturating_sub(1)).copied();
+                }
+                None
+            })
+            .collect()
+    }
+}
+
+// ============================================================================
+// HGNetV2Config defaults (HGNetV2-L architecture)
+// ============================================================================
+
+fn default_hgnet_v2_model_type() -> String {
+    "hgnet_v2".to_string()
+}
+fn default_num_channels() -> i32 {
+    3
+}
+fn default_embedding_size() -> i32 {
+    48 // stem_channels[2] for B4/L variant
+}
+fn default_depths() -> Vec<i32> {
+    vec![3, 4, 6, 3]
+}
+fn default_hidden_sizes() -> Vec<i32> {
+    vec![256, 512, 1024, 2048]
+}
+fn default_hidden_act() -> String {
+    "relu".to_string()
+}
+fn default_stem_channels() -> Vec<i32> {
+    vec![3, 32, 48]
+}
+fn default_stage_in_channels() -> Vec<i32> {
+    vec![48, 128, 512, 1024]
+}
+fn default_stage_mid_channels() -> Vec<i32> {
+    vec![48, 96, 192, 384]
+}
+fn default_stage_out_channels() -> Vec<i32> {
+    vec![128, 512, 1024, 2048]
+}
+fn default_stage_num_blocks() -> Vec<i32> {
+    vec![1, 1, 3, 1]
+}
+fn default_stage_downsample() -> Vec<bool> {
+    vec![false, true, true, true]
+}
+fn default_stage_light_block() -> Vec<bool> {
+    vec![false, false, true, true]
+}
+fn default_stage_kernel_size() -> Vec<i32> {
+    vec![3, 3, 5, 5]
+}
+fn default_stage_numb_of_layers() -> Vec<i32> {
+    vec![6, 6, 6, 6]
+}
+fn default_stage_strides() -> Vec<(i32, i32)> {
+    vec![(2, 2), (2, 2), (2, 2), (2, 2)]
+}
+fn default_stem3_stride() -> (i32, i32) {
+    (2, 2)
+}
+fn default_out_features() -> Vec<String> {
+    vec![
+        "stage1".to_string(),
+        "stage2".to_string(),
+        "stage3".to_string(),
+        "stage4".to_string(),
+    ]
+}
+fn default_initializer_range_backbone() -> f64 {
+    0.02
+}
+
+// ============================================================================
+// PP-DocLayoutV3 Full Model Configuration
+// ============================================================================
+
+/// Full configuration for the PP-DocLayoutV3 model.
+///
+/// This includes the backbone config plus all encoder/decoder parameters.
+/// Corresponds to PPDocLayoutV3Config in HuggingFace Transformers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PPDocLayoutV3Config {
+    /// Standard deviation for weight initialization
+    #[serde(default = "default_initializer_range")]
+    pub initializer_range: f64,
+
+    /// Bias initializer prior probability (None uses 1/(num_labels+1))
+    #[serde(default)]
+    pub initializer_bias_prior_prob: Option<f64>,
+
+    /// Epsilon for layer normalization
+    #[serde(default = "default_layer_norm_eps")]
+    pub layer_norm_eps: f64,
+
+    /// Epsilon for batch normalization
+    #[serde(default = "default_batch_norm_eps")]
+    pub batch_norm_eps: f64,
+
+    // -- Backbone --
+    /// HGNetV2 backbone configuration
+    #[serde(default)]
+    pub backbone_config: HGNetV2Config,
+
+    /// Whether to freeze batch norms in the backbone
+    #[serde(default = "default_true")]
+    pub freeze_backbone_batch_norms: bool,
+
+    // -- Encoder (PPDocLayoutV3HybridEncoder) --
+    /// Hidden dimension of the encoder
+    #[serde(default = "default_encoder_hidden_dim")]
+    pub encoder_hidden_dim: i32,
+
+    /// Input channel dimensions from backbone to encoder
+    #[serde(default = "default_encoder_in_channels")]
+    pub encoder_in_channels: Vec<i32>,
+
+    /// Feature strides for each feature level
+    #[serde(default = "default_feat_strides", alias = "feature_strides")]
+    pub feat_strides: Vec<i32>,
+
+    /// Number of transformer encoder layers
+    #[serde(default = "default_one")]
+    pub encoder_layers: i32,
+
+    /// FFN dimension in the encoder
+    #[serde(default = "default_ffn_dim")]
+    pub encoder_ffn_dim: i32,
+
+    /// Number of attention heads in the encoder
+    #[serde(default = "default_eight")]
+    pub encoder_attention_heads: i32,
+
+    /// Dropout rate
+    #[serde(default)]
+    pub dropout: f64,
+
+    /// Activation dropout rate
+    #[serde(default)]
+    pub activation_dropout: f64,
+
+    /// Indices of projected encoder layers
+    #[serde(default = "default_encode_proj_layers")]
+    pub encode_proj_layers: Vec<i32>,
+
+    /// Temperature for positional encoding
+    #[serde(default = "default_positional_encoding_temperature")]
+    pub positional_encoding_temperature: i32,
+
+    /// Encoder activation function (e.g., "gelu")
+    #[serde(default = "default_encoder_activation")]
+    pub encoder_activation_function: String,
+
+    /// General activation function (e.g., "silu")
+    #[serde(default = "default_activation_function")]
+    pub activation_function: String,
+
+    /// Eval image size [height, width] for fixed positional embeddings
+    #[serde(default)]
+    pub eval_size: Option<Vec<i32>>,
+
+    /// Whether to apply layer norm before attention
+    #[serde(default)]
+    pub normalize_before: bool,
+
+    /// Expansion ratio for RepVGG/CSPRep blocks
+    #[serde(default = "default_one_f64")]
+    pub hidden_expansion: f64,
+
+    /// Channels for mask feature FPN
+    #[serde(default = "default_mask_feature_channels")]
+    pub mask_feature_channels: Vec<i32>,
+
+    /// Dimension of the x4 (stride-4) feature map
+    #[serde(default = "default_x4_feat_dim")]
+    pub x4_feat_dim: i32,
+
+    // -- Decoder (PPDocLayoutV3Transformer) --
+    /// Model dimension (used in decoder, queries, heads)
+    #[serde(default = "default_d_model")]
+    pub d_model: i32,
+
+    /// Number of prototypes for mask prediction
+    #[serde(default = "default_num_prototypes")]
+    pub num_prototypes: i32,
+
+    /// Label noise ratio for denoising training
+    #[serde(default = "default_noise_ratio")]
+    pub label_noise_ratio: f64,
+
+    /// Box noise scale for denoising training
+    #[serde(default = "default_noise_ratio")]
+    pub box_noise_scale: f64,
+
+    /// Whether to use mask-enhanced attention
+    #[serde(default = "default_true")]
+    pub mask_enhanced: bool,
+
+    /// Number of object queries
+    #[serde(default = "default_num_queries")]
+    pub num_queries: i32,
+
+    /// Decoder input channel dimensions
+    #[serde(default = "default_decoder_in_channels")]
+    pub decoder_in_channels: Vec<i32>,
+
+    /// FFN dimension in the decoder
+    #[serde(default = "default_ffn_dim")]
+    pub decoder_ffn_dim: i32,
+
+    /// Number of feature levels in the decoder
+    #[serde(default = "default_num_feature_levels")]
+    pub num_feature_levels: i32,
+
+    /// Number of sampling points per attention head in the decoder
+    #[serde(default = "default_decoder_n_points")]
+    pub decoder_n_points: i32,
+
+    /// Number of decoder layers
+    #[serde(default = "default_decoder_layers")]
+    pub decoder_layers: i32,
+
+    /// Number of attention heads in the decoder
+    #[serde(default = "default_eight")]
+    pub decoder_attention_heads: i32,
+
+    /// Decoder activation function (e.g., "relu")
+    #[serde(default = "default_decoder_activation")]
+    pub decoder_activation_function: String,
+
+    /// Attention dropout rate
+    #[serde(default)]
+    pub attention_dropout: f64,
+
+    /// Number of denoising queries
+    #[serde(default = "default_num_denoising")]
+    pub num_denoising: i32,
+
+    /// Whether to learn initial query embeddings
+    #[serde(default)]
+    pub learn_initial_query: bool,
+
+    /// Anchor image size for fixed anchors [height, width]
+    #[serde(default)]
+    pub anchor_image_size: Option<Vec<i32>>,
+
+    /// Whether to disable custom CUDA kernels
+    #[serde(default = "default_true")]
+    pub disable_custom_kernels: bool,
+
+    /// Global pointer head size
+    #[serde(default = "default_global_pointer_head_size")]
+    pub global_pointer_head_size: i32,
+
+    /// Global pointer dropout value
+    #[serde(default = "default_gp_dropout")]
+    pub gp_dropout_value: f64,
+
+    // -- Labels --
+    /// Number of label classes (layout categories)
+    #[serde(default = "default_num_labels")]
+    pub num_labels: i32,
+
+    /// Mapping from class ID to label name
+    #[serde(default = "default_id2label")]
+    pub id2label: HashMap<String, String>,
+
+    /// Mapping from label name to class ID
+    #[serde(default)]
+    pub label2id: HashMap<String, i32>,
+}
+
+impl Default for PPDocLayoutV3Config {
+    fn default() -> Self {
+        Self {
+            initializer_range: default_initializer_range(),
+            initializer_bias_prior_prob: None,
+            layer_norm_eps: default_layer_norm_eps(),
+            batch_norm_eps: default_batch_norm_eps(),
+            backbone_config: HGNetV2Config::default(),
+            freeze_backbone_batch_norms: true,
+            encoder_hidden_dim: default_encoder_hidden_dim(),
+            encoder_in_channels: default_encoder_in_channels(),
+            feat_strides: default_feat_strides(),
+            encoder_layers: 1,
+            encoder_ffn_dim: default_ffn_dim(),
+            encoder_attention_heads: 8,
+            dropout: 0.0,
+            activation_dropout: 0.0,
+            encode_proj_layers: default_encode_proj_layers(),
+            positional_encoding_temperature: default_positional_encoding_temperature(),
+            encoder_activation_function: default_encoder_activation(),
+            activation_function: default_activation_function(),
+            eval_size: None,
+            normalize_before: false,
+            hidden_expansion: 1.0,
+            mask_feature_channels: default_mask_feature_channels(),
+            x4_feat_dim: default_x4_feat_dim(),
+            d_model: default_d_model(),
+            num_prototypes: default_num_prototypes(),
+            label_noise_ratio: default_noise_ratio(),
+            box_noise_scale: default_noise_ratio(),
+            mask_enhanced: true,
+            num_queries: default_num_queries(),
+            decoder_in_channels: default_decoder_in_channels(),
+            decoder_ffn_dim: default_ffn_dim(),
+            num_feature_levels: default_num_feature_levels(),
+            decoder_n_points: default_decoder_n_points(),
+            decoder_layers: default_decoder_layers(),
+            decoder_attention_heads: 8,
+            decoder_activation_function: default_decoder_activation(),
+            attention_dropout: 0.0,
+            num_denoising: default_num_denoising(),
+            learn_initial_query: false,
+            anchor_image_size: None,
+            disable_custom_kernels: true,
+            global_pointer_head_size: default_global_pointer_head_size(),
+            gp_dropout_value: default_gp_dropout(),
+            num_labels: default_num_labels(),
+            id2label: default_id2label(),
+            label2id: HashMap::new(),
+        }
+    }
+}
+
+impl PPDocLayoutV3Config {
+    /// Get the intermediate channel sizes from the backbone (for stages in out_features)
+    pub fn backbone_output_channels(&self) -> Vec<i32> {
+        self.backbone_config.output_channels()
+    }
+
+    /// Fix up derived fields after deserialization.
+    ///
+    /// HuggingFace derives `num_labels` from `id2label` when not explicitly provided.
+    /// The actual PP-DocLayoutV3 config.json omits `num_labels`, so we infer it here.
+    pub fn fixup_after_load(&mut self) {
+        if !self.id2label.is_empty() {
+            let inferred = self.id2label.len() as i32;
+            // Only override if num_labels was left at default and id2label disagrees
+            if self.num_labels != inferred {
+                self.num_labels = inferred;
+            }
+        }
+    }
+}
+
+// ============================================================================
+// PPDocLayoutV3Config defaults
+// ============================================================================
+
+fn default_initializer_range() -> f64 {
+    0.01
+}
+fn default_layer_norm_eps() -> f64 {
+    1e-5
+}
+fn default_batch_norm_eps() -> f64 {
+    1e-5
+}
+fn default_true() -> bool {
+    true
+}
+fn default_encoder_hidden_dim() -> i32 {
+    256
+}
+fn default_encoder_in_channels() -> Vec<i32> {
+    vec![512, 1024, 2048]
+}
+fn default_feat_strides() -> Vec<i32> {
+    vec![8, 16, 32]
+}
+fn default_one() -> i32 {
+    1
+}
+fn default_ffn_dim() -> i32 {
+    1024
+}
+fn default_eight() -> i32 {
+    8
+}
+fn default_encode_proj_layers() -> Vec<i32> {
+    vec![2]
+}
+fn default_positional_encoding_temperature() -> i32 {
+    10000
+}
+fn default_encoder_activation() -> String {
+    "gelu".to_string()
+}
+fn default_activation_function() -> String {
+    "silu".to_string()
+}
+fn default_one_f64() -> f64 {
+    1.0
+}
+fn default_mask_feature_channels() -> Vec<i32> {
+    vec![64, 64]
+}
+fn default_x4_feat_dim() -> i32 {
+    128
+}
+fn default_d_model() -> i32 {
+    256
+}
+fn default_num_prototypes() -> i32 {
+    32
+}
+fn default_noise_ratio() -> f64 {
+    0.4
+}
+fn default_num_queries() -> i32 {
+    300
+}
+fn default_decoder_in_channels() -> Vec<i32> {
+    vec![256, 256, 256]
+}
+fn default_num_feature_levels() -> i32 {
+    3
+}
+fn default_decoder_n_points() -> i32 {
+    4
+}
+fn default_decoder_layers() -> i32 {
+    6
+}
+fn default_decoder_activation() -> String {
+    "relu".to_string()
+}
+fn default_num_denoising() -> i32 {
+    100
+}
+fn default_global_pointer_head_size() -> i32 {
+    64
+}
+fn default_gp_dropout() -> f64 {
+    0.1
+}
+fn default_num_labels() -> i32 {
+    25
+}
+
+fn default_id2label() -> HashMap<String, String> {
+    // Default labels matching the PaddlePaddle/PP-DocLayoutV3_safetensors HuggingFace model.
+    // At runtime, these are overridden by id2label from the model's config.json.
+    let labels = [
+        (0, "abstract"),
+        (1, "algorithm"),
+        (2, "aside_text"),
+        (3, "chart"),
+        (4, "content"),
+        (5, "formula"),
+        (6, "doc_title"),
+        (7, "figure_title"),
+        (8, "footer"),
+        (9, "footer"),
+        (10, "footnote"),
+        (11, "formula_number"),
+        (12, "header"),
+        (13, "header"),
+        (14, "image"),
+        (15, "formula"),
+        (16, "number"),
+        (17, "paragraph_title"),
+        (18, "reference"),
+        (19, "reference_content"),
+        (20, "seal"),
+        (21, "table"),
+        (22, "text"),
+        (23, "text"),
+        (24, "vision_footnote"),
+    ];
+    labels
+        .iter()
+        .map(|(id, label)| (id.to_string(), label.to_string()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_hgnetv2_config() {
+        let config = HGNetV2Config::default();
+        assert_eq!(config.model_type, "hgnet_v2");
+        assert_eq!(config.num_channels, 3);
+        assert_eq!(config.embedding_size, 48);
+        assert_eq!(config.stem_channels, vec![3, 32, 48]);
+        assert_eq!(config.stage_in_channels, vec![48, 128, 512, 1024]);
+        assert_eq!(config.stage_mid_channels, vec![48, 96, 192, 384]);
+        assert_eq!(config.stage_out_channels, vec![128, 512, 1024, 2048]);
+        assert_eq!(config.stage_num_blocks, vec![1, 1, 3, 1]);
+        assert_eq!(config.stage_downsample, vec![false, true, true, true]);
+        assert_eq!(config.stage_light_block, vec![false, false, true, true]);
+        assert_eq!(config.stage_kernel_size, vec![3, 3, 5, 5]);
+        assert_eq!(config.stage_numb_of_layers, vec![6, 6, 6, 6]);
+        assert!(!config.use_learnable_affine_block);
+        assert_eq!(config.hidden_act, "relu");
+        assert_eq!(config.num_stages(), 4);
+    }
+
+    #[test]
+    fn test_hgnetv2_output_channels() {
+        let config = HGNetV2Config::default();
+        let channels = config.output_channels();
+        assert_eq!(channels, vec![128, 512, 1024, 2048]);
+    }
+
+    #[test]
+    fn test_default_pp_doclayout_v3_config() {
+        let config = PPDocLayoutV3Config::default();
+        assert_eq!(config.encoder_hidden_dim, 256);
+        assert_eq!(config.encoder_in_channels, vec![512, 1024, 2048]);
+        assert_eq!(config.feat_strides, vec![8, 16, 32]);
+        assert_eq!(config.encoder_layers, 1);
+        assert_eq!(config.encoder_ffn_dim, 1024);
+        assert_eq!(config.encoder_attention_heads, 8);
+        assert_eq!(config.d_model, 256);
+        assert_eq!(config.num_queries, 300);
+        assert_eq!(config.decoder_layers, 6);
+        assert_eq!(config.decoder_attention_heads, 8);
+        assert_eq!(config.decoder_ffn_dim, 1024);
+        assert_eq!(config.decoder_n_points, 4);
+        assert_eq!(config.num_feature_levels, 3);
+        assert_eq!(config.num_labels, 25);
+        assert_eq!(config.num_prototypes, 32);
+        assert_eq!(config.global_pointer_head_size, 64);
+        assert_eq!(config.layer_norm_eps, 1e-5);
+        assert_eq!(config.batch_norm_eps, 1e-5);
+        assert!(config.freeze_backbone_batch_norms);
+        assert!(config.mask_enhanced);
+        assert_eq!(config.activation_function, "silu");
+        assert_eq!(config.encoder_activation_function, "gelu");
+        assert_eq!(config.decoder_activation_function, "relu");
+    }
+
+    #[test]
+    fn test_id2label_mapping() {
+        let config = PPDocLayoutV3Config::default();
+        assert_eq!(config.id2label.len(), 25);
+        assert_eq!(config.id2label.get("0"), Some(&"abstract".to_string()));
+        assert_eq!(
+            config.id2label.get("17"),
+            Some(&"paragraph_title".to_string())
+        );
+        assert_eq!(config.id2label.get("21"), Some(&"table".to_string()));
+        assert_eq!(config.id2label.get("22"), Some(&"text".to_string()));
+        assert_eq!(
+            config.id2label.get("24"),
+            Some(&"vision_footnote".to_string())
+        );
+    }
+
+    #[test]
+    fn test_backbone_output_channels() {
+        let config = PPDocLayoutV3Config::default();
+        let channels = config.backbone_output_channels();
+        assert_eq!(channels, vec![128, 512, 1024, 2048]);
+    }
+
+    #[test]
+    fn test_deserialize_hgnetv2_config() {
+        let json = r#"{
+            "model_type": "hgnet_v2",
+            "num_channels": 3,
+            "stem_channels": [3, 32, 48],
+            "stage_in_channels": [48, 128, 512, 1024],
+            "stage_mid_channels": [48, 96, 192, 384],
+            "stage_out_channels": [128, 512, 1024, 2048],
+            "stage_num_blocks": [1, 1, 3, 1],
+            "stage_downsample": [false, true, true, true],
+            "stage_light_block": [false, false, true, true],
+            "stage_kernel_size": [3, 3, 5, 5],
+            "stage_numb_of_layers": [6, 6, 6, 6],
+            "out_features": ["stage1", "stage2", "stage3", "stage4"]
+        }"#;
+        let config: HGNetV2Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.model_type, "hgnet_v2");
+        assert_eq!(config.stem_channels, vec![3, 32, 48]);
+        assert_eq!(config.stage_out_channels, vec![128, 512, 1024, 2048]);
+    }
+
+    #[test]
+    fn test_deserialize_full_config() {
+        let json = r#"{
+            "encoder_hidden_dim": 256,
+            "d_model": 256,
+            "num_queries": 300,
+            "num_labels": 25,
+            "backbone_config": {
+                "model_type": "hgnet_v2",
+                "stem_channels": [3, 32, 48],
+                "stage_out_channels": [128, 512, 1024, 2048]
+            }
+        }"#;
+        let config: PPDocLayoutV3Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.encoder_hidden_dim, 256);
+        assert_eq!(config.d_model, 256);
+        assert_eq!(config.num_queries, 300);
+        assert_eq!(config.num_labels, 25);
+        assert_eq!(
+            config.backbone_config.stage_out_channels,
+            vec![128, 512, 1024, 2048]
+        );
+    }
+
+    #[test]
+    fn test_fixup_derives_num_labels_from_id2label() {
+        // Simulate the actual PP-DocLayoutV3 config.json which has id2label but no num_labels.
+        let json = r#"{
+            "id2label": {
+                "0": "abstract",
+                "1": "algorithm",
+                "2": "aside_text"
+            }
+        }"#;
+        let mut config: PPDocLayoutV3Config = serde_json::from_str(json).unwrap();
+        // Before fixup, num_labels is the default (25) but id2label has only 3 entries
+        assert_eq!(config.num_labels, 25);
+        assert_eq!(config.id2label.len(), 3);
+
+        config.fixup_after_load();
+        // After fixup, num_labels should match id2label length
+        assert_eq!(config.num_labels, 3);
+    }
+
+    #[test]
+    fn test_feature_strides_alias() {
+        // The actual model config.json uses "feature_strides" instead of "feat_strides"
+        let json = r#"{
+            "feature_strides": [8, 16, 32]
+        }"#;
+        let config: PPDocLayoutV3Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.feat_strides, vec![8, 16, 32]);
+    }
+}

--- a/crates/mlx-core/src/models/pp_doclayout_v3/decoder.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/decoder.rs
@@ -1,0 +1,1449 @@
+//! PP-DocLayoutV3 Transformer Decoder
+//!
+//! Implements the decoder for PP-DocLayoutV3 object detection, including:
+//! - **SelfAttention**: Multi-head attention with positional embeddings on Q/K (not V)
+//! - **MultiscaleDeformableAttention**: Deformable attention sampling features at learned offsets
+//! - **DecoderLayer**: self-attn → cross-attn (deformable) → FFN with residual connections
+//! - **Decoder**: Stack of 6 decoder layers with iterative bbox refinement
+//!
+//! All operations use float32 for compute. Shapes follow [batch, seq, dim] convention.
+//!
+//! Reference: modeling_pp_doclayout_v3.py
+//! (PPDocLayoutV3MultiheadAttention, PPDocLayoutV3MultiscaleDeformableAttention,
+//!  PPDocLayoutV3DecoderLayer, PPDocLayoutV3Decoder)
+
+use crate::array::MxArray;
+use crate::nn::activations::Activations;
+use crate::nn::linear::Linear;
+use crate::nn::normalization::LayerNorm;
+use napi::Either;
+use napi::bindgen_prelude::*;
+
+use super::heads::{GlobalPointer, MLPPredictionHead};
+
+// ============================================================================
+// Utility: inverse_sigmoid
+// ============================================================================
+
+/// Compute the inverse sigmoid (logit) function.
+///
+/// `inverse_sigmoid(x) = log(x / (1 - x))`
+///
+/// Clamps input to [eps, 1-eps] for numerical stability.
+pub fn inverse_sigmoid(x: &MxArray, eps: f64) -> Result<MxArray> {
+    // x = clamp(x, eps, 1 - eps)
+    let x = x.clip(Some(eps), Some(1.0 - eps))?;
+    // log(x / (1 - x))
+    let one_minus_x = x.sub_scalar(1.0)?.negative()?; // 1 - x
+    let ratio = x.div(&one_minus_x)?;
+    ratio.log()
+}
+
+// ============================================================================
+// Self-Attention (Multi-Head Attention with Position Embeddings)
+// ============================================================================
+
+/// Standard multi-head attention used in the decoder's self-attention.
+///
+/// Key behavior: Position embeddings are added to Q and K, but NOT to V.
+///
+/// Architecture:
+/// 1. hidden_states_with_pos = hidden_states + position_embeddings
+/// 2. Q = q_proj(hidden_states_with_pos) * scale
+/// 3. K = k_proj(hidden_states_with_pos)
+/// 4. V = v_proj(hidden_states)  (original, without position!)
+/// 5. attn = softmax(Q @ K^T) @ V
+/// 6. output = out_proj(attn)
+///
+/// Corresponds to PPDocLayoutV3MultiheadAttention in the reference.
+pub struct SelfAttention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    out_proj: Linear,
+    num_heads: i32,
+    head_dim: i32,
+    scaling: f64,
+}
+
+impl SelfAttention {
+    /// Create a new SelfAttention layer.
+    ///
+    /// # Arguments
+    /// * `embed_dim` - Model dimension (d_model, default 256)
+    /// * `num_heads` - Number of attention heads (default 8)
+    pub fn new(embed_dim: u32, num_heads: i32) -> Result<Self> {
+        let head_dim = embed_dim as i32 / num_heads;
+        if head_dim * num_heads != embed_dim as i32 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "embed_dim ({}) must be divisible by num_heads ({})",
+                    embed_dim, num_heads
+                ),
+            ));
+        }
+        let scaling = (head_dim as f64).powf(-0.5);
+
+        Ok(Self {
+            q_proj: Linear::new(embed_dim, embed_dim, Some(true))?,
+            k_proj: Linear::new(embed_dim, embed_dim, Some(true))?,
+            v_proj: Linear::new(embed_dim, embed_dim, Some(true))?,
+            out_proj: Linear::new(embed_dim, embed_dim, Some(true))?,
+            num_heads,
+            head_dim,
+            scaling,
+        })
+    }
+
+    /// Create from pre-loaded weights with explicit embed_dim.
+    pub fn from_weights_with_dim(
+        q_proj: Linear,
+        k_proj: Linear,
+        v_proj: Linear,
+        out_proj: Linear,
+        embed_dim: i32,
+        num_heads: i32,
+    ) -> Self {
+        let head_dim = embed_dim / num_heads;
+        let scaling = (head_dim as f64).powf(-0.5);
+        Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            out_proj,
+            num_heads,
+            head_dim,
+            scaling,
+        }
+    }
+
+    /// Forward pass for self-attention.
+    ///
+    /// # Arguments
+    /// * `hidden_states` - [batch, target_len, embed_dim]
+    /// * `position_embeddings` - Optional [batch, target_len, embed_dim], added to Q and K
+    /// * `attention_mask` - Optional [target_len, target_len] attention mask
+    ///
+    /// # Returns
+    /// Output tensor [batch, target_len, embed_dim]
+    pub fn forward(
+        &self,
+        hidden_states: &MxArray,
+        position_embeddings: Option<&MxArray>,
+        attention_mask: Option<&MxArray>,
+    ) -> Result<MxArray> {
+        let shape = hidden_states.shape()?;
+        let shape: Vec<i64> = shape.as_ref().to_vec();
+        let batch_size = shape[0];
+        let target_len = shape[1];
+        let embed_dim = shape[2];
+
+        // Add position embeddings to Q/K input (but NOT to V input)
+        let qk_input = if let Some(pos_emb) = position_embeddings {
+            hidden_states.add(pos_emb)?
+        } else {
+            hidden_states.clone()
+        };
+
+        // Project Q, K, V
+        // Q = q_proj(hidden_states + pos) * scale
+        let query_states = self.q_proj.forward(&qk_input)?;
+        let query_states = query_states.mul_scalar(self.scaling)?;
+
+        // K = k_proj(hidden_states + pos)
+        let key_states = self.k_proj.forward(&qk_input)?;
+
+        // V = v_proj(hidden_states)  -- NO position embeddings on V!
+        let value_states = self.v_proj.forward(hidden_states)?;
+
+        // Reshape to [batch, seq, num_heads, head_dim] then transpose to [batch, num_heads, seq, head_dim]
+        let nh = self.num_heads as i64;
+        let hd = self.head_dim as i64;
+
+        let query_states = query_states.reshape(&[batch_size, target_len, nh, hd])?;
+        let query_states = query_states.transpose(Some(&[0, 2, 1, 3]))?;
+        // Flatten to [batch * num_heads, target_len, head_dim]
+        let query_states = query_states.reshape(&[batch_size * nh, target_len, hd])?;
+
+        let key_states = key_states.reshape(&[batch_size, target_len, nh, hd])?;
+        let key_states = key_states.transpose(Some(&[0, 2, 1, 3]))?;
+        let key_states = key_states.reshape(&[batch_size * nh, target_len, hd])?;
+
+        let value_states = value_states.reshape(&[batch_size, target_len, nh, hd])?;
+        let value_states = value_states.transpose(Some(&[0, 2, 1, 3]))?;
+        let value_states = value_states.reshape(&[batch_size * nh, target_len, hd])?;
+
+        // Compute attention: Q @ K^T → [batch*num_heads, target_len, target_len]
+        let key_states_t = key_states.transpose(Some(&[0, 2, 1]))?;
+        let mut attn_weights = query_states.matmul(&key_states_t)?;
+
+        // Apply attention mask if provided
+        if let Some(mask) = attention_mask {
+            // mask shape: [target_len, target_len] → expand to [batch, 1, target_len, target_len]
+            let mask_expanded = mask
+                .expand_dims(0)?
+                .expand_dims(0)?
+                .broadcast_to(&[batch_size, 1, target_len, target_len])?;
+
+            // Reshape attn_weights to [batch, num_heads, target_len, target_len]
+            attn_weights = attn_weights.reshape(&[batch_size, nh, target_len, target_len])?;
+
+            // For the mask: where mask is True (non-zero), fill with -inf
+            // The PyTorch code checks if mask is bool and fills True positions with -inf.
+            // Here the mask values are already 0.0 (no mask) or -inf (mask).
+            // So we add the mask directly.
+            attn_weights = attn_weights.add(&mask_expanded)?;
+
+            // Flatten back
+            attn_weights = attn_weights.reshape(&[batch_size * nh, target_len, target_len])?;
+        }
+
+        // Softmax
+        attn_weights = Activations::softmax(&attn_weights, Some(-1))?;
+
+        // attn_output = attn_weights @ V → [batch*num_heads, target_len, head_dim]
+        let attn_output = attn_weights.matmul(&value_states)?;
+
+        // Reshape back: [batch, num_heads, target_len, head_dim] → [batch, target_len, embed_dim]
+        let attn_output = attn_output.reshape(&[batch_size, nh, target_len, hd])?;
+        let attn_output = attn_output.transpose(Some(&[0, 2, 1, 3]))?;
+        let attn_output = attn_output.reshape(&[batch_size, target_len, embed_dim])?;
+
+        // Output projection
+        self.out_proj.forward(&attn_output)
+    }
+}
+
+// ============================================================================
+// Multi-Scale Deformable Attention
+// ============================================================================
+
+/// Multi-scale deformable attention mechanism.
+///
+/// For each query, instead of attending to all spatial positions (like standard attention),
+/// this module:
+/// 1. Predicts a small set of sampling offsets relative to reference points
+/// 2. Samples features from the encoder feature maps at those locations
+/// 3. Weights the sampled features with learned attention weights
+///
+/// This is much more efficient than full attention over all spatial positions,
+/// and allows the model to focus on relevant regions.
+///
+/// Parameters:
+/// - `num_heads=8, num_levels=3, num_points=4, d_model=256`
+/// - Each query produces `num_heads * num_levels * num_points = 96` sampling locations
+/// - Each location is a 2D offset relative to the reference point
+///
+/// Corresponds to PPDocLayoutV3MultiscaleDeformableAttention in the reference.
+pub struct MultiscaleDeformableAttention {
+    /// Project value features: Linear(d_model, d_model)
+    value_proj: Linear,
+    /// Predict sampling offsets: Linear(d_model, num_heads * num_levels * num_points * 2)
+    sampling_offsets: Linear,
+    /// Predict attention weights: Linear(d_model, num_heads * num_levels * num_points)
+    attention_weights: Linear,
+    /// Output projection: Linear(d_model, d_model)
+    output_proj: Linear,
+    /// Model dimension
+    d_model: i32,
+    /// Number of attention heads
+    n_heads: i32,
+    /// Number of feature levels
+    n_levels: i32,
+    /// Number of sampling points per head per level
+    n_points: i32,
+}
+
+impl MultiscaleDeformableAttention {
+    /// Create a new MultiscaleDeformableAttention.
+    ///
+    /// # Arguments
+    /// * `d_model` - Model dimension (default 256)
+    /// * `num_heads` - Number of attention heads (default 8)
+    /// * `n_levels` - Number of feature levels (default 3)
+    /// * `n_points` - Number of sampling points per head per level (default 4)
+    pub fn new(d_model: i32, num_heads: i32, n_levels: i32, n_points: i32) -> Result<Self> {
+        let total_points = (num_heads * n_levels * n_points * 2) as u32;
+        let total_weights = (num_heads * n_levels * n_points) as u32;
+        let dm = d_model as u32;
+
+        Ok(Self {
+            value_proj: Linear::new(dm, dm, Some(true))?,
+            sampling_offsets: Linear::new(dm, total_points, Some(true))?,
+            attention_weights: Linear::new(dm, total_weights, Some(true))?,
+            output_proj: Linear::new(dm, dm, Some(true))?,
+            d_model,
+            n_heads: num_heads,
+            n_levels,
+            n_points,
+        })
+    }
+
+    /// Create from pre-loaded weights.
+    pub fn from_weights(
+        value_proj: Linear,
+        sampling_offsets: Linear,
+        attention_weights: Linear,
+        output_proj: Linear,
+        d_model: i32,
+        n_heads: i32,
+        n_levels: i32,
+        n_points: i32,
+    ) -> Self {
+        Self {
+            value_proj,
+            sampling_offsets,
+            attention_weights,
+            output_proj,
+            d_model,
+            n_heads,
+            n_levels,
+            n_points,
+        }
+    }
+
+    /// Forward pass for multi-scale deformable attention.
+    ///
+    /// # Arguments
+    /// * `hidden_states` - Query features [batch, num_queries, d_model]
+    /// * `encoder_hidden_states` - Flattened encoder features [batch, total_seq_len, d_model]
+    /// * `position_embeddings` - Optional [batch, num_queries, d_model], added to hidden_states
+    /// * `reference_points` - [batch, num_queries, 1, 2] or [batch, num_queries, num_levels, 2]
+    ///   Normalized reference points in [0, 1]
+    /// * `spatial_shapes` - [num_levels, 2] (height, width) for each feature level
+    /// * `spatial_shapes_list` - Vec of (height, width) tuples
+    /// * `level_start_index` - [num_levels] cumulative start indices
+    ///
+    /// # Returns
+    /// Output tensor [batch, num_queries, d_model]
+    pub fn forward(
+        &self,
+        hidden_states: &MxArray,
+        encoder_hidden_states: &MxArray,
+        position_embeddings: Option<&MxArray>,
+        reference_points: &MxArray,
+        spatial_shapes: &MxArray,
+        spatial_shapes_list: &[(i64, i64)],
+        _level_start_index: &MxArray,
+    ) -> Result<MxArray> {
+        // Add position embeddings to hidden states
+        let query_input = if let Some(pos_emb) = position_embeddings {
+            hidden_states.add(pos_emb)?
+        } else {
+            hidden_states.clone()
+        };
+
+        let q_shape = query_input.shape()?;
+        let q_shape: Vec<i64> = q_shape.as_ref().to_vec();
+        let batch_size = q_shape[0];
+        let num_queries = q_shape[1];
+
+        let hidden_dim = self.d_model as i64 / self.n_heads as i64;
+        let nh = self.n_heads as i64;
+        let nl = self.n_levels as i64;
+        let np = self.n_points as i64;
+
+        // Project values: [B, total_seq, d_model] → [B, total_seq, n_heads, hidden_dim]
+        let value = self.value_proj.forward(encoder_hidden_states)?;
+        let value = value.reshape(&[batch_size, -1, nh, hidden_dim])?;
+
+        // Predict sampling offsets: [B, num_queries, n_heads * n_levels * n_points * 2]
+        let offsets = self.sampling_offsets.forward(&query_input)?;
+        let offsets = offsets.reshape(&[batch_size, num_queries, nh, nl, np, 2])?;
+
+        // Predict attention weights: [B, num_queries, n_heads * n_levels * n_points]
+        let attn_weights = self.attention_weights.forward(&query_input)?;
+        let attn_weights = attn_weights.reshape(&[batch_size, num_queries, nh, nl * np])?;
+        let attn_weights = Activations::softmax(&attn_weights, Some(-1))?;
+        let attn_weights = attn_weights.reshape(&[batch_size, num_queries, nh, nl, np])?;
+
+        // Compute sampling locations from reference points + offsets
+        // reference_points: [B, num_queries, 1, 2] (for 2D case)
+        // offset_normalizer: [width, height] per level (note: x=width, y=height)
+        // sampling_locations = reference_points[:, :, None, :, None, :] + offsets / normalizer
+        let ref_shape = reference_points.shape()?;
+        let ref_shape: Vec<i64> = ref_shape.as_ref().to_vec();
+        let num_coords = ref_shape[ref_shape.len() - 1];
+
+        let sampling_locations = if num_coords == 2 {
+            // offset_normalizer: stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], -1)
+            // This gives [width, height] for each level → [num_levels, 2]
+            // We need to normalize offsets by the spatial dimensions
+            //
+            // spatial_shapes: [num_levels, 2] where [:,0]=height, [:,1]=width
+            // offset_normalizer: [num_levels, 2] where [:,0]=width, [:,1]=height
+            let shapes_h = spatial_shapes.slice(&[0, 0], &[nl, 1])?; // [nl, 1] heights
+            let shapes_w = spatial_shapes.slice(&[0, 1], &[nl, 2])?; // [nl, 1] widths
+            let offset_normalizer = MxArray::concatenate(&shapes_w, &shapes_h, 1)?; // [nl, 2] = [w, h]
+
+            // Reshape normalizer for broadcasting: [1, 1, 1, nl, 1, 2]
+            let normalizer = offset_normalizer.reshape(&[1, 1, 1, nl, 1, 2])?;
+
+            // Normalize offsets
+            let normalized_offsets = offsets.div(&normalizer)?;
+
+            // reference_points has shape [B, num_queries, 1, 2]
+            // Expand to [B, num_queries, 1, 1, 1, 2] for broadcasting
+            // with normalized_offsets [B, num_queries, n_heads, n_levels, n_points, 2]
+            let ref_expanded = reference_points.reshape(&[batch_size, num_queries, 1, 1, 1, 2])?;
+            let ref_broadcast =
+                ref_expanded.broadcast_to(&[batch_size, num_queries, nh, nl, np, 2])?;
+
+            ref_broadcast.add(&normalized_offsets)?
+        } else if num_coords == 4 {
+            // 4-coordinate reference points: center_x, center_y, width, height
+            // sampling_locations = ref[:,:,None,:,None,:2] +
+            //   offsets / n_points * ref[:,:,None,:,None,2:] * 0.5
+            let ref_xy =
+                reference_points.slice(&[0, 0, 0, 0], &[batch_size, num_queries, nl, 2])?;
+            let ref_wh =
+                reference_points.slice(&[0, 0, 0, 2], &[batch_size, num_queries, nl, 4])?;
+
+            let ref_xy_expanded = ref_xy.reshape(&[batch_size, num_queries, 1, nl, 1, 2])?;
+            let ref_wh_expanded = ref_wh.reshape(&[batch_size, num_queries, 1, nl, 1, 2])?;
+
+            let ref_xy_broadcast =
+                ref_xy_expanded.broadcast_to(&[batch_size, num_queries, nh, nl, np, 2])?;
+            let ref_wh_broadcast =
+                ref_wh_expanded.broadcast_to(&[batch_size, num_queries, nh, nl, np, 2])?;
+
+            let scaled_offsets = offsets
+                .div_scalar(self.n_points as f64)?
+                .mul(&ref_wh_broadcast)?
+                .mul_scalar(0.5)?;
+
+            ref_xy_broadcast.add(&scaled_offsets)?
+        } else {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "reference_points last dim must be 2 or 4, got {}",
+                    num_coords
+                ),
+            ));
+        };
+
+        // Now perform the actual deformable attention using bilinear interpolation.
+        //
+        // For each level, we need to:
+        // 1. Extract the value features for that level
+        // 2. Convert normalized sampling locations to absolute pixel coordinates
+        // 3. Perform bilinear interpolation to sample features
+        // 4. Weight by attention weights and sum
+
+        // Convert sampling locations from [0,1] to grid coordinates [-1, 1] for grid_sample equiv
+        // Actually, we'll do bilinear interpolation directly in absolute coordinates.
+
+        // Split value by levels using spatial_shapes_list
+        let mut level_values: Vec<MxArray> = Vec::with_capacity(self.n_levels as usize);
+        let mut offset = 0i64;
+        for &(h, w) in spatial_shapes_list {
+            let len = h * w;
+            // value_level: [B, h*w, n_heads, hidden_dim]
+            let value_level = value.slice(
+                &[0, offset, 0, 0],
+                &[batch_size, offset + len, nh, hidden_dim],
+            )?;
+            level_values.push(value_level);
+            offset += len;
+        }
+
+        // For each level, sample features at the predicted locations using bilinear interpolation
+        // sampling_locations: [B, num_queries, n_heads, n_levels, n_points, 2] in [0, 1]
+        let mut sampled_values_per_level: Vec<MxArray> = Vec::with_capacity(self.n_levels as usize);
+
+        for (level_id, &(h, w)) in spatial_shapes_list.iter().enumerate() {
+            let lid = level_id as i64;
+
+            // Get value features for this level: [B, h*w, n_heads, hidden_dim]
+            // Reshape to [B, h, w, n_heads, hidden_dim]
+            let value_l = level_values[level_id].reshape(&[batch_size, h, w, nh, hidden_dim])?;
+
+            // Get sampling locations for this level: [B, num_queries, n_heads, n_points, 2]
+            let sample_locs = sampling_locations.slice(
+                &[0, 0, 0, lid, 0, 0],
+                &[batch_size, num_queries, nh, lid + 1, np, 2],
+            )?;
+            let sample_locs = sample_locs.squeeze(Some(&[3]))?;
+            // sample_locs: [B, num_queries, n_heads, n_points, 2] in [0, 1]
+
+            // Convert to absolute coordinates using PyTorch grid_sample align_corners=False convention:
+            // pixel_coord = sample * size - 0.5
+            let loc_x = sample_locs
+                .slice(&[0, 0, 0, 0, 0], &[batch_size, num_queries, nh, np, 1])?
+                .squeeze(Some(&[4]))?
+                .mul_scalar(w as f64)?
+                .sub_scalar(0.5)?;
+            let loc_y = sample_locs
+                .slice(&[0, 0, 0, 0, 1], &[batch_size, num_queries, nh, np, 2])?
+                .squeeze(Some(&[4]))?
+                .mul_scalar(h as f64)?
+                .sub_scalar(0.5)?;
+
+            // Bilinear interpolation
+            // Floor and ceil coordinates
+            let loc_x_floor = loc_x.floor()?;
+            let loc_y_floor = loc_y.floor()?;
+            let loc_x_ceil = loc_x_floor.add_scalar(1.0)?;
+            let loc_y_ceil = loc_y_floor.add_scalar(1.0)?;
+
+            // Interpolation weights
+            let wx = loc_x.sub(&loc_x_floor)?; // fractional part x
+            let wy = loc_y.sub(&loc_y_floor)?; // fractional part y
+            let one_minus_wx = wx.sub_scalar(1.0)?.negative()?;
+            let one_minus_wy = wy.sub_scalar(1.0)?.negative()?;
+
+            // Weights for 4 corners
+            let w_tl = one_minus_wx.mul(&one_minus_wy)?; // (1-wx) * (1-wy)
+            let w_tr = wx.mul(&one_minus_wy)?; // wx * (1-wy)
+            let w_bl = one_minus_wx.mul(&wy)?; // (1-wx) * wy
+            let w_br = wx.mul(&wy)?; // wx * wy
+
+            // Build per-corner validity masks BEFORE clamping (for zero-padding behavior).
+            // PyTorch's F.grid_sample with padding_mode="zeros" checks each corner
+            // independently: out-of-bounds corners contribute 0, but in-bounds corners
+            // still contribute their real values weighted by their bilinear weights.
+            let zero = MxArray::from_float32(&[0.0], &[1])?;
+            let max_x = MxArray::from_float32(&[(w - 1) as f32], &[1])?;
+            let max_y = MxArray::from_float32(&[(h - 1) as f32], &[1])?;
+
+            // Per-coordinate validity (unclamped)
+            let floor_x_valid = loc_x_floor
+                .greater_equal(&zero)?
+                .logical_and(&loc_x_floor.less_equal(&max_x)?)?;
+            let ceil_x_valid = loc_x_ceil
+                .greater_equal(&zero)?
+                .logical_and(&loc_x_ceil.less_equal(&max_x)?)?;
+            let floor_y_valid = loc_y_floor
+                .greater_equal(&zero)?
+                .logical_and(&loc_y_floor.less_equal(&max_y)?)?;
+            let ceil_y_valid = loc_y_ceil
+                .greater_equal(&zero)?
+                .logical_and(&loc_y_ceil.less_equal(&max_y)?)?;
+
+            // 4 per-corner masks: [B, num_queries, n_heads, n_points] (bool)
+            let mask_tl = floor_x_valid.logical_and(&floor_y_valid)?; // top-left (x0, y0)
+            let mask_tr = ceil_x_valid.logical_and(&floor_y_valid)?; // top-right (x1, y0)
+            let mask_bl = floor_x_valid.logical_and(&ceil_y_valid)?; // bottom-left (x0, y1)
+            let mask_br = ceil_x_valid.logical_and(&ceil_y_valid)?; // bottom-right (x1, y1)
+
+            // Clamp coordinates to valid range for safe array indexing
+            let x0 = loc_x_floor.maximum(&zero)?.minimum(&max_x)?;
+            let y0 = loc_y_floor.maximum(&zero)?.minimum(&max_y)?;
+            let x1 = loc_x_ceil.maximum(&zero)?.minimum(&max_x)?;
+            let y1 = loc_y_ceil.maximum(&zero)?.minimum(&max_y)?;
+
+            // Convert to integer indices for gathering
+            // Compute linear indices into the [h, w] feature map
+            // index = y * w + x
+            let w_scalar = MxArray::from_float32(&[w as f32], &[1])?;
+
+            // Compute 4 linear indices for the 4 corners
+            let idx_tl = y0.mul(&w_scalar)?.add(&x0)?; // y0 * w + x0
+            let idx_tr = y0.mul(&w_scalar)?.add(&x1)?; // y0 * w + x1
+            let idx_bl = y1.mul(&w_scalar)?.add(&x0)?; // y1 * w + x0
+            let idx_br = y1.mul(&w_scalar)?.add(&x1)?; // y1 * w + x1
+
+            // Reshape value_l from [B, h, w, n_heads, hidden_dim] to [B, h*w, n_heads, hidden_dim]
+            let value_hw = value_l.reshape(&[batch_size, h * w, nh, hidden_dim])?;
+
+            // Per-head gather approach:
+            // For each (query, head, point), we sample from value_hw[:, :, h, :].
+            // Transpose to [B, n_heads, h*w, hidden_dim] then flatten batch and heads
+            // so we can gather per-head spatial features efficiently.
+            let value_hw_t = value_hw.transpose(Some(&[0, 2, 1, 3]))?;
+            // [B, n_heads, h*w, hidden_dim]
+
+            // Reshape to [B * n_heads, h*w, hidden_dim]
+            let value_bh = value_hw_t.reshape(&[batch_size * nh, h * w, hidden_dim])?;
+
+            // Reshape indices to [B, n_heads, num_queries * n_points]
+            // Original idx shape: [B, num_queries, n_heads, n_points]
+            // First reshape: [B, num_queries, n_heads, n_points] → transpose → [B, n_heads, num_queries, n_points]
+            // → reshape → [B * n_heads, num_queries * n_points]
+            let qp = num_queries * np;
+
+            let idx_tl_4d = idx_tl
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .astype(crate::array::DType::Int32)?;
+            let idx_tl_t = idx_tl_4d
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp])?;
+
+            let idx_tr_4d = idx_tr
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .astype(crate::array::DType::Int32)?;
+            let idx_tr_t = idx_tr_4d
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp])?;
+
+            let idx_bl_4d = idx_bl
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .astype(crate::array::DType::Int32)?;
+            let idx_bl_t = idx_bl_4d
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp])?;
+
+            let idx_br_4d = idx_br
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .astype(crate::array::DType::Int32)?;
+            let idx_br_t = idx_br_4d
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp])?;
+
+            // Expand indices for broadcasting with hidden_dim
+            let idx_tl_bh =
+                idx_tl_t
+                    .expand_dims(2)?
+                    .broadcast_to(&[batch_size * nh, qp, hidden_dim])?;
+            let idx_tr_bh =
+                idx_tr_t
+                    .expand_dims(2)?
+                    .broadcast_to(&[batch_size * nh, qp, hidden_dim])?;
+            let idx_bl_bh =
+                idx_bl_t
+                    .expand_dims(2)?
+                    .broadcast_to(&[batch_size * nh, qp, hidden_dim])?;
+            let idx_br_bh =
+                idx_br_t
+                    .expand_dims(2)?
+                    .broadcast_to(&[batch_size * nh, qp, hidden_dim])?;
+
+            // Gather: [B*n_heads, num_queries*n_points, hidden_dim]
+            let g_tl = value_bh.take_along_axis(&idx_tl_bh, 1)?;
+            let g_tr = value_bh.take_along_axis(&idx_tr_bh, 1)?;
+            let g_bl = value_bh.take_along_axis(&idx_bl_bh, 1)?;
+            let g_br = value_bh.take_along_axis(&idx_br_bh, 1)?;
+
+            // Apply bilinear weights
+            // Reshape weights to [B*n_heads, num_queries*n_points, 1]
+            let w_tl_t = w_tl
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp, 1])?;
+            let w_tr_t = w_tr
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp, 1])?;
+            let w_bl_t = w_bl
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp, 1])?;
+            let w_br_t = w_br
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp, 1])?;
+
+            // Reshape per-corner validity masks to [B*n_heads, num_queries*n_points, 1]
+            // to broadcast with gathered values [B*n_heads, qp, hidden_dim].
+            let mask_tl_t = mask_tl
+                .astype(crate::array::DType::Float32)?
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp, 1])?;
+            let mask_tr_t = mask_tr
+                .astype(crate::array::DType::Float32)?
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp, 1])?;
+            let mask_bl_t = mask_bl
+                .astype(crate::array::DType::Float32)?
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp, 1])?;
+            let mask_br_t = mask_br
+                .astype(crate::array::DType::Float32)?
+                .reshape(&[batch_size, num_queries, nh, np])?
+                .transpose(Some(&[0, 2, 1, 3]))?
+                .reshape(&[batch_size * nh, qp, 1])?;
+
+            // Bilinear interpolation with per-corner zero-padding:
+            // Each corner's contribution is masked independently. Out-of-bounds corners
+            // contribute 0, while in-bounds corners contribute their real values.
+            let interpolated = g_tl
+                .mul(&w_tl_t)?
+                .mul(&mask_tl_t)?
+                .add(&g_tr.mul(&w_tr_t)?.mul(&mask_tr_t)?)?
+                .add(&g_bl.mul(&w_bl_t)?.mul(&mask_bl_t)?)?
+                .add(&g_br.mul(&w_br_t)?.mul(&mask_br_t)?)?;
+            // interpolated: [B*n_heads, num_queries*n_points, hidden_dim]
+
+            // Reshape to [B*n_heads, hidden_dim, num_queries, n_points]
+            let interpolated = interpolated
+                .reshape(&[batch_size * nh, num_queries, np, hidden_dim])?
+                .transpose(Some(&[0, 3, 1, 2]))?;
+            // [B*n_heads, hidden_dim, num_queries, n_points]
+
+            sampled_values_per_level.push(interpolated);
+        }
+
+        // Stack sampled values across levels: [B*n_heads, hidden_dim, num_queries, n_levels, n_points]
+        // Then flatten last two dims: [B*n_heads, hidden_dim, num_queries, n_levels * n_points]
+        let sampled_refs: Vec<&MxArray> = sampled_values_per_level.iter().collect();
+        let stacked = MxArray::stack(sampled_refs, Some(3))?;
+        // stacked: [B*n_heads, hidden_dim, num_queries, n_levels, n_points]
+        let stacked_flat = stacked.reshape(&[batch_size * nh, hidden_dim, num_queries, nl * np])?;
+
+        // Apply attention weights
+        // attn_weights: [B, num_queries, n_heads, n_levels, n_points]
+        // Reshape to [B*n_heads, 1, num_queries, n_levels * n_points]
+        let attn_w = attn_weights.transpose(Some(&[0, 2, 1, 3, 4]))?.reshape(&[
+            batch_size * nh,
+            1,
+            num_queries,
+            nl * np,
+        ])?;
+
+        // Weighted sum: element-wise multiply and sum over last dim
+        // stacked_flat: [B*n_heads, hidden_dim, num_queries, n_levels*n_points]
+        // attn_w:       [B*n_heads, 1,          num_queries, n_levels*n_points]
+        let weighted = stacked_flat.mul(&attn_w)?;
+        // Sum over the last dimension (sampling points): [B*n_heads, hidden_dim, num_queries]
+        let output = weighted.sum(Some(&[3]), Some(false))?;
+
+        // Reshape: [B*n_heads, hidden_dim, num_queries] → [B, n_heads*hidden_dim, num_queries]
+        let output = output.reshape(&[batch_size, nh * hidden_dim, num_queries])?;
+
+        // Transpose to [B, num_queries, d_model]
+        let output = output.transpose(Some(&[0, 2, 1]))?;
+
+        // Output projection
+        self.output_proj.forward(&output)
+    }
+}
+
+// ============================================================================
+// Decoder Layer
+// ============================================================================
+
+/// A single decoder layer combining self-attention, cross-attention, and FFN.
+///
+/// Architecture:
+/// 1. Self-attention with position embeddings (on Q/K only) + residual + LayerNorm
+/// 2. Multi-scale deformable cross-attention + residual + LayerNorm
+/// 3. FFN (fc1 → activation → fc2) + residual + LayerNorm
+///
+/// Corresponds to PPDocLayoutV3DecoderLayer in the reference.
+pub struct DecoderLayer {
+    /// Self-attention
+    self_attn: SelfAttention,
+    /// Self-attention layer norm
+    self_attn_layer_norm: LayerNorm,
+    /// Cross-attention (deformable)
+    encoder_attn: MultiscaleDeformableAttention,
+    /// Cross-attention layer norm
+    encoder_attn_layer_norm: LayerNorm,
+    /// First feed-forward layer: d_model → ffn_dim
+    fc1: Linear,
+    /// Second feed-forward layer: ffn_dim → d_model
+    fc2: Linear,
+    /// Final layer norm
+    final_layer_norm: LayerNorm,
+    /// Activation function name
+    activation: String,
+}
+
+impl DecoderLayer {
+    /// Create a new DecoderLayer.
+    ///
+    /// # Arguments
+    /// * `d_model` - Model dimension (default 256)
+    /// * `ffn_dim` - FFN intermediate dimension (default 1024)
+    /// * `num_heads` - Number of attention heads (default 8)
+    /// * `n_levels` - Number of feature levels (default 3)
+    /// * `n_points` - Number of sampling points (default 4)
+    /// * `layer_norm_eps` - LayerNorm epsilon (default 1e-5)
+    /// * `activation` - Activation function name (default "relu")
+    pub fn new(
+        d_model: i32,
+        ffn_dim: i32,
+        num_heads: i32,
+        n_levels: i32,
+        n_points: i32,
+        layer_norm_eps: f64,
+        activation: &str,
+    ) -> Result<Self> {
+        let dm = d_model as u32;
+        let ff = ffn_dim as u32;
+        let eps = Some(layer_norm_eps);
+
+        Ok(Self {
+            self_attn: SelfAttention::new(dm, num_heads)?,
+            self_attn_layer_norm: LayerNorm::new(dm, eps)?,
+            encoder_attn: MultiscaleDeformableAttention::new(
+                d_model, num_heads, n_levels, n_points,
+            )?,
+            encoder_attn_layer_norm: LayerNorm::new(dm, eps)?,
+            fc1: Linear::new(dm, ff, Some(true))?,
+            fc2: Linear::new(ff, dm, Some(true))?,
+            final_layer_norm: LayerNorm::new(dm, eps)?,
+            activation: activation.to_string(),
+        })
+    }
+
+    /// Create from pre-loaded components.
+    pub fn from_components(
+        self_attn: SelfAttention,
+        self_attn_layer_norm: LayerNorm,
+        encoder_attn: MultiscaleDeformableAttention,
+        encoder_attn_layer_norm: LayerNorm,
+        fc1: Linear,
+        fc2: Linear,
+        final_layer_norm: LayerNorm,
+        activation: &str,
+    ) -> Self {
+        Self {
+            self_attn,
+            self_attn_layer_norm,
+            encoder_attn,
+            encoder_attn_layer_norm,
+            fc1,
+            fc2,
+            final_layer_norm,
+            activation: activation.to_string(),
+        }
+    }
+
+    /// Forward pass through one decoder layer.
+    ///
+    /// # Arguments
+    /// * `hidden_states` - [batch, num_queries, d_model]
+    /// * `position_embeddings` - [batch, num_queries, d_model]
+    /// * `encoder_hidden_states` - [batch, total_seq_len, d_model]
+    /// * `reference_points` - [batch, num_queries, 1, 2] or [batch, num_queries, num_levels, 2]
+    /// * `spatial_shapes` - [num_levels, 2]
+    /// * `spatial_shapes_list` - Vec of (height, width)
+    /// * `level_start_index` - [num_levels]
+    /// * `encoder_attention_mask` - Optional attention mask for self-attention
+    ///
+    /// # Returns
+    /// Output tensor [batch, num_queries, d_model]
+    pub fn forward(
+        &self,
+        hidden_states: &MxArray,
+        position_embeddings: &MxArray,
+        encoder_hidden_states: &MxArray,
+        reference_points: &MxArray,
+        spatial_shapes: &MxArray,
+        spatial_shapes_list: &[(i64, i64)],
+        level_start_index: &MxArray,
+        encoder_attention_mask: Option<&MxArray>,
+    ) -> Result<MxArray> {
+        // 1. Self-Attention with position embeddings
+        let residual = hidden_states.clone();
+        let attn_output = self.self_attn.forward(
+            hidden_states,
+            Some(position_embeddings),
+            encoder_attention_mask,
+        )?;
+        let hidden_states = residual.add(&attn_output)?;
+        let hidden_states = self.self_attn_layer_norm.forward(&hidden_states)?;
+
+        // 2. Cross-Attention (deformable)
+        let second_residual = hidden_states.clone();
+        let cross_output = self.encoder_attn.forward(
+            &hidden_states,
+            encoder_hidden_states,
+            Some(position_embeddings),
+            reference_points,
+            spatial_shapes,
+            spatial_shapes_list,
+            level_start_index,
+        )?;
+        let hidden_states = second_residual.add(&cross_output)?;
+        let hidden_states = self.encoder_attn_layer_norm.forward(&hidden_states)?;
+
+        // 3. FFN
+        let residual = hidden_states.clone();
+        let fc1_out = self.fc1.forward(&hidden_states)?;
+        let activated = super::apply_activation(&fc1_out, &self.activation)?;
+        let fc2_out = self.fc2.forward(&activated)?;
+        let hidden_states = residual.add(&fc2_out)?;
+        let hidden_states = self.final_layer_norm.forward(&hidden_states)?;
+
+        Ok(hidden_states)
+    }
+}
+
+// ============================================================================
+// Decoder Output
+// ============================================================================
+
+/// Output of the PP-DocLayoutV3 decoder.
+pub struct DecoderOutput {
+    /// Last hidden state from the final decoder layer: [batch, num_queries, d_model]
+    pub last_hidden_state: MxArray,
+    /// Stacked intermediate hidden states: [batch, num_layers, num_queries, d_model]
+    pub intermediate_hidden_states: MxArray,
+    /// Stacked intermediate class logits: [batch, num_layers, num_queries, num_labels]
+    pub intermediate_logits: MxArray,
+    /// Stacked intermediate reference points: [batch, num_layers, num_queries, 4]
+    pub intermediate_reference_points: MxArray,
+    /// Stacked reading order logits: [batch, num_layers, num_queries, num_queries]
+    pub decoder_out_order_logits: MxArray,
+    /// Stacked mask predictions: [batch, num_layers, num_queries, mask_h, mask_w]
+    pub decoder_out_masks: MxArray,
+}
+
+// ============================================================================
+// Full Decoder
+// ============================================================================
+
+/// PP-DocLayoutV3 Transformer Decoder.
+///
+/// Consists of a stack of decoder layers with iterative bounding box refinement.
+/// After each layer:
+/// 1. Bbox refinement: predict offset → add to inverse_sigmoid(reference_points) → sigmoid
+/// 2. Class prediction: class_embed(norm(hidden_states))
+/// 3. Mask generation: mask_query_head(norm(hidden_states)) @ mask_feat
+/// 4. Reading order: global_pointer(order_head(norm(hidden_states)))
+///
+/// Corresponds to PPDocLayoutV3Decoder in the reference.
+pub struct Decoder {
+    /// Stack of decoder layers
+    layers: Vec<DecoderLayer>,
+    /// Query position head: maps reference points (4D) to position embeddings
+    query_pos_head: MLPPredictionHead,
+    /// Bbox refinement head (one shared across layers, or set externally)
+    pub bbox_embed: Option<MLPPredictionHead>,
+    /// Class prediction head (one shared, or set externally)
+    pub class_embed: Option<Linear>,
+    /// Number of object queries
+    num_queries: i32,
+}
+
+impl Decoder {
+    /// Create a new Decoder.
+    ///
+    /// # Arguments
+    /// * `d_model` - Model dimension (default 256)
+    /// * `ffn_dim` - FFN dimension (default 1024)
+    /// * `num_heads` - Number of attention heads (default 8)
+    /// * `n_levels` - Number of feature levels (default 3)
+    /// * `n_points` - Number of sampling points (default 4)
+    /// * `num_layers` - Number of decoder layers (default 6)
+    /// * `num_queries` - Number of object queries (default 300)
+    /// * `layer_norm_eps` - LayerNorm epsilon
+    /// * `activation` - Activation function name
+    pub fn new(
+        d_model: i32,
+        ffn_dim: i32,
+        num_heads: i32,
+        n_levels: i32,
+        n_points: i32,
+        num_layers: i32,
+        num_queries: i32,
+        layer_norm_eps: f64,
+        activation: &str,
+    ) -> Result<Self> {
+        let mut layers = Vec::with_capacity(num_layers as usize);
+        for _ in 0..num_layers {
+            layers.push(DecoderLayer::new(
+                d_model,
+                ffn_dim,
+                num_heads,
+                n_levels,
+                n_points,
+                layer_norm_eps,
+                activation,
+            )?);
+        }
+
+        // query_pos_head: MLP(4, 2*d_model, d_model, 2 layers)
+        let query_pos_head = MLPPredictionHead::new(4, (2 * d_model) as u32, d_model as u32, 2)?;
+
+        Ok(Self {
+            layers,
+            query_pos_head,
+            bbox_embed: None,
+            class_embed: None,
+            num_queries,
+        })
+    }
+
+    /// Create from pre-loaded components.
+    pub fn from_components(
+        layers: Vec<DecoderLayer>,
+        query_pos_head: MLPPredictionHead,
+        bbox_embed: Option<MLPPredictionHead>,
+        class_embed: Option<Linear>,
+        num_queries: i32,
+    ) -> Self {
+        Self {
+            layers,
+            query_pos_head,
+            bbox_embed,
+            class_embed,
+            num_queries,
+        }
+    }
+
+    /// Forward pass through the full decoder.
+    ///
+    /// # Arguments
+    /// * `inputs_embeds` - Query embeddings [batch, num_queries, d_model]
+    /// * `encoder_hidden_states` - Flattened encoder features [batch, total_seq_len, d_model]
+    /// * `reference_points` - Initial reference points (pre-sigmoid) [batch, num_queries, 4]
+    /// * `spatial_shapes` - [num_levels, 2] (height, width)
+    /// * `spatial_shapes_list` - Vec of (height, width)
+    /// * `level_start_index` - [num_levels]
+    /// * `encoder_attention_mask` - Optional mask for self-attention [target_len, target_len]
+    /// * `order_heads` - Per-layer order head linear projections
+    /// * `global_pointer` - Global pointer reading order head
+    /// * `mask_query_head` - Mask query MLP head
+    /// * `norm` - Output normalization (LayerNorm)
+    /// * `mask_feat` - Mask features from encoder [batch, num_prototypes, mask_h, mask_w] (NCHW)
+    ///
+    /// # Returns
+    /// DecoderOutput with all intermediate predictions
+    pub fn forward(
+        &self,
+        inputs_embeds: &MxArray,
+        encoder_hidden_states: &MxArray,
+        reference_points_input: &MxArray,
+        spatial_shapes: &MxArray,
+        spatial_shapes_list: &[(i64, i64)],
+        level_start_index: &MxArray,
+        encoder_attention_mask: Option<&MxArray>,
+        order_heads: &[Linear],
+        global_pointer: &GlobalPointer,
+        mask_query_head: &MLPPredictionHead,
+        norm: &LayerNorm,
+        mask_feat: &MxArray,
+    ) -> Result<DecoderOutput> {
+        let mut hidden_states = inputs_embeds.clone();
+
+        // Apply sigmoid to get initial reference points in [0, 1]
+        let mut reference_points = Activations::sigmoid(reference_points_input)?;
+
+        let mut intermediate_hidden_states: Vec<MxArray> = Vec::new();
+        let mut intermediate_reference_points: Vec<MxArray> = Vec::new();
+        let mut intermediate_logits: Vec<MxArray> = Vec::new();
+        let mut decoder_out_order_logits: Vec<MxArray> = Vec::new();
+        let mut decoder_out_masks: Vec<MxArray> = Vec::new();
+
+        for (idx, decoder_layer) in self.layers.iter().enumerate() {
+            // Expand reference points: [B, Q, 4] → [B, Q, n_levels, 4] for deformable attention
+            // The deformable attention slices along the level dimension, so we need to
+            // broadcast the reference points across all feature levels.
+            let n_levels = spatial_shapes_list.len() as i64;
+            let rp_shape = reference_points.shape()?;
+            let rp_shape: Vec<i64> = rp_shape.as_ref().to_vec();
+            let reference_points_expanded = reference_points.expand_dims(2)?.broadcast_to(&[
+                rp_shape[0],
+                rp_shape[1],
+                n_levels,
+                rp_shape[2],
+            ])?;
+
+            // Compute position embeddings from reference points
+            let position_embeddings = self.query_pos_head.forward(&reference_points)?;
+
+            // Run decoder layer
+            hidden_states = decoder_layer.forward(
+                &hidden_states,
+                &position_embeddings,
+                encoder_hidden_states,
+                &reference_points_expanded,
+                spatial_shapes,
+                spatial_shapes_list,
+                level_start_index,
+                encoder_attention_mask,
+            )?;
+
+            // Iterative bbox refinement
+            if let Some(ref bbox_embed) = self.bbox_embed {
+                let predicted_corners = bbox_embed.forward(&hidden_states)?;
+                let inv_ref = inverse_sigmoid(&reference_points, 1e-5)?;
+                let new_reference_points = Activations::sigmoid(&predicted_corners.add(&inv_ref)?)?;
+                reference_points = new_reference_points.clone();
+
+                intermediate_reference_points.push(new_reference_points);
+            } else {
+                intermediate_reference_points.push(reference_points.clone());
+            }
+
+            intermediate_hidden_states.push(hidden_states.clone());
+
+            // Post-layer predictions: class, mask, order
+            let out_query = norm.forward(&hidden_states)?;
+
+            // Mask generation: mask_query_head(out_query) @ mask_feat.flatten(2)
+            let mask_query_embed = mask_query_head.forward(&out_query)?;
+            // mask_query_embed: [B, Q, num_prototypes]
+            // mask_feat: [B, num_prototypes, mask_h, mask_w]
+
+            let mf_shape = mask_feat.shape()?;
+            let mf_shape: Vec<i64> = mf_shape.as_ref().to_vec();
+            let mask_h = mf_shape[2];
+            let mask_w = mf_shape[3];
+            let batch_size = mf_shape[0];
+
+            // Flatten mask_feat spatial dims: [B, num_prototypes, mask_h * mask_w]
+            let mask_feat_flat = mask_feat.reshape(&[batch_size, mf_shape[1], mask_h * mask_w])?;
+
+            // bmm: [B, Q, num_prototypes] @ [B, num_prototypes, mask_h*mask_w] → [B, Q, mask_h*mask_w]
+            let out_mask = mask_query_embed.matmul(&mask_feat_flat)?;
+            // Reshape to [B, Q, mask_h, mask_w]
+            let mq_shape = mask_query_embed.shape()?;
+            let mq_shape: Vec<i64> = mq_shape.as_ref().to_vec();
+            let mask_dim = mq_shape[1];
+            let out_mask = out_mask.reshape(&[batch_size, mask_dim, mask_h, mask_w])?;
+            decoder_out_masks.push(out_mask);
+
+            // Class prediction
+            if let Some(ref class_embed) = self.class_embed {
+                let logits = class_embed.forward(&out_query)?;
+                intermediate_logits.push(logits);
+            }
+
+            // Reading order prediction
+            if idx < order_heads.len() {
+                // Extract valid queries (last num_queries queries, in case denoising added more)
+                let q_shape = out_query.shape()?;
+                let q_shape: Vec<i64> = q_shape.as_ref().to_vec();
+                let total_queries = q_shape[1];
+                let nq = self.num_queries as i64;
+                let start = total_queries - nq;
+
+                let valid_query = if start > 0 {
+                    out_query.slice(&[0, start, 0], &[q_shape[0], total_queries, q_shape[2]])?
+                } else {
+                    out_query.clone()
+                };
+
+                let order_projected = order_heads[idx].forward(&valid_query)?;
+                let order_logits = global_pointer.forward(&order_projected)?;
+                decoder_out_order_logits.push(order_logits);
+            }
+        }
+
+        // Stack all intermediate outputs along dim=1
+        let inter_hidden_refs: Vec<&MxArray> = intermediate_hidden_states.iter().collect();
+        let stacked_hidden = MxArray::stack(inter_hidden_refs, Some(1))?;
+
+        let inter_ref_refs: Vec<&MxArray> = intermediate_reference_points.iter().collect();
+        let stacked_refs = MxArray::stack(inter_ref_refs, Some(1))?;
+
+        let stacked_logits = if !intermediate_logits.is_empty() {
+            let inter_logit_refs: Vec<&MxArray> = intermediate_logits.iter().collect();
+            MxArray::stack(inter_logit_refs, Some(1))?
+        } else {
+            MxArray::zeros(&[1], None)?
+        };
+
+        let stacked_order = if !decoder_out_order_logits.is_empty() {
+            let order_refs: Vec<&MxArray> = decoder_out_order_logits.iter().collect();
+            MxArray::stack(order_refs, Some(1))?
+        } else {
+            MxArray::zeros(&[1], None)?
+        };
+
+        let mask_refs: Vec<&MxArray> = decoder_out_masks.iter().collect();
+        let stacked_masks = MxArray::stack(mask_refs, Some(1))?;
+
+        Ok(DecoderOutput {
+            last_hidden_state: hidden_states,
+            intermediate_hidden_states: stacked_hidden,
+            intermediate_logits: stacked_logits,
+            intermediate_reference_points: stacked_refs,
+            decoder_out_order_logits: stacked_order,
+            decoder_out_masks: stacked_masks,
+        })
+    }
+}
+
+// ============================================================================
+// Utility: mask_to_box_coordinate
+// ============================================================================
+
+/// Convert binary masks to bounding box coordinates in center format.
+///
+/// For each mask in the batch, finds the bounding box of the True region
+/// and returns normalized (center_x, center_y, width, height) coordinates.
+///
+/// # Arguments
+/// * `mask` - Boolean mask tensor [..., height, width]
+///
+/// # Returns
+/// Bounding boxes [..., 4] in (cx, cy, w, h) format, normalized to [0, 1]
+pub fn mask_to_box_coordinate(mask: &MxArray) -> Result<MxArray> {
+    let shape = mask.shape()?;
+    let shape: Vec<i64> = shape.as_ref().to_vec();
+    let ndim = shape.len();
+
+    let height = shape[ndim - 2];
+    let width = shape[ndim - 1];
+
+    // Create coordinate grids
+    let y_coords = MxArray::arange(0.0, height as f64, Some(1.0), None)?;
+    let x_coords = MxArray::arange(0.0, width as f64, Some(1.0), None)?;
+
+    // y_coords: [H, 1], x_coords: [1, W]
+    let y_grid = y_coords
+        .reshape(&[height, 1])?
+        .broadcast_to(&[height, width])?;
+    let x_grid = x_coords
+        .reshape(&[1, width])?
+        .broadcast_to(&[height, width])?;
+
+    // Mask the coordinates: where mask is True, keep coord; where False, use 0 for max, 1e8 for min
+    let large = MxArray::full(&[1], Either::A(1e8), None)?;
+
+    // x_coords_masked = x_grid * mask
+    let mask_float = mask.astype(crate::array::DType::Float32)?;
+
+    // For max: masked positions get 0 (won't affect max of valid coords)
+    let x_for_max = x_grid.mul(&mask_float)?;
+    let y_for_max = y_grid.mul(&mask_float)?;
+
+    // For min: masked-out positions get 1e8 (won't affect min of valid coords)
+    let x_for_min = mask_float.where_(&x_grid, &large)?;
+    let y_for_min = mask_float.where_(&y_grid, &large)?;
+
+    // Flatten spatial dims and compute min/max
+    // We need to handle arbitrary batch dimensions.
+    // Flatten the last 2 dims into one, then reduce.
+    let batch_shape: Vec<i64> = shape[..ndim - 2].to_vec();
+    let spatial = height * width;
+
+    let mut flat_shape = batch_shape.clone();
+    flat_shape.push(spatial);
+
+    let x_max_flat = x_for_max.reshape(&flat_shape)?;
+    let x_max = x_max_flat.max(Some(&[-1]), Some(false))?.add_scalar(1.0)?;
+
+    let x_min_flat = x_for_min.reshape(&flat_shape)?;
+    let x_min = x_min_flat.min(Some(&[-1]), Some(false))?;
+
+    let y_max_flat = y_for_max.reshape(&flat_shape)?;
+    let y_max = y_max_flat.max(Some(&[-1]), Some(false))?.add_scalar(1.0)?;
+
+    let y_min_flat = y_for_min.reshape(&flat_shape)?;
+    let y_min = y_min_flat.min(Some(&[-1]), Some(false))?;
+
+    // Check for empty masks: any(mask, dim=(-2, -1))
+    let any_mask = mask_float
+        .reshape(&flat_shape)?
+        .max(Some(&[-1]), Some(false))?;
+    // any_mask > 0 means mask has at least one True value
+
+    // Stack [x_min, y_min, x_max, y_max]
+    let bbox_parts = [&x_min, &y_min, &x_max, &y_max];
+    let bbox_refs: Vec<&MxArray> = bbox_parts.to_vec();
+    let unnormalized_bbox = MxArray::stack(bbox_refs, Some(-1))?;
+
+    // Zero out empty masks
+    let any_mask_expanded = any_mask.expand_dims(-1)?;
+    let unnormalized_bbox = unnormalized_bbox.mul(&any_mask_expanded)?;
+
+    // Normalize by [width, height, width, height]
+    let norm_data = [width as f32, height as f32, width as f32, height as f32];
+    let norm_tensor = MxArray::from_float32(&norm_data, &[4])?;
+    let normalized = unnormalized_bbox.div(&norm_tensor)?;
+
+    // Convert from xyxy to cxcywh
+    // Slice out components
+    let mut bbox_shape = batch_shape.clone();
+    bbox_shape.push(4);
+
+    let normalized = normalized.reshape(&bbox_shape)?;
+
+    // x_min_n, y_min_n, x_max_n, y_max_n
+    let starts_x_min = vec![0i64; bbox_shape.len()];
+    let mut stops_x_min: Vec<i64> = bbox_shape.clone();
+    *stops_x_min.last_mut().unwrap() = 1;
+
+    let mut starts_y_min = vec![0i64; bbox_shape.len()];
+    *starts_y_min.last_mut().unwrap() = 1;
+    let mut stops_y_min: Vec<i64> = bbox_shape.clone();
+    *stops_y_min.last_mut().unwrap() = 2;
+
+    let mut starts_x_max = vec![0i64; bbox_shape.len()];
+    *starts_x_max.last_mut().unwrap() = 2;
+    let mut stops_x_max: Vec<i64> = bbox_shape.clone();
+    *stops_x_max.last_mut().unwrap() = 3;
+
+    let mut starts_y_max = vec![0i64; bbox_shape.len()];
+    *starts_y_max.last_mut().unwrap() = 3;
+    let stops_y_max: Vec<i64> = bbox_shape.clone();
+
+    let x_min_n = normalized.slice(&starts_x_min, &stops_x_min)?;
+    let y_min_n = normalized.slice(&starts_y_min, &stops_y_min)?;
+    let x_max_n = normalized.slice(&starts_x_max, &stops_x_max)?;
+    let y_max_n = normalized.slice(&starts_y_max, &stops_y_max)?;
+
+    // center_x = (x_min + x_max) / 2, center_y = (y_min + y_max) / 2
+    let center_x = x_min_n.add(&x_max_n)?.div_scalar(2.0)?;
+    let center_y = y_min_n.add(&y_max_n)?.div_scalar(2.0)?;
+    let box_w = x_max_n.sub(&x_min_n)?;
+    let box_h = y_max_n.sub(&y_min_n)?;
+
+    // Stack [cx, cy, w, h] along last dim
+    let parts = [&center_x, &center_y, &box_w, &box_h];
+    let part_refs: Vec<&MxArray> = parts.to_vec();
+    let result = MxArray::concatenate_many(part_refs, Some(-1))?;
+
+    Ok(result)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_inverse_sigmoid() {
+        // inverse_sigmoid(0.5) should be ~0
+        let x = MxArray::from_float32(&[0.5], &[1]).unwrap();
+        let result = inverse_sigmoid(&x, 1e-5).unwrap();
+        result.eval();
+        let val = result.to_float32().unwrap();
+        assert!((val[0]).abs() < 0.01);
+
+        // inverse_sigmoid(sigmoid(2.0)) should be ~2.0
+        let x = MxArray::from_float32(&[2.0], &[1]).unwrap();
+        let sig = Activations::sigmoid(&x).unwrap();
+        let inv = inverse_sigmoid(&sig, 1e-5).unwrap();
+        inv.eval();
+        let val = inv.to_float32().unwrap();
+        assert!((val[0] - 2.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_self_attention_shapes() {
+        let attn = SelfAttention::new(64, 4).unwrap();
+        let hidden = MxArray::random_uniform(&[1, 10, 64], -1.0, 1.0, None).unwrap();
+        let pos = MxArray::random_uniform(&[1, 10, 64], -1.0, 1.0, None).unwrap();
+
+        let output = attn.forward(&hidden, Some(&pos), None).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 10, 64]);
+    }
+
+    #[test]
+    fn test_self_attention_no_position() {
+        let attn = SelfAttention::new(64, 4).unwrap();
+        let hidden = MxArray::random_uniform(&[2, 5, 64], -1.0, 1.0, None).unwrap();
+
+        let output = attn.forward(&hidden, None, None).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![2, 5, 64]);
+    }
+
+    #[test]
+    fn test_multiscale_deformable_attention_shapes() {
+        let msda = MultiscaleDeformableAttention::new(64, 4, 2, 2).unwrap();
+
+        let batch = 1i64;
+        let num_queries = 10i64;
+        let h1 = 4i64;
+        let w1 = 4i64;
+        let h2 = 2i64;
+        let w2 = 2i64;
+        let total_seq = h1 * w1 + h2 * w2;
+
+        let hidden = MxArray::random_uniform(&[batch, num_queries, 64], -1.0, 1.0, None).unwrap();
+        let encoder = MxArray::random_uniform(&[batch, total_seq, 64], -1.0, 1.0, None).unwrap();
+
+        // Reference points: [B, Q, 1, 2] normalized
+        let ref_points =
+            MxArray::random_uniform(&[batch, num_queries, 1, 2], 0.1, 0.9, None).unwrap();
+
+        let spatial_shapes =
+            MxArray::from_float32(&[h1 as f32, w1 as f32, h2 as f32, w2 as f32], &[2, 2]).unwrap();
+        let spatial_shapes_list = vec![(h1, w1), (h2, w2)];
+        let level_start = MxArray::from_float32(&[0.0, (h1 * w1) as f32], &[2]).unwrap();
+
+        let output = msda
+            .forward(
+                &hidden,
+                &encoder,
+                None,
+                &ref_points,
+                &spatial_shapes,
+                &spatial_shapes_list,
+                &level_start,
+            )
+            .unwrap();
+
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![batch, num_queries, 64]);
+    }
+
+    #[test]
+    fn test_decoder_layer_shapes() {
+        let layer = DecoderLayer::new(64, 128, 4, 2, 2, 1e-5, "relu").unwrap();
+
+        let batch = 1i64;
+        let num_queries = 10i64;
+        let h1 = 4i64;
+        let w1 = 4i64;
+        let h2 = 2i64;
+        let w2 = 2i64;
+        let total_seq = h1 * w1 + h2 * w2;
+
+        let hidden = MxArray::random_uniform(&[batch, num_queries, 64], -1.0, 1.0, None).unwrap();
+        let pos = MxArray::random_uniform(&[batch, num_queries, 64], -1.0, 1.0, None).unwrap();
+        let encoder = MxArray::random_uniform(&[batch, total_seq, 64], -1.0, 1.0, None).unwrap();
+        let ref_points =
+            MxArray::random_uniform(&[batch, num_queries, 1, 2], 0.1, 0.9, None).unwrap();
+        let spatial_shapes =
+            MxArray::from_float32(&[h1 as f32, w1 as f32, h2 as f32, w2 as f32], &[2, 2]).unwrap();
+        let spatial_shapes_list = vec![(h1, w1), (h2, w2)];
+        let level_start = MxArray::from_float32(&[0.0, (h1 * w1) as f32], &[2]).unwrap();
+
+        let output = layer
+            .forward(
+                &hidden,
+                &pos,
+                &encoder,
+                &ref_points,
+                &spatial_shapes,
+                &spatial_shapes_list,
+                &level_start,
+                None,
+            )
+            .unwrap();
+
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![batch, num_queries, 64]);
+    }
+
+    #[test]
+    fn test_mask_to_box_coordinate() {
+        // Create a simple 4x4 mask with a 2x2 region set to true
+        // Region at rows 1-2, cols 1-2
+        let mask_data: Vec<f32> = vec![
+            0.0, 0.0, 0.0, 0.0, // row 0
+            0.0, 1.0, 1.0, 0.0, // row 1
+            0.0, 1.0, 1.0, 0.0, // row 2
+            0.0, 0.0, 0.0, 0.0, // row 3
+        ];
+        let mask = MxArray::from_float32(&mask_data, &[1, 4, 4]).unwrap();
+
+        let bbox = mask_to_box_coordinate(&mask).unwrap();
+        bbox.eval();
+
+        let shape: Vec<i64> = bbox.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 4]);
+
+        let data = bbox.to_float32().unwrap();
+        let data: Vec<f32> = data.to_vec();
+
+        // Expected: x_min=1, y_min=1, x_max=3, y_max=3 (exclusive)
+        // Normalized by [4, 4, 4, 4]: [0.25, 0.25, 0.75, 0.75]
+        // center_x = (0.25 + 0.75) / 2 = 0.5
+        // center_y = (0.25 + 0.75) / 2 = 0.5
+        // width = 0.75 - 0.25 = 0.5
+        // height = 0.75 - 0.25 = 0.5
+        assert!((data[0] - 0.5).abs() < 0.01, "cx: {}", data[0]);
+        assert!((data[1] - 0.5).abs() < 0.01, "cy: {}", data[1]);
+        assert!((data[2] - 0.5).abs() < 0.01, "w: {}", data[2]);
+        assert!((data[3] - 0.5).abs() < 0.01, "h: {}", data[3]);
+    }
+}

--- a/crates/mlx-core/src/models/pp_doclayout_v3/decoder.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/decoder.rs
@@ -264,6 +264,12 @@ impl MultiscaleDeformableAttention {
     /// * `n_levels` - Number of feature levels (default 3)
     /// * `n_points` - Number of sampling points per head per level (default 4)
     pub fn new(d_model: i32, num_heads: i32, n_levels: i32, n_points: i32) -> Result<Self> {
+        if d_model % num_heads != 0 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("d_model ({d_model}) must be divisible by num_heads ({num_heads})"),
+            ));
+        }
         let total_points = (num_heads * n_levels * n_points * 2) as u32;
         let total_weights = (num_heads * n_levels * n_points) as u32;
         let dm = d_model as u32;

--- a/crates/mlx-core/src/models/pp_doclayout_v3/encoder.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/encoder.rs
@@ -1,0 +1,1324 @@
+//! PP-DocLayoutV3 Hybrid Encoder
+//!
+//! Implements the hybrid encoder for the PP-DocLayoutV3 model, which combines:
+//! - AIFI (Attention-based Intra-scale Feature Interaction): Transformer encoder
+//!   applied to the highest-level (lowest resolution) feature map
+//! - FPN (Feature Pyramid Network): Top-down path with lateral connections
+//! - PAN (Path Aggregation Network): Bottom-up path with downsampling
+//! - MaskFeatFPN: Multi-level mask feature head producing 32-channel mask features
+//!
+//! All operations use NHWC format (MLX native).
+//! Weight tensors follow MLX conventions:
+//! - Conv2d weights: [out_channels, kernel_h, kernel_w, in_channels/groups]
+//! - Linear weights: [out_features, in_features]
+//! - BatchNorm params: [channels]
+//! - LayerNorm params: [channels]
+
+use crate::array::MxArray;
+use crate::nn::activations::Activations;
+use crate::nn::{LayerNorm, Linear};
+use napi::Either;
+use napi::bindgen_prelude::*;
+
+use super::backbone::{FrozenBatchNorm2d, NativeConv2d};
+use super::config::PPDocLayoutV3Config;
+
+// ============================================================================
+// ConvNormLayer: Conv2d + BatchNorm + optional Activation
+// ============================================================================
+
+/// Convolution + Batch Normalization + optional Activation layer.
+///
+/// Corresponds to PPDocLayoutV3ConvNormLayer in the reference implementation.
+/// Uses Conv2d (no bias) + FrozenBatchNorm2d + optional activation.
+///
+/// Padding is automatically computed as (kernel_size - 1) / 2.
+pub struct ConvNormLayer {
+    /// Convolution layer (no bias)
+    conv: NativeConv2d,
+    /// Frozen batch normalization
+    norm: FrozenBatchNorm2d,
+    /// Activation function name (None for identity)
+    activation: Option<String>,
+}
+
+impl ConvNormLayer {
+    /// Create a new ConvNormLayer.
+    ///
+    /// # Arguments
+    /// * `conv` - NativeConv2d layer (no bias)
+    /// * `norm` - FrozenBatchNorm2d layer
+    /// * `activation` - Optional activation name ("relu", "silu", "gelu")
+    pub fn new(conv: NativeConv2d, norm: FrozenBatchNorm2d, activation: Option<&str>) -> Self {
+        Self {
+            conv,
+            norm,
+            activation: activation.map(|s| s.to_string()),
+        }
+    }
+
+    /// Forward pass: Conv -> BN -> (optional Activation)
+    ///
+    /// Input/Output: [batch, height, width, channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let mut x = self.conv.forward(input)?;
+        x = self.norm.forward(&x)?;
+        if let Some(ref act) = self.activation {
+            x = super::apply_activation(&x, act)?;
+        }
+        Ok(x)
+    }
+}
+
+// ============================================================================
+// ConvLayer: Conv2d + BatchNorm + Activation (always has activation)
+// ============================================================================
+
+/// Convolution + Batch Normalization + Activation layer.
+///
+/// Corresponds to PPDocLayoutV3ConvLayer in the reference implementation.
+/// Like ConvNormLayer but activation is always present.
+/// Padding = kernel_size // 2.
+pub struct ConvLayer {
+    /// Convolution layer (no bias)
+    conv: NativeConv2d,
+    /// Frozen batch normalization
+    norm: FrozenBatchNorm2d,
+    /// Activation function name
+    activation: String,
+}
+
+impl ConvLayer {
+    /// Create a new ConvLayer.
+    pub fn new(conv: NativeConv2d, norm: FrozenBatchNorm2d, activation: &str) -> Self {
+        Self {
+            conv,
+            norm,
+            activation: activation.to_string(),
+        }
+    }
+
+    /// Forward pass: Conv -> BN -> Activation
+    ///
+    /// Input/Output: [batch, height, width, channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let mut x = self.conv.forward(input)?;
+        x = self.norm.forward(&x)?;
+        super::apply_activation(&x, &self.activation)
+    }
+}
+
+// ============================================================================
+// 2D Sinusoidal Position Embedding
+// ============================================================================
+
+/// Build 2D sinusoidal position embeddings.
+///
+/// Creates a [1, H*W, embed_dim] position encoding tensor using sin/cos
+/// of grid coordinates, divided into 4 quadrants:
+/// [sin(h), cos(h), sin(w), cos(w)], each with embed_dim/4 frequencies.
+///
+/// # Arguments
+/// * `width` - Feature map width
+/// * `height` - Feature map height
+/// * `embed_dim` - Embedding dimension (must be divisible by 4)
+/// * `temperature` - Temperature for frequency scaling (default 10000)
+pub fn build_2d_sincos_position_embedding(
+    width: i64,
+    height: i64,
+    embed_dim: i64,
+    temperature: f64,
+) -> Result<MxArray> {
+    if embed_dim % 4 != 0 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "Embed dimension must be divisible by 4 for 2D sin-cos position embedding, got {embed_dim}"
+            ),
+        ));
+    }
+
+    let pos_dim = embed_dim / 4;
+
+    // grid_w = arange(width), shape [width]
+    let grid_w = MxArray::arange(0.0, width as f64, Some(1.0), None)?;
+    // grid_h = arange(height), shape [height]
+    let grid_h = MxArray::arange(0.0, height as f64, Some(1.0), None)?;
+
+    // Create meshgrid: grid_w[i,j] = j, grid_h[i,j] = i
+    // meshgrid with indexing="xy": grid_w varies along columns (axis=1), grid_h along rows (axis=0)
+    // grid_w: [width] -> [1, width] -> [height, width]
+    // grid_h: [height] -> [height, 1] -> [height, width]
+    let grid_w_2d = grid_w
+        .reshape(&[1, width])?
+        .broadcast_to(&[height, width])?;
+    let grid_h_2d = grid_h
+        .reshape(&[height, 1])?
+        .broadcast_to(&[height, width])?;
+
+    // omega = arange(pos_dim) / pos_dim
+    let omega =
+        MxArray::arange(0.0, pos_dim as f64, Some(1.0), None)?.div_scalar(pos_dim as f64)?;
+    // omega = 1.0 / (temperature ** omega)
+    let temp_arr = MxArray::full(&[pos_dim], Either::A(temperature), None)?;
+    let omega = temp_arr.power(&omega)?.reciprocal()?;
+
+    // out_w = grid_w.flatten()[..., None] @ omega[None]
+    // grid_w.flatten(): [H*W] -> [H*W, 1]
+    // omega: [pos_dim] -> [1, pos_dim]
+    // Result: [H*W, pos_dim]
+    let hw = height * width;
+    let grid_w_flat = grid_w_2d.reshape(&[hw, 1])?;
+    let grid_h_flat = grid_h_2d.reshape(&[hw, 1])?;
+    let omega_row = omega.reshape(&[1, pos_dim])?;
+
+    let out_w = grid_w_flat.matmul(&omega_row)?; // [H*W, pos_dim]
+    let out_h = grid_h_flat.matmul(&omega_row)?; // [H*W, pos_dim]
+
+    // Compute sin and cos
+    let sin_h = out_h.sin()?;
+    let cos_h = out_h.cos()?;
+    let sin_w = out_w.sin()?;
+    let cos_w = out_w.cos()?;
+
+    // Concatenate: [sin_h, cos_h, sin_w, cos_w] along dim=1
+    // Each is [H*W, pos_dim], result is [H*W, embed_dim]
+    let pos_embed = MxArray::concatenate_many(vec![&sin_h, &cos_h, &sin_w, &cos_w], Some(1))?;
+
+    // Add batch dimension: [1, H*W, embed_dim]
+    pos_embed.expand_dims(0)
+}
+
+// ============================================================================
+// Multi-Head Attention
+// ============================================================================
+
+/// Multi-headed self-attention.
+///
+/// Corresponds to PPDocLayoutV3MultiheadAttention in the reference implementation.
+/// Position embeddings are added to queries and keys before projection.
+///
+/// Input: [batch, seq_len, embed_dim]
+/// Output: [batch, seq_len, embed_dim]
+pub struct MultiheadAttention {
+    /// Query projection [embed_dim, embed_dim]
+    q_proj: Linear,
+    /// Key projection [embed_dim, embed_dim]
+    k_proj: Linear,
+    /// Value projection [embed_dim, embed_dim]
+    v_proj: Linear,
+    /// Output projection [embed_dim, embed_dim]
+    out_proj: Linear,
+    /// Number of attention heads
+    num_heads: i32,
+    /// Dimension per head
+    head_dim: i32,
+    /// Scaling factor: 1/sqrt(head_dim)
+    scaling: f64,
+}
+
+impl MultiheadAttention {
+    /// Create a new MultiheadAttention layer.
+    pub fn new(
+        q_proj: Linear,
+        k_proj: Linear,
+        v_proj: Linear,
+        out_proj: Linear,
+        num_heads: i32,
+    ) -> Result<Self> {
+        // Infer embed_dim from q_proj weight shape
+        let q_weight = q_proj.get_weight();
+        let embed_dim = q_weight.shape_at(0)? as i32;
+        let head_dim = embed_dim / num_heads;
+        if head_dim * num_heads != embed_dim {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})"),
+            ));
+        }
+        let scaling = (head_dim as f64).powf(-0.5);
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            out_proj,
+            num_heads,
+            head_dim,
+            scaling,
+        })
+    }
+
+    /// Forward pass.
+    ///
+    /// # Arguments
+    /// * `hidden_states` - [batch, seq_len, embed_dim]
+    /// * `position_embeddings` - Optional [1, seq_len, embed_dim] or [batch, seq_len, embed_dim]
+    ///
+    /// # Returns
+    /// * Output tensor [batch, seq_len, embed_dim]
+    pub fn forward(
+        &self,
+        hidden_states: &MxArray,
+        position_embeddings: Option<&MxArray>,
+    ) -> Result<MxArray> {
+        let shape = hidden_states.shape()?;
+        let batch_size = shape[0];
+        let target_len = shape[1];
+        let embed_dim = shape[2];
+
+        // Add position embeddings to hidden states for Q/K projections
+        let hidden_with_pos = if let Some(pos_emb) = position_embeddings {
+            hidden_states.add(pos_emb)?
+        } else {
+            hidden_states.clone()
+        };
+
+        // Project queries (from hidden + pos), keys (from hidden + pos), values (from hidden only)
+        // Q, K use position-enhanced states; V uses original states
+        let query_states = self
+            .q_proj
+            .forward(&hidden_with_pos)?
+            .mul_scalar(self.scaling)?;
+        let key_states = self.k_proj.forward(&hidden_with_pos)?;
+        let value_states = self.v_proj.forward(hidden_states)?;
+
+        // Reshape to [batch, seq_len, num_heads, head_dim] and transpose to [batch, num_heads, seq_len, head_dim]
+        let nh = self.num_heads as i64;
+        let hd = self.head_dim as i64;
+
+        let query_states = query_states
+            .reshape(&[batch_size, target_len, nh, hd])?
+            .transpose(Some(&[0, 2, 1, 3]))?; // [B, nh, T, hd]
+
+        let key_states = key_states
+            .reshape(&[batch_size, target_len, nh, hd])?
+            .transpose(Some(&[0, 2, 1, 3]))?; // [B, nh, T, hd]
+
+        let value_states = value_states
+            .reshape(&[batch_size, target_len, nh, hd])?
+            .transpose(Some(&[0, 2, 1, 3]))?; // [B, nh, T, hd]
+
+        // Attention: Q @ K^T -> [B, nh, T, T]
+        let key_states_t = key_states.transpose(Some(&[0, 1, 3, 2]))?; // [B, nh, hd, T]
+        let attn_weights = query_states.matmul(&key_states_t)?;
+
+        // Softmax
+        let attn_weights = Activations::softmax(&attn_weights, Some(-1))?;
+
+        // Attention output: weights @ V -> [B, nh, T, hd]
+        let attn_output = attn_weights.matmul(&value_states)?;
+
+        // Reshape: [B, nh, T, hd] -> [B, T, nh, hd] -> [B, T, embed_dim]
+        let attn_output = attn_output
+            .transpose(Some(&[0, 2, 1, 3]))? // [B, T, nh, hd]
+            .reshape(&[batch_size, target_len, embed_dim])?;
+
+        // Output projection
+        self.out_proj.forward(&attn_output)
+    }
+}
+
+// ============================================================================
+// Encoder Layer (Transformer)
+// ============================================================================
+
+/// Transformer encoder layer with self-attention and FFN.
+///
+/// Corresponds to PPDocLayoutV3EncoderLayer in the reference implementation.
+///
+/// Architecture (post-norm, normalize_before=false):
+/// 1. Self-attention + residual + LayerNorm
+/// 2. FFN (fc1 -> activation -> fc2) + residual + LayerNorm
+pub struct EncoderLayer {
+    /// Self-attention
+    self_attn: MultiheadAttention,
+    /// LayerNorm after self-attention
+    self_attn_layer_norm: LayerNorm,
+    /// FFN first linear (hidden_dim -> ffn_dim)
+    fc1: Linear,
+    /// FFN second linear (ffn_dim -> hidden_dim)
+    fc2: Linear,
+    /// LayerNorm after FFN
+    final_layer_norm: LayerNorm,
+    /// Activation function for FFN
+    activation: String,
+    /// Whether to normalize before (pre-norm) or after (post-norm)
+    normalize_before: bool,
+}
+
+impl EncoderLayer {
+    /// Create a new EncoderLayer.
+    pub fn new(
+        self_attn: MultiheadAttention,
+        self_attn_layer_norm: LayerNorm,
+        fc1: Linear,
+        fc2: Linear,
+        final_layer_norm: LayerNorm,
+        activation: &str,
+        normalize_before: bool,
+    ) -> Self {
+        Self {
+            self_attn,
+            self_attn_layer_norm,
+            fc1,
+            fc2,
+            final_layer_norm,
+            activation: activation.to_string(),
+            normalize_before,
+        }
+    }
+
+    /// Forward pass.
+    ///
+    /// # Arguments
+    /// * `hidden_states` - [batch, seq_len, embed_dim]
+    /// * `position_embeddings` - Optional positional embeddings
+    ///
+    /// # Returns
+    /// * Output tensor [batch, seq_len, embed_dim]
+    pub fn forward(
+        &self,
+        hidden_states: &MxArray,
+        position_embeddings: Option<&MxArray>,
+    ) -> Result<MxArray> {
+        // Self-attention block
+        let residual = hidden_states.clone();
+
+        let mut x = if self.normalize_before {
+            self.self_attn_layer_norm.forward(hidden_states)?
+        } else {
+            hidden_states.clone()
+        };
+
+        x = self.self_attn.forward(&x, position_embeddings)?;
+        x = residual.add(&x)?;
+
+        let mut x = if !self.normalize_before {
+            self.self_attn_layer_norm.forward(&x)?
+        } else {
+            x
+        };
+
+        // FFN block
+        if self.normalize_before {
+            x = self.final_layer_norm.forward(&x)?;
+        }
+        let residual = x.clone();
+
+        x = self.fc1.forward(&x)?;
+        x = super::apply_activation(&x, &self.activation)?;
+        x = self.fc2.forward(&x)?;
+        x = residual.add(&x)?;
+
+        if !self.normalize_before {
+            x = self.final_layer_norm.forward(&x)?;
+        }
+
+        Ok(x)
+    }
+}
+
+// ============================================================================
+// Encoder (stack of encoder layers)
+// ============================================================================
+
+/// Stack of transformer encoder layers.
+///
+/// Corresponds to PPDocLayoutV3Encoder in the reference implementation.
+pub struct Encoder {
+    layers: Vec<EncoderLayer>,
+}
+
+impl Encoder {
+    pub fn new(layers: Vec<EncoderLayer>) -> Self {
+        Self { layers }
+    }
+
+    /// Forward pass through all encoder layers.
+    ///
+    /// # Arguments
+    /// * `src` - [batch, seq_len, embed_dim]
+    /// * `pos_embed` - Optional positional embeddings
+    ///
+    /// # Returns
+    /// * Output tensor [batch, seq_len, embed_dim]
+    pub fn forward(&self, src: &MxArray, pos_embed: Option<&MxArray>) -> Result<MxArray> {
+        let mut hidden_states = src.clone();
+        for layer in &self.layers {
+            hidden_states = layer.forward(&hidden_states, pos_embed)?;
+        }
+        Ok(hidden_states)
+    }
+}
+
+// ============================================================================
+// RepVGG Block
+// ============================================================================
+
+/// RepVGG block: parallel 3x3 and 1x1 convolutions with addition.
+///
+/// Corresponds to PPDocLayoutV3RepVggBlock in the reference implementation.
+///
+/// Architecture:
+/// output = activation(conv3x3(x) + conv1x1(x))
+pub struct RepVggBlock {
+    /// 3x3 convolution branch
+    conv1: ConvNormLayer,
+    /// 1x1 convolution branch
+    conv2: ConvNormLayer,
+    /// Activation function
+    activation: String,
+}
+
+impl RepVggBlock {
+    /// Create a new RepVggBlock.
+    pub fn new(conv1: ConvNormLayer, conv2: ConvNormLayer, activation: &str) -> Self {
+        Self {
+            conv1,
+            conv2,
+            activation: activation.to_string(),
+        }
+    }
+
+    /// Forward pass: activation(conv3x3(x) + conv1x1(x))
+    ///
+    /// Input/Output: [batch, height, width, channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let y1 = self.conv1.forward(input)?;
+        let y2 = self.conv2.forward(input)?;
+        let y = y1.add(&y2)?;
+        super::apply_activation(&y, &self.activation)
+    }
+}
+
+// ============================================================================
+// CSPRepLayer (Cross-Stage Partial with RepVGG blocks)
+// ============================================================================
+
+/// Cross-Stage Partial network layer with RepVGG blocks.
+///
+/// Corresponds to PPDocLayoutV3CSPRepLayer in the reference implementation.
+///
+/// Architecture:
+/// 1. Split input through conv1 (for bottleneck path) and conv2 (shortcut path)
+/// 2. Pass conv1 output through a sequence of RepVGG blocks
+/// 3. Add the two paths
+/// 4. Optionally project with conv3 if hidden_channels != out_channels
+///
+/// Input: [batch, H, W, in_channels] where in_channels = encoder_hidden_dim * 2
+/// Output: [batch, H, W, out_channels] where out_channels = encoder_hidden_dim
+pub struct CSPRepLayer {
+    /// 1x1 conv for bottleneck path (in_channels -> hidden_channels)
+    conv1: ConvNormLayer,
+    /// 1x1 conv for shortcut path (in_channels -> hidden_channels)
+    conv2: ConvNormLayer,
+    /// RepVGG bottleneck blocks
+    bottlenecks: Vec<RepVggBlock>,
+    /// Optional 1x1 conv for output projection (hidden_channels -> out_channels)
+    /// None if hidden_channels == out_channels (identity)
+    conv3: Option<ConvNormLayer>,
+}
+
+impl CSPRepLayer {
+    /// Create a new CSPRepLayer.
+    pub fn new(
+        conv1: ConvNormLayer,
+        conv2: ConvNormLayer,
+        bottlenecks: Vec<RepVggBlock>,
+        conv3: Option<ConvNormLayer>,
+    ) -> Self {
+        Self {
+            conv1,
+            conv2,
+            bottlenecks,
+            conv3,
+        }
+    }
+
+    /// Forward pass.
+    ///
+    /// Input: [batch, H, W, in_channels] (NHWC)
+    /// Output: [batch, H, W, out_channels] (NHWC)
+    pub fn forward(&self, hidden_state: &MxArray) -> Result<MxArray> {
+        // Bottleneck path
+        let mut x1 = self.conv1.forward(hidden_state)?;
+        for block in &self.bottlenecks {
+            x1 = block.forward(&x1)?;
+        }
+
+        // Shortcut path
+        let x2 = self.conv2.forward(hidden_state)?;
+
+        // Merge
+        let merged = x1.add(&x2)?;
+
+        // Optional output projection
+        if let Some(ref conv3) = self.conv3 {
+            conv3.forward(&merged)
+        } else {
+            Ok(merged)
+        }
+    }
+}
+
+// ============================================================================
+// Nearest-neighbor 2x Upsampling (NHWC)
+// ============================================================================
+
+/// Upsample a feature map by 2x using nearest-neighbor interpolation.
+///
+/// Input: [batch, height, width, channels] (NHWC)
+/// Output: [batch, height*2, width*2, channels] (NHWC)
+///
+/// Uses reshape + broadcast approach:
+/// [B, H, W, C] -> [B, H, 1, W, 1, C] -> [B, H, 2, W, 2, C] -> [B, H*2, W*2, C]
+fn upsample_nearest_2x(input: &MxArray) -> Result<MxArray> {
+    let shape = input.shape()?;
+    let shape: Vec<i64> = shape.as_ref().to_vec();
+    let batch = shape[0];
+    let h = shape[1];
+    let w = shape[2];
+    let c = shape[3];
+
+    // Reshape to [B, H, 1, W, 1, C]
+    let expanded = input.reshape(&[batch, h, 1, w, 1, c])?;
+
+    // Broadcast to [B, H, 2, W, 2, C]
+    let upsampled = expanded.broadcast_to(&[batch, h, 2, w, 2, c])?;
+
+    // Reshape to [B, H*2, W*2, C]
+    upsampled.reshape(&[batch, h * 2, w * 2, c])
+}
+
+// ============================================================================
+// Bilinear 2x Upsampling (NHWC, align_corners=False)
+// ============================================================================
+
+/// Upsample a feature map by 2x using bilinear interpolation.
+///
+/// Matches PyTorch's `F.interpolate(x, scale_factor=2, mode="bilinear", align_corners=False)`.
+///
+/// Input: [batch, height, width, channels] (NHWC)
+/// Output: [batch, height*2, width*2, channels] (NHWC)
+///
+/// Uses separable bilinear interpolation via `take` + weighted blending:
+/// 1. Interpolate along height (axis 1): gather rows by y0/y1, blend with wy
+/// 2. Interpolate along width (axis 2): gather columns by x0/x1, blend with wx
+///
+/// For `align_corners=False`, output pixel `oy` maps to input coordinate:
+///   `src_y = (oy + 0.5) / scale - 0.5 = (oy + 0.5) / 2.0 - 0.5`
+fn upsample_bilinear_2x(input: &MxArray) -> Result<MxArray> {
+    let shape = input.shape()?;
+    let shape: Vec<i64> = shape.as_ref().to_vec();
+    let h = shape[1];
+    let w = shape[2];
+
+    // --- Step 1: Interpolate along height (axis 1) ---
+    // For each output row oy in [0, 2*H), compute:
+    //   src_y = (oy + 0.5) / 2.0 - 0.5
+    //   y0 = clamp(floor(src_y), 0, H-1)
+    //   y1 = clamp(floor(src_y) + 1, 0, H-1)
+    //   wy = src_y - floor(src_y)  (but when src_y < 0, wy is clamped via y0==y1==0)
+    let out_h = h * 2;
+    let mut y0_idx = Vec::with_capacity(out_h as usize);
+    let mut y1_idx = Vec::with_capacity(out_h as usize);
+    let mut wy_vals = Vec::with_capacity(out_h as usize);
+
+    for oy in 0..out_h {
+        let src_y = (oy as f64 + 0.5) / 2.0 - 0.5;
+        let y0_raw = src_y.floor() as i64;
+        let y0 = y0_raw.clamp(0, h - 1) as i32;
+        let y1 = (y0_raw + 1).clamp(0, h - 1) as i32;
+        let wy = (src_y - src_y.floor()) as f32;
+        // When src_y < 0, floor(src_y) = -1, so wy = src_y - (-1) = src_y + 1.
+        // But both y0 and y1 clamp to 0, so the weight doesn't matter (both point to same row).
+        // We still store the correct wy for clarity.
+        y0_idx.push(y0);
+        y1_idx.push(y1);
+        wy_vals.push(wy);
+    }
+
+    let y0_arr = MxArray::from_int32(&y0_idx, &[out_h])?;
+    let y1_arr = MxArray::from_int32(&y1_idx, &[out_h])?;
+    // wy shape: [1, 2*H, 1, 1] for broadcasting over [B, 2*H, W, C]
+    let wy_arr = MxArray::from_float32(&wy_vals, &[1, out_h, 1, 1])?;
+
+    // Gather rows: input.take(y0, axis=1) -> [B, 2*H, W, C]
+    let rows_y0 = input.take(&y0_arr, 1)?;
+    let rows_y1 = input.take(&y1_arr, 1)?;
+
+    // Blend: result_h = rows_y0 * (1 - wy) + rows_y1 * wy
+    let one_minus_wy = MxArray::from_float32(
+        &wy_vals.iter().map(|w| 1.0 - w).collect::<Vec<f32>>(),
+        &[1, out_h, 1, 1],
+    )?;
+    let h_interp = rows_y0.mul(&one_minus_wy)?.add(&rows_y1.mul(&wy_arr)?)?;
+
+    // --- Step 2: Interpolate along width (axis 2) ---
+    let out_w = w * 2;
+    let mut x0_idx = Vec::with_capacity(out_w as usize);
+    let mut x1_idx = Vec::with_capacity(out_w as usize);
+    let mut wx_vals = Vec::with_capacity(out_w as usize);
+
+    for ox in 0..out_w {
+        let src_x = (ox as f64 + 0.5) / 2.0 - 0.5;
+        let x0_raw = src_x.floor() as i64;
+        let x0 = x0_raw.clamp(0, w - 1) as i32;
+        let x1 = (x0_raw + 1).clamp(0, w - 1) as i32;
+        let wx = (src_x - src_x.floor()) as f32;
+        x0_idx.push(x0);
+        x1_idx.push(x1);
+        wx_vals.push(wx);
+    }
+
+    let x0_arr = MxArray::from_int32(&x0_idx, &[out_w])?;
+    let x1_arr = MxArray::from_int32(&x1_idx, &[out_w])?;
+    // wx shape: [1, 1, 2*W, 1] for broadcasting over [B, 2*H, 2*W, C]
+    let wx_arr = MxArray::from_float32(&wx_vals, &[1, 1, out_w, 1])?;
+
+    // Gather columns: h_interp.take(x0, axis=2) -> [B, 2*H, 2*W, C]
+    let cols_x0 = h_interp.take(&x0_arr, 2)?;
+    let cols_x1 = h_interp.take(&x1_arr, 2)?;
+
+    // Blend: result = cols_x0 * (1 - wx) + cols_x1 * wx
+    let one_minus_wx = MxArray::from_float32(
+        &wx_vals.iter().map(|w| 1.0 - w).collect::<Vec<f32>>(),
+        &[1, 1, out_w, 1],
+    )?;
+    cols_x0.mul(&one_minus_wx)?.add(&cols_x1.mul(&wx_arr)?)
+}
+
+// ============================================================================
+// ScaleHead: Conv + optional Upsample chain
+// ============================================================================
+
+/// Scale head for the MaskFeatFPN.
+///
+/// Corresponds to PPDocLayoutV3ScaleHead in the reference implementation.
+///
+/// Contains a sequence of ConvLayer + optional Upsample pairs.
+/// The number of layers depends on log2(fpn_stride / base_stride).
+/// Each layer has a 3x3 ConvLayer followed by 2x bilinear upsampling
+/// (if fpn_stride != base_stride). Uses align_corners=False to match Python reference.
+pub enum ScaleHeadLayer {
+    Conv(ConvLayer),
+    Upsample,
+}
+
+pub struct ScaleHead {
+    layers: Vec<ScaleHeadLayer>,
+}
+
+impl ScaleHead {
+    pub fn new(layers: Vec<ScaleHeadLayer>) -> Self {
+        Self { layers }
+    }
+
+    /// Forward pass through conv + upsample chain.
+    ///
+    /// Input/Output: [batch, height, width, channels] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let mut x = input.clone();
+        for layer in &self.layers {
+            match layer {
+                ScaleHeadLayer::Conv(conv) => {
+                    x = conv.forward(&x)?;
+                }
+                ScaleHeadLayer::Upsample => {
+                    x = upsample_bilinear_2x(&x)?;
+                }
+            }
+        }
+        Ok(x)
+    }
+}
+
+// ============================================================================
+// MaskFeatFPN
+// ============================================================================
+
+/// Multi-level mask feature head producing mask features.
+///
+/// Corresponds to PPDocLayoutV3MaskFeatFPN in the reference implementation.
+///
+/// Takes pan_feature_maps (ordered by stride ascending) and produces a
+/// single feature map at the finest resolution among the inputs.
+///
+/// Architecture:
+/// 1. Reorder inputs by stride (ascending)
+/// 2. Process each level through a ScaleHead (conv + upsample to finest resolution)
+/// 3. Sum all processed levels
+/// 4. Final 3x3 conv to produce output
+pub struct MaskFeatFPN {
+    /// Reorder indices to sort by stride ascending
+    reorder_index: Vec<usize>,
+    /// Scale heads for each level
+    scale_heads: Vec<ScaleHead>,
+    /// Final output convolution
+    output_conv: ConvLayer,
+}
+
+impl MaskFeatFPN {
+    /// Create a new MaskFeatFPN.
+    ///
+    /// # Arguments
+    /// * `reorder_index` - Indices to reorder inputs by ascending stride
+    /// * `scale_heads` - Scale heads for each level
+    /// * `output_conv` - Final 3x3 conv
+    pub fn new(
+        reorder_index: Vec<usize>,
+        scale_heads: Vec<ScaleHead>,
+        output_conv: ConvLayer,
+    ) -> Self {
+        Self {
+            reorder_index,
+            scale_heads,
+            output_conv,
+        }
+    }
+
+    /// Forward pass.
+    ///
+    /// # Arguments
+    /// * `inputs` - Vec of feature maps [batch, H_i, W_i, C] (NHWC), one per level
+    ///
+    /// # Returns
+    /// * Mask feature map [batch, H_finest, W_finest, out_channels] (NHWC)
+    pub fn forward(&self, inputs: &[MxArray]) -> Result<MxArray> {
+        // Reorder by stride ascending
+        let x: Vec<&MxArray> = self.reorder_index.iter().map(|&i| &inputs[i]).collect();
+
+        // Process first level (finest stride)
+        let mut output = self.scale_heads[0].forward(x[0])?;
+
+        // Add other levels (upsampled to match output resolution)
+        #[allow(clippy::needless_range_loop)]
+        for i in 1..self.scale_heads.len() {
+            let processed = self.scale_heads[i].forward(x[i])?;
+
+            // Upsample processed to match output spatial size using bilinear interpolation
+            // (align_corners=False) to match Python reference's F.interpolate(..., mode="bilinear").
+            // The ScaleHead already handles upsampling internally, but we may need
+            // to interpolate to match exactly if sizes differ.
+            let out_shape = output.shape()?;
+            let proc_shape = processed.shape()?;
+            let out_h = out_shape[1];
+            let out_w = out_shape[2];
+            let proc_h = proc_shape[1];
+            let proc_w = proc_shape[2];
+
+            let processed = if proc_h != out_h || proc_w != out_w {
+                // Use bilinear upsampling to match output size
+                // Since we're dealing with power-of-2 relationships, repeated 2x upsampling works
+                let mut p = processed;
+                loop {
+                    let ps = p.shape()?;
+                    if ps[1] >= out_h && ps[2] >= out_w {
+                        break;
+                    }
+                    p = upsample_bilinear_2x(&p)?;
+                }
+                // If we overshot, slice to exact size
+                let ps = p.shape()?;
+                if ps[1] != out_h || ps[2] != out_w {
+                    p.slice(&[0, 0, 0, 0], &[ps[0], out_h, out_w, ps[3]])?
+                } else {
+                    p
+                }
+            } else {
+                processed
+            };
+
+            output = output.add(&processed)?;
+        }
+
+        // Final output conv
+        self.output_conv.forward(&output)
+    }
+}
+
+// ============================================================================
+// EncoderMaskOutput
+// ============================================================================
+
+/// Encoder mask output: ConvLayer + 1x1 Conv2d.
+///
+/// Corresponds to PPDocLayoutV3EncoderMaskOutput in the reference implementation.
+///
+/// Produces the final mask prototype features (num_prototypes channels).
+pub struct EncoderMaskOutput {
+    /// 3x3 ConvLayer (in_channels -> in_channels)
+    base_conv: ConvLayer,
+    /// 1x1 Conv2d (in_channels -> num_prototypes), with bias
+    conv: NativeConv2d,
+}
+
+impl EncoderMaskOutput {
+    pub fn new(base_conv: ConvLayer, conv: NativeConv2d) -> Self {
+        Self { base_conv, conv }
+    }
+
+    /// Forward pass.
+    ///
+    /// Input: [batch, H, W, in_channels] (NHWC)
+    /// Output: [batch, H, W, num_prototypes] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let x = self.base_conv.forward(input)?;
+        self.conv.forward(&x)
+    }
+}
+
+// ============================================================================
+// Input Projection: Conv2d(1x1, no bias) + BN
+// ============================================================================
+
+/// Input projection layer: 1x1 Conv2d (no bias) + BatchNorm2d.
+///
+/// Used to project backbone features to the encoder's hidden dimension.
+/// Corresponds to `encoder_input_proj` in the model forward.
+pub struct InputProjection {
+    /// 1x1 Conv2d (no bias)
+    conv: NativeConv2d,
+    /// Frozen batch normalization
+    norm: FrozenBatchNorm2d,
+}
+
+impl InputProjection {
+    pub fn new(conv: NativeConv2d, norm: FrozenBatchNorm2d) -> Self {
+        Self { conv, norm }
+    }
+
+    /// Forward pass: Conv2d(1x1) -> BN
+    ///
+    /// Input: [batch, H, W, in_channels] (NHWC)
+    /// Output: [batch, H, W, hidden_dim] (NHWC)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let x = self.conv.forward(input)?;
+        self.norm.forward(&x)
+    }
+}
+
+// ============================================================================
+// HybridEncoder
+// ============================================================================
+
+/// PP-DocLayoutV3 Hybrid Encoder.
+///
+/// Corresponds to PPDocLayoutV3HybridEncoder in the reference implementation.
+///
+/// Architecture:
+/// 1. Input projection (Conv2d 1x1 + BN) for each feature level (done outside, passed as projected)
+/// 2. AIFI: Transformer encoder on the highest-level feature with 2D sinusoidal position encoding
+/// 3. FPN (top-down): Lateral 1x1 convs + 2x upsample + concat + CSPRepLayer
+/// 4. PAN (bottom-up): Stride-2 3x3 convs for downsampling + concat + CSPRepLayer
+/// 5. MaskFeatFPN: Multi-level mask feature head
+/// 6. Encoder mask lateral + output for final mask features
+///
+/// Input: Vec of projected feature maps [B, H_i, W_i, 256] (NHWC)
+///        + x4_feat [B, H/4, W/4, x4_feat_dim] (stride-4 feature from backbone)
+/// Output: (pan_feature_maps, mask_feat)
+pub struct HybridEncoder {
+    /// Hidden dimension (256)
+    encoder_hidden_dim: i32,
+    /// Indices of features to apply transformer encoder to
+    encode_proj_layers: Vec<i32>,
+    /// Temperature for positional encoding
+    positional_encoding_temperature: i32,
+    /// Number of FPN stages (len(in_channels) - 1)
+    num_fpn_stages: usize,
+    /// Number of PAN stages (len(in_channels) - 1)
+    num_pan_stages: usize,
+    /// Number of encoder layers
+    encoder_layers: i32,
+
+    // Transformer encoder(s) - one per encode_proj_layer
+    encoders: Vec<Encoder>,
+
+    // FPN (top-down)
+    /// Lateral 1x1 convolutions for FPN
+    lateral_convs: Vec<ConvNormLayer>,
+    /// CSPRepLayer blocks for FPN
+    fpn_blocks: Vec<CSPRepLayer>,
+
+    // PAN (bottom-up)
+    /// Stride-2 3x3 convolutions for downsampling
+    downsample_convs: Vec<ConvNormLayer>,
+    /// CSPRepLayer blocks for PAN
+    pan_blocks: Vec<CSPRepLayer>,
+
+    // Mask feature head
+    /// MaskFeatFPN for multi-level mask features
+    mask_feature_head: MaskFeatFPN,
+    /// Lateral convolution for x4_feat
+    encoder_mask_lateral: ConvLayer,
+    /// Final mask output (ConvLayer + 1x1 Conv)
+    encoder_mask_output: EncoderMaskOutput,
+}
+
+impl HybridEncoder {
+    /// Create a new HybridEncoder.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        config: &PPDocLayoutV3Config,
+        encoders: Vec<Encoder>,
+        lateral_convs: Vec<ConvNormLayer>,
+        fpn_blocks: Vec<CSPRepLayer>,
+        downsample_convs: Vec<ConvNormLayer>,
+        pan_blocks: Vec<CSPRepLayer>,
+        mask_feature_head: MaskFeatFPN,
+        encoder_mask_lateral: ConvLayer,
+        encoder_mask_output: EncoderMaskOutput,
+    ) -> Self {
+        let num_levels = config.encoder_in_channels.len();
+        Self {
+            encoder_hidden_dim: config.encoder_hidden_dim,
+            encode_proj_layers: config.encode_proj_layers.clone(),
+            positional_encoding_temperature: config.positional_encoding_temperature,
+            num_fpn_stages: num_levels - 1,
+            num_pan_stages: num_levels - 1,
+            encoder_layers: config.encoder_layers,
+            encoders,
+            lateral_convs,
+            fpn_blocks,
+            downsample_convs,
+            pan_blocks,
+            mask_feature_head,
+            encoder_mask_lateral,
+            encoder_mask_output,
+        }
+    }
+
+    /// Forward pass through the hybrid encoder.
+    ///
+    /// # Arguments
+    /// * `inputs_embeds` - Vec of projected feature maps [B, H_i, W_i, 256] (NHWC)
+    ///   Ordered from finest to coarsest resolution (stride 8, 16, 32)
+    /// * `x4_feat` - Stride-4 feature map [B, H/4, W/4, x4_feat_dim] (NHWC)
+    ///
+    /// # Returns
+    /// * `(pan_feature_maps, mask_feat)` where:
+    ///   - pan_feature_maps: Vec of [B, H_i, W_i, 256] at each stride level
+    ///   - mask_feat: [B, H/4, W/4, num_prototypes] mask prototype features
+    pub fn forward(
+        &self,
+        inputs_embeds: &mut [MxArray],
+        x4_feat: &MxArray,
+    ) -> Result<(Vec<MxArray>, MxArray)> {
+        // ---- AIFI: Transformer encoder on selected feature levels ----
+        if self.encoder_layers > 0 {
+            for (i, &enc_ind) in self.encode_proj_layers.iter().enumerate() {
+                let enc_ind = enc_ind as usize;
+
+                let feat_shape = inputs_embeds[enc_ind].shape()?;
+                let batch = feat_shape[0];
+                let height = feat_shape[1];
+                let width = feat_shape[2];
+
+                // Flatten spatial dims: [B, H, W, C] -> [B, H*W, C]
+                let src_flatten = inputs_embeds[enc_ind].reshape(&[
+                    batch,
+                    height * width,
+                    self.encoder_hidden_dim as i64,
+                ])?;
+
+                // Build 2D sinusoidal position embedding
+                let pos_embed = build_2d_sincos_position_embedding(
+                    width,
+                    height,
+                    self.encoder_hidden_dim as i64,
+                    self.positional_encoding_temperature as f64,
+                )?;
+
+                // Run through transformer encoder
+                let encoded = self.encoders[i].forward(&src_flatten, Some(&pos_embed))?;
+
+                // Reshape back: [B, H*W, C] -> [B, H, W, C]
+                inputs_embeds[enc_ind] =
+                    encoded.reshape(&[batch, height, width, self.encoder_hidden_dim as i64])?;
+            }
+        }
+
+        // ---- FPN: Top-down path ----
+        // Start from the coarsest (highest-level) feature
+        let num_levels = inputs_embeds.len();
+        let mut fpn_feature_maps: Vec<MxArray> = vec![inputs_embeds[num_levels - 1].clone()];
+
+        for idx in 0..self.num_fpn_stages {
+            // Get the backbone feature at the corresponding level (going top-down)
+            let backbone_feature_map = &inputs_embeds[self.num_fpn_stages - idx - 1];
+
+            // Apply lateral conv to current top feature
+            let top_fpn = self.lateral_convs[idx].forward(&fpn_feature_maps[idx])?;
+            // Update in place
+            fpn_feature_maps[idx] = top_fpn.clone();
+
+            // Upsample by 2x
+            let upsampled = upsample_nearest_2x(&top_fpn)?;
+
+            // Concatenate along channel axis (NHWC: axis=3)
+            let fused = MxArray::concatenate(&upsampled, backbone_feature_map, 3)?;
+
+            // Apply CSPRepLayer
+            let new_fpn = self.fpn_blocks[idx].forward(&fused)?;
+            fpn_feature_maps.push(new_fpn);
+        }
+
+        // Reverse so finest resolution is first
+        fpn_feature_maps.reverse();
+
+        // ---- PAN: Bottom-up path ----
+        let mut pan_feature_maps: Vec<MxArray> = vec![fpn_feature_maps[0].clone()];
+
+        for idx in 0..self.num_pan_stages {
+            let top_pan = &pan_feature_maps[idx];
+            let fpn_feat = &fpn_feature_maps[idx + 1];
+
+            // Downsample with stride-2 conv
+            let downsampled = self.downsample_convs[idx].forward(top_pan)?;
+
+            // Concatenate along channel axis (NHWC: axis=3)
+            let fused = MxArray::concatenate(&downsampled, fpn_feat, 3)?;
+
+            // Apply CSPRepLayer
+            let new_pan = self.pan_blocks[idx].forward(&fused)?;
+            pan_feature_maps.push(new_pan);
+        }
+
+        // ---- Mask feature head ----
+        let mut mask_feat = self.mask_feature_head.forward(&pan_feature_maps)?;
+
+        // Upsample mask_feat by 2x (to go from stride-8 to stride-4)
+        // Uses bilinear interpolation (align_corners=False) to match Python reference
+        mask_feat = upsample_bilinear_2x(&mask_feat)?;
+
+        // Add x4_feat (stride-4 feature from backbone) via lateral conv
+        let x4_lateral = self.encoder_mask_lateral.forward(x4_feat)?;
+        mask_feat = mask_feat.add(&x4_lateral)?;
+
+        // Final mask output
+        mask_feat = self.encoder_mask_output.forward(&mask_feat)?;
+
+        Ok((pan_feature_maps, mask_feat))
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_2d_sincos_position_embedding() {
+        let pos = build_2d_sincos_position_embedding(4, 3, 256, 10000.0).unwrap();
+        let shape: Vec<i64> = pos.shape().unwrap().as_ref().to_vec();
+        // [1, H*W, embed_dim] = [1, 12, 256]
+        assert_eq!(shape, vec![1, 12, 256]);
+
+        // Values should be in [-1, 1] (sin/cos range)
+        pos.eval();
+        let data = pos.to_float32().unwrap();
+        let data: Vec<f32> = data.to_vec();
+        for &v in &data {
+            assert!(
+                (-1.0..=1.0).contains(&v),
+                "Position embedding value {v} out of range [-1, 1]"
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_2d_sincos_position_embedding_rejects_bad_dim() {
+        let result = build_2d_sincos_position_embedding(4, 3, 255, 10000.0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_upsample_nearest_2x() {
+        // Input: [1, 2, 2, 1]
+        let input = MxArray::from_float32(&[1.0, 2.0, 3.0, 4.0], &[1, 2, 2, 1]).unwrap();
+
+        let output = upsample_nearest_2x(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 4, 4, 1]);
+
+        output.eval();
+        let data = output.to_float32().unwrap();
+        let data: Vec<f32> = data.to_vec();
+        // Expected: each pixel repeated in a 2x2 block
+        // [1,1,2,2, 1,1,2,2, 3,3,4,4, 3,3,4,4]
+        assert_eq!(
+            data,
+            vec![
+                1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 3.0, 3.0, 4.0, 4.0
+            ]
+        );
+    }
+
+    #[test]
+    fn test_upsample_nearest_2x_multichannel() {
+        // Input: [1, 2, 2, 2]
+        let input =
+            MxArray::from_float32(&[1.0, 10.0, 2.0, 20.0, 3.0, 30.0, 4.0, 40.0], &[1, 2, 2, 2])
+                .unwrap();
+
+        let output = upsample_nearest_2x(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 4, 4, 2]);
+    }
+
+    #[test]
+    fn test_upsample_bilinear_2x_shape() {
+        // Input: [1, 3, 4, 2]
+        let input = MxArray::from_float32(&[1.0; 3 * 4 * 2], &[1, 3, 4, 2]).unwrap();
+
+        let output = upsample_bilinear_2x(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 6, 8, 2]);
+    }
+
+    #[test]
+    fn test_upsample_bilinear_2x_values() {
+        // Input: [1, 2, 2, 1] with values [[1, 2], [3, 4]]
+        // Test that bilinear interpolation produces smooth output
+        let input = MxArray::from_float32(&[1.0, 2.0, 3.0, 4.0], &[1, 2, 2, 1]).unwrap();
+
+        let output = upsample_bilinear_2x(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 4, 4, 1]);
+
+        output.eval();
+        let data: Vec<f32> = output.to_float32().unwrap().to_vec();
+
+        // With align_corners=False and scale_factor=2:
+        // Output pixel (oy, ox) maps to src = ((oy+0.5)/2 - 0.5, (ox+0.5)/2 - 0.5)
+        //
+        // oy=0: src_y = -0.25 -> y0=0,y1=0 (both clamped), wy=0.75 (irrelevant, same row)
+        // oy=1: src_y =  0.25 -> y0=0,y1=1, wy=0.25
+        // oy=2: src_y =  0.75 -> y0=0,y1=1, wy=0.75
+        // oy=3: src_y =  1.25 -> y0=1,y1=1 (y1 clamped), wy=0.25 (irrelevant, same row)
+        //
+        // ox=0: src_x = -0.25 -> x0=0,x1=0, wx=0.75 (irrelevant)
+        // ox=1: src_x =  0.25 -> x0=0,x1=1, wx=0.25
+        // ox=2: src_x =  0.75 -> x0=0,x1=1, wx=0.75
+        // ox=3: src_x =  1.25 -> x0=1,x1=1, wx=0.25 (irrelevant)
+        //
+        // Row 0 (src_y clamps to 0): input row = [1, 2]
+        //   (0,0): 1.0*1.0 = 1.0
+        //   (0,1): 0.75*1.0 + 0.25*2.0 = 1.25
+        //   (0,2): 0.25*1.0 + 0.75*2.0 = 1.75
+        //   (0,3): 1.0*2.0 = 2.0
+        //
+        // Row 1 (src_y=0.25): interp = 0.75*row0 + 0.25*row1
+        //   row0=[1,2], row1=[3,4] -> h_interp = [1.5, 2.5]
+        //   (1,0): 1.5
+        //   (1,1): 0.75*1.5 + 0.25*2.5 = 1.75
+        //   (1,2): 0.25*1.5 + 0.75*2.5 = 2.25
+        //   (1,3): 2.5
+        //
+        // Row 2 (src_y=0.75): interp = 0.25*row0 + 0.75*row1
+        //   -> h_interp = [2.5, 3.5]
+        //   (2,0): 2.5
+        //   (2,1): 0.75*2.5 + 0.25*3.5 = 2.75
+        //   (2,2): 0.25*2.5 + 0.75*3.5 = 3.25
+        //   (2,3): 3.5
+        //
+        // Row 3 (src_y clamps to 1): input row = [3, 4]
+        //   (3,0): 3.0
+        //   (3,1): 0.75*3.0 + 0.25*4.0 = 3.25
+        //   (3,2): 0.25*3.0 + 0.75*4.0 = 3.75
+        //   (3,3): 4.0
+        let expected = vec![
+            1.0, 1.25, 1.75, 2.0, 1.5, 1.75, 2.25, 2.5, 2.5, 2.75, 3.25, 3.5, 3.0, 3.25, 3.75, 4.0,
+        ];
+        for (i, (&got, &exp)) in data.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (got - exp).abs() < 1e-5,
+                "Mismatch at index {i}: got {got}, expected {exp}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_upsample_bilinear_2x_uniform() {
+        // A uniform input should produce uniform output
+        let input = MxArray::from_float32(&[5.0; 3 * 3], &[1, 3, 3, 1]).unwrap();
+
+        let output = upsample_bilinear_2x(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 6, 6, 1]);
+
+        output.eval();
+        let data: Vec<f32> = output.to_float32().unwrap().to_vec();
+        for (i, &v) in data.iter().enumerate() {
+            assert!(
+                (v - 5.0).abs() < 1e-5,
+                "Uniform input should give uniform output, but index {i} = {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_upsample_bilinear_2x_multichannel() {
+        // Input: [1, 2, 2, 3] — multi-channel should work independently per channel
+        let input = MxArray::from_float32(
+            &[
+                // pixel (0,0): channels [1, 10, 100]
+                1.0, 10.0, 100.0, // pixel (0,1): channels [2, 20, 200]
+                2.0, 20.0, 200.0, // pixel (1,0): channels [3, 30, 300]
+                3.0, 30.0, 300.0, // pixel (1,1): channels [4, 40, 400]
+                4.0, 40.0, 400.0,
+            ],
+            &[1, 2, 2, 3],
+        )
+        .unwrap();
+
+        let output = upsample_bilinear_2x(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 4, 4, 3]);
+
+        output.eval();
+        let data: Vec<f32> = output.to_float32().unwrap().to_vec();
+        // Channel 1 should be 10x channel 0, channel 2 should be 100x channel 0
+        // Check center pixel (1,1) which is a blend: channel 0 should be 1.75
+        // (row 1: 0.75*[1,2] + 0.25*[3,4] = [1.5, 2.5], then col 1: 0.75*1.5 + 0.25*2.5 = 1.75)
+        let ch0_11 = data[(4 + 1) * 3]; // row=1, col=1, ch=0
+        let ch1_11 = data[(4 + 1) * 3 + 1]; // row=1, col=1, ch=1
+        let ch2_11 = data[(4 + 1) * 3 + 2]; // row=1, col=1, ch=2
+        assert!((ch0_11 - 1.75).abs() < 1e-5, "ch0 at (1,1) = {ch0_11}");
+        assert!((ch1_11 - 17.5).abs() < 1e-4, "ch1 at (1,1) = {ch1_11}");
+        assert!((ch2_11 - 175.0).abs() < 1e-3, "ch2 at (1,1) = {ch2_11}");
+    }
+
+    #[test]
+    fn test_conv_norm_layer_shape() {
+        // Create a simple 1x1 conv with identity BN
+        let channels = 4;
+        let weight = MxArray::from_float32(
+            &vec![0.1; (channels * channels) as usize],
+            &[channels as i64, 1, 1, channels as i64],
+        )
+        .unwrap();
+        let bn_weight = MxArray::ones(&[channels as i64], None).unwrap();
+        let bn_bias = MxArray::zeros(&[channels as i64], None).unwrap();
+        let bn_mean = MxArray::zeros(&[channels as i64], None).unwrap();
+        let bn_var = MxArray::ones(&[channels as i64], None).unwrap();
+
+        let conv = NativeConv2d::new(&weight, None, (1, 1), (0, 0), (1, 1), 1);
+        let norm = FrozenBatchNorm2d::new(&bn_weight, &bn_bias, &bn_mean, &bn_var, 1e-5);
+        let layer = ConvNormLayer::new(conv, norm, Some("relu"));
+
+        let input = MxArray::from_float32(
+            &vec![1.0; (4 * 4 * channels) as usize],
+            &[1, 4, 4, channels as i64],
+        )
+        .unwrap();
+
+        let output = layer.forward(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 4, 4, channels as i64]);
+    }
+}

--- a/crates/mlx-core/src/models/pp_doclayout_v3/encoder.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/encoder.rs
@@ -401,10 +401,10 @@ impl EncoderLayer {
         };
 
         // FFN block
+        let residual = x.clone();
         if self.normalize_before {
             x = self.final_layer_norm.forward(&x)?;
         }
-        let residual = x.clone();
 
         x = self.fc1.forward(&x)?;
         x = super::apply_activation(&x, &self.activation)?;

--- a/crates/mlx-core/src/models/pp_doclayout_v3/heads.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/heads.rs
@@ -1,0 +1,271 @@
+//! PP-DocLayoutV3 Prediction Heads
+//!
+//! Detection, classification, mask, and reading order heads for the PP-DocLayoutV3 model.
+//! Ported from the HuggingFace Transformers implementation.
+//!
+//! Components:
+//! - **MLPPredictionHead**: Stack of Linear + ReLU layers (used for bbox_embed and mask_query_head)
+//! - **GlobalPointer**: Reading order prediction via bilinear attention between queries
+//!
+//! Reference: modeling_pp_doclayout_v3.py (PPDocLayoutV3MLPPredictionHead, PPDocLayoutV3GlobalPointer)
+
+use crate::array::MxArray;
+use crate::nn::activations::Activations;
+use crate::nn::linear::Linear;
+use napi::Either;
+use napi::bindgen_prelude::*;
+
+// ============================================================================
+// MLP Prediction Head
+// ============================================================================
+
+/// Multi-layer perceptron prediction head.
+///
+/// Used for:
+/// - `bbox_embed`: Linear(256→256→4), 3 layers with ReLU between
+/// - `mask_query_head`: Linear(256→256→32), 3 layers with ReLU between
+///
+/// Architecture: Linear → ReLU → Linear → ReLU → ... → Linear (no activation on last)
+///
+/// Corresponds to PPDocLayoutV3MLPPredictionHead in the reference implementation.
+pub struct MLPPredictionHead {
+    /// Stack of linear layers
+    layers: Vec<Linear>,
+    /// Total number of layers (ReLU applied to all but last)
+    num_layers: usize,
+}
+
+impl MLPPredictionHead {
+    /// Create a new MLPPredictionHead.
+    ///
+    /// # Arguments
+    /// * `input_dim` - Input dimension
+    /// * `d_model` - Hidden dimension (used for intermediate layers)
+    /// * `output_dim` - Output dimension
+    /// * `num_layers` - Total number of linear layers
+    pub fn new(input_dim: u32, d_model: u32, output_dim: u32, num_layers: usize) -> Result<Self> {
+        // Build layer dimensions: [input_dim] + [d_model] * (num_layers - 1) → [d_model] * (num_layers - 1) + [output_dim]
+        // E.g. for num_layers=3, input=256, hidden=256, output=4:
+        //   layers = [Linear(256,256), Linear(256,256), Linear(256,4)]
+        let mut layers = Vec::with_capacity(num_layers);
+
+        for i in 0..num_layers {
+            let in_dim = if i == 0 { input_dim } else { d_model };
+            let out_dim = if i == num_layers - 1 {
+                output_dim
+            } else {
+                d_model
+            };
+            layers.push(Linear::new(in_dim, out_dim, Some(true))?);
+        }
+
+        Ok(Self { layers, num_layers })
+    }
+
+    /// Create from pre-loaded weights.
+    ///
+    /// # Arguments
+    /// * `layers` - Pre-constructed Linear layers
+    pub fn from_layers(layers: Vec<Linear>) -> Self {
+        let num_layers = layers.len();
+        Self { layers, num_layers }
+    }
+
+    /// Forward pass: Linear → ReLU → Linear → ReLU → ... → Linear
+    ///
+    /// Input: [batch, num_queries, input_dim]
+    /// Output: [batch, num_queries, output_dim]
+    pub fn forward(&self, x: &MxArray) -> Result<MxArray> {
+        let mut hidden = x.clone();
+        for (i, layer) in self.layers.iter().enumerate() {
+            hidden = layer.forward(&hidden)?;
+            // Apply ReLU to all but the last layer
+            if i < self.num_layers - 1 {
+                hidden = Activations::relu(&hidden)?;
+            }
+        }
+        Ok(hidden)
+    }
+}
+
+// ============================================================================
+// Global Pointer (Reading Order Prediction)
+// ============================================================================
+
+/// Reading order prediction head using bilinear attention.
+///
+/// Projects input to query/key pairs, computes scaled dot-product attention
+/// between queries and keys, then masks the lower triangle (self-connections
+/// and backward connections) with -inf.
+///
+/// Architecture:
+/// 1. Linear(d_model, head_size * 2) → split into queries and keys
+/// 2. queries @ keys^T / sqrt(head_size)
+/// 3. Mask lower triangle with -1e4
+///
+/// Output: order logits [batch, num_queries, num_queries]
+/// Upper triangle values represent reading order relationships.
+///
+/// Corresponds to PPDocLayoutV3GlobalPointer in the reference implementation.
+pub struct GlobalPointer {
+    /// Linear projection to query + key space
+    dense: Linear,
+    /// Head size for scaling (default: 64)
+    head_size: i32,
+}
+
+impl GlobalPointer {
+    /// Create a new GlobalPointer.
+    ///
+    /// # Arguments
+    /// * `d_model` - Input dimension (default: 256)
+    /// * `head_size` - Size of each query/key head (default: 64)
+    pub fn new(d_model: u32, head_size: i32) -> Result<Self> {
+        let dense = Linear::new(d_model, (head_size * 2) as u32, Some(true))?;
+        Ok(Self { dense, head_size })
+    }
+
+    /// Create from pre-loaded weights.
+    pub fn from_weights(dense: Linear, head_size: i32) -> Self {
+        Self { dense, head_size }
+    }
+
+    /// Forward pass: compute reading order logits.
+    ///
+    /// Input: [batch, num_queries, d_model]
+    /// Output: [batch, num_queries, num_queries]
+    ///
+    /// The output represents reading order relationships:
+    /// - logits[b, i, j] > 0 means query i comes before query j
+    /// - Lower triangle is masked with -1e4 (only upper triangle is meaningful)
+    pub fn forward(&self, inputs: &MxArray) -> Result<MxArray> {
+        let shape = inputs.shape()?;
+        let shape: Vec<i64> = shape.as_ref().to_vec();
+        let batch_size = shape[0];
+        let seq_len = shape[1];
+
+        // Project to query + key space: [B, S, 2 * head_size]
+        let qk_proj = self.dense.forward(inputs)?;
+
+        // Reshape to [B, S, 2, head_size]
+        let qk_proj = qk_proj.reshape(&[batch_size, seq_len, 2, self.head_size as i64])?;
+
+        // Split into queries [B, S, head_size] and keys [B, S, head_size]
+        // queries = qk_proj[:, :, 0, :]
+        let queries = qk_proj.slice(
+            &[0, 0, 0, 0],
+            &[batch_size, seq_len, 1, self.head_size as i64],
+        )?;
+        let queries = queries.squeeze(Some(&[2]))?;
+
+        // keys = qk_proj[:, :, 1, :]
+        let keys = qk_proj.slice(
+            &[0, 0, 1, 0],
+            &[batch_size, seq_len, 2, self.head_size as i64],
+        )?;
+        let keys = keys.squeeze(Some(&[2]))?;
+
+        // Compute attention: queries @ keys^T / sqrt(head_size)
+        // queries: [B, S, head_size], keys: [B, S, head_size]
+        // keys^T: [B, head_size, S]
+        let keys_t = keys.transpose(Some(&[0, 2, 1]))?;
+        let scale = (self.head_size as f64).sqrt();
+        let logits = queries.matmul(&keys_t)?;
+        let logits = logits.div_scalar(scale)?;
+
+        // Create lower-triangular mask and fill with -1e4
+        // tril mask: True where row >= col (lower triangle + diagonal)
+        // In PyTorch: mask = torch.tril(torch.ones(S, S)).bool()
+        //             logits = logits.masked_fill(mask.unsqueeze(0), -1e4)
+        //
+        // We create this using arange comparisons:
+        // row_idx >= col_idx → lower triangle (True)
+        let row_idx = MxArray::arange(0.0, seq_len as f64, Some(1.0), None)?;
+        let row_idx = row_idx.reshape(&[seq_len, 1])?;
+        let col_idx = MxArray::arange(0.0, seq_len as f64, Some(1.0), None)?;
+        let col_idx = col_idx.reshape(&[1, seq_len])?;
+
+        // mask[i,j] = True where i >= j (lower triangle including diagonal)
+        let mask = row_idx.greater_equal(&col_idx)?;
+
+        // Expand mask to [1, S, S] for broadcasting with [B, S, S]
+        let mask = mask.expand_dims(0)?;
+
+        // Fill masked positions with -1e4
+        let neg_inf = MxArray::full(&[1, seq_len, seq_len], Either::A(-1e4), None)?;
+        let logits = mask.where_(&neg_inf, &logits)?;
+
+        Ok(logits)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mlp_prediction_head_shapes() {
+        // bbox_embed: 256 → 256 → 4 (3 layers)
+        let head = MLPPredictionHead::new(256, 256, 4, 3).unwrap();
+        let input = MxArray::random_uniform(&[1, 300, 256], -1.0, 1.0, None).unwrap();
+        let output = head.forward(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 300, 4]);
+    }
+
+    #[test]
+    fn test_mlp_prediction_head_mask() {
+        // mask_query_head: 256 → 256 → 32 (3 layers)
+        let head = MLPPredictionHead::new(256, 256, 32, 3).unwrap();
+        let input = MxArray::random_uniform(&[1, 300, 256], -1.0, 1.0, None).unwrap();
+        let output = head.forward(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 300, 32]);
+    }
+
+    #[test]
+    fn test_mlp_prediction_head_2_layers() {
+        // query_pos_head: 4 → 512 → 256 (2 layers)
+        let head = MLPPredictionHead::new(4, 512, 256, 2).unwrap();
+        let input = MxArray::random_uniform(&[1, 300, 4], -1.0, 1.0, None).unwrap();
+        let output = head.forward(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 300, 256]);
+    }
+
+    #[test]
+    fn test_global_pointer_shapes() {
+        let gp = GlobalPointer::new(256, 64).unwrap();
+        let input = MxArray::random_uniform(&[1, 300, 256], -1.0, 1.0, None).unwrap();
+        let output = gp.forward(&input).unwrap();
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 300, 300]);
+    }
+
+    #[test]
+    fn test_global_pointer_masking() {
+        let gp = GlobalPointer::new(8, 4).unwrap();
+        // Small example: batch=1, 4 queries, d_model=8
+        let input = MxArray::random_uniform(&[1, 4, 8], -1.0, 1.0, None).unwrap();
+        let output = gp.forward(&input).unwrap();
+        output.eval();
+
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 4, 4]);
+
+        // Check that lower triangle is masked to -1e4
+        let data = output.to_float32().unwrap();
+        let data: Vec<f32> = data.to_vec();
+
+        // Lower triangle + diagonal should be -1e4
+        // Position (0,0) = -1e4 (diagonal)
+        assert!((data[0] - (-1e4)).abs() < 1.0);
+        // Position (1,0) = -1e4 (below diagonal)
+        assert!((data[4] - (-1e4)).abs() < 1.0);
+        // Position (1,1) = -1e4 (diagonal)
+        assert!((data[5] - (-1e4)).abs() < 1.0);
+
+        // Position (0,1) should NOT be -1e4 (upper triangle)
+        assert!((data[1] - (-1e4)).abs() > 1.0);
+    }
+}

--- a/crates/mlx-core/src/models/pp_doclayout_v3/heads.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/heads.rs
@@ -121,6 +121,12 @@ impl GlobalPointer {
     /// * `d_model` - Input dimension (default: 256)
     /// * `head_size` - Size of each query/key head (default: 64)
     pub fn new(d_model: u32, head_size: i32) -> Result<Self> {
+        if head_size <= 0 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("head_size must be positive, got {head_size}"),
+            ));
+        }
         let dense = Linear::new(d_model, (head_size * 2) as u32, Some(true))?;
         Ok(Self { dense, head_size })
     }

--- a/crates/mlx-core/src/models/pp_doclayout_v3/mod.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/mod.rs
@@ -1,0 +1,32 @@
+//! PP-DocLayoutV3 Model
+//!
+//! Document layout analysis model based on RT-DETR architecture with HGNetV2 backbone.
+//! Ported from the HuggingFace Transformers implementation.
+
+use crate::array::MxArray;
+use crate::nn::activations::Activations;
+use napi::bindgen_prelude::*;
+
+pub mod backbone;
+pub mod config;
+pub mod decoder;
+pub mod encoder;
+pub mod heads;
+pub mod model;
+pub mod persistence;
+pub mod postprocessing;
+pub mod processing;
+
+/// Apply activation function by name.
+pub fn apply_activation(input: &MxArray, activation: &str) -> Result<MxArray> {
+    match activation {
+        "relu" => Activations::relu(input),
+        "silu" | "swish" => Activations::silu(input),
+        "gelu" => Activations::gelu(input),
+        "none" | "identity" => Ok(input.clone()),
+        _ => Err(Error::new(
+            Status::InvalidArg,
+            format!("Unsupported activation: {activation}"),
+        )),
+    }
+}

--- a/crates/mlx-core/src/models/pp_doclayout_v3/model.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/model.rs
@@ -1,0 +1,422 @@
+//! PP-DocLayoutV3 Full Model
+//!
+//! Top-level model combining backbone, encoder, decoder, and heads.
+//! Provides the NAPI `DocLayoutModel` class with `load()` and `detect()` methods.
+//!
+//! Architecture (inference path):
+//! 1. Image preprocessing: resize to 800x800, rescale to [0,1]
+//! 2. Backbone (HGNetV2-L): extract 4 feature maps at strides 4, 8, 16, 32
+//! 3. Encoder input projection: project 3 feature maps (strides 8, 16, 32) to hidden_dim
+//! 4. Hybrid Encoder: AIFI transformer + FPN + PAN + mask feature head
+//! 5. Decoder input projection: project PAN features
+//! 6. Generate anchors + select top-K queries from encoder output
+//! 7. Mask-enhanced reference point refinement
+//! 8. Decoder: iterative bbox refinement + class prediction + reading order
+//! 9. Post-processing: score thresholding + box decoding + reading order
+
+use crate::array::MxArray;
+use crate::nn::linear::Linear;
+use crate::nn::normalization::LayerNorm;
+use napi::Either;
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+use super::backbone::HGNetV2Backbone;
+use super::config::PPDocLayoutV3Config;
+use super::decoder::{Decoder, inverse_sigmoid, mask_to_box_coordinate};
+use super::encoder::{HybridEncoder, InputProjection};
+use super::heads::{GlobalPointer, MLPPredictionHead};
+use super::postprocessing::{LayoutElement, postprocess_detection};
+use super::processing::PPDocLayoutV3ImageProcessor;
+
+/// PP-DocLayoutV3 full model for document layout analysis.
+///
+/// Combines HGNetV2 backbone, hybrid encoder, and RT-DETR decoder
+/// with mask-enhanced attention and reading order prediction.
+///
+/// Weights must be downloaded from `PaddlePaddle/PP-DocLayoutV3_safetensors` on HuggingFace.
+/// The regular `PaddlePaddle/PP-DocLayoutV3` repo uses PaddlePaddle format and is not compatible.
+#[napi(js_name = "DocLayoutModel")]
+pub struct PPDocLayoutV3Model {
+    config: PPDocLayoutV3Config,
+    backbone: HGNetV2Backbone,
+    encoder_input_proj: Vec<InputProjection>,
+    encoder: HybridEncoder,
+    enc_output_linear: Linear,
+    enc_output_norm: LayerNorm,
+    enc_score_head: Linear,
+    enc_bbox_head: MLPPredictionHead,
+    decoder_input_proj: Vec<InputProjection>,
+    decoder: Decoder,
+    decoder_order_head: Vec<Linear>,
+    decoder_global_pointer: GlobalPointer,
+    decoder_norm: LayerNorm,
+    mask_query_head: MLPPredictionHead,
+    _denoising_class_embed: Option<MxArray>,
+    image_processor: PPDocLayoutV3ImageProcessor,
+}
+
+/// Generate anchor points for all feature levels.
+///
+/// For each level with the given spatial shapes, generates a grid of anchor
+/// points in normalized coordinates with associated width/height.
+///
+/// # Arguments
+/// * `spatial_shapes_list` - Vec of (height, width) for each feature level
+/// * `grid_size` - Base grid size (default 0.05)
+///
+/// # Returns
+/// * `(anchors, valid_mask)` where:
+///   - anchors: [1, total_tokens, 4] in inverse_sigmoid space
+///   - valid_mask: [1, total_tokens, 1] boolean mask for valid anchors
+fn generate_anchors(
+    spatial_shapes_list: &[(i64, i64)],
+    grid_size: f64,
+) -> Result<(MxArray, MxArray)> {
+    let mut all_anchors: Vec<MxArray> = Vec::new();
+
+    for (level, &(height, width)) in spatial_shapes_list.iter().enumerate() {
+        // Create grid
+        let grid_y = MxArray::arange(0.0, height as f64, Some(1.0), None)?;
+        let grid_x = MxArray::arange(0.0, width as f64, Some(1.0), None)?;
+
+        // Meshgrid: grid_y varies along rows, grid_x along columns
+        let grid_x_2d = grid_x
+            .reshape(&[1, width])?
+            .broadcast_to(&[height, width])?;
+        let grid_y_2d = grid_y
+            .reshape(&[height, 1])?
+            .broadcast_to(&[height, width])?;
+
+        // Stack [grid_x, grid_y] and add 0.5, normalize
+        let grid_x_norm = grid_x_2d.add_scalar(0.5)?.div_scalar(width as f64)?;
+        let grid_y_norm = grid_y_2d.add_scalar(0.5)?.div_scalar(height as f64)?;
+
+        // Stack to [height, width, 2]
+        let grid_xy = MxArray::stack(vec![&grid_x_norm, &grid_y_norm], Some(-1))?;
+
+        // Width/height: ones * grid_size * 2^level
+        let wh_val = grid_size * (2.0f64).powi(level as i32);
+        let wh = MxArray::full(&[height, width, 2], Either::A(wh_val), None)?;
+
+        // Concatenate [grid_xy, wh] → [height, width, 4]
+        let anchors_level = MxArray::concatenate(&grid_xy, &wh, 2)?;
+
+        // Reshape to [1, height*width, 4]
+        let anchors_flat = anchors_level.reshape(&[1, height * width, 4])?;
+        all_anchors.push(anchors_flat);
+    }
+
+    // Concatenate all levels: [1, total_tokens, 4]
+    let anchor_refs: Vec<&MxArray> = all_anchors.iter().collect();
+    let anchors = MxArray::concatenate_many(anchor_refs, Some(1))?;
+
+    // Valid mask: all coordinates in (eps, 1-eps)
+    let eps = 1e-2;
+    let eps_arr = MxArray::from_float32(&[eps as f32], &[1])?;
+    let one_minus_eps_arr = MxArray::from_float32(&[(1.0 - eps) as f32], &[1])?;
+    let above_eps = anchors.greater(&eps_arr)?;
+    let below_1_eps = anchors.less(&one_minus_eps_arr)?;
+    let valid_per_coord = above_eps.logical_and(&below_1_eps)?;
+
+    // All 4 coordinates must be valid: reduce along last dim
+    // min along axis -1 for boolean (all true → true)
+    let valid_mask = valid_per_coord.min(Some(&[-1]), Some(true))?;
+
+    // Apply inverse sigmoid to anchors
+    let anchors_clamped = anchors.clip(Some(eps), Some(1.0 - eps))?;
+    let inv_anchors = inverse_sigmoid(&anchors_clamped, eps)?;
+
+    // Where invalid, fill with large value
+    let large_val = MxArray::full(&[1], Either::A(f32::MAX as f64 * 0.5), None)?;
+    let inv_anchors = valid_mask.where_(&inv_anchors, &large_val)?;
+
+    Ok((inv_anchors, valid_mask))
+}
+
+#[napi]
+impl PPDocLayoutV3Model {
+    /// Load a PP-DocLayoutV3 model from a directory containing `config.json` and `model.safetensors`.
+    ///
+    /// The model directory should be cloned from `PaddlePaddle/PP-DocLayoutV3_safetensors` on HuggingFace.
+    ///
+    /// # Arguments
+    /// * `model_path` - Path to model directory
+    ///
+    /// # Returns
+    /// * Initialized DocLayoutModel ready for inference
+    #[napi(factory)]
+    pub fn load(model_path: String) -> Result<Self> {
+        super::persistence::load_model(&model_path)
+    }
+
+    /// Detect document layout elements in an image.
+    ///
+    /// # Arguments
+    /// * `image_path` - Path to the input image
+    /// * `threshold` - Optional confidence threshold (default 0.5)
+    ///
+    /// # Returns
+    /// * Vec of LayoutElements sorted by reading order
+    #[napi]
+    pub fn detect(&self, image_path: String, threshold: Option<f64>) -> Result<Vec<LayoutElement>> {
+        let threshold = threshold.unwrap_or(0.5);
+
+        // 1. Preprocess image
+        let (pixel_values, orig_h, orig_w) = self.image_processor.process_file(&image_path)?;
+
+        // 2. Run backbone
+        let features = self.backbone.forward(&pixel_values)?;
+        // features: [stage1(H/4), stage2(H/8), stage3(H/16), stage4(H/32)]
+
+        // 3. Extract x4_feat (stride-4 feature) and remaining features
+        let x4_feat = &features[0]; // stage1: [B, H/4, W/4, 128]
+        let encoder_features = &features[1..]; // stage2, stage3, stage4
+
+        // 4. Apply encoder input projections
+        let mut proj_feats: Vec<MxArray> = Vec::with_capacity(encoder_features.len());
+        for (level, feat) in encoder_features.iter().enumerate() {
+            let projected = self.encoder_input_proj[level].forward(feat)?;
+            proj_feats.push(projected);
+        }
+
+        // 5. Run hybrid encoder
+        let (pan_features, mask_feat) = self.encoder.forward(&mut proj_feats, x4_feat)?;
+
+        // 6. Apply decoder input projections and flatten
+        let mut source_flatten_parts: Vec<MxArray> = Vec::new();
+        let mut spatial_shapes_list: Vec<(i64, i64)> = Vec::new();
+
+        for (level, pan_feat) in pan_features.iter().enumerate() {
+            let projected = self.decoder_input_proj[level].forward(pan_feat)?;
+            let proj_shape = projected.shape()?;
+            let proj_shape: Vec<i64> = proj_shape.as_ref().to_vec();
+            let batch = proj_shape[0];
+            let h = proj_shape[1];
+            let w = proj_shape[2];
+            let c = proj_shape[3];
+
+            spatial_shapes_list.push((h, w));
+
+            // Flatten spatial dims: [B, H, W, C] → [B, H*W, C]
+            let flat = projected.reshape(&[batch, h * w, c])?;
+            source_flatten_parts.push(flat);
+        }
+
+        let flat_refs: Vec<&MxArray> = source_flatten_parts.iter().collect();
+        let source_flatten = MxArray::concatenate_many(flat_refs, Some(1))?;
+
+        // Compute spatial_shapes tensor [num_levels, 2]
+        let num_levels = spatial_shapes_list.len();
+        let mut shapes_data: Vec<f32> = Vec::with_capacity(num_levels * 2);
+        for &(h, w) in &spatial_shapes_list {
+            shapes_data.push(h as f32);
+            shapes_data.push(w as f32);
+        }
+        let spatial_shapes = MxArray::from_float32(&shapes_data, &[num_levels as i64, 2])?;
+
+        // Compute level_start_index
+        let mut start_indices: Vec<f32> = Vec::with_capacity(num_levels);
+        let mut cumsum: f32 = 0.0;
+        for &(h, w) in &spatial_shapes_list {
+            start_indices.push(cumsum);
+            cumsum += (h * w) as f32;
+        }
+        let level_start_index = MxArray::from_float32(&start_indices, &[num_levels as i64])?;
+
+        // 7. Generate anchors
+        let (anchors, valid_mask) = generate_anchors(&spatial_shapes_list, 0.05)?;
+
+        // 8. Apply valid mask and compute encoder output
+        let valid_mask_float = valid_mask.astype(crate::array::DType::Float32)?;
+        let memory = valid_mask_float.mul(&source_flatten)?;
+
+        // enc_output = enc_output_norm(enc_output_linear(memory))
+        let output_memory = self.enc_output_linear.forward(&memory)?;
+        let output_memory = self.enc_output_norm.forward(&output_memory)?;
+
+        // 9. Score and bbox prediction
+        let enc_outputs_class = self.enc_score_head.forward(&output_memory)?;
+        let enc_outputs_coord = self.enc_bbox_head.forward(&output_memory)?;
+        let enc_outputs_coord = enc_outputs_coord.add(&anchors)?;
+
+        // 10. Top-K query selection
+        let num_queries = self.config.num_queries as i64;
+
+        // enc_outputs_class.max(-1) → [B, total_tokens]
+        let class_max = enc_outputs_class.max(Some(&[-1]), Some(false))?;
+
+        // Argsort descending along dim 1 to get top-k indices
+        let neg_class_max = class_max.negative()?;
+        let sorted_indices = neg_class_max.argsort(Some(1))?;
+
+        // Take first num_queries indices
+        let sf_shape = source_flatten.shape()?;
+        let batch_size = sf_shape[0];
+
+        let topk_indices = sorted_indices.slice(&[0, 0], &[batch_size, num_queries])?;
+
+        // Gather reference points and target queries
+        let d_model = self.config.d_model as i64;
+        let num_labels = self.config.num_labels as i64;
+
+        // Expand topk_indices for gathering: [B, num_queries] → [B, num_queries, 4]
+        let topk_idx_box = topk_indices
+            .expand_dims(2)?
+            .broadcast_to(&[batch_size, num_queries, 4])?
+            .astype(crate::array::DType::Int32)?;
+        let reference_points_unact = enc_outputs_coord.take_along_axis(&topk_idx_box, 1)?;
+
+        // Gather target queries from output_memory
+        let topk_idx_emb = topk_indices
+            .expand_dims(2)?
+            .broadcast_to(&[batch_size, num_queries, d_model])?
+            .astype(crate::array::DType::Int32)?;
+        let target = output_memory.take_along_axis(&topk_idx_emb, 1)?;
+
+        // 11. Mask-enhanced reference points (if enabled)
+        let reference_points_unact = if self.config.mask_enhanced {
+            // Compute encoder output masks from the selected queries
+            let out_query = self.decoder_norm.forward(&target)?;
+            let mask_query_embed = self.mask_query_head.forward(&out_query)?;
+
+            // mask_feat needs to be in NCHW for bmm: [B, H, W, C] → [B, C, H, W]
+            let mask_feat_nchw = mask_feat.transpose(Some(&[0, 3, 1, 2]))?;
+            let mf_shape = mask_feat_nchw.shape()?;
+            let mf_shape: Vec<i64> = mf_shape.as_ref().to_vec();
+            let mask_h = mf_shape[2];
+            let mask_w = mf_shape[3];
+            let num_proto = mf_shape[1];
+
+            // Flatten mask_feat spatial dims: [B, num_proto, H*W]
+            let mask_feat_flat =
+                mask_feat_nchw.reshape(&[batch_size, num_proto, mask_h * mask_w])?;
+
+            // bmm: [B, num_queries, num_proto] @ [B, num_proto, H*W] → [B, num_queries, H*W]
+            let enc_out_masks = mask_query_embed.matmul(&mask_feat_flat)?;
+            let enc_out_masks =
+                enc_out_masks.reshape(&[batch_size, num_queries, mask_h, mask_w])?;
+
+            // mask_to_box_coordinate(enc_out_masks > 0)
+            let zero = MxArray::from_float32(&[0.0], &[1])?;
+            let mask_bool = enc_out_masks.greater(&zero)?;
+            let reference_points = mask_to_box_coordinate(&mask_bool)?;
+            inverse_sigmoid(&reference_points, 1e-5)?
+        } else {
+            reference_points_unact
+        };
+
+        // 12. Convert mask_feat to NCHW for decoder
+        let mask_feat_nchw = mask_feat.transpose(Some(&[0, 3, 1, 2]))?;
+
+        // 13. Run decoder
+        let decoder_output = self.decoder.forward(
+            &target,
+            &source_flatten,
+            &reference_points_unact,
+            &spatial_shapes,
+            &spatial_shapes_list,
+            &level_start_index,
+            None, // no attention mask at inference
+            &self.decoder_order_head,
+            &self.decoder_global_pointer,
+            &self.mask_query_head,
+            &self.decoder_norm,
+            &mask_feat_nchw,
+        )?;
+
+        // 14. Extract last layer outputs
+        let num_decoder_layers = self.config.decoder_layers as i64;
+
+        // intermediate_logits: [B, num_layers, num_queries, num_labels]
+        // Take last layer: [:, -1, :, :]
+        let logits = decoder_output.intermediate_logits.slice(
+            &[0, num_decoder_layers - 1, 0, 0],
+            &[batch_size, num_decoder_layers, num_queries, num_labels],
+        )?;
+        let logits = logits.squeeze(Some(&[1]))?;
+
+        // intermediate_reference_points: [B, num_layers, num_queries, 4]
+        let pred_boxes = decoder_output.intermediate_reference_points.slice(
+            &[0, num_decoder_layers - 1, 0, 0],
+            &[batch_size, num_decoder_layers, num_queries, 4],
+        )?;
+        let pred_boxes = pred_boxes.squeeze(Some(&[1]))?;
+
+        // decoder_out_order_logits: [B, num_layers, num_queries, num_queries]
+        let order_logits = decoder_output.decoder_out_order_logits.slice(
+            &[0, num_decoder_layers - 1, 0, 0],
+            &[batch_size, num_decoder_layers, num_queries, num_queries],
+        )?;
+        let order_logits = order_logits.squeeze(Some(&[1]))?;
+
+        // 15. Post-process
+        postprocess_detection(
+            &logits,
+            &pred_boxes,
+            &order_logits,
+            orig_h,
+            orig_w,
+            threshold,
+            &self.config.id2label,
+        )
+    }
+}
+
+/// Create an uninitialized PPDocLayoutV3Model (used by persistence).
+///
+/// This is called from persistence.rs after loading all weights.
+pub(super) fn create_model(
+    config: PPDocLayoutV3Config,
+    backbone: HGNetV2Backbone,
+    encoder_input_proj: Vec<InputProjection>,
+    encoder: HybridEncoder,
+    enc_output_linear: Linear,
+    enc_output_norm: LayerNorm,
+    enc_score_head: Linear,
+    enc_bbox_head: MLPPredictionHead,
+    decoder_input_proj: Vec<InputProjection>,
+    decoder: Decoder,
+    decoder_order_head: Vec<Linear>,
+    decoder_global_pointer: GlobalPointer,
+    decoder_norm: LayerNorm,
+    mask_query_head: MLPPredictionHead,
+    denoising_class_embed: Option<MxArray>,
+) -> PPDocLayoutV3Model {
+    PPDocLayoutV3Model {
+        config,
+        backbone,
+        encoder_input_proj,
+        encoder,
+        enc_output_linear,
+        enc_output_norm,
+        enc_score_head,
+        enc_bbox_head,
+        decoder_input_proj,
+        decoder,
+        decoder_order_head,
+        decoder_global_pointer,
+        decoder_norm,
+        mask_query_head,
+        _denoising_class_embed: denoising_class_embed,
+        image_processor: PPDocLayoutV3ImageProcessor::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_anchors() {
+        let shapes = vec![(100, 100), (50, 50), (25, 25)];
+        let (anchors, valid_mask) = generate_anchors(&shapes, 0.05).unwrap();
+
+        let a_shape: Vec<i64> = anchors.shape().unwrap().as_ref().to_vec();
+        let total = 100 * 100 + 50 * 50 + 25 * 25;
+        assert_eq!(a_shape, vec![1, total, 4]);
+
+        let v_shape: Vec<i64> = valid_mask.shape().unwrap().as_ref().to_vec();
+        assert_eq!(v_shape, vec![1, total, 1]);
+    }
+}

--- a/crates/mlx-core/src/models/pp_doclayout_v3/persistence.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/persistence.rs
@@ -1,0 +1,1041 @@
+//! PP-DocLayoutV3 Weight Loading
+//!
+//! SafeTensors weight loading for the PP-DocLayoutV3 model.
+//! Handles key mapping from HuggingFace naming conventions and
+//! Conv2d weight transposition from PyTorch [O,I,kH,kW] to MLX [O,kH,kW,I].
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::nn::linear::Linear;
+use crate::nn::normalization::LayerNorm;
+use crate::utils::safetensors::SafeTensorsFile;
+
+use super::backbone::{
+    ConvBNAct, ConvBNActLight, FrozenBatchNorm2d, HGBlock, HGBlockLayer, HGNetV2Backbone,
+    HGNetV2Embeddings, HGNetV2Encoder, HGNetV2Stage, LearnableAffineBlock, NativeConv2d,
+};
+use super::config::PPDocLayoutV3Config;
+use super::decoder::{Decoder, DecoderLayer, MultiscaleDeformableAttention, SelfAttention};
+use super::encoder::{
+    CSPRepLayer, ConvLayer, ConvNormLayer, Encoder, EncoderLayer, EncoderMaskOutput, HybridEncoder,
+    InputProjection, MaskFeatFPN, MultiheadAttention, RepVggBlock, ScaleHead, ScaleHeadLayer,
+};
+use super::heads::{GlobalPointer, MLPPredictionHead};
+use super::model::{PPDocLayoutV3Model, create_model};
+
+// ============================================================================
+// Helper functions
+// ============================================================================
+
+/// Get a tensor from the param map, stripping the "model." prefix if present.
+pub(crate) fn get_tensor(params: &HashMap<String, MxArray>, key: &str) -> Result<MxArray> {
+    params
+        .get(key)
+        .cloned()
+        .ok_or_else(|| Error::from_reason(format!("Missing weight: {}", key)))
+}
+
+/// Transpose a Conv2d weight from PyTorch [O, I, kH, kW] to MLX [O, kH, kW, I].
+pub(crate) fn transpose_conv_weight(weight: &MxArray) -> Result<MxArray> {
+    weight.transpose(Some(&[0, 2, 3, 1]))
+}
+
+/// Load a FrozenBatchNorm2d from parameters.
+pub(crate) fn load_frozen_bn(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    eps: f64,
+) -> Result<FrozenBatchNorm2d> {
+    let weight = get_tensor(params, &format!("{}.weight", prefix))?;
+    let bias = get_tensor(params, &format!("{}.bias", prefix))?;
+    let running_mean = get_tensor(params, &format!("{}.running_mean", prefix))?;
+    let running_var = get_tensor(params, &format!("{}.running_var", prefix))?;
+    Ok(FrozenBatchNorm2d::new(
+        &weight,
+        &bias,
+        &running_mean,
+        &running_var,
+        eps,
+    ))
+}
+
+/// Load a NativeConv2d from parameters (transposing weights from OIHW to OHWI).
+pub(crate) fn load_conv2d(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    stride: (i32, i32),
+    padding: (i32, i32),
+    dilation: (i32, i32),
+    groups: i32,
+    has_bias: bool,
+) -> Result<NativeConv2d> {
+    let weight_raw = get_tensor(params, &format!("{}.weight", prefix))?;
+    let weight = transpose_conv_weight(&weight_raw)?;
+    let bias = if has_bias {
+        Some(get_tensor(params, &format!("{}.bias", prefix))?)
+    } else {
+        None
+    };
+    Ok(NativeConv2d::new(
+        &weight,
+        bias.as_ref(),
+        stride,
+        padding,
+        dilation,
+        groups,
+    ))
+}
+
+/// Load a Linear layer from parameters.
+pub(crate) fn load_linear(params: &HashMap<String, MxArray>, prefix: &str) -> Result<Linear> {
+    let weight = get_tensor(params, &format!("{}.weight", prefix))?;
+    let bias = params.get(&format!("{}.bias", prefix));
+    Linear::from_weights(&weight, bias)
+}
+
+/// Load a LayerNorm from parameters.
+pub(crate) fn load_layer_norm(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    eps: f64,
+) -> Result<LayerNorm> {
+    let weight = get_tensor(params, &format!("{}.weight", prefix))?;
+    let bias = params.get(&format!("{}.bias", prefix));
+    LayerNorm::from_weights(&weight, bias, Some(eps))
+}
+
+/// Load a ConvBNAct (Conv + BN + Activation) from the backbone.
+pub(crate) fn load_conv_bn_act(
+    params: &HashMap<String, MxArray>,
+    conv_prefix: &str,
+    bn_prefix: &str,
+    activation: &str,
+    stride: (i32, i32),
+    padding: (i32, i32),
+    groups: i32,
+    eps: f64,
+    lab_prefix: Option<&str>,
+) -> Result<ConvBNAct> {
+    let conv = load_conv2d(params, conv_prefix, stride, padding, (1, 1), groups, false)?;
+    let norm = load_frozen_bn(params, bn_prefix, eps)?;
+    let lab = if let Some(lp) = lab_prefix {
+        let scale = get_tensor(params, &format!("{}.scale", lp))?;
+        let bias = get_tensor(params, &format!("{}.bias", lp))?;
+        Some(LearnableAffineBlock::new(&scale, &bias))
+    } else {
+        None
+    };
+    Ok(ConvBNAct::new(conv, norm, activation, lab))
+}
+
+/// Load an InputProjection (1x1 Conv + BN) from parameters.
+fn load_input_projection(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    eps: f64,
+) -> Result<InputProjection> {
+    let conv = load_conv2d(
+        params,
+        &format!("{}.0", prefix),
+        (1, 1),
+        (0, 0),
+        (1, 1),
+        1,
+        false,
+    )?;
+    let norm = load_frozen_bn(params, &format!("{}.1", prefix), eps)?;
+    Ok(InputProjection::new(conv, norm))
+}
+
+/// Load a ConvNormLayer from parameters.
+pub(crate) fn load_conv_norm_layer(
+    params: &HashMap<String, MxArray>,
+    conv_prefix: &str,
+    bn_prefix: &str,
+    activation: Option<&str>,
+    stride: (i32, i32),
+    padding: (i32, i32),
+    groups: i32,
+    eps: f64,
+) -> Result<ConvNormLayer> {
+    let conv = load_conv2d(params, conv_prefix, stride, padding, (1, 1), groups, false)?;
+    let norm = load_frozen_bn(params, bn_prefix, eps)?;
+    Ok(ConvNormLayer::new(conv, norm, activation))
+}
+
+/// Load a ConvLayer (Conv + BN + Activation, always with activation).
+pub(crate) fn load_conv_layer(
+    params: &HashMap<String, MxArray>,
+    conv_prefix: &str,
+    bn_prefix: &str,
+    activation: &str,
+    stride: (i32, i32),
+    padding: (i32, i32),
+    groups: i32,
+    eps: f64,
+) -> Result<ConvLayer> {
+    let conv = load_conv2d(params, conv_prefix, stride, padding, (1, 1), groups, false)?;
+    let norm = load_frozen_bn(params, bn_prefix, eps)?;
+    Ok(ConvLayer::new(conv, norm, activation))
+}
+
+/// Load an MLPPredictionHead from parameters.
+fn load_mlp_head(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    num_layers: usize,
+) -> Result<MLPPredictionHead> {
+    let mut layers = Vec::with_capacity(num_layers);
+    for i in 0..num_layers {
+        let linear = load_linear(params, &format!("{}.layers.{}", prefix, i))?;
+        layers.push(linear);
+    }
+    Ok(MLPPredictionHead::from_layers(layers))
+}
+
+// ============================================================================
+// Backbone Loading
+// ============================================================================
+
+fn load_backbone(
+    params: &HashMap<String, MxArray>,
+    config: &PPDocLayoutV3Config,
+) -> Result<HGNetV2Backbone> {
+    let bc = &config.backbone_config;
+    let eps = config.batch_norm_eps;
+    let act = bc.hidden_act.as_str();
+    let use_lab = bc.use_learnable_affine_block;
+
+    // Load stem (embeddings)
+    // HF hierarchy: backbone.model.embedder.{stem1,stem2a,stem2b,stem3,stem4}
+    // Each stem is an HGNetV2ConvLayer with .convolution, .normalization, .lab
+    let stem_prefix = "backbone.model.embedder";
+
+    let lab0 = format!("{}.stem1.lab", stem_prefix);
+    let stem1 = load_conv_bn_act(
+        params,
+        &format!("{}.stem1.convolution", stem_prefix),
+        &format!("{}.stem1.normalization", stem_prefix),
+        act,
+        (2, 2),
+        (1, 1),
+        1,
+        eps,
+        if use_lab { Some(lab0.as_str()) } else { None },
+    )?;
+
+    let lab1 = format!("{}.stem2a.lab", stem_prefix);
+    let stem2a = load_conv_bn_act(
+        params,
+        &format!("{}.stem2a.convolution", stem_prefix),
+        &format!("{}.stem2a.normalization", stem_prefix),
+        act,
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+        if use_lab { Some(lab1.as_str()) } else { None },
+    )?;
+
+    let lab2 = format!("{}.stem2b.lab", stem_prefix);
+    let stem2b = load_conv_bn_act(
+        params,
+        &format!("{}.stem2b.convolution", stem_prefix),
+        &format!("{}.stem2b.normalization", stem_prefix),
+        act,
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+        if use_lab { Some(lab2.as_str()) } else { None },
+    )?;
+
+    let lab3 = format!("{}.stem3.lab", stem_prefix);
+    let stem3 = load_conv_bn_act(
+        params,
+        &format!("{}.stem3.convolution", stem_prefix),
+        &format!("{}.stem3.normalization", stem_prefix),
+        act,
+        bc.stem3_stride,
+        (1, 1),
+        1,
+        eps,
+        if use_lab { Some(lab3.as_str()) } else { None },
+    )?;
+
+    let lab4 = format!("{}.stem4.lab", stem_prefix);
+    let stem4 = load_conv_bn_act(
+        params,
+        &format!("{}.stem4.convolution", stem_prefix),
+        &format!("{}.stem4.normalization", stem_prefix),
+        act,
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+        if use_lab { Some(lab4.as_str()) } else { None },
+    )?;
+
+    let embedder = HGNetV2Embeddings::new(stem1, stem2a, stem2b, stem3, stem4);
+
+    // Load encoder stages
+    let mut stages = Vec::with_capacity(bc.num_stages());
+
+    for stage_idx in 0..bc.num_stages() {
+        let stage_prefix = format!("backbone.model.encoder.stages.{}", stage_idx);
+        let do_downsample = bc.stage_downsample[stage_idx];
+        let in_channels = bc.stage_in_channels[stage_idx];
+        let out_channels = bc.stage_out_channels[stage_idx];
+        let is_light = bc.stage_light_block[stage_idx];
+        let kernel_size = bc.stage_kernel_size[stage_idx];
+        let num_blocks = bc.stage_num_blocks[stage_idx] as usize;
+        let num_layers_per_block = bc.stage_numb_of_layers[stage_idx] as usize;
+        let mid_channels = bc.stage_mid_channels[stage_idx];
+        let stage_stride = bc.stage_strides.get(stage_idx).copied().unwrap_or((2, 2));
+
+        // Downsample conv (depthwise)
+        let downsample = if do_downsample {
+            let ds = load_conv_bn_act(
+                params,
+                &format!("{}.downsample.convolution", stage_prefix),
+                &format!("{}.downsample.normalization", stage_prefix),
+                "none",
+                stage_stride,
+                (1, 1),
+                in_channels,
+                eps,
+                None,
+            )?;
+            Some(ds)
+        } else {
+            None
+        };
+
+        // Load HGBlocks
+        let mut blocks = Vec::with_capacity(num_blocks);
+
+        for block_idx in 0..num_blocks {
+            let block_prefix = format!("{}.blocks.{}", stage_prefix, block_idx);
+            let is_first_block = block_idx == 0;
+
+            // Determine channels for this block
+            let block_in = if is_first_block {
+                in_channels
+            } else {
+                out_channels
+            };
+
+            // Load conv layers
+            let mut layers: Vec<HGBlockLayer> = Vec::with_capacity(num_layers_per_block);
+            for layer_idx in 0..num_layers_per_block {
+                let layer_prefix = format!("{}.layers.{}", block_prefix, layer_idx);
+                let layer_in = if layer_idx == 0 {
+                    block_in
+                } else {
+                    mid_channels
+                };
+                let kp = (kernel_size / 2, kernel_size / 2); // padding = k // 2
+
+                if is_light {
+                    // Light block: conv1 (1x1 pointwise, no activation) + conv2 (kxk depthwise)
+                    // HF: HGNetV2ConvLayerLight -> self.conv1 = HGNetV2ConvLayer, self.conv2 = HGNetV2ConvLayer
+                    // HGNetV2ConvLayer uses .convolution and .normalization
+                    let conv1 = load_conv_bn_act(
+                        params,
+                        &format!("{}.conv1.convolution", layer_prefix),
+                        &format!("{}.conv1.normalization", layer_prefix),
+                        "none",
+                        (1, 1),
+                        (0, 0),
+                        1,
+                        eps,
+                        None,
+                    )?;
+                    let conv2_lab = format!("{}.conv2.lab", layer_prefix);
+                    let conv2 = load_conv_bn_act(
+                        params,
+                        &format!("{}.conv2.convolution", layer_prefix),
+                        &format!("{}.conv2.normalization", layer_prefix),
+                        act,
+                        (1, 1),
+                        kp,
+                        mid_channels,
+                        eps,
+                        if use_lab {
+                            Some(conv2_lab.as_str())
+                        } else {
+                            None
+                        },
+                    )?;
+                    layers.push(HGBlockLayer::Light(ConvBNActLight::new(conv1, conv2)));
+                } else {
+                    // Standard conv
+                    // HF: HGNetV2ConvLayer uses .convolution and .normalization
+                    let _ = layer_in; // channels handled by the loaded weights
+                    let std_lab = format!("{}.lab", layer_prefix);
+                    let conv = load_conv_bn_act(
+                        params,
+                        &format!("{}.convolution", layer_prefix),
+                        &format!("{}.normalization", layer_prefix),
+                        act,
+                        (1, 1),
+                        kp,
+                        1,
+                        eps,
+                        if use_lab {
+                            Some(std_lab.as_str())
+                        } else {
+                            None
+                        },
+                    )?;
+                    layers.push(HGBlockLayer::Standard(conv));
+                }
+            }
+
+            // Aggregation: squeeze + excitation
+            // HF: self.aggregation = nn.Sequential(squeeze_conv, excitation_conv)
+            // Each is HGNetV2ConvLayer with .convolution, .normalization, .lab
+            let agg_prefix = format!("{}.aggregation", block_prefix);
+            let agg_lab0 = format!("{}.0.lab", agg_prefix);
+            let agg_squeeze = load_conv_bn_act(
+                params,
+                &format!("{}.0.convolution", agg_prefix),
+                &format!("{}.0.normalization", agg_prefix),
+                act,
+                (1, 1),
+                (0, 0),
+                1,
+                eps,
+                if use_lab {
+                    Some(agg_lab0.as_str())
+                } else {
+                    None
+                },
+            )?;
+            let agg_lab1 = format!("{}.1.lab", agg_prefix);
+            let agg_excitation = load_conv_bn_act(
+                params,
+                &format!("{}.1.convolution", agg_prefix),
+                &format!("{}.1.normalization", agg_prefix),
+                act,
+                (1, 1),
+                (0, 0),
+                1,
+                eps,
+                if use_lab {
+                    Some(agg_lab1.as_str())
+                } else {
+                    None
+                },
+            )?;
+
+            let residual = !is_first_block;
+            blocks.push(HGBlock::new(layers, agg_squeeze, agg_excitation, residual));
+        }
+
+        stages.push(HGNetV2Stage::new(downsample, blocks));
+    }
+
+    let encoder = HGNetV2Encoder::new(stages);
+    Ok(HGNetV2Backbone::new(embedder, encoder, bc))
+}
+
+// ============================================================================
+// Encoder Loading
+// ============================================================================
+
+fn load_hybrid_encoder(
+    params: &HashMap<String, MxArray>,
+    config: &PPDocLayoutV3Config,
+) -> Result<HybridEncoder> {
+    let eps = config.batch_norm_eps;
+    let ln_eps = config.layer_norm_eps;
+    let _hidden_dim = config.encoder_hidden_dim;
+    let act_fn = config.activation_function.as_str();
+    let enc_act = config.encoder_activation_function.as_str();
+
+    // Load transformer encoder(s)
+    // HF: self.aifi = nn.ModuleList([PPDocLayoutV3AIFILayer(...)])
+    // PPDocLayoutV3AIFILayer has self.layers = nn.ModuleList([PPDocLayoutV3EncoderLayer(...)])
+    let mut encoders = Vec::new();
+    for _enc_idx in 0..config.encode_proj_layers.len() {
+        // Each encoder has config.encoder_layers layers
+        let mut enc_layers = Vec::new();
+        for layer_idx in 0..config.encoder_layers {
+            let prefix = format!("encoder.encoder.{}.layers.{}", _enc_idx, layer_idx);
+
+            // Self-attention (PPDocLayoutV3SelfAttention uses q_proj, k_proj, v_proj, o_proj)
+            let q_proj = load_linear(params, &format!("{}.self_attn.q_proj", prefix))?;
+            let k_proj = load_linear(params, &format!("{}.self_attn.k_proj", prefix))?;
+            let v_proj = load_linear(params, &format!("{}.self_attn.v_proj", prefix))?;
+            let out_proj = load_linear(params, &format!("{}.self_attn.out_proj", prefix))?;
+            let self_attn = MultiheadAttention::new(
+                q_proj,
+                k_proj,
+                v_proj,
+                out_proj,
+                config.encoder_attention_heads,
+            )?;
+
+            let self_attn_ln =
+                load_layer_norm(params, &format!("{}.self_attn_layer_norm", prefix), ln_eps)?;
+
+            // FFN is inside self.mlp = PPDocLayoutV3MLP which has self.fc1, self.fc2
+            let fc1 = load_linear(params, &format!("{}.fc1", prefix))?;
+            let fc2 = load_linear(params, &format!("{}.fc2", prefix))?;
+
+            let final_ln =
+                load_layer_norm(params, &format!("{}.final_layer_norm", prefix), ln_eps)?;
+
+            enc_layers.push(EncoderLayer::new(
+                self_attn,
+                self_attn_ln,
+                fc1,
+                fc2,
+                final_ln,
+                enc_act,
+                config.normalize_before,
+            ));
+        }
+        encoders.push(Encoder::new(enc_layers));
+    }
+
+    // Load FPN lateral convs
+    let num_levels = config.encoder_in_channels.len();
+    let num_fpn = num_levels - 1;
+
+    let mut lateral_convs = Vec::with_capacity(num_fpn);
+    for i in 0..num_fpn {
+        let prefix = format!("encoder.lateral_convs.{}", i);
+        let cnl = load_conv_norm_layer(
+            params,
+            &format!("{}.conv", prefix),
+            &format!("{}.norm", prefix),
+            Some(act_fn),
+            (1, 1),
+            (0, 0),
+            1,
+            eps,
+        )?;
+        lateral_convs.push(cnl);
+    }
+
+    // Load FPN CSPRepLayer blocks
+    let mut fpn_blocks = Vec::with_capacity(num_fpn);
+    for i in 0..num_fpn {
+        let prefix = format!("encoder.fpn_blocks.{}", i);
+        fpn_blocks.push(load_csp_rep_layer(params, &prefix, act_fn, eps)?);
+    }
+
+    // Load PAN downsample convs
+    let mut downsample_convs = Vec::with_capacity(num_fpn);
+    for i in 0..num_fpn {
+        let prefix = format!("encoder.downsample_convs.{}", i);
+        let cnl = load_conv_norm_layer(
+            params,
+            &format!("{}.conv", prefix),
+            &format!("{}.norm", prefix),
+            Some(act_fn),
+            (2, 2),
+            (1, 1),
+            1,
+            eps,
+        )?;
+        downsample_convs.push(cnl);
+    }
+
+    // Load PAN CSPRepLayer blocks
+    let mut pan_blocks = Vec::with_capacity(num_fpn);
+    for i in 0..num_fpn {
+        let prefix = format!("encoder.pan_blocks.{}", i);
+        pan_blocks.push(load_csp_rep_layer(params, &prefix, act_fn, eps)?);
+    }
+
+    // Load MaskFeatFPN
+    let mask_feature_head = load_mask_feat_fpn(params, config)?;
+
+    // Load encoder_mask_lateral
+    // HF: PPDocLayoutV3ConvLayer uses .convolution and .normalization
+    // This is a 3x3 conv so padding = (kernel_size - 1) / 2 = 1
+    let encoder_mask_lateral = load_conv_layer(
+        params,
+        "encoder.encoder_mask_lateral.convolution",
+        "encoder.encoder_mask_lateral.normalization",
+        act_fn,
+        (1, 1),
+        (1, 1),
+        1,
+        eps,
+    )?;
+
+    // Load encoder_mask_output
+    // HF: PPDocLayoutV3EncoderMaskOutput.base_conv = PPDocLayoutV3ConvLayer (uses .convolution, .normalization)
+    let base_conv = load_conv_layer(
+        params,
+        "encoder.encoder_mask_output.base_conv.convolution",
+        "encoder.encoder_mask_output.base_conv.normalization",
+        act_fn,
+        (1, 1),
+        (1, 1),
+        1,
+        eps,
+    )?;
+    let mask_output_conv = load_conv2d(
+        params,
+        "encoder.encoder_mask_output.conv",
+        (1, 1),
+        (0, 0),
+        (1, 1),
+        1,
+        true,
+    )?;
+    let encoder_mask_output = EncoderMaskOutput::new(base_conv, mask_output_conv);
+
+    Ok(HybridEncoder::new(
+        config,
+        encoders,
+        lateral_convs,
+        fpn_blocks,
+        downsample_convs,
+        pan_blocks,
+        mask_feature_head,
+        encoder_mask_lateral,
+        encoder_mask_output,
+    ))
+}
+
+fn load_csp_rep_layer(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    act_fn: &str,
+    eps: f64,
+) -> Result<CSPRepLayer> {
+    let conv1 = load_conv_norm_layer(
+        params,
+        &format!("{}.conv1.conv", prefix),
+        &format!("{}.conv1.norm", prefix),
+        Some(act_fn),
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+    )?;
+    let conv2 = load_conv_norm_layer(
+        params,
+        &format!("{}.conv2.conv", prefix),
+        &format!("{}.conv2.norm", prefix),
+        Some(act_fn),
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+    )?;
+
+    // Load bottleneck RepVGG blocks
+    let mut bottlenecks = Vec::new();
+    let mut idx = 0;
+    loop {
+        let key = format!("{}.bottlenecks.{}.conv1.conv.weight", prefix, idx);
+        if !params.contains_key(&key) {
+            break;
+        }
+        let rep_conv1 = load_conv_norm_layer(
+            params,
+            &format!("{}.bottlenecks.{}.conv1.conv", prefix, idx),
+            &format!("{}.bottlenecks.{}.conv1.norm", prefix, idx),
+            None,
+            (1, 1),
+            (1, 1),
+            1,
+            eps,
+        )?;
+        let rep_conv2 = load_conv_norm_layer(
+            params,
+            &format!("{}.bottlenecks.{}.conv2.conv", prefix, idx),
+            &format!("{}.bottlenecks.{}.conv2.norm", prefix, idx),
+            None,
+            (1, 1),
+            (0, 0),
+            1,
+            eps,
+        )?;
+        bottlenecks.push(RepVggBlock::new(rep_conv1, rep_conv2, act_fn));
+        idx += 1;
+    }
+
+    // Optional conv3
+    let conv3_key = format!("{}.conv3.conv.weight", prefix);
+    let conv3 = if params.contains_key(&conv3_key) {
+        Some(load_conv_norm_layer(
+            params,
+            &format!("{}.conv3.conv", prefix),
+            &format!("{}.conv3.norm", prefix),
+            Some(act_fn),
+            (1, 1),
+            (0, 0),
+            1,
+            eps,
+        )?)
+    } else {
+        None
+    };
+
+    Ok(CSPRepLayer::new(conv1, conv2, bottlenecks, conv3))
+}
+
+fn load_mask_feat_fpn(
+    params: &HashMap<String, MxArray>,
+    config: &PPDocLayoutV3Config,
+) -> Result<MaskFeatFPN> {
+    let eps = config.batch_norm_eps;
+    let act_fn = config.activation_function.as_str();
+    let feat_strides = &config.feat_strides;
+    let num_levels = feat_strides.len();
+
+    // Reorder by stride ascending (they already are for default config)
+    let mut stride_indices: Vec<(usize, i32)> = feat_strides
+        .iter()
+        .enumerate()
+        .map(|(i, &s)| (i, s))
+        .collect();
+    stride_indices.sort_by_key(|&(_, s)| s);
+    let reorder_index: Vec<usize> = stride_indices.iter().map(|&(i, _)| i).collect();
+    let sorted_strides: Vec<i32> = stride_indices.iter().map(|&(_, s)| s).collect();
+
+    // Build scale heads
+    let base_stride = sorted_strides[0];
+    let mut scale_heads = Vec::with_capacity(num_levels);
+
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..num_levels {
+        let fpn_stride = sorted_strides[i];
+        let num_scale_layers = (fpn_stride as f64 / base_stride as f64).log2() as usize;
+        let mut layers = Vec::new();
+
+        if num_scale_layers == 0 {
+            // Single conv, no upsample
+            // HF: PPDocLayoutV3ScaleHead.layers[0] = PPDocLayoutV3ConvLayer (uses .convolution, .normalization)
+            let conv = load_conv_layer(
+                params,
+                &format!(
+                    "encoder.mask_feature_head.scale_heads.{}.layers.0.convolution",
+                    i
+                ),
+                &format!(
+                    "encoder.mask_feature_head.scale_heads.{}.layers.0.normalization",
+                    i
+                ),
+                act_fn,
+                (1, 1),
+                (1, 1),
+                1,
+                eps,
+            )?;
+            layers.push(ScaleHeadLayer::Conv(conv));
+        } else {
+            for j in 0..num_scale_layers {
+                // HF: layers[j*2] = PPDocLayoutV3ConvLayer, layers[j*2+1] = nn.Upsample
+                let conv = load_conv_layer(
+                    params,
+                    &format!(
+                        "encoder.mask_feature_head.scale_heads.{}.layers.{}.convolution",
+                        i,
+                        j * 2
+                    ),
+                    &format!(
+                        "encoder.mask_feature_head.scale_heads.{}.layers.{}.normalization",
+                        i,
+                        j * 2
+                    ),
+                    act_fn,
+                    (1, 1),
+                    (1, 1),
+                    1,
+                    eps,
+                )?;
+                layers.push(ScaleHeadLayer::Conv(conv));
+                layers.push(ScaleHeadLayer::Upsample);
+            }
+        }
+
+        scale_heads.push(ScaleHead::new(layers));
+    }
+
+    // Output conv
+    // HF: PPDocLayoutV3ConvLayer uses .convolution and .normalization
+    let output_conv = load_conv_layer(
+        params,
+        "encoder.mask_feature_head.output_conv.convolution",
+        "encoder.mask_feature_head.output_conv.normalization",
+        act_fn,
+        (1, 1),
+        (1, 1),
+        1,
+        eps,
+    )?;
+
+    Ok(MaskFeatFPN::new(reorder_index, scale_heads, output_conv))
+}
+
+// ============================================================================
+// Decoder Loading
+// ============================================================================
+
+fn load_decoder(
+    params: &HashMap<String, MxArray>,
+    config: &PPDocLayoutV3Config,
+) -> Result<Decoder> {
+    let d_model = config.d_model;
+    let num_heads = config.decoder_attention_heads;
+    let n_levels = config.num_feature_levels;
+    let n_points = config.decoder_n_points;
+    let ln_eps = config.layer_norm_eps;
+    let dec_act = config.decoder_activation_function.as_str();
+
+    let mut decoder_layers = Vec::with_capacity(config.decoder_layers as usize);
+    for i in 0..config.decoder_layers {
+        let prefix = format!("decoder.layers.{}", i);
+
+        // Self-attention (PPDocLayoutV3SelfAttention uses q_proj, k_proj, v_proj, o_proj)
+        let sa_q = load_linear(params, &format!("{}.self_attn.q_proj", prefix))?;
+        let sa_k = load_linear(params, &format!("{}.self_attn.k_proj", prefix))?;
+        let sa_v = load_linear(params, &format!("{}.self_attn.v_proj", prefix))?;
+        let sa_out = load_linear(params, &format!("{}.self_attn.out_proj", prefix))?;
+        let self_attn =
+            SelfAttention::from_weights_with_dim(sa_q, sa_k, sa_v, sa_out, d_model, num_heads);
+
+        let self_attn_ln =
+            load_layer_norm(params, &format!("{}.self_attn_layer_norm", prefix), ln_eps)?;
+
+        // Cross-attention (deformable)
+        let ea_prefix = format!("{}.encoder_attn", prefix);
+        let value_proj = load_linear(params, &format!("{}.value_proj", ea_prefix))?;
+        let sampling_offsets = load_linear(params, &format!("{}.sampling_offsets", ea_prefix))?;
+        let attn_weights = load_linear(params, &format!("{}.attention_weights", ea_prefix))?;
+        let output_proj = load_linear(params, &format!("{}.output_proj", ea_prefix))?;
+        let encoder_attn = MultiscaleDeformableAttention::from_weights(
+            value_proj,
+            sampling_offsets,
+            attn_weights,
+            output_proj,
+            d_model,
+            num_heads,
+            n_levels,
+            n_points,
+        );
+
+        let encoder_attn_ln = load_layer_norm(
+            params,
+            &format!("{}.encoder_attn_layer_norm", prefix),
+            ln_eps,
+        )?;
+
+        // FFN (fc1/fc2 are directly on the layer, not under mlp. prefix)
+        let fc1 = load_linear(params, &format!("{}.fc1", prefix))?;
+        let fc2 = load_linear(params, &format!("{}.fc2", prefix))?;
+        let final_ln = load_layer_norm(params, &format!("{}.final_layer_norm", prefix), ln_eps)?;
+
+        decoder_layers.push(DecoderLayer::from_components(
+            self_attn,
+            self_attn_ln,
+            encoder_attn,
+            encoder_attn_ln,
+            fc1,
+            fc2,
+            final_ln,
+            dec_act,
+        ));
+    }
+
+    // Query position head
+    let query_pos_head = load_mlp_head(params, "decoder.query_pos_head", 2)?;
+
+    // Bbox embed (shared with enc_bbox_head via weight tying in checkpoint)
+    let bbox_embed = load_mlp_head(params, "enc_bbox_head", 3)?;
+
+    // Class embed (shared with enc_score_head via weight tying in checkpoint)
+    let class_embed = load_linear(params, "enc_score_head")?;
+
+    Ok(Decoder::from_components(
+        decoder_layers,
+        query_pos_head,
+        Some(bbox_embed),
+        Some(class_embed),
+        config.num_queries,
+    ))
+}
+
+// ============================================================================
+// Main Load Function
+// ============================================================================
+
+/// Load the full PP-DocLayoutV3 model from a directory.
+///
+/// The directory must be cloned from `PaddlePaddle/PP-DocLayoutV3_safetensors` on HuggingFace
+/// and contain:
+/// - `config.json`: Model configuration
+/// - `model.safetensors`: Model weights in SafeTensors format
+///
+/// Note: The regular `PaddlePaddle/PP-DocLayoutV3` repo uses PaddlePaddle format and is not compatible.
+///
+/// # Arguments
+/// * `model_path` - Path to model directory
+///
+/// # Returns
+/// * Fully initialized PPDocLayoutV3Model
+pub fn load_model(model_path: &str) -> Result<PPDocLayoutV3Model> {
+    let path = Path::new(model_path);
+
+    if !path.exists() {
+        return Err(Error::from_reason(format!(
+            "Model path does not exist: {}",
+            model_path
+        )));
+    }
+
+    // Load config
+    let config_path = path.join("config.json");
+    if !config_path.exists() {
+        return Err(Error::from_reason(format!(
+            "Config file not found: {}",
+            config_path.display()
+        )));
+    }
+
+    let config_data = fs::read_to_string(&config_path)
+        .map_err(|e| Error::from_reason(format!("Failed to read config: {}", e)))?;
+
+    let mut config: PPDocLayoutV3Config = serde_json::from_str(&config_data)
+        .map_err(|e| Error::from_reason(format!("Failed to parse config: {}", e)))?;
+
+    // Derive num_labels from id2label if not explicitly set (matches HuggingFace behavior)
+    config.fixup_after_load();
+
+    // Validate num_feature_levels == 3 (persistence and model inference hardcode 3 levels)
+    if config.num_feature_levels != 3 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "PP-DocLayoutV3 only supports num_feature_levels=3, got {}",
+                config.num_feature_levels
+            ),
+        ));
+    }
+    if config.encoder_in_channels.len() != 3 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "PP-DocLayoutV3 requires encoder_in_channels to have exactly 3 entries, got {}",
+                config.encoder_in_channels.len()
+            ),
+        ));
+    }
+    if config.decoder_in_channels.len() != 3 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "PP-DocLayoutV3 requires decoder_in_channels to have exactly 3 entries, got {}",
+                config.decoder_in_channels.len()
+            ),
+        ));
+    }
+
+    // Load weights
+    let weights_path = path.join("model.safetensors");
+    if !weights_path.exists() {
+        return Err(Error::from_reason(format!(
+            "Weights file not found: {}",
+            weights_path.display()
+        )));
+    }
+
+    let st_file = SafeTensorsFile::load(&weights_path)?;
+    let raw_params = st_file.load_tensors(&weights_path)?;
+
+    // Strip "model." prefix from all keys
+    let mut params: HashMap<String, MxArray> = HashMap::with_capacity(raw_params.len());
+    for (key, value) in raw_params {
+        let mapped_key = key.strip_prefix("model.").unwrap_or(&key).to_string();
+        params.insert(mapped_key, value);
+    }
+
+    // Build all components
+    let backbone = load_backbone(&params, &config)?;
+
+    // Encoder input projections (3 levels: stages 2, 3, 4)
+    let mut encoder_input_proj = Vec::with_capacity(3);
+    for i in 0..3 {
+        let proj = load_input_projection(
+            &params,
+            &format!("encoder_input_proj.{}", i),
+            config.batch_norm_eps,
+        )?;
+        encoder_input_proj.push(proj);
+    }
+
+    let encoder = load_hybrid_encoder(&params, &config)?;
+
+    // Encoder output head
+    let enc_output_linear = load_linear(&params, "enc_output.0")?;
+    let enc_output_norm = load_layer_norm(&params, "enc_output.1", config.layer_norm_eps)?;
+
+    let enc_score_head = load_linear(&params, "enc_score_head")?;
+    let enc_bbox_head = load_mlp_head(&params, "enc_bbox_head", 3)?;
+
+    // Decoder input projections
+    let mut decoder_input_proj = Vec::with_capacity(3);
+    for i in 0..3 {
+        let proj = load_input_projection(
+            &params,
+            &format!("decoder_input_proj.{}", i),
+            config.batch_norm_eps,
+        )?;
+        decoder_input_proj.push(proj);
+    }
+
+    let decoder = load_decoder(&params, &config)?;
+
+    // Decoder order heads (one per decoder layer)
+    let mut decoder_order_head = Vec::with_capacity(config.decoder_layers as usize);
+    for i in 0..config.decoder_layers {
+        let head = load_linear(&params, &format!("decoder_order_head.{}", i))?;
+        decoder_order_head.push(head);
+    }
+
+    // Global pointer
+    let gp_dense = load_linear(&params, "decoder_global_pointer.dense")?;
+    let decoder_global_pointer =
+        GlobalPointer::from_weights(gp_dense, config.global_pointer_head_size);
+
+    // Decoder norm
+    let decoder_norm = load_layer_norm(&params, "decoder_norm", config.layer_norm_eps)?;
+
+    // Mask query head
+    let mask_query_head = load_mlp_head(&params, "mask_query_head", 3)?;
+
+    // Denoising class embed (optional, not used in inference)
+    let denoising_class_embed = params.get("denoising_class_embed.weight").cloned();
+
+    Ok(create_model(
+        config,
+        backbone,
+        encoder_input_proj,
+        encoder,
+        enc_output_linear,
+        enc_output_norm,
+        enc_score_head,
+        enc_bbox_head,
+        decoder_input_proj,
+        decoder,
+        decoder_order_head,
+        decoder_global_pointer,
+        decoder_norm,
+        mask_query_head,
+        denoising_class_embed,
+    ))
+}

--- a/crates/mlx-core/src/models/pp_doclayout_v3/postprocessing.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/postprocessing.rs
@@ -1,0 +1,243 @@
+//! PP-DocLayoutV3 Post-Processing
+//!
+//! Post-processing for detection outputs: score thresholding, box decoding,
+//! and reading order extraction.
+
+use crate::array::MxArray;
+use crate::nn::activations::Activations;
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use std::collections::HashMap;
+
+/// A single detected layout element.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct LayoutElement {
+    /// Detection confidence score
+    pub score: f64,
+    /// Class label ID (0-24)
+    pub label: u32,
+    /// Human-readable label name (e.g., "title", "text", "table")
+    pub label_name: String,
+    /// Bounding box in original image coordinates [x1, y1, x2, y2]
+    pub bbox: Vec<f64>,
+    /// Reading order index (0 = first element to read)
+    pub order: u32,
+}
+
+/// Post-process model outputs into layout elements.
+///
+/// # Arguments
+/// * `logits` - Class logits [batch, num_queries, num_labels]
+/// * `pred_boxes` - Predicted boxes in (cx, cy, w, h) format [batch, num_queries, 4]
+/// * `order_logits` - Reading order logits [batch, num_queries, num_queries]
+/// * `orig_h` - Original image height
+/// * `orig_w` - Original image width
+/// * `threshold` - Score threshold for detection (default 0.5)
+/// * `id2label` - Mapping from class ID to label name
+///
+/// # Returns
+/// Vec of LayoutElements sorted by reading order
+pub fn postprocess_detection(
+    logits: &MxArray,
+    pred_boxes: &MxArray,
+    order_logits: &MxArray,
+    orig_h: u32,
+    orig_w: u32,
+    threshold: f64,
+    id2label: &HashMap<String, String>,
+) -> Result<Vec<LayoutElement>> {
+    // Apply sigmoid to logits to get scores
+    let scores = Activations::sigmoid(logits)?;
+    scores.eval();
+
+    // Get shapes
+    let scores_shape = scores.shape()?;
+    let scores_shape: Vec<i64> = scores_shape.as_ref().to_vec();
+    let num_queries = scores_shape[1] as usize;
+    let num_labels = scores_shape[2] as usize;
+
+    // Read scores data
+    let scores_data = scores.to_float32()?;
+    let scores_vec: Vec<f32> = scores_data.to_vec();
+
+    // Read box data
+    pred_boxes.eval();
+    let boxes_data = pred_boxes.to_float32()?;
+    let boxes_vec: Vec<f32> = boxes_data.to_vec();
+
+    // Top-k flattened selection (matches HuggingFace reference implementation):
+    // Instead of per-query argmax (one detection per query), we flatten all
+    // (query, class) scores and select the top num_queries entries globally.
+    // This allows multiple detections per query with different class labels.
+
+    // Build vec of (score, flattened_index) for all query-label pairs
+    let total = num_queries * num_labels;
+    let mut scored_indices: Vec<(f32, usize)> = scores_vec[..total]
+        .iter()
+        .enumerate()
+        .map(|(i, &s)| (s, i))
+        .collect();
+
+    // Sort by score descending
+    scored_indices
+        .sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Take top num_queries entries, decode flattened index, apply threshold
+    let mut detections: Vec<(usize, u32, f64, [f64; 4])> = Vec::new();
+
+    let oh = orig_h as f64;
+    let ow = orig_w as f64;
+
+    for &(score, flat_idx) in scored_indices.iter().take(num_queries) {
+        if (score as f64) < threshold {
+            continue;
+        }
+
+        let query_idx = flat_idx / num_labels;
+        let label_idx = (flat_idx % num_labels) as u32;
+
+        // Convert box from (cx, cy, w, h) normalized to (x1, y1, x2, y2) in original image coords
+        let cx = boxes_vec[query_idx * 4] as f64;
+        let cy = boxes_vec[query_idx * 4 + 1] as f64;
+        let bw = boxes_vec[query_idx * 4 + 2] as f64;
+        let bh = boxes_vec[query_idx * 4 + 3] as f64;
+
+        let x1 = ((cx - bw / 2.0) * ow).max(0.0);
+        let y1 = ((cy - bh / 2.0) * oh).max(0.0);
+        let x2 = ((cx + bw / 2.0) * ow).min(ow);
+        let y2 = ((cy + bh / 2.0) * oh).min(oh);
+
+        detections.push((query_idx, label_idx, score as f64, [x1, y1, x2, y2]));
+    }
+
+    if detections.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Compute reading order from order_logits
+    // order_logits: [1, num_queries, num_queries]
+    // Computes global pairwise votes over all queries, ranks them ascending,
+    // then gathers ranks for selected detections only.
+    let order_scores = compute_reading_order(order_logits, &detections, num_queries)?;
+
+    // Build (order_score, detection_index) pairs and sort by order_score ascending.
+    // This matches the HuggingFace reference which sorts filtered detections by order_seq.
+    let mut ordered_indices: Vec<(u32, usize)> = order_scores
+        .iter()
+        .enumerate()
+        .map(|(i, &o)| (o, i))
+        .collect();
+    ordered_indices.sort_by_key(|&(o, _)| o);
+
+    // Build LayoutElements in reading order with contiguous 0-based order values
+    let mut elements: Vec<LayoutElement> = Vec::with_capacity(detections.len());
+    for (new_order, &(_, det_idx)) in ordered_indices.iter().enumerate() {
+        let (_, label, score, bbox) = &detections[det_idx];
+        let label_name = id2label
+            .get(&label.to_string())
+            .cloned()
+            .unwrap_or_else(|| format!("class_{}", label));
+
+        elements.push(LayoutElement {
+            score: *score,
+            label: *label,
+            label_name,
+            bbox: bbox.to_vec(),
+            order: new_order as u32,
+        });
+    }
+
+    Ok(elements)
+}
+
+/// Compute reading order from pairwise order logits.
+///
+/// Matches the HuggingFace reference implementation:
+///   1. Compute votes GLOBALLY over ALL queries (not just detected ones)
+///   2. Argsort ASCENDING to get global ranking (lowest vote = rank 0 = read first)
+///   3. Assign ranks via inverse permutation
+///   4. Gather ranks for detected queries only
+///
+/// # Arguments
+/// * `order_logits` - [1, num_queries, num_queries] pairwise ordering logits
+/// * `detections` - Vec of (query_idx, label, score, bbox) for detected elements
+/// * `num_queries` - Total number of queries
+///
+/// # Returns
+/// Vec of reading order ranks (0-indexed) aligned with detections
+fn compute_reading_order(
+    order_logits: &MxArray,
+    detections: &[(usize, u32, f64, [f64; 4])],
+    num_queries: usize,
+) -> Result<Vec<u32>> {
+    let n = detections.len();
+    if n <= 1 {
+        return Ok(vec![0; n]);
+    }
+
+    // Apply sigmoid to order logits
+    let order_sigmoid = Activations::sigmoid(order_logits)?;
+    order_sigmoid.eval();
+    let order_data = order_sigmoid.to_float32()?;
+    let order_vec: Vec<f32> = order_data.to_vec();
+
+    // Step 1: Compute votes GLOBALLY for ALL queries
+    // For each query i: vote[i] = sum_j>i(score[i,j]) + sum_j<i(1 - score[j,i])
+    // This matches: triu(diagonal=1).sum(dim=1) + (1 - scores.T).tril(diagonal=-1).sum(dim=1)
+    let mut votes: Vec<f64> = Vec::with_capacity(num_queries);
+    for i in 0..num_queries {
+        let mut vote = 0.0f64;
+        for j in 0..num_queries {
+            if j > i {
+                // Upper triangle: score[i, j]
+                vote += order_vec[i * num_queries + j] as f64;
+            } else if j < i {
+                // Lower triangle: 1 - score[j, i]
+                vote += 1.0 - order_vec[j * num_queries + i] as f64;
+            }
+        }
+        votes.push(vote);
+    }
+
+    // Step 2: Argsort ASCENDING (lowest vote → rank 0 → read first)
+    let mut sorted_indices: Vec<usize> = (0..num_queries).collect();
+    sorted_indices.sort_by(|&a, &b| {
+        votes[a]
+            .partial_cmp(&votes[b])
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // Step 3: Assign ranks (inverse permutation)
+    let mut order_seq = vec![0u32; num_queries];
+    for (rank, &idx) in sorted_indices.iter().enumerate() {
+        order_seq[idx] = rank as u32;
+    }
+
+    // Step 4: Gather ranks for detected queries only
+    let ranks: Vec<u32> = detections
+        .iter()
+        .map(|(q, _, _, _)| order_seq[*q])
+        .collect();
+
+    Ok(ranks)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layout_element_struct() {
+        let elem = LayoutElement {
+            score: 0.95,
+            label: 0,
+            label_name: "title".to_string(),
+            bbox: vec![10.0, 20.0, 300.0, 50.0],
+            order: 0,
+        };
+        assert_eq!(elem.label, 0);
+        assert_eq!(elem.label_name, "title");
+        assert_eq!(elem.bbox.len(), 4);
+    }
+}

--- a/crates/mlx-core/src/models/pp_doclayout_v3/processing.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/processing.rs
@@ -1,0 +1,120 @@
+//! PP-DocLayoutV3 Image Processing
+//!
+//! Image preprocessing pipeline: load → resize to 800x800 → rescale to [0,1] → NHWC tensor.
+//! PP-DocLayoutV3 uses image_mean=[0,0,0] and image_std=[1,1,1], so no normalization
+//! beyond rescaling is needed.
+
+use crate::array::MxArray;
+use image::ImageReader;
+use image::imageops::FilterType;
+use napi::bindgen_prelude::*;
+use std::path::Path;
+
+/// Image processor for PP-DocLayoutV3 document layout analysis.
+///
+/// Resizes images to 800x800 and rescales pixel values to [0, 1].
+/// Output is in NHWC format [1, 800, 800, 3] as required by the MLX backbone.
+pub struct PPDocLayoutV3ImageProcessor {
+    target_height: u32,
+    target_width: u32,
+}
+
+impl Default for PPDocLayoutV3ImageProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PPDocLayoutV3ImageProcessor {
+    /// Create a new image processor with default 800x800 target size.
+    pub fn new() -> Self {
+        Self {
+            target_height: 800,
+            target_width: 800,
+        }
+    }
+
+    /// Process an image file for model input.
+    ///
+    /// # Arguments
+    /// * `path` - Path to the image file
+    ///
+    /// # Returns
+    /// * `(pixel_values, original_height, original_width)` where:
+    ///   - pixel_values: MxArray [1, 800, 800, 3] in NHWC format, float32, rescaled to [0,1]
+    ///   - original_height: Original image height before resize
+    ///   - original_width: Original image width before resize
+    pub fn process_file(&self, path: &str) -> Result<(MxArray, u32, u32)> {
+        let img_path = Path::new(path);
+        if !img_path.exists() {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("Image file not found: {}", img_path.display()),
+            ));
+        }
+
+        // Load image
+        let img = ImageReader::open(img_path)
+            .map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to open image: {}", e),
+                )
+            })?
+            .decode()
+            .map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to decode image: {}", e),
+                )
+            })?;
+
+        // Get original dimensions
+        let original_width = img.width();
+        let original_height = img.height();
+
+        // Resize to target dimensions using bicubic (CatmullRom) interpolation
+        let resized = img.resize_exact(
+            self.target_width,
+            self.target_height,
+            FilterType::CatmullRom,
+        );
+
+        // Convert to RGB8
+        let rgb_img = resized.to_rgb8();
+
+        // Convert pixels to float32 and rescale to [0, 1]
+        let h = self.target_height as usize;
+        let w = self.target_width as usize;
+        let channels = 3usize;
+        let mut pixel_data: Vec<f32> = Vec::with_capacity(h * w * channels);
+
+        for y in 0..h {
+            for x in 0..w {
+                let pixel = rgb_img.get_pixel(x as u32, y as u32);
+                for c in 0..channels {
+                    let val = pixel[c] as f32 / 255.0;
+                    pixel_data.push(val);
+                }
+            }
+        }
+
+        // Create MxArray [1, H, W, 3] in NHWC format
+        let pixel_values =
+            MxArray::from_float32(&pixel_data, &[1, h as i64, w as i64, channels as i64])?;
+
+        Ok((pixel_values, original_height, original_width))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_image_processor_creation() {
+        let processor = PPDocLayoutV3ImageProcessor::new();
+        assert_eq!(processor.target_height, 800);
+        assert_eq!(processor.target_width, 800);
+    }
+}

--- a/crates/mlx-core/src/models/pp_text_det/config.rs
+++ b/crates/mlx-core/src/models/pp_text_det/config.rs
@@ -1,0 +1,175 @@
+//! Text Detection Configuration
+//!
+//! Configuration for the DBNet text detection model with PPHGNetV2_B4 backbone.
+
+use serde::Deserialize;
+
+use crate::models::pp_doclayout_v3::config::HGNetV2Config;
+
+/// Configuration for the text detection model.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TextDetConfig {
+    /// HGNetV2 backbone configuration
+    #[serde(default = "default_backbone_config")]
+    pub backbone: HGNetV2Config,
+
+    /// Batch normalization epsilon
+    #[serde(default = "default_bn_eps")]
+    pub batch_norm_eps: f64,
+
+    /// LKPAN output channels
+    #[serde(default = "default_lkpan_out_channels")]
+    pub lkpan_out_channels: i32,
+
+    /// Large kernel size for LKPAN depthwise convolutions
+    #[serde(default = "default_large_kernel_size")]
+    pub large_kernel_size: i32,
+
+    /// Activation function
+    #[serde(default = "default_activation")]
+    pub activation: String,
+
+    /// DBHead inner channels (in_channels // 4 of LKPAN out)
+    #[serde(default = "default_db_inner_channels")]
+    pub db_inner_channels: i32,
+
+    /// PFHeadLocal k value (for differentiable binarization step function)
+    #[serde(default = "default_pf_head_k")]
+    pub pf_head_k: i32,
+
+    /// PFHeadLocal mode: "large" or "small" — controls LocalModule mid_channels
+    #[serde(default = "default_pf_head_mode")]
+    pub pf_head_mode: String,
+
+    /// Detection threshold for binarization
+    #[serde(default = "default_det_threshold")]
+    pub det_threshold: f64,
+
+    /// Box threshold (mean score inside box)
+    #[serde(default = "default_box_threshold")]
+    pub box_threshold: f64,
+
+    /// Unclip ratio for box expansion
+    #[serde(default = "default_unclip_ratio")]
+    pub unclip_ratio: f64,
+
+    /// Maximum number of candidates
+    #[serde(default = "default_max_candidates")]
+    pub max_candidates: usize,
+
+    /// Minimum box side length
+    #[serde(default = "default_min_size")]
+    pub min_size: f64,
+}
+
+impl Default for TextDetConfig {
+    fn default() -> Self {
+        Self {
+            backbone: default_backbone_config(),
+            batch_norm_eps: default_bn_eps(),
+            lkpan_out_channels: default_lkpan_out_channels(),
+            large_kernel_size: default_large_kernel_size(),
+            activation: default_activation(),
+            db_inner_channels: default_db_inner_channels(),
+            pf_head_k: default_pf_head_k(),
+            pf_head_mode: default_pf_head_mode(),
+            det_threshold: default_det_threshold(),
+            box_threshold: default_box_threshold(),
+            unclip_ratio: default_unclip_ratio(),
+            max_candidates: default_max_candidates(),
+            min_size: default_min_size(),
+        }
+    }
+}
+
+/// PPHGNetV2_B4 backbone config for text detection.
+/// Matches PaddleOCR's `PPHGNetV2_B4(det=True)` with `stage_config_det`.
+fn default_backbone_config() -> HGNetV2Config {
+    HGNetV2Config {
+        model_type: "hgnet_v2".to_string(),
+        num_channels: 3,
+        embedding_size: 48,
+        depths: vec![1, 1, 3, 1],
+        hidden_sizes: vec![128, 512, 1024, 2048],
+        hidden_act: "relu".to_string(),
+        stem_channels: vec![3, 32, 48],
+        stage_in_channels: vec![48, 128, 512, 1024],
+        stage_mid_channels: vec![48, 96, 192, 384],
+        stage_out_channels: vec![128, 512, 1024, 2048],
+        stage_num_blocks: vec![1, 1, 3, 1],
+        stage_downsample: vec![false, true, true, true],
+        stage_light_block: vec![false, false, true, true],
+        stage_kernel_size: vec![3, 3, 5, 5],
+        stage_numb_of_layers: vec![6, 6, 6, 6],
+        use_learnable_affine_block: false,
+        stage_strides: vec![(2, 2), (2, 2), (2, 2), (2, 2)],
+        stem3_stride: (2, 2),
+        out_features: vec![
+            "stage1".to_string(),
+            "stage2".to_string(),
+            "stage3".to_string(),
+            "stage4".to_string(),
+        ],
+        out_indices: None,
+        initializer_range: 0.02,
+    }
+}
+
+fn default_bn_eps() -> f64 {
+    1e-5
+}
+fn default_lkpan_out_channels() -> i32 {
+    256
+}
+fn default_large_kernel_size() -> i32 {
+    9
+}
+fn default_activation() -> String {
+    "relu".to_string()
+}
+fn default_db_inner_channels() -> i32 {
+    64
+}
+fn default_pf_head_k() -> i32 {
+    50
+}
+fn default_pf_head_mode() -> String {
+    "large".to_string()
+}
+fn default_det_threshold() -> f64 {
+    0.3
+}
+fn default_box_threshold() -> f64 {
+    0.6
+}
+fn default_unclip_ratio() -> f64 {
+    1.5
+}
+fn default_max_candidates() -> usize {
+    1000
+}
+fn default_min_size() -> f64 {
+    3.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_text_det_config() {
+        let config = TextDetConfig::default();
+        assert_eq!(config.backbone.stem_channels, vec![3, 32, 48]);
+        assert_eq!(
+            config.backbone.stage_out_channels,
+            vec![128, 512, 1024, 2048]
+        );
+        assert_eq!(config.backbone.stage_numb_of_layers, vec![6, 6, 6, 6]);
+        assert_eq!(config.backbone.embedding_size, 48);
+        assert_eq!(config.lkpan_out_channels, 256);
+        assert_eq!(config.large_kernel_size, 9);
+        assert_eq!(config.db_inner_channels, 64);
+        assert!((config.det_threshold - 0.3).abs() < 1e-10);
+        assert!((config.box_threshold - 0.6).abs() < 1e-10);
+    }
+}

--- a/crates/mlx-core/src/models/pp_text_det/db_head.rs
+++ b/crates/mlx-core/src/models/pp_text_det/db_head.rs
@@ -1,0 +1,205 @@
+//! DBHead and PFHeadLocal (Differentiable Binarization Head)
+//!
+//! Produces shrink map + threshold map from neck features.
+//!
+//! ## Head (binarize/thresh branch):
+//!   Conv2d(in_ch->inner_ch, k=3, pad=1, bias=False) -> BN -> ReLU
+//!   ConvTranspose2d(inner_ch->inner_ch, k=2, stride=2) -> BN -> ReLU
+//!   ConvTranspose2d(inner_ch->1, k=2, stride=2) -> Sigmoid
+//!
+//! ## PFHeadLocal (inference):
+//!   1. binarize head runs and returns both sigmoid output AND intermediate features f
+//!      (after deconv1 + BN + ReLU, before deconv2 + sigmoid)
+//!   2. up_conv: nearest-neighbor 2x upsample of f
+//!   3. cbn_layer (LocalModule): [shrink_maps, up_conv(f)] -> conv1(BN+ReLU) -> conv2
+//!   4. sigmoid(cbn_output) -> cbn_maps
+//!   5. return 0.5 * (base_maps + cbn_maps)
+
+use crate::array::MxArray;
+use crate::nn::activations::Activations;
+use napi::bindgen_prelude::*;
+
+use crate::models::pp_doclayout_v3::backbone::{
+    FrozenBatchNorm2d, NativeConv2d, NativeConvTranspose2d,
+};
+
+/// Head: a single branch (binarize or threshold) of the DB head.
+///
+/// Corresponds to PaddleOCR's `Head` class in `det_db_head.py`.
+pub struct Head {
+    /// Conv2d(in_ch->inner_ch, k=3, pad=1, bias=False) + BN + ReLU
+    conv1: NativeConv2d,
+    bn1: FrozenBatchNorm2d,
+    /// ConvTranspose2d(inner_ch->inner_ch, k=2, stride=2) + BN + ReLU
+    deconv1: NativeConvTranspose2d,
+    bn2: FrozenBatchNorm2d,
+    /// ConvTranspose2d(inner_ch->1, k=2, stride=2) -> Sigmoid
+    deconv2: NativeConvTranspose2d,
+}
+
+impl Head {
+    pub fn new(
+        conv1: NativeConv2d,
+        bn1: FrozenBatchNorm2d,
+        deconv1: NativeConvTranspose2d,
+        bn2: FrozenBatchNorm2d,
+        deconv2: NativeConvTranspose2d,
+    ) -> Self {
+        Self {
+            conv1,
+            bn1,
+            deconv1,
+            bn2,
+            deconv2,
+        }
+    }
+
+    /// Forward pass: produces probability map.
+    ///
+    /// Input: [B, H, W, C] where H,W are at stride-4 relative to input image
+    /// Output: [B, H*4, W*4, 1] probability map at original resolution
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        // Conv + BN + ReLU
+        let x = self.conv1.forward(input)?;
+        let x = self.bn1.forward(&x)?;
+        let x = Activations::relu(&x)?;
+
+        // Deconv (2x upsample) + BN + ReLU
+        let x = self.deconv1.forward(&x)?;
+        let x = self.bn2.forward(&x)?;
+        let x = Activations::relu(&x)?;
+
+        // Deconv (2x upsample) + Sigmoid
+        let x = self.deconv2.forward(&x)?;
+        Activations::sigmoid(&x)
+    }
+
+    /// Forward pass with intermediate feature return (for PFHeadLocal).
+    ///
+    /// Returns (sigmoid_output, intermediate_features) where intermediate_features
+    /// is the output of deconv1 + BN + ReLU (before deconv2 + sigmoid).
+    pub fn forward_with_features(&self, input: &MxArray) -> Result<(MxArray, MxArray)> {
+        // Conv + BN + ReLU
+        let x = self.conv1.forward(input)?;
+        let x = self.bn1.forward(&x)?;
+        let x = Activations::relu(&x)?;
+
+        // Deconv (2x upsample) + BN + ReLU
+        let x = self.deconv1.forward(&x)?;
+        let x = self.bn2.forward(&x)?;
+        let f = Activations::relu(&x)?;
+
+        // Deconv (2x upsample) + Sigmoid
+        let x = self.deconv2.forward(&f)?;
+        let shrink_maps = Activations::sigmoid(&x)?;
+
+        Ok((shrink_maps, f))
+    }
+}
+
+/// LocalModule: refinement branch of PFHeadLocal.
+///
+/// Corresponds to PaddleOCR's `LocalModule` class.
+///
+/// Architecture:
+///   Input: concatenate [shrink_maps(1ch), up_conv(f)(inner_ch)] -> (inner_channels + 1) channels
+///   conv1: Conv2d(inner_ch+1 -> mid_ch, k=3, pad=1, bias=False) + BN + ReLU
+///   conv2: Conv2d(mid_ch -> 1, k=1, pad=0, bias=False)
+///   Output: 1-channel feature map (before sigmoid)
+pub struct LocalModule {
+    /// Conv2d(inner_ch+1 -> mid_ch, k=3, pad=1) + BN + ReLU
+    conv1: NativeConv2d,
+    bn1: FrozenBatchNorm2d,
+    /// Conv2d(mid_ch -> 1, k=1, pad=0)
+    conv2: NativeConv2d,
+}
+
+impl LocalModule {
+    pub fn new(conv1: NativeConv2d, bn1: FrozenBatchNorm2d, conv2: NativeConv2d) -> Self {
+        Self { conv1, bn1, conv2 }
+    }
+
+    /// Forward pass: refine the shrink map.
+    ///
+    /// # Arguments
+    /// * `x` - Upsampled intermediate features [B, H, W, inner_ch]
+    /// * `init_map` - Shrink map from binarize head [B, H, W, 1]
+    ///
+    /// # Returns
+    /// * Refined feature map [B, H, W, 1] (before sigmoid)
+    pub fn forward(&self, x: &MxArray, init_map: &MxArray) -> Result<MxArray> {
+        // Concatenate [init_map, x] along channel axis (axis=3 in NHWC)
+        let outf = MxArray::concatenate(init_map, x, 3)?;
+        // Conv1 + BN + ReLU
+        let out = self.conv1.forward(&outf)?;
+        let out = self.bn1.forward(&out)?;
+        let out = Activations::relu(&out)?;
+        // Conv2
+        self.conv2.forward(&out)
+    }
+}
+
+/// PFHeadLocal: DB head with local refinement branch.
+///
+/// Corresponds to PaddleOCR's `PFHeadLocal` class.
+///
+/// At inference time:
+/// 1. binarize head produces shrink_maps AND intermediate features f
+/// 2. f is 2x nearest-upsampled
+/// 3. LocalModule refines using [shrink_maps, upsample(f)]
+/// 4. Returns 0.5 * (base_maps + sigmoid(cbn_output))
+pub struct PFHeadLocal {
+    /// Binarize (shrink map) head
+    binarize: Head,
+    /// CBN refinement layer
+    cbn_layer: LocalModule,
+}
+
+impl PFHeadLocal {
+    pub fn new(binarize: Head, cbn_layer: LocalModule) -> Self {
+        Self {
+            binarize,
+            cbn_layer,
+        }
+    }
+
+    /// Forward pass (inference only).
+    ///
+    /// Input: [B, H, W, C] where H,W are at stride-4 relative to input image
+    /// Output: [B, H*4, W*4, 1] probability map at original resolution
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        // 1. Run binarize head with intermediate feature return
+        let (shrink_maps, f) = self.binarize.forward_with_features(input)?;
+
+        // 2. Nearest-neighbor 2x upsample of intermediate features
+        let f_up = upsample_nearest_2x(&f)?;
+
+        // 3. Run cbn_layer (LocalModule)
+        let cbn_out = self.cbn_layer.forward(&f_up, &shrink_maps)?;
+        let cbn_maps = Activations::sigmoid(&cbn_out)?;
+
+        // 4. Return 0.5 * (base_maps + cbn_maps)
+        let sum = shrink_maps.add(&cbn_maps)?;
+        sum.mul_scalar(0.5)
+    }
+}
+
+/// 2x nearest-neighbor upsample for NHWC tensors.
+///
+/// Input: [B, H, W, C]
+/// Output: [B, H*2, W*2, C]
+fn upsample_nearest_2x(input: &MxArray) -> Result<MxArray> {
+    let shape = input.shape()?;
+    let batch = shape[0];
+    let h = shape[1];
+    let w = shape[2];
+    let c = shape[3];
+
+    // Reshape to [B, H, 1, W, 1, C], broadcast to [B, H, 2, W, 2, C], reshape back
+    let expanded = input.reshape(&[batch, h, 1, w, 1, c])?;
+    let upsampled = expanded.broadcast_to(&[batch, h, 2, w, 2, c])?;
+    upsampled.reshape(&[batch, h * 2, w * 2, c])
+}
+
+// Legacy type alias for backward compatibility in persistence.rs
+pub type DBHead = Head;

--- a/crates/mlx-core/src/models/pp_text_det/lkpan.rs
+++ b/crates/mlx-core/src/models/pp_text_det/lkpan.rs
@@ -206,6 +206,12 @@ impl LKPAN {
     /// * Single fused feature map [B, H_finest, W_finest, out_channels]
     pub fn forward(&self, features: &[MxArray]) -> Result<MxArray> {
         let n = features.len();
+        if n != 4 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("LKPAN expects exactly 4 feature levels, got {}", n),
+            ));
+        }
 
         // 1. ins_conv: project all levels to out_channels (256)
         let mut ins: Vec<MxArray> = Vec::with_capacity(n);

--- a/crates/mlx-core/src/models/pp_text_det/lkpan.rs
+++ b/crates/mlx-core/src/models/pp_text_det/lkpan.rs
@@ -1,0 +1,288 @@
+//! LKPAN Neck (Large Kernel PAN) with optional IntraCL
+//!
+//! Feature Pyramid Network with Path Aggregation using large-kernel convolutions.
+//! Corresponds to PaddleOCR's LKPAN class (mode="large") from
+//! `ppocr/modeling/necks/db_fpn.py`.
+//!
+//! Architecture:
+//! 1. ins_conv: 1x1 Conv2D per level projecting backbone channels -> out_channels (256)
+//! 2. FPN top-down: upsample + add (fuse coarse -> fine)
+//! 3. inp_conv: 9x9 Conv2D per level reducing out_channels -> out_channels/4 (64)
+//! 4. PAN bottom-up: pan_head_conv (3x3, stride=2) downsamples + add
+//! 5. pan_lat_conv: 9x9 Conv2D per level (final lateral convolution)
+//! 6. Optional IntraCL blocks applied after pan_lat_conv
+//! 7. Upsample all levels to finest resolution -> concatenate (4 x 64 = 256)
+//!
+//! All convolutions are plain Conv2D with NO batch normalization, NO activation,
+//! and NO bias -- matching PaddleOCR's LKPAN in "large" mode.
+//!
+//! ## IntraCLBlock
+//!
+//! Intra-Class Level attention module. Applies directional convolution attention
+//! using cascaded multi-scale (7x7, 5x5, 3x3) convolutions with vertical and
+//! horizontal stripe convolution branches, followed by channel expansion and residual.
+//!
+//! Reference: PaddleOCR's `ppocr/modeling/necks/intracl.py`
+
+use crate::array::MxArray;
+use crate::nn::activations::Activations;
+use napi::bindgen_prelude::*;
+
+use crate::models::pp_doclayout_v3::backbone::{FrozenBatchNorm2d, NativeConv2d};
+
+// ============================================================================
+// IntraCLBlock
+// ============================================================================
+
+/// IntraCLBlock: Intra-class level attention block.
+///
+/// Applies directional convolution attention using cascaded multi-scale convolutions.
+///
+/// Architecture:
+///   1. conv1x1_reduce: channels -> channels // reduce_factor
+///   2. Cascaded 7->5->3 with square + vertical + horizontal branches at each level:
+///      x_7 = c_7x7(x_reduced) + v_7x1(x_reduced) + q_1x7(x_reduced)
+///      x_5 = c_5x5(x_7) + v_5x1(x_7) + q_1x5(x_7)
+///      x_3 = c_3x3(x_5) + v_3x1(x_5) + q_1x3(x_5)
+///   3. conv1x1_return: channels // reduce_factor -> channels
+///   4. BatchNorm + ReLU
+///   5. Residual: output = input + relation
+pub struct IntraCLBlock {
+    /// Channel reduction: Conv2d(channels -> channels//rf, k=1)
+    conv1x1_reduce: NativeConv2d,
+    /// Channel expansion: Conv2d(channels//rf -> channels, k=1)
+    conv1x1_return: NativeConv2d,
+
+    // 7x7 level
+    c_layer_7x7: NativeConv2d,
+    v_layer_7x1: NativeConv2d,
+    q_layer_1x7: NativeConv2d,
+
+    // 5x5 level
+    c_layer_5x5: NativeConv2d,
+    v_layer_5x1: NativeConv2d,
+    q_layer_1x5: NativeConv2d,
+
+    // 3x3 level
+    c_layer_3x3: NativeConv2d,
+    v_layer_3x1: NativeConv2d,
+    q_layer_1x3: NativeConv2d,
+
+    /// BatchNorm2D(channels)
+    bn: FrozenBatchNorm2d,
+}
+
+impl IntraCLBlock {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        conv1x1_reduce: NativeConv2d,
+        conv1x1_return: NativeConv2d,
+        c_layer_7x7: NativeConv2d,
+        v_layer_7x1: NativeConv2d,
+        q_layer_1x7: NativeConv2d,
+        c_layer_5x5: NativeConv2d,
+        v_layer_5x1: NativeConv2d,
+        q_layer_1x5: NativeConv2d,
+        c_layer_3x3: NativeConv2d,
+        v_layer_3x1: NativeConv2d,
+        q_layer_1x3: NativeConv2d,
+        bn: FrozenBatchNorm2d,
+    ) -> Self {
+        Self {
+            conv1x1_reduce,
+            conv1x1_return,
+            c_layer_7x7,
+            v_layer_7x1,
+            q_layer_1x7,
+            c_layer_5x5,
+            v_layer_5x1,
+            q_layer_1x5,
+            c_layer_3x3,
+            v_layer_3x1,
+            q_layer_1x3,
+            bn,
+        }
+    }
+
+    /// Forward pass: apply IntraCL attention.
+    ///
+    /// Input: [B, H, W, C] (NHWC)
+    /// Output: [B, H, W, C] (NHWC) — same shape with residual connection
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        // 1. Channel reduction
+        let x_new = self.conv1x1_reduce.forward(input)?;
+
+        // 2. Cascaded 7 -> 5 -> 3
+        let x_7_c = self.c_layer_7x7.forward(&x_new)?;
+        let x_7_v = self.v_layer_7x1.forward(&x_new)?;
+        let x_7_q = self.q_layer_1x7.forward(&x_new)?;
+        let x_7 = x_7_c.add(&x_7_v)?.add(&x_7_q)?;
+
+        let x_5_c = self.c_layer_5x5.forward(&x_7)?;
+        let x_5_v = self.v_layer_5x1.forward(&x_7)?;
+        let x_5_q = self.q_layer_1x5.forward(&x_7)?;
+        let x_5 = x_5_c.add(&x_5_v)?.add(&x_5_q)?;
+
+        let x_3_c = self.c_layer_3x3.forward(&x_5)?;
+        let x_3_v = self.v_layer_3x1.forward(&x_5)?;
+        let x_3_q = self.q_layer_1x3.forward(&x_5)?;
+        let x_3 = x_3_c.add(&x_3_v)?.add(&x_3_q)?;
+
+        // 3. Channel expansion
+        let x_relation = self.conv1x1_return.forward(&x_3)?;
+
+        // 4. BN + ReLU
+        let x_relation = self.bn.forward(&x_relation)?;
+        let x_relation = Activations::relu(&x_relation)?;
+
+        // 5. Residual
+        input.add(&x_relation)
+    }
+}
+
+// ============================================================================
+// LKPAN
+// ============================================================================
+
+/// Large Kernel PAN neck for text detection.
+///
+/// Takes multi-scale backbone features and produces a single fused feature map
+/// by combining FPN top-down + PAN bottom-up paths with 9x9 convolutions.
+///
+/// Returns a single tensor [B, H, W, out_channels] where out_channels = 256.
+pub struct LKPAN {
+    /// 1x1 Conv2D projections (one per level) -- project to out_channels
+    ins_convs: Vec<NativeConv2d>,
+    /// 9x9 Conv2D reducing out_channels -> out_channels/4 (one per level)
+    inp_convs: Vec<NativeConv2d>,
+    /// 3x3 stride-2 Conv2D for PAN downsampling (n_levels - 1)
+    pan_head_convs: Vec<NativeConv2d>,
+    /// 9x9 Conv2D for PAN lateral output (one per level)
+    pan_lat_convs: Vec<NativeConv2d>,
+    /// Optional IntraCL blocks (one per level), applied after pan_lat_conv
+    intracl_blocks: Option<Vec<IntraCLBlock>>,
+}
+
+impl LKPAN {
+    pub fn new(
+        ins_convs: Vec<NativeConv2d>,
+        inp_convs: Vec<NativeConv2d>,
+        pan_head_convs: Vec<NativeConv2d>,
+        pan_lat_convs: Vec<NativeConv2d>,
+    ) -> Self {
+        Self {
+            ins_convs,
+            inp_convs,
+            pan_head_convs,
+            pan_lat_convs,
+            intracl_blocks: None,
+        }
+    }
+
+    /// Create LKPAN with IntraCL blocks.
+    pub fn with_intracl(
+        ins_convs: Vec<NativeConv2d>,
+        inp_convs: Vec<NativeConv2d>,
+        pan_head_convs: Vec<NativeConv2d>,
+        pan_lat_convs: Vec<NativeConv2d>,
+        intracl_blocks: Vec<IntraCLBlock>,
+    ) -> Self {
+        Self {
+            ins_convs,
+            inp_convs,
+            pan_head_convs,
+            pan_lat_convs,
+            intracl_blocks: Some(intracl_blocks),
+        }
+    }
+
+    /// Forward pass matching PaddleOCR's LKPAN exactly.
+    ///
+    /// # Arguments
+    /// * `features` - Vec of backbone feature maps [B, H_i, W_i, C_i] (NHWC),
+    ///   ordered from finest (stage1) to coarsest (stage4)
+    ///
+    /// # Returns
+    /// * Single fused feature map [B, H_finest, W_finest, out_channels]
+    pub fn forward(&self, features: &[MxArray]) -> Result<MxArray> {
+        let n = features.len();
+
+        // 1. ins_conv: project all levels to out_channels (256)
+        let mut ins: Vec<MxArray> = Vec::with_capacity(n);
+        for (i, feat) in features.iter().enumerate() {
+            ins.push(self.ins_convs[i].forward(feat)?);
+        }
+
+        // 2. FPN top-down: from coarsest to finest
+        // Indices: 0=finest (c2), 1=c3, 2=c4, 3=coarsest (c5)
+        let out4 = ins[2].add(&upsample_nearest_to_match(&ins[3], &ins[2])?)?;
+        let out3 = ins[1].add(&upsample_nearest_to_match(&out4, &ins[1])?)?;
+        let out2 = ins[0].add(&upsample_nearest_to_match(&out3, &ins[0])?)?;
+
+        // 3. inp_conv: reduce 256 -> 64 on each level
+        // Note: coarsest level (in5) uses raw projection (no top-down fusion)
+        let f5 = self.inp_convs[3].forward(&ins[3])?;
+        let f4 = self.inp_convs[2].forward(&out4)?;
+        let f3 = self.inp_convs[1].forward(&out3)?;
+        let f2 = self.inp_convs[0].forward(&out2)?;
+
+        // 4. PAN bottom-up: stride-2 downsample + add
+        let pan3 = f3.add(&self.pan_head_convs[0].forward(&f2)?)?;
+        let pan4 = f4.add(&self.pan_head_convs[1].forward(&pan3)?)?;
+        let pan5 = f5.add(&self.pan_head_convs[2].forward(&pan4)?)?;
+
+        // 5. pan_lat_conv: 9x9 lateral on each level
+        let mut p2 = self.pan_lat_convs[0].forward(&f2)?;
+        let mut p3 = self.pan_lat_convs[1].forward(&pan3)?;
+        let mut p4 = self.pan_lat_convs[2].forward(&pan4)?;
+        let mut p5 = self.pan_lat_convs[3].forward(&pan5)?;
+
+        // 5.5. Optional IntraCL blocks
+        // PaddleOCR ordering: incl4(p5), incl3(p4), incl2(p3), incl1(p2)
+        if let Some(ref blocks) = self.intracl_blocks {
+            p5 = blocks[3].forward(&p5)?;
+            p4 = blocks[2].forward(&p4)?;
+            p3 = blocks[1].forward(&p3)?;
+            p2 = blocks[0].forward(&p2)?;
+        }
+
+        // 6. Upsample all to finest resolution and concatenate
+        let p5_up = upsample_nearest_to_match(&p5, &p2)?;
+        let p4_up = upsample_nearest_to_match(&p4, &p2)?;
+        let p3_up = upsample_nearest_to_match(&p3, &p2)?;
+
+        // Concat along channels: [p5, p4, p3, p2] = 4 x 64 = 256
+        MxArray::concatenate_many(vec![&p5_up, &p4_up, &p3_up, &p2], Some(3))
+    }
+}
+
+/// Upsample `src` using nearest neighbor to match the spatial dimensions of `target`.
+fn upsample_nearest_to_match(src: &MxArray, target: &MxArray) -> Result<MxArray> {
+    let target_shape = target.shape()?;
+    let target_h = target_shape[1];
+    let target_w = target_shape[2];
+
+    let mut x = src.clone();
+    loop {
+        let shape = x.shape()?;
+        let h = shape[1];
+        let w = shape[2];
+        if h >= target_h && w >= target_w {
+            break;
+        }
+        // 2x nearest upsample
+        let batch = shape[0];
+        let c = shape[3];
+        let expanded = x.reshape(&[batch, h, 1, w, 1, c])?;
+        let upsampled = expanded.broadcast_to(&[batch, h, 2, w, 2, c])?;
+        x = upsampled.reshape(&[batch, h * 2, w * 2, c])?;
+    }
+
+    // Slice to exact target size if we overshot
+    let shape = x.shape()?;
+    if shape[1] != target_h || shape[2] != target_w {
+        x = x.slice(&[0, 0, 0, 0], &[shape[0], target_h, target_w, shape[3]])?;
+    }
+
+    Ok(x)
+}

--- a/crates/mlx-core/src/models/pp_text_det/mod.rs
+++ b/crates/mlx-core/src/models/pp_text_det/mod.rs
@@ -1,0 +1,13 @@
+//! PP-OCRv5 Text Detection Model (DBNet)
+//!
+//! Text line detection model based on DBNet (Differentiable Binarization Network).
+//! Uses PPHGNetV2_B4 backbone + LKPAN neck + DBHead.
+//! Ported from PaddleOCR PP-OCRv5_server_det.
+
+pub mod config;
+pub mod db_head;
+pub mod lkpan;
+pub mod model;
+pub mod persistence;
+pub mod postprocessing;
+pub mod processing;

--- a/crates/mlx-core/src/models/pp_text_det/model.rs
+++ b/crates/mlx-core/src/models/pp_text_det/model.rs
@@ -1,0 +1,113 @@
+//! Text Detection Full Model
+//!
+//! Top-level model combining HGNetV2 backbone, LKPAN neck, and DBHead.
+//! Provides the NAPI `TextDetModel` class with `load()` and `detect()` methods.
+
+use crate::array::MxArray;
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+use crate::models::pp_doclayout_v3::backbone::HGNetV2Backbone;
+
+use super::config::TextDetConfig;
+use super::db_head::PFHeadLocal;
+use super::lkpan::LKPAN;
+use super::postprocessing::{TextBox, postprocess_db};
+use super::processing::TextDetImageProcessor;
+
+/// PP-OCRv5 Text Detection model (DBNet with PPHGNetV2 backbone).
+///
+/// Detects text lines in document images and returns bounding boxes.
+#[napi(js_name = "TextDetModel")]
+pub struct TextDetModel {
+    config: TextDetConfig,
+    backbone: HGNetV2Backbone,
+    neck: LKPAN,
+    head: PFHeadLocal,
+    image_processor: TextDetImageProcessor,
+}
+
+#[napi]
+impl TextDetModel {
+    /// Load a TextDetModel from a directory containing model.safetensors.
+    ///
+    /// # Arguments
+    /// * `model_path` - Path to model directory
+    #[napi(factory)]
+    pub fn load(model_path: String) -> Result<Self> {
+        super::persistence::load_model(&model_path)
+    }
+
+    /// Detect text lines in an image.
+    ///
+    /// # Arguments
+    /// * `image_path` - Path to the input image
+    /// * `threshold` - Optional detection threshold (default from config, typically 0.3)
+    ///
+    /// # Returns
+    /// * Vec of TextBox with bounding boxes and confidence scores
+    #[napi]
+    pub fn detect(&self, image_path: String, threshold: Option<f64>) -> Result<Vec<TextBox>> {
+        let det_threshold = threshold.unwrap_or(self.config.det_threshold);
+
+        // 1. Preprocess
+        let (pixel_values, orig_h, orig_w, resized_h, resized_w) =
+            self.image_processor.process_file(&image_path)?;
+
+        // 2. Run model
+        let prob_map = self.forward(&pixel_values)?;
+
+        // 3. Postprocess
+        let map_shape = prob_map.shape()?;
+        let map_h = map_shape[1] as usize;
+        let map_w = map_shape[2] as usize;
+
+        prob_map.eval();
+        let prob_data = prob_map.to_float32()?;
+        let prob_vec: Vec<f32> = prob_data.to_vec();
+
+        Ok(postprocess_db(
+            &prob_vec,
+            map_h,
+            map_w,
+            orig_h,
+            orig_w,
+            resized_h,
+            resized_w,
+            det_threshold,
+            self.config.box_threshold,
+            self.config.unclip_ratio,
+            self.config.max_candidates,
+            self.config.min_size,
+        ))
+    }
+
+    /// Run the full model forward pass.
+    fn forward(&self, pixel_values: &MxArray) -> Result<MxArray> {
+        // Backbone: extract multi-scale features
+        let features = self.backbone.forward(pixel_values)?;
+
+        // Neck: LKPAN fuses features via FPN + PAN and returns a single tensor
+        // [B, H, W, 256] at the finest feature level resolution
+        let fused = self.neck.forward(&features)?;
+
+        // Head: produce probability map
+        self.head.forward(&fused)
+    }
+}
+
+/// Create an initialized TextDetModel (called from persistence).
+pub(super) fn create_model(
+    config: TextDetConfig,
+    backbone: HGNetV2Backbone,
+    neck: LKPAN,
+    head: PFHeadLocal,
+) -> TextDetModel {
+    TextDetModel {
+        config,
+        backbone,
+        neck,
+        head,
+        image_processor: TextDetImageProcessor::new(),
+    }
+}

--- a/crates/mlx-core/src/models/pp_text_det/persistence.rs
+++ b/crates/mlx-core/src/models/pp_text_det/persistence.rs
@@ -1,0 +1,628 @@
+//! Text Detection Weight Loading
+//!
+//! SafeTensors weight loading for the DBNet text detection model.
+//! Reuses shared persistence helpers from pp_doclayout_v3.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::models::pp_doclayout_v3::backbone::{
+    ConvBNActLight, HGBlock, HGBlockLayer, HGNetV2Backbone, HGNetV2Embeddings, HGNetV2Encoder,
+    HGNetV2Stage, NativeConvTranspose2d,
+};
+use crate::models::pp_doclayout_v3::persistence::{
+    get_tensor, load_conv_bn_act, load_conv2d, load_frozen_bn,
+};
+use crate::utils::safetensors::SafeTensorsFile;
+
+use super::config::TextDetConfig;
+use super::db_head::{Head, LocalModule, PFHeadLocal};
+use super::lkpan::{IntraCLBlock, LKPAN};
+use super::model::{TextDetModel, create_model};
+
+// ============================================================================
+// Backbone Loading (reuses HGNetV2 with text-det config)
+// ============================================================================
+
+fn load_backbone(
+    params: &HashMap<String, MxArray>,
+    config: &TextDetConfig,
+) -> Result<HGNetV2Backbone> {
+    let bc = &config.backbone;
+    let eps = config.batch_norm_eps;
+    let act = bc.hidden_act.as_str();
+    let use_lab = bc.use_learnable_affine_block;
+
+    // Load stem
+    let stem_prefix = "backbone";
+
+    let lab0 = format!("{}.stem1.lab", stem_prefix);
+    let stem1 = load_conv_bn_act(
+        params,
+        &format!("{}.stem1.convolution", stem_prefix),
+        &format!("{}.stem1.normalization", stem_prefix),
+        act,
+        (2, 2),
+        (1, 1),
+        1,
+        eps,
+        if use_lab { Some(lab0.as_str()) } else { None },
+    )?;
+
+    let lab1 = format!("{}.stem2a.lab", stem_prefix);
+    let stem2a = load_conv_bn_act(
+        params,
+        &format!("{}.stem2a.convolution", stem_prefix),
+        &format!("{}.stem2a.normalization", stem_prefix),
+        act,
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+        if use_lab { Some(lab1.as_str()) } else { None },
+    )?;
+
+    let lab2 = format!("{}.stem2b.lab", stem_prefix);
+    let stem2b = load_conv_bn_act(
+        params,
+        &format!("{}.stem2b.convolution", stem_prefix),
+        &format!("{}.stem2b.normalization", stem_prefix),
+        act,
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+        if use_lab { Some(lab2.as_str()) } else { None },
+    )?;
+
+    let lab3 = format!("{}.stem3.lab", stem_prefix);
+    let stem3 = load_conv_bn_act(
+        params,
+        &format!("{}.stem3.convolution", stem_prefix),
+        &format!("{}.stem3.normalization", stem_prefix),
+        act,
+        bc.stem3_stride,
+        (1, 1),
+        1,
+        eps,
+        if use_lab { Some(lab3.as_str()) } else { None },
+    )?;
+
+    let lab4 = format!("{}.stem4.lab", stem_prefix);
+    let stem4 = load_conv_bn_act(
+        params,
+        &format!("{}.stem4.convolution", stem_prefix),
+        &format!("{}.stem4.normalization", stem_prefix),
+        act,
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+        if use_lab { Some(lab4.as_str()) } else { None },
+    )?;
+
+    let embedder = HGNetV2Embeddings::new(stem1, stem2a, stem2b, stem3, stem4);
+
+    // Load encoder stages
+    let mut stages = Vec::with_capacity(bc.num_stages());
+
+    for stage_idx in 0..bc.num_stages() {
+        let stage_prefix = format!("{}.stages.{}", stem_prefix, stage_idx);
+        let do_downsample = bc.stage_downsample[stage_idx];
+        let in_channels = bc.stage_in_channels[stage_idx];
+        let is_light = bc.stage_light_block[stage_idx];
+        let kernel_size = bc.stage_kernel_size[stage_idx];
+        let num_blocks = bc.stage_num_blocks[stage_idx] as usize;
+        let num_layers_per_block = bc.stage_numb_of_layers[stage_idx] as usize;
+        let mid_channels = bc.stage_mid_channels[stage_idx];
+
+        let stage_stride = bc.stage_strides.get(stage_idx).copied().unwrap_or((2, 2));
+        let downsample = if do_downsample {
+            Some(load_conv_bn_act(
+                params,
+                &format!("{}.downsample.convolution", stage_prefix),
+                &format!("{}.downsample.normalization", stage_prefix),
+                "none",
+                stage_stride,
+                (1, 1),
+                in_channels,
+                eps,
+                None,
+            )?)
+        } else {
+            None
+        };
+
+        let mut blocks = Vec::with_capacity(num_blocks);
+
+        for block_idx in 0..num_blocks {
+            let block_prefix = format!("{}.blocks.{}", stage_prefix, block_idx);
+
+            let mut layers: Vec<HGBlockLayer> = Vec::with_capacity(num_layers_per_block);
+            for layer_idx in 0..num_layers_per_block {
+                let layer_prefix = format!("{}.layers.{}", block_prefix, layer_idx);
+                let kp = (kernel_size / 2, kernel_size / 2);
+
+                if is_light {
+                    let conv1 = load_conv_bn_act(
+                        params,
+                        &format!("{}.conv1.convolution", layer_prefix),
+                        &format!("{}.conv1.normalization", layer_prefix),
+                        "none",
+                        (1, 1),
+                        (0, 0),
+                        1,
+                        eps,
+                        None,
+                    )?;
+                    let conv2_lab = format!("{}.conv2.lab", layer_prefix);
+                    let conv2 = load_conv_bn_act(
+                        params,
+                        &format!("{}.conv2.convolution", layer_prefix),
+                        &format!("{}.conv2.normalization", layer_prefix),
+                        act,
+                        (1, 1),
+                        kp,
+                        mid_channels,
+                        eps,
+                        if use_lab {
+                            Some(conv2_lab.as_str())
+                        } else {
+                            None
+                        },
+                    )?;
+                    layers.push(HGBlockLayer::Light(ConvBNActLight::new(conv1, conv2)));
+                } else {
+                    let std_lab = format!("{}.lab", layer_prefix);
+                    let conv = load_conv_bn_act(
+                        params,
+                        &format!("{}.convolution", layer_prefix),
+                        &format!("{}.normalization", layer_prefix),
+                        act,
+                        (1, 1),
+                        kp,
+                        1,
+                        eps,
+                        if use_lab {
+                            Some(std_lab.as_str())
+                        } else {
+                            None
+                        },
+                    )?;
+                    layers.push(HGBlockLayer::Standard(conv));
+                }
+            }
+
+            // Aggregation
+            let agg_prefix = format!("{}.aggregation", block_prefix);
+            let agg_lab0 = format!("{}.0.lab", agg_prefix);
+            let agg_squeeze = load_conv_bn_act(
+                params,
+                &format!("{}.0.convolution", agg_prefix),
+                &format!("{}.0.normalization", agg_prefix),
+                act,
+                (1, 1),
+                (0, 0),
+                1,
+                eps,
+                if use_lab {
+                    Some(agg_lab0.as_str())
+                } else {
+                    None
+                },
+            )?;
+            let agg_lab1 = format!("{}.1.lab", agg_prefix);
+            let agg_excitation = load_conv_bn_act(
+                params,
+                &format!("{}.1.convolution", agg_prefix),
+                &format!("{}.1.normalization", agg_prefix),
+                act,
+                (1, 1),
+                (0, 0),
+                1,
+                eps,
+                if use_lab {
+                    Some(agg_lab1.as_str())
+                } else {
+                    None
+                },
+            )?;
+
+            let residual = block_idx != 0;
+            blocks.push(HGBlock::new(layers, agg_squeeze, agg_excitation, residual));
+        }
+
+        stages.push(HGNetV2Stage::new(downsample, blocks));
+    }
+
+    let encoder = HGNetV2Encoder::new(stages);
+    Ok(HGNetV2Backbone::new(embedder, encoder, bc))
+}
+
+// ============================================================================
+// LKPAN Loading
+// ============================================================================
+
+/// Load a single IntraCLBlock from parameters.
+///
+/// All convolutions in IntraCLBlock have bias (PaddlePaddle default for Conv2D).
+/// reduce_factor=2 for LKPAN (channels=64, reduced=32).
+fn load_intracl_block(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    eps: f64,
+) -> Result<IntraCLBlock> {
+    // Channel reduction/expansion 1x1 convs (have bias by default in Paddle)
+    let conv1x1_reduce = load_conv2d(
+        params,
+        &format!("{}.conv1x1_reduce_channel", prefix),
+        (1, 1),
+        (0, 0),
+        (1, 1),
+        1,
+        true,
+    )?;
+    let conv1x1_return = load_conv2d(
+        params,
+        &format!("{}.conv1x1_return_channel", prefix),
+        (1, 1),
+        (0, 0),
+        (1, 1),
+        1,
+        true,
+    )?;
+
+    // 7x7 level
+    let c_layer_7x7 = load_conv2d(
+        params,
+        &format!("{}.c_layer_7x7", prefix),
+        (1, 1),
+        (3, 3),
+        (1, 1),
+        1,
+        true,
+    )?;
+    let v_layer_7x1 = load_conv2d(
+        params,
+        &format!("{}.v_layer_7x1", prefix),
+        (1, 1),
+        (3, 0),
+        (1, 1),
+        1,
+        true,
+    )?;
+    let q_layer_1x7 = load_conv2d(
+        params,
+        &format!("{}.q_layer_1x7", prefix),
+        (1, 1),
+        (0, 3),
+        (1, 1),
+        1,
+        true,
+    )?;
+
+    // 5x5 level
+    let c_layer_5x5 = load_conv2d(
+        params,
+        &format!("{}.c_layer_5x5", prefix),
+        (1, 1),
+        (2, 2),
+        (1, 1),
+        1,
+        true,
+    )?;
+    let v_layer_5x1 = load_conv2d(
+        params,
+        &format!("{}.v_layer_5x1", prefix),
+        (1, 1),
+        (2, 0),
+        (1, 1),
+        1,
+        true,
+    )?;
+    let q_layer_1x5 = load_conv2d(
+        params,
+        &format!("{}.q_layer_1x5", prefix),
+        (1, 1),
+        (0, 2),
+        (1, 1),
+        1,
+        true,
+    )?;
+
+    // 3x3 level
+    let c_layer_3x3 = load_conv2d(
+        params,
+        &format!("{}.c_layer_3x3", prefix),
+        (1, 1),
+        (1, 1),
+        (1, 1),
+        1,
+        true,
+    )?;
+    let v_layer_3x1 = load_conv2d(
+        params,
+        &format!("{}.v_layer_3x1", prefix),
+        (1, 1),
+        (1, 0),
+        (1, 1),
+        1,
+        true,
+    )?;
+    let q_layer_1x3 = load_conv2d(
+        params,
+        &format!("{}.q_layer_1x3", prefix),
+        (1, 1),
+        (0, 1),
+        (1, 1),
+        1,
+        true,
+    )?;
+
+    // BatchNorm2D (PaddleOCR uses nn.BatchNorm2D)
+    let bn = load_frozen_bn(params, &format!("{}.bn", prefix), eps)?;
+
+    Ok(IntraCLBlock::new(
+        conv1x1_reduce,
+        conv1x1_return,
+        c_layer_7x7,
+        v_layer_7x1,
+        q_layer_1x7,
+        c_layer_5x5,
+        v_layer_5x1,
+        q_layer_1x5,
+        c_layer_3x3,
+        v_layer_3x1,
+        q_layer_1x3,
+        bn,
+    ))
+}
+
+fn load_lkpan(params: &HashMap<String, MxArray>, config: &TextDetConfig) -> Result<LKPAN> {
+    let lk = config.large_kernel_size;
+    let lk_pad = lk / 2;
+    let n_levels = config.backbone.stage_out_channels.len();
+    let eps = config.batch_norm_eps;
+
+    // ins_conv: 1x1 Conv2D (no bias) per level -- project backbone channels -> 256
+    let mut ins_convs = Vec::with_capacity(n_levels);
+    for i in 0..n_levels {
+        ins_convs.push(load_conv2d(
+            params,
+            &format!("neck.ins_conv.{}", i),
+            (1, 1),
+            (0, 0),
+            (1, 1),
+            1,
+            false,
+        )?);
+    }
+
+    // inp_conv: 9x9 Conv2D (no bias) per level -- reduce 256 -> 64
+    let mut inp_convs = Vec::with_capacity(n_levels);
+    for i in 0..n_levels {
+        inp_convs.push(load_conv2d(
+            params,
+            &format!("neck.inp_conv.{}", i),
+            (1, 1),
+            (lk_pad, lk_pad),
+            (1, 1),
+            1,
+            false,
+        )?);
+    }
+
+    // pan_head_conv: 3x3 stride-2 Conv2D (no bias) -- n_levels-1
+    let mut pan_head_convs = Vec::with_capacity(n_levels - 1);
+    for i in 0..n_levels - 1 {
+        pan_head_convs.push(load_conv2d(
+            params,
+            &format!("neck.pan_head_conv.{}", i),
+            (2, 2),
+            (1, 1),
+            (1, 1),
+            1,
+            false,
+        )?);
+    }
+
+    // pan_lat_conv: 9x9 Conv2D (no bias) per level
+    let mut pan_lat_convs = Vec::with_capacity(n_levels);
+    for i in 0..n_levels {
+        pan_lat_convs.push(load_conv2d(
+            params,
+            &format!("neck.pan_lat_conv.{}", i),
+            (1, 1),
+            (lk_pad, lk_pad),
+            (1, 1),
+            1,
+            false,
+        )?);
+    }
+
+    // Try loading IntraCL blocks (optional, check if weights exist)
+    let intracl_key = "neck.incl1.conv1x1_reduce_channel.weight";
+    if params.contains_key(intracl_key) {
+        // Load 4 IntraCL blocks: incl1, incl2, incl3, incl4
+        let mut intracl_blocks = Vec::with_capacity(4);
+        for i in 1..=4 {
+            intracl_blocks.push(load_intracl_block(params, &format!("neck.incl{}", i), eps)?);
+        }
+        Ok(LKPAN::with_intracl(
+            ins_convs,
+            inp_convs,
+            pan_head_convs,
+            pan_lat_convs,
+            intracl_blocks,
+        ))
+    } else {
+        Ok(LKPAN::new(
+            ins_convs,
+            inp_convs,
+            pan_head_convs,
+            pan_lat_convs,
+        ))
+    }
+}
+
+// ============================================================================
+// DBHead Loading
+// ============================================================================
+
+fn load_conv_transpose2d(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    stride: (i32, i32),
+    padding: (i32, i32),
+    has_bias: bool,
+) -> Result<NativeConvTranspose2d> {
+    let weight_raw = get_tensor(params, &format!("{}.weight", prefix))?;
+    // ConvTranspose2d weights in Paddle are (C_in, C_out, kH, kW) = IOHW,
+    // whereas regular Conv2d is (C_out, C_in, kH, kW) = OIHW.
+    // MLX expects (C_out, kH, kW, C_in) = OHWI, so we need [1, 2, 3, 0].
+    let weight = weight_raw.transpose(Some(&[1, 2, 3, 0]))?;
+    let bias = if has_bias {
+        Some(get_tensor(params, &format!("{}.bias", prefix))?)
+    } else {
+        None
+    };
+    Ok(NativeConvTranspose2d::new(
+        &weight,
+        bias.as_ref(),
+        stride,
+        padding,
+        (1, 1),
+        1,
+    ))
+}
+
+/// Load a single Head branch (binarize or thresh).
+fn load_head_branch(params: &HashMap<String, MxArray>, prefix: &str, eps: f64) -> Result<Head> {
+    // Conv2d(in_ch->inner_ch, k=3, pad=1, bias=False) + BN
+    let conv1 = load_conv2d(
+        params,
+        &format!("{}.conv1", prefix),
+        (1, 1),
+        (1, 1),
+        (1, 1),
+        1,
+        false,
+    )?;
+    let bn1 = load_frozen_bn(params, &format!("{}.bn1", prefix), eps)?;
+
+    // ConvTranspose2d(inner_ch->inner_ch, k=2, stride=2) + BN
+    let deconv1 =
+        load_conv_transpose2d(params, &format!("{}.deconv1", prefix), (2, 2), (0, 0), true)?;
+    let bn2 = load_frozen_bn(params, &format!("{}.bn2", prefix), eps)?;
+
+    // ConvTranspose2d(inner_ch->1, k=2, stride=2)
+    let deconv2 =
+        load_conv_transpose2d(params, &format!("{}.deconv2", prefix), (2, 2), (0, 0), true)?;
+
+    Ok(Head::new(conv1, bn1, deconv1, bn2, deconv2))
+}
+
+/// Load LocalModule (refinement branch of PFHeadLocal).
+///
+/// PaddleOCR's LocalModule:
+///   self.last_3 = ConvBNLayer(in_c + 1, mid_c, 3, 1, 1, act="relu")
+///   self.last_1 = nn.Conv2D(mid_c, 1, 1, 1, 0)
+///
+/// ConvBNLayer = Conv2D(bias=False) + BatchNorm(act=None) -> relu
+fn load_local_module(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    eps: f64,
+) -> Result<LocalModule> {
+    // conv1: Conv2d(in_c+1 -> mid_c, k=3, pad=1, bias=False) + BN
+    let conv1 = load_conv2d(
+        params,
+        &format!("{}.conv1", prefix),
+        (1, 1),
+        (1, 1),
+        (1, 1),
+        1,
+        false,
+    )?;
+    let bn1 = load_frozen_bn(params, &format!("{}.conv1_bn", prefix), eps)?;
+
+    // conv2: Conv2d(mid_c -> 1, k=1, pad=0, bias=True)
+    // PaddleOCR: nn.Conv2D(mid_c, 1, 1, 1, 0) — bias_attr defaults to True
+    let conv2 = load_conv2d(
+        params,
+        &format!("{}.conv2", prefix),
+        (1, 1),
+        (0, 0),
+        (1, 1),
+        1,
+        true,
+    )?;
+
+    Ok(LocalModule::new(conv1, bn1, conv2))
+}
+
+/// Load PFHeadLocal (DB head with local refinement branch).
+fn load_pf_head_local(
+    params: &HashMap<String, MxArray>,
+    config: &TextDetConfig,
+) -> Result<PFHeadLocal> {
+    let eps = config.batch_norm_eps;
+
+    // Load the binarize (shrink map) head branch
+    let binarize = load_head_branch(params, "head.shrink_map", eps)?;
+
+    // Load the cbn_layer (LocalModule)
+    let cbn_layer = load_local_module(params, "head.cbn_layer", eps)?;
+
+    Ok(PFHeadLocal::new(binarize, cbn_layer))
+}
+
+// ============================================================================
+// Main Load Function
+// ============================================================================
+
+/// Load a TextDetModel from a directory containing config.json and model.safetensors.
+pub fn load_model(model_path: &str) -> Result<TextDetModel> {
+    let path = Path::new(model_path);
+
+    if !path.exists() {
+        return Err(Error::from_reason(format!(
+            "Model path does not exist: {}",
+            model_path
+        )));
+    }
+
+    // Load config
+    let config_path = path.join("config.json");
+    let config: TextDetConfig = if config_path.exists() {
+        let config_data = fs::read_to_string(&config_path)
+            .map_err(|e| Error::from_reason(format!("Failed to read config: {e}")))?;
+        serde_json::from_str(&config_data)
+            .map_err(|e| Error::from_reason(format!("Failed to parse config: {e}")))?
+    } else {
+        TextDetConfig::default()
+    };
+
+    // Load weights
+    let weights_path = path.join("model.safetensors");
+    if !weights_path.exists() {
+        return Err(Error::from_reason(format!(
+            "Weights file not found: {}",
+            weights_path.display()
+        )));
+    }
+
+    let st_file = SafeTensorsFile::load(&weights_path)?;
+    let params = st_file.load_tensors(&weights_path)?;
+
+    // Build components
+    let backbone = load_backbone(&params, &config)?;
+    let neck = load_lkpan(&params, &config)?;
+    let head = load_pf_head_local(&params, &config)?;
+
+    Ok(create_model(config, backbone, neck, head))
+}

--- a/crates/mlx-core/src/models/pp_text_det/postprocessing.rs
+++ b/crates/mlx-core/src/models/pp_text_det/postprocessing.rs
@@ -1,0 +1,344 @@
+//! DB PostProcessor
+//!
+//! Converts the probability map output by DBHead into text bounding boxes.
+//!
+//! Algorithm:
+//! 1. Binarize the probability map (threshold > det_threshold)
+//! 2. Connected component labeling (pure Rust, no OpenCV)
+//! 3. Extract bounding rectangle per component
+//! 4. Score each box (mean probability inside box)
+//! 5. Filter by box_threshold
+//! 6. Expand boxes by unclip_ratio
+//! 7. Map coordinates back to original image size
+
+use napi_derive::napi;
+
+/// A detected text bounding box.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct TextBox {
+    /// Bounding box in original image coordinates [x1, y1, x2, y2]
+    pub bbox: Vec<f64>,
+    /// Detection confidence score (mean probability inside box)
+    pub score: f64,
+}
+
+/// Post-process the probability map into text boxes.
+///
+/// # Arguments
+/// * `prob_map` - Probability map values (flattened, H*W)
+/// * `map_h` - Probability map height
+/// * `map_w` - Probability map width
+/// * `orig_h` - Original image height
+/// * `orig_w` - Original image width
+/// * `_resized_h` - Resized image height (unused; map_h is used for scaling)
+/// * `_resized_w` - Resized image width (unused; map_w is used for scaling)
+/// * `det_threshold` - Binarization threshold
+/// * `box_threshold` - Minimum mean score inside box
+/// * `unclip_ratio` - Box expansion ratio
+/// * `max_candidates` - Maximum number of candidates
+/// * `min_size` - Minimum box side length
+pub fn postprocess_db(
+    prob_map: &[f32],
+    map_h: usize,
+    map_w: usize,
+    orig_h: u32,
+    orig_w: u32,
+    _resized_h: u32,
+    _resized_w: u32,
+    det_threshold: f64,
+    box_threshold: f64,
+    unclip_ratio: f64,
+    max_candidates: usize,
+    min_size: f64,
+) -> Vec<TextBox> {
+    // 1. Binarize
+    let mut binary: Vec<bool> = Vec::with_capacity(map_h * map_w);
+    for &p in prob_map.iter().take(map_h * map_w) {
+        binary.push(p as f64 > det_threshold);
+    }
+
+    // 2. Connected component labeling
+    let labels = connected_components(&binary, map_h, map_w);
+    let num_labels = *labels.iter().max().unwrap_or(&0);
+
+    if num_labels == 0 {
+        return Vec::new();
+    }
+
+    // 3. Extract bounding rectangles and scores per component
+    //
+    // PaddleOCR's boxes_from_bitmap() order:
+    //   get_mini_boxes -> first min_size check -> score check -> unclip
+    //   -> get_mini_boxes again -> second min_size check -> scale coordinates
+    let mut boxes: Vec<TextBox> = Vec::new();
+
+    for label_id in 1..=num_labels {
+        // Find bounding rect
+        let mut min_x = map_w;
+        let mut min_y = map_h;
+        let mut max_x = 0usize;
+        let mut max_y = 0usize;
+        let mut score_sum = 0.0f64;
+        let mut count = 0usize;
+
+        for y in 0..map_h {
+            for x in 0..map_w {
+                let idx = y * map_w + x;
+                if labels[idx] == label_id {
+                    min_x = min_x.min(x);
+                    min_y = min_y.min(y);
+                    max_x = max_x.max(x);
+                    max_y = max_y.max(y);
+                    score_sum += prob_map[idx] as f64;
+                    count += 1;
+                }
+            }
+        }
+
+        if count == 0 {
+            continue;
+        }
+
+        let box_w = (max_x - min_x + 1) as f64;
+        let box_h = (max_y - min_y + 1) as f64;
+
+        // First min_size check (PaddleOCR: sside < min_size -> continue)
+        // This comes BEFORE the score check, matching PaddleOCR's order.
+        if box_w.min(box_h) < min_size {
+            continue;
+        }
+
+        // Score check (PaddleOCR: box_thresh > score -> continue)
+        let mean_score = score_sum / count as f64;
+        if mean_score < box_threshold {
+            continue;
+        }
+
+        // Expand box by unclip_ratio using the Clipper library offset formula.
+        //
+        // PaddleOCR's DBPostProcessor.unclip() computes:
+        //   distance = poly.area * unclip_ratio / poly.length
+        // where poly.length is the full perimeter (Shapely convention).
+        //
+        // For an axis-aligned rectangle of width w and height h:
+        //   area = w * h
+        //   perimeter = 2 * (w + h)
+        //   distance = (w * h * unclip_ratio) / (2 * (w + h))
+        //
+        // PaddleOCR then uses pyclipper.PyclipperOffset with JT_ROUND to expand
+        // each polygon edge outward by `distance` pixels (Minkowski sum). For a
+        // rectangle, this is equivalent to shifting each edge outward by `distance`:
+        //   x1 -= distance, y1 -= distance, x2 += distance, y2 += distance
+        //
+        // Reference: PaddleOCR/ppocr/postprocess/db_postprocess.py, DBPostProcess.unclip()
+        let perimeter = 2.0 * (box_w + box_h);
+        let area = box_w * box_h;
+        let distance = area * unclip_ratio / perimeter;
+
+        let x1 = (min_x as f64 - distance).max(0.0);
+        let y1 = (min_y as f64 - distance).max(0.0);
+        let x2 = (max_x as f64 + distance).min(map_w as f64 - 1.0);
+        let y2 = (max_y as f64 + distance).min(map_h as f64 - 1.0);
+
+        // Second min_size check after unclip (PaddleOCR: sside < min_size + 2)
+        let exp_w = x2 - x1;
+        let exp_h = y2 - y1;
+        if exp_w.min(exp_h) < min_size + 2.0 {
+            continue;
+        }
+
+        // Map back to original image coordinates with rounding.
+        // PaddleOCR uses np.round() when scaling coordinates:
+        //   box[:, 0] = np.clip(np.round(box[:, 0] / width * dest_width), 0, dest_width)
+        //   box[:, 1] = np.clip(np.round(box[:, 1] / height * dest_height), 0, dest_height)
+        let scale_x = orig_w as f64 / map_w as f64;
+        let scale_y = orig_h as f64 / map_h as f64;
+
+        let ox1 = (x1 * scale_x).round().max(0.0).min(orig_w as f64);
+        let oy1 = (y1 * scale_y).round().max(0.0).min(orig_h as f64);
+        let ox2 = (x2 * scale_x).round().max(0.0).min(orig_w as f64);
+        let oy2 = (y2 * scale_y).round().max(0.0).min(orig_h as f64);
+
+        boxes.push(TextBox {
+            bbox: vec![ox1, oy1, ox2, oy2],
+            score: mean_score,
+        });
+
+        if boxes.len() >= max_candidates {
+            break;
+        }
+    }
+
+    // Sort spatially: top-to-bottom (y1 ascending), then left-to-right (x1 ascending).
+    // This matches PaddleOCR's contour-order output which is roughly spatial,
+    // and is more useful for OCR pipelines than score-based sorting.
+    boxes.sort_by(|a, b| {
+        let y_cmp = a.bbox[1]
+            .partial_cmp(&b.bbox[1])
+            .unwrap_or(std::cmp::Ordering::Equal);
+        if y_cmp != std::cmp::Ordering::Equal {
+            y_cmp
+        } else {
+            a.bbox[0]
+                .partial_cmp(&b.bbox[0])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        }
+    });
+
+    boxes
+}
+
+/// Connected component labeling using union-find.
+///
+/// 8-connected components on a binary image (matches cv2.findContours behavior).
+/// Checks all 8 neighbors: up, left, up-left diagonal, and up-right diagonal.
+/// Returns label array (0 = background, 1..N = component IDs).
+fn connected_components(binary: &[bool], h: usize, w: usize) -> Vec<usize> {
+    let n = h * w;
+    let mut parent: Vec<usize> = (0..n).collect();
+    let mut rank: Vec<usize> = vec![0; n];
+
+    fn find(parent: &mut [usize], x: usize) -> usize {
+        if parent[x] != x {
+            parent[x] = find(parent, parent[x]);
+        }
+        parent[x]
+    }
+
+    fn union(parent: &mut [usize], rank: &mut [usize], x: usize, y: usize) {
+        let rx = find(parent, x);
+        let ry = find(parent, y);
+        if rx == ry {
+            return;
+        }
+        if rank[rx] < rank[ry] {
+            parent[rx] = ry;
+        } else if rank[rx] > rank[ry] {
+            parent[ry] = rx;
+        } else {
+            parent[ry] = rx;
+            rank[rx] += 1;
+        }
+    }
+
+    // First pass: union adjacent foreground pixels (8-connectivity)
+    // For each pixel (y, x), check previously visited neighbors:
+    //   (y-1, x-1) above-left, (y-1, x) above, (y-1, x+1) above-right, (y, x-1) left
+    for y in 0..h {
+        for x in 0..w {
+            let idx = y * w + x;
+            if !binary[idx] {
+                continue;
+            }
+            // Check left neighbor
+            if x > 0 && binary[idx - 1] {
+                union(&mut parent, &mut rank, idx, idx - 1);
+            }
+            // Check above neighbor
+            if y > 0 && binary[(y - 1) * w + x] {
+                union(&mut parent, &mut rank, idx, (y - 1) * w + x);
+            }
+            // Check above-left diagonal
+            if y > 0 && x > 0 && binary[(y - 1) * w + (x - 1)] {
+                union(&mut parent, &mut rank, idx, (y - 1) * w + (x - 1));
+            }
+            // Check above-right diagonal
+            if y > 0 && x + 1 < w && binary[(y - 1) * w + (x + 1)] {
+                union(&mut parent, &mut rank, idx, (y - 1) * w + (x + 1));
+            }
+        }
+    }
+
+    // Assign contiguous labels
+    let mut label_map: Vec<usize> = vec![0; n];
+    let mut next_label = 1usize;
+    let mut root_to_label = std::collections::HashMap::new();
+
+    for i in 0..n {
+        if !binary[i] {
+            continue;
+        }
+        let root = find(&mut parent, i);
+        let label = *root_to_label.entry(root).or_insert_with(|| {
+            let l = next_label;
+            next_label += 1;
+            l
+        });
+        label_map[i] = label;
+    }
+
+    label_map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_connected_components_simple() {
+        // 4x4 binary image with two components (no diagonal connection between them)
+        #[rustfmt::skip]
+        let binary = vec![
+            true,  true,  false, false,
+            true,  false, false, false,
+            false, false, true,  true,
+            false, false, true,  true,
+        ];
+        let labels = connected_components(&binary, 4, 4);
+        // First component (top-left L-shape) should have same label
+        assert_eq!(labels[0], labels[1]);
+        assert_eq!(labels[0], labels[4]);
+        // Second component (bottom-right square) should have same label
+        assert_eq!(labels[10], labels[11]);
+        assert_eq!(labels[10], labels[14]);
+        assert_eq!(labels[10], labels[15]);
+        // Two components should have different labels
+        assert_ne!(labels[0], labels[10]);
+        // Background should be 0
+        assert_eq!(labels[2], 0);
+    }
+
+    #[test]
+    fn test_connected_components_8_connectivity() {
+        // 3x3 binary image where pixels are only connected diagonally.
+        // With 4-connectivity these would be separate; with 8-connectivity
+        // they should be the same component.
+        #[rustfmt::skip]
+        let binary = vec![
+            true,  false, false,
+            false, true,  false,
+            false, false, true,
+        ];
+        let labels = connected_components(&binary, 3, 3);
+        // All three diagonal pixels should be in the same component (8-connected)
+        assert_ne!(labels[0], 0);
+        assert_eq!(labels[0], labels[4]); // (0,0) and (1,1)
+        assert_eq!(labels[0], labels[8]); // (0,0) and (2,2)
+    }
+
+    #[test]
+    fn test_postprocess_empty() {
+        let prob_map = vec![0.0f32; 100];
+        let boxes = postprocess_db(
+            &prob_map, 10, 10, 100, 100, 10, 10, 0.3, 0.6, 1.5, 1000, 3.0,
+        );
+        assert!(boxes.is_empty());
+    }
+
+    #[test]
+    fn test_postprocess_single_box() {
+        let mut prob_map = vec![0.0f32; 400]; // 20x20
+        // Place a high-probability region
+        for y in 5..15 {
+            for x in 5..15 {
+                prob_map[y * 20 + x] = 0.9;
+            }
+        }
+        let boxes = postprocess_db(
+            &prob_map, 20, 20, 200, 200, 20, 20, 0.3, 0.6, 1.5, 1000, 3.0,
+        );
+        assert!(!boxes.is_empty());
+        assert!(boxes[0].score > 0.8);
+    }
+}

--- a/crates/mlx-core/src/models/pp_text_det/processing.rs
+++ b/crates/mlx-core/src/models/pp_text_det/processing.rs
@@ -180,6 +180,16 @@ impl TextDetImageProcessor {
         width: u32,
         height: u32,
     ) -> Result<(MxArray, u32, u32)> {
+        if width == 0 || height == 0 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "Image dimensions must be non-zero, got {}x{}",
+                    width, height
+                ),
+            ));
+        }
+
         // Compute resize ratio using PaddleOCR's DetResizeForTest logic
         let ratio = self.compute_ratio(height, width);
         let new_h = (height as f64 * ratio) as u32;

--- a/crates/mlx-core/src/models/pp_text_det/processing.rs
+++ b/crates/mlx-core/src/models/pp_text_det/processing.rs
@@ -1,0 +1,264 @@
+//! Text Detection Image Preprocessing
+//!
+//! Resize, normalize, and convert images for the text detection model.
+//! Implements PaddleOCR's DetResizeForTest with configurable limit_type and limit_side_len.
+//!
+//! PaddleOCR uses OpenCV which loads images as BGR. Our image loading uses RGB.
+//! We swap R and B channels before normalization to match PaddleOCR's convention.
+
+use crate::array::MxArray;
+use image::ImageReader;
+use image::imageops::FilterType;
+
+/// PaddleOCR uses cv2.INTER_LINEAR (bilinear). The closest equivalent
+/// in the `image` crate is `FilterType::Triangle` (bilinear interpolation).
+const RESIZE_FILTER: FilterType = FilterType::Triangle;
+use napi::bindgen_prelude::*;
+use std::path::Path;
+
+/// Limit type for resize behavior, matching PaddleOCR's DetResizeForTest.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LimitType {
+    /// Scale so that max(h, w) <= limit_side_len (don't upscale)
+    Max,
+    /// Scale so that min(h, w) >= limit_side_len (don't downscale beyond max constraint)
+    Min,
+}
+
+/// Image processor for text detection.
+pub struct TextDetImageProcessor {
+    /// Side length limit (PaddleOCR inference CLI default: 960)
+    pub limit_side_len: u32,
+    /// Limit type: "max" or "min" (PaddleOCR inference CLI default: "max")
+    pub limit_type: LimitType,
+    /// Image mean for normalization [B, G, R] (BGR order, matching PaddleOCR)
+    mean: [f32; 3],
+    /// Image std for normalization [B, G, R] (BGR order, matching PaddleOCR)
+    std: [f32; 3],
+}
+
+impl Default for TextDetImageProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TextDetImageProcessor {
+    /// Create a new processor with PaddleOCR inference CLI defaults.
+    ///
+    /// PaddleOCR's inference CLI (tools/infer/utility.py) uses:
+    ///   det_limit_side_len=960, det_limit_type="max"
+    /// which are the defaults most users expect.
+    pub fn new() -> Self {
+        Self {
+            limit_side_len: 960,
+            limit_type: LimitType::Max,
+            mean: [0.485, 0.456, 0.406],
+            std: [0.229, 0.224, 0.225],
+        }
+    }
+
+    /// Create a processor with custom limit_side_len and limit_type.
+    pub fn with_config(limit_side_len: u32, limit_type: LimitType) -> Self {
+        Self {
+            limit_side_len,
+            limit_type,
+            mean: [0.485, 0.456, 0.406],
+            std: [0.229, 0.224, 0.225],
+        }
+    }
+
+    /// Compute the resize ratio based on limit_type and limit_side_len.
+    ///
+    /// Matches PaddleOCR's DetResizeForTest.resize_image_type0():
+    ///   - limit_type == "max": if max(h,w) > limit, ratio = limit / max(h,w), else 1.0
+    ///   - limit_type == "min": if min(h,w) < limit, ratio = limit / min(h,w), else 1.0
+    fn compute_ratio(&self, h: u32, w: u32) -> f64 {
+        let limit = self.limit_side_len as f64;
+        match self.limit_type {
+            LimitType::Max => {
+                if h.max(w) as f64 > limit {
+                    if h > w {
+                        limit / h as f64
+                    } else {
+                        limit / w as f64
+                    }
+                } else {
+                    1.0
+                }
+            }
+            LimitType::Min => {
+                if (h.min(w) as f64) < limit {
+                    if h < w {
+                        limit / h as f64
+                    } else {
+                        limit / w as f64
+                    }
+                } else {
+                    1.0
+                }
+            }
+        }
+    }
+
+    /// Process an image file.
+    ///
+    /// Returns (pixel_values, original_h, original_w, resized_h, resized_w)
+    /// pixel_values: [1, padded_h, padded_w, 3] normalized float32
+    pub fn process_file(&self, path: &str) -> Result<(MxArray, u32, u32, u32, u32)> {
+        let img_path = Path::new(path);
+        if !img_path.exists() {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("Image file not found: {}", img_path.display()),
+            ));
+        }
+
+        let img = ImageReader::open(img_path)
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to open image: {e}")))?
+            .decode()
+            .map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to decode image: {e}"),
+                )
+            })?;
+
+        let orig_w = img.width();
+        let orig_h = img.height();
+
+        // Compute resize ratio using PaddleOCR's DetResizeForTest logic
+        let ratio = self.compute_ratio(orig_h, orig_w);
+        let new_h = (orig_h as f64 * ratio) as u32;
+        let new_w = (orig_w as f64 * ratio) as u32;
+
+        // Round to nearest multiple of 32 (not ceil) -- matches PaddleOCR:
+        //   resize_h = max(int(round(resize_h / 32) * 32), 32)
+        let round_w = ((new_w as f64 / 32.0).round() as u32 * 32).max(32);
+        let round_h = ((new_h as f64 / 32.0).round() as u32 * 32).max(32);
+
+        // Resize directly to rounded dimensions (no padding)
+        let resized = img.resize_exact(round_w, round_h, RESIZE_FILTER);
+        let rgb_img = resized.to_rgb8();
+
+        let h = round_h as usize;
+        let w = round_w as usize;
+        let mut pixel_data: Vec<f32> = vec![0.0; h * w * 3];
+
+        // Channel mapping: RGB->BGR. PaddleOCR loads as BGR (cv2.imread) and
+        // the mean/std values are in BGR order. We swap R and B before normalizing.
+        let channel_map = [2usize, 1, 0]; // BGR ordering
+
+        for y in 0..h {
+            for x in 0..w {
+                let pixel = rgb_img.get_pixel(x as u32, y as u32);
+                for c in 0..3 {
+                    let src_c = channel_map[c];
+                    let val = pixel[src_c] as f32 / 255.0;
+                    let normalized = (val - self.mean[c]) / self.std[c];
+                    pixel_data[(y * w + x) * 3 + c] = normalized;
+                }
+            }
+        }
+
+        let pixel_values = MxArray::from_float32(&pixel_data, &[1, h as i64, w as i64, 3])?;
+
+        Ok((pixel_values, orig_h, orig_w, round_h, round_w))
+    }
+
+    /// Process raw image bytes (RGB, already decoded).
+    ///
+    /// # Arguments
+    /// * `rgb_data` - Raw RGB pixel data
+    /// * `width` - Image width
+    /// * `height` - Image height
+    ///
+    /// Returns (pixel_values, resized_h, resized_w)
+    pub fn process_crop(
+        &self,
+        rgb_data: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<(MxArray, u32, u32)> {
+        // Compute resize ratio using PaddleOCR's DetResizeForTest logic
+        let ratio = self.compute_ratio(height, width);
+        let new_h = (height as f64 * ratio) as u32;
+        let new_w = (width as f64 * ratio) as u32;
+
+        // Round to nearest multiple of 32 (not ceil) -- matches PaddleOCR
+        let round_w = ((new_w as f64 / 32.0).round() as u32 * 32).max(32);
+        let round_h = ((new_h as f64 / 32.0).round() as u32 * 32).max(32);
+
+        // Create image from raw data and resize directly to rounded dimensions
+        let img = image::RgbImage::from_raw(width, height, rgb_data.to_vec())
+            .ok_or_else(|| Error::new(Status::InvalidArg, "Invalid RGB data dimensions"))?;
+        let resized = image::imageops::resize(&img, round_w, round_h, RESIZE_FILTER);
+
+        let h = round_h as usize;
+        let w = round_w as usize;
+        let mut pixel_data: Vec<f32> = vec![0.0; h * w * 3];
+
+        // Channel mapping: RGB->BGR (same as process_file)
+        let channel_map = [2usize, 1, 0];
+
+        for y in 0..h {
+            for x in 0..w {
+                let pixel = resized.get_pixel(x as u32, y as u32);
+                for c in 0..3 {
+                    let src_c = channel_map[c];
+                    let val = pixel[src_c] as f32 / 255.0;
+                    let normalized = (val - self.mean[c]) / self.std[c];
+                    pixel_data[(y * w + x) * 3 + c] = normalized;
+                }
+            }
+        }
+
+        let pixel_values = MxArray::from_float32(&pixel_data, &[1, h as i64, w as i64, 3])?;
+
+        Ok((pixel_values, round_h, round_w))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_processor_creation() {
+        let proc = TextDetImageProcessor::new();
+        assert_eq!(proc.limit_side_len, 960);
+        assert_eq!(proc.limit_type, LimitType::Max);
+    }
+
+    #[test]
+    fn test_processor_with_config() {
+        let proc = TextDetImageProcessor::with_config(960, LimitType::Max);
+        assert_eq!(proc.limit_side_len, 960);
+        assert_eq!(proc.limit_type, LimitType::Max);
+    }
+
+    #[test]
+    fn test_compute_ratio_max_type() {
+        let proc = TextDetImageProcessor::with_config(960, LimitType::Max);
+        // Image 1920x1080: max=1920 > 960, ratio = 960/1920 = 0.5
+        let ratio = proc.compute_ratio(1080, 1920);
+        assert!((ratio - 0.5).abs() < 1e-6);
+        // Image 640x480: max=640 < 960, ratio = 1.0
+        let ratio = proc.compute_ratio(480, 640);
+        assert!((ratio - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_compute_ratio_min_type() {
+        let proc = TextDetImageProcessor::with_config(736, LimitType::Min);
+        // Image 1920x1080: min=1080 > 736, ratio = 1.0
+        let ratio = proc.compute_ratio(1080, 1920);
+        assert!((ratio - 1.0).abs() < 1e-6);
+        // Image 640x480: min=480 < 736, ratio = 736/480
+        let ratio = proc.compute_ratio(480, 640);
+        assert!((ratio - 736.0 / 480.0).abs() < 1e-6);
+        // Image 320x240: min=240 < 736, ratio = 736/240
+        let ratio = proc.compute_ratio(240, 320);
+        assert!((ratio - 736.0 / 240.0).abs() < 1e-6);
+    }
+}

--- a/crates/mlx-core/src/models/pp_text_rec/config.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/config.rs
@@ -1,0 +1,173 @@
+//! Text Recognition Configuration
+
+use serde::Deserialize;
+
+use crate::models::pp_doclayout_v3::config::HGNetV2Config;
+
+/// Configuration for the text recognition model.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TextRecConfig {
+    /// HGNetV2 backbone configuration
+    #[serde(default = "default_backbone_config")]
+    pub backbone: HGNetV2Config,
+
+    /// Batch normalization epsilon
+    #[serde(default = "default_bn_eps")]
+    pub batch_norm_eps: f64,
+
+    /// SVTR neck hidden dimension (default: 120 from PP-OCRv5_server_rec.yml)
+    #[serde(default = "default_svtr_hidden_dim")]
+    pub svtr_hidden_dim: i32,
+
+    /// Number of SVTR transformer encoder layers
+    #[serde(default = "default_svtr_num_layers")]
+    pub svtr_num_layers: i32,
+
+    /// Number of attention heads in SVTR
+    #[serde(default = "default_svtr_num_heads")]
+    pub svtr_num_heads: i32,
+
+    /// FFN expansion ratio in SVTR (default: 2.0 for EncoderWithSVTR)
+    #[serde(default = "default_svtr_ffn_ratio")]
+    pub svtr_ffn_ratio: f64,
+
+    /// SVTR output dimensionality (default: 120 from PP-OCRv5_server_rec.yml)
+    #[serde(default = "default_svtr_output_dims")]
+    pub svtr_output_dims: i32,
+
+    /// Number of output classes (characters + blank)
+    #[serde(default = "default_num_classes")]
+    pub num_classes: i32,
+
+    /// Input image height
+    #[serde(default = "default_input_height")]
+    pub input_height: i32,
+
+    /// Input image max width
+    #[serde(default = "default_input_max_width")]
+    pub input_max_width: i32,
+}
+
+impl Default for TextRecConfig {
+    fn default() -> Self {
+        Self {
+            backbone: default_backbone_config(),
+            batch_norm_eps: default_bn_eps(),
+            svtr_hidden_dim: default_svtr_hidden_dim(),
+            svtr_num_layers: default_svtr_num_layers(),
+            svtr_num_heads: default_svtr_num_heads(),
+            svtr_ffn_ratio: default_svtr_ffn_ratio(),
+            svtr_output_dims: default_svtr_output_dims(),
+            num_classes: default_num_classes(),
+            input_height: default_input_height(),
+            input_max_width: default_input_max_width(),
+        }
+    }
+}
+
+/// PPHGNetV2_B4 backbone config for text recognition.
+/// Matches PaddleOCR's PPHGNetV2_B4 with text_rec=True.
+/// Uses asymmetric strides to preserve height for CTC: [(2,1),(1,2),(2,1),(2,1)].
+/// stem3 uses stride=1 (not 2) when text_rec=True.
+/// Reference: PaddleOCR/ppocr/modeling/backbones/rec_pphgnetv2.py
+fn default_backbone_config() -> HGNetV2Config {
+    HGNetV2Config {
+        model_type: "hgnet_v2".to_string(),
+        num_channels: 3,
+        embedding_size: 48,
+        depths: vec![1, 1, 3, 1],
+        hidden_sizes: vec![128, 512, 1024, 2048],
+        hidden_act: "relu".to_string(),
+        stem_channels: vec![3, 32, 48],
+        stage_in_channels: vec![48, 128, 512, 1024],
+        stage_mid_channels: vec![48, 96, 192, 384],
+        stage_out_channels: vec![128, 512, 1024, 2048],
+        stage_num_blocks: vec![1, 1, 3, 1],
+        stage_downsample: vec![true, true, true, true],
+        stage_light_block: vec![false, false, true, true],
+        stage_kernel_size: vec![3, 3, 5, 5],
+        stage_numb_of_layers: vec![6, 6, 6, 6],
+        use_learnable_affine_block: false,
+        // Asymmetric strides for text recognition. At input height=48:
+        // stem1 (2,2) → 24, stem3 (1,1) → 24, stage1 (2,1) → 12,
+        // stage2 (1,2) → 12, stage3 (2,1) → 6, stage4 (2,1) → 3.
+        // Final H=3 → avg_pool2d([3,2]) → H=1 → SVTR neck → CTC.
+        stage_strides: vec![(2, 1), (1, 2), (2, 1), (2, 1)],
+        // stem3 stride is (1,1) when text_rec=True
+        stem3_stride: (1, 1),
+        out_features: vec!["stage4".to_string()],
+        out_indices: None,
+        initializer_range: 0.02,
+    }
+}
+
+fn default_bn_eps() -> f64 {
+    1e-5
+}
+fn default_svtr_hidden_dim() -> i32 {
+    120
+}
+fn default_svtr_num_layers() -> i32 {
+    2
+}
+fn default_svtr_num_heads() -> i32 {
+    8
+}
+fn default_svtr_ffn_ratio() -> f64 {
+    2.0
+}
+fn default_svtr_output_dims() -> i32 {
+    120
+}
+fn default_num_classes() -> i32 {
+    6625
+}
+fn default_input_height() -> i32 {
+    48
+}
+fn default_input_max_width() -> i32 {
+    960
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_text_rec_config() {
+        let config = TextRecConfig::default();
+        // B4 rec backbone config
+        assert_eq!(config.backbone.stem_channels, vec![3, 32, 48]);
+        assert_eq!(config.backbone.stage_in_channels, vec![48, 128, 512, 1024]);
+        assert_eq!(config.backbone.stage_mid_channels, vec![48, 96, 192, 384]);
+        assert_eq!(
+            config.backbone.stage_out_channels,
+            vec![128, 512, 1024, 2048]
+        );
+        assert_eq!(config.backbone.stage_num_blocks, vec![1, 1, 3, 1]);
+        assert_eq!(config.backbone.stage_numb_of_layers, vec![6, 6, 6, 6]);
+        assert_eq!(
+            config.backbone.stage_downsample,
+            vec![true, true, true, true]
+        );
+        assert_eq!(
+            config.backbone.stage_light_block,
+            vec![false, false, true, true]
+        );
+        assert_eq!(config.backbone.stage_kernel_size, vec![3, 3, 5, 5]);
+        assert!(!config.backbone.use_learnable_affine_block);
+        // SVTR config
+        assert_eq!(config.svtr_hidden_dim, 120);
+        assert_eq!(config.svtr_num_layers, 2);
+        assert_eq!(config.svtr_output_dims, 120);
+        assert_eq!(config.num_classes, 6625);
+        assert_eq!(config.input_height, 48);
+        // stem3 stride is (1,1) for text_rec=True
+        assert_eq!(config.backbone.stem3_stride, (1, 1));
+        // Asymmetric strides for text rec
+        assert_eq!(
+            config.backbone.stage_strides,
+            vec![(2, 1), (1, 2), (2, 1), (2, 1)]
+        );
+    }
+}

--- a/crates/mlx-core/src/models/pp_text_rec/ctc_head.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/ctc_head.rs
@@ -59,6 +59,12 @@ impl CTCHead {
 /// * Vec of (char_indices, scores) per batch element
 pub fn ctc_greedy_decode(logits: &MxArray) -> Result<Vec<(Vec<usize>, Vec<f32>)>> {
     let shape = logits.shape()?;
+    if shape.len() != 3 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!("CTC logits must be 3D [B, T, C], got {}D", shape.len()),
+        ));
+    }
     let batch = shape[0] as usize;
     let seq_len = shape[1] as usize;
     let num_classes = shape[2] as usize;

--- a/crates/mlx-core/src/models/pp_text_rec/ctc_head.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/ctc_head.rs
@@ -1,0 +1,102 @@
+//! CTC Head
+//!
+//! Simple linear projection from hidden dimension to number of classes (characters + blank).
+//! The blank token is typically at index 0 for CTC decoding.
+
+use crate::array::MxArray;
+use crate::nn::Linear;
+use napi::bindgen_prelude::*;
+
+/// CTC (Connectionist Temporal Classification) head.
+///
+/// Projects from the SVTR neck's hidden dimension to the character vocabulary.
+/// Output logits are used for CTC decoding (argmax -> collapse -> remove blanks).
+///
+/// **Design note on softmax placement**: PaddleOCR's `CTCHead.forward()` applies
+/// `F.softmax(predicts, axis=2)` when `not self.training` (inference mode). We
+/// intentionally omit softmax here and instead apply it in `ctc_greedy_decode()`.
+/// This produces identical results because:
+/// - argmax(logits) == argmax(softmax(logits)) (softmax is monotonic)
+/// - Probability scores are extracted from the softmax output in both cases
+///
+/// Reference: `ppocr/modeling/heads/rec_ctc_head.py`
+pub struct CTCHead {
+    /// Linear projection: hidden_dim -> num_classes
+    fc: Linear,
+}
+
+impl CTCHead {
+    pub fn new(fc: Linear) -> Self {
+        Self { fc }
+    }
+
+    /// Forward pass — returns raw logits (softmax applied in decode step).
+    ///
+    /// Input: [B, seq_len, hidden_dim]
+    /// Output: [B, seq_len, num_classes] (raw logits, not probabilities)
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        self.fc.forward(input)
+    }
+}
+
+/// CTC greedy decoder.
+///
+/// Decodes the CTC output logits into character indices by:
+/// 1. Apply softmax to convert logits to probabilities
+/// 2. Argmax at each timestep
+/// 3. Collapse consecutive duplicate indices
+/// 4. Remove blank token (index 0)
+///
+/// This is equivalent to PaddleOCR's approach where softmax is applied in the
+/// CTC head's forward pass and `CTCLabelDecode` calls `preds.argmax(axis=2)`
+/// and `preds.max(axis=2)` on the already-softmaxed output. Both produce
+/// identical character indices and confidence scores.
+///
+/// # Arguments
+/// * `logits` - [B, seq_len, num_classes] raw logits from CTCHead
+///
+/// # Returns
+/// * Vec of (char_indices, scores) per batch element
+pub fn ctc_greedy_decode(logits: &MxArray) -> Result<Vec<(Vec<usize>, Vec<f32>)>> {
+    let shape = logits.shape()?;
+    let batch = shape[0] as usize;
+    let seq_len = shape[1] as usize;
+    let num_classes = shape[2] as usize;
+
+    // Softmax to get probabilities
+    let probs = crate::nn::activations::Activations::softmax(logits, Some(-1))?;
+
+    // Argmax along last dimension
+    let indices = logits.argmax(-1, Some(false))?;
+    indices.eval();
+    probs.eval();
+
+    let indices_flat = indices.to_int32()?.to_vec();
+    let probs_flat = probs.to_float32()?.to_vec();
+
+    let mut results = Vec::with_capacity(batch);
+
+    for b in 0..batch {
+        let mut chars = Vec::new();
+        let mut scores = Vec::new();
+        let mut prev_idx: i32 = -1;
+
+        for t in 0..seq_len {
+            let flat_idx = b * seq_len + t;
+            let idx = indices_flat[flat_idx];
+
+            // Skip blank (index 0) and consecutive duplicates
+            if idx != 0 && idx != prev_idx {
+                chars.push(idx as usize);
+                // Get the probability of this character
+                let prob_offset = (b * seq_len + t) * num_classes + idx as usize;
+                scores.push(probs_flat[prob_offset]);
+            }
+            prev_idx = idx;
+        }
+
+        results.push((chars, scores));
+    }
+
+    Ok(results)
+}

--- a/crates/mlx-core/src/models/pp_text_rec/dictionary.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/dictionary.rs
@@ -1,0 +1,130 @@
+//! Character Dictionary
+//!
+//! Loads the character-to-index mapping from a text file.
+//! Each line in the dictionary file contains one character.
+//! Index 0 is reserved for the CTC blank token.
+
+use napi::bindgen_prelude::*;
+use std::fs;
+use std::path::Path;
+
+/// Character dictionary for CTC decoding.
+pub struct CharDictionary {
+    /// Index → character mapping (index 0 = blank)
+    chars: Vec<String>,
+}
+
+impl CharDictionary {
+    /// Load a dictionary from a text file.
+    ///
+    /// Each line contains one character. The blank token is automatically
+    /// prepended at index 0.
+    ///
+    /// `use_space_char` controls whether a space character is appended to the
+    /// dictionary. PaddleOCR's `BaseRecLabelDecode.__init__()` only adds space
+    /// when `use_space_char=True` (see `rec_postprocess.py`).
+    /// PP-OCRv5_server_rec.yml sets `use_space_char: true`, so the default is true.
+    pub fn load(dict_path: &str) -> Result<Self> {
+        Self::load_with_options(dict_path, true)
+    }
+
+    /// Load a dictionary with explicit `use_space_char` control.
+    ///
+    /// When `use_space_char` is true, a space token `" "` is appended after all
+    /// dictionary characters, matching PaddleOCR's behavior.
+    pub fn load_with_options(dict_path: &str, use_space_char: bool) -> Result<Self> {
+        let path = Path::new(dict_path);
+        if !path.exists() {
+            return Err(Error::from_reason(format!(
+                "Dictionary file not found: {}",
+                dict_path
+            )));
+        }
+
+        let content = fs::read_to_string(path)
+            .map_err(|e| Error::from_reason(format!("Failed to read dictionary: {e}")))?;
+
+        // Index 0 = blank token
+        let mut chars = vec!["".to_string()];
+
+        for line in content.lines() {
+            // Only strip trailing \r (lines() already strips \n).
+            // Do NOT use trim() — it strips Unicode whitespace like U+3000
+            // (ideographic space) which is a valid dictionary character.
+            let ch = line.trim_end_matches('\r');
+            if !ch.is_empty() {
+                chars.push(ch.to_string());
+            }
+        }
+
+        // PaddleOCR only adds space when use_space_char=True
+        // (see BaseRecLabelDecode.__init__ in rec_postprocess.py)
+        if use_space_char {
+            chars.push(" ".to_string());
+        }
+
+        Ok(Self { chars })
+    }
+
+    /// Create a dictionary from an explicit character list.
+    pub fn from_chars(chars: Vec<String>) -> Self {
+        Self { chars }
+    }
+
+    /// Get the number of classes (including blank).
+    pub fn num_classes(&self) -> usize {
+        self.chars.len()
+    }
+
+    /// Decode character indices into a string.
+    ///
+    /// Skips index 0 (blank token) and any out-of-range indices.
+    pub fn decode(&self, indices: &[usize]) -> String {
+        let mut result = String::new();
+        for &idx in indices {
+            if idx > 0 && idx < self.chars.len() {
+                result.push_str(&self.chars[idx]);
+            }
+        }
+        result
+    }
+
+    /// Decode with confidence score (mean of character probabilities).
+    pub fn decode_with_score(&self, indices: &[usize], scores: &[f32]) -> (String, f32) {
+        let text = self.decode(indices);
+        let avg_score = if scores.is_empty() {
+            0.0
+        } else {
+            scores.iter().sum::<f32>() / scores.len() as f32
+        };
+        (text, avg_score)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode() {
+        let dict = CharDictionary::from_chars(vec![
+            "".to_string(), // blank
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+        ]);
+        assert_eq!(dict.num_classes(), 4);
+        assert_eq!(dict.decode(&[1, 2, 3]), "abc");
+        assert_eq!(dict.decode(&[0, 1, 0, 2]), "ab"); // blanks skipped
+        assert_eq!(dict.decode(&[]), "");
+    }
+
+    #[test]
+    fn test_decode_with_score() {
+        let dict =
+            CharDictionary::from_chars(vec!["".to_string(), "h".to_string(), "i".to_string()]);
+        let (text, score) = dict.decode_with_score(&[1, 2], &[0.9, 0.8]);
+        assert_eq!(text, "hi");
+        assert!((score - 0.85).abs() < 1e-6);
+    }
+}

--- a/crates/mlx-core/src/models/pp_text_rec/mod.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/mod.rs
@@ -1,0 +1,13 @@
+//! PP-OCRv5 Text Recognition Model (SVTR + CTC)
+//!
+//! Text recognition model that reads characters from cropped text line images.
+//! Uses PPHGNetV2 backbone + SVTR (Scene Text Visual Representation) neck + CTC head.
+//! Ported from PaddleOCR PP-OCRv5_server_rec.
+
+pub mod config;
+pub mod ctc_head;
+pub mod dictionary;
+pub mod model;
+pub mod persistence;
+pub mod processing;
+pub mod svtr_neck;

--- a/crates/mlx-core/src/models/pp_text_rec/model.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/model.rs
@@ -199,6 +199,12 @@ impl TextRecModel {
 /// matching PyTorch/PaddlePaddle's truncation behavior for non-divisible inputs.
 fn avg_pool2d_k3x2(input: &MxArray) -> Result<MxArray> {
     let shape = input.shape()?;
+    if shape.len() != 4 {
+        return Err(Error::from_reason(format!(
+            "avg_pool2d_k3x2: expected 4D input [B, H, W, C], got {}D",
+            shape.len()
+        )));
+    }
     let batch = shape[0];
     let h = shape[1];
     let w = shape[2];

--- a/crates/mlx-core/src/models/pp_text_rec/model.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/model.rs
@@ -1,0 +1,252 @@
+//! Text Recognition Full Model
+//!
+//! Top-level model combining HGNetV2 backbone, SVTR neck, and CTC head.
+//! Provides the NAPI `TextRecModel` class with `load()` and `recognize()` methods.
+
+use crate::array::MxArray;
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+use crate::models::pp_doclayout_v3::backbone::HGNetV2Backbone;
+
+use super::config::TextRecConfig;
+use super::ctc_head::{CTCHead, ctc_greedy_decode};
+use super::dictionary::CharDictionary;
+use super::processing::TextRecImageProcessor;
+use super::svtr_neck::SVTRNeck;
+
+/// Result of text recognition.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct RecResult {
+    /// Recognized text
+    pub text: String,
+    /// Confidence score (mean character probability)
+    pub score: f64,
+}
+
+/// PP-OCRv5 Text Recognition model (PPHGNetV2 + SVTR + CTC).
+///
+/// Recognizes text from cropped text line images.
+#[napi(js_name = "TextRecModel")]
+pub struct TextRecModel {
+    backbone: HGNetV2Backbone,
+    neck: SVTRNeck,
+    head: CTCHead,
+    dictionary: CharDictionary,
+    image_processor: TextRecImageProcessor,
+}
+
+#[napi]
+impl TextRecModel {
+    /// Load a TextRecModel from a directory containing model.safetensors.
+    ///
+    /// # Arguments
+    /// * `model_path` - Path to model directory
+    /// * `dict_path` - Path to character dictionary text file
+    #[napi(factory)]
+    pub fn load(model_path: String, dict_path: String) -> Result<Self> {
+        super::persistence::load_model(&model_path, &dict_path)
+    }
+
+    /// Recognize text from a single image file.
+    ///
+    /// # Arguments
+    /// * `image_path` - Path to a cropped text line image
+    ///
+    /// # Returns
+    /// * RecResult with recognized text and confidence score
+    #[napi]
+    pub fn recognize(&self, image_path: String) -> Result<RecResult> {
+        let pixel_values = self.image_processor.process_file(&image_path)?;
+        let logits = self.forward(&pixel_values)?;
+        let decoded = ctc_greedy_decode(&logits)?;
+
+        if decoded.is_empty() {
+            return Ok(RecResult {
+                text: String::new(),
+                score: 0.0,
+            });
+        }
+
+        let (indices, scores) = &decoded[0];
+        let (text, score) = self.dictionary.decode_with_score(indices, scores);
+
+        Ok(RecResult {
+            text,
+            score: score as f64,
+        })
+    }
+
+    /// Recognize text from multiple image files (batch).
+    ///
+    /// # Arguments
+    /// * `image_paths` - Paths to cropped text line images
+    ///
+    /// # Returns
+    /// * Vec of RecResult with recognized text and confidence scores
+    #[napi]
+    pub fn recognize_batch(&self, image_paths: Vec<String>) -> Result<Vec<RecResult>> {
+        let mut results = Vec::with_capacity(image_paths.len());
+
+        // Process images one at a time through the model
+        // (batching requires all images to have same dimensions after processing)
+        for path in &image_paths {
+            let pixel_values = self.image_processor.process_file(path)?;
+            let logits = self.forward(&pixel_values)?;
+            let decoded = ctc_greedy_decode(&logits)?;
+
+            if decoded.is_empty() {
+                results.push(RecResult {
+                    text: String::new(),
+                    score: 0.0,
+                });
+                continue;
+            }
+
+            let (indices, scores) = &decoded[0];
+            let (text, score) = self.dictionary.decode_with_score(indices, scores);
+
+            results.push(RecResult {
+                text,
+                score: score as f64,
+            });
+        }
+
+        Ok(results)
+    }
+
+    /// Recognize text from raw RGB crop data.
+    ///
+    /// # Arguments
+    /// * `rgb_data` - Raw RGB pixel data of a cropped text line
+    /// * `width` - Image width
+    /// * `height` - Image height
+    ///
+    /// # Returns
+    /// * RecResult with recognized text and confidence score
+    #[napi]
+    pub fn recognize_crop(&self, rgb_data: &[u8], width: u32, height: u32) -> Result<RecResult> {
+        let pixel_values = self.image_processor.process_crop(rgb_data, width, height)?;
+        let logits = self.forward(&pixel_values)?;
+        let decoded = ctc_greedy_decode(&logits)?;
+
+        if decoded.is_empty() {
+            return Ok(RecResult {
+                text: String::new(),
+                score: 0.0,
+            });
+        }
+
+        let (indices, scores) = &decoded[0];
+        let (text, score) = self.dictionary.decode_with_score(indices, scores);
+
+        Ok(RecResult {
+            text,
+            score: score as f64,
+        })
+    }
+
+    /// Run the full model forward pass.
+    fn forward(&self, pixel_values: &MxArray) -> Result<MxArray> {
+        // Backbone: extract features (only last stage for text rec)
+        let features = self.backbone.forward(pixel_values)?;
+        let last_feature = features
+            .last()
+            .ok_or_else(|| Error::from_reason("Backbone produced no features"))?;
+
+        // Apply avg_pool2d with kernel [3, 2] to match PaddleOCR's text_rec mode.
+        // PaddleOCR backbone.forward() does: x = F.avg_pool2d(x, [3, 2])
+        // when text_rec=True and not training.
+        // This collapses H from 3 to 1 and halves W.
+        // Implementation: reshape [B, H, W, C] -> [B, H/3, 3, W/2, 2, C] -> mean(axes=[2,4])
+        let pooled = avg_pool2d_k3x2(last_feature)?;
+
+        // Neck: SVTR with EncoderWithSVTR architecture
+        // Input is [B, 1, W/2, C] after pooling. Returns [B, 1, W/2, dims].
+        let spatial = self.neck.forward(&pooled)?;
+
+        // Im2Seq: assert H==1, squeeze H, result is [B, W, dims]
+        // PaddleOCR's Im2Seq does: assert H==1; x = x.squeeze(axis=2); x = x.transpose([0,2,1])
+        // In NHWC, H is axis 1. We squeeze axis 1 to get [B, W, dims].
+        let shape = spatial.shape()?;
+        let batch = shape[0];
+        let h = shape[1];
+        let w = shape[2];
+        let dims = shape[3];
+
+        let sequence = if h == 1 {
+            spatial.reshape(&[batch, w, dims])?
+        } else {
+            // Fallback: pool height dimension if somehow H > 1
+            spatial.mean(Some(&[1]), Some(false))?
+        };
+
+        // Head: CTC projection
+        self.head.forward(&sequence)
+    }
+}
+
+/// Average pooling with kernel [3, 2] and stride [3, 2] (stride defaults to kernel size).
+///
+/// Matches PaddleOCR's `F.avg_pool2d(x, [3, 2])` in the backbone's text_rec forward.
+/// Input: [B, H, W, C] (NHWC)
+/// Output: [B, floor(H/3), floor(W/2), C] (NHWC)
+///
+/// Implemented as reshape + mean since MLX doesn't have a native avg_pool2d FFI:
+///   [B, H', W', C] -> [B, H'/3, 3, W'/2, 2, C] -> mean(axes=[2, 4]) -> [B, H'/3, W'/2, C]
+/// where H' and W' are truncated to be divisible by 3 and 2 respectively,
+/// matching PyTorch/PaddlePaddle's truncation behavior for non-divisible inputs.
+fn avg_pool2d_k3x2(input: &MxArray) -> Result<MxArray> {
+    let shape = input.shape()?;
+    let batch = shape[0];
+    let h = shape[1];
+    let w = shape[2];
+    let c = shape[3];
+
+    let h_out = h / 3;
+    let w_out = w / 2;
+
+    if h_out == 0 || w_out == 0 {
+        return Err(Error::from_reason(format!(
+            "avg_pool2d_k3x2: input H={} or W={} too small for kernel [3, 2]",
+            h, w
+        )));
+    }
+
+    // Truncate to exact multiples (matching PyTorch's floor behavior)
+    let h_trunc = h_out * 3;
+    let w_trunc = w_out * 2;
+    let truncated = if h_trunc != h || w_trunc != w {
+        input.slice(&[0, 0, 0, 0], &[batch, h_trunc, w_trunc, c])?
+    } else {
+        input.clone()
+    };
+
+    // Reshape: [B, H', W', C] -> [B, H'/3, 3, W'/2, 2, C]
+    let reshaped = truncated.reshape(&[batch, h_out, 3, w_out, 2, c])?;
+
+    // Mean over the kernel dimensions (axes 2 and 4) to compute the average
+    let pooled = reshaped.mean(Some(&[2, 4]), Some(false))?;
+
+    Ok(pooled)
+}
+
+/// Create an initialized TextRecModel (called from persistence).
+pub(super) fn create_model(
+    config: &TextRecConfig,
+    backbone: HGNetV2Backbone,
+    neck: SVTRNeck,
+    head: CTCHead,
+    dictionary: CharDictionary,
+) -> TextRecModel {
+    let image_processor =
+        TextRecImageProcessor::new(config.input_height as u32, config.input_max_width as u32);
+    TextRecModel {
+        backbone,
+        neck,
+        head,
+        dictionary,
+        image_processor,
+    }
+}

--- a/crates/mlx-core/src/models/pp_text_rec/persistence.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/persistence.rs
@@ -1,0 +1,418 @@
+//! Text Recognition Weight Loading
+//!
+//! SafeTensors weight loading for the text recognition model.
+//! Reuses shared persistence helpers from pp_doclayout_v3.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::models::pp_doclayout_v3::backbone::{
+    ConvBNActLight, HGBlock, HGBlockLayer, HGNetV2Backbone, HGNetV2Embeddings, HGNetV2Encoder,
+    HGNetV2Stage,
+};
+use crate::models::pp_doclayout_v3::persistence::{
+    load_conv_bn_act, load_conv2d, load_frozen_bn, load_layer_norm, load_linear,
+};
+use crate::utils::safetensors::SafeTensorsFile;
+
+use super::config::TextRecConfig;
+use super::ctc_head::CTCHead;
+use super::dictionary::CharDictionary;
+use super::model::{TextRecModel, create_model};
+use super::svtr_neck::{SVTRConvBN, SVTREncoderLayer, SVTRNeck};
+
+// ============================================================================
+// Backbone Loading (reuses HGNetV2 with text-rec config)
+// ============================================================================
+
+fn load_backbone(
+    params: &HashMap<String, MxArray>,
+    config: &TextRecConfig,
+) -> Result<HGNetV2Backbone> {
+    let bc = &config.backbone;
+    let eps = config.batch_norm_eps;
+    let act = bc.hidden_act.as_str();
+    let use_lab = bc.use_learnable_affine_block;
+
+    // Load stem
+    let stem_prefix = "backbone";
+
+    let lab0 = format!("{}.stem1.lab", stem_prefix);
+    let stem1 = load_conv_bn_act(
+        params,
+        &format!("{}.stem1.convolution", stem_prefix),
+        &format!("{}.stem1.normalization", stem_prefix),
+        act,
+        (2, 2),
+        (1, 1),
+        1,
+        eps,
+        if use_lab { Some(lab0.as_str()) } else { None },
+    )?;
+
+    let lab1 = format!("{}.stem2a.lab", stem_prefix);
+    let stem2a = load_conv_bn_act(
+        params,
+        &format!("{}.stem2a.convolution", stem_prefix),
+        &format!("{}.stem2a.normalization", stem_prefix),
+        act,
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+        if use_lab { Some(lab1.as_str()) } else { None },
+    )?;
+
+    let lab2 = format!("{}.stem2b.lab", stem_prefix);
+    let stem2b = load_conv_bn_act(
+        params,
+        &format!("{}.stem2b.convolution", stem_prefix),
+        &format!("{}.stem2b.normalization", stem_prefix),
+        act,
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+        if use_lab { Some(lab2.as_str()) } else { None },
+    )?;
+
+    let lab3 = format!("{}.stem3.lab", stem_prefix);
+    let stem3 = load_conv_bn_act(
+        params,
+        &format!("{}.stem3.convolution", stem_prefix),
+        &format!("{}.stem3.normalization", stem_prefix),
+        act,
+        bc.stem3_stride,
+        (1, 1),
+        1,
+        eps,
+        if use_lab { Some(lab3.as_str()) } else { None },
+    )?;
+
+    let lab4 = format!("{}.stem4.lab", stem_prefix);
+    let stem4 = load_conv_bn_act(
+        params,
+        &format!("{}.stem4.convolution", stem_prefix),
+        &format!("{}.stem4.normalization", stem_prefix),
+        act,
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+        if use_lab { Some(lab4.as_str()) } else { None },
+    )?;
+
+    let embedder = HGNetV2Embeddings::new(stem1, stem2a, stem2b, stem3, stem4);
+
+    // Load encoder stages
+    let mut stages = Vec::with_capacity(bc.num_stages());
+
+    for stage_idx in 0..bc.num_stages() {
+        let stage_prefix = format!("{}.stages.{}", stem_prefix, stage_idx);
+        let do_downsample = bc.stage_downsample[stage_idx];
+        let in_channels = bc.stage_in_channels[stage_idx];
+        let is_light = bc.stage_light_block[stage_idx];
+        let kernel_size = bc.stage_kernel_size[stage_idx];
+        let num_blocks = bc.stage_num_blocks[stage_idx] as usize;
+        let num_layers_per_block = bc.stage_numb_of_layers[stage_idx] as usize;
+        let mid_channels = bc.stage_mid_channels[stage_idx];
+
+        let stage_stride = bc.stage_strides.get(stage_idx).copied().unwrap_or((2, 2));
+        let downsample = if do_downsample {
+            Some(load_conv_bn_act(
+                params,
+                &format!("{}.downsample.convolution", stage_prefix),
+                &format!("{}.downsample.normalization", stage_prefix),
+                "none",
+                stage_stride,
+                (1, 1),
+                in_channels,
+                eps,
+                None,
+            )?)
+        } else {
+            None
+        };
+
+        let mut blocks = Vec::with_capacity(num_blocks);
+
+        for block_idx in 0..num_blocks {
+            let block_prefix = format!("{}.blocks.{}", stage_prefix, block_idx);
+            let mut layers: Vec<HGBlockLayer> = Vec::with_capacity(num_layers_per_block);
+            for layer_idx in 0..num_layers_per_block {
+                let layer_prefix = format!("{}.layers.{}", block_prefix, layer_idx);
+                let kp = (kernel_size / 2, kernel_size / 2);
+
+                if is_light {
+                    let conv1 = load_conv_bn_act(
+                        params,
+                        &format!("{}.conv1.convolution", layer_prefix),
+                        &format!("{}.conv1.normalization", layer_prefix),
+                        "none",
+                        (1, 1),
+                        (0, 0),
+                        1,
+                        eps,
+                        None,
+                    )?;
+                    let conv2_lab = format!("{}.conv2.lab", layer_prefix);
+                    let conv2 = load_conv_bn_act(
+                        params,
+                        &format!("{}.conv2.convolution", layer_prefix),
+                        &format!("{}.conv2.normalization", layer_prefix),
+                        act,
+                        (1, 1),
+                        kp,
+                        mid_channels,
+                        eps,
+                        if use_lab {
+                            Some(conv2_lab.as_str())
+                        } else {
+                            None
+                        },
+                    )?;
+                    layers.push(HGBlockLayer::Light(ConvBNActLight::new(conv1, conv2)));
+                } else {
+                    let std_lab = format!("{}.lab", layer_prefix);
+                    let conv = load_conv_bn_act(
+                        params,
+                        &format!("{}.convolution", layer_prefix),
+                        &format!("{}.normalization", layer_prefix),
+                        act,
+                        (1, 1),
+                        kp,
+                        1,
+                        eps,
+                        if use_lab {
+                            Some(std_lab.as_str())
+                        } else {
+                            None
+                        },
+                    )?;
+                    layers.push(HGBlockLayer::Standard(conv));
+                }
+            }
+
+            // Aggregation
+            let agg_prefix = format!("{}.aggregation", block_prefix);
+            let agg_lab0 = format!("{}.0.lab", agg_prefix);
+            let agg_squeeze = load_conv_bn_act(
+                params,
+                &format!("{}.0.convolution", agg_prefix),
+                &format!("{}.0.normalization", agg_prefix),
+                act,
+                (1, 1),
+                (0, 0),
+                1,
+                eps,
+                if use_lab {
+                    Some(agg_lab0.as_str())
+                } else {
+                    None
+                },
+            )?;
+            let agg_lab1 = format!("{}.1.lab", agg_prefix);
+            let agg_excitation = load_conv_bn_act(
+                params,
+                &format!("{}.1.convolution", agg_prefix),
+                &format!("{}.1.normalization", agg_prefix),
+                act,
+                (1, 1),
+                (0, 0),
+                1,
+                eps,
+                if use_lab {
+                    Some(agg_lab1.as_str())
+                } else {
+                    None
+                },
+            )?;
+
+            let residual = block_idx != 0;
+            blocks.push(HGBlock::new(layers, agg_squeeze, agg_excitation, residual));
+        }
+
+        stages.push(HGNetV2Stage::new(downsample, blocks));
+    }
+
+    let encoder = HGNetV2Encoder::new(stages);
+    Ok(HGNetV2Backbone::new(embedder, encoder, bc))
+}
+
+// ============================================================================
+// SVTR Neck Loading (EncoderWithSVTR architecture)
+// ============================================================================
+
+/// Load a SVTRConvBN (conv + batchnorm + activation) from parameters.
+fn load_svtr_conv_bn(
+    params: &HashMap<String, MxArray>,
+    conv_prefix: &str,
+    bn_prefix: &str,
+    activation: &str,
+    stride: (i32, i32),
+    padding: (i32, i32),
+    groups: i32,
+    eps: f64,
+) -> Result<SVTRConvBN> {
+    let conv = load_conv2d(params, conv_prefix, stride, padding, (1, 1), groups, false)?;
+    let bn = load_frozen_bn(params, bn_prefix, eps)?;
+    Ok(SVTRConvBN::new(conv, bn, activation))
+}
+
+fn load_svtr_neck(params: &HashMap<String, MxArray>, config: &TextRecConfig) -> Result<SVTRNeck> {
+    let num_layers = config.svtr_num_layers as usize;
+    let num_heads = config.svtr_num_heads;
+    let eps = config.batch_norm_eps;
+
+    // Conv1: Conv2d(C → C/8, k=[1,3], pad=[0,1])
+    let conv1 = load_svtr_conv_bn(
+        params,
+        "neck.svtr.conv1.conv",
+        "neck.svtr.conv1.norm",
+        "swish",
+        (1, 1),
+        (0, 1),
+        1,
+        eps,
+    )?;
+
+    // Conv2: Conv2d(C/8 → hidden, k=1, pad=0)
+    let conv2 = load_svtr_conv_bn(
+        params,
+        "neck.svtr.conv2.conv",
+        "neck.svtr.conv2.norm",
+        "swish",
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+    )?;
+
+    // Transformer encoder layers (pre-norm: norm before sublayer)
+    // PaddleOCR uses fused QKV projection (self.qkv) and output projection (self.proj)
+    let embed_dim = config.svtr_hidden_dim;
+    let mut layers = Vec::with_capacity(num_layers);
+    for i in 0..num_layers {
+        let prefix = format!("neck.svtr.layers.{}", i);
+
+        // Fused QKV: Linear(dim, dim * 3)
+        let qkv = load_linear(params, &format!("{}.qkv", prefix))?;
+        // Output projection: Linear(dim, dim)
+        let proj = load_linear(params, &format!("{}.proj", prefix))?;
+
+        // Pre-norm: LayerNorm applied before attention/FFN
+        let norm1 = load_layer_norm(params, &format!("{}.norm1", prefix), 1e-5)?;
+        let fc1 = load_linear(params, &format!("{}.fc1", prefix))?;
+        let fc2 = load_linear(params, &format!("{}.fc2", prefix))?;
+        let norm2 = load_layer_norm(params, &format!("{}.norm2", prefix), 1e-5)?;
+
+        layers.push(SVTREncoderLayer::new(
+            qkv, proj, num_heads, embed_dim, norm1, fc1, fc2, norm2,
+        ));
+    }
+
+    // Final LayerNorm after all transformer blocks (eps=1e-6)
+    let final_norm = load_layer_norm(params, "neck.svtr.norm", 1e-6)?;
+
+    // Conv3: Conv2d(hidden → C, k=1, pad=0)
+    let conv3 = load_svtr_conv_bn(
+        params,
+        "neck.svtr.conv3.conv",
+        "neck.svtr.conv3.norm",
+        "swish",
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+    )?;
+
+    // Conv4: Conv2d(2C → C/8, k=[1,3], pad=[0,1]) — after concat with shortcut
+    let conv4 = load_svtr_conv_bn(
+        params,
+        "neck.svtr.conv4.conv",
+        "neck.svtr.conv4.norm",
+        "swish",
+        (1, 1),
+        (0, 1),
+        1,
+        eps,
+    )?;
+
+    // Conv1x1: Conv2d(C/8 → dims, k=1, pad=0) — final projection
+    let conv1x1 = load_svtr_conv_bn(
+        params,
+        "neck.svtr.conv1x1.conv",
+        "neck.svtr.conv1x1.norm",
+        "swish",
+        (1, 1),
+        (0, 0),
+        1,
+        eps,
+    )?;
+
+    Ok(SVTRNeck::new(
+        conv1, conv2, layers, final_norm, conv3, conv4, conv1x1,
+    ))
+}
+
+// ============================================================================
+// CTC Head Loading
+// ============================================================================
+
+fn load_ctc_head(params: &HashMap<String, MxArray>) -> Result<CTCHead> {
+    let fc = load_linear(params, "head.fc")?;
+    Ok(CTCHead::new(fc))
+}
+
+// ============================================================================
+// Main Load Function
+// ============================================================================
+
+/// Load a TextRecModel from a directory containing model.safetensors and a dictionary file.
+pub fn load_model(model_path: &str, dict_path: &str) -> Result<TextRecModel> {
+    let path = Path::new(model_path);
+
+    if !path.exists() {
+        return Err(Error::from_reason(format!(
+            "Model path does not exist: {}",
+            model_path
+        )));
+    }
+
+    // Load config
+    let config_path = path.join("config.json");
+    let config: TextRecConfig = if config_path.exists() {
+        let config_data = fs::read_to_string(&config_path)
+            .map_err(|e| Error::from_reason(format!("Failed to read config: {e}")))?;
+        serde_json::from_str(&config_data)
+            .map_err(|e| Error::from_reason(format!("Failed to parse config: {e}")))?
+    } else {
+        TextRecConfig::default()
+    };
+
+    // Load dictionary
+    let dictionary = CharDictionary::load(dict_path)?;
+
+    // Load weights
+    let weights_path = path.join("model.safetensors");
+    if !weights_path.exists() {
+        return Err(Error::from_reason(format!(
+            "Weights file not found: {}",
+            weights_path.display()
+        )));
+    }
+
+    let st_file = SafeTensorsFile::load(&weights_path)?;
+    let params = st_file.load_tensors(&weights_path)?;
+
+    // Build components
+    let backbone = load_backbone(&params, &config)?;
+    let neck = load_svtr_neck(&params, &config)?;
+    let head = load_ctc_head(&params)?;
+
+    Ok(create_model(&config, backbone, neck, head, dictionary))
+}

--- a/crates/mlx-core/src/models/pp_text_rec/processing.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/processing.rs
@@ -1,0 +1,266 @@
+//! Text Recognition Image Preprocessing
+//!
+//! Resize cropped text line images to fixed height (48) with variable width,
+//! then normalize for the recognition model.
+//!
+//! **Dynamic width expansion** (matching PaddleOCR's behavior):
+//! - For single images: the output width equals the resized width based on aspect
+//!   ratio, clamped to `max_width`. No zero-padding is applied.
+//! - For batches: the maximum aspect ratio across all images is computed, and all
+//!   images are padded to a common width = min(ceil(target_height * max_ratio), max_width).
+//!
+//! PaddleOCR uses OpenCV which loads images as BGR. Our image loading uses RGB.
+//! We swap R<->B channels before normalization to match PaddleOCR's convention.
+
+use crate::array::MxArray;
+use image::ImageReader;
+use image::imageops::FilterType;
+
+/// PaddleOCR uses cv2.INTER_LINEAR (bilinear). The closest equivalent
+/// in the `image` crate is `FilterType::Triangle` (bilinear interpolation).
+const RESIZE_FILTER: FilterType = FilterType::Triangle;
+use napi::bindgen_prelude::*;
+use std::path::Path;
+
+/// Image processor for text recognition.
+pub struct TextRecImageProcessor {
+    /// Target image height
+    target_height: u32,
+    /// Maximum image width (upper bound to prevent OOM)
+    max_width: u32,
+    /// Image mean for normalization [R, G, B]
+    mean: [f32; 3],
+    /// Image std for normalization [R, G, B]
+    std: [f32; 3],
+}
+
+impl TextRecImageProcessor {
+    pub fn new(target_height: u32, max_width: u32) -> Self {
+        Self {
+            target_height,
+            max_width,
+            mean: [0.5, 0.5, 0.5],
+            std: [0.5, 0.5, 0.5],
+        }
+    }
+
+    /// Compute the resized width for a given image, preserving aspect ratio.
+    ///
+    /// Following PaddleOCR's `resize_norm_img`:
+    ///   resized_w = ceil(imgH * (w / h)), clamped to [1, img_w_limit]
+    fn compute_resized_width(&self, width: u32, height: u32, img_w_limit: u32) -> u32 {
+        let ratio = width as f64 / height as f64;
+        let new_w = (self.target_height as f64 * ratio).ceil() as u32;
+        new_w.max(1).min(img_w_limit)
+    }
+
+    /// Process an image file for recognition.
+    ///
+    /// The output width equals the actual resized width (based on aspect ratio),
+    /// clamped to `max_width`. No zero-padding is applied for single images.
+    ///
+    /// Returns pixel_values: [1, target_height, resized_width, 3] normalized float32
+    pub fn process_file(&self, path: &str) -> Result<MxArray> {
+        let img_path = Path::new(path);
+        if !img_path.exists() {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("Image file not found: {}", img_path.display()),
+            ));
+        }
+
+        let img = ImageReader::open(img_path)
+            .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to open image: {e}")))?
+            .decode()
+            .map_err(|e| {
+                Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to decode image: {e}"),
+                )
+            })?;
+
+        let rgb_img = img.to_rgb8();
+        self.process_rgb_single(&rgb_img, rgb_img.width(), rgb_img.height())
+    }
+
+    /// Process raw RGB image data (single image, no padding).
+    ///
+    /// The output width equals the actual resized width (based on aspect ratio),
+    /// clamped to `max_width`. No zero-padding is applied.
+    ///
+    /// # Arguments
+    /// * `rgb_data` - Raw RGB pixel data
+    /// * `width` - Image width
+    /// * `height` - Image height
+    pub fn process_crop(&self, rgb_data: &[u8], width: u32, height: u32) -> Result<MxArray> {
+        let img = image::RgbImage::from_raw(width, height, rgb_data.to_vec())
+            .ok_or_else(|| Error::new(Status::InvalidArg, "Invalid RGB data dimensions"))?;
+        self.process_rgb_single(&img, width, height)
+    }
+
+    /// Process a single RGB image without zero-padding.
+    ///
+    /// Resizes to target_height, computes width from aspect ratio (clamped to max_width),
+    /// and outputs a tensor of shape [1, target_height, resized_width, 3].
+    /// Swaps R<->B channels to match PaddleOCR's BGR convention before normalization.
+    fn process_rgb_single(
+        &self,
+        img: &image::RgbImage,
+        width: u32,
+        height: u32,
+    ) -> Result<MxArray> {
+        let new_w = self.compute_resized_width(width, height, self.max_width);
+        let new_h = self.target_height;
+
+        // Resize
+        let resized = image::imageops::resize(img, new_w, new_h, RESIZE_FILTER);
+
+        // Output is exactly the resized dimensions (no padding)
+        let out_w = new_w as usize;
+        let out_h = new_h as usize;
+        let mut pixel_data: Vec<f32> = Vec::with_capacity(out_h * out_w * 3);
+
+        // Channel mapping: RGB->BGR. Pixel[0]=R->out[2], Pixel[1]=G->out[1], Pixel[2]=B->out[0]
+        let channel_map = [2usize, 1, 0]; // BGR ordering
+
+        for y in 0..out_h {
+            for x in 0..out_w {
+                let pixel = resized.get_pixel(x as u32, y as u32);
+                for (c, &src_c) in channel_map.iter().enumerate() {
+                    let val = pixel[src_c] as f32 / 255.0;
+                    let normalized = (val - self.mean[c]) / self.std[c];
+                    pixel_data.push(normalized);
+                }
+            }
+        }
+
+        MxArray::from_float32(&pixel_data, &[1, out_h as i64, out_w as i64, 3])
+    }
+
+    /// Process a single RGB image, resizing and then padding to a specified target width.
+    ///
+    /// Used internally by `process_batch` to pad all images to a common width.
+    /// Swaps R<->B channels to match PaddleOCR's BGR convention before normalization.
+    fn process_rgb_padded(
+        &self,
+        img: &image::RgbImage,
+        width: u32,
+        height: u32,
+        target_width: u32,
+        output: &mut [f32],
+    ) -> Result<()> {
+        let new_w = self.compute_resized_width(width, height, target_width);
+        let new_h = self.target_height;
+        let out_w = target_width as usize;
+
+        // Resize
+        let resized = image::imageops::resize(img, new_w, new_h, RESIZE_FILTER);
+
+        // Channel mapping: RGB->BGR
+        let channel_map = [2usize, 1, 0];
+
+        for y in 0..new_h as usize {
+            for x in 0..new_w as usize {
+                let pixel = resized.get_pixel(x as u32, y as u32);
+                let base = (y * out_w + x) * 3;
+                for c in 0..3 {
+                    let src_c = channel_map[c];
+                    let val = pixel[src_c] as f32 / 255.0;
+                    output[base + c] = (val - self.mean[c]) / self.std[c];
+                }
+            }
+        }
+        // Remaining pixels (x >= new_w) are already zero-initialized by the caller.
+
+        Ok(())
+    }
+
+    /// Process multiple images into a batch with dynamic width.
+    ///
+    /// Follows PaddleOCR's batch processing approach:
+    /// 1. Compute max aspect ratio across all images in the batch
+    /// 2. Set batch_width = min(ceil(target_height * max_aspect_ratio), max_width)
+    /// 3. Resize each image preserving aspect ratio, pad to batch_width with zeros
+    ///
+    /// Swaps R<->B channels to match PaddleOCR's BGR convention.
+    /// Returns [batch, target_height, batch_width, 3]
+    pub fn process_batch(&self, images: &[(Vec<u8>, u32, u32)]) -> Result<MxArray> {
+        if images.is_empty() {
+            return Err(Error::new(Status::InvalidArg, "Empty image batch"));
+        }
+
+        let out_h = self.target_height as usize;
+
+        // Step 1: Compute the maximum w/h ratio across all images in the batch.
+        // Following PaddleOCR: max_wh_ratio starts at imgW/imgH (default_width / target_height),
+        // then is updated with each image's actual ratio.
+        let default_ratio = self.max_width as f64 / self.target_height as f64;
+        let mut max_wh_ratio: f64 = 0.0;
+        for (_rgb_data, width, height) in images.iter() {
+            let ratio = *width as f64 / *height as f64;
+            if ratio > max_wh_ratio {
+                max_wh_ratio = ratio;
+            }
+        }
+        // PaddleOCR clamps the minimum to the default ratio (imgW/imgH).
+        // But here we just need the max across images; the default ratio acts as a floor
+        // only if no image is wider. We don't enforce the floor because we want narrow
+        // images to produce narrow tensors when the batch is entirely narrow.
+        // However, we do need to cap at max_width.
+        let _ = default_ratio; // Not used as a floor; max_width cap is sufficient.
+
+        // Step 2: Compute batch_width from max aspect ratio
+        let batch_width = ((self.target_height as f64 * max_wh_ratio).ceil() as u32)
+            .max(1)
+            .min(self.max_width);
+
+        let out_w = batch_width as usize;
+        let batch = images.len();
+        let mut pixel_data: Vec<f32> = vec![0.0; batch * out_h * out_w * 3];
+
+        // Step 3: Process each image, resize and pad to batch_width
+        for (b, (rgb_data, width, height)) in images.iter().enumerate() {
+            let img = image::RgbImage::from_raw(*width, *height, rgb_data.clone())
+                .ok_or_else(|| Error::new(Status::InvalidArg, "Invalid RGB data dimensions"))?;
+
+            let offset = b * out_h * out_w * 3;
+            let slice = &mut pixel_data[offset..offset + out_h * out_w * 3];
+            self.process_rgb_padded(&img, *width, *height, batch_width, slice)?;
+        }
+
+        MxArray::from_float32(&pixel_data, &[batch as i64, out_h as i64, out_w as i64, 3])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_processor_creation() {
+        let proc = TextRecImageProcessor::new(48, 960);
+        assert_eq!(proc.target_height, 48);
+        assert_eq!(proc.max_width, 960);
+    }
+
+    #[test]
+    fn test_compute_resized_width_narrow() {
+        let proc = TextRecImageProcessor::new(48, 960);
+        // Image 100x48 (ratio=2.08), new_w = ceil(48*100/48) = 100
+        assert_eq!(proc.compute_resized_width(100, 48, 960), 100);
+    }
+
+    #[test]
+    fn test_compute_resized_width_wide() {
+        let proc = TextRecImageProcessor::new(48, 960);
+        // Image 2000x48 (ratio=41.67), new_w = ceil(48*2000/48) = 2000 -> clamped to 960
+        assert_eq!(proc.compute_resized_width(2000, 48, 960), 960);
+    }
+
+    #[test]
+    fn test_compute_resized_width_tall() {
+        let proc = TextRecImageProcessor::new(48, 960);
+        // Image 320x96 (ratio=3.33), new_w = ceil(48*3.33) = 160
+        assert_eq!(proc.compute_resized_width(320, 96, 960), 160);
+    }
+}

--- a/crates/mlx-core/src/models/pp_text_rec/processing.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/processing.rs
@@ -28,9 +28,9 @@ pub struct TextRecImageProcessor {
     target_height: u32,
     /// Maximum image width (upper bound to prevent OOM)
     max_width: u32,
-    /// Image mean for normalization [R, G, B]
+    /// Image mean for normalization in BGR order (applied after RGB→BGR channel swap)
     mean: [f32; 3],
-    /// Image std for normalization [R, G, B]
+    /// Image std for normalization in BGR order (applied after RGB→BGR channel swap)
     std: [f32; 3],
 }
 
@@ -49,6 +49,9 @@ impl TextRecImageProcessor {
     /// Following PaddleOCR's `resize_norm_img`:
     ///   resized_w = ceil(imgH * (w / h)), clamped to [1, img_w_limit]
     fn compute_resized_width(&self, width: u32, height: u32, img_w_limit: u32) -> u32 {
+        if height == 0 {
+            return 1;
+        }
         let ratio = width as f64 / height as f64;
         let new_w = (self.target_height as f64 * ratio).ceil() as u32;
         new_w.max(1).min(img_w_limit)

--- a/crates/mlx-core/src/models/pp_text_rec/svtr_neck.rs
+++ b/crates/mlx-core/src/models/pp_text_rec/svtr_neck.rs
@@ -1,0 +1,276 @@
+//! SVTR Neck (EncoderWithSVTR)
+//!
+//! Matches PaddleOCR's EncoderWithSVTR from `ppocr/modeling/necks/rnn.py`.
+//! Unlike the simpler pool→transformer approach, this keeps 2D spatial structure
+//! throughout and uses conv bottlenecks for dimensionality reduction.
+//!
+//! Architecture (from PaddleOCR reference, kernel_size=[1,3] from YAML config):
+//!   1. conv1: Conv2d(C → C/8, k=[1,3], pad=[0,1])      — channel reduction
+//!   2. conv2: Conv2d(C/8 → hidden, k=1, pad=0)          — project to hidden_dims
+//!   3. Flatten: [B, H, W, hidden] → [B, H*W, hidden]
+//!   4. N transformer encoder blocks (pre-norm, Swish activation, mlp_ratio=2.0)
+//!   5. Reshape: [B, H*W, hidden] → [B, H, W, hidden]
+//!   6. conv3: Conv2d(hidden → C, k=1, pad=0)            — project back
+//!   7. Concatenate conv3 output with shortcut (from input) → [B, H, W, 2C]
+//!   8. conv4: Conv2d(2C → C/8, k=[1,3], pad=[0,1])     — reduce concatenated
+//!   9. conv1x1: Conv2d(C/8 → dims, k=1, pad=0)         — final projection
+//!      Output: [B, H, W, dims]
+//!
+//! The model.rs caller then pools height to get [B, W, dims] for CTC.
+
+use crate::array::MxArray;
+use crate::models::pp_doclayout_v3::backbone::{FrozenBatchNorm2d, NativeConv2d};
+use crate::nn::activations::Activations;
+use crate::nn::{LayerNorm, Linear};
+use napi::bindgen_prelude::*;
+
+// ============================================================================
+// ConvBNLayer helper (conv + optional BN + optional activation)
+// ============================================================================
+
+/// Conv2d + BatchNorm layer used in SVTR neck bottleneck convolutions.
+pub struct SVTRConvBN {
+    conv: NativeConv2d,
+    bn: FrozenBatchNorm2d,
+    activation: String,
+}
+
+impl SVTRConvBN {
+    pub fn new(conv: NativeConv2d, bn: FrozenBatchNorm2d, activation: &str) -> Self {
+        Self {
+            conv,
+            bn,
+            activation: activation.to_string(),
+        }
+    }
+
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let x = self.conv.forward(input)?;
+        let x = self.bn.forward(&x)?;
+        match self.activation.as_str() {
+            "swish" | "silu" => Activations::silu(&x),
+            "relu" => Activations::relu(&x),
+            "none" => Ok(x),
+            _ => Activations::silu(&x),
+        }
+    }
+}
+
+// ============================================================================
+// Pre-norm Transformer Encoder Layer
+// ============================================================================
+
+/// A single SVTR transformer encoder layer with **pre-norm**.
+///
+/// PaddleOCR's EncoderWithSVTR uses `Block(prenorm=False)` which applies
+/// LayerNorm BEFORE the sublayer (attention/FFN), then adds the residual.
+/// This is the standard pre-norm pattern.
+///
+/// Uses a FUSED QKV projection (single Linear projecting to 3*dim),
+/// matching PaddleOCR's `Attention` class.
+///
+/// FFN uses Swish (SiLU) activation and mlp_ratio=2.0 by default.
+pub struct SVTREncoderLayer {
+    /// Fused Q, K, V projection: Linear(dim, dim * 3)
+    qkv: Linear,
+    /// Output projection: Linear(dim, dim)
+    proj: Linear,
+    num_heads: i32,
+    head_dim: i32,
+    /// LayerNorm before self-attention (pre-norm)
+    norm1: LayerNorm,
+    /// FFN
+    fc1: Linear,
+    fc2: Linear,
+    /// LayerNorm before FFN (pre-norm)
+    norm2: LayerNorm,
+}
+
+impl SVTREncoderLayer {
+    pub fn new(
+        qkv: Linear,
+        proj: Linear,
+        num_heads: i32,
+        embed_dim: i32,
+        norm1: LayerNorm,
+        fc1: Linear,
+        fc2: Linear,
+        norm2: LayerNorm,
+    ) -> Self {
+        let head_dim = embed_dim / num_heads;
+        Self {
+            qkv,
+            proj,
+            num_heads,
+            head_dim,
+            norm1,
+            fc1,
+            fc2,
+            norm2,
+        }
+    }
+
+    /// Forward pass: pre-norm transformer encoder layer.
+    ///
+    /// PaddleOCR's Block with prenorm=False does:
+    ///   x = x + mixer(norm1(x))
+    ///   x = x + mlp(norm2(x))
+    /// This is the standard pre-norm pattern (norm before sublayer).
+    ///
+    /// Uses fused QKV projection matching PaddleOCR's Attention class:
+    ///   qkv = self.qkv(x).reshape(B, seq, 3, num_heads, head_dim).transpose(2,0,3,1,4)
+    ///   q, k, v = qkv[0] * scale, qkv[1], qkv[2]
+    ///
+    /// Input/Output: [B, seq_len, hidden_dim]
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let shape = input.shape()?;
+        let batch = shape[0];
+        let seq_len = shape[1];
+        let embed_dim = shape[2];
+
+        // Pre-norm: LayerNorm BEFORE attention
+        let normed = self.norm1.forward(input)?;
+
+        // Fused QKV projection: [B, seq, dim] → [B, seq, 3*dim]
+        let qkv = self.qkv.forward(&normed)?;
+
+        let nh = self.num_heads as i64;
+        let hd = self.head_dim as i64;
+
+        // Reshape: [B, seq, 3*dim] → [B, seq, 3, nh, hd] → [3, B, nh, seq, hd]
+        let qkv = qkv
+            .reshape(&[batch, seq_len, 3, nh, hd])?
+            .transpose(Some(&[2, 0, 3, 1, 4]))?;
+
+        // Split into Q, K, V along the first dimension (size 3)
+        // qkv shape: [3, B, nh, seq, hd]
+        let q = qkv.slice_axis(0, 0, 1)?.squeeze(Some(&[0]))?; // [B, nh, seq, hd]
+        let k = qkv.slice_axis(0, 1, 2)?.squeeze(Some(&[0]))?; // [B, nh, seq, hd]
+        let v = qkv.slice_axis(0, 2, 3)?.squeeze(Some(&[0]))?; // [B, nh, seq, hd]
+
+        // Scale Q
+        let scaling = (self.head_dim as f64).powf(-0.5);
+        let q = q.mul_scalar(scaling)?;
+
+        // Attention: Q @ K^T → softmax → @ V
+        let k_t = k.transpose(Some(&[0, 1, 3, 2]))?;
+        let attn = q.matmul(&k_t)?;
+        let attn = Activations::softmax(&attn, Some(-1))?;
+        let attn_out = attn.matmul(&v)?;
+
+        // Reshape back: [B, nh, seq, hd] → [B, seq, embed_dim]
+        let attn_out = attn_out
+            .transpose(Some(&[0, 2, 1, 3]))?
+            .reshape(&[batch, seq_len, embed_dim])?;
+        let attn_out = self.proj.forward(&attn_out)?;
+
+        // Residual add to UNNORMALIZED input
+        let x = input.add(&attn_out)?;
+
+        // Pre-norm: LayerNorm BEFORE FFN
+        let normed = self.norm2.forward(&x)?;
+        let ff = self.fc1.forward(&normed)?;
+        let ff = Activations::silu(&ff)?;
+        let ff = self.fc2.forward(&ff)?;
+
+        // Residual add
+        x.add(&ff)
+    }
+}
+
+// ============================================================================
+// SVTRNeck (EncoderWithSVTR)
+// ============================================================================
+
+/// SVTR Neck matching PaddleOCR's EncoderWithSVTR architecture.
+///
+/// Keeps 2D spatial structure throughout, uses conv bottlenecks for
+/// dimensionality reduction, and concatenates the shortcut with
+/// transformer output.
+pub struct SVTRNeck {
+    /// Conv2d(C → C/8, k=[1,3], pad=[0,1]) — channel reduction
+    conv1: SVTRConvBN,
+    /// Conv2d(C/8 → hidden, k=1, pad=0) — project to hidden
+    conv2: SVTRConvBN,
+    /// Transformer encoder layers (pre-norm, Swish FFN)
+    layers: Vec<SVTREncoderLayer>,
+    /// Final LayerNorm applied after all transformer blocks (eps=1e-6)
+    final_norm: LayerNorm,
+    /// Conv2d(hidden → C, k=1, pad=0) — project back
+    conv3: SVTRConvBN,
+    /// Conv2d(2C → C/8, k=[1,3], pad=[0,1]) — reduce concatenated
+    conv4: SVTRConvBN,
+    /// Conv2d(C/8 → dims, k=1, pad=0) — final projection to output dims
+    conv1x1: SVTRConvBN,
+}
+
+impl SVTRNeck {
+    pub fn new(
+        conv1: SVTRConvBN,
+        conv2: SVTRConvBN,
+        layers: Vec<SVTREncoderLayer>,
+        final_norm: LayerNorm,
+        conv3: SVTRConvBN,
+        conv4: SVTRConvBN,
+        conv1x1: SVTRConvBN,
+    ) -> Self {
+        Self {
+            conv1,
+            conv2,
+            layers,
+            final_norm,
+            conv3,
+            conv4,
+            conv1x1,
+        }
+    }
+
+    /// Forward pass.
+    ///
+    /// Input: [B, H, W, C] from backbone (NHWC)
+    /// Output: [B, H, W, dims] spatial features
+    ///
+    /// The caller (model.rs) pools height to get [B, W, dims] for CTC.
+    pub fn forward(&self, input: &MxArray) -> Result<MxArray> {
+        let shape = input.shape()?;
+        let batch = shape[0];
+        let h = shape[1];
+        let w = shape[2];
+
+        // Save shortcut for later concatenation
+        let shortcut = input.clone();
+
+        // Step 1-2: Conv bottleneck to reduce to hidden dims
+        let x = self.conv1.forward(input)?;
+        let x = self.conv2.forward(&x)?;
+
+        // Step 3: Flatten spatial dims for transformer
+        let hidden_shape = x.shape()?;
+        let hidden_dim = hidden_shape[3];
+        let x = x.reshape(&[batch, h * w, hidden_dim])?;
+
+        // Step 4: Transformer encoder layers
+        let mut x = x;
+        for layer in &self.layers {
+            x = layer.forward(&x)?;
+        }
+
+        // Step 4.5: Final LayerNorm after all transformer blocks
+        let x = self.final_norm.forward(&x)?;
+
+        // Step 5: Reshape back to 2D spatial
+        let x = x.reshape(&[batch, h, w, hidden_dim])?;
+
+        // Step 6: Project back to original channel count
+        let x = self.conv3.forward(&x)?;
+
+        // Step 7: Concatenate shortcut (first) with conv3 output (second) along channels
+        // PaddleOCR: z = paddle.concat((h, z), axis=1) — h=shortcut, z=conv3 output
+        // In NHWC, axis=3 is the channel dimension
+        let x = MxArray::concatenate(&shortcut, &x, 3)?;
+
+        // Step 8-9: Reduce and project to output dims
+        let x = self.conv4.forward(&x)?;
+        self.conv1x1.forward(&x)
+    }
+}

--- a/crates/mlx-core/src/vision/conv2d.rs
+++ b/crates/mlx-core/src/vision/conv2d.rs
@@ -217,12 +217,39 @@ pub fn conv2d_forward(
         return Ok(output);
     }
 
-    // General convolution with im2col - more complex but handles all cases
-    // This is a fallback for non-patch-embedding cases
-    Err(Error::new(
-        Status::GenericFailure,
-        "General Conv2d not yet implemented. Only patch embedding (stride == kernel_size) is supported.",
-    ))
+    // General convolution using MLX native conv2d
+    unsafe {
+        let input_handle = input.handle.0;
+        let weight_handle = weight.handle.0;
+
+        let result_handle = mlx_sys::mlx_conv2d(
+            input_handle,
+            weight_handle,
+            stride.0 as i32,
+            stride.1 as i32,
+            padding.0 as i32,
+            padding.1 as i32,
+            _dilation.0 as i32,
+            _dilation.1 as i32,
+            _groups as i32,
+        );
+
+        if result_handle.is_null() {
+            return Err(Error::new(
+                Status::GenericFailure,
+                "MLX conv2d returned null",
+            ));
+        }
+
+        let mut output = MxArray::from_handle(result_handle, "conv2d")?;
+
+        // Add bias if present
+        if let Some(b) = bias {
+            output = output.add(b)?;
+        }
+
+        Ok(output)
+    }
 }
 
 #[cfg(test)]
@@ -302,5 +329,248 @@ mod tests {
 
         let output_shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
         assert_eq!(output_shape, vec![1, 1, 1, 8]);
+    }
+
+    // ---- General FFI path tests (mlx_conv2d) ----
+
+    #[test]
+    fn test_conv2d_general_3x3_stride1_pad1() {
+        // Standard 3x3 conv with stride=1, padding=1 (preserves spatial dims)
+        // This hits the general FFI path since kernel_size != stride
+        let batch = 1i64;
+        let h = 4i64;
+        let w = 4i64;
+        let in_c = 3i64;
+        let out_c = 8i64;
+        let k = 3i64;
+
+        // Deterministic input: sequential values scaled to [0, 1)
+        let input_data: Vec<f32> = (0..(batch * h * w * in_c) as usize)
+            .map(|i| (i % 256) as f32 / 255.0)
+            .collect();
+        let input = MxArray::from_float32(&input_data, &[batch, h, w, in_c]).unwrap();
+
+        // Deterministic weights: centered around zero
+        let weight_data: Vec<f32> = (0..(out_c * k * k * in_c) as usize)
+            .map(|i| ((i % 100) as f32 - 50.0) / 100.0)
+            .collect();
+        let weight = MxArray::from_float32(&weight_data, &[out_c, k, k, in_c]).unwrap();
+
+        let output = conv2d_forward(
+            &input,
+            &weight,
+            None,
+            (1, 1), // stride
+            (1, 1), // padding
+            (1, 1), // dilation
+            1,      // groups
+        )
+        .unwrap();
+
+        // With stride=1, padding=1, 3x3 kernel: out_dim = (4 + 2*1 - 3)/1 + 1 = 4
+        let output_shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(output_shape, vec![1, 4, 4, 8]);
+
+        // Verify output is not all zeros (FFI actually computed something)
+        output.eval();
+        let abs_output = output.abs().unwrap();
+        let sum = abs_output.sum(None, None).unwrap();
+        sum.eval();
+        let sum_data: Vec<f32> = sum.to_float32().unwrap().to_vec();
+        assert!(sum_data[0] > 0.0, "conv2d output should not be all zeros");
+    }
+
+    #[test]
+    fn test_conv2d_general_3x3_stride2_pad1() {
+        // 3x3 conv with stride=2, padding=1 (downsamples spatial dims by 2x)
+        // Used extensively in PP-DocLayoutV3 backbone for downsampling
+        let batch = 1i64;
+        let h = 8i64;
+        let w = 8i64;
+        let in_c = 3i64;
+        let out_c = 16i64;
+        let k = 3i64;
+
+        let input_data: Vec<f32> = (0..(batch * h * w * in_c) as usize)
+            .map(|i| (i % 256) as f32 / 255.0)
+            .collect();
+        let input = MxArray::from_float32(&input_data, &[batch, h, w, in_c]).unwrap();
+
+        let weight_data: Vec<f32> = (0..(out_c * k * k * in_c) as usize)
+            .map(|i| ((i % 100) as f32 - 50.0) / 100.0)
+            .collect();
+        let weight = MxArray::from_float32(&weight_data, &[out_c, k, k, in_c]).unwrap();
+
+        let output = conv2d_forward(
+            &input,
+            &weight,
+            None,
+            (2, 2), // stride
+            (1, 1), // padding
+            (1, 1), // dilation
+            1,      // groups
+        )
+        .unwrap();
+
+        // With stride=2, padding=1, 3x3 kernel: out_dim = (8 + 2*1 - 3)/2 + 1 = 4
+        let output_shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(output_shape, vec![1, 4, 4, 16]);
+
+        // Verify output is not all zeros
+        output.eval();
+        let abs_output = output.abs().unwrap();
+        let sum = abs_output.sum(None, None).unwrap();
+        sum.eval();
+        let sum_data: Vec<f32> = sum.to_float32().unwrap().to_vec();
+        assert!(sum_data[0] > 0.0, "conv2d output should not be all zeros");
+    }
+
+    #[test]
+    fn test_conv2d_general_1x1_stride1_pad0() {
+        // 1x1 pointwise convolution (channel projection)
+        // This also hits the general path since kernel_size (1) == stride (1)
+        // BUT padding is (0,0), so it actually hits the fast path.
+        // To force the general path, we use conv2d_forward directly and
+        // verify correctness of this common configuration regardless of path.
+        //
+        // Note: 1x1 with stride=1 and pad=0 matches the fast path condition
+        // (k_h == stride && k_w == stride && padding == 0). We still test it
+        // because it validates the output shape and computation for pointwise ops.
+        let batch = 1i64;
+        let h = 4i64;
+        let w = 4i64;
+        let in_c = 64i64;
+        let out_c = 32i64;
+        let k = 1i64;
+
+        let input_data: Vec<f32> = (0..(batch * h * w * in_c) as usize)
+            .map(|i| (i % 256) as f32 / 255.0)
+            .collect();
+        let input = MxArray::from_float32(&input_data, &[batch, h, w, in_c]).unwrap();
+
+        let weight_data: Vec<f32> = (0..(out_c * k * k * in_c) as usize)
+            .map(|i| ((i % 100) as f32 - 50.0) / 100.0)
+            .collect();
+        let weight = MxArray::from_float32(&weight_data, &[out_c, k, k, in_c]).unwrap();
+
+        let output = conv2d_forward(
+            &input,
+            &weight,
+            None,
+            (1, 1), // stride
+            (0, 0), // padding
+            (1, 1), // dilation
+            1,      // groups
+        )
+        .unwrap();
+
+        // With stride=1, padding=0, 1x1 kernel: out_dim = (4 + 0 - 1)/1 + 1 = 4
+        let output_shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(output_shape, vec![1, 4, 4, 32]);
+
+        // Verify output is not all zeros
+        output.eval();
+        let abs_output = output.abs().unwrap();
+        let sum = abs_output.sum(None, None).unwrap();
+        sum.eval();
+        let sum_data: Vec<f32> = sum.to_float32().unwrap().to_vec();
+        assert!(sum_data[0] > 0.0, "conv2d output should not be all zeros");
+    }
+
+    #[test]
+    fn test_conv2d_general_3x3_stride1_pad1_with_bias() {
+        // General path 3x3 conv with bias to verify bias addition works
+        // in the FFI path
+        let batch = 1i64;
+        let h = 4i64;
+        let w = 4i64;
+        let in_c = 3i64;
+        let out_c = 8i64;
+        let k = 3i64;
+
+        // Use all-ones input for predictable behavior
+        let input_data: Vec<f32> = vec![1.0; (batch * h * w * in_c) as usize];
+        let input = MxArray::from_float32(&input_data, &[batch, h, w, in_c]).unwrap();
+
+        // Use all-zeros weight so conv output is zero, then bias is the only contributor
+        let weight_data: Vec<f32> = vec![0.0; (out_c * k * k * in_c) as usize];
+        let weight = MxArray::from_float32(&weight_data, &[out_c, k, k, in_c]).unwrap();
+
+        let bias_data: Vec<f32> = (0..out_c as usize).map(|i| (i + 1) as f32).collect();
+        let bias = MxArray::from_float32(&bias_data, &[out_c]).unwrap();
+
+        let output = conv2d_forward(
+            &input,
+            &weight,
+            Some(&bias),
+            (1, 1), // stride
+            (1, 1), // padding
+            (1, 1), // dilation
+            1,      // groups
+        )
+        .unwrap();
+
+        let output_shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(output_shape, vec![1, 4, 4, 8]);
+
+        // With zero weights, output = bias broadcast over [1, 4, 4, 8]
+        // Each spatial position should have bias values [1, 2, 3, 4, 5, 6, 7, 8]
+        output.eval();
+        let data: Vec<f32> = output.to_float32().unwrap().to_vec();
+        // Check first spatial position has bias values
+        for (c, &val) in data.iter().enumerate().take(out_c as usize) {
+            assert!(
+                (val - (c + 1) as f32).abs() < 1e-5,
+                "Expected bias value {} at channel {}, got {}",
+                c + 1,
+                c,
+                val
+            );
+        }
+    }
+
+    #[test]
+    fn test_conv2d_general_5x5_stride1_pad2() {
+        // 5x5 conv with stride=1, padding=2 (preserves spatial dims)
+        // Verifies the general path works with larger kernels
+        let batch = 1i64;
+        let h = 6i64;
+        let w = 6i64;
+        let in_c = 3i64;
+        let out_c = 4i64;
+        let k = 5i64;
+
+        let input_data: Vec<f32> = (0..(batch * h * w * in_c) as usize)
+            .map(|i| (i % 256) as f32 / 255.0)
+            .collect();
+        let input = MxArray::from_float32(&input_data, &[batch, h, w, in_c]).unwrap();
+
+        let weight_data: Vec<f32> = (0..(out_c * k * k * in_c) as usize)
+            .map(|i| ((i % 100) as f32 - 50.0) / 100.0)
+            .collect();
+        let weight = MxArray::from_float32(&weight_data, &[out_c, k, k, in_c]).unwrap();
+
+        let output = conv2d_forward(
+            &input,
+            &weight,
+            None,
+            (1, 1), // stride
+            (2, 2), // padding
+            (1, 1), // dilation
+            1,      // groups
+        )
+        .unwrap();
+
+        // With stride=1, padding=2, 5x5 kernel: out_dim = (6 + 2*2 - 5)/1 + 1 = 6
+        let output_shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(output_shape, vec![1, 6, 6, 4]);
+
+        // Verify output is not all zeros
+        output.eval();
+        let abs_output = output.abs().unwrap();
+        let sum = abs_output.sum(None, None).unwrap();
+        sum.eval();
+        let sum_data: Vec<f32> = sum.to_float32().unwrap().to_vec();
+        assert!(sum_data[0] > 0.0, "conv2d output should not be all zeros");
     }
 }

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -803,6 +803,32 @@ unsafe extern "C" {
         out_dtype: i32, // -1 for input dtype
     ) -> *mut mlx_array;
 
+    // 2D Convolution using MLX native conv2d
+    pub fn mlx_conv2d(
+        input: *mut mlx_array,
+        weight: *mut mlx_array,
+        stride_h: i32,
+        stride_w: i32,
+        padding_h: i32,
+        padding_w: i32,
+        dilation_h: i32,
+        dilation_w: i32,
+        groups: i32,
+    ) -> *mut mlx_array;
+
+    // 2D Transposed Convolution using MLX native conv_transpose2d
+    pub fn mlx_conv_transpose2d(
+        input: *mut mlx_array,
+        weight: *mut mlx_array,
+        stride_h: i32,
+        stride_w: i32,
+        padding_h: i32,
+        padding_w: i32,
+        dilation_h: i32,
+        dilation_w: i32,
+        groups: i32,
+    ) -> *mut mlx_array;
+
     /// Fused PaddleOCR-VL forward pass - entire transformer forward in one FFI call.
     /// Uses mRoPE (multimodal rotary position embedding) instead of standard RoPE.
     /// 9 weights per layer: [input_norm, post_attn_norm, q, k, v, o, gate, up, down]
@@ -826,6 +852,32 @@ unsafe extern "C" {
         out_logits: *mut *mut mlx_array,
         out_kv_keys: *mut *mut mlx_array,   // [num_layers]
         out_kv_values: *mut *mut mlx_array, // [num_layers]
+        out_cache_idx: *mut i32,
+    );
+
+    /// Batched PaddleOCR-VL forward pass with left-padding-aware attention masking.
+    /// Like mlx_paddleocr_vl_forward_step but supports batch > 1 during decode.
+    pub fn mlx_paddleocr_vl_forward_step_batched(
+        input_embeds: *mut mlx_array,         // [batch, seq_len, hidden_size]
+        layer_weights: *const *mut mlx_array, // [num_layers * 9]
+        num_layers: i32,
+        final_norm_weight: *mut mlx_array,
+        lm_head_weight: *mut mlx_array,
+        inv_freq: *mut mlx_array,
+        position_ids: *mut mlx_array, // [3, batch, seq_len]
+        mrope_section: *const i32,
+        hidden_size: i32,
+        num_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        norm_eps: f32,
+        left_padding: *mut mlx_array, // [batch] - left padding amounts
+        kv_keys_in: *const *mut mlx_array,
+        kv_values_in: *const *mut mlx_array,
+        cache_idx_in: i32,
+        out_logits: *mut *mut mlx_array,
+        out_kv_keys: *mut *mut mlx_array,
+        out_kv_values: *mut *mut mlx_array,
         out_cache_idx: *mut i32,
     );
 }

--- a/crates/mlx-sys/src/mlx.cpp
+++ b/crates/mlx-sys/src/mlx.cpp
@@ -4796,4 +4796,241 @@ void mlx_paddleocr_vl_forward_step(
     *out_cache_idx = cache_indices[0];
 }
 
+// Helper: single PaddleOCR-VL transformer block forward with KV cache + batched mask
+// Like paddleocr_vl_block_forward_cached but uses create_batched_causal_mask for
+// left-padding-aware attention masking needed during batched decode.
+static array paddleocr_vl_block_forward_batched(
+    const array& x,
+    const array& input_norm_w,
+    const array& post_attn_norm_w,
+    const array& w_q_t, const array& w_k_t, const array& w_v_t, const array& w_o_t,
+    const array& w_gate_t, const array& w_up_t, const array& w_down_t,
+    int n_heads, int n_kv_heads, int head_dim,
+    float attn_scale, float norm_eps,
+    const array& cos_final, const array& sin_final,
+    std::optional<array>& cached_keys, std::optional<array>& cached_values,
+    int& cache_idx,
+    const array& left_padding
+) {
+    int batch = static_cast<int>(x.shape(0));
+    int seq_len = static_cast<int>(x.shape(1));
+
+    // Self-Attention
+    auto normed = fast::rms_norm(x, std::optional<array>(input_norm_w), norm_eps, {});
+
+    auto queries = matmul(normed, w_q_t);
+    auto keys = matmul(normed, w_k_t);
+    auto values = matmul(normed, w_v_t);
+
+    queries = transpose(reshape(queries, {batch, seq_len, n_heads, head_dim}), {0, 2, 1, 3});
+    keys = transpose(reshape(keys, {batch, seq_len, n_kv_heads, head_dim}), {0, 2, 1, 3});
+    values = transpose(reshape(values, {batch, seq_len, n_kv_heads, head_dim}), {0, 2, 1, 3});
+
+    // Apply pre-sectioned mRoPE
+    auto [q_rotated, k_rotated] = apply_mrope_paddleocr(queries, keys, cos_final, sin_final);
+
+    // KV Cache Update
+    int prev_cache_idx = cache_idx;
+    int new_idx = cache_idx + seq_len;
+
+    if (!cached_keys.has_value()) {
+        int initial_capacity = ((seq_len + KV_CACHE_CHUNK_SIZE - 1) / KV_CACHE_CHUNK_SIZE) * KV_CACHE_CHUNK_SIZE;
+        initial_capacity = std::max(initial_capacity, KV_CACHE_CHUNK_SIZE);
+
+        auto buffer_shape = Shape{batch, n_kv_heads, initial_capacity, head_dim};
+        cached_keys = zeros(buffer_shape, k_rotated.dtype());
+        cached_values = zeros(buffer_shape, values.dtype());
+
+        cached_keys = slice_update(*cached_keys, k_rotated, {0, 0, cache_idx, 0}, {batch, n_kv_heads, new_idx, head_dim});
+        cached_values = slice_update(*cached_values, values, {0, 0, cache_idx, 0}, {batch, n_kv_heads, new_idx, head_dim});
+    } else {
+        int current_capacity = static_cast<int>(cached_keys->shape()[2]);
+        if (new_idx > current_capacity) {
+            int new_capacity = ((new_idx + KV_CACHE_CHUNK_SIZE - 1) / KV_CACHE_CHUNK_SIZE) * KV_CACHE_CHUNK_SIZE;
+            auto new_shape = Shape{batch, n_kv_heads, new_capacity, head_dim};
+            auto new_k_buffer = zeros(new_shape, cached_keys->dtype());
+            auto new_v_buffer = zeros(new_shape, cached_values->dtype());
+            new_k_buffer = slice_update(new_k_buffer, *cached_keys, {0, 0, 0, 0}, cached_keys->shape());
+            new_v_buffer = slice_update(new_v_buffer, *cached_values, {0, 0, 0, 0}, cached_values->shape());
+            cached_keys = new_k_buffer;
+            cached_values = new_v_buffer;
+        }
+        cached_keys = slice_update(*cached_keys, k_rotated, {0, 0, cache_idx, 0}, {batch, n_kv_heads, new_idx, head_dim});
+        cached_values = slice_update(*cached_values, values, {0, 0, cache_idx, 0}, {batch, n_kv_heads, new_idx, head_dim});
+    }
+
+    auto keys_valid = slice(*cached_keys, {0, 0, 0, 0}, {batch, n_kv_heads, new_idx, head_dim});
+    auto values_valid = slice(*cached_values, {0, 0, 0, 0}, {batch, n_kv_heads, new_idx, head_dim});
+    cache_idx = new_idx;
+
+    // Create left-padding-aware attention mask
+    auto mask = create_batched_causal_mask(left_padding, seq_len, new_idx, prev_cache_idx);
+    auto attn_output = fast::scaled_dot_product_attention(q_rotated, keys_valid, values_valid, attn_scale, "", mask, std::nullopt, {});
+
+    // Output projection + residual
+    attn_output = transpose(attn_output, {0, 2, 1, 3});
+    attn_output = reshape(attn_output, {batch, seq_len, n_heads * head_dim});
+    attn_output = matmul(attn_output, w_o_t);
+    auto h = x + attn_output;
+
+    // MLP (SwiGLU) + residual
+    auto mlp_input = fast::rms_norm(h, std::optional<array>(post_attn_norm_w), norm_eps, {});
+    auto gate = matmul(mlp_input, w_gate_t);
+    auto up = matmul(mlp_input, w_up_t);
+    auto activated = compiled_swiglu()({gate, up})[0];
+    auto mlp_output = matmul(activated, w_down_t);
+
+    return h + mlp_output;
+}
+
+// Batched PaddleOCR-VL forward step: input_embeds → mRoPE → layers → norm → LM head
+// Like mlx_paddleocr_vl_forward_step but with left_padding for batched decode.
+void mlx_paddleocr_vl_forward_step_batched(
+    mlx_array* input_embeds_handle,
+    mlx_array* const* layer_weights,
+    int num_layers,
+    mlx_array* final_norm_weight_handle,
+    mlx_array* lm_head_weight_handle,
+    mlx_array* inv_freq_handle,
+    mlx_array* position_ids_handle,
+    const int* mrope_section,
+    int hidden_size, int num_heads, int num_kv_heads, int head_dim,
+    float norm_eps,
+    mlx_array* left_padding_handle,
+    mlx_array* const* kv_keys_in,
+    mlx_array* const* kv_values_in,
+    int cache_idx_in,
+    mlx_array** out_logits,
+    mlx_array** out_kv_keys,
+    mlx_array** out_kv_values,
+    int* out_cache_idx
+) {
+    auto& input_embeds = *reinterpret_cast<array*>(input_embeds_handle);
+    auto& final_norm_w = *reinterpret_cast<array*>(final_norm_weight_handle);
+    auto& lm_head_w = *reinterpret_cast<array*>(lm_head_weight_handle);
+    auto& inv_freq = *reinterpret_cast<array*>(inv_freq_handle);
+    auto& position_ids = *reinterpret_cast<array*>(position_ids_handle);
+    auto& left_padding = *reinterpret_cast<array*>(left_padding_handle);
+
+    float attn_scale = 1.0f / std::sqrt(static_cast<float>(head_dim));
+
+    // Compute mRoPE cos/sin once, then pre-section for all layers
+    auto [mrope_cos, mrope_sin] = compute_mrope_cos_sin(inv_freq, position_ids, head_dim);
+    auto [cos_final, sin_final] = compute_mrope_sectioned(mrope_cos, mrope_sin, mrope_section);
+
+    cos_final = astype(cos_final, input_embeds.dtype());
+    sin_final = astype(sin_final, input_embeds.dtype());
+
+    // Pre-transpose all layer weights once
+    struct LayerWeightsT {
+        array norm_in, norm_post;
+        array q_t, k_t, v_t, o_t, gate_t, up_t, down_t;
+    };
+    std::vector<LayerWeightsT> layer_w;
+    layer_w.reserve(num_layers);
+    for (int i = 0; i < num_layers; i++) {
+        int base = i * 9;
+        auto& w_q = *reinterpret_cast<array*>(layer_weights[base + 2]);
+        auto& w_k = *reinterpret_cast<array*>(layer_weights[base + 3]);
+        auto& w_v = *reinterpret_cast<array*>(layer_weights[base + 4]);
+        auto& w_o = *reinterpret_cast<array*>(layer_weights[base + 5]);
+        auto& w_gate = *reinterpret_cast<array*>(layer_weights[base + 6]);
+        auto& w_up = *reinterpret_cast<array*>(layer_weights[base + 7]);
+        auto& w_down = *reinterpret_cast<array*>(layer_weights[base + 8]);
+        layer_w.push_back({
+            *reinterpret_cast<array*>(layer_weights[base + 0]),
+            *reinterpret_cast<array*>(layer_weights[base + 1]),
+            transpose(w_q, {1, 0}), transpose(w_k, {1, 0}),
+            transpose(w_v, {1, 0}), transpose(w_o, {1, 0}),
+            transpose(w_gate, {1, 0}), transpose(w_up, {1, 0}),
+            transpose(w_down, {1, 0})
+        });
+    }
+
+    // Initialize per-layer KV cache state
+    std::vector<std::optional<array>> kv_keys(num_layers);
+    std::vector<std::optional<array>> kv_values(num_layers);
+    std::vector<int> cache_indices(num_layers, cache_idx_in);
+
+    if (kv_keys_in != nullptr && kv_values_in != nullptr) {
+        for (int i = 0; i < num_layers; i++) {
+            if (kv_keys_in[i] != nullptr) kv_keys[i] = *reinterpret_cast<array*>(kv_keys_in[i]);
+            if (kv_values_in[i] != nullptr) kv_values[i] = *reinterpret_cast<array*>(kv_values_in[i]);
+        }
+    }
+
+    // Forward through all layers with batched mask
+    auto hidden = input_embeds;
+    for (int i = 0; i < num_layers; i++) {
+        auto& lw = layer_w[i];
+        hidden = paddleocr_vl_block_forward_batched(
+            hidden, lw.norm_in, lw.norm_post,
+            lw.q_t, lw.k_t, lw.v_t, lw.o_t, lw.gate_t, lw.up_t, lw.down_t,
+            num_heads, num_kv_heads, head_dim,
+            attn_scale, norm_eps,
+            cos_final, sin_final,
+            kv_keys[i], kv_values[i], cache_indices[i],
+            left_padding);
+    }
+
+    // Final norm + LM head
+    hidden = fast::rms_norm(hidden, std::optional<array>(final_norm_w), norm_eps, {});
+    auto logits = matmul(hidden, transpose(lm_head_w, {1, 0}));
+
+    *out_logits = reinterpret_cast<mlx_array*>(new array(std::move(logits)));
+
+    for (int i = 0; i < num_layers; i++) {
+        out_kv_keys[i] = kv_keys[i].has_value() ? reinterpret_cast<mlx_array*>(new array(std::move(*kv_keys[i]))) : nullptr;
+        out_kv_values[i] = kv_values[i].has_value() ? reinterpret_cast<mlx_array*>(new array(std::move(*kv_values[i]))) : nullptr;
+    }
+    *out_cache_idx = cache_indices[0];
+}
+
+mlx_array* mlx_conv2d(
+    mlx_array* input,
+    mlx_array* weight,
+    int stride_h, int stride_w,
+    int padding_h, int padding_w,
+    int dilation_h, int dilation_w,
+    int groups
+) {
+    auto inp = reinterpret_cast<mlx::core::array*>(input);
+    auto wt = reinterpret_cast<mlx::core::array*>(weight);
+    mlx::core::array result = mlx::core::conv2d(
+        *inp, *wt,
+        {stride_h, stride_w},
+        {padding_h, padding_w},
+        {dilation_h, dilation_w},
+        groups
+    );
+    return reinterpret_cast<mlx_array*>(new mlx::core::array(std::move(result)));
+}
+
+mlx_array* mlx_conv_transpose2d(
+    mlx_array* input,
+    mlx_array* weight,
+    int stride_h, int stride_w,
+    int padding_h, int padding_w,
+    int dilation_h, int dilation_w,
+    int groups
+) {
+    auto inp = reinterpret_cast<mlx::core::array*>(input);
+    auto wt = reinterpret_cast<mlx::core::array*>(weight);
+
+    // Output padding is hardcoded to (0, 0) since current usage (DBHead) requires
+    // exact upsampling with kernel=2, stride=2, padding=0:
+    //   output_h = (input_h - 1) * stride_h - 2*padding_h + kernel_h + output_padding_h
+    //            = (input_h - 1) * 2 - 0 + 2 + 0 = 2 * input_h (exact 2x)
+    // For future use cases requiring non-zero output_padding, expose as parameter.
+    mlx::core::array result = mlx::core::conv_transpose2d(
+        *inp, *wt,
+        std::pair<int,int>{stride_h, stride_w},
+        std::pair<int,int>{padding_h, padding_w},
+        std::pair<int,int>{dilation_h, dilation_w},
+        std::pair<int,int>{0, 0},
+        groups
+    );
+    return reinterpret_cast<mlx_array*>(new mlx::core::array(std::move(result)));
+}
+
 }  // End extern "C"

--- a/examples/package.json
+++ b/examples/package.json
@@ -6,8 +6,9 @@
     "@mlx-node/lm": "workspace:*",
     "@mlx-node/trl": "workspace:*",
     "@mlx-node/vlm": "workspace:*",
-    "@openrouter/ai-sdk-provider": "^1.5.4",
-    "ai": "^6.0.12",
+    "@napi-rs/image": "1.12.0",
+    "@openrouter/ai-sdk-provider": "^2.2.1",
+    "ai": "^6.0.78",
     "zod": "^4.3.5"
   }
 }

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -6,5 +6,5 @@
     "composite": true
   },
   "include": ["./**/*.ts"],
-  "references": [{ "path": "../packages/lm" }, { "path": "../packages/trl" }]
+  "references": [{ "path": "../packages/lm" }, { "path": "../packages/trl" }, { "path": "../packages/vlm" }]
 }

--- a/examples/vlm-inference.ts
+++ b/examples/vlm-inference.ts
@@ -33,7 +33,7 @@ const imagePath = args.find((a) => !a.startsWith('--'));
 const vlmOnly = args.includes('--vlm-only');
 const layoutOnly = args.includes('--layout-only');
 const thresholdIdx = args.indexOf('--threshold');
-const threshold = thresholdIdx !== -1 ? parseFloat(args[thresholdIdx + 1]) : 0.5;
+const threshold = thresholdIdx !== -1 && !isNaN(parseFloat(args[thresholdIdx + 1])) ? parseFloat(args[thresholdIdx + 1]) : 0.5;
 
 const vlmModelPath = '.cache/models/PaddleOCR-VL-1.5-mlx';
 // Clone from HuggingFace: PaddlePaddle/PP-DocLayoutV3_safetensors (NOT PaddlePaddle/PP-DocLayoutV3)
@@ -202,7 +202,7 @@ function formatElement(labelName: string, text: string): string {
       return `<!-- ${labelName}: ${trimmed} -->\n`;
     case 'footnote':
     case 'table_footnote':
-      return `[^]: ${trimmed}\n`;
+      return `[^note]: ${trimmed}\n`;
     case 'list':
       return `${trimmed}\n`;
     default:

--- a/examples/vlm-inference.ts
+++ b/examples/vlm-inference.ts
@@ -1,60 +1,282 @@
 /**
- * VLM Inference Example (PaddleOCR-VL-1.5)
+ * Document Layout Analysis + OCR Pipeline
+ *
+ * Combines PP-DocLayoutV3 (layout detection) with PaddleOCR-VL-1.5 (OCR)
+ * to extract structured markdown from document images.
+ *
+ * Pipeline:
+ *   1. DocLayoutModel detects layout elements (titles, text, tables, figures...)
+ *   2. Each element is cropped from the source image
+ *   3. VLModel OCRs each cropped region with type-appropriate prompts
+ *   4. Results are assembled into formatted markdown following reading order
  *
  * Usage:
- *   oxnode examples/vlm-inference.ts [image_path] [format]
+ *   oxnode examples/vlm-inference.ts <image_path> [--threshold 0.5] [--vlm-only] [--layout-only]
  *
  * Examples:
- *   oxnode examples/vlm-inference.ts                              # Text-only chat
- *   oxnode examples/vlm-inference.ts ./examples/ocr.png           # OCR with markdown output
- *   oxnode examples/vlm-inference.ts ./examples/ocr.png plain     # OCR with plain text
- *   oxnode examples/vlm-inference.ts ./examples/ocr.png html      # OCR with HTML output
- *   oxnode examples/vlm-inference.ts ./examples/ocr.png raw       # OCR with raw tokens
+ *   oxnode examples/vlm-inference.ts ./examples/ocr.png                # Full pipeline
+ *   oxnode examples/vlm-inference.ts ./examples/ocr.png --vlm-only     # VLM OCR only
+ *   oxnode examples/vlm-inference.ts ./examples/ocr.png --layout-only  # Layout detection only
+ *   oxnode examples/vlm-inference.ts ./examples/ocr.png --threshold 0.3
  */
-import { ChatRole } from '@mlx-node/core';
-import { VLModel, parsePaddleResponse, type OutputFormat } from '@mlx-node/vlm';
+import { readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ChatRole, type LayoutElement } from '@mlx-node/core';
+import { DocLayoutModel, VLModel, parsePaddleResponse, OutputFormat } from '@mlx-node/vlm';
+import { Transformer } from '@napi-rs/image';
 
-const modelPath = '.cache/models/PaddleOCR-VL-1.5-mlx';
-const imagePath = process.argv[2];
-const outputFormat = (process.argv[3] || 'Markdown') as OutputFormat;
+// --- CLI args ---
+const args = process.argv.slice(2);
+const imagePath = args.find((a) => !a.startsWith('--'));
+const vlmOnly = args.includes('--vlm-only');
+const layoutOnly = args.includes('--layout-only');
+const thresholdIdx = args.indexOf('--threshold');
+const threshold = thresholdIdx !== -1 ? parseFloat(args[thresholdIdx + 1]) : 0.5;
 
-// === Load Model (includes tokenizer) ===
-console.log('Loading VLM...');
-console.time('Model load');
-const model = await VLModel.load(modelPath);
-console.timeEnd('Model load');
+const vlmModelPath = '.cache/models/PaddleOCR-VL-1.5-mlx';
+// Clone from HuggingFace: PaddlePaddle/PP-DocLayoutV3_safetensors (NOT PaddlePaddle/PP-DocLayoutV3)
+const layoutModelPath = '.cache/models/PP-DocLayoutV3';
 
-console.log('\n✅ Model loaded successfully!');
-console.log(`   Vision: ${model.config.visionConfig.numHiddenLayers} layers`);
-console.log(`   Language: ${model.config.textConfig.numHiddenLayers} layers`);
+if (!imagePath) {
+  console.log('Usage: oxnode examples/vlm-inference.ts <image_path> [options]');
+  console.log('Options:');
+  console.log('  --vlm-only       VLM OCR only (no layout detection)');
+  console.log('  --layout-only    Layout detection only (no OCR)');
+  console.log('  --threshold N    Detection confidence threshold (default: 0.5)');
+  process.exit(1);
+}
 
-if (imagePath) {
-  // === Simple OCR ===
+// --- VLM-only mode (original behavior) ---
+if (vlmOnly) {
+  console.log('Loading VLM...');
+  console.time('VLM load');
+  const vlm = await VLModel.load(vlmModelPath);
+  console.timeEnd('VLM load');
+
   console.log(`\n--- OCR: ${imagePath} ---`);
-  console.log(`   Output format: ${outputFormat}`);
   console.time('OCR');
-  const vlmResult = model.chat([{ role: ChatRole.User, content: 'Extract the text in this image' }], {
+  const result = vlm.chat([{ role: ChatRole.User, content: 'Extract the text in this image' }], {
     imagePaths: [imagePath],
   });
   console.timeEnd('OCR');
 
-  // Parse and format the output
-  const formatted = parsePaddleResponse(vlmResult.text, { format: outputFormat });
-
-  console.log(`\n📝 Extracted Text:\n${formatted}`);
-} else {
-  // === Text-only Chat ===
-  console.log('\n--- Text-only Chat ---');
-  console.log('(Pass an image path to test with vision)');
-
-  console.time('Chat');
-  const result = model.chat([{ role: ChatRole.User, content: 'Hello! What can you help me with?' }], {
-    maxNewTokens: 100,
-    temperature: 0.0, // Greedy decoding
-    repetitionPenalty: 1.5,
-  });
-  console.timeEnd('Chat');
-
-  console.log(`\n📝 Response:\n${result.text}`);
-  console.log(`\nTokens generated: ${result.numTokens}`);
+  const formatted = parsePaddleResponse(result.text, { format: OutputFormat.Markdown });
+  console.log(`\n${formatted}`);
+  process.exit(0);
 }
+
+// --- Layout-only mode ---
+if (layoutOnly) {
+  console.log('Loading DocLayoutModel...');
+  console.time('Layout model load');
+  const layout = DocLayoutModel.load(layoutModelPath);
+  console.timeEnd('Layout model load');
+
+  console.log(`\n--- Layout Detection: ${imagePath} (threshold=${threshold}) ---`);
+  console.time('Detection');
+  const elements = layout.detect(imagePath, threshold);
+  console.timeEnd('Detection');
+
+  console.log(`\nDetected ${elements.length} elements:\n`);
+  for (const el of elements) {
+    const [x1, y1, x2, y2] = el.bbox;
+    console.log(
+      `  [${el.order}] ${el.labelName} (${el.label}) - score: ${el.score.toFixed(3)} ` +
+        `bbox: [${x1.toFixed(0)}, ${y1.toFixed(0)}, ${x2.toFixed(0)}, ${y2.toFixed(0)}]`,
+    );
+  }
+  process.exit(0);
+}
+
+// --- Full pipeline: Layout + OCR → Markdown ---
+console.log('Loading models...');
+console.time('Models load');
+const layout = DocLayoutModel.load(layoutModelPath);
+const vlm = await VLModel.load(vlmModelPath);
+console.timeEnd('Models load');
+
+// Step 1: Detect layout
+console.log(`\n--- Layout Detection (threshold=${threshold}) ---`);
+console.time('Detection');
+const elements = layout.detect(imagePath, threshold);
+console.timeEnd('Detection');
+console.log(`Detected ${elements.length} elements`);
+
+if (elements.length === 0) {
+  console.log('No elements detected. Try lowering the threshold with --threshold 0.3');
+  process.exit(0);
+}
+
+// Step 2: Crop regions and OCR each element
+const imageBuffer = readFileSync(imagePath);
+const tmpDir = mkdtempSync(join(tmpdir(), 'vlm-crop-'));
+
+async function cropElement(el: LayoutElement): Promise<string> {
+  const [x1, y1, x2, y2] = el.bbox;
+  const x = Math.max(0, Math.round(x1));
+  const y = Math.max(0, Math.round(y1));
+  const w = Math.max(1, Math.round(x2 - x1));
+  const h = Math.max(1, Math.round(y2 - y1));
+
+  const cropped = await new Transformer(imageBuffer).crop(x, y, w, h).png();
+  const cropPath = join(tmpDir, `crop_${el.order}.png`);
+  await writeFile(cropPath, cropped);
+  return cropPath;
+}
+
+/** Get OCR prompt based on element type */
+function getPrompt(labelName: string): string {
+  switch (labelName) {
+    case 'table':
+      return 'Extract this table as a markdown table. Preserve all rows and columns.';
+    case 'isolate_formula':
+      return 'Extract this mathematical formula in LaTeX notation.';
+    case 'code_txt':
+      return 'Extract this code exactly as shown, preserving indentation.';
+    case 'chart':
+    case 'figure':
+      return 'Describe what is shown in this image briefly.';
+    default:
+      return 'Extract the text in this image exactly as shown.';
+  }
+}
+
+/** Elements that should be OCR'd */
+const ocrLabels = new Set([
+  'title',
+  'doc_title',
+  'paragraph_title',
+  'text',
+  'abstract',
+  'list',
+  'table',
+  'table_caption',
+  'table_footnote',
+  'figure_caption',
+  'chart_caption',
+  'isolate_formula',
+  'formula_caption',
+  'code_txt',
+  'header',
+  'footer',
+  'footnote',
+  'margin_note',
+  'reference',
+  'content',
+  'index',
+  'handwriting',
+]);
+
+/** Format OCR text based on element type */
+function formatElement(labelName: string, text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return '';
+
+  switch (labelName) {
+    case 'doc_title':
+      return `# ${trimmed}\n`;
+    case 'title':
+      return `## ${trimmed}\n`;
+    case 'paragraph_title':
+      return `### ${trimmed}\n`;
+    case 'abstract':
+      return `> ${trimmed}\n`;
+    case 'table':
+      return `${trimmed}\n`;
+    case 'table_caption':
+    case 'figure_caption':
+    case 'chart_caption':
+    case 'formula_caption':
+      return `*${trimmed}*\n`;
+    case 'isolate_formula':
+      return `$$\n${trimmed}\n$$\n`;
+    case 'code_txt':
+      return `\`\`\`\n${trimmed}\n\`\`\`\n`;
+    case 'figure':
+    case 'chart':
+      return `[${labelName}: ${trimmed}]\n`;
+    case 'header':
+    case 'footer':
+      return `<!-- ${labelName}: ${trimmed} -->\n`;
+    case 'footnote':
+    case 'table_footnote':
+      return `[^]: ${trimmed}\n`;
+    case 'list':
+      return `${trimmed}\n`;
+    default:
+      return `${trimmed}\n`;
+  }
+}
+
+// Step 3: Crop all elements and prepare batch OCR items
+type OcrItem = { index: number; label: string; cropPath: string; prompt: string };
+const ocrItems: OcrItem[] = [];
+const nonOcrParts: Map<number, string> = new Map(); // index -> markdown for non-OCR elements
+
+let idx = 0;
+for (const el of elements) {
+  const label = el.labelName;
+
+  // Skip non-content elements
+  if (label === 'abandon' || label === 'seal') {
+    continue;
+  }
+
+  // For figures/charts without text, just note their position
+  if (label === 'figure' || label === 'chart') {
+    nonOcrParts.set(idx, `[${label}]\n`);
+    idx++;
+    continue;
+  }
+
+  if (!ocrLabels.has(label)) {
+    continue;
+  }
+
+  const cropPath = await cropElement(el);
+  const prompt = getPrompt(label);
+  console.log(`  [${el.order}] ${label} (${el.score.toFixed(2)})`);
+  ocrItems.push({ index: idx, label, cropPath, prompt });
+  idx++;
+}
+
+// Step 4: Batch OCR all cropped elements
+console.log(`\n--- Batch OCR (${ocrItems.length} elements) ---`);
+console.time('Batch OCR');
+
+const batchItems = ocrItems.map((item) => ({
+  messages: [{ role: ChatRole.User as const, content: item.prompt }],
+  imagePaths: [item.cropPath],
+}));
+const batchResults = vlm.batch(batchItems);
+
+console.timeEnd('Batch OCR');
+
+// Step 5: Assemble markdown in reading order
+const markdownParts: string[] = [];
+let ocrResultIdx = 0;
+
+for (let i = 0; i < idx; i++) {
+  if (nonOcrParts.has(i)) {
+    markdownParts.push(nonOcrParts.get(i)!);
+  } else {
+    const item = ocrItems[ocrResultIdx];
+    const result = batchResults[ocrResultIdx];
+    const text = parsePaddleResponse(result.text, { format: OutputFormat.Markdown });
+    const formatted = formatElement(item.label, text);
+    if (formatted) {
+      markdownParts.push(formatted);
+    }
+    ocrResultIdx++;
+  }
+}
+
+// Cleanup temp files
+rmSync(tmpDir, { recursive: true, force: true });
+
+// Output
+const markdown = markdownParts.join('\n');
+console.log('\n--- Result ---\n');
+console.log(markdown);

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -25,6 +25,11 @@ for (const output of outputs) {
     const { code } = await format(output.path, await readFile(output.path, 'utf-8'), viteConfig.fmt);
     await writeFile(output.path, code);
   }
+  if (output.kind === 'dts') {
+    const code = await readFile(output.path, 'utf-8');
+    const replaced = code.replace('export declare const enum OutputFormat {', 'export enum OutputFormat {');
+    await writeFile(output.path, replaced);
+  }
 }
 
 // Copy mlx.metallib for colocated Metal shader loading

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -737,6 +737,8 @@ if (!nativeBinding) {
 module.exports = nativeBinding;
 module.exports.BatchGenerationResult = nativeBinding.BatchGenerationResult;
 module.exports.ChatResult = nativeBinding.ChatResult;
+module.exports.DocLayoutModel = nativeBinding.DocLayoutModel;
+module.exports.PPDocLayoutV3Model = nativeBinding.PPDocLayoutV3Model;
 module.exports.GenerationResult = nativeBinding.GenerationResult;
 module.exports.GrpoTrainingEngine = nativeBinding.GrpoTrainingEngine;
 module.exports.GRPOTrainingEngine = nativeBinding.GRPOTrainingEngine;
@@ -747,6 +749,8 @@ module.exports.Qwen3Model = nativeBinding.Qwen3Model;
 module.exports.Qwen3Tokenizer = nativeBinding.Qwen3Tokenizer;
 module.exports.SftTrainingEngine = nativeBinding.SftTrainingEngine;
 module.exports.Tensor = nativeBinding.Tensor;
+module.exports.TextDetModel = nativeBinding.TextDetModel;
+module.exports.TextRecModel = nativeBinding.TextRecModel;
 module.exports.VlmChatResult = nativeBinding.VlmChatResult;
 module.exports.VLMChatResult = nativeBinding.VLMChatResult;
 module.exports.VLModel = nativeBinding.VLModel;

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -71,6 +71,42 @@ export declare class ChatResult {
   get rawText(): string;
 }
 
+/**
+ * PP-DocLayoutV3 full model for document layout analysis.
+ *
+ * Combines HGNetV2 backbone, hybrid encoder, and RT-DETR decoder
+ * with mask-enhanced attention and reading order prediction.
+ *
+ * Weights must be downloaded from `PaddlePaddle/PP-DocLayoutV3_safetensors` on HuggingFace.
+ * The regular `PaddlePaddle/PP-DocLayoutV3` repo uses PaddlePaddle format and is not compatible.
+ */
+export declare class DocLayoutModel {
+  /**
+   * Load a PP-DocLayoutV3 model from a directory containing `config.json` and `model.safetensors`.
+   *
+   * The model directory should be cloned from `PaddlePaddle/PP-DocLayoutV3_safetensors` on HuggingFace.
+   *
+   * # Arguments
+   * * `model_path` - Path to model directory
+   *
+   * # Returns
+   * * Initialized DocLayoutModel ready for inference
+   */
+  static load(modelPath: string): DocLayoutModel;
+  /**
+   * Detect document layout elements in an image.
+   *
+   * # Arguments
+   * * `image_path` - Path to the input image
+   * * `threshold` - Optional confidence threshold (default 0.5)
+   *
+   * # Returns
+   * * Vec of LayoutElements sorted by reading order
+   */
+  detect(imagePath: string, threshold?: number | undefined | null): Array<LayoutElement>;
+}
+export type PPDocLayoutV3Model = DocLayoutModel;
+
 /** Result from text generation with detailed metadata */
 export declare class GenerationResult {
   /** Get the decoded text */
@@ -1392,6 +1428,80 @@ export declare class Tensor {
   eval(): void;
 }
 
+/**
+ * PP-OCRv5 Text Detection model (DBNet with PPHGNetV2 backbone).
+ *
+ * Detects text lines in document images and returns bounding boxes.
+ */
+export declare class TextDetModel {
+  /**
+   * Load a TextDetModel from a directory containing model.safetensors.
+   *
+   * # Arguments
+   * * `model_path` - Path to model directory
+   */
+  static load(modelPath: string): TextDetModel;
+  /**
+   * Detect text lines in an image.
+   *
+   * # Arguments
+   * * `image_path` - Path to the input image
+   * * `threshold` - Optional detection threshold (default from config, typically 0.3)
+   *
+   * # Returns
+   * * Vec of TextBox with bounding boxes and confidence scores
+   */
+  detect(imagePath: string, threshold?: number | undefined | null): Array<TextBox>;
+}
+
+/**
+ * PP-OCRv5 Text Recognition model (PPHGNetV2 + SVTR + CTC).
+ *
+ * Recognizes text from cropped text line images.
+ */
+export declare class TextRecModel {
+  /**
+   * Load a TextRecModel from a directory containing model.safetensors.
+   *
+   * # Arguments
+   * * `model_path` - Path to model directory
+   * * `dict_path` - Path to character dictionary text file
+   */
+  static load(modelPath: string, dictPath: string): TextRecModel;
+  /**
+   * Recognize text from a single image file.
+   *
+   * # Arguments
+   * * `image_path` - Path to a cropped text line image
+   *
+   * # Returns
+   * * RecResult with recognized text and confidence score
+   */
+  recognize(imagePath: string): RecResult;
+  /**
+   * Recognize text from multiple image files (batch).
+   *
+   * # Arguments
+   * * `image_paths` - Paths to cropped text line images
+   *
+   * # Returns
+   * * Vec of RecResult with recognized text and confidence scores
+   */
+  recognizeBatch(imagePaths: Array<string>): Array<RecResult>;
+  /**
+   * Recognize text from raw RGB crop data.
+   *
+   * # Arguments
+   * * `rgb_data` - Raw RGB pixel data of a cropped text line
+   * * `width` - Image width
+   * * `height` - Image height
+   *
+   * # Returns
+   * * RecResult with recognized text and confidence score
+   */
+  recognizeCrop(rgbData: Uint8Array, width: number, height: number): RecResult;
+}
+
 /** Result from VLM chat */
 export declare class VlmChatResult {
   /** Get the response text */
@@ -1516,6 +1626,37 @@ export declare class VLModel {
     imageGridThw?: MxArray | undefined | null,
     config?: GenerationConfig | undefined | null,
   ): GenerationResult;
+  /**
+   * Batch OCR: extract text from multiple images simultaneously
+   *
+   * Processes N images with sequential prefill + batched decode for ~N× decode throughput.
+   *
+   * # Arguments
+   * * `image_paths` - Paths to image files
+   * * `config` - Optional chat configuration (shared across all items)
+   *
+   * # Returns
+   * * Vec of extracted text strings, one per image
+   *
+   * # Example
+   * ```typescript
+   * const texts = model.ocrBatch(['page1.jpg', 'page2.jpg', 'page3.jpg']);
+   * ```
+   */
+  ocrBatch(imagePaths: Array<string>, config?: VlmChatConfig | undefined | null): Array<string>;
+  /**
+   * Batch chat: process multiple items simultaneously
+   *
+   * Sequential prefill + batched decode. Each item can have different images/prompts.
+   *
+   * # Arguments
+   * * `batch` - Batch items, each with messages and optional image_paths
+   * * `config` - Optional shared chat configuration
+   *
+   * # Returns
+   * * Vec of VLMChatResult, one per batch item
+   */
+  batch(batch: Array<VlmBatchItem>, config?: VlmChatConfig | undefined | null): Array<VlmChatResult>;
   /** Get model configuration */
   get config(): ModelConfig;
   /** Check if model is fully initialized */
@@ -2171,6 +2312,20 @@ export interface GrpoLossConfig {
   vocabChunkSize?: number;
 }
 
+/** A single detected layout element. */
+export interface LayoutElement {
+  /** Detection confidence score */
+  score: number;
+  /** Class label ID (0-24) */
+  label: number;
+  /** Human-readable label name (e.g., "title", "text", "table") */
+  labelName: string;
+  /** Bounding box in original image coordinates [x1, y1, x2, y2] */
+  bbox: Array<number>;
+  /** Reading order index (0 = first element to read) */
+  order: number;
+}
+
 /** Full model configuration */
 export interface ModelConfig {
   visionConfig: VisionConfig;
@@ -2185,7 +2340,7 @@ export interface ModelConfig {
 }
 
 /** Output format options */
-export declare const enum OutputFormat {
+export enum OutputFormat {
   /** Raw output with minimal processing */
   Raw = 'Raw',
   /** Plain text with aligned columns */
@@ -2372,6 +2527,14 @@ export interface Qwen3Config {
    * Default: false
    */
   useFp8Cache?: boolean | undefined;
+}
+
+/** Result of text recognition. */
+export interface RecResult {
+  /** Recognized text */
+  text: string;
+  /** Confidence score (mean character probability) */
+  score: number;
 }
 
 /** Result of resume position computation */
@@ -2604,6 +2767,14 @@ export interface TableRow {
   cells: Array<TableCell>;
 }
 
+/** A detected text bounding box. */
+export interface TextBox {
+  /** Bounding box in original image coordinates [x1, y1, x2, y2] */
+  bbox: Array<number>;
+  /** Detection confidence score (mean probability inside box) */
+  score: number;
+}
+
 /** Language model (text decoder) configuration */
 export interface TextConfig {
   modelType: string;
@@ -2740,6 +2911,14 @@ export interface VisionConfig {
   layerNormEps: number;
   attentionDropout: number;
   spatialMergeSize: number;
+}
+
+/** A batch item for VLM batch inference */
+export interface VlmBatchItem {
+  /** Chat messages for this item */
+  messages: Array<VlmChatMessage>;
+  /** Image paths for this item (one image per item for OCR) */
+  imagePaths?: Array<string>;
 }
 
 /** Configuration for VLM chat */

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["."],
+  "exclude": ["build.ts"]
+}

--- a/packages/vlm/package.json
+++ b/packages/vlm/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@mlx-node/core": "workspace:*",
-    "@mlx-node/lm": "workspace:*"
+    "@mlx-node/lm": "workspace:*",
+    "@napi-rs/image": "1.12.0"
   }
 }

--- a/packages/vlm/src/index.ts
+++ b/packages/vlm/src/index.ts
@@ -20,6 +20,9 @@
  *
  * // Simple OCR
  * const text = model.ocr('./document.jpg');
+ *
+ * // Batch OCR (multiple images in parallel)
+ * const texts = model.ocrBatch(['page1.jpg', 'page2.jpg', 'page3.jpg']);
  * ```
  */
 
@@ -28,8 +31,31 @@
 // Main model class and factory functions (exposed directly from Rust)
 export { VLModel, createPaddleocrVlConfig } from '@mlx-node/core';
 
+// Document layout analysis model
+export { DocLayoutModel, type LayoutElement } from '@mlx-node/core';
+
+// Text detection and recognition models (PP-OCRv5)
+export { TextDetModel, type TextBox, TextRecModel, type RecResult } from '@mlx-node/core';
+
+// Document understanding pipeline (PP-StructureV3)
+export {
+  StructureV3Pipeline,
+  type StructureV3Config,
+  type AnalyzeOptions,
+  type StructuredElement,
+  type StructuredDocument,
+  type TextLine,
+} from './pipeline/structure-v3.js';
+
 // Configuration types
-export type { VisionConfig, TextConfig, ModelConfig, VlmChatConfig, VlmChatMessage } from '@mlx-node/core';
+export type {
+  VisionConfig,
+  TextConfig,
+  ModelConfig,
+  VlmChatConfig,
+  VlmChatMessage,
+  VlmBatchItem,
+} from '@mlx-node/core';
 
 // Model-specific configs
 export { PADDLEOCR_VL_CONFIGS, type PaddleOCRVLConfig } from './models/paddleocr-vl-configs.js';

--- a/packages/vlm/src/pipeline/structure-v3.ts
+++ b/packages/vlm/src/pipeline/structure-v3.ts
@@ -384,7 +384,7 @@ function formatElement(label: string, text: string): string {
       return `<!-- ${label}: ${trimmed} -->\n`;
     case 'footnote':
     case 'table_footnote':
-      return `[^]: ${trimmed}\n`;
+      return `[^note]: ${trimmed}\n`;
     case 'list':
       return `${trimmed}\n`;
     case 'seal':

--- a/packages/vlm/src/pipeline/structure-v3.ts
+++ b/packages/vlm/src/pipeline/structure-v3.ts
@@ -1,0 +1,409 @@
+/**
+ * PP-StructureV3 Document Understanding Pipeline
+ *
+ * Combines PP-DocLayoutV3 (layout detection) with PP-OCRv5 (text detection + recognition)
+ * for fast, accurate document understanding without a VLM.
+ *
+ * Pipeline:
+ *   1. DocLayoutModel detects layout elements (titles, text, tables, figures...)
+ *   2. For text/title/list elements: TextDetModel detects text lines → TextRecModel recognizes text
+ *   3. For table/formula/chart: VLM fallback (optional)
+ *   4. Results assembled into structured markdown in reading order
+ *
+ * @example
+ * ```typescript
+ * import { StructureV3Pipeline } from '@mlx-node/vlm';
+ *
+ * const pipeline = StructureV3Pipeline.load({
+ *   layoutModelPath: './models/PP-DocLayoutV3',
+ *   textDetModelPath: './models/PP-OCRv5_server_det',
+ *   textRecModelPath: './models/PP-OCRv5_server_rec',
+ *   dictPath: './models/PP-OCRv5_server_rec/ppocr_keys_v1.txt',
+ * });
+ *
+ * const result = pipeline.analyze('./document.png');
+ * console.log(result.markdown);
+ * ```
+ */
+
+import { readFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { DocLayoutModel, TextDetModel, TextRecModel, type LayoutElement } from '@mlx-node/core';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Configuration for loading the StructureV3 pipeline. */
+export interface StructureV3Config {
+  /** Path to PP-DocLayoutV3 model directory */
+  layoutModelPath: string;
+  /** Path to PP-OCRv5 text detection model directory */
+  textDetModelPath: string;
+  /** Path to PP-OCRv5 text recognition model directory */
+  textRecModelPath: string;
+  /** Path to character dictionary file (e.g., ppocr_keys_v1.txt) */
+  dictPath: string;
+}
+
+/** Options for document analysis. */
+export interface AnalyzeOptions {
+  /** Layout detection confidence threshold (default: 0.5) */
+  layoutThreshold?: number;
+  /** Text detection confidence threshold (default: 0.3) */
+  textDetThreshold?: number;
+  /** Whether to include element-level details in output (default: false) */
+  includeDetails?: boolean;
+}
+
+/** A recognized text line within a layout element. */
+export interface TextLine {
+  /** Bounding box [x1, y1, x2, y2] relative to the element crop */
+  bbox: number[];
+  /** Recognized text */
+  text: string;
+  /** Recognition confidence */
+  score: number;
+}
+
+/** A structured document element with recognized content. */
+export interface StructuredElement {
+  /** Element type from layout detection */
+  label: string;
+  /** Detection confidence */
+  score: number;
+  /** Bounding box [x1, y1, x2, y2] in original image coordinates */
+  bbox: number[];
+  /** Reading order index */
+  order: number;
+  /** Recognized text content */
+  text: string;
+  /** Individual text lines (if includeDetails is true) */
+  lines?: TextLine[];
+}
+
+/** Result of document analysis. */
+export interface StructuredDocument {
+  /** Structured elements in reading order */
+  elements: StructuredElement[];
+  /** Assembled markdown output */
+  markdown: string;
+}
+
+// ============================================================================
+// Element type sets
+// ============================================================================
+
+/** Elements that contain text and should be processed with OCR */
+const TEXT_LABELS = new Set([
+  'title',
+  'doc_title',
+  'paragraph_title',
+  'text',
+  'abstract',
+  'list',
+  'table_caption',
+  'table_footnote',
+  'figure_caption',
+  'chart_caption',
+  'formula_caption',
+  'code_txt',
+  'header',
+  'footer',
+  'footnote',
+  'margin_note',
+  'reference',
+  'content',
+  'index',
+  'handwriting',
+]);
+
+/** Elements that are non-content (skipped) */
+const SKIP_LABELS = new Set(['abandon']);
+
+// ============================================================================
+// Pipeline
+// ============================================================================
+
+/**
+ * PP-StructureV3 document understanding pipeline.
+ *
+ * Uses dedicated OCR models (TextDet + TextRec) instead of a VLM,
+ * providing ~4-5x faster text extraction with ~6x lower memory usage.
+ */
+export class StructureV3Pipeline {
+  private layout: DocLayoutModel;
+  private textDet: TextDetModel;
+  private textRec: TextRecModel;
+
+  private constructor(layout: DocLayoutModel, textDet: TextDetModel, textRec: TextRecModel) {
+    this.layout = layout;
+    this.textDet = textDet;
+    this.textRec = textRec;
+  }
+
+  /**
+   * Load all models and create the pipeline.
+   */
+  static load(config: StructureV3Config): StructureV3Pipeline {
+    const layout = DocLayoutModel.load(config.layoutModelPath);
+    const textDet = TextDetModel.load(config.textDetModelPath);
+    const textRec = TextRecModel.load(config.textRecModelPath, config.dictPath);
+    return new StructureV3Pipeline(layout, textDet, textRec);
+  }
+
+  /**
+   * Analyze a document image and extract structured content.
+   *
+   * @param imagePath - Path to the document image
+   * @param options - Analysis options
+   * @returns Structured document with elements and markdown
+   */
+  async analyze(imagePath: string, options: AnalyzeOptions = {}): Promise<StructuredDocument> {
+    const { layoutThreshold = 0.5, textDetThreshold, includeDetails = false } = options;
+
+    // Step 1: Layout detection
+    const layoutElements = this.layout.detect(imagePath, layoutThreshold);
+
+    if (layoutElements.length === 0) {
+      return { elements: [], markdown: '' };
+    }
+
+    // Step 2: Process each element
+    const imageBuffer = readFileSync(imagePath);
+    const tmpDir = mkdtempSync(join(tmpdir(), 'structv3-'));
+
+    try {
+      const elements: StructuredElement[] = [];
+
+      for (const el of layoutElements) {
+        const label = el.labelName;
+
+        if (SKIP_LABELS.has(label)) {
+          continue;
+        }
+
+        if (TEXT_LABELS.has(label)) {
+          // OCR path: detect text lines then recognize
+          const cropPath = await this.cropElement(imageBuffer, el, tmpDir);
+          const textLines = await this.ocrRegion(cropPath, tmpDir, textDetThreshold);
+
+          const fullText = textLines.map((l) => l.text).join('\n');
+
+          elements.push({
+            label,
+            score: el.score,
+            bbox: el.bbox,
+            order: el.order,
+            text: fullText,
+            lines: includeDetails ? textLines : undefined,
+          });
+        } else if (label === 'table') {
+          // Table: detect text lines in each cell (simplified - full table parsing in Phase 4)
+          const cropPath = await this.cropElement(imageBuffer, el, tmpDir);
+          const textLines = await this.ocrRegion(cropPath, tmpDir, textDetThreshold);
+          const fullText = textLines.map((l) => l.text).join('\n');
+
+          elements.push({
+            label,
+            score: el.score,
+            bbox: el.bbox,
+            order: el.order,
+            text: fullText,
+            lines: includeDetails ? textLines : undefined,
+          });
+        } else if (label === 'isolate_formula') {
+          // Formula: basic OCR for now (Phase 5 adds LaTeX recognition)
+          const cropPath = await this.cropElement(imageBuffer, el, tmpDir);
+          const textLines = await this.ocrRegion(cropPath, tmpDir, textDetThreshold);
+          const fullText = textLines.map((l) => l.text).join(' ');
+
+          elements.push({
+            label,
+            score: el.score,
+            bbox: el.bbox,
+            order: el.order,
+            text: fullText,
+          });
+        } else {
+          // figure, chart, seal, etc. - placeholder
+          elements.push({
+            label,
+            score: el.score,
+            bbox: el.bbox,
+            order: el.order,
+            text: '',
+          });
+        }
+      }
+
+      // Step 3: Assemble markdown
+      const markdown = assembleMarkdown(elements);
+
+      return { elements, markdown };
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  /**
+   * Run text detection + recognition on a single image (no layout detection).
+   *
+   * Useful for processing pre-cropped text regions.
+   */
+  async ocrImage(imagePath: string, textDetThreshold?: number): Promise<TextLine[]> {
+    const tempDir = mkdtempSync(join(tmpdir(), 'ocr-'));
+    try {
+      return await this.ocrRegion(imagePath, tempDir, textDetThreshold);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  /**
+   * Detect text lines and recognize text in a cropped region.
+   *
+   * For each detected text line bounding box, sub-crops that line from the
+   * crop image and passes the individual line image to text recognition.
+   */
+  private async ocrRegion(imagePath: string, tmpDir: string, textDetThreshold?: number): Promise<TextLine[]> {
+    // Detect text lines within the crop
+    const textBoxes = this.textDet.detect(imagePath, textDetThreshold);
+
+    if (textBoxes.length === 0) {
+      // Fall back to recognizing the entire crop as one text line
+      const result = this.textRec.recognize(imagePath);
+      if (result.text.trim()) {
+        return [{ bbox: [0, 0, 0, 0], text: result.text, score: result.score }];
+      }
+      return [];
+    }
+
+    // Sort text boxes by vertical position (top to bottom, left to right)
+    const sorted = [...textBoxes].sort((a, b) => {
+      const yDiff = a.bbox[1] - b.bbox[1];
+      if (Math.abs(yDiff) > 10) return yDiff;
+      return a.bbox[0] - b.bbox[0];
+    });
+
+    // Single detected line: recognize the full crop directly (no sub-crop needed)
+    if (sorted.length === 1) {
+      const result = this.textRec.recognize(imagePath);
+      return [
+        {
+          bbox: sorted[0].bbox,
+          text: result.text,
+          score: result.score,
+        },
+      ];
+    }
+
+    // Multiple detected lines: sub-crop each line from the crop image
+    const cropBuffer = readFileSync(imagePath);
+    const { Transformer } = await import('@napi-rs/image');
+
+    const linePaths: string[] = [];
+    for (let i = 0; i < sorted.length; i++) {
+      const [x1, y1, x2, y2] = sorted[i].bbox;
+      const x = Math.max(0, Math.round(x1));
+      const y = Math.max(0, Math.round(y1));
+      const w = Math.max(1, Math.round(x2 - x1));
+      const h = Math.max(1, Math.round(y2 - y1));
+
+      const linePng = await new Transformer(cropBuffer).crop(x, y, w, h).png();
+      const linePath = join(tmpDir, `line_${i}.png`);
+      await writeFile(linePath, linePng);
+      linePaths.push(linePath);
+    }
+
+    const results = this.textRec.recognizeBatch(linePaths);
+
+    return sorted.map((box, i) => ({
+      bbox: box.bbox,
+      text: results[i]?.text ?? '',
+      score: results[i]?.score ?? 0,
+    }));
+  }
+
+  /**
+   * Crop a layout element from the source image and save to a temporary file.
+   */
+  private async cropElement(imageBuffer: Buffer, el: LayoutElement, tmpDir: string): Promise<string> {
+    const [x1, y1, x2, y2] = el.bbox;
+    const x = Math.max(0, Math.round(x1));
+    const y = Math.max(0, Math.round(y1));
+    const w = Math.max(1, Math.round(x2 - x1));
+    const h = Math.max(1, Math.round(y2 - y1));
+
+    // Use @napi-rs/image for cropping
+    const { Transformer } = await import('@napi-rs/image');
+    const cropped = await new Transformer(imageBuffer).crop(x, y, w, h).png();
+    const cropPath = join(tmpDir, `crop_${el.order}.png`);
+    await writeFile(cropPath, cropped);
+    return cropPath;
+  }
+}
+
+// ============================================================================
+// Markdown assembly
+// ============================================================================
+
+/** Format a single element as markdown. */
+function formatElement(label: string, text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return '';
+
+  switch (label) {
+    case 'doc_title':
+      return `# ${trimmed}\n`;
+    case 'title':
+      return `## ${trimmed}\n`;
+    case 'paragraph_title':
+      return `### ${trimmed}\n`;
+    case 'abstract':
+      return `> ${trimmed}\n`;
+    case 'table':
+      return `${trimmed}\n`;
+    case 'table_caption':
+    case 'figure_caption':
+    case 'chart_caption':
+    case 'formula_caption':
+      return `*${trimmed}*\n`;
+    case 'isolate_formula':
+      return `$$\n${trimmed}\n$$\n`;
+    case 'code_txt':
+      return `\`\`\`\n${trimmed}\n\`\`\`\n`;
+    case 'figure':
+    case 'chart':
+      return trimmed ? `[${label}: ${trimmed}]\n` : `[${label}]\n`;
+    case 'header':
+    case 'footer':
+      return `<!-- ${label}: ${trimmed} -->\n`;
+    case 'footnote':
+    case 'table_footnote':
+      return `[^]: ${trimmed}\n`;
+    case 'list':
+      return `${trimmed}\n`;
+    case 'seal':
+      return `[seal: ${trimmed}]\n`;
+    default:
+      return `${trimmed}\n`;
+  }
+}
+
+/** Assemble structured elements into markdown. */
+function assembleMarkdown(elements: StructuredElement[]): string {
+  const parts: string[] = [];
+
+  for (const el of elements) {
+    const formatted = formatElement(el.label, el.text);
+    if (formatted) {
+      parts.push(formatted);
+    }
+  }
+
+  return parts.join('\n');
+}

--- a/packages/vlm/tsconfig.json
+++ b/packages/vlm/tsconfig.json
@@ -6,5 +6,5 @@
     "composite": true
   },
   "include": ["src/**/*.ts"],
-  "references": [{ "path": "../lm" }]
+  "references": [{ "path": "../core" }, { "path": "../lm" }]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "files": [],
   "references": [
+    { "path": "./packages/core" },
     { "path": "./packages/lm" },
     { "path": "./packages/trl" },
     { "path": "./packages/vlm" },
@@ -13,8 +14,6 @@
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "target": "ESNext",
-    "declaration": true,
-    "declarationMap": true
+    "target": "ESNext"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,38 +5,38 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@ai-sdk/gateway@npm:3.0.22":
-  version: 3.0.22
-  resolution: "@ai-sdk/gateway@npm:3.0.22"
+"@ai-sdk/gateway@npm:3.0.39":
+  version: 3.0.39
+  resolution: "@ai-sdk/gateway@npm:3.0.39"
   dependencies:
-    "@ai-sdk/provider": "npm:3.0.5"
-    "@ai-sdk/provider-utils": "npm:4.0.9"
+    "@ai-sdk/provider": "npm:3.0.8"
+    "@ai-sdk/provider-utils": "npm:4.0.14"
     "@vercel/oidc": "npm:3.1.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/94551537fe8cc4e3b2330d7876221b233c7daf3a56317775d13b0ef804aa26517ef1fc7e97d7cbf50d87283f3cace45f92b578b25d5e531f243b491a0e9a8df8
+  checksum: 10c0/b7a8ea6b1b6aa13ab264b683efc06529cadf21ab5a857bbc624158a24a59f95cc6d432f31a0e3819666da7ca82355ee4f7094f5c6ebb2ad836ca647ad0d89b95
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider-utils@npm:4.0.9":
-  version: 4.0.9
-  resolution: "@ai-sdk/provider-utils@npm:4.0.9"
+"@ai-sdk/provider-utils@npm:4.0.14":
+  version: 4.0.14
+  resolution: "@ai-sdk/provider-utils@npm:4.0.14"
   dependencies:
-    "@ai-sdk/provider": "npm:3.0.5"
+    "@ai-sdk/provider": "npm:3.0.8"
     "@standard-schema/spec": "npm:^1.1.0"
     eventsource-parser: "npm:^3.0.6"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/b3b52357b27ddd7bd0489c42a2818ba3ce2c31e9f2aae424b324200de0491376ae9f422c58867140081e368a58ca8777427efa6327b878163b824342f4bc57fc
+  checksum: 10c0/613ec8c9efb2b3a5fd0083319e0e54e66737c071a0a7957be8248a23533325ba7a26149393a850a8e38c01bf62fe706f776687e01c3513d7558475a2856ca06e
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider@npm:3.0.5":
-  version: 3.0.5
-  resolution: "@ai-sdk/provider@npm:3.0.5"
+"@ai-sdk/provider@npm:3.0.8":
+  version: 3.0.8
+  resolution: "@ai-sdk/provider@npm:3.0.8"
   dependencies:
     json-schema: "npm:^0.4.0"
-  checksum: 10c0/e3994d9b8b066bae69b160202c42fe1f3a8323484590bcf1d3f19f637f6548b398be7e774706239ae5ad61d65f7f998895dc0c6ce8dc30a977344cc7874ec4db
+  checksum: 10c0/c68637c0139a6ce8af17bac1d7d539f531860026237c5c971dcecda2daa8b1e42d8c05e1e664ece60c15edb325c0253fd5b091ee54d32f870a750a493acbb0b7
   languageName: node
   linkType: hard
 
@@ -497,6 +497,7 @@ __metadata:
   dependencies:
     "@mlx-node/core": "workspace:*"
     "@mlx-node/lm": "workspace:*"
+    "@napi-rs/image": "npm:1.12.0"
   languageName: unknown
   linkType: soft
 
@@ -568,6 +569,147 @@ __metadata:
     "@napi-rs/cross-toolchain-x64-target-x86_64":
       optional: true
   checksum: 10c0/fcc7877c1e47ba6bf4801a4154240d3130703524b1fed17e736126ce58b53960872b9933f8434e3e86b4635e4c7fe881228be0d237210dd96c2087244523750f
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-android-arm64@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-android-arm64@npm:1.12.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-darwin-arm64@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-darwin-arm64@npm:1.12.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-darwin-x64@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-darwin-x64@npm:1.12.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-freebsd-x64@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-freebsd-x64@npm:1.12.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-linux-arm-gnueabihf@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-linux-arm-gnueabihf@npm:1.12.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-linux-arm64-gnu@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-linux-arm64-gnu@npm:1.12.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-linux-arm64-musl@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-linux-arm64-musl@npm:1.12.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-linux-x64-gnu@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-linux-x64-gnu@npm:1.12.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-linux-x64-musl@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-linux-x64-musl@npm:1.12.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-wasm32-wasi@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-wasm32-wasi@npm:1.12.0"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:^1.1.0"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-win32-arm64-msvc@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-win32-arm64-msvc@npm:1.12.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-win32-ia32-msvc@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-win32-ia32-msvc@npm:1.12.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image-win32-x64-msvc@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image-win32-x64-msvc@npm:1.12.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/image@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@napi-rs/image@npm:1.12.0"
+  dependencies:
+    "@napi-rs/image-android-arm64": "npm:1.12.0"
+    "@napi-rs/image-darwin-arm64": "npm:1.12.0"
+    "@napi-rs/image-darwin-x64": "npm:1.12.0"
+    "@napi-rs/image-freebsd-x64": "npm:1.12.0"
+    "@napi-rs/image-linux-arm-gnueabihf": "npm:1.12.0"
+    "@napi-rs/image-linux-arm64-gnu": "npm:1.12.0"
+    "@napi-rs/image-linux-arm64-musl": "npm:1.12.0"
+    "@napi-rs/image-linux-x64-gnu": "npm:1.12.0"
+    "@napi-rs/image-linux-x64-musl": "npm:1.12.0"
+    "@napi-rs/image-wasm32-wasi": "npm:1.12.0"
+    "@napi-rs/image-win32-arm64-msvc": "npm:1.12.0"
+    "@napi-rs/image-win32-ia32-msvc": "npm:1.12.0"
+    "@napi-rs/image-win32-x64-msvc": "npm:1.12.0"
+  dependenciesMeta:
+    "@napi-rs/image-android-arm64":
+      optional: true
+    "@napi-rs/image-darwin-arm64":
+      optional: true
+    "@napi-rs/image-darwin-x64":
+      optional: true
+    "@napi-rs/image-freebsd-x64":
+      optional: true
+    "@napi-rs/image-linux-arm-gnueabihf":
+      optional: true
+    "@napi-rs/image-linux-arm64-gnu":
+      optional: true
+    "@napi-rs/image-linux-arm64-musl":
+      optional: true
+    "@napi-rs/image-linux-x64-gnu":
+      optional: true
+    "@napi-rs/image-linux-x64-musl":
+      optional: true
+    "@napi-rs/image-wasm32-wasi":
+      optional: true
+    "@napi-rs/image-win32-arm64-msvc":
+      optional: true
+    "@napi-rs/image-win32-ia32-msvc":
+      optional: true
+    "@napi-rs/image-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/35e9db81b29c1d7bcaaa48f929da1920cb1abf8bf169b3515d1f8fdaa4755063eb8c3c37eefb23dd47619587b199d4d9665f708e690ff827e0d610d0cc084d07
   languageName: node
   linkType: hard
 
@@ -1211,7 +1353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.0.3, @napi-rs/wasm-runtime@npm:^1.0.7, @napi-rs/wasm-runtime@npm:^1.1.1":
+"@napi-rs/wasm-runtime@npm:^1.0.3, @napi-rs/wasm-runtime@npm:^1.0.7, @napi-rs/wasm-runtime@npm:^1.1.0, @napi-rs/wasm-runtime@npm:^1.1.1":
   version: 1.1.1
   resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
   dependencies:
@@ -1682,24 +1824,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openrouter/ai-sdk-provider@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "@openrouter/ai-sdk-provider@npm:1.5.4"
-  dependencies:
-    "@openrouter/sdk": "npm:^0.1.27"
+"@openrouter/ai-sdk-provider@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@openrouter/ai-sdk-provider@npm:2.2.1"
   peerDependencies:
-    ai: ^5.0.0
-    zod: ^3.24.1 || ^v4
-  checksum: 10c0/6360a779a3b13de5df0fca9ff3dda4b18cce2652c6c0db26a3f1c1f558f5bb3f75b45d6553c14d5eed4ab1fac7fe4a4bd577195ff6652dbf5a5a14378460bbd2
-  languageName: node
-  linkType: hard
-
-"@openrouter/sdk@npm:^0.1.27":
-  version: 0.1.27
-  resolution: "@openrouter/sdk@npm:0.1.27"
-  dependencies:
-    zod: "npm:^3.25.0 || ^4.0.0"
-  checksum: 10c0/c63972851b4544a6585babacb2909b8af529444c6319e0a98b8e219f75295a25d433ba1978f24c0252fbb41ac2471bf209c2728649bf0c42b7a722c3868e267e
+    ai: ^6.0.0
+    zod: ^3.25.0 || ^4.0.0
+  checksum: 10c0/ee83fdf6e888fa6bc9653d0a2cb2ec677e3320b745e0c924b35ef8a5960ce033c65b130f959b60fb7c2a26044c848e0013f1b163831b31fabac775e4f4ac76ca
   languageName: node
   linkType: hard
 
@@ -2493,17 +2624,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ai@npm:^6.0.12":
-  version: 6.0.49
-  resolution: "ai@npm:6.0.49"
+"ai@npm:^6.0.78":
+  version: 6.0.78
+  resolution: "ai@npm:6.0.78"
   dependencies:
-    "@ai-sdk/gateway": "npm:3.0.22"
-    "@ai-sdk/provider": "npm:3.0.5"
-    "@ai-sdk/provider-utils": "npm:4.0.9"
+    "@ai-sdk/gateway": "npm:3.0.39"
+    "@ai-sdk/provider": "npm:3.0.8"
+    "@ai-sdk/provider-utils": "npm:4.0.14"
     "@opentelemetry/api": "npm:1.9.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/01f48ed3eff7664c396166006d6e435564b2345ed14146e081596498d4f09c490ed415cee5007f6f29c5ebe6d25a99481ec8cda6e6f1fdee48c9f16a94089cbc
+  checksum: 10c0/875c63ecb10e9f79644f9969b090a982cbe914d41f8af9888808bf2e354ad38071d1540d6c6c2cfcc79aa2766f8c5857ef70735f661a4e455cea329c712cc693
   languageName: node
   linkType: hard
 
@@ -2732,8 +2863,9 @@ __metadata:
     "@mlx-node/lm": "workspace:*"
     "@mlx-node/trl": "workspace:*"
     "@mlx-node/vlm": "workspace:*"
-    "@openrouter/ai-sdk-provider": "npm:^1.5.4"
-    ai: "npm:^6.0.12"
+    "@napi-rs/image": "npm:1.12.0"
+    "@openrouter/ai-sdk-provider": "npm:^2.2.1"
+    ai: "npm:^6.0.78"
     zod: "npm:^4.3.5"
   languageName: unknown
   linkType: soft
@@ -3906,7 +4038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25.0 || ^4.0.0, zod@npm:^4.3.5":
+"zod@npm:^4.3.5":
   version: 4.3.6
   resolution: "zod@npm:4.3.6"
   checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307


### PR DESCRIPTION
Implements the full PP-StructureV3 pipeline: PP-DocLayoutV3 (layout detection) + PP-OCRv5 TextDet (text line detection with LKPAN neck + DB head) + PP-OCRv5 TextRec (text recognition with HGNetV2 backbone + SVTR neck + CTC head).

Achieves ~4-5x faster text extraction than VLM-based OCR with ~6x smaller model footprint (292MB vs 1.7GB). Includes PaddlePaddle .pdiparams conversion scripts, ConvTranspose2d FFI support, and the StructureV3Pipeline TypeScript API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk due to large new model surface area plus new batched generation logic that merges/filters KV caches and calls unsafe FFI (`mlx_paddleocr_vl_forward_step_batched`), which can impact correctness and memory/perf.
> 
> **Overview**
> Adds new model modules for PP-Structure components, including an initial PP-DocLayoutV3 implementation (HGNetV2 backbone/config plus transformer decoder with deformable attention) with accompanying unit tests.
> 
> Extends `paddleocr_vl` with N-API batch inputs (`VLMBatchItem`) and new `VLModel.batch`/`VLModel.ocr_batch` APIs that do per-item prefill, merge/left-pad KV caches, then run a batched decode loop via a new `ERNIELanguageModel` batched fused forward path. Includes regression tests to prevent cross-item token/KV misalignment when batch items finish early.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed2fed80761652094ce8ecd855012a3817350ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DocLayoutModel (PP-DocLayoutV3), TextDetModel and TextRecModel for layout, text detection, and recognition.
  * VLM: added batch OCR endpoints (ocrBatch, batch) and VlmBatchItem support.
  * New StructureV3 pipeline: end-to-end layout + OCR with Markdown output.

* **API / Types**
  * JS exports and typings extended: LayoutElement, TextBox, RecResult, VlmBatchItem; VLModel gains ocrBatch/batch.

* **Chores**
  * Updated example, packaging and image-processing dependencies and build typings to support new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->