### PR TITLE
fix: correct num_parameters() undercount in Qwen3 and Qwen3.5 models

### DIFF
--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -3559,16 +3559,21 @@ impl Qwen3Model {
                 )
             })?
             .len();
-        for _ in 0..num_layers {
-            // Each layer has:
-            // Q, K, V, O projections: 4 * (hidden_size * hidden_size)
-            // MLP: gate, up, down projections
-            // Norms: 2 * hidden_size
-            let hidden_size = self.config.hidden_size as i64;
-            let intermediate_size = self.config.intermediate_size as i64;
+        let hidden_size = self.config.hidden_size as i64;
+        let intermediate_size = self.config.intermediate_size as i64;
+        let head_dim = self.config.head_dim as i64;
+        let kv_dim = self.config.num_kv_heads as i64 * head_dim;
 
-            // Attention: Q, K, V, O
-            total += hidden_size * hidden_size * 4;
+        for _ in 0..num_layers {
+            // Attention: Q, K, V, O projections (GQA: K/V use num_kv_heads * head_dim)
+            total += hidden_size * hidden_size // q_proj
+                + hidden_size * kv_dim         // k_proj
+                + hidden_size * kv_dim         // v_proj
+                + hidden_size * hidden_size; // o_proj
+            // QK norms (when enabled)
+            if self.config.use_qk_norm {
+                total += head_dim * 2; // q_norm + k_norm (each [head_dim])
+            }
             // MLP: gate, up, down
             total += hidden_size * intermediate_size * 2; // gate + up
             total += intermediate_size * hidden_size; // down
@@ -3577,10 +3582,12 @@ impl Qwen3Model {
         }
 
         // Final norm
-        total += self.config.hidden_size as i64;
+        total += hidden_size;
 
-        // LM head
-        total += (self.config.hidden_size * self.config.vocab_size) as i64;
+        // LM head (only when not tied to embeddings)
+        if !self.config.tie_word_embeddings {
+            total += hidden_size * self.config.vocab_size as i64;
+        }
 
         Ok(total)
     }

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -574,9 +574,11 @@ impl Qwen3_5Model {
             } else {
                 // Full attention layer parameters
                 // Note: assumes num_heads * head_dim == hidden_size (true for standard configs)
+                let d = self.config.head_dim as i64;
                 total += h * h * 2 // q_proj (2x for gate)
-                    + h * (self.config.num_kv_heads as i64 * self.config.head_dim as i64) * 2 // k, v
-                    + h * h; // o_proj
+                    + h * (self.config.num_kv_heads as i64 * d) * 2 // k, v
+                    + h * h // o_proj
+                    + d * 2; // q_norm + k_norm (each [head_dim])
             }
 
             // MLP params
@@ -592,6 +594,9 @@ impl Qwen3_5Model {
             // Norms (2 per layer)
             total += h * 2;
         }
+
+        // Final norm
+        total += h;
 
         total
     }


### PR DESCRIPTION
Qwen3.5: add missing final_norm (hidden_size) and q_norm/k_norm (head_dim * 2 per full-attention layer) to parameter count.

Qwen3: fix GQA sizing for K/V projections (use num_kv_heads * head_dim instead of hidden_size), add q_norm/k_norm when use_qk_norm is enabled, and skip LM head count when tie_word_embeddings is true.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect parameter-count reporting math and do not alter forward/inference behavior; risk is limited to incorrect metrics if the new formulas are wrong for edge configs.
> 
> **Overview**
> Fixes `num_parameters()` for Qwen3 and Qwen3.5 so reported parameter totals match actual model weights.
> 
> Qwen3 now counts GQA `k_proj`/`v_proj` using `num_kv_heads * head_dim` (not `hidden_size`), conditionally includes `q_norm`/`k_norm` when `use_qk_norm` is enabled, and skips LM head parameters when `tie_word_embeddings` is true. Qwen3.5 now includes missing per-layer `q_norm`/`k_norm` params for full-attention layers and adds the final norm weights to the total.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8143f86eb382a45832eeed5a8dd5b693b1919009. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined parameter counting accuracy for Qwen3 and Qwen3.5 models.
  * Enhanced attention mechanism calculations with more precise projection layer accounting.
  * Improved support for optional normalization features and tied embedding configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->