### PR TITLE
feat: add chatStream() streaming API for Qwen3.5 models

### DIFF
--- a/__test__/models/qwen35-stream.test.ts
+++ b/__test__/models/qwen35-stream.test.ts
@@ -1,70 +1,52 @@
 import { describe, it, expect } from 'vite-plus/test';
+import type { ChatStreamChunk, ChatStreamHandle } from '@mlx-node/core';
 import type { ChatStreamEvent } from '@mlx-node/lm';
-import { Qwen35Model } from '@mlx-node/lm';
-import type { Qwen35Config } from '@mlx-node/lm';
-
-// Tiny config for stream tests — 4 layers (1 full cycle), random weights, no tokenizer.
-const TINY_STREAM_CONFIG: Qwen35Config = {
-  vocabSize: 1000,
-  hiddenSize: 128,
-  numLayers: 4,
-  numHeads: 4,
-  numKvHeads: 2,
-  intermediateSize: 256,
-  rmsNormEps: 1e-6,
-  headDim: 32,
-  tieWordEmbeddings: true,
-  attentionBias: false,
-  maxPositionEmbeddings: 512,
-  padTokenId: 0,
-  eosTokenId: 1,
-  bosTokenId: 0,
-  linearNumValueHeads: 8,
-  linearNumKeyHeads: 4,
-  linearKeyHeadDim: 32,
-  linearValueHeadDim: 16,
-  linearConvKernelDim: 4,
-  fullAttentionInterval: 4,
-  partialRotaryFactor: 0.25,
-  ropeTheta: 10000.0,
-};
+import { _createChatStream } from '@mlx-node/lm';
 
 /**
- * Creates a mock model that simulates streaming via callbacks,
- * matching the native chatStream signature.
+ * Creates a fake native chatStream callback method that emits `numTokens`
+ * delta chunks followed by a final done chunk, matching the Rust signature.
  */
-function createMockModel(numTokens: number) {
-  const model = new Qwen35Model(TINY_STREAM_CONFIG);
+function fakeNativeMethod(numTokens: number) {
+  return (
+    _messages: unknown[],
+    _config: unknown,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ): Promise<ChatStreamHandle> => {
+    let cancelledFlag = false;
+    const handle = { cancel: () => { cancelledFlag = true; } } as ChatStreamHandle;
 
-  // Patch native chatStream to use mock implementation
-  (model as any).chatStream = async function* () {
-    for (let i = 0; i < numTokens; i++) {
-      yield { text: `token${i}`, done: false } as const;
-    }
-    yield {
-      text: 'final text',
-      done: true,
-      finishReason: 'eos',
-      toolCalls: [],
-      thinking: 'some thinking',
-      numTokens,
-      rawText: 'raw final text',
-    } as const;
+    setTimeout(() => {
+      for (let i = 0; i < numTokens; i++) {
+        if (cancelledFlag) break;
+        callback(null, { text: `token${i}`, done: false } as ChatStreamChunk);
+      }
+      if (!cancelledFlag) {
+        callback(null, {
+          text: 'final text',
+          done: true,
+          finishReason: 'eos',
+          toolCalls: [],
+          thinking: 'some thinking',
+          numTokens,
+          rawText: 'raw final text',
+        } as ChatStreamChunk);
+      }
+    }, 0);
+
+    return Promise.resolve(handle);
   };
-
-  return model;
 }
 
-describe.sequential('Qwen35Model.chatStream() AsyncGenerator', () => {
+describe.sequential('_createChatStream bridge', () => {
   it('should yield delta chunks followed by a final chunk', async () => {
-    const model = createMockModel(3);
     const events: ChatStreamEvent[] = [];
+    const gen = _createChatStream(fakeNativeMethod(3), null, [{ role: 'user', content: 'Hi' }], null);
 
-    for await (const event of model.chatStream([{ role: 'user', content: 'Hi' }])) {
+    for await (const event of gen) {
       events.push(event);
     }
 
-    // 3 delta chunks + 1 final
     expect(events).toHaveLength(4);
     expect(events[0]).toEqual({ text: 'token0', done: false });
     expect(events[1]).toEqual({ text: 'token1', done: false });
@@ -73,10 +55,10 @@ describe.sequential('Qwen35Model.chatStream() AsyncGenerator', () => {
   });
 
   it('should populate final chunk fields correctly', async () => {
-    const model = createMockModel(2);
     let finalEvent: ChatStreamEvent | null = null;
+    const gen = _createChatStream(fakeNativeMethod(2), null, [{ role: 'user', content: 'Hi' }], null);
 
-    for await (const event of model.chatStream([{ role: 'user', content: 'Hi' }])) {
+    for await (const event of gen) {
       if (event.done) finalEvent = event;
     }
 
@@ -91,11 +73,29 @@ describe.sequential('Qwen35Model.chatStream() AsyncGenerator', () => {
     });
   });
 
-  it('should stop generation on break', async () => {
-    const model = createMockModel(100);
-    const events: string[] = [];
+  it('should cancel generation on break via finally block', async () => {
+    let cancelCalled = false;
+    const native = (
+      _messages: unknown[],
+      _config: unknown,
+      callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+    ): Promise<ChatStreamHandle> => {
+      const handle = {
+        cancel: () => { cancelCalled = true; },
+      } as ChatStreamHandle;
 
-    for await (const event of model.chatStream([{ role: 'user', content: 'Hi' }])) {
+      setTimeout(() => {
+        for (let i = 0; i < 100; i++) {
+          callback(null, { text: `t${i}`, done: false } as ChatStreamChunk);
+        }
+        callback(null, { text: '', done: true, finishReason: 'length', numTokens: 100 } as ChatStreamChunk);
+      }, 0);
+
+      return Promise.resolve(handle);
+    };
+
+    const events: string[] = [];
+    for await (const event of _createChatStream(native, null, [{ role: 'user', content: 'Hi' }], null)) {
       if (!event.done) {
         events.push(event.text);
         if (events.length >= 3) break;
@@ -103,15 +103,25 @@ describe.sequential('Qwen35Model.chatStream() AsyncGenerator', () => {
     }
 
     expect(events).toHaveLength(3);
+    expect(cancelCalled).toBe(true);
   });
 
-  it('should be an AsyncGenerator (Symbol.asyncIterator)', async () => {
-    const model = createMockModel(1);
-    const stream = model.chatStream([{ role: 'user', content: 'Hi' }]);
-    expect(stream[Symbol.asyncIterator]).toBeDefined();
-    // Consume to avoid hanging
-    for await (const _ of stream) {
-      /* drain */
-    }
+  it('should propagate errors from callback', async () => {
+    const native = (
+      _messages: unknown[],
+      _config: unknown,
+      callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+    ): Promise<ChatStreamHandle> => {
+      setTimeout(() => {
+        callback(new Error('generation failed'), null as unknown as ChatStreamChunk);
+      }, 0);
+      return Promise.resolve({ cancel: () => {} } as ChatStreamHandle);
+    };
+
+    await expect(async () => {
+      for await (const _event of _createChatStream(native, null, [{ role: 'user', content: 'Hi' }], null)) {
+        // Should throw
+      }
+    }).rejects.toThrow('generation failed');
   });
 });

--- a/__test__/models/qwen35-stream.test.ts
+++ b/__test__/models/qwen35-stream.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vite-plus/test';
+import type { ChatStreamEvent } from '@mlx-node/lm';
+import { Qwen35Model } from '@mlx-node/lm';
+import type { Qwen35Config } from '@mlx-node/lm';
+
+// Tiny config for stream tests — 4 layers (1 full cycle), random weights, no tokenizer.
+const TINY_STREAM_CONFIG: Qwen35Config = {
+  vocabSize: 1000,
+  hiddenSize: 128,
+  numLayers: 4,
+  numHeads: 4,
+  numKvHeads: 2,
+  intermediateSize: 256,
+  rmsNormEps: 1e-6,
+  headDim: 32,
+  tieWordEmbeddings: true,
+  attentionBias: false,
+  maxPositionEmbeddings: 512,
+  padTokenId: 0,
+  eosTokenId: 1,
+  bosTokenId: 0,
+  linearNumValueHeads: 8,
+  linearNumKeyHeads: 4,
+  linearKeyHeadDim: 32,
+  linearValueHeadDim: 16,
+  linearConvKernelDim: 4,
+  fullAttentionInterval: 4,
+  partialRotaryFactor: 0.25,
+  ropeTheta: 10000.0,
+};
+
+/**
+ * Creates a mock model that simulates streaming via callbacks,
+ * matching the native chatStream signature.
+ */
+function createMockModel(numTokens: number) {
+  const model = new Qwen35Model(TINY_STREAM_CONFIG);
+
+  // Patch native chatStream to use mock implementation
+  (model as any).chatStream = async function* () {
+    for (let i = 0; i < numTokens; i++) {
+      yield { text: `token${i}`, done: false } as const;
+    }
+    yield {
+      text: 'final text',
+      done: true,
+      finishReason: 'eos',
+      toolCalls: [],
+      thinking: 'some thinking',
+      numTokens,
+      rawText: 'raw final text',
+    } as const;
+  };
+
+  return model;
+}
+
+describe.sequential('Qwen35Model.chatStream() AsyncGenerator', () => {
+  it('should yield delta chunks followed by a final chunk', async () => {
+    const model = createMockModel(3);
+    const events: ChatStreamEvent[] = [];
+
+    for await (const event of model.chatStream([{ role: 'user', content: 'Hi' }])) {
+      events.push(event);
+    }
+
+    // 3 delta chunks + 1 final
+    expect(events).toHaveLength(4);
+    expect(events[0]).toEqual({ text: 'token0', done: false });
+    expect(events[1]).toEqual({ text: 'token1', done: false });
+    expect(events[2]).toEqual({ text: 'token2', done: false });
+    expect(events[3].done).toBe(true);
+  });
+
+  it('should populate final chunk fields correctly', async () => {
+    const model = createMockModel(2);
+    let finalEvent: ChatStreamEvent | null = null;
+
+    for await (const event of model.chatStream([{ role: 'user', content: 'Hi' }])) {
+      if (event.done) finalEvent = event;
+    }
+
+    expect(finalEvent).toEqual({
+      text: 'final text',
+      done: true,
+      finishReason: 'eos',
+      toolCalls: [],
+      thinking: 'some thinking',
+      numTokens: 2,
+      rawText: 'raw final text',
+    });
+  });
+
+  it('should stop generation on break', async () => {
+    const model = createMockModel(100);
+    const events: string[] = [];
+
+    for await (const event of model.chatStream([{ role: 'user', content: 'Hi' }])) {
+      if (!event.done) {
+        events.push(event.text);
+        if (events.length >= 3) break;
+      }
+    }
+
+    expect(events).toHaveLength(3);
+  });
+
+  it('should be an AsyncGenerator (Symbol.asyncIterator)', async () => {
+    const model = createMockModel(1);
+    const stream = model.chatStream([{ role: 'user', content: 'Hi' }]);
+    expect(stream[Symbol.asyncIterator]).toBeDefined();
+    // Consume to avoid hanging
+    for await (const _ of stream) {
+      /* drain */
+    }
+  });
+});

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1134,25 +1134,8 @@ impl Qwen3_5Model {
                             generated_tokens.push(token_id);
                             token_history.push(token_id);
 
-                            // Check cancellation
                             if cancelled_inner.load(Ordering::Relaxed) {
                                 finish_reason = String::from("cancelled");
-                                // Stream the token before breaking
-                                let token_text = tokenizer_for_decode
-                                    .decode_sync(&[token_id], true)
-                                    .unwrap_or_default();
-                                callback.call(
-                                    Ok(ChatStreamChunk {
-                                        text: token_text,
-                                        done: false,
-                                        finish_reason: None,
-                                        tool_calls: None,
-                                        thinking: None,
-                                        num_tokens: None,
-                                        raw_text: None,
-                                    }),
-                                    ThreadsafeFunctionCallMode::NonBlocking,
-                                );
                                 break;
                             }
 
@@ -1221,24 +1204,8 @@ impl Qwen3_5Model {
                             generated_tokens.push(token_id);
                             token_history.push(token_id);
 
-                            // Check cancellation
                             if cancelled_inner.load(Ordering::Relaxed) {
                                 finish_reason = String::from("cancelled");
-                                let token_text = tokenizer_for_decode
-                                    .decode_sync(&[token_id], true)
-                                    .unwrap_or_default();
-                                callback.call(
-                                    Ok(ChatStreamChunk {
-                                        text: token_text,
-                                        done: false,
-                                        finish_reason: None,
-                                        tool_calls: None,
-                                        thinking: None,
-                                        num_tokens: None,
-                                        raw_text: None,
-                                    }),
-                                    ThreadsafeFunctionCallMode::NonBlocking,
-                                );
                                 break;
                             }
 

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1,6 +1,8 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use napi::bindgen_prelude::*;
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 use tokio::sync::Mutex as TokioMutex;
 use tracing::{info, warn};
@@ -111,6 +113,33 @@ pub struct Qwen3_5ChatResult {
     pub num_tokens: u32,
     pub finish_reason: String,
     pub raw_text: String,
+}
+
+/// A single chunk emitted during streaming chat generation.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct ChatStreamChunk {
+    pub text: String,
+    pub done: bool,
+    pub finish_reason: Option<String>,
+    pub tool_calls: Option<Vec<ToolCallResult>>,
+    pub thinking: Option<String>,
+    pub num_tokens: Option<u32>,
+    pub raw_text: Option<String>,
+}
+
+/// Handle returned by `chat_stream()` to control an in-progress streaming generation.
+#[napi]
+pub struct ChatStreamHandle {
+    pub(crate) cancelled: Arc<AtomicBool>,
+}
+
+#[napi]
+impl ChatStreamHandle {
+    #[napi]
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Relaxed);
+    }
 }
 
 /// Qwen3.5 Model -- hybrid linear/full attention with optional MoE.
@@ -882,6 +911,459 @@ impl Qwen3_5Model {
         })
         .await
         .map_err(|e| Error::from_reason(format!("Chat task failed: {}", e)))?
+    }
+
+    /// Streaming chat API with tool calling support.
+    ///
+    /// Same as `chat()` but streams tokens one-by-one via the callback.
+    /// Returns a `ChatStreamHandle` immediately; generation runs in background.
+    /// Call `handle.cancel()` to abort generation early.
+    #[napi(
+        ts_args_type = "messages: ChatMessage[], config: Qwen35ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+    )]
+    pub async fn chat_stream(
+        &self,
+        messages: Vec<ChatMessage>,
+        config: Option<Qwen3_5ChatConfig>,
+        callback: ThreadsafeFunction<ChatStreamChunk, ()>,
+    ) -> Result<ChatStreamHandle> {
+        let config = config.unwrap_or(Qwen3_5ChatConfig {
+            max_new_tokens: None,
+            temperature: None,
+            top_k: None,
+            top_p: None,
+            min_p: None,
+            repetition_penalty: None,
+            repetition_context_size: None,
+            max_consecutive_tokens: None,
+            max_ngram_repeats: None,
+            ngram_size: None,
+            tools: None,
+        });
+
+        // Tokenize messages using chat template
+        let tokenizer = self
+            .tokenizer
+            .clone()
+            .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?;
+
+        // Clone Arcs and data needed for the closure
+        let embedding_weight = self.embedding.get_weight();
+        let layers_arc = self.layers.clone();
+        let final_norm_arc = self.final_norm.clone();
+        let lm_head_arc = self.lm_head.clone();
+        let caches_arc = self.caches.clone();
+        let model_config = self.config.clone();
+        let fa_idx = self.fa_idx;
+        let tokenizer_for_decode = tokenizer.clone();
+
+        // Check if compiled path will be used (C++ weights loaded from safetensors).
+        let use_compiled = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+
+        // Serialize compiled lifecycle — prevents concurrent C++ global corruption.
+        // Acquire in async context, move into tokio::spawn so it stays held during generation.
+        let compiled_lock = if use_compiled {
+            Some(DENSE_COMPILED_MUTEX.lock().await)
+        } else {
+            None
+        };
+
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancelled_inner = cancelled.clone();
+
+        let callback = Arc::new(callback);
+
+        tokio::spawn(async move {
+            // Hold the compiled lock for the duration of generation
+            let _compiled_lock = compiled_lock;
+
+            let callback_err = callback.clone();
+            let result =
+                napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
+                    let tool_defs = config.tools.as_deref();
+                    let tokens = tokenizer
+                        .apply_chat_template_sync(&messages, Some(true), tool_defs, None)?;
+
+                    // Create prompt tensor
+                    let prompt = MxArray::from_uint32(&tokens, &[1, tokens.len() as i64])?;
+
+                    let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
+                    let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
+                    let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+                    let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
+                    let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
+                    let ngram_size = config.ngram_size.unwrap_or(64);
+                    let sampling_config = Some(SamplingConfig {
+                        temperature: config.temperature,
+                        top_k: config.top_k.or(Some(20)),
+                        top_p: config.top_p,
+                        min_p: config.min_p,
+                    });
+
+                    // Acquire all locks ONCE for the entire prefill+decode sequence
+                    let mut layers_guard = layers_arc.write().map_err(|_| {
+                        Error::from_reason("Failed to acquire layers write lock")
+                    })?;
+                    let mut caches_guard = caches_arc.write().map_err(|_| {
+                        Error::from_reason("Failed to acquire caches write lock")
+                    })?;
+                    let final_norm_guard = final_norm_arc.read().map_err(|_| {
+                        Error::from_reason("Failed to acquire final_norm read lock")
+                    })?;
+                    let lm_head_guard = lm_head_arc
+                        .read()
+                        .map_err(|_| Error::from_reason("Failed to acquire lm_head read lock"))?;
+
+                    // Init fresh caches (old ones dropped on overwrite)
+                    *caches_guard = Some(
+                        (0..model_config.num_layers as usize)
+                            .map(|i| {
+                                if model_config.is_linear_layer(i) {
+                                    Qwen3_5LayerCache::new_linear()
+                                } else {
+                                    Qwen3_5LayerCache::new_full_attention()
+                                }
+                            })
+                            .collect(),
+                    );
+
+                    let eos_id = model_config.eos_token_id as u32;
+                    let mut generated_tokens: Vec<u32> = Vec::new();
+                    let mut finish_reason = String::from("length");
+
+                    // Track token history for repetition penalty
+                    let mut token_history: Vec<u32> = tokens.clone();
+
+                    let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
+                    let generation_stream = Stream::new(DeviceType::Gpu);
+                    let model_size_bytes = model_config.estimate_memory_bytes() as usize;
+                    let _wired_ctx = crate::stream::WiredLimitContext::new(
+                        model_size_bytes,
+                        vec![generation_stream],
+                    );
+
+                    // Prefill
+                    let logits = {
+                        let _stream_ctx = StreamContext::new(generation_stream);
+                        forward_inner(
+                            &prompt,
+                            &embedding_weight,
+                            &mut layers_guard,
+                            &mut caches_guard,
+                            &final_norm_guard,
+                            &lm_head_guard,
+                            fa_idx,
+                            Some(&embedding_weight_t),
+                        )?
+                    };
+
+                    let seq_len = logits.shape_at(1)?;
+                    let last_logits = logits.slice_axis(1, seq_len - 1, seq_len)?;
+                    let mut last_logits = last_logits.squeeze(Some(&[1]))?;
+
+                    // Apply repetition penalty to prefill logits
+                    if repetition_penalty != 1.0 && !token_history.is_empty() {
+                        last_logits = apply_repetition_penalty(
+                            &last_logits,
+                            &token_history,
+                            repetition_penalty,
+                            Some(repetition_context_size),
+                        )?;
+                    }
+
+                    let mut y = sample(&last_logits, sampling_config)?;
+                    MxArray::async_eval_arrays(&[&y]);
+
+                    let _compiled_guard = if use_compiled {
+                        Some(CompiledResetGuard)
+                    } else {
+                        None
+                    };
+
+                    if use_compiled {
+                        use mlx_sys as sys;
+                        let prefill_len = seq_len as i32;
+                        let max_kv_len = ((prefill_len + max_new_tokens + 255) / 256) * 256;
+                        let num_layers = model_config.num_layers as usize;
+                        let mut cache_ptrs: Vec<*mut sys::mlx_array> =
+                            vec![std::ptr::null_mut(); num_layers * 2];
+                        if let Some(ref caches) = *caches_guard {
+                            for (i, cache) in caches.iter().enumerate() {
+                                let (p0, p1) = cache.export_ptrs();
+                                cache_ptrs[i * 2] = p0;
+                                cache_ptrs[i * 2 + 1] = p1;
+                            }
+                        }
+                        // Drop non-cache locks — not needed during compiled decode
+                        drop(layers_guard);
+                        drop(final_norm_guard);
+                        drop(lm_head_guard);
+                        unsafe {
+                            sys::mlx_qwen35_compiled_init_from_prefill(
+                                model_config.num_layers,
+                                model_config.hidden_size,
+                                model_config.num_heads,
+                                model_config.num_kv_heads,
+                                model_config.head_dim,
+                                model_config.rope_theta as f32,
+                                model_config.rope_dims(),
+                                model_config.rms_norm_eps as f32,
+                                model_config.full_attention_interval,
+                                model_config.linear_num_key_heads,
+                                model_config.linear_num_value_heads,
+                                model_config.linear_key_head_dim,
+                                model_config.linear_value_head_dim,
+                                model_config.linear_conv_kernel_dim,
+                                if model_config.tie_word_embeddings {
+                                    1
+                                } else {
+                                    0
+                                },
+                                max_kv_len,
+                                1,
+                                cache_ptrs.as_mut_ptr(),
+                                prefill_len,
+                            );
+                        }
+                        drop(caches_guard);
+
+                        // Compiled C++ decode loop
+                        for step in 0..max_new_tokens {
+                            y.eval();
+                            let token_id = y.item_at_int32(0)? as u32;
+                            generated_tokens.push(token_id);
+                            token_history.push(token_id);
+
+                            // Check cancellation
+                            if cancelled_inner.load(Ordering::Relaxed) {
+                                finish_reason = String::from("cancelled");
+                                // Stream the token before breaking
+                                let token_text = tokenizer_for_decode
+                                    .decode_sync(&[token_id], true)
+                                    .unwrap_or_default();
+                                callback.call(
+                                    Ok(ChatStreamChunk {
+                                        text: token_text,
+                                        done: false,
+                                        finish_reason: None,
+                                        tool_calls: None,
+                                        thinking: None,
+                                        num_tokens: None,
+                                        raw_text: None,
+                                    }),
+                                    ThreadsafeFunctionCallMode::NonBlocking,
+                                );
+                                break;
+                            }
+
+                            // Decode and stream this token
+                            let token_text = tokenizer_for_decode
+                                .decode_sync(&[token_id], true)
+                                .unwrap_or_default();
+                            callback.call(
+                                Ok(ChatStreamChunk {
+                                    text: token_text,
+                                    done: false,
+                                    finish_reason: None,
+                                    tool_calls: None,
+                                    thinking: None,
+                                    num_tokens: None,
+                                    raw_text: None,
+                                }),
+                                ThreadsafeFunctionCallMode::NonBlocking,
+                            );
+
+                            if token_id == eos_id {
+                                finish_reason = String::from("eos");
+                                break;
+                            }
+
+                            if let Some(reason) = check_repetition_cutoff(
+                                &generated_tokens,
+                                max_consecutive_tokens,
+                                max_ngram_repeats,
+                                ngram_size,
+                            ) {
+                                finish_reason = reason.to_string();
+                                break;
+                            }
+
+                            if step + 1 >= max_new_tokens {
+                                break;
+                            }
+                            {
+                                let _stream_ctx = StreamContext::new(generation_stream);
+                                let next_ids = y.reshape(&[1, 1])?;
+                                let mut logits =
+                                    forward_compiled(&next_ids, &embedding_weight)?;
+                                if repetition_penalty != 1.0 {
+                                    logits = apply_repetition_penalty(
+                                        &logits,
+                                        &token_history,
+                                        repetition_penalty,
+                                        Some(repetition_context_size),
+                                    )?;
+                                }
+                                let next_token = sample(&logits, sampling_config)?;
+                                eval_token_and_compiled_caches(&next_token);
+                                y = next_token;
+                            }
+
+                            if (step + 1) % 256 == 0 {
+                                crate::array::synchronize_and_clear_cache();
+                            }
+                        }
+                    } else {
+                        // Rust fallback decode loop (locks held for entire loop)
+                        for step in 0..max_new_tokens {
+                            y.eval();
+                            let token_id = y.item_at_int32(0)? as u32;
+                            generated_tokens.push(token_id);
+                            token_history.push(token_id);
+
+                            // Check cancellation
+                            if cancelled_inner.load(Ordering::Relaxed) {
+                                finish_reason = String::from("cancelled");
+                                let token_text = tokenizer_for_decode
+                                    .decode_sync(&[token_id], true)
+                                    .unwrap_or_default();
+                                callback.call(
+                                    Ok(ChatStreamChunk {
+                                        text: token_text,
+                                        done: false,
+                                        finish_reason: None,
+                                        tool_calls: None,
+                                        thinking: None,
+                                        num_tokens: None,
+                                        raw_text: None,
+                                    }),
+                                    ThreadsafeFunctionCallMode::NonBlocking,
+                                );
+                                break;
+                            }
+
+                            // Decode and stream this token
+                            let token_text = tokenizer_for_decode
+                                .decode_sync(&[token_id], true)
+                                .unwrap_or_default();
+                            callback.call(
+                                Ok(ChatStreamChunk {
+                                    text: token_text,
+                                    done: false,
+                                    finish_reason: None,
+                                    tool_calls: None,
+                                    thinking: None,
+                                    num_tokens: None,
+                                    raw_text: None,
+                                }),
+                                ThreadsafeFunctionCallMode::NonBlocking,
+                            );
+
+                            if token_id == eos_id {
+                                finish_reason = String::from("eos");
+                                break;
+                            }
+
+                            if let Some(reason) = check_repetition_cutoff(
+                                &generated_tokens,
+                                max_consecutive_tokens,
+                                max_ngram_repeats,
+                                ngram_size,
+                            ) {
+                                finish_reason = reason.to_string();
+                                break;
+                            }
+
+                            if step + 1 >= max_new_tokens {
+                                break;
+                            }
+                            {
+                                let _stream_ctx = StreamContext::new(generation_stream);
+                                let next_ids = y.reshape(&[1, 1])?;
+                                let logits = forward_inner(
+                                    &next_ids,
+                                    &embedding_weight,
+                                    &mut layers_guard,
+                                    &mut caches_guard,
+                                    &final_norm_guard,
+                                    &lm_head_guard,
+                                    fa_idx,
+                                    Some(&embedding_weight_t),
+                                )?;
+                                let mut logits = logits.squeeze(Some(&[1]))?;
+                                if repetition_penalty != 1.0 {
+                                    logits = apply_repetition_penalty(
+                                        &logits,
+                                        &token_history,
+                                        repetition_penalty,
+                                        Some(repetition_context_size),
+                                    )?;
+                                }
+                                let next_token = sample(&logits, sampling_config)?;
+                                eval_token_and_caches_inner(&next_token, &caches_guard);
+                                y = next_token;
+                            }
+
+                            if (step + 1) % 256 == 0 {
+                                crate::array::synchronize_and_clear_cache();
+                            }
+                        }
+                    }
+
+                    // _compiled_guard dropped here (if Some), calling mlx_qwen35_compiled_reset()
+
+                    // Decode full text for final chunk
+                    let text = tokenizer_for_decode
+                        .decode_sync(&generated_tokens, true)
+                        .unwrap_or_else(|e| {
+                            warn!("Failed to decode generated tokens: {}", e);
+                            String::new()
+                        });
+
+                    let num_tokens = generated_tokens.len() as u32;
+
+                    // Parse tool calls and thinking from the generated text
+                    let (clean_text, tool_calls, thinking) =
+                        tools::parse_generation_output(&text);
+
+                    // If we have valid tool calls, override finish reason
+                    let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
+                        "tool_calls".to_string()
+                    } else {
+                        finish_reason
+                    };
+
+                    // Send final done chunk
+                    callback.call(
+                        Ok(ChatStreamChunk {
+                            text: clean_text,
+                            done: true,
+                            finish_reason: Some(finish_reason),
+                            tool_calls: Some(tool_calls),
+                            thinking,
+                            num_tokens: Some(num_tokens),
+                            raw_text: Some(text),
+                        }),
+                        ThreadsafeFunctionCallMode::NonBlocking,
+                    );
+
+                    Ok(())
+                })
+                .await;
+
+            // If spawn_blocking itself failed (e.g. panic), send error via callback
+            if let Err(e) = result {
+                callback_err.call(
+                    Err(Error::from_reason(format!(
+                        "Chat stream task failed: {}",
+                        e
+                    ))),
+                    ThreadsafeFunctionCallMode::NonBlocking,
+                );
+            }
+        });
+
+        Ok(ChatStreamHandle { cancelled })
     }
 
     /// Get the number of parameters in the model.

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -981,8 +981,12 @@ impl Qwen3_5Model {
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
                     let tool_defs = config.tools.as_deref();
-                    let tokens = tokenizer
-                        .apply_chat_template_sync(&messages, Some(true), tool_defs, None)?;
+                    let tokens = tokenizer.apply_chat_template_sync(
+                        &messages,
+                        Some(true),
+                        tool_defs,
+                        None,
+                    )?;
 
                     // Create prompt tensor
                     let prompt = MxArray::from_uint32(&tokens, &[1, tokens.len() as i64])?;
@@ -1001,12 +1005,12 @@ impl Qwen3_5Model {
                     });
 
                     // Acquire all locks ONCE for the entire prefill+decode sequence
-                    let mut layers_guard = layers_arc.write().map_err(|_| {
-                        Error::from_reason("Failed to acquire layers write lock")
-                    })?;
-                    let mut caches_guard = caches_arc.write().map_err(|_| {
-                        Error::from_reason("Failed to acquire caches write lock")
-                    })?;
+                    let mut layers_guard = layers_arc
+                        .write()
+                        .map_err(|_| Error::from_reason("Failed to acquire layers write lock"))?;
+                    let mut caches_guard = caches_arc
+                        .write()
+                        .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
                     let final_norm_guard = final_norm_arc.read().map_err(|_| {
                         Error::from_reason("Failed to acquire final_norm read lock")
                     })?;
@@ -1177,8 +1181,7 @@ impl Qwen3_5Model {
                             {
                                 let _stream_ctx = StreamContext::new(generation_stream);
                                 let next_ids = y.reshape(&[1, 1])?;
-                                let mut logits =
-                                    forward_compiled(&next_ids, &embedding_weight)?;
+                                let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
                                 if repetition_penalty != 1.0 {
                                     logits = apply_repetition_penalty(
                                         &logits,
@@ -1290,8 +1293,7 @@ impl Qwen3_5Model {
                     let num_tokens = generated_tokens.len() as u32;
 
                     // Parse tool calls and thinking from the generated text
-                    let (clean_text, tool_calls, thinking) =
-                        tools::parse_generation_output(&text);
+                    let (clean_text, tool_calls, thinking) = tools::parse_generation_output(&text);
 
                     // If we have valid tool calls, override finish reason
                     let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
@@ -1318,15 +1320,22 @@ impl Qwen3_5Model {
                 })
                 .await;
 
-            // If spawn_blocking itself failed (e.g. panic), send error via callback
-            if let Err(e) = result {
-                callback_err.call(
-                    Err(Error::from_reason(format!(
-                        "Chat stream task failed: {}",
-                        e
-                    ))),
-                    ThreadsafeFunctionCallMode::NonBlocking,
-                );
+            match result {
+                Ok(Ok(())) => {} // Success — final chunk already sent via callback
+                Ok(Err(e)) => {
+                    // Inner closure error (tokenization, lock, array ops, etc.)
+                    callback_err.call(Err(e), ThreadsafeFunctionCallMode::NonBlocking);
+                }
+                Err(e) => {
+                    // JoinError (panic in spawn_blocking)
+                    callback_err.call(
+                        Err(Error::from_reason(format!(
+                            "Chat stream task panicked: {}",
+                            e
+                        ))),
+                        ThreadsafeFunctionCallMode::NonBlocking,
+                    );
+                }
             }
         });
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -943,8 +943,12 @@ impl Qwen3_5MoeModel {
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
                     let tool_defs = config.tools.as_deref();
-                    let tokens = tokenizer
-                        .apply_chat_template_sync(&messages, Some(true), tool_defs, None)?;
+                    let tokens = tokenizer.apply_chat_template_sync(
+                        &messages,
+                        Some(true),
+                        tool_defs,
+                        None,
+                    )?;
 
                     let prompt = MxArray::from_uint32(&tokens, &[1, tokens.len() as i64])?;
 
@@ -962,12 +966,12 @@ impl Qwen3_5MoeModel {
                     });
 
                     // Acquire all locks ONCE for the entire prefill+decode sequence
-                    let mut layers_guard = layers_arc.write().map_err(|_| {
-                        Error::from_reason("Failed to acquire layers write lock")
-                    })?;
-                    let mut caches_guard = caches_arc.write().map_err(|_| {
-                        Error::from_reason("Failed to acquire caches write lock")
-                    })?;
+                    let mut layers_guard = layers_arc
+                        .write()
+                        .map_err(|_| Error::from_reason("Failed to acquire layers write lock"))?;
+                    let mut caches_guard = caches_arc
+                        .write()
+                        .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
                     let final_norm_guard = final_norm_arc.read().map_err(|_| {
                         Error::from_reason("Failed to acquire final_norm read lock")
                     })?;
@@ -1269,8 +1273,7 @@ impl Qwen3_5MoeModel {
                     let num_tokens = generated_tokens.len() as u32;
 
                     // Parse tool calls and thinking from the generated text
-                    let (clean_text, tool_calls, thinking) =
-                        tools::parse_generation_output(&text);
+                    let (clean_text, tool_calls, thinking) = tools::parse_generation_output(&text);
 
                     // If we have valid tool calls, override finish reason
                     let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
@@ -1297,15 +1300,22 @@ impl Qwen3_5MoeModel {
                 })
                 .await;
 
-            // If spawn_blocking itself failed (e.g. panic), send error via callback
-            if let Err(e) = result {
-                callback_err.call(
-                    Err(Error::from_reason(format!(
-                        "Chat stream task failed: {}",
-                        e
-                    ))),
-                    ThreadsafeFunctionCallMode::NonBlocking,
-                );
+            match result {
+                Ok(Ok(())) => {} // Success — final chunk already sent via callback
+                Ok(Err(e)) => {
+                    // Inner closure error (tokenization, lock, array ops, etc.)
+                    callback_err.call(Err(e), ThreadsafeFunctionCallMode::NonBlocking);
+                }
+                Err(e) => {
+                    // JoinError (panic in spawn_blocking)
+                    callback_err.call(
+                        Err(Error::from_reason(format!(
+                            "Chat stream task panicked: {}",
+                            e
+                        ))),
+                        ThreadsafeFunctionCallMode::NonBlocking,
+                    );
+                }
             }
         });
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1114,24 +1114,8 @@ impl Qwen3_5MoeModel {
                             generated_tokens.push(token_id);
                             token_history.push(token_id);
 
-                            // Check cancellation
                             if cancelled_inner.load(Ordering::Relaxed) {
                                 finish_reason = String::from("cancelled");
-                                let token_text = tokenizer_for_decode
-                                    .decode_sync(&[token_id], true)
-                                    .unwrap_or_default();
-                                callback.call(
-                                    Ok(ChatStreamChunk {
-                                        text: token_text,
-                                        done: false,
-                                        finish_reason: None,
-                                        tool_calls: None,
-                                        thinking: None,
-                                        num_tokens: None,
-                                        raw_text: None,
-                                    }),
-                                    ThreadsafeFunctionCallMode::NonBlocking,
-                                );
                                 break;
                             }
 
@@ -1198,24 +1182,8 @@ impl Qwen3_5MoeModel {
                             generated_tokens.push(token_id);
                             token_history.push(token_id);
 
-                            // Check cancellation
                             if cancelled_inner.load(Ordering::Relaxed) {
                                 finish_reason = String::from("cancelled");
-                                let token_text = tokenizer_for_decode
-                                    .decode_sync(&[token_id], true)
-                                    .unwrap_or_default();
-                                callback.call(
-                                    Ok(ChatStreamChunk {
-                                        text: token_text,
-                                        done: false,
-                                        finish_reason: None,
-                                        tool_calls: None,
-                                        thinking: None,
-                                        num_tokens: None,
-                                        raw_text: None,
-                                    }),
-                                    ThreadsafeFunctionCallMode::NonBlocking,
-                                );
                                 break;
                             }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1,9 +1,13 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use napi::bindgen_prelude::*;
+use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 use tokio::sync::Mutex as TokioMutex;
 use tracing::{info, warn};
+
+use crate::models::qwen3_5::model::{ChatStreamChunk, ChatStreamHandle};
 
 use super::quantized_linear::LinearProj;
 use crate::array::MxArray;
@@ -871,6 +875,473 @@ impl Qwen3_5MoeModel {
         })
         .await
         .map_err(|e| Error::from_reason(format!("Chat task failed: {}", e)))?
+    }
+
+    /// Streaming chat API with tool calling support.
+    ///
+    /// Same as `chat()` but streams tokens one-by-one via the callback.
+    /// Returns a `ChatStreamHandle` immediately; generation runs in background.
+    /// Call `handle.cancel()` to abort generation early.
+    #[napi(
+        ts_args_type = "messages: ChatMessage[], config: Qwen35MoeChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+    )]
+    pub async fn chat_stream(
+        &self,
+        messages: Vec<ChatMessage>,
+        config: Option<Qwen3_5MoeChatConfig>,
+        callback: ThreadsafeFunction<ChatStreamChunk, ()>,
+    ) -> Result<ChatStreamHandle> {
+        let config = config.unwrap_or(Qwen3_5MoeChatConfig {
+            max_new_tokens: None,
+            temperature: None,
+            top_k: None,
+            top_p: None,
+            min_p: None,
+            repetition_penalty: None,
+            repetition_context_size: None,
+            max_consecutive_tokens: None,
+            max_ngram_repeats: None,
+            ngram_size: None,
+            tools: None,
+        });
+
+        let tokenizer = self
+            .tokenizer
+            .clone()
+            .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?;
+
+        let embedding_weight = self.embedding.get_weight();
+        let layers_arc = self.layers.clone();
+        let final_norm_arc = self.final_norm.clone();
+        let lm_head_arc = self.lm_head.clone();
+        let caches_arc = self.caches.clone();
+        let model_config = self.config.clone();
+        let fa_idx = self.fa_idx;
+        let tokenizer_for_decode = tokenizer.clone();
+
+        // Check if C++ MoE path will be used (weights loaded from safetensors).
+        let use_cpp = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+
+        // Serialize MoE compiled lifecycle — prevents concurrent C++ global corruption.
+        // Acquire in async context, move into tokio::spawn so it stays held during generation.
+        let moe_lock = if use_cpp {
+            Some(MOE_COMPILED_MUTEX.lock().await)
+        } else {
+            None
+        };
+
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancelled_inner = cancelled.clone();
+
+        let callback = Arc::new(callback);
+
+        tokio::spawn(async move {
+            // Hold the MoE lock for the duration of generation
+            let _moe_lock = moe_lock;
+
+            let callback_err = callback.clone();
+            let result =
+                napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
+                    let tool_defs = config.tools.as_deref();
+                    let tokens = tokenizer
+                        .apply_chat_template_sync(&messages, Some(true), tool_defs, None)?;
+
+                    let prompt = MxArray::from_uint32(&tokens, &[1, tokens.len() as i64])?;
+
+                    let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
+                    let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
+                    let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+                    let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
+                    let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
+                    let ngram_size = config.ngram_size.unwrap_or(64);
+                    let sampling_config = Some(SamplingConfig {
+                        temperature: config.temperature,
+                        top_k: config.top_k.or(Some(20)),
+                        top_p: config.top_p,
+                        min_p: config.min_p,
+                    });
+
+                    // Acquire all locks ONCE for the entire prefill+decode sequence
+                    let mut layers_guard = layers_arc.write().map_err(|_| {
+                        Error::from_reason("Failed to acquire layers write lock")
+                    })?;
+                    let mut caches_guard = caches_arc.write().map_err(|_| {
+                        Error::from_reason("Failed to acquire caches write lock")
+                    })?;
+                    let final_norm_guard = final_norm_arc.read().map_err(|_| {
+                        Error::from_reason("Failed to acquire final_norm read lock")
+                    })?;
+                    let lm_head_guard = lm_head_arc
+                        .read()
+                        .map_err(|_| Error::from_reason("Failed to acquire lm_head read lock"))?;
+
+                    // Reset and init caches
+                    if let Some(ref mut caches) = *caches_guard {
+                        for cache in caches.iter_mut() {
+                            cache.reset();
+                        }
+                    }
+                    let new_caches = (0..model_config.num_layers as usize)
+                        .map(|i| {
+                            if model_config.is_linear_layer(i) {
+                                Qwen3_5LayerCache::new_linear()
+                            } else {
+                                Qwen3_5LayerCache::new_full_attention()
+                            }
+                        })
+                        .collect();
+                    *caches_guard = Some(new_caches);
+
+                    let eos_id = model_config.eos_token_id as u32;
+                    let mut generated_tokens: Vec<u32> = Vec::new();
+                    let mut finish_reason = String::from("length");
+
+                    // Track token history for repetition penalty
+                    let mut token_history: Vec<u32> = tokens.clone();
+
+                    let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
+                    let generation_stream = Stream::new(DeviceType::Gpu);
+                    let model_size_bytes = model_config.estimate_memory_bytes() as usize;
+                    let _wired_ctx = crate::stream::WiredLimitContext::new(
+                        model_size_bytes,
+                        vec![generation_stream],
+                    );
+
+                    // StreamContext created ONCE for entire prefill+decode (MoE pattern)
+                    let _stream_ctx = StreamContext::new(generation_stream);
+
+                    // Prefill
+                    let logits = forward_inner(
+                        &prompt,
+                        &embedding_weight,
+                        &mut layers_guard,
+                        &mut caches_guard,
+                        &final_norm_guard,
+                        &lm_head_guard,
+                        fa_idx,
+                        Some(&embedding_weight_t),
+                    )?;
+
+                    let seq_len = logits.shape_at(1)?;
+                    let last_logits = logits.slice_axis(1, seq_len - 1, seq_len)?;
+                    let mut last_logits = last_logits.squeeze(Some(&[1]))?;
+
+                    // Apply repetition penalty to prefill logits
+                    if repetition_penalty != 1.0 && !token_history.is_empty() {
+                        last_logits = apply_repetition_penalty(
+                            &last_logits,
+                            &token_history,
+                            repetition_penalty,
+                            Some(repetition_context_size),
+                        )?;
+                    }
+
+                    let mut y = sample(&last_logits, sampling_config)?;
+                    MxArray::async_eval_arrays(&[&y]);
+
+                    if use_cpp {
+                        // Guard ensures mlx_qwen35_moe_reset() is called even if `?` returns early.
+                        let _moe_guard = MoeResetGuard;
+                        // Initialize C++ MoE forward pass from prefill caches
+                        use mlx_sys as sys;
+                        let prefill_len = seq_len as i32;
+                        let max_kv_len = ((prefill_len + max_new_tokens + 255) / 256) * 256;
+                        let num_layers = model_config.num_layers as usize;
+                        let mut cache_ptrs: Vec<*mut sys::mlx_array> =
+                            vec![std::ptr::null_mut(); num_layers * 2];
+                        if let Some(ref caches) = *caches_guard {
+                            for (i, cache) in caches.iter().enumerate() {
+                                let (p0, p1) = cache.export_ptrs();
+                                cache_ptrs[i * 2] = p0;
+                                cache_ptrs[i * 2 + 1] = p1;
+                            }
+                        }
+                        let mlp_only: Vec<i32> = model_config
+                            .mlp_only_layers
+                            .as_deref()
+                            .unwrap_or(&[])
+                            .to_vec();
+                        // Drop non-cache locks — not needed during C++ MoE decode
+                        drop(layers_guard);
+                        drop(final_norm_guard);
+                        drop(lm_head_guard);
+                        // Keep caches_guard alive through init_from_prefill so cache_ptrs
+                        // (raw pointers into the cache MxArrays) remain valid.
+                        unsafe {
+                            sys::mlx_qwen35_moe_init_from_prefill(
+                                model_config.num_layers,
+                                model_config.hidden_size,
+                                model_config.num_heads,
+                                model_config.num_kv_heads,
+                                model_config.head_dim,
+                                model_config.rope_theta as f32,
+                                model_config.rope_dims(),
+                                model_config.rms_norm_eps as f32,
+                                model_config.full_attention_interval,
+                                model_config.linear_num_key_heads,
+                                model_config.linear_num_value_heads,
+                                model_config.linear_key_head_dim,
+                                model_config.linear_value_head_dim,
+                                model_config.linear_conv_kernel_dim,
+                                if model_config.tie_word_embeddings {
+                                    1
+                                } else {
+                                    0
+                                },
+                                max_kv_len,
+                                1, // batch_size
+                                model_config.num_experts,
+                                model_config.num_experts_per_tok,
+                                if model_config.norm_topk_prob { 1 } else { 0 },
+                                model_config.decoder_sparse_step,
+                                if mlp_only.is_empty() {
+                                    std::ptr::null()
+                                } else {
+                                    mlp_only.as_ptr()
+                                },
+                                mlp_only.len() as i32,
+                                cache_ptrs.as_mut_ptr(),
+                                prefill_len,
+                            );
+                        }
+                        // C++ has copied arrays into its own globals — safe to release
+                        drop(caches_guard);
+
+                        // C++ decode loop (all locks dropped — C++ owns the state)
+                        for step in 0..max_new_tokens {
+                            y.eval();
+                            let token_id = y.item_at_int32(0)? as u32;
+                            generated_tokens.push(token_id);
+                            token_history.push(token_id);
+
+                            // Check cancellation
+                            if cancelled_inner.load(Ordering::Relaxed) {
+                                finish_reason = String::from("cancelled");
+                                let token_text = tokenizer_for_decode
+                                    .decode_sync(&[token_id], true)
+                                    .unwrap_or_default();
+                                callback.call(
+                                    Ok(ChatStreamChunk {
+                                        text: token_text,
+                                        done: false,
+                                        finish_reason: None,
+                                        tool_calls: None,
+                                        thinking: None,
+                                        num_tokens: None,
+                                        raw_text: None,
+                                    }),
+                                    ThreadsafeFunctionCallMode::NonBlocking,
+                                );
+                                break;
+                            }
+
+                            // Decode and stream this token
+                            let token_text = tokenizer_for_decode
+                                .decode_sync(&[token_id], true)
+                                .unwrap_or_default();
+                            callback.call(
+                                Ok(ChatStreamChunk {
+                                    text: token_text,
+                                    done: false,
+                                    finish_reason: None,
+                                    tool_calls: None,
+                                    thinking: None,
+                                    num_tokens: None,
+                                    raw_text: None,
+                                }),
+                                ThreadsafeFunctionCallMode::NonBlocking,
+                            );
+
+                            if token_id == eos_id {
+                                finish_reason = String::from("eos");
+                                break;
+                            }
+
+                            if let Some(reason) = check_repetition_cutoff(
+                                &generated_tokens,
+                                max_consecutive_tokens,
+                                max_ngram_repeats,
+                                ngram_size,
+                            ) {
+                                finish_reason = reason.to_string();
+                                break;
+                            }
+
+                            if step + 1 >= max_new_tokens {
+                                break;
+                            }
+
+                            let next_ids = y.reshape(&[1, 1])?;
+                            let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
+                            if repetition_penalty != 1.0 {
+                                logits = apply_repetition_penalty(
+                                    &logits,
+                                    &token_history,
+                                    repetition_penalty,
+                                    Some(repetition_context_size),
+                                )?;
+                            }
+                            let next_token = sample(&logits, sampling_config)?;
+                            eval_token_and_moe_caches(&next_token);
+                            y = next_token;
+
+                            if (step + 1) % 256 == 0 {
+                                crate::array::clear_cache();
+                            }
+                        }
+                        // _moe_guard dropped here, calling mlx_qwen35_moe_reset()
+                    } else {
+                        // Rust fallback decode loop (locks held for entire loop)
+                        for step in 0..max_new_tokens {
+                            y.eval();
+                            let token_id = y.item_at_int32(0)? as u32;
+                            generated_tokens.push(token_id);
+                            token_history.push(token_id);
+
+                            // Check cancellation
+                            if cancelled_inner.load(Ordering::Relaxed) {
+                                finish_reason = String::from("cancelled");
+                                let token_text = tokenizer_for_decode
+                                    .decode_sync(&[token_id], true)
+                                    .unwrap_or_default();
+                                callback.call(
+                                    Ok(ChatStreamChunk {
+                                        text: token_text,
+                                        done: false,
+                                        finish_reason: None,
+                                        tool_calls: None,
+                                        thinking: None,
+                                        num_tokens: None,
+                                        raw_text: None,
+                                    }),
+                                    ThreadsafeFunctionCallMode::NonBlocking,
+                                );
+                                break;
+                            }
+
+                            // Decode and stream this token
+                            let token_text = tokenizer_for_decode
+                                .decode_sync(&[token_id], true)
+                                .unwrap_or_default();
+                            callback.call(
+                                Ok(ChatStreamChunk {
+                                    text: token_text,
+                                    done: false,
+                                    finish_reason: None,
+                                    tool_calls: None,
+                                    thinking: None,
+                                    num_tokens: None,
+                                    raw_text: None,
+                                }),
+                                ThreadsafeFunctionCallMode::NonBlocking,
+                            );
+
+                            if token_id == eos_id {
+                                finish_reason = String::from("eos");
+                                break;
+                            }
+
+                            if let Some(reason) = check_repetition_cutoff(
+                                &generated_tokens,
+                                max_consecutive_tokens,
+                                max_ngram_repeats,
+                                ngram_size,
+                            ) {
+                                finish_reason = reason.to_string();
+                                break;
+                            }
+
+                            if step + 1 >= max_new_tokens {
+                                break;
+                            }
+
+                            let next_ids = y.reshape(&[1, 1])?;
+                            let logits = forward_inner(
+                                &next_ids,
+                                &embedding_weight,
+                                &mut layers_guard,
+                                &mut caches_guard,
+                                &final_norm_guard,
+                                &lm_head_guard,
+                                fa_idx,
+                                Some(&embedding_weight_t),
+                            )?;
+                            let mut logits = logits.squeeze(Some(&[1]))?;
+                            if repetition_penalty != 1.0 {
+                                logits = apply_repetition_penalty(
+                                    &logits,
+                                    &token_history,
+                                    repetition_penalty,
+                                    Some(repetition_context_size),
+                                )?;
+                            }
+                            let next_token = sample(&logits, sampling_config)?;
+                            eval_token_and_caches_inner(&next_token, &caches_guard);
+                            y = next_token;
+
+                            if (step + 1) % 256 == 0 {
+                                crate::array::clear_cache();
+                            }
+                        }
+
+                        drop(layers_guard);
+                        drop(caches_guard);
+                        drop(final_norm_guard);
+                        drop(lm_head_guard);
+                    }
+
+                    // Decode full text for final chunk
+                    let text = tokenizer_for_decode
+                        .decode_sync(&generated_tokens, true)
+                        .unwrap_or_else(|e| {
+                            warn!("Failed to decode generated tokens: {}", e);
+                            String::new()
+                        });
+
+                    let num_tokens = generated_tokens.len() as u32;
+
+                    // Parse tool calls and thinking from the generated text
+                    let (clean_text, tool_calls, thinking) =
+                        tools::parse_generation_output(&text);
+
+                    // If we have valid tool calls, override finish reason
+                    let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
+                        "tool_calls".to_string()
+                    } else {
+                        finish_reason
+                    };
+
+                    // Send final done chunk
+                    callback.call(
+                        Ok(ChatStreamChunk {
+                            text: clean_text,
+                            done: true,
+                            finish_reason: Some(finish_reason),
+                            tool_calls: Some(tool_calls),
+                            thinking,
+                            num_tokens: Some(num_tokens),
+                            raw_text: Some(text),
+                        }),
+                        ThreadsafeFunctionCallMode::NonBlocking,
+                    );
+
+                    Ok(())
+                })
+                .await;
+
+            // If spawn_blocking itself failed (e.g. panic), send error via callback
+            if let Err(e) = result {
+                callback_err.call(
+                    Err(Error::from_reason(format!(
+                        "Chat stream task failed: {}",
+                        e
+                    ))),
+                    ThreadsafeFunctionCallMode::NonBlocking,
+                );
+            }
+        });
+
+        Ok(ChatStreamHandle { cancelled })
     }
 
     #[napi]

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -737,6 +737,7 @@ if (!nativeBinding) {
 module.exports = nativeBinding;
 module.exports.BatchGenerationResult = nativeBinding.BatchGenerationResult;
 module.exports.ChatResult = nativeBinding.ChatResult;
+module.exports.ChatStreamHandle = nativeBinding.ChatStreamHandle;
 module.exports.DocLayoutModel = nativeBinding.DocLayoutModel;
 module.exports.PPDocLayoutV3Model = nativeBinding.PPDocLayoutV3Model;
 module.exports.DocOrientationModel = nativeBinding.DocOrientationModel;

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -71,6 +71,11 @@ export declare class ChatResult {
   get rawText(): string;
 }
 
+/** Handle returned by `chat_stream()` to control an in-progress streaming generation. */
+export declare class ChatStreamHandle {
+  cancel(): void;
+}
+
 /**
  * PP-DocLayoutV3 full model for document layout analysis.
  *
@@ -705,6 +710,18 @@ export declare class Qwen35Model {
    * to avoid blocking the Node.js event loop.
    */
   chat(messages: Array<ChatMessage>, config?: Qwen35ChatConfig | undefined | null): Promise<Qwen35ChatResult>;
+  /**
+   * Streaming chat API with tool calling support.
+   *
+   * Same as `chat()` but streams tokens one-by-one via the callback.
+   * Returns a `ChatStreamHandle` immediately; generation runs in background.
+   * Call `handle.cancel()` to abort generation early.
+   */
+  chatStream(
+    messages: ChatMessage[],
+    config: Qwen35ChatConfig | null,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ): Promise<ChatStreamHandle>;
   /** Get the number of parameters in the model. */
   numParameters(): number;
 }
@@ -726,6 +743,18 @@ export declare class Qwen35MoeModel {
   static loadPretrained(path: string): Promise<Qwen35MoeModel>;
   generate(promptTokens: MxArray, config: Qwen35MoeGenerationConfig): Promise<Qwen35MoeGenerationResult>;
   chat(messages: Array<ChatMessage>, config?: Qwen35MoeChatConfig | undefined | null): Promise<Qwen35MoeChatResult>;
+  /**
+   * Streaming chat API with tool calling support.
+   *
+   * Same as `chat()` but streams tokens one-by-one via the callback.
+   * Returns a `ChatStreamHandle` immediately; generation runs in background.
+   * Call `handle.cancel()` to abort generation early.
+   */
+  chatStream(
+    messages: ChatMessage[],
+    config: Qwen35MoeChatConfig | null,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ): Promise<ChatStreamHandle>;
   numParameters(): number;
 }
 export type Qwen3_5MoeModel = Qwen35MoeModel;
@@ -1943,6 +1972,17 @@ export declare const enum ChatRole {
   Assistant = 'Assistant',
   /** System prompt */
   System = 'System',
+}
+
+/** A single chunk emitted during streaming chat generation. */
+export interface ChatStreamChunk {
+  text: string;
+  done: boolean;
+  finishReason?: string;
+  toolCalls?: Array<ToolCallResult>;
+  thinking?: string;
+  numTokens?: number;
+  rawText?: string;
 }
 
 /** Result from classify_and_rotate: orientation info + corrected image bytes. */

--- a/packages/lm/src/index.ts
+++ b/packages/lm/src/index.ts
@@ -15,7 +15,7 @@
 
 // Model classes (for inference)
 export { Qwen3Model, Qwen3Tokenizer } from '@mlx-node/core';
-export { Qwen35Model, Qwen35Model as Qwen3_5Model } from '@mlx-node/core';
+export { Qwen35Model, Qwen35Model as Qwen3_5Model } from './stream';
 export type {
   Qwen35Config,
   Qwen35ChatConfig,
@@ -25,7 +25,7 @@ export type {
 } from '@mlx-node/core';
 
 // MoE variant
-export { Qwen35MoeModel, Qwen35MoeModel as Qwen3_5MoeModel } from '@mlx-node/core';
+export { Qwen35MoeModel, Qwen35MoeModel as Qwen3_5MoeModel } from './stream';
 export type {
   Qwen35MoeConfig,
   Qwen35MoeChatConfig,
@@ -42,6 +42,10 @@ export type { SamplingConfig, BatchGenerationResult } from '@mlx-node/core';
 
 // Chat API types from core (for model.chat() API)
 export type { ToolCallResult, ChatResult, ChatConfig, ChatMessage } from '@mlx-node/core';
+
+// Streaming chat API
+export type { ChatStreamDelta, ChatStreamFinal, ChatStreamEvent } from './stream';
+export type { ChatStreamChunk, ChatStreamHandle } from '@mlx-node/core';
 
 // Model utilities (TypeScript-only)
 export {

--- a/packages/lm/src/index.ts
+++ b/packages/lm/src/index.ts
@@ -46,6 +46,8 @@ export type { ToolCallResult, ChatResult, ChatConfig, ChatMessage } from '@mlx-n
 // Streaming chat API
 export type { ChatStreamDelta, ChatStreamFinal, ChatStreamEvent } from './stream';
 export type { ChatStreamChunk, ChatStreamHandle } from '@mlx-node/core';
+/** @internal Exported for testing the callback-to-AsyncGenerator bridge. */
+export { _createChatStream } from './stream';
 
 // Model utilities (TypeScript-only)
 export {

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -6,8 +6,9 @@
 
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { Qwen3Model, Qwen35Model, Qwen35MoeModel } from '@mlx-node/core';
-import type { Qwen3_5Model, Qwen3_5MoeModel } from '@mlx-node/core';
+import { Qwen3Model } from '@mlx-node/core';
+import { Qwen35Model, Qwen35MoeModel } from '../stream';
+import type { Qwen35Model as Qwen3_5Model, Qwen35MoeModel as Qwen3_5MoeModel } from '../stream';
 
 /**
  * Model loader for Qwen3 and Qwen3.5 models

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -1,0 +1,157 @@
+import { Qwen35Model as Qwen35ModelNative, Qwen35MoeModel as Qwen35MoeModelNative } from '@mlx-node/core';
+import type {
+  ChatMessage,
+  ChatStreamChunk,
+  ChatStreamHandle,
+  Qwen35ChatConfig,
+  Qwen35Config,
+  Qwen35MoeChatConfig,
+  Qwen35MoeConfig,
+  ToolCallResult,
+} from '@mlx-node/core';
+
+export interface ChatStreamDelta {
+  text: string;
+  done: false;
+}
+
+export interface ChatStreamFinal {
+  text: string;
+  done: true;
+  finishReason: string;
+  toolCalls: ToolCallResult[];
+  thinking: string | null;
+  numTokens: number;
+  rawText: string;
+}
+
+export type ChatStreamEvent = ChatStreamDelta | ChatStreamFinal;
+
+// Save references to the native callback-based methods before we override them
+const _nativeDenseChatStream = Qwen35ModelNative.prototype.chatStream;
+const _nativeMoeChatStream = Qwen35MoeModelNative.prototype.chatStream;
+
+/**
+ * Shared AsyncGenerator implementation that wraps a native callback-based
+ * chatStream into a `for await...of`-compatible stream.
+ *
+ * Cancellation is automatic via the generator's `finally` block.
+ */
+async function* _createChatStream(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  nativeMethod: (
+    messages: ChatMessage[],
+    config: any,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ) => Promise<ChatStreamHandle>,
+  self: unknown,
+  messages: ChatMessage[],
+  config: unknown,
+): AsyncGenerator<ChatStreamEvent> {
+  const queue: Array<{ chunk?: ChatStreamChunk; error?: Error }> = [];
+  let resolve: (() => void) | null = null;
+
+  const waitForItem = () =>
+    queue.length > 0
+      ? Promise.resolve()
+      : new Promise<void>((r) => {
+          resolve = r;
+        });
+
+  const notify = () => {
+    if (resolve) {
+      const r = resolve;
+      resolve = null;
+      r();
+    }
+  };
+
+  const callback = (err: Error | null, chunk: ChatStreamChunk) => {
+    queue.push(err ? { error: err } : { chunk });
+    notify();
+  };
+
+  const handle = await nativeMethod.call(self, messages, config ?? null, callback);
+
+  try {
+    while (true) {
+      await waitForItem();
+      while (queue.length > 0) {
+        const item = queue.shift()!;
+        if (item.error) throw item.error;
+        const chunk = item.chunk!;
+        if (chunk.done) {
+          yield {
+            text: chunk.text,
+            done: true,
+            finishReason: chunk.finishReason!,
+            toolCalls: chunk.toolCalls ?? [],
+            thinking: chunk.thinking ?? null,
+            numTokens: chunk.numTokens!,
+            rawText: chunk.rawText!,
+          } as ChatStreamFinal;
+          return;
+        }
+        yield { text: chunk.text, done: false } as ChatStreamDelta;
+      }
+    }
+  } finally {
+    handle.cancel();
+  }
+}
+
+/**
+ * Qwen3.5 dense model with AsyncGenerator-based `chatStream()`.
+ *
+ * @example
+ * ```typescript
+ * const model = await ModelLoader.loadPretrained('./models/qwen3.5-3b');
+ * for await (const event of model.chatStream(messages)) {
+ *   if (!event.done) process.stdout.write(event.text);
+ * }
+ * ```
+ */
+export class Qwen35Model extends Qwen35ModelNative {
+  constructor(config: Qwen35Config) {
+    super(config);
+  }
+
+  static override async loadPretrained(modelPath: string): Promise<Qwen35Model> {
+    const instance = await Qwen35ModelNative.loadPretrained(modelPath);
+    Object.setPrototypeOf(instance, Qwen35Model.prototype);
+    return instance as unknown as Qwen35Model;
+  }
+
+  // @ts-expect-error — override callback-based chatStream with AsyncGenerator
+  async *chatStream(messages: ChatMessage[], config?: Qwen35ChatConfig | null): AsyncGenerator<ChatStreamEvent> {
+    yield* _createChatStream(_nativeDenseChatStream, this, messages, config);
+  }
+}
+
+/**
+ * Qwen3.5 MoE model with AsyncGenerator-based `chatStream()`.
+ *
+ * @example
+ * ```typescript
+ * const model = await ModelLoader.loadPretrained('./models/qwen3.5-moe');
+ * for await (const event of model.chatStream(messages)) {
+ *   if (!event.done) process.stdout.write(event.text);
+ * }
+ * ```
+ */
+export class Qwen35MoeModel extends Qwen35MoeModelNative {
+  constructor(config: Qwen35MoeConfig) {
+    super(config);
+  }
+
+  static override async loadPretrained(modelPath: string): Promise<Qwen35MoeModel> {
+    const instance = await Qwen35MoeModelNative.loadPretrained(modelPath);
+    Object.setPrototypeOf(instance, Qwen35MoeModel.prototype);
+    return instance as unknown as Qwen35MoeModel;
+  }
+
+  // @ts-expect-error — override callback-based chatStream with AsyncGenerator
+  async *chatStream(messages: ChatMessage[], config?: Qwen35MoeChatConfig | null): AsyncGenerator<ChatStreamEvent> {
+    yield* _createChatStream(_nativeMoeChatStream, this, messages, config);
+  }
+}

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -4,9 +4,7 @@ import type {
   ChatStreamChunk,
   ChatStreamHandle,
   Qwen35ChatConfig,
-  Qwen35Config,
   Qwen35MoeChatConfig,
-  Qwen35MoeConfig,
   ToolCallResult,
 } from '@mlx-node/core';
 
@@ -37,7 +35,8 @@ const _nativeMoeChatStream = Qwen35MoeModelNative.prototype.chatStream;
  *
  * Cancellation is automatic via the generator's `finally` block.
  */
-async function* _createChatStream(
+/** @internal Exported for testing only. */
+export async function* _createChatStream(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   nativeMethod: (
     messages: ChatMessage[],
@@ -112,10 +111,6 @@ async function* _createChatStream(
  * ```
  */
 export class Qwen35Model extends Qwen35ModelNative {
-  constructor(config: Qwen35Config) {
-    super(config);
-  }
-
   static override async loadPretrained(modelPath: string): Promise<Qwen35Model> {
     const instance = await Qwen35ModelNative.loadPretrained(modelPath);
     Object.setPrototypeOf(instance, Qwen35Model.prototype);
@@ -140,10 +135,6 @@ export class Qwen35Model extends Qwen35ModelNative {
  * ```
  */
 export class Qwen35MoeModel extends Qwen35MoeModelNative {
-  constructor(config: Qwen35MoeConfig) {
-    super(config);
-  }
-
   static override async loadPretrained(modelPath: string): Promise<Qwen35MoeModel> {
     const instance = await Qwen35MoeModelNative.loadPretrained(modelPath);
     Object.setPrototypeOf(instance, Qwen35MoeModel.prototype);


### PR DESCRIPTION
Add token-by-token streaming for interactive UIs via AsyncGenerator. The Rust decode loop pushes each token through a ThreadsafeFunction callback, and the TypeScript layer wraps it into `async *chatStream()` directly on the model classes.

- Rust: chat_stream() on Qwen3_5Model and Qwen3_5MoeModel using ThreadsafeFunction with cancellation via Arc<AtomicBool>
- TypeScript: Qwen35Model/Qwen35MoeModel subclasses override chatStream() as AsyncGenerator<ChatStreamEvent>
- Cancellation automatic via generator finally block on break/return
- ModelLoader returns subclasses so loadPretrained() includes streaming

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new token-by-token streaming generation paths in the Rust Qwen3.5 dense/MoE models and bridges them to JS via threadsafe callbacks, which touches core inference loops and concurrency/cancellation behavior.
> 
> **Overview**
> Adds a **streaming chat** capability for Qwen3.5 dense and MoE models: Rust now exposes `chat_stream()` that emits per-token `ChatStreamChunk` callbacks and returns a `ChatStreamHandle` that can `cancel()` an in-flight generation.
> 
> Updates the JS/TS surface to include `ChatStreamChunk`/`ChatStreamHandle` types and wraps the native callback API into an `AsyncGenerator`-based `chatStream()` via new `packages/lm/src/stream.ts`, with automatic cancellation in a `finally` block; `ModelLoader`/exports are adjusted so `loadPretrained()` returns these streaming-enabled subclasses. Adds tests validating the callback-to-async-iterator bridge, final-chunk field mapping, cancellation on early break, and error propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09a0116f92233c8390dd48cb606e7def2e88bac5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming chat for Qwen3.5 and Qwen3.5 MoE: real-time token streaming via callback or async iterator, immediate stream handle with cancel(), incremental delta events and a final event including finishReason, toolCalls, thinking, token counts, and raw text; supports cancellation and error propagation.

* **Tests**
  * Added tests validating streaming tokens, final-chunk metadata, cancellation behavior, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->