### PR TITLE
fix: deduplicate ChatRole type across lm and trl packages

### DIFF
--- a/packages/trl/src/types.ts
+++ b/packages/trl/src/types.ts
@@ -2,7 +2,9 @@
 export type { CompletionInfo, RewardOutput } from '@mlx-node/core';
 import type { RewardOutput } from '@mlx-node/core';
 
-export type ChatRole = 'system' | 'user' | 'assistant' | 'tool';
+// Re-export ChatRole from @mlx-node/lm (single source of truth)
+import type { ChatRole } from '@mlx-node/lm';
+export type { ChatRole };
 
 export interface ChatMessage {
   role: ChatRole;


### PR DESCRIPTION
Import ChatRole from @mlx-node/lm instead of redefining it in @mlx-node/trl, establishing a single source of truth.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change that centralizes a shared enum-like union; risk is limited to potential compile-time incompatibilities if downstream code relied on the old local definition.
> 
> **Overview**
> `packages/trl` no longer defines its own `ChatRole` union type; it now imports and re-exports `ChatRole` from `@mlx-node/lm` so consumers use a single shared type.
> 
> All `ChatMessage`/completion typing in `trl` continues to reference `ChatRole`, but the source of the type is centralized to `lm` to avoid drift between packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf50bf6cb308035c95bdb14445128c929bfa7403. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal type declarations for improved code organization and maintainability. No changes to public APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->