### PR TITLE
feat: model-agnostic training support for Qwen3 and Qwen 3.5

### DIFF
--- a/crates/mlx-core/src/array/ops.rs
+++ b/crates/mlx-core/src/array/ops.rs
@@ -121,6 +121,26 @@ impl MxArray {
         MxArray::from_handle(handle, "array_addmm")
     }
 
+    /// Indexed matrix multiply for MoE expert selection.
+    /// Uses MLX's gather_mm which has full VJP support for autograd.
+    ///
+    /// - `self` (a): input tokens (expanded shape)
+    /// - `b`: expert weights (pre-transposed)
+    /// - `rhs_indices`: which experts per token
+    /// - `sorted`: whether indices are pre-sorted by expert
+    pub fn gather_mm(&self, b: &MxArray, rhs_indices: &MxArray, sorted: bool) -> Result<MxArray> {
+        let handle = unsafe {
+            sys::mlx_gather_mm(
+                self.handle.0,
+                b.handle.0,
+                std::ptr::null_mut(), // no lhs_indices
+                rhs_indices.handle.0,
+                sorted,
+            )
+        };
+        MxArray::from_handle(handle, "gather_mm")
+    }
+
     // Additional math operations
 
     #[napi]
@@ -334,6 +354,13 @@ impl MxArray {
         sum.eval();
         let count = sum.item_at_int32(0)?;
         Ok(count > 0)
+    }
+
+    /// Detach tensor from the computation graph (no gradients flow through).
+    /// Used for MoE routing indices during training.
+    pub fn stop_gradient(&self) -> Result<MxArray> {
+        let handle = unsafe { sys::mlx_stop_gradient(self.handle.0) };
+        MxArray::from_handle(handle, "stop_gradient")
     }
 
     /// Check if array contains any NaN or Inf values (GPU-native)

--- a/crates/mlx-core/src/autograd.rs
+++ b/crates/mlx-core/src/autograd.rs
@@ -104,12 +104,9 @@ extern "C" fn loss_function_callback(
         }
     }
 
-    // Check if already called
-    if context_ref.called {
-        error!("loss_function_callback: function called multiple times");
-        context_ref.error = Some("Loss function called multiple times".to_string());
-        return std::ptr::null_mut();
-    }
+    // Note: MLX may call the loss function multiple times during value_and_grad.
+    // The first call builds the computation graph, subsequent calls may happen
+    // during VJP tracing. We must allow all calls.
     context_ref.called = true;
 
     // Call user's loss function

--- a/crates/mlx-core/src/autograd.rs
+++ b/crates/mlx-core/src/autograd.rs
@@ -43,14 +43,11 @@ use tracing::error;
 /// This struct holds all the data needed by the loss function, including:
 /// - Closure for computing loss given parameters
 /// - Error storage for propagating Rust errors through C FFI
-/// - Flag to ensure closure is only called once
 struct LossFunctionContext {
     /// User-provided loss function closure (FnMut to allow multiple calls if needed)
     loss_fn: Option<Box<dyn FnMut(&[MxArray]) -> Result<MxArray>>>,
     /// Error message if loss function fails
     error: Option<String>,
-    /// Track if function has been called
-    called: bool,
 }
 
 /// External C callback function for MLX autograd
@@ -103,11 +100,6 @@ extern "C" fn loss_function_callback(
             }
         }
     }
-
-    // Note: MLX may call the loss function multiple times during value_and_grad.
-    // The first call builds the computation graph, subsequent calls may happen
-    // during VJP tracing. We must allow all calls.
-    context_ref.called = true;
 
     // Call user's loss function
     let result = if let Some(ref mut loss_fn) = context_ref.loss_fn {
@@ -189,7 +181,6 @@ where
     let mut context = Box::new(LossFunctionContext {
         loss_fn: Some(Box::new(loss_fn)),
         error: None,
-        called: false,
     });
     let context_ptr = &mut *context as *mut LossFunctionContext as *mut c_void;
 
@@ -263,7 +254,6 @@ where
     let mut context = Box::new(LossFunctionContext {
         loss_fn: Some(Box::new(loss_fn)),
         error: None,
-        called: false,
     });
     let context_ptr = &mut *context as *mut LossFunctionContext as *mut c_void;
 
@@ -307,6 +297,210 @@ where
         .collect();
 
     gradients
+}
+
+// ============================================================================
+// Gradient Checkpointing
+// ============================================================================
+
+/// Context for the layer function callback used by checkpoint
+struct LayerFunctionContext {
+    layer_fn: Option<Box<dyn FnMut(&[MxArray]) -> Result<Vec<MxArray>>>>,
+    error: Option<String>,
+}
+
+/// External C callback for checkpoint layer function
+///
+/// Takes input arrays, calls the Rust layer function, writes output arrays.
+/// Returns number of outputs written.
+extern "C" fn layer_function_callback(
+    inputs: *const *mut sys::mlx_array,
+    input_count: usize,
+    outputs: *mut *mut sys::mlx_array,
+    max_outputs: usize,
+    context: *mut c_void,
+) -> usize {
+    let context_ptr = context as *mut LayerFunctionContext;
+    let context_ref = unsafe {
+        if context_ptr.is_null() {
+            error!("layer_function_callback: null context pointer");
+            return 0;
+        }
+        &mut *context_ptr
+    };
+
+    // Convert input handles to MxArray
+    let input_slice = unsafe {
+        if inputs.is_null() || input_count == 0 {
+            context_ref.error = Some("Invalid input handles".to_string());
+            return 0;
+        }
+        std::slice::from_raw_parts(inputs, input_count)
+    };
+
+    let mut param_arrays = Vec::with_capacity(input_count);
+    for &handle in input_slice {
+        match MxArray::from_handle(handle, "checkpoint_input") {
+            Ok(arr) => param_arrays.push(arr),
+            Err(e) => {
+                context_ref.error = Some(format!("Failed to create array: {:?}", e));
+                return 0;
+            }
+        }
+    }
+
+    // Call user's layer function
+    let result = if let Some(ref mut layer_fn) = context_ref.layer_fn {
+        layer_fn(&param_arrays)
+    } else {
+        context_ref.error = Some("Layer function not available".to_string());
+        return 0;
+    };
+
+    // CRITICAL: Don't drop param_arrays — C++ owns these handles
+    std::mem::forget(param_arrays);
+
+    match result {
+        Ok(output_arrays) => {
+            if output_arrays.len() > max_outputs {
+                context_ref.error = Some(format!(
+                    "Layer returned {} outputs but max is {}",
+                    output_arrays.len(),
+                    max_outputs
+                ));
+                return 0;
+            }
+
+            let count = output_arrays.len();
+            let output_slice = unsafe { std::slice::from_raw_parts_mut(outputs, max_outputs) };
+
+            for (i, arr) in output_arrays.into_iter().enumerate() {
+                let handle = arr.handle.0;
+                std::mem::forget(arr); // MLX takes ownership
+                output_slice[i] = handle;
+            }
+
+            count
+        }
+        Err(e) => {
+            context_ref.error = Some(format!("{:?}", e));
+            0
+        }
+    }
+}
+
+/// Apply a function with gradient checkpointing
+///
+/// Wraps the given layer function with MLX's `checkpoint()` transform, which
+/// discards intermediate activations during the forward pass and recomputes
+/// them during backward. This reduces memory from O(num_layers) to O(1) for
+/// intermediate states.
+///
+/// # Arguments
+/// * `inputs` - Input arrays (typically [hidden_states, param1, param2, ...])
+/// * `layer_fn` - Function implementing the layer forward pass
+///
+/// # Returns
+/// * Output arrays from the layer function, annotated with checkpoint metadata
+///   so MLX autograd knows to recompute during backward
+/// Collects checkpoint context pointers that must survive until the backward pass.
+///
+/// During `checkpoint_apply`, contexts are allocated via `Box::into_raw` so the C++
+/// callback pointer stays valid through MLX's backward recomputation. After
+/// `value_and_grad` + eval completes, call `reclaim()` to free them all.
+///
+/// Create one per `value_and_grad` call, pass it through the forward functions,
+/// and reclaim after eval.
+pub struct CheckpointContexts {
+    contexts: Vec<*mut LayerFunctionContext>,
+}
+
+impl CheckpointContexts {
+    pub fn new() -> Self {
+        Self {
+            contexts: Vec::new(),
+        }
+    }
+
+    /// Reclaim all checkpoint contexts. Call after value_and_grad + eval completes
+    /// (when the MLX computation graph has been freed and no callbacks reference them).
+    pub fn reclaim(&mut self) {
+        for ptr in self.contexts.drain(..) {
+            unsafe {
+                drop(Box::from_raw(ptr));
+            }
+        }
+    }
+}
+
+impl Drop for CheckpointContexts {
+    fn drop(&mut self) {
+        self.reclaim();
+    }
+}
+
+pub fn checkpoint_apply<F>(
+    inputs: Vec<&MxArray>,
+    layer_fn: F,
+    contexts: &mut CheckpointContexts,
+) -> Result<Vec<MxArray>>
+where
+    F: FnMut(&[MxArray]) -> Result<Vec<MxArray>> + 'static,
+{
+    if inputs.is_empty() {
+        return Err(Error::from_reason(
+            "checkpoint_apply: inputs cannot be empty",
+        ));
+    }
+
+    let input_handles: Vec<*mut sys::mlx_array> = inputs.iter().map(|p| p.handle.0).collect();
+    let input_count = input_handles.len();
+
+    const MAX_OUTPUTS: usize = 16;
+    let mut output_handles: Vec<*mut sys::mlx_array> = vec![std::ptr::null_mut(); MAX_OUTPUTS];
+
+    let context = Box::new(LayerFunctionContext {
+        layer_fn: Some(Box::new(layer_fn)),
+        error: None,
+    });
+    // Box::into_raw so the context survives until MLX's backward pass
+    // re-invokes the callback. Tracked in `contexts` for later reclamation.
+    let context_ptr = Box::into_raw(context);
+    contexts.contexts.push(context_ptr);
+
+    let num_outputs = unsafe {
+        sys::mlx_checkpoint_apply(
+            layer_function_callback,
+            context_ptr as *mut c_void,
+            input_handles.as_ptr(),
+            input_count,
+            output_handles.as_mut_ptr(),
+            MAX_OUTPUTS,
+        )
+    };
+
+    // Read error from context (still valid — reclaimed later via contexts.reclaim())
+    let context_ref = unsafe { &*context_ptr };
+    if let Some(ref error) = context_ref.error {
+        return Err(Error::from_reason(format!(
+            "checkpoint_apply: layer function failed: {}",
+            error
+        )));
+    }
+
+    if num_outputs == 0 {
+        return Err(Error::from_reason(
+            "checkpoint_apply: MLX checkpoint failed (returned 0)".to_string(),
+        ));
+    }
+
+    let outputs: Result<Vec<MxArray>> = output_handles[..num_outputs]
+        .iter()
+        .enumerate()
+        .map(|(_, &handle)| MxArray::from_handle(handle, "checkpoint_output"))
+        .collect();
+
+    outputs
 }
 
 #[cfg(test)]
@@ -496,5 +690,61 @@ mod tests {
             (get_scalar(&grads[0]) - 6.0).abs() < 1e-5,
             "gradient should be 6.0"
         );
+    }
+
+    #[test]
+    fn test_checkpoint_produces_correct_gradients() {
+        // Test that checkpoint_apply produces the same gradients as direct computation.
+        // checkpoint() should only affect memory (discard/recompute intermediates),
+        // not the mathematical result.
+
+        let x = MxArray::from_float32(&[1.0, 2.0, 3.0], &[3]).unwrap();
+        let w = MxArray::from_float32(&[0.5, -0.5, 1.0], &[3]).unwrap();
+
+        // Path 1: Direct computation (no checkpointing)
+        let (loss_direct, grads_direct) = value_and_grad(vec![&x, &w], |params| {
+            let product = params[0].mul(&params[1])?;
+            let squared = product.square()?;
+            to_scalar(squared)
+        })
+        .unwrap();
+
+        // Path 2: Same computation wrapped in checkpoint_apply
+        let ckpt_rc = std::rc::Rc::new(std::cell::RefCell::new(CheckpointContexts::new()));
+        let ckpt_inner = ckpt_rc.clone();
+        let (loss_ckpt, grads_ckpt) = value_and_grad(vec![&x, &w], move |params| {
+            // Wrap the "layer" computation in checkpoint
+            let outputs = super::checkpoint_apply(vec![&params[0], &params[1]], |arrays| {
+                let product = arrays[0].mul(&arrays[1])?;
+                let squared = product.square()?;
+                Ok(vec![squared])
+            }, &mut ckpt_inner.borrow_mut())?;
+            to_scalar(outputs.into_iter().next().unwrap())
+        })
+        .unwrap();
+        ckpt_rc.borrow_mut().reclaim();
+
+        // Both paths should produce identical results
+        let loss_d = get_scalar(&loss_direct);
+        let loss_c = get_scalar(&loss_ckpt);
+        assert!(
+            (loss_d - loss_c).abs() < 1e-5,
+            "Loss mismatch: direct={}, checkpoint={}",
+            loss_d,
+            loss_c
+        );
+
+        // Gradients should match
+        for i in 0..2 {
+            let gd = get_scalar(&grads_direct[i]);
+            let gc = get_scalar(&grads_ckpt[i]);
+            assert!(
+                (gd - gc).abs() < 1e-5,
+                "Gradient {} mismatch: direct={}, checkpoint={}",
+                i,
+                gd,
+                gc
+            );
+        }
     }
 }

--- a/crates/mlx-core/src/autograd.rs
+++ b/crates/mlx-core/src/autograd.rs
@@ -389,20 +389,6 @@ extern "C" fn layer_function_callback(
     }
 }
 
-/// Apply a function with gradient checkpointing
-///
-/// Wraps the given layer function with MLX's `checkpoint()` transform, which
-/// discards intermediate activations during the forward pass and recomputes
-/// them during backward. This reduces memory from O(num_layers) to O(1) for
-/// intermediate states.
-///
-/// # Arguments
-/// * `inputs` - Input arrays (typically [hidden_states, param1, param2, ...])
-/// * `layer_fn` - Function implementing the layer forward pass
-///
-/// # Returns
-/// * Output arrays from the layer function, annotated with checkpoint metadata
-///   so MLX autograd knows to recompute during backward
 /// Collects checkpoint context pointers that must survive until the backward pass.
 ///
 /// During `checkpoint_apply`, contexts are allocated via `Box::into_raw` so the C++
@@ -413,6 +399,12 @@ extern "C" fn layer_function_callback(
 /// and reclaim after eval.
 pub struct CheckpointContexts {
     contexts: Vec<*mut LayerFunctionContext>,
+}
+
+impl Default for CheckpointContexts {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CheckpointContexts {
@@ -439,6 +431,21 @@ impl Drop for CheckpointContexts {
     }
 }
 
+/// Apply a function with gradient checkpointing.
+///
+/// Wraps the given layer function with MLX's `checkpoint()` transform, which
+/// discards intermediate activations during the forward pass and recomputes
+/// them during backward. This reduces memory from O(num_layers) to O(1) for
+/// intermediate states.
+///
+/// # Arguments
+/// * `inputs` - Input arrays (typically `[hidden_states, param1, param2, ...]`)
+/// * `layer_fn` - Function implementing the layer forward pass
+/// * `contexts` - Collector for checkpoint context pointers (reclaimed after eval)
+///
+/// # Returns
+/// Output arrays from the layer function, annotated with checkpoint metadata
+/// so MLX autograd knows to recompute during backward.
 pub fn checkpoint_apply<F>(
     inputs: Vec<&MxArray>,
     layer_fn: F,
@@ -496,8 +503,7 @@ where
 
     let outputs: Result<Vec<MxArray>> = output_handles[..num_outputs]
         .iter()
-        .enumerate()
-        .map(|(_, &handle)| MxArray::from_handle(handle, "checkpoint_output"))
+        .map(|&handle| MxArray::from_handle(handle, "checkpoint_output"))
         .collect();
 
     outputs
@@ -714,11 +720,15 @@ mod tests {
         let ckpt_inner = ckpt_rc.clone();
         let (loss_ckpt, grads_ckpt) = value_and_grad(vec![&x, &w], move |params| {
             // Wrap the "layer" computation in checkpoint
-            let outputs = super::checkpoint_apply(vec![&params[0], &params[1]], |arrays| {
-                let product = arrays[0].mul(&arrays[1])?;
-                let squared = product.square()?;
-                Ok(vec![squared])
-            }, &mut ckpt_inner.borrow_mut())?;
+            let outputs = super::checkpoint_apply(
+                vec![&params[0], &params[1]],
+                |arrays| {
+                    let product = arrays[0].mul(&arrays[1])?;
+                    let squared = product.square()?;
+                    Ok(vec![squared])
+                },
+                &mut ckpt_inner.borrow_mut(),
+            )?;
             to_scalar(outputs.into_iter().next().unwrap())
         })
         .unwrap();

--- a/crates/mlx-core/src/grpo/autograd.rs
+++ b/crates/mlx-core/src/grpo/autograd.rs
@@ -31,9 +31,9 @@ use napi::bindgen_prelude::*;
 use crate::array::{MxArray, pad_float_sequences, pad_sequences};
 use crate::autograd;
 use crate::grpo::{advantages::compute_advantages, loss as grpo_loss};
-use crate::models::qwen3::Qwen3Config;
 use crate::nn::efficient_selective_log_softmax;
 use crate::param_manager;
+use crate::training_model::ModelType;
 use crate::utils::functional;
 
 /// Compute GRPO loss with automatic differentiation using functional forward pass
@@ -57,54 +57,12 @@ use crate::utils::functional;
 /// # Returns
 /// * `(loss_value, gradients)` - Scalar loss and gradients for each parameter
 ///
-/// # Example
+/// # Usage
 ///
-/// ```no_run
-/// # use mlx_core::grpo::compute_loss_and_gradients_autograd;
-/// # use mlx_core::models::qwen3::Qwen3Config;
-/// # use mlx_core::grpo::GRPOLossConfig;
-/// # use std::collections::HashMap;
-/// # let config = Qwen3Config {
-/// #     vocab_size: 151936,
-/// #     hidden_size: 1024,
-/// #     num_layers: 28,
-/// #     num_heads: 16,
-/// #     num_kv_heads: 8,
-/// #     intermediate_size: 3072,
-/// #     rms_norm_eps: 1e-6,
-/// #     rope_theta: 1000000.0,
-/// #     max_position_embeddings: 40960,
-/// #     head_dim: 64,
-/// #     use_qk_norm: true,
-/// #     tie_word_embeddings: true,
-/// #     pad_token_id: 151643,
-/// #     eos_token_id: 151645,
-/// #     bos_token_id: 151643,
-/// #     use_paged_attention: None,
-/// #     paged_cache_memory_mb: None,
-/// #     paged_block_size: None,
-/// #     use_fp8_cache: None,
-/// # };
-/// # let params = HashMap::new();
-/// # let prompt_tokens = vec![];
-/// # let completion_tokens = vec![];
-/// # let old_logprobs = vec![];
-/// # let rewards = vec![];
-/// # let group_size = 4;
-/// # let loss_config = GRPOLossConfig::default();
-/// let (loss, grads) = compute_loss_and_gradients_autograd(
-///     &config,
-///     &params,
-///     &prompt_tokens,
-///     &completion_tokens,
-///     &old_logprobs,
-///     &rewards,
-///     group_size,
-///     loss_config,
-/// ).unwrap();
-/// ```
-pub fn compute_loss_and_gradients_autograd(
-    model_config: &Qwen3Config,
+/// Called by GRPO engine with a `ModelType` enum that dispatches to the correct
+/// functional forward pass (Qwen3, Qwen3.5 Dense, or Qwen3.5 MoE).
+pub(crate) fn compute_loss_and_gradients_autograd(
+    model_type: &ModelType,
     model_params: &HashMap<String, MxArray>,
     prompt_tokens: &[&MxArray],
     completion_tokens: &[&MxArray],
@@ -191,7 +149,7 @@ pub fn compute_loss_and_gradients_autograd(
 
     // Use the model's actual pad_token_id for padding sequences
     // Using wrong padding (like 0) can cause extreme logits and NaN
-    let pad_token_id = model_config.pad_token_id;
+    let pad_token_id = model_type.pad_token_id();
 
     let padded_prompts_result = pad_sequences(prompts_expanded, pad_token_id)?;
     let padded_prompts = padded_prompts_result.get_padded()?;
@@ -234,7 +192,7 @@ pub fn compute_loss_and_gradients_autograd(
         // CHUNKED AUTOGRAD PATH: Run autograd per chunk and accumulate gradients
         // This allows MLX to release the computation graph after each chunk.
         return compute_loss_and_gradients_chunked_autograd(
-            model_config,
+            model_type,
             &param_names,
             &param_arrays,
             &input_ids,
@@ -255,7 +213,7 @@ pub fn compute_loss_and_gradients_autograd(
     let padded_old_logprobs_clone = padded_old_logprobs.clone();
     let advantages_clone = advantages_array.clone();
     let completion_masks_clone = completion_masks.clone();
-    let config_clone = model_config.clone();
+    let config_clone = model_type.clone();
     let loss_config_clone = loss_config.clone();
 
     // 5. Define loss function for autograd
@@ -281,7 +239,7 @@ pub fn compute_loss_and_gradients_autograd(
             // we process the LM head in chunks to reduce peak memory.
 
             // Get hidden states (before LM head)
-            let hidden_states = functional::qwen3_forward_hidden_states(
+            let hidden_states = functional::forward_hidden_states_dispatch(
                 &config_clone,
                 &param_dict,
                 &input_ids_clone,
@@ -290,11 +248,11 @@ pub fn compute_loss_and_gradients_autograd(
             // Extract completion hidden states: [B, prompt_len:, :]
             let completion_hidden = hidden_states.slice(
                 &[0, prompt_len, 0],
-                &[batch_size, total_seq_len, config_clone.hidden_size as i64],
+                &[batch_size, total_seq_len, config_clone.hidden_size() as i64],
             )?;
 
             // Get LM head weight
-            let lm_head_weight = if config_clone.tie_word_embeddings {
+            let lm_head_weight = if config_clone.tie_word_embeddings() {
                 param_dict
                     .get("embedding.weight")
                     .ok_or_else(|| Error::from_reason("Missing embedding.weight"))?
@@ -310,19 +268,22 @@ pub fn compute_loss_and_gradients_autograd(
                 lm_head_weight,
                 &padded_completions_clone,
                 chunk_size,
-                config_clone.tie_word_embeddings,
+                config_clone.tie_word_embeddings(),
             )?
         } else {
             // FULL PATH: Standard computation (for small batches or testing)
             //
             // Recompute forward pass with parameters in native dtype
-            let logits =
-                functional::qwen3_forward_functional(&config_clone, &param_dict, &input_ids_clone)?;
+            let logits = functional::forward_functional_dispatch(
+                &config_clone,
+                &param_dict,
+                &input_ids_clone,
+            )?;
 
             // Get logits for completion tokens only
             let completion_logits = logits.slice(
                 &[0, prompt_len, 0],
-                &[batch_size, total_seq_len, config_clone.vocab_size as i64],
+                &[batch_size, total_seq_len, config_clone.vocab_size() as i64],
             )?;
 
             // Memory-efficient log-softmax using logsumexp decomposition
@@ -420,7 +381,7 @@ pub fn compute_loss_and_gradients_autograd(
 /// * `loss_config` - GRPO loss configuration
 /// * `chunk_size` - Number of sequences per chunk
 fn compute_loss_and_gradients_chunked_autograd(
-    model_config: &Qwen3Config,
+    model_type: &ModelType,
     param_names: &[String],
     param_arrays: &[&MxArray],
     input_ids: &MxArray,
@@ -459,7 +420,7 @@ fn compute_loss_and_gradients_chunked_autograd(
         let chunk_old_logprobs_clone = chunk_old_logprobs.clone();
         let chunk_advantages_clone = chunk_advantages.clone();
         let chunk_masks_clone = chunk_masks.clone();
-        let config_clone = model_config.clone();
+        let config_clone = model_type.clone();
         let loss_config_clone = loss_config.clone();
         let lm_head_chunk_size = loss_config.lm_head_chunk_size;
 
@@ -475,7 +436,7 @@ fn compute_loss_and_gradients_chunked_autograd(
             // Compute logprobs for this chunk
             let completion_logprobs = if let Some(lm_chunk) = lm_head_chunk_size {
                 // Chunked LM head path
-                let hidden_states = functional::qwen3_forward_hidden_states(
+                let hidden_states = functional::forward_hidden_states_dispatch(
                     &config_clone,
                     &param_dict,
                     &chunk_input_ids_clone,
@@ -486,11 +447,11 @@ fn compute_loss_and_gradients_chunked_autograd(
                     &[
                         chunk_batch,
                         chunk_total_seq,
-                        config_clone.hidden_size as i64,
+                        config_clone.hidden_size() as i64,
                     ],
                 )?;
 
-                let lm_head_weight = if config_clone.tie_word_embeddings {
+                let lm_head_weight = if config_clone.tie_word_embeddings() {
                     param_dict
                         .get("embedding.weight")
                         .ok_or_else(|| Error::from_reason("Missing embedding.weight"))?
@@ -505,11 +466,11 @@ fn compute_loss_and_gradients_chunked_autograd(
                     lm_head_weight,
                     &chunk_completions_clone,
                     lm_chunk,
-                    config_clone.tie_word_embeddings,
+                    config_clone.tie_word_embeddings(),
                 )?
             } else {
                 // Full path
-                let logits = functional::qwen3_forward_functional(
+                let logits = functional::forward_functional_dispatch(
                     &config_clone,
                     &param_dict,
                     &chunk_input_ids_clone,
@@ -517,7 +478,11 @@ fn compute_loss_and_gradients_chunked_autograd(
 
                 let completion_logits = logits.slice(
                     &[0, chunk_prompt_len, 0],
-                    &[chunk_batch, chunk_total_seq, config_clone.vocab_size as i64],
+                    &[
+                        chunk_batch,
+                        chunk_total_seq,
+                        config_clone.vocab_size() as i64,
+                    ],
                 )?;
 
                 efficient_selective_log_softmax(

--- a/crates/mlx-core/src/grpo/autograd.rs
+++ b/crates/mlx-core/src/grpo/autograd.rs
@@ -223,7 +223,8 @@ pub(crate) fn compute_loss_and_gradients_autograd(
     // Parameters are in native dtype (bfloat16 for pretrained models)
     let lm_head_chunk_size = loss_config.lm_head_chunk_size;
     let use_ckpt = use_checkpointing;
-    let ckpt_contexts = std::rc::Rc::new(std::cell::RefCell::new(autograd::CheckpointContexts::new()));
+    let ckpt_contexts =
+        std::rc::Rc::new(std::cell::RefCell::new(autograd::CheckpointContexts::new()));
     let ckpt_ctx = ckpt_contexts.clone();
     let loss_fn = move |params: &[MxArray]| -> Result<MxArray> {
         // Map params to structured dictionary
@@ -427,7 +428,8 @@ fn compute_loss_and_gradients_chunked_autograd(
         let loss_config_clone = loss_config.clone();
         let lm_head_chunk_size = loss_config.lm_head_chunk_size;
         let use_ckpt = use_checkpointing;
-        let ckpt_contexts = std::rc::Rc::new(std::cell::RefCell::new(autograd::CheckpointContexts::new()));
+        let ckpt_contexts =
+            std::rc::Rc::new(std::cell::RefCell::new(autograd::CheckpointContexts::new()));
         let ckpt_ctx = ckpt_contexts.clone();
 
         // Define loss function for this chunk

--- a/crates/mlx-core/src/grpo/autograd.rs
+++ b/crates/mlx-core/src/grpo/autograd.rs
@@ -66,10 +66,11 @@ pub(crate) fn compute_loss_and_gradients_autograd(
     model_params: &HashMap<String, MxArray>,
     prompt_tokens: &[&MxArray],
     completion_tokens: &[&MxArray],
-    old_logprobs: &[&MxArray], // Changed: use old_logprobs instead of recomputing
+    old_logprobs: &[&MxArray],
     rewards: &[f64],
     group_size: i32,
     loss_config: grpo_loss::GRPOLossConfig,
+    use_checkpointing: bool,
 ) -> Result<(f64, HashMap<String, MxArray>)> {
     // Early validation: KL penalty (beta > 0) requires reference model which isn't supported
     if loss_config.beta > 0.0 {
@@ -202,6 +203,7 @@ pub(crate) fn compute_loss_and_gradients_autograd(
             &completion_masks,
             &loss_config,
             chunk_size,
+            use_checkpointing,
         );
     }
 
@@ -220,6 +222,9 @@ pub(crate) fn compute_loss_and_gradients_autograd(
     // This closure will be called by MLX with updated parameter values
     // Parameters are in native dtype (bfloat16 for pretrained models)
     let lm_head_chunk_size = loss_config.lm_head_chunk_size;
+    let use_ckpt = use_checkpointing;
+    let ckpt_contexts = std::rc::Rc::new(std::cell::RefCell::new(autograd::CheckpointContexts::new()));
+    let ckpt_ctx = ckpt_contexts.clone();
     let loss_fn = move |params: &[MxArray]| -> Result<MxArray> {
         // Map params to structured dictionary
         let param_dict = param_manager::map_params_to_dict(params, &param_names_clone)?;
@@ -243,6 +248,8 @@ pub(crate) fn compute_loss_and_gradients_autograd(
                 &config_clone,
                 &param_dict,
                 &input_ids_clone,
+                use_ckpt,
+                &mut ckpt_ctx.borrow_mut(),
             )?;
 
             // Extract completion hidden states: [B, prompt_len:, :]
@@ -278,6 +285,8 @@ pub(crate) fn compute_loss_and_gradients_autograd(
                 &config_clone,
                 &param_dict,
                 &input_ids_clone,
+                use_ckpt,
+                &mut ckpt_ctx.borrow_mut(),
             )?;
 
             // Get logits for completion tokens only
@@ -324,20 +333,13 @@ pub(crate) fn compute_loss_and_gradients_autograd(
     // 6. Compute value and gradients using MLX autograd
     let (loss_array, grad_arrays) = autograd::value_and_grad(param_arrays.clone(), loss_fn)?;
 
-    // === CRITICAL MEMORY OPTIMIZATION: Eval ALL tensors IMMEDIATELY, then cleanup ===
-    //
-    // MLX builds a computation graph during value_and_grad. This graph holds references
-    // to ALL intermediate tensors. Calling eval() materializes the results and allows
-    // the graph nodes to be released. We MUST:
-    // Eval all outputs before extracting values
     loss_array.eval();
-
     for grad in &grad_arrays {
         grad.eval();
     }
 
-    // CRITICAL: heavy_cleanup releases the autograd computation graph
-    // synchronize_and_clear_cache only clears MLX cache, not the graph
+    // Reclaim checkpoint contexts now that the computation graph has been eval'd
+    ckpt_contexts.borrow_mut().reclaim();
     crate::array::heavy_cleanup();
 
     // Extract the loss value
@@ -391,6 +393,7 @@ fn compute_loss_and_gradients_chunked_autograd(
     completion_masks: &MxArray,
     loss_config: &grpo_loss::GRPOLossConfig,
     chunk_size: i64,
+    use_checkpointing: bool,
 ) -> Result<(f64, HashMap<String, MxArray>)> {
     let batch_size = input_ids.shape_at(0)?;
     let total_seq_len = input_ids.shape_at(1)?;
@@ -423,6 +426,9 @@ fn compute_loss_and_gradients_chunked_autograd(
         let config_clone = model_type.clone();
         let loss_config_clone = loss_config.clone();
         let lm_head_chunk_size = loss_config.lm_head_chunk_size;
+        let use_ckpt = use_checkpointing;
+        let ckpt_contexts = std::rc::Rc::new(std::cell::RefCell::new(autograd::CheckpointContexts::new()));
+        let ckpt_ctx = ckpt_contexts.clone();
 
         // Define loss function for this chunk
         let chunk_loss_fn = move |params: &[MxArray]| -> Result<MxArray> {
@@ -440,6 +446,8 @@ fn compute_loss_and_gradients_chunked_autograd(
                     &config_clone,
                     &param_dict,
                     &chunk_input_ids_clone,
+                    use_ckpt,
+                    &mut ckpt_ctx.borrow_mut(),
                 )?;
 
                 let completion_hidden = hidden_states.slice(
@@ -474,6 +482,8 @@ fn compute_loss_and_gradients_chunked_autograd(
                     &config_clone,
                     &param_dict,
                     &chunk_input_ids_clone,
+                    use_ckpt,
+                    &mut ckpt_ctx.borrow_mut(),
                 )?;
 
                 let completion_logits = logits.slice(
@@ -521,6 +531,9 @@ fn compute_loss_and_gradients_chunked_autograd(
             grad.eval();
         }
 
+        // Reclaim checkpoint contexts now that this chunk's graph is eval'd
+        ckpt_contexts.borrow_mut().reclaim();
+
         // Extract loss value
         let chunk_loss_value = chunk_loss_array.item_at_float32(0)? as f64;
 
@@ -529,16 +542,19 @@ fn compute_loss_and_gradients_chunked_autograd(
 
         // Accumulate gradients
         if let Some(ref mut acc_grads) = accumulated_gradients {
-            // Add to existing gradients
+            // Add to existing gradients and eval immediately to break the lazy chain.
+            // Without eval, each add creates a lazy graph referencing ALL previous chunks'
+            // gradients, causing +1.5GB leak per chunk (entire model's gradient set).
             for (i, grad) in chunk_grad_arrays.into_iter().enumerate() {
                 acc_grads[i] = acc_grads[i].add(&grad)?;
+                acc_grads[i].eval();
             }
         } else {
             // First chunk - initialize accumulated gradients
             accumulated_gradients = Some(chunk_grad_arrays);
         }
 
-        // CRITICAL: Release computation graph for this chunk
+        // Release computation graph for this chunk
         crate::array::heavy_cleanup();
 
         start = end;

--- a/crates/mlx-core/src/grpo/engine.rs
+++ b/crates/mlx-core/src/grpo/engine.rs
@@ -2601,12 +2601,11 @@ impl GRPOTrainingEngine {
         let st_file = crate::utils::safetensors::SafeTensorsFile::load(&path)?;
 
         // Restore step from metadata
-        if let Some(metadata) = &st_file.metadata {
-            if let Some(step_str) = metadata.get("step").and_then(|v| v.as_str()) {
-                if let Ok(step) = step_str.parse::<i64>() {
-                    opt.set_step(step);
-                }
-            }
+        if let Some(metadata) = &st_file.metadata
+            && let Some(step_str) = metadata.get("step").and_then(|v| v.as_str())
+            && let Ok(step) = step_str.parse::<i64>()
+        {
+            opt.set_step(step);
         }
 
         // Load all tensors

--- a/crates/mlx-core/src/grpo/engine.rs
+++ b/crates/mlx-core/src/grpo/engine.rs
@@ -651,7 +651,7 @@ impl GRPOTrainingEngine {
                 let model = model_arc.read().map_err(|_| {
                     Error::new(Status::GenericFailure, "Failed to acquire model read lock")
                 })?;
-                model.get_parameters()
+                model.get_parameters()?
             };
 
             let prompt_refs: Vec<&MxArray> = prompt_tokens_all.iter().collect();
@@ -1262,7 +1262,7 @@ impl GRPOTrainingEngine {
                 let model = model_arc.read().map_err(|_| {
                     Error::new(Status::GenericFailure, "Failed to acquire model read lock")
                 })?;
-                model.get_parameters()
+                model.get_parameters()?
             };
 
             let prompt_refs: Vec<&MxArray> = prompt_tokens_all.iter().collect();
@@ -1944,7 +1944,7 @@ impl GRPOTrainingEngine {
                 let model = model_arc.read().map_err(|_| {
                     Error::new(Status::GenericFailure, "Failed to acquire model read lock")
                 })?;
-                model.get_parameters()
+                model.get_parameters()?
             };
 
             let prompt_refs: Vec<&MxArray> = prompt_tokens.iter().collect();

--- a/crates/mlx-core/src/grpo/engine.rs
+++ b/crates/mlx-core/src/grpo/engine.rs
@@ -51,10 +51,13 @@ use crate::grpo::rewards::{
     BuiltinRewardConfig, JsonSchemaReward, LengthReward, RewardRegistry, ToolUseReward,
     XMLFormatReward,
 };
-use crate::models::qwen3::{GenerationConfig, Qwen3Config, Qwen3Model};
+use crate::models::qwen3::{GenerationConfig, Qwen3Model};
+use crate::models::qwen3_5::model::Qwen3_5Model;
+use crate::models::qwen3_5_moe::model::Qwen3_5MoeModel;
 use crate::optimizers::GradientUtils;
 use crate::tokenizer::{ChatMessage, ToolDefinition};
 use crate::tools::build_reward_outputs;
+use crate::training_model::{ModelType, TrainableModel, TrainableModelEnum};
 
 /// Configuration for the GRPO training engine
 #[napi(object)]
@@ -343,9 +346,9 @@ impl Default for EngineState {
 #[napi]
 pub struct GRPOTrainingEngine {
     /// The model being trained
-    model: Arc<RwLock<Qwen3Model>>,
-    /// Model configuration (for functional forward pass)
-    model_config: Qwen3Config,
+    model: Arc<RwLock<TrainableModelEnum>>,
+    /// Model type (carries config for functional forward pass in autograd)
+    model_type: ModelType,
     /// Engine configuration
     config: GRPOEngineConfig,
     /// Reward registry (built-in rewards)
@@ -356,26 +359,72 @@ pub struct GRPOTrainingEngine {
 
 #[napi]
 impl GRPOTrainingEngine {
-    /// Create a new training engine from an existing model
+    /// Create a new training engine from a Qwen3 model
     ///
     /// # Arguments
     /// * `model` - The Qwen3 model to train (will be cloned internally)
     /// * `config` - Engine configuration
     #[napi(constructor)]
     pub fn new(model: &Qwen3Model, config: GRPOEngineConfig) -> Result<Self> {
-        let model_config = model.get_config();
+        let model_type = ModelType::Qwen3(model.get_config());
 
         info!(
             "Creating training engine: {} layers, {} hidden, eos_token_id={}, pad_token_id={}",
-            model_config.num_layers,
-            model_config.hidden_size,
-            model_config.eos_token_id,
-            model_config.pad_token_id
+            model_type.num_layers(),
+            model_type.hidden_size(),
+            model_type.eos_token_id(),
+            model_type.pad_token_id()
         );
 
         Ok(Self {
-            model: Arc::new(RwLock::new(model.clone_for_session()?)),
-            model_config,
+            model: Arc::new(RwLock::new(TrainableModelEnum::Qwen3(
+                model.clone_for_session()?,
+            ))),
+            model_type,
+            config,
+            reward_registry: RewardRegistry::new(),
+            state: Arc::new(RwLock::new(EngineState::default())),
+        })
+    }
+
+    /// Create a new training engine from a Qwen3.5 dense model
+    #[napi(factory)]
+    pub fn from_qwen35(model: &Qwen3_5Model, config: GRPOEngineConfig) -> Result<Self> {
+        let model_type = ModelType::Qwen35Dense(model.get_config());
+
+        info!(
+            "Creating training engine (Qwen3.5 Dense): {} layers, {} hidden",
+            model_type.num_layers(),
+            model_type.hidden_size()
+        );
+
+        Ok(Self {
+            model: Arc::new(RwLock::new(TrainableModelEnum::Qwen35Dense(
+                model.clone_for_training()?,
+            ))),
+            model_type,
+            config,
+            reward_registry: RewardRegistry::new(),
+            state: Arc::new(RwLock::new(EngineState::default())),
+        })
+    }
+
+    /// Create a new training engine from a Qwen3.5 MoE model
+    #[napi(factory)]
+    pub fn from_qwen35_moe(model: &Qwen3_5MoeModel, config: GRPOEngineConfig) -> Result<Self> {
+        let model_type = ModelType::Qwen35Moe(model.get_config());
+
+        info!(
+            "Creating training engine (Qwen3.5 MoE): {} layers, {} hidden",
+            model_type.num_layers(),
+            model_type.hidden_size()
+        );
+
+        Ok(Self {
+            model: Arc::new(RwLock::new(TrainableModelEnum::Qwen35Moe(
+                model.clone_for_training()?,
+            ))),
+            model_type,
             config,
             reward_registry: RewardRegistry::new(),
             state: Arc::new(RwLock::new(EngineState::default())),
@@ -493,7 +542,7 @@ impl GRPOTrainingEngine {
         // Clone Arcs for the blocking task
         let model_arc = Arc::clone(&self.model);
         let state_arc = Arc::clone(&self.state);
-        let model_config = self.model_config.clone();
+        let model_type = self.model_type.clone();
         let config = self.config.clone();
         let enable_thinking = config.enable_thinking;
         let tools = config.tools.clone();
@@ -510,7 +559,7 @@ impl GRPOTrainingEngine {
             max_consecutive_tokens: Some(16),
             max_ngram_repeats: Some(8),
             ngram_size: Some(3),
-            eos_token_id: Some(model_config.eos_token_id),
+            eos_token_id: Some(model_type.eos_token_id()),
             return_logprobs: Some(true),
             prefill_step_size: None, // Use default (2048)
             kv_cache_bits: None,     // Default: no quantization
@@ -610,7 +659,7 @@ impl GRPOTrainingEngine {
             let logprob_refs: Vec<&MxArray> = completion_logprobs_all.iter().collect();
 
             let (loss_value, gradients) = compute_loss_and_gradients_autograd(
-                &model_config,
+                &model_type,
                 &params,
                 &prompt_refs,
                 &completion_refs,
@@ -816,7 +865,7 @@ impl GRPOTrainingEngine {
 
                 let grads_refs: HashMap<String, &MxArray> =
                     grads.iter().map(|(k, v)| (k.clone(), v)).collect();
-                model_mut.apply_gradients(grads_refs, lr)?;
+                model_mut.apply_gradients_with_params(grads_refs, lr, &params)?;
 
                 debug!("Applied gradients with lr: {}", lr);
 
@@ -937,7 +986,7 @@ impl GRPOTrainingEngine {
 
         let model_arc = Arc::clone(&self.model);
         let config = self.config.clone();
-        let model_config = self.model_config.clone();
+        let model_type = self.model_type.clone();
         let enable_thinking = config.enable_thinking;
         let tools = config.tools.clone();
 
@@ -953,7 +1002,7 @@ impl GRPOTrainingEngine {
             max_consecutive_tokens: Some(16),
             max_ngram_repeats: Some(8),
             ngram_size: Some(3),
-            eos_token_id: Some(model_config.eos_token_id),
+            eos_token_id: Some(model_type.eos_token_id()),
             return_logprobs: Some(true),
             prefill_step_size: None, // Use default (2048)
             kv_cache_bits: None,     // Default: no quantization
@@ -994,7 +1043,16 @@ impl GRPOTrainingEngine {
                     Error::new(Status::GenericFailure, "Failed to acquire model read lock")
                 })?;
                 if use_parallel {
-                    model.generate_batch_parallel_sync(&prompt_arrays, group_size, Some(gen_config.clone()))?
+                    // Parallel batch generation is only available for Qwen3 models
+                    match &*model {
+                        TrainableModelEnum::Qwen3(m) => {
+                            m.generate_batch_parallel_sync(&prompt_arrays, group_size, Some(gen_config.clone()))?
+                        }
+                        _ => {
+                            // Fall back to sequential for non-Qwen3 models
+                            model.generate_batch_for_training_sync(&prompt_arrays, group_size, Some(gen_config.clone()))?
+                        }
+                    }
                 } else {
                     model.generate_batch_for_training_sync(&prompt_arrays, group_size, Some(gen_config.clone()))?
                 }
@@ -1035,7 +1093,7 @@ impl GRPOTrainingEngine {
                 // Bounds check with helpful error message
                 let reason = batch_result.finish_reasons
                     .get(prompt_idx)
-                    .and_then(|reasons| reasons.get(group_idx))
+                    .and_then(|reasons: &Vec<String>| reasons.get(group_idx))
                     .cloned()
                     .unwrap_or_else(|| {
                         eprintln!(
@@ -1125,7 +1183,7 @@ impl GRPOTrainingEngine {
         // Clone Arcs for the blocking task
         let model_arc = Arc::clone(&self.model);
         let state_arc = Arc::clone(&self.state);
-        let model_config = self.model_config.clone();
+        let model_type = self.model_type.clone();
         let config = self.config.clone();
         let enable_thinking = config.enable_thinking;
         let tools = config.tools.clone();
@@ -1212,7 +1270,7 @@ impl GRPOTrainingEngine {
             let logprob_refs: Vec<&MxArray> = completion_logprobs_all.iter().collect();
 
             let (loss_value, gradients) = compute_loss_and_gradients_autograd(
-                &model_config,
+                &model_type,
                 &params,
                 &prompt_refs,
                 &completion_refs,
@@ -1412,7 +1470,7 @@ impl GRPOTrainingEngine {
 
                 let grads_refs: HashMap<String, &MxArray> =
                     grads.iter().map(|(k, v)| (k.clone(), v)).collect();
-                model_mut.apply_gradients(grads_refs, lr)?;
+                model_mut.apply_gradients_with_params(grads_refs, lr, &params)?;
 
                 debug!("Applied gradients with lr: {}", lr);
 
@@ -1538,7 +1596,7 @@ impl GRPOTrainingEngine {
 
         // Clone Arcs for the blocking task
         let model_arc = Arc::clone(&self.model);
-        let model_config = self.model_config.clone();
+        let model_type = self.model_type.clone();
         let config = self.config.clone();
         let enable_thinking = config.enable_thinking;
         let tools = config.tools.clone();
@@ -1555,7 +1613,7 @@ impl GRPOTrainingEngine {
             max_consecutive_tokens: Some(16),
             max_ngram_repeats: Some(8),
             ngram_size: Some(3),
-            eos_token_id: Some(model_config.eos_token_id),
+            eos_token_id: Some(model_type.eos_token_id()),
             return_logprobs: Some(true),
             prefill_step_size: None, // Use default (2048)
             kv_cache_bits: None,     // Default: no quantization
@@ -1859,7 +1917,7 @@ impl GRPOTrainingEngine {
 
         let model_arc = Arc::clone(&self.model);
         let state_arc = Arc::clone(&self.state);
-        let model_config = self.model_config.clone();
+        let model_type = self.model_type.clone();
         let config = self.config.clone();
         let rewards_clone = filtered_rewards.clone();
         let group_size_for_training = effective_group_size as i32;
@@ -1901,7 +1959,7 @@ impl GRPOTrainingEngine {
             let grad_start = std::time::Instant::now();
 
             let (loss_value, gradients) = compute_loss_and_gradients_autograd(
-                &model_config,
+                &model_type,
                 &params,
                 &prompt_refs,
                 &completion_refs,
@@ -2073,7 +2131,7 @@ impl GRPOTrainingEngine {
 
                 let grads_refs: HashMap<String, &MxArray> =
                     grads.iter().map(|(k, v)| (k.clone(), v)).collect();
-                model_mut.apply_gradients(grads_refs, lr)?;
+                model_mut.apply_gradients_with_params(grads_refs, lr, &params)?;
                 drop(model_mut);
                 drop(grads);
 

--- a/crates/mlx-core/src/grpo/engine.rs
+++ b/crates/mlx-core/src/grpo/engine.rs
@@ -155,6 +155,24 @@ pub struct GRPOEngineConfig {
     /// When false, uses the sequential generation (process one prompt at a time,
     /// then expand KV cache for G completions).
     pub use_parallel_batch_generation: Option<bool>,
+
+    /// Enable gradient checkpointing (default: true).
+    /// When true, each transformer layer's activations are discarded during the forward
+    /// pass and recomputed during backward, reducing peak memory from O(num_layers) to O(1)
+    /// for intermediate states. For Qwen3.5 0.8B, this reduces autograd peak from ~105GB to ~11GB.
+    /// The trade-off is ~30% more compute (one extra forward pass per layer during backward).
+    pub gradient_checkpointing: Option<bool>,
+
+    /// Optimizer type: "sgd" or "adamw" (default: "adamw")
+    pub optimizer_type: Option<String>,
+    /// AdamW beta1 (default: 0.9)
+    pub adamw_beta1: Option<f64>,
+    /// AdamW beta2 (default: 0.999)
+    pub adamw_beta2: Option<f64>,
+    /// AdamW epsilon (default: 1e-8)
+    pub adamw_eps: Option<f64>,
+    /// Weight decay for AdamW (default: 0.01)
+    pub weight_decay: Option<f64>,
 }
 
 impl Default for GRPOEngineConfig {
@@ -178,10 +196,16 @@ impl Default for GRPOEngineConfig {
             verbose_nan_detection: Some(false),
             enable_thinking: Some(true),
             tools: None,
-            lm_head_chunk_size: None,      // Default: no chunking
-            forward_chunk_size: None,      // Default: no chunking
+            lm_head_chunk_size: Some(2), // Default: 2 (chunked for memory efficiency)
+            forward_chunk_size: None,    // Default: no chunking
             vocab_chunk_size: Some(65536), // Default: 2^16 chunks for large vocabularies
             use_parallel_batch_generation: Some(false), // Default: use sequential for stability
+            gradient_checkpointing: Some(true), // Default: enable for memory efficiency
+            optimizer_type: Some("adamw".to_string()),
+            adamw_beta1: Some(0.9),
+            adamw_beta2: Some(0.999),
+            adamw_eps: Some(1e-8),
+            weight_decay: Some(0.01),
         }
     }
 }
@@ -355,6 +379,111 @@ pub struct GRPOTrainingEngine {
     reward_registry: RewardRegistry,
     /// Training state
     state: Arc<RwLock<EngineState>>,
+    /// AdamW optimizer (used when optimizer_type is "adamw")
+    optimizer: Option<Arc<std::sync::Mutex<crate::optimizers::AdamW>>>,
+}
+
+/// Apply gradients to model using either AdamW or SGD.
+fn apply_optimizer_step(
+    model: &mut TrainableModelEnum,
+    grads: &HashMap<String, MxArray>,
+    params: &HashMap<String, MxArray>,
+    lr: f64,
+    optimizer: &Option<Arc<std::sync::Mutex<crate::optimizers::AdamW>>>,
+    grad_acc_steps: i32,
+) -> Result<()> {
+    if let Some(opt_arc) = optimizer {
+        // AdamW path
+        let mut opt = opt_arc
+            .lock()
+            .map_err(|_| Error::new(Status::GenericFailure, "Failed to acquire optimizer lock"))?;
+
+        let mut param_names_vec: Vec<String> = Vec::new();
+        let mut param_refs: Vec<&MxArray> = Vec::new();
+        let mut grad_refs: Vec<&MxArray> = Vec::new();
+
+        // When using gradient accumulation, gradients are summed (not averaged).
+        // SGD compensates by dividing lr, but AdamW ignores lr (uses delta trick with 1.0).
+        // So we must average the gradients explicitly before passing to AdamW.
+        let scaled_grads: HashMap<String, MxArray>;
+        let grads_to_use = if grad_acc_steps > 1 {
+            let scale = 1.0 / grad_acc_steps as f32;
+            let scale_arr = MxArray::from_float32(&[scale], &[]).unwrap();
+            scaled_grads = grads
+                .iter()
+                .map(|(name, grad)| (name.clone(), grad.mul(&scale_arr).unwrap()))
+                .collect();
+            &scaled_grads
+        } else {
+            grads
+        };
+
+        for (name, grad) in grads_to_use {
+            if let Some(param) = params.get(name) {
+                param_names_vec.push(name.clone());
+                param_refs.push(param);
+                grad_refs.push(grad);
+            }
+        }
+
+        let updated = opt.update_batch(param_names_vec.clone(), param_refs.clone(), grad_refs)?;
+
+        // Create deltas: delta = param - updated (so param - 1.0 * delta = updated)
+        let deltas: HashMap<String, MxArray> = param_names_vec
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                let delta = param_refs[i].sub(&updated[i]).unwrap();
+                (name.clone(), delta)
+            })
+            .collect();
+
+        let delta_refs: HashMap<String, &MxArray> =
+            deltas.iter().map(|(k, v)| (k.clone(), v)).collect();
+        model.apply_gradients_with_params(delta_refs, 1.0, params)?;
+
+        debug!("Applied AdamW update (step={})", opt.get_step());
+    } else {
+        // SGD path
+        let grads_refs: HashMap<String, &MxArray> =
+            grads.iter().map(|(k, v)| (k.clone(), v)).collect();
+        model.apply_gradients_with_params(grads_refs, lr, params)?;
+
+        debug!("Applied SGD gradients with lr: {}", lr);
+    }
+
+    Ok(())
+}
+
+/// Create an AdamW optimizer from engine config, or None for SGD.
+fn create_optimizer(
+    config: &GRPOEngineConfig,
+) -> Option<Arc<std::sync::Mutex<crate::optimizers::AdamW>>> {
+    let opt_type = config.optimizer_type.as_deref().unwrap_or("adamw");
+    if opt_type == "adamw" {
+        let optimizer = crate::optimizers::AdamW::new(
+            config.learning_rate,
+            config.adamw_beta1,
+            config.adamw_beta2,
+            config.adamw_eps,
+            config.weight_decay,
+            Some(true), // bias correction
+        );
+        info!(
+            "Using AdamW optimizer (lr={}, beta1={}, beta2={}, wd={})",
+            config.learning_rate.unwrap_or(1e-6),
+            config.adamw_beta1.unwrap_or(0.9),
+            config.adamw_beta2.unwrap_or(0.999),
+            config.weight_decay.unwrap_or(0.01),
+        );
+        Some(Arc::new(std::sync::Mutex::new(optimizer)))
+    } else {
+        info!(
+            "Using SGD optimizer (lr={})",
+            config.learning_rate.unwrap_or(1e-6)
+        );
+        None
+    }
 }
 
 #[napi]
@@ -376,6 +505,8 @@ impl GRPOTrainingEngine {
             model_type.pad_token_id()
         );
 
+        let optimizer = create_optimizer(&config);
+
         Ok(Self {
             model: Arc::new(RwLock::new(TrainableModelEnum::Qwen3(
                 model.clone_for_session()?,
@@ -384,6 +515,7 @@ impl GRPOTrainingEngine {
             config,
             reward_registry: RewardRegistry::new(),
             state: Arc::new(RwLock::new(EngineState::default())),
+            optimizer,
         })
     }
 
@@ -398,6 +530,8 @@ impl GRPOTrainingEngine {
             model_type.hidden_size()
         );
 
+        let optimizer = create_optimizer(&config);
+
         Ok(Self {
             model: Arc::new(RwLock::new(TrainableModelEnum::Qwen35Dense(
                 model.clone_for_training()?,
@@ -406,6 +540,7 @@ impl GRPOTrainingEngine {
             config,
             reward_registry: RewardRegistry::new(),
             state: Arc::new(RwLock::new(EngineState::default())),
+            optimizer,
         })
     }
 
@@ -420,6 +555,8 @@ impl GRPOTrainingEngine {
             model_type.hidden_size()
         );
 
+        let optimizer = create_optimizer(&config);
+
         Ok(Self {
             model: Arc::new(RwLock::new(TrainableModelEnum::Qwen35Moe(
                 model.clone_for_training()?,
@@ -428,6 +565,7 @@ impl GRPOTrainingEngine {
             config,
             reward_registry: RewardRegistry::new(),
             state: Arc::new(RwLock::new(EngineState::default())),
+            optimizer,
         })
     }
 
@@ -542,6 +680,7 @@ impl GRPOTrainingEngine {
         // Clone Arcs for the blocking task
         let model_arc = Arc::clone(&self.model);
         let state_arc = Arc::clone(&self.state);
+        let optimizer_arc = self.optimizer.clone();
         let model_type = self.model_type.clone();
         let config = self.config.clone();
         let enable_thinking = config.enable_thinking;
@@ -667,6 +806,7 @@ impl GRPOTrainingEngine {
                 &rewards,
                 config.group_size.unwrap_or(4),
                 loss_config,
+                config.gradient_checkpointing.unwrap_or(true),
             )?;
 
             // Check for NaN
@@ -863,11 +1003,7 @@ impl GRPOTrainingEngine {
                     Error::new(Status::GenericFailure, "Failed to acquire model write lock")
                 })?;
 
-                let grads_refs: HashMap<String, &MxArray> =
-                    grads.iter().map(|(k, v)| (k.clone(), v)).collect();
-                model_mut.apply_gradients_with_params(grads_refs, lr, &params)?;
-
-                debug!("Applied gradients with lr: {}", lr);
+                apply_optimizer_step(&mut model_mut, &grads, &params, lr, &optimizer_arc, grad_acc_steps)?;
 
                 // Re-acquire state lock
                 let mut state = state_arc.write().map_err(|_| {
@@ -1183,6 +1319,7 @@ impl GRPOTrainingEngine {
         // Clone Arcs for the blocking task
         let model_arc = Arc::clone(&self.model);
         let state_arc = Arc::clone(&self.state);
+        let optimizer_arc = self.optimizer.clone();
         let model_type = self.model_type.clone();
         let config = self.config.clone();
         let enable_thinking = config.enable_thinking;
@@ -1278,6 +1415,7 @@ impl GRPOTrainingEngine {
                 &rewards,
                 config.group_size.unwrap_or(4),
                 loss_config,
+                config.gradient_checkpointing.unwrap_or(true),
             )?;
 
             // Check for NaN
@@ -1468,11 +1606,7 @@ impl GRPOTrainingEngine {
                     Error::new(Status::GenericFailure, "Failed to acquire model write lock")
                 })?;
 
-                let grads_refs: HashMap<String, &MxArray> =
-                    grads.iter().map(|(k, v)| (k.clone(), v)).collect();
-                model_mut.apply_gradients_with_params(grads_refs, lr, &params)?;
-
-                debug!("Applied gradients with lr: {}", lr);
+                apply_optimizer_step(&mut model_mut, &grads, &params, lr, &optimizer_arc, grad_acc_steps)?;
 
                 // Re-acquire state lock
                 let mut state = state_arc.write().map_err(|_| {
@@ -1917,6 +2051,7 @@ impl GRPOTrainingEngine {
 
         let model_arc = Arc::clone(&self.model);
         let state_arc = Arc::clone(&self.state);
+        let optimizer_arc = self.optimizer.clone();
         let model_type = self.model_type.clone();
         let config = self.config.clone();
         let rewards_clone = filtered_rewards.clone();
@@ -1967,6 +2102,7 @@ impl GRPOTrainingEngine {
                 &rewards_clone,
                 group_size_for_training,
                 loss_config,
+                config.gradient_checkpointing.unwrap_or(true),
             )?;
 
             info!(
@@ -2129,9 +2265,14 @@ impl GRPOTrainingEngine {
                     Error::new(Status::GenericFailure, "Failed to acquire model write lock")
                 })?;
 
-                let grads_refs: HashMap<String, &MxArray> =
-                    grads.iter().map(|(k, v)| (k.clone(), v)).collect();
-                model_mut.apply_gradients_with_params(grads_refs, lr, &params)?;
+                apply_optimizer_step(
+                    &mut model_mut,
+                    &grads,
+                    &params,
+                    lr,
+                    &optimizer_arc,
+                    grad_acc_steps,
+                )?;
                 drop(model_mut);
                 drop(grads);
 
@@ -2327,6 +2468,14 @@ impl GRPOTrainingEngine {
             .map_err(|_| Error::new(Status::GenericFailure, "Failed to acquire state lock"))?;
 
         *state = EngineState::default();
+
+        // Reset optimizer state if present
+        if let Some(ref optimizer) = self.optimizer
+            && let Ok(mut opt) = optimizer.lock()
+        {
+            opt.reset();
+        }
+
         synchronize_and_clear_cache();
 
         info!("Training engine reset");
@@ -2384,6 +2533,94 @@ impl GRPOTrainingEngine {
             .write()
             .map_err(|_| Error::new(Status::GenericFailure, "Failed to acquire state lock"))?;
         state.needs_emergency_save = false;
+        Ok(())
+    }
+
+    /// Save optimizer state (moment tensors + step) to a SafeTensors file.
+    ///
+    /// The step counter is stored in the `__metadata__` field.
+    /// Each parameter's first moment (m) and second moment (v) are stored as
+    /// `{param_name}.m` and `{param_name}.v` tensors.
+    ///
+    /// No-op if the engine uses SGD (no optimizer state to save).
+    #[napi]
+    pub fn save_optimizer_state(&self, path: String) -> Result<()> {
+        let opt_arc = match &self.optimizer {
+            Some(opt) => opt,
+            None => return Ok(()), // SGD — no state to save
+        };
+
+        let opt = opt_arc
+            .lock()
+            .map_err(|_| Error::new(Status::GenericFailure, "Failed to acquire optimizer lock"))?;
+
+        let step = opt.get_step();
+        let keys = opt.get_state_keys();
+
+        if keys.is_empty() {
+            return Ok(()); // No state accumulated yet
+        }
+
+        let mut tensors: HashMap<String, MxArray> = HashMap::new();
+
+        for key in &keys {
+            if let Some(m) = opt.get_first_moment(key.clone()) {
+                tensors.insert(format!("{}.m", key), m);
+            }
+            if let Some(v) = opt.get_second_moment(key.clone()) {
+                tensors.insert(format!("{}.v", key), v);
+            }
+        }
+
+        let metadata = serde_json::json!({
+            "step": step.to_string(),
+            "format": "adamw_optimizer_state",
+        });
+
+        crate::utils::safetensors::save_safetensors(&path, &tensors, Some(metadata))
+    }
+
+    /// Load optimizer state (moment tensors + step) from a SafeTensors file.
+    ///
+    /// Restores the step counter from metadata and sets first/second moment
+    /// tensors for each parameter found in the file.
+    ///
+    /// No-op if the engine uses SGD (no optimizer to restore).
+    #[napi]
+    pub fn load_optimizer_state(&self, path: String) -> Result<()> {
+        let opt_arc = match &self.optimizer {
+            Some(opt) => opt,
+            None => return Ok(()), // SGD — nothing to restore
+        };
+
+        let mut opt = opt_arc
+            .lock()
+            .map_err(|_| Error::new(Status::GenericFailure, "Failed to acquire optimizer lock"))?;
+
+        // Load SafeTensors file
+        let st_file = crate::utils::safetensors::SafeTensorsFile::load(&path)?;
+
+        // Restore step from metadata
+        if let Some(metadata) = &st_file.metadata {
+            if let Some(step_str) = metadata.get("step").and_then(|v| v.as_str()) {
+                if let Ok(step) = step_str.parse::<i64>() {
+                    opt.set_step(step);
+                }
+            }
+        }
+
+        // Load all tensors
+        let tensors = st_file.load_tensors(&path)?;
+
+        // Restore moment tensors: keys are "{param_name}.m" and "{param_name}.v"
+        for (tensor_key, array) in &tensors {
+            if let Some(param_name) = tensor_key.strip_suffix(".m") {
+                opt.set_first_moment(param_name.to_string(), array)?;
+            } else if let Some(param_name) = tensor_key.strip_suffix(".v") {
+                opt.set_second_moment(param_name.to_string(), array)?;
+            }
+        }
+
         Ok(())
     }
 }

--- a/crates/mlx-core/src/grpo/mod.rs
+++ b/crates/mlx-core/src/grpo/mod.rs
@@ -19,7 +19,7 @@ pub mod rewards;
 
 // Re-export all public items
 pub use advantages::*;
-pub use autograd::*;
+// autograd functions are pub(crate) - used directly by engine
 pub use callbacks::*;
 pub use engine::*;
 pub use entropy::*;

--- a/crates/mlx-core/src/lib.rs
+++ b/crates/mlx-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod tensor;
 pub mod tokenizer;
 pub mod tools;
 pub mod tracing;
+pub mod training_model;
 pub mod transformer;
 pub mod utils;
 pub mod vision;

--- a/crates/mlx-core/src/models/mod.rs
+++ b/crates/mlx-core/src/models/mod.rs
@@ -12,3 +12,4 @@ pub mod pp_text_rec;
 pub mod qwen3;
 pub mod qwen3_5;
 pub mod qwen3_5_moe;
+pub(crate) mod training_generate;

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -4088,6 +4088,7 @@ impl Qwen3Model {
             rewards,
             group_size,
             config,
+            false, // No gradient checkpointing in legacy API
         )?;
 
         // 3. Apply gradients to update parameters
@@ -4167,6 +4168,7 @@ impl Qwen3Model {
             rewards,
             group_size,
             config,
+            false, // No gradient checkpointing in legacy API
         )?;
 
         // 3. Compute metrics (DON'T apply gradients)

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -22,6 +22,7 @@ use crate::sampling::{
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::tools;
+use crate::training_model::ModelType;
 use crate::transformer::{
     ContinuousBatchingScheduler, KVCache, PagedAttentionConfig, PagedKVCache, PendingRequest,
     SchedulerConfig, TransformerBlock,
@@ -4077,8 +4078,9 @@ impl Qwen3Model {
         let params = self.get_parameters();
 
         // 2. Compute loss and gradients using autograd
+        let model_type = ModelType::Qwen3(self.config.clone());
         let (loss_value, gradients) = compute_loss_and_gradients_autograd(
-            &self.config,
+            &model_type,
             &params,
             &prompt_tokens,
             &completion_tokens,
@@ -4155,8 +4157,9 @@ impl Qwen3Model {
         let params = self.get_parameters();
 
         // 2. Compute loss and gradients using autograd
+        let model_type = ModelType::Qwen3(self.config.clone());
         let (loss_value, gradients) = compute_loss_and_gradients_autograd(
-            &self.config,
+            &model_type,
             &params,
             &prompt_tokens,
             &completion_tokens,

--- a/crates/mlx-core/src/models/qwen3/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3/persistence.rs
@@ -635,31 +635,6 @@ impl Qwen3Model {
         Ok(promise)
     }
 
-    /// Save model synchronously (for use from training engines via TrainableModel trait)
-    pub(crate) fn save_model_sync(&self, path: &str) -> Result<()> {
-        let params = self.get_parameters();
-
-        // Ensure directory exists
-        std::fs::create_dir_all(path)
-            .map_err(|e| Error::from_reason(format!("Failed to create directory: {}", e)))?;
-
-        // Save config.json
-        let config = self.get_config();
-        let config_json = serde_json::to_string_pretty(&config)
-            .map_err(|e| Error::from_reason(format!("Failed to serialize config: {}", e)))?;
-        std::fs::write(format!("{}/config.json", path), config_json)
-            .map_err(|e| Error::from_reason(format!("Failed to write config: {}", e)))?;
-
-        // Save weights as safetensors
-        save_safetensors(
-            std::path::Path::new(path).join("weights.safetensors"),
-            &params,
-            None,
-        )?;
-
-        Ok(())
-    }
-
     /// Validate that a set of parameters has all required weights with correct shapes
     ///
     /// This is useful for validating parameters before loading them into a model,

--- a/crates/mlx-core/src/models/qwen3/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3/persistence.rs
@@ -635,6 +635,31 @@ impl Qwen3Model {
         Ok(promise)
     }
 
+    /// Save model synchronously (for use from training engines via TrainableModel trait)
+    pub(crate) fn save_model_sync(&self, path: &str) -> Result<()> {
+        let params = self.get_parameters();
+
+        // Ensure directory exists
+        std::fs::create_dir_all(path)
+            .map_err(|e| Error::from_reason(format!("Failed to create directory: {}", e)))?;
+
+        // Save config.json
+        let config = self.get_config();
+        let config_json = serde_json::to_string_pretty(&config)
+            .map_err(|e| Error::from_reason(format!("Failed to serialize config: {}", e)))?;
+        std::fs::write(format!("{}/config.json", path), config_json)
+            .map_err(|e| Error::from_reason(format!("Failed to write config: {}", e)))?;
+
+        // Save weights as safetensors
+        save_safetensors(
+            std::path::Path::new(path).join("weights.safetensors"),
+            &params,
+            None,
+        )?;
+
+        Ok(())
+    }
+
     /// Validate that a set of parameters has all required weights with correct shapes
     ///
     /// This is useful for validating parameters before loading them into a model,

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -264,4 +264,25 @@ impl Qwen3_5Attention {
     pub fn set_quantized_o_proj(&mut self, ql: QuantizedLinear) {
         self.o_proj.set_quantized(ql);
     }
+
+    // ========== Weight getters (for training parameter extraction) ==========
+
+    pub fn get_q_proj_weight(&self) -> MxArray {
+        self.q_proj.get_weight()
+    }
+    pub fn get_k_proj_weight(&self) -> MxArray {
+        self.k_proj.get_weight()
+    }
+    pub fn get_v_proj_weight(&self) -> MxArray {
+        self.v_proj.get_weight()
+    }
+    pub fn get_o_proj_weight(&self) -> MxArray {
+        self.o_proj.get_weight()
+    }
+    pub fn get_q_norm_weight(&self) -> MxArray {
+        self.q_norm.get_weight()
+    }
+    pub fn get_k_norm_weight(&self) -> MxArray {
+        self.k_norm.get_weight()
+    }
 }

--- a/crates/mlx-core/src/models/qwen3_5/decoder_layer.rs
+++ b/crates/mlx-core/src/models/qwen3_5/decoder_layer.rs
@@ -73,6 +73,7 @@ impl DecoderLayer {
         mask: Option<&MxArray>,
         cache: Option<&mut Qwen3_5LayerCache>,
         position_ids: Option<&MxArray>,
+        use_kernel: bool,
     ) -> Result<MxArray> {
         // Pre-norm + attention
         let normed = self.input_layernorm.forward(x)?;
@@ -80,7 +81,7 @@ impl DecoderLayer {
             AttentionType::Linear(gdn) => {
                 let ac = cache.and_then(|c| c.as_arrays_cache_mut());
                 // Linear attention layers don't use explicit position IDs
-                gdn.forward(&normed, mask, ac)?
+                gdn.forward(&normed, mask, ac, use_kernel)?
             }
             AttentionType::Full(attn) => {
                 let kvc = cache.and_then(|c| c.as_kv_cache_mut());
@@ -107,6 +108,16 @@ impl DecoderLayer {
 
     pub fn set_post_attention_layernorm_weight(&mut self, w: &MxArray) -> Result<()> {
         self.post_attention_layernorm.set_weight(w)
+    }
+
+    // ========== Weight getters (for training parameter extraction) ==========
+
+    pub fn get_input_layernorm_weight(&self) -> MxArray {
+        self.input_layernorm.get_weight()
+    }
+
+    pub fn get_post_attention_layernorm_weight(&self) -> MxArray {
+        self.post_attention_layernorm.get_weight()
     }
 
     /// Replace the dense MLP with a quantized version.

--- a/crates/mlx-core/src/models/qwen3_5/gated_delta.rs
+++ b/crates/mlx-core/src/models/qwen3_5/gated_delta.rs
@@ -334,12 +334,50 @@ pub fn gated_delta_update(
     dt_bias: &MxArray,
     state: Option<&MxArray>,
     mask: Option<&MxArray>,
+    use_kernel: bool,
 ) -> Result<(MxArray, MxArray)> {
     let batch = q.shape_at(0)?;
     let num_k_heads = q.shape_at(2)?;
     let num_v_heads = v.shape_at(2)?;
     let v_dim = v.shape_at(3)?;
     let k_dim = q.shape_at(3)?;
+
+    // When use_kernel=false, use only ops-based paths for full differentiability (autograd).
+    // compute_g builds a standard MLX expression graph via C++ (differentiable),
+    // but the fused_gdn_gating Metal kernel and recurrence kernels are NOT differentiable.
+    if !use_kernel {
+        let beta = Activations::sigmoid(b)?;
+        // compute_g returns exp(g_log) directly — use it as the decay gate without log/exp round-trip
+        let g = compute_g(a_log, a, dt_bias)?;
+
+        // GQA head expansion
+        let (q, k) = if num_v_heads != num_k_heads {
+            if num_k_heads == 0 {
+                return Err(Error::from_reason(
+                    "GatedDelta: num_k_heads is 0, cannot compute GQA repeat factor",
+                ));
+            }
+            if num_v_heads % num_k_heads != 0 {
+                return Err(Error::from_reason(format!(
+                    "GatedDelta: num_v_heads ({}) must be divisible by num_k_heads ({})",
+                    num_v_heads, num_k_heads
+                )));
+            }
+            let repeat_factor = num_v_heads / num_k_heads;
+            let q_expanded = q.repeat(repeat_factor as i32, 2)?;
+            let k_expanded = k.repeat(repeat_factor as i32, 2)?;
+            (q_expanded, k_expanded)
+        } else {
+            (q.clone(), k.clone())
+        };
+
+        let initial_state = match state {
+            Some(s) => s.clone(),
+            None => MxArray::zeros(&[batch, num_v_heads, v_dim, k_dim], Some(v.dtype()?))?,
+        };
+
+        return gated_delta_ops(&q, &k, v, &g, &beta, &initial_state, mask);
+    }
 
     // Compute beta = sigmoid(b) and g_log = -exp(A_log) * softplus(a + dt_bias)
     // Try fused Metal kernel first (single dispatch), fall back to separate ops.

--- a/crates/mlx-core/src/models/qwen3_5/gated_delta_net.rs
+++ b/crates/mlx-core/src/models/qwen3_5/gated_delta_net.rs
@@ -113,6 +113,7 @@ impl GatedDeltaNet {
         x: &MxArray,
         mask: Option<&MxArray>,
         mut cache: Option<&mut ArraysCache>,
+        use_kernel: bool,
     ) -> Result<MxArray> {
         let batch = x.shape_at(0)?;
         let seq_len = x.shape_at(1)?;
@@ -243,6 +244,7 @@ impl GatedDeltaNet {
             &self.dt_bias,
             recurrent_state,
             mask,
+            use_kernel,
         )?;
 
         // Update recurrent state in cache
@@ -315,6 +317,30 @@ impl GatedDeltaNet {
     }
     pub fn set_quantized_out_proj(&mut self, ql: QuantizedLinear) {
         self.out_proj.set_quantized(ql);
+    }
+
+    // ========== Weight getters (for training parameter extraction) ==========
+
+    pub fn get_in_proj_qkvz_weight(&self) -> MxArray {
+        self.in_proj_qkvz.get_weight()
+    }
+    pub fn get_in_proj_ba_weight(&self) -> MxArray {
+        self.in_proj_ba.get_weight()
+    }
+    pub fn get_conv1d_weight(&self) -> MxArray {
+        self.conv1d.get_weight()
+    }
+    pub fn get_norm_weight(&self) -> MxArray {
+        self.norm.get_weight()
+    }
+    pub fn get_out_proj_weight(&self) -> MxArray {
+        self.out_proj.get_weight()
+    }
+    pub fn get_dt_bias(&self) -> MxArray {
+        self.dt_bias.clone()
+    }
+    pub fn get_a_log(&self) -> MxArray {
+        self.a_log.clone()
     }
 }
 

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -3,6 +3,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
+use futures::TryFutureExt;
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
@@ -1837,6 +1838,126 @@ impl Qwen3_5Model {
 
         total
     }
+
+    /// Save the model weights and configuration to a directory.
+    ///
+    /// This saves:
+    /// - config.json: Model configuration (with model_type for detectModelType)
+    /// - weights.safetensors: Full model weights in SafeTensors format
+    /// - weights.mlx: Parameter metadata (for reference)
+    ///
+    /// # Arguments
+    /// * `save_path` - Directory to save the model
+    #[napi]
+    pub fn save_model<'env>(
+        &self,
+        env: &'env Env,
+        save_path: String,
+    ) -> Result<PromiseRaw<'env, ()>> {
+        let mut params = self.get_parameters_for_training()?;
+
+        // Include vision encoder weights when present (VLM models)
+        if let Some(ref vision_enc) = self.vision_encoder {
+            let vision_params = vision_enc.get_parameters();
+            params.extend(vision_params);
+        }
+
+        // Validate all parameters for NaN/Inf before saving
+        for (name, param) in params.iter() {
+            let data = param.to_float32()?;
+            let invalid_count = data
+                .iter()
+                .filter(|v| v.is_nan() || v.is_infinite())
+                .count();
+            if invalid_count > 0 {
+                return Err(napi::Error::new(
+                    Status::GenericFailure,
+                    format!(
+                        "Cannot save model: parameter '{}' contains {} NaN/Inf values. \
+                        Model weights are corrupted, likely due to training instability. \
+                        Consider reducing learning rate or using an earlier checkpoint.",
+                        name, invalid_count
+                    ),
+                ));
+            }
+        }
+
+        let params_clone: HashMap<String, MxArray> =
+            params.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+        // Create weights metadata (for reference)
+        let mut weights_metadata = serde_json::Map::new();
+        for (key, array) in params.iter() {
+            let shape_data = array.shape()?;
+            let shape: Vec<i64> = shape_data.as_ref().to_vec();
+            let dtype = array.dtype()?;
+
+            let mut param_info = serde_json::Map::new();
+            param_info.insert("shape".to_string(), serde_json::json!(shape));
+            param_info.insert("dtype".to_string(), serde_json::json!(dtype as i32));
+
+            weights_metadata.insert(key.clone(), serde_json::Value::Object(param_info));
+        }
+
+        // Serialize config and inject model_type for detectModelType
+        let config = self.get_config();
+        let mut config_value = serde_json::to_value(&config).map_err(|e| {
+            napi::Error::new(Status::GenericFailure, format!("Failed to serialize config: {e}"))
+        })?;
+        if let serde_json::Value::Object(ref mut map) = config_value {
+            map.insert("model_type".to_string(), serde_json::json!("qwen3_5"));
+        }
+
+        let weights_json = serde_json::json!({
+            "version": "1.0",
+            "config": config_value,
+            "weights": weights_metadata,
+            "note": "Full weights are in weights.safetensors"
+        });
+
+        let promise = env.spawn_future(async move {
+            tokio::task::spawn_blocking(move || {
+                let path = std::path::Path::new(&save_path);
+                std::fs::create_dir_all(path)?;
+
+                info!("Saving model to {}", save_path);
+
+                // 1. Save configuration as JSON
+                let config_path = path.join("config.json");
+                let config_json = serde_json::to_string_pretty(&config_value)?;
+                std::fs::write(&config_path, config_json)?;
+                info!("Saved config.json");
+
+                // 2. Save full weights in SafeTensors format
+                let safetensors_path = path.join("weights.safetensors");
+                let metadata = Some(serde_json::json!({
+                    "format": "mlx-node",
+                    "version": "1.0"
+                }));
+                crate::utils::safetensors::save_safetensors(&safetensors_path, &params_clone, metadata)?;
+                info!("Saved weights.safetensors");
+
+                // 3. Save weights metadata (for reference)
+                let weights_str = serde_json::to_string_pretty(&weights_json)?;
+                let weights_path = path.join("weights.mlx");
+                std::fs::write(&weights_path, weights_str)?;
+                info!("Saved weights.mlx metadata");
+
+                Ok::<_, Error>(())
+            })
+            .map_err(|err| {
+                napi::Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to save model: {}", err),
+                )
+            })
+            .await
+            .flatten()?;
+            Ok(())
+        })?;
+
+        Ok(promise)
+    }
 }
 
 /// Forward pass through the model, acquiring all necessary locks.
@@ -2456,7 +2577,10 @@ impl Qwen3_5Model {
     }
 
     /// Generate a single completion with logprob tracking (for GRPO training).
-    /// Uses the Rust forward path (NOT compiled C++) to ensure differentiability.
+    ///
+    /// Uses the compiled C++ forward path when available (~10x faster than Rust).
+    /// Generation does NOT need differentiability — gradients are computed separately
+    /// via the functional forward path in autograd Phase 2.
     pub(crate) fn generate_for_training_sync(
         &self,
         input_ids: &MxArray,
@@ -2464,6 +2588,18 @@ impl Qwen3_5Model {
     ) -> Result<GenerationResult> {
         let config = config.unwrap_or_default();
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
+
+        // Check if compiled path is available (C++ weights loaded from safetensors)
+        let use_compiled = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+
+        // Try to acquire compiled mutex (non-blocking, safe from sync context).
+        // If locked (concurrent generate() call), fall back to Rust path.
+        let compiled_lock = if use_compiled {
+            DENSE_COMPILED_MUTEX.try_lock().ok()
+        } else {
+            None
+        };
+        let use_compiled = compiled_lock.is_some();
 
         // Ensure caches exist
         self.init_caches()?;
@@ -2488,31 +2624,130 @@ impl Qwen3_5Model {
             .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
 
         let fa_idx = self.fa_idx;
-        let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {
-            forward_inner(
-                ids,
-                &embedding_weight,
-                &mut layers_guard,
-                &mut caches_guard,
-                &final_norm_guard,
-                &lm_head_guard,
-                fa_idx,
-                None,
-            )
+
+        // === Prefill (always uses Rust forward — runs once) ===
+        let logits = forward_inner(
+            input_ids,
+            &embedding_weight,
+            &mut layers_guard,
+            &mut caches_guard,
+            &final_norm_guard,
+            &lm_head_guard,
+            fa_idx,
+            None,
+        )?;
+        let seq_len = logits.shape_at(1)?;
+        let last_logits = logits.slice_axis(1, seq_len - 1, seq_len)?;
+        let last_logits = last_logits.squeeze(Some(&[1]))?;
+        let input_tokens = input_ids.to_uint32()?;
+
+        let result = if use_compiled {
+            // === Compiled C++ decode path ===
+            let _compiled_guard = CompiledResetGuard;
+            let max_new_tokens = config.max_new_tokens.unwrap_or(100);
+            let prefill_len = seq_len as i32;
+            let max_kv_len = ((prefill_len + max_new_tokens + 255) / 256) * 256;
+            let num_layers = self.config.num_layers as usize;
+            let mut cache_ptrs: Vec<*mut mlx_sys::mlx_array> =
+                vec![std::ptr::null_mut(); num_layers * 2];
+            if let Some(ref caches) = *caches_guard {
+                for (i, cache) in caches.iter().enumerate() {
+                    let (p0, p1) = cache.export_ptrs();
+                    cache_ptrs[i * 2] = p0;
+                    cache_ptrs[i * 2 + 1] = p1;
+                }
+            }
+            // Drop locks not needed during compiled decode
+            drop(layers_guard);
+            drop(final_norm_guard);
+            drop(lm_head_guard);
+            // Keep caches_guard alive through init_from_prefill so cache_ptrs remain valid
+            unsafe {
+                mlx_sys::mlx_qwen35_compiled_init_from_prefill(
+                    self.config.num_layers,
+                    self.config.hidden_size,
+                    self.config.num_heads,
+                    self.config.num_kv_heads,
+                    self.config.head_dim,
+                    self.config.rope_theta as f32,
+                    self.config.rope_dims(),
+                    self.config.rms_norm_eps as f32,
+                    self.config.full_attention_interval,
+                    self.config.linear_num_key_heads,
+                    self.config.linear_num_value_heads,
+                    self.config.linear_key_head_dim,
+                    self.config.linear_value_head_dim,
+                    self.config.linear_conv_kernel_dim,
+                    if self.config.tie_word_embeddings {
+                        1
+                    } else {
+                        0
+                    },
+                    max_kv_len,
+                    1, // batch_size
+                    cache_ptrs.as_mut_ptr(),
+                    prefill_len,
+                );
+            }
+            // C++ has copied arrays into g_compiled_caches — safe to release
+            drop(caches_guard);
+
+            // Decode using compiled forward with synchronous cache eval.
+            // Caches are eval'd BEFORE each forward call to ensure the previous step's
+            // caches are materialized, breaking lazy dependency chains that would otherwise
+            // cause O(N²) graph growth and 100+GB memory.
+            let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {
+                // Sync-eval compiled caches from the previous step before building new graph.
+                // Uses synchronous eval (not async_eval) to avoid interaction issues with
+                // the training loop's own synchronous eval calls.
+                unsafe { mlx_sys::mlx_qwen35_sync_eval_compiled_caches() };
+                let logits = forward_compiled(ids, &embedding_weight)?;
+                // forward_compiled returns [1, vocab] but training loop expects [1, 1, vocab]
+                let logits = logits.reshape(&[1, 1, -1])?;
+                Ok(logits)
+            };
+
+            crate::models::training_generate::generate_decode_loop_for_training(
+                &last_logits,
+                &input_tokens,
+                &config,
+                eos_token_id,
+                &mut forward_fn,
+            )?
+            // _compiled_guard dropped here → mlx_qwen35_compiled_reset()
+        } else {
+            // === Rust fallback decode path ===
+            let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {
+                forward_inner(
+                    ids,
+                    &embedding_weight,
+                    &mut layers_guard,
+                    &mut caches_guard,
+                    &final_norm_guard,
+                    &lm_head_guard,
+                    fa_idx,
+                    None,
+                )
+            };
+
+            let result = crate::models::training_generate::generate_decode_loop_for_training(
+                &last_logits,
+                &input_tokens,
+                &config,
+                eos_token_id,
+                &mut forward_fn,
+            )?;
+
+            drop(layers_guard);
+            drop(final_norm_guard);
+            drop(lm_head_guard);
+            drop(caches_guard);
+
+            result
         };
 
-        let result = crate::models::training_generate::generate_for_training_loop(
-            input_ids,
-            &config,
-            eos_token_id,
-            &mut forward_fn,
-        )?;
-
-        // Reset caches after generation
-        drop(layers_guard);
-        drop(final_norm_guard);
-        drop(lm_head_guard);
-        drop(caches_guard);
+        // Drop compiled lock before reset_caches
+        drop(compiled_lock);
         self.reset_caches()?;
 
         Ok(result)

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -11,6 +11,7 @@ use tracing::{info, warn};
 
 use crate::array::MxArray;
 use crate::array::mask::create_causal_mask;
+use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::sampling::{SamplingConfig, apply_repetition_penalty, check_repetition_cutoff, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
@@ -1880,7 +1881,7 @@ fn forward_inner(
             fa_mask.as_ref()
         };
         let cache = caches.as_mut().map(|c| &mut c[i]);
-        h = layers[i].forward(&h, mask, cache, None)?;
+        h = layers[i].forward(&h, mask, cache, None, true)?;
     }
 
     let h = final_norm.forward(&h)?;
@@ -1980,7 +1981,7 @@ impl Qwen3_5Model {
             };
 
             let cache = caches_guard.as_mut().map(|c| &mut c[i]);
-            h = layers_guard[i].forward(&h, mask, cache, None)?;
+            h = layers_guard[i].forward(&h, mask, cache, None, true)?;
         }
 
         // Drop locks early -- no longer needed
@@ -2048,7 +2049,7 @@ impl Qwen3_5Model {
             } else {
                 position_ids
             };
-            h = layers_guard[i].forward(&h, mask, cache, layer_pos)?;
+            h = layers_guard[i].forward(&h, mask, cache, layer_pos, true)?;
         }
 
         drop(layers_guard);
@@ -2152,6 +2153,426 @@ impl Qwen3_5Model {
     /// An all-ones mask is a no-op that adds unnecessary graph nodes and Metal overhead.
     fn create_ssm_mask(&self, _hidden_states: &MxArray) -> Result<Option<MxArray>> {
         Ok(None)
+    }
+}
+
+// ========== Training Support Methods ==========
+// These methods are Rust-internal only (not exposed via NAPI).
+// They implement the TrainableModel trait interface.
+
+impl Qwen3_5Model {
+    /// Get model configuration.
+    pub(crate) fn get_config(&self) -> Qwen3_5Config {
+        self.config.clone()
+    }
+
+    /// Create a cheap clone for training sessions.
+    /// Arc-clones all shared components, no deep copy.
+    pub(crate) fn clone_for_training(&self) -> Result<Self> {
+        Ok(Self {
+            config: self.config.clone(),
+            embedding: Embedding::from_weight(&self.embedding.get_weight())?,
+            layers: Arc::clone(&self.layers),
+            final_norm: Arc::clone(&self.final_norm),
+            lm_head: Arc::clone(&self.lm_head),
+            caches: Arc::new(RwLock::new(None)), // Fresh empty caches
+            tokenizer: self.tokenizer.clone(),
+            fa_idx: self.fa_idx,
+            vision_encoder: None, // Not needed for training
+            image_processor: None,
+            spatial_merge_size: None,
+            vision_cache: Arc::new(Mutex::new(VisionCacheInner {
+                entries: HashMap::new(),
+                generation: 0,
+            })),
+        })
+    }
+
+    /// Extract all trainable parameters as a name→array map.
+    ///
+    /// Parameter naming convention matches HuggingFace format:
+    /// - `embedding.weight`
+    /// - Linear attention layers: `layers.{i}.linear_attn.{in_proj_qkvz,in_proj_ba,conv1d,norm,out_proj}.weight`
+    /// - Linear attention learnable: `layers.{i}.linear_attn.{a_log,dt_bias}`
+    /// - Full attention layers: `layers.{i}.self_attn.{q_proj,k_proj,v_proj,o_proj}.weight`
+    /// - Full attention norms: `layers.{i}.self_attn.{q_norm,k_norm}.weight`
+    /// - All layers: `layers.{i}.mlp.{gate_proj,up_proj,down_proj}.weight`
+    /// - All layers: `layers.{i}.{input_layernorm,post_attention_layernorm}.weight`
+    /// - `final_norm.weight`
+    /// - `lm_head.weight` (if not tied)
+    pub(crate) fn get_parameters_for_training(&self) -> HashMap<String, MxArray> {
+        use super::decoder_layer::AttentionType;
+
+        let mut params = HashMap::new();
+
+        let layers_guard = self
+            .layers
+            .read()
+            .expect("Failed to acquire layers read lock");
+        let final_norm_guard = self
+            .final_norm
+            .read()
+            .expect("Failed to acquire final_norm read lock");
+        let lm_head_guard = self
+            .lm_head
+            .read()
+            .expect("Failed to acquire lm_head read lock");
+
+        // Embedding
+        params.insert("embedding.weight".to_string(), self.embedding.get_weight());
+
+        // Transformer layers
+        for (i, layer) in layers_guard.iter().enumerate() {
+            let prefix = format!("layers.{}", i);
+
+            match &layer.attn {
+                AttentionType::Linear(gdn) => {
+                    params.insert(
+                        format!("{}.linear_attn.in_proj_qkvz.weight", prefix),
+                        gdn.get_in_proj_qkvz_weight(),
+                    );
+                    params.insert(
+                        format!("{}.linear_attn.in_proj_ba.weight", prefix),
+                        gdn.get_in_proj_ba_weight(),
+                    );
+                    params.insert(
+                        format!("{}.linear_attn.conv1d.weight", prefix),
+                        gdn.get_conv1d_weight(),
+                    );
+                    params.insert(
+                        format!("{}.linear_attn.norm.weight", prefix),
+                        gdn.get_norm_weight(),
+                    );
+                    params.insert(
+                        format!("{}.linear_attn.out_proj.weight", prefix),
+                        gdn.get_out_proj_weight(),
+                    );
+                    params.insert(format!("{}.linear_attn.dt_bias", prefix), gdn.get_dt_bias());
+                    params.insert(format!("{}.linear_attn.a_log", prefix), gdn.get_a_log());
+                }
+                AttentionType::Full(attn) => {
+                    params.insert(
+                        format!("{}.self_attn.q_proj.weight", prefix),
+                        attn.get_q_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.k_proj.weight", prefix),
+                        attn.get_k_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.v_proj.weight", prefix),
+                        attn.get_v_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.o_proj.weight", prefix),
+                        attn.get_o_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.q_norm.weight", prefix),
+                        attn.get_q_norm_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.k_norm.weight", prefix),
+                        attn.get_k_norm_weight(),
+                    );
+                }
+            }
+
+            // MLP (all layers have dense MLP)
+            params.insert(
+                format!("{}.mlp.gate_proj.weight", prefix),
+                layer.mlp.get_gate_proj_weight(),
+            );
+            params.insert(
+                format!("{}.mlp.up_proj.weight", prefix),
+                layer.mlp.get_up_proj_weight(),
+            );
+            params.insert(
+                format!("{}.mlp.down_proj.weight", prefix),
+                layer.mlp.get_down_proj_weight(),
+            );
+
+            // Layer norms
+            params.insert(
+                format!("{}.input_layernorm.weight", prefix),
+                layer.get_input_layernorm_weight(),
+            );
+            params.insert(
+                format!("{}.post_attention_layernorm.weight", prefix),
+                layer.get_post_attention_layernorm_weight(),
+            );
+        }
+
+        // Final norm
+        params.insert(
+            "final_norm.weight".to_string(),
+            final_norm_guard.get_weight(),
+        );
+
+        // LM head (only if not tied)
+        if !self.config.tie_word_embeddings
+            && let Some(ref lm_head) = *lm_head_guard
+        {
+            params.insert("lm_head.weight".to_string(), lm_head.get_weight());
+        }
+
+        params
+    }
+
+    /// Apply gradients to model parameters using pre-fetched params.
+    /// SGD update: param = param - lr * grad.
+    pub(crate) fn apply_gradients_with_params(
+        &mut self,
+        gradients: HashMap<String, &MxArray>,
+        learning_rate: f64,
+        current_params: &HashMap<String, MxArray>,
+    ) -> Result<()> {
+        use crate::training_model::compute_sgd_updates;
+
+        // Compute updated parameters using shared SGD helper
+        let updated_params = compute_sgd_updates(&gradients, learning_rate, current_params)?;
+
+        // Acquire write locks
+        let mut layers = self.layers.write().map_err(|_| {
+            Error::new(
+                Status::GenericFailure,
+                "Failed to acquire layers write lock",
+            )
+        })?;
+        let mut final_norm = self.final_norm.write().map_err(|_| {
+            Error::new(
+                Status::GenericFailure,
+                "Failed to acquire final_norm write lock",
+            )
+        })?;
+        let mut lm_head = self.lm_head.write().map_err(|_| {
+            Error::new(
+                Status::GenericFailure,
+                "Failed to acquire lm_head write lock",
+            )
+        })?;
+
+        // Apply updates
+        for (name, updated_param) in updated_params.iter() {
+            if name == "lm_head.weight" {
+                if let Some(ref mut lm) = *lm_head {
+                    lm.set_weight(updated_param)?;
+                }
+            } else if name == "final_norm.weight" {
+                final_norm.set_weight(updated_param)?;
+            } else if name == "embedding.weight" {
+                self.embedding.set_weight(updated_param)?;
+            } else if name.starts_with("layers.") {
+                let parts: Vec<&str> = name.split('.').collect();
+                if parts.len() >= 3
+                    && let Ok(layer_idx) = parts[1].parse::<usize>()
+                    && layer_idx < layers.len()
+                {
+                    let layer = &mut layers[layer_idx];
+                    self.apply_layer_gradient(layer, name, updated_param)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn apply_layer_gradient(
+        &self,
+        layer: &mut super::decoder_layer::DecoderLayer,
+        name: &str,
+        updated_param: &MxArray,
+    ) -> Result<()> {
+        use super::decoder_layer::AttentionType;
+
+        if name.contains(".linear_attn.") {
+            if let AttentionType::Linear(ref mut gdn) = layer.attn {
+                if name.ends_with(".in_proj_qkvz.weight") {
+                    gdn.set_in_proj_qkvz_weight(updated_param)?;
+                } else if name.ends_with(".in_proj_ba.weight") {
+                    gdn.set_in_proj_ba_weight(updated_param)?;
+                } else if name.ends_with(".conv1d.weight") {
+                    gdn.set_conv1d_weight(updated_param)?;
+                } else if name.ends_with(".norm.weight") {
+                    gdn.set_norm_weight(updated_param)?;
+                } else if name.ends_with(".out_proj.weight") {
+                    gdn.set_out_proj_weight(updated_param)?;
+                } else if name.ends_with(".dt_bias") {
+                    gdn.set_dt_bias(updated_param);
+                } else if name.ends_with(".a_log") {
+                    gdn.set_a_log(updated_param)?;
+                }
+            }
+        } else if name.contains(".self_attn.") {
+            if let AttentionType::Full(ref mut attn) = layer.attn {
+                if name.ends_with(".q_proj.weight") {
+                    attn.set_q_proj_weight(updated_param)?;
+                } else if name.ends_with(".k_proj.weight") {
+                    attn.set_k_proj_weight(updated_param)?;
+                } else if name.ends_with(".v_proj.weight") {
+                    attn.set_v_proj_weight(updated_param)?;
+                } else if name.ends_with(".o_proj.weight") {
+                    attn.set_o_proj_weight(updated_param)?;
+                } else if name.ends_with(".q_norm.weight") {
+                    attn.set_q_norm_weight(updated_param)?;
+                } else if name.ends_with(".k_norm.weight") {
+                    attn.set_k_norm_weight(updated_param)?;
+                }
+            }
+        } else if name.contains(".mlp.") {
+            if name.ends_with(".gate_proj.weight") {
+                layer.mlp.set_gate_proj_weight(updated_param)?;
+            } else if name.ends_with(".up_proj.weight") {
+                layer.mlp.set_up_proj_weight(updated_param)?;
+            } else if name.ends_with(".down_proj.weight") {
+                layer.mlp.set_down_proj_weight(updated_param)?;
+            }
+        } else if name.ends_with(".input_layernorm.weight") {
+            layer.set_input_layernorm_weight(updated_param)?;
+        } else if name.ends_with(".post_attention_layernorm.weight") {
+            layer.set_post_attention_layernorm_weight(updated_param)?;
+        }
+
+        Ok(())
+    }
+
+    /// Tokenize messages using the model's chat template.
+    pub(crate) fn apply_chat_template_sync(
+        &self,
+        messages: &[ChatMessage],
+        add_generation_prompt: Option<bool>,
+        tools: Option<&[ToolDefinition]>,
+        enable_thinking: Option<bool>,
+    ) -> Result<Vec<u32>> {
+        let tokenizer = self.tokenizer.as_ref().ok_or_else(|| {
+            Error::from_reason("Tokenizer not loaded - call load_pretrained first")
+        })?;
+        tokenizer.apply_chat_template_sync(messages, add_generation_prompt, tools, enable_thinking)
+    }
+
+    /// Generate a single completion with logprob tracking (for GRPO training).
+    /// Uses the Rust forward path (NOT compiled C++) to ensure differentiability.
+    pub(crate) fn generate_for_training_sync(
+        &self,
+        input_ids: &MxArray,
+        config: Option<GenerationConfig>,
+    ) -> Result<GenerationResult> {
+        let config = config.unwrap_or_default();
+        let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
+
+        // Ensure caches exist
+        self.init_caches()?;
+
+        // Acquire locks
+        let embedding_weight = self.embedding.get_weight();
+        let mut layers_guard = self
+            .layers
+            .write()
+            .map_err(|_| Error::from_reason("Lock"))?;
+        let final_norm_guard = self
+            .final_norm
+            .read()
+            .map_err(|_| Error::from_reason("Lock"))?;
+        let lm_head_guard = self
+            .lm_head
+            .read()
+            .map_err(|_| Error::from_reason("Lock"))?;
+        let mut caches_guard = self
+            .caches
+            .write()
+            .map_err(|_| Error::from_reason("Lock"))?;
+
+        let fa_idx = self.fa_idx;
+        let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {
+            forward_inner(
+                ids,
+                &embedding_weight,
+                &mut layers_guard,
+                &mut caches_guard,
+                &final_norm_guard,
+                &lm_head_guard,
+                fa_idx,
+                None,
+            )
+        };
+
+        let result = crate::models::training_generate::generate_for_training_loop(
+            input_ids,
+            &config,
+            eos_token_id,
+            &mut forward_fn,
+        )?;
+
+        // Reset caches after generation
+        drop(layers_guard);
+        drop(final_norm_guard);
+        drop(lm_head_guard);
+        drop(caches_guard);
+        self.reset_caches()?;
+
+        Ok(result)
+    }
+
+    /// Generate a batch of completions for GRPO training.
+    pub(crate) fn generate_batch_for_training_sync(
+        &self,
+        prompt_arrays: &[MxArray],
+        group_size: usize,
+        config: Option<GenerationConfig>,
+    ) -> Result<BatchGenerationResult> {
+        let tokenizer = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?;
+
+        crate::models::training_generate::generate_batch_for_training_loop(
+            prompt_arrays,
+            group_size,
+            config,
+            tokenizer,
+            |prompt, cfg| self.generate_for_training_sync(prompt, cfg),
+        )
+    }
+
+    /// Decode token IDs to text.
+    pub(crate) fn decode_tokens_sync(&self, tokens: &MxArray) -> Result<String> {
+        let tokenizer = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?;
+        let token_ids = tokens.to_uint32()?;
+        tokenizer.decode_sync(&token_ids, true)
+    }
+
+    /// Calculate total memory size of all parameters in bytes.
+    pub(crate) fn calculate_memory_size(&self) -> usize {
+        let params = self.get_parameters_for_training();
+        params.values().map(|p| p.nbytes()).sum()
+    }
+
+    /// Save model weights and config to a directory.
+    pub(crate) fn save_model_sync(&self, path: &str) -> Result<()> {
+        use std::fs;
+
+        // Ensure directory exists
+        fs::create_dir_all(path)
+            .map_err(|e| Error::from_reason(format!("Failed to create directory: {}", e)))?;
+
+        // Save config.json
+        let config_json = serde_json::to_string_pretty(&self.config)
+            .map_err(|e| Error::from_reason(format!("Failed to serialize config: {}", e)))?;
+        fs::write(format!("{}/config.json", path), config_json)
+            .map_err(|e| Error::from_reason(format!("Failed to write config: {}", e)))?;
+
+        // Save weights as safetensors
+        let params = self.get_parameters_for_training();
+        crate::utils::safetensors::save_safetensors(
+            format!("{}/model.safetensors", path),
+            &params,
+            None,
+        )?;
+
+        Ok(())
     }
 }
 
@@ -2671,7 +3092,7 @@ fn vlm_prefill(
                 } else {
                     Some(&position_ids)
                 };
-                h = layers_guard[i].forward(&h, mask, cache, layer_pos)?;
+                h = layers_guard[i].forward(&h, mask, cache, layer_pos, true)?;
             }
 
             let h = final_norm_guard.forward(&h)?;

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2543,37 +2543,6 @@ impl Qwen3_5Model {
         let token_ids = tokens.to_uint32()?;
         tokenizer.decode_sync(&token_ids, true)
     }
-
-    /// Calculate total memory size of all parameters in bytes.
-    pub(crate) fn calculate_memory_size(&self) -> usize {
-        let params = self.get_parameters_for_training();
-        params.values().map(|p| p.nbytes()).sum()
-    }
-
-    /// Save model weights and config to a directory.
-    pub(crate) fn save_model_sync(&self, path: &str) -> Result<()> {
-        use std::fs;
-
-        // Ensure directory exists
-        fs::create_dir_all(path)
-            .map_err(|e| Error::from_reason(format!("Failed to create directory: {}", e)))?;
-
-        // Save config.json
-        let config_json = serde_json::to_string_pretty(&self.config)
-            .map_err(|e| Error::from_reason(format!("Failed to serialize config: {}", e)))?;
-        fs::write(format!("{}/config.json", path), config_json)
-            .map_err(|e| Error::from_reason(format!("Failed to write config: {}", e)))?;
-
-        // Save weights as safetensors
-        let params = self.get_parameters_for_training();
-        crate::utils::safetensors::save_safetensors(
-            format!("{}/model.safetensors", path),
-            &params,
-            None,
-        )?;
-
-        Ok(())
-    }
 }
 
 // ============================================================================

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1902,7 +1902,10 @@ impl Qwen3_5Model {
         // Serialize config and inject model_type for detectModelType
         let config = self.get_config();
         let mut config_value = serde_json::to_value(&config).map_err(|e| {
-            napi::Error::new(Status::GenericFailure, format!("Failed to serialize config: {e}"))
+            napi::Error::new(
+                Status::GenericFailure,
+                format!("Failed to serialize config: {e}"),
+            )
         })?;
         if let serde_json::Value::Object(ref mut map) = config_value {
             map.insert("model_type".to_string(), serde_json::json!("qwen3_5"));
@@ -1934,7 +1937,11 @@ impl Qwen3_5Model {
                     "format": "mlx-node",
                     "version": "1.0"
                 }));
-                crate::utils::safetensors::save_safetensors(&safetensors_path, &params_clone, metadata)?;
+                crate::utils::safetensors::save_safetensors(
+                    &safetensors_path,
+                    &params_clone,
+                    metadata,
+                )?;
                 info!("Saved weights.safetensors");
 
                 // 3. Save weights metadata (for reference)

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2200,7 +2200,7 @@ impl Qwen3_5Model {
     /// - All layers: `layers.{i}.{input_layernorm,post_attention_layernorm}.weight`
     /// - `final_norm.weight`
     /// - `lm_head.weight` (if not tied)
-    pub(crate) fn get_parameters_for_training(&self) -> HashMap<String, MxArray> {
+    pub(crate) fn get_parameters_for_training(&self) -> Result<HashMap<String, MxArray>> {
         use super::decoder_layer::AttentionType;
 
         let mut params = HashMap::new();
@@ -2208,15 +2208,15 @@ impl Qwen3_5Model {
         let layers_guard = self
             .layers
             .read()
-            .expect("Failed to acquire layers read lock");
+            .map_err(|_| Error::from_reason("Failed to acquire layers read lock"))?;
         let final_norm_guard = self
             .final_norm
             .read()
-            .expect("Failed to acquire final_norm read lock");
+            .map_err(|_| Error::from_reason("Failed to acquire final_norm read lock"))?;
         let lm_head_guard = self
             .lm_head
             .read()
-            .expect("Failed to acquire lm_head read lock");
+            .map_err(|_| Error::from_reason("Failed to acquire lm_head read lock"))?;
 
         // Embedding
         params.insert("embedding.weight".to_string(), self.embedding.get_weight());
@@ -2316,7 +2316,7 @@ impl Qwen3_5Model {
             params.insert("lm_head.weight".to_string(), lm_head.get_weight());
         }
 
-        params
+        Ok(params)
     }
 
     /// Apply gradients to model parameters using pre-fetched params.
@@ -2431,6 +2431,11 @@ impl Qwen3_5Model {
             layer.set_input_layernorm_weight(updated_param)?;
         } else if name.ends_with(".post_attention_layernorm.weight") {
             layer.set_post_attention_layernorm_weight(updated_param)?;
+        } else {
+            tracing::warn!(
+                "Unrecognized parameter name in apply_layer_gradient: {}",
+                name
+            );
         }
 
         Ok(())
@@ -2468,19 +2473,19 @@ impl Qwen3_5Model {
         let mut layers_guard = self
             .layers
             .write()
-            .map_err(|_| Error::from_reason("Lock"))?;
+            .map_err(|_| Error::from_reason("Failed to acquire layers write lock"))?;
         let final_norm_guard = self
             .final_norm
             .read()
-            .map_err(|_| Error::from_reason("Lock"))?;
+            .map_err(|_| Error::from_reason("Failed to acquire final_norm read lock"))?;
         let lm_head_guard = self
             .lm_head
             .read()
-            .map_err(|_| Error::from_reason("Lock"))?;
+            .map_err(|_| Error::from_reason("Failed to acquire lm_head read lock"))?;
         let mut caches_guard = self
             .caches
             .write()
-            .map_err(|_| Error::from_reason("Lock"))?;
+            .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
 
         let fa_idx = self.fa_idx;
         let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {

--- a/crates/mlx-core/src/models/qwen3_5/quantized_linear.rs
+++ b/crates/mlx-core/src/models/qwen3_5/quantized_linear.rs
@@ -59,6 +59,20 @@ impl LinearProj {
     pub fn set_quantized(&mut self, ql: QuantizedLinear) {
         *self = LinearProj::Quantized(ql);
     }
+
+    pub fn get_weight(&self) -> MxArray {
+        match self {
+            LinearProj::Standard(l) => l.get_weight(),
+            LinearProj::Quantized(ql) => ql.get_weight().clone(),
+        }
+    }
+
+    pub fn get_bias(&self) -> Option<MxArray> {
+        match self {
+            LinearProj::Standard(l) => l.get_bias(),
+            LinearProj::Quantized(_) => None,
+        }
+    }
 }
 
 /// An MLP that can be either standard or quantized.
@@ -86,6 +100,54 @@ impl MLPVariant {
                 let up = up_proj.forward(x)?;
                 let activated = Activations::swiglu(&gate, &up)?;
                 down_proj.forward(&activated)
+            }
+        }
+    }
+
+    pub fn get_gate_proj_weight(&self) -> MxArray {
+        match self {
+            MLPVariant::Standard(mlp) => mlp.get_gate_proj_weight(),
+            MLPVariant::Quantized { gate_proj, .. } => gate_proj.get_weight().clone(),
+        }
+    }
+
+    pub fn get_up_proj_weight(&self) -> MxArray {
+        match self {
+            MLPVariant::Standard(mlp) => mlp.get_up_proj_weight(),
+            MLPVariant::Quantized { up_proj, .. } => up_proj.get_weight().clone(),
+        }
+    }
+
+    pub fn get_down_proj_weight(&self) -> MxArray {
+        match self {
+            MLPVariant::Standard(mlp) => mlp.get_down_proj_weight(),
+            MLPVariant::Quantized { down_proj, .. } => down_proj.get_weight().clone(),
+        }
+    }
+
+    pub fn set_gate_proj_weight(&mut self, w: &MxArray) -> Result<()> {
+        match self {
+            MLPVariant::Standard(mlp) => mlp.set_gate_proj_weight(w),
+            MLPVariant::Quantized { .. } => {
+                Err(Error::from_reason("Cannot set weight on quantized MLP"))
+            }
+        }
+    }
+
+    pub fn set_up_proj_weight(&mut self, w: &MxArray) -> Result<()> {
+        match self {
+            MLPVariant::Standard(mlp) => mlp.set_up_proj_weight(w),
+            MLPVariant::Quantized { .. } => {
+                Err(Error::from_reason("Cannot set weight on quantized MLP"))
+            }
+        }
+    }
+
+    pub fn set_down_proj_weight(&mut self, w: &MxArray) -> Result<()> {
+        match self {
+            MLPVariant::Standard(mlp) => mlp.set_down_proj_weight(w),
+            MLPVariant::Quantized { .. } => {
+                Err(Error::from_reason("Cannot set weight on quantized MLP"))
             }
         }
     }

--- a/crates/mlx-core/src/models/qwen3_5/vision.rs
+++ b/crates/mlx-core/src/models/qwen3_5/vision.rs
@@ -11,6 +11,7 @@ use crate::vision::encoder::VisionEncoderLayer;
 use crate::vision::projector::SpatialProjector;
 use crate::vision::rope_vision::VisionRotaryEmbedding;
 use napi::bindgen_prelude::*;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Qwen3.5 Vision Encoder configuration
@@ -106,6 +107,99 @@ impl Qwen3_5VisionEncoder {
     /// Set the merger (spatial projector)
     pub fn set_merger(&mut self, merger: SpatialProjector) {
         self.merger = Some(Arc::new(merger));
+    }
+
+    /// Extract all vision encoder parameters as a flat map.
+    ///
+    /// Keys use the `visual.` prefix so they round-trip through save/load
+    /// (load_pretrained detects keys starting with `visual.`).
+    /// Internal keys mirror the load convention: `patch_embed.proj.weight`,
+    /// `pos_embed.weight`, `blocks.{i}.attn.qkv.weight`, etc.
+    pub fn get_parameters(&self) -> HashMap<String, MxArray> {
+        let mut params = HashMap::new();
+
+        // Patch embedding
+        params.insert(
+            "visual.patch_embed.proj.weight".to_string(),
+            self.patch_embed.weight(),
+        );
+
+        // Position embedding
+        if let Some(ref pe) = self.pos_embed {
+            params.insert("visual.pos_embed.weight".to_string(), pe.as_ref().clone());
+        }
+
+        // Encoder layers
+        for (i, layer) in self.layers.iter().enumerate() {
+            let prefix = format!("visual.blocks.{}", i);
+
+            // Attention
+            let attn = layer.self_attn();
+            params.insert(format!("{}.attn.qkv.weight", prefix), attn.get_qkv_weight());
+            if let Some(b) = attn.get_qkv_bias() {
+                params.insert(format!("{}.attn.qkv.bias", prefix), b);
+            }
+            params.insert(
+                format!("{}.attn.proj.weight", prefix),
+                attn.get_out_proj_weight(),
+            );
+            if let Some(b) = attn.get_out_proj_bias() {
+                params.insert(format!("{}.attn.proj.bias", prefix), b);
+            }
+
+            // MLP
+            let mlp = layer.mlp();
+            params.insert(
+                format!("{}.mlp.linear_fc1.weight", prefix),
+                mlp.get_fc1_weight(),
+            );
+            if let Some(b) = mlp.get_fc1_bias() {
+                params.insert(format!("{}.mlp.linear_fc1.bias", prefix), b);
+            }
+            params.insert(
+                format!("{}.mlp.linear_fc2.weight", prefix),
+                mlp.get_fc2_weight(),
+            );
+            if let Some(b) = mlp.get_fc2_bias() {
+                params.insert(format!("{}.mlp.linear_fc2.bias", prefix), b);
+            }
+
+            // Layer norms
+            let ln1 = layer.layer_norm1();
+            params.insert(format!("{}.norm1.weight", prefix), ln1.get_weight());
+            params.insert(format!("{}.norm1.bias", prefix), ln1.get_bias());
+
+            let ln2 = layer.layer_norm2();
+            params.insert(format!("{}.norm2.weight", prefix), ln2.get_weight());
+            params.insert(format!("{}.norm2.bias", prefix), ln2.get_bias());
+        }
+
+        // Merger (spatial projector)
+        if let Some(ref merger) = self.merger {
+            let norm = merger.pre_norm();
+            params.insert("visual.merger.norm.weight".to_string(), norm.get_weight());
+            params.insert("visual.merger.norm.bias".to_string(), norm.get_bias());
+
+            let l1 = merger.linear_1();
+            params.insert(
+                "visual.merger.linear_fc1.weight".to_string(),
+                l1.get_weight(),
+            );
+            if let Some(b) = l1.get_bias() {
+                params.insert("visual.merger.linear_fc1.bias".to_string(), b);
+            }
+
+            let l2 = merger.linear_2();
+            params.insert(
+                "visual.merger.linear_fc2.weight".to_string(),
+                l2.get_weight(),
+            );
+            if let Some(b) = l2.get_bias() {
+                params.insert("visual.merger.linear_fc2.bias".to_string(), b);
+            }
+        }
+
+        params
     }
 
     /// Compute 2D rotary position embeddings for the grid

--- a/crates/mlx-core/src/models/qwen3_5_moe/decoder_layer.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/decoder_layer.rs
@@ -80,12 +80,13 @@ impl DecoderLayer {
         mask: Option<&MxArray>,
         cache: Option<&mut Qwen3_5LayerCache>,
         position_ids: Option<&MxArray>,
+        use_kernel: bool,
     ) -> Result<MxArray> {
         let normed = self.input_layernorm.forward(x)?;
         let attn_out = match &mut self.attn {
             AttentionType::Linear(gdn) => {
                 let ac = cache.and_then(|c| c.as_arrays_cache_mut());
-                gdn.forward(&normed, mask, ac)?
+                gdn.forward(&normed, mask, ac, use_kernel)?
             }
             AttentionType::Full(attn) => {
                 let kvc = cache.and_then(|c| c.as_kv_cache_mut());
@@ -110,6 +111,16 @@ impl DecoderLayer {
 
     pub fn set_post_attention_layernorm_weight(&mut self, w: &MxArray) -> Result<()> {
         self.post_attention_layernorm.set_weight(w)
+    }
+
+    // ========== Weight getters (for training parameter extraction) ==========
+
+    pub fn get_input_layernorm_weight(&self) -> MxArray {
+        self.input_layernorm.get_weight()
+    }
+
+    pub fn get_post_attention_layernorm_weight(&self) -> MxArray {
+        self.post_attention_layernorm.get_weight()
     }
 
     pub fn set_quantized_dense_mlp(

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1784,7 +1784,10 @@ impl Qwen3_5MoeModel {
         // Serialize config and inject model_type for detectModelType
         let config = self.get_config();
         let mut config_value = serde_json::to_value(&config).map_err(|e| {
-            napi::Error::new(Status::GenericFailure, format!("Failed to serialize config: {e}"))
+            napi::Error::new(
+                Status::GenericFailure,
+                format!("Failed to serialize config: {e}"),
+            )
         })?;
         if let serde_json::Value::Object(ref mut map) = config_value {
             map.insert("model_type".to_string(), serde_json::json!("qwen3_5_moe"));
@@ -1816,7 +1819,11 @@ impl Qwen3_5MoeModel {
                     "format": "mlx-node",
                     "version": "1.0"
                 }));
-                crate::utils::safetensors::save_safetensors(&safetensors_path, &params_clone, metadata)?;
+                crate::utils::safetensors::save_safetensors(
+                    &safetensors_path,
+                    &params_clone,
+                    metadata,
+                )?;
                 info!("Saved weights.safetensors");
 
                 // 3. Save weights metadata (for reference)

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -2165,7 +2165,7 @@ impl Qwen3_5MoeModel {
     /// - All layers: `layers.{i}.{input_layernorm,post_attention_layernorm}.weight`
     /// - `final_norm.weight`
     /// - `lm_head.weight` (if not tied)
-    pub(crate) fn get_parameters_for_training(&self) -> HashMap<String, MxArray> {
+    pub(crate) fn get_parameters_for_training(&self) -> Result<HashMap<String, MxArray>> {
         use super::decoder_layer::{AttentionType, MLPType};
 
         let mut params = HashMap::new();
@@ -2173,15 +2173,15 @@ impl Qwen3_5MoeModel {
         let layers_guard = self
             .layers
             .read()
-            .expect("Failed to acquire layers read lock");
+            .map_err(|_| Error::from_reason("Failed to acquire layers read lock"))?;
         let final_norm_guard = self
             .final_norm
             .read()
-            .expect("Failed to acquire final_norm read lock");
+            .map_err(|_| Error::from_reason("Failed to acquire final_norm read lock"))?;
         let lm_head_guard = self
             .lm_head
             .read()
-            .expect("Failed to acquire lm_head read lock");
+            .map_err(|_| Error::from_reason("Failed to acquire lm_head read lock"))?;
 
         // Embedding
         params.insert("embedding.weight".to_string(), self.embedding.get_weight());
@@ -2322,7 +2322,7 @@ impl Qwen3_5MoeModel {
             params.insert("lm_head.weight".to_string(), lm_head.get_weight());
         }
 
-        params
+        Ok(params)
     }
 
     /// Apply gradients to model parameters using pre-fetched params.
@@ -2464,6 +2464,11 @@ impl Qwen3_5MoeModel {
             layer.set_input_layernorm_weight(updated_param)?;
         } else if name.ends_with(".post_attention_layernorm.weight") {
             layer.set_post_attention_layernorm_weight(updated_param)?;
+        } else {
+            tracing::warn!(
+                "Unrecognized parameter name in apply_layer_gradient: {}",
+                name
+            );
         }
 
         Ok(())
@@ -2501,19 +2506,19 @@ impl Qwen3_5MoeModel {
         let mut layers_guard = self
             .layers
             .write()
-            .map_err(|_| Error::from_reason("Lock"))?;
+            .map_err(|_| Error::from_reason("Failed to acquire layers write lock"))?;
         let final_norm_guard = self
             .final_norm
             .read()
-            .map_err(|_| Error::from_reason("Lock"))?;
+            .map_err(|_| Error::from_reason("Failed to acquire final_norm read lock"))?;
         let lm_head_guard = self
             .lm_head
             .read()
-            .map_err(|_| Error::from_reason("Lock"))?;
+            .map_err(|_| Error::from_reason("Failed to acquire lm_head read lock"))?;
         let mut caches_guard = self
             .caches
             .write()
-            .map_err(|_| Error::from_reason("Lock"))?;
+            .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
 
         let fa_idx = self.fa_idx;
         let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -2576,35 +2576,4 @@ impl Qwen3_5MoeModel {
         let token_ids = tokens.to_uint32()?;
         tokenizer.decode_sync(&token_ids, true)
     }
-
-    /// Calculate total memory size of all parameters in bytes.
-    pub(crate) fn calculate_memory_size(&self) -> usize {
-        let params = self.get_parameters_for_training();
-        params.values().map(|p| p.nbytes()).sum()
-    }
-
-    /// Save model weights and config to a directory.
-    pub(crate) fn save_model_sync(&self, path: &str) -> Result<()> {
-        use std::fs;
-
-        // Ensure directory exists
-        fs::create_dir_all(path)
-            .map_err(|e| Error::from_reason(format!("Failed to create directory: {}", e)))?;
-
-        // Save config.json
-        let config_json = serde_json::to_string_pretty(&self.config)
-            .map_err(|e| Error::from_reason(format!("Failed to serialize config: {}", e)))?;
-        fs::write(format!("{}/config.json", path), config_json)
-            .map_err(|e| Error::from_reason(format!("Failed to write config: {}", e)))?;
-
-        // Save weights as safetensors
-        let params = self.get_parameters_for_training();
-        crate::utils::safetensors::save_safetensors(
-            format!("{}/model.safetensors", path),
-            &params,
-            None,
-        )?;
-
-        Ok(())
-    }
 }

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -20,10 +20,11 @@ use crate::models::qwen3_5::vision::Qwen3_5VisionEncoder;
 use super::quantized_linear::LinearProj;
 use crate::array::MxArray;
 use crate::array::mask::create_causal_mask;
+use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::sampling::{SamplingConfig, apply_repetition_penalty, check_repetition_cutoff, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
-use crate::tokenizer::{ChatMessage, Qwen3Tokenizer};
+use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::tools;
 
 use super::config::Qwen3_5MoeConfig;
@@ -1759,7 +1760,7 @@ fn forward_inner(
             fa_mask.as_ref()
         };
         let cache = caches.as_mut().map(|c| &mut c[i]);
-        h = layers[i].forward(&h, mask, cache, None)?;
+        h = layers[i].forward(&h, mask, cache, None, true)?;
     }
 
     let h = final_norm.forward(&h)?;
@@ -1949,7 +1950,7 @@ fn vlm_prefill_moe(
             } else {
                 Some(&position_ids)
             };
-            h = layers_guard[i].forward(&h, mask, cache, layer_pos)?;
+            h = layers_guard[i].forward(&h, mask, cache, layer_pos, true)?;
         }
 
         let h = final_norm_guard.forward(&h)?;
@@ -2047,7 +2048,7 @@ impl Qwen3_5MoeModel {
             } else {
                 position_ids
             };
-            h = layers_guard[i].forward(&h, mask, cache, layer_pos)?;
+            h = layers_guard[i].forward(&h, mask, cache, layer_pos, true)?;
         }
 
         drop(layers_guard);
@@ -2112,5 +2113,498 @@ impl Qwen3_5MoeModel {
     /// Set the spatial merge size.
     pub(crate) fn set_spatial_merge_size(&mut self, size: i32) {
         self.spatial_merge_size = Some(size);
+    }
+}
+
+// ========== Training Support Methods ==========
+// These methods are Rust-internal only (not exposed via NAPI).
+// They implement the TrainableModel trait interface for MoE.
+
+impl Qwen3_5MoeModel {
+    /// Get model configuration.
+    pub(crate) fn get_config(&self) -> Qwen3_5MoeConfig {
+        self.config.clone()
+    }
+
+    /// Create a cheap clone for training sessions.
+    /// Arc-clones all shared components, no deep copy. No VLM components.
+    pub(crate) fn clone_for_training(&self) -> Result<Self> {
+        Ok(Self {
+            config: self.config.clone(),
+            embedding: Embedding::from_weight(&self.embedding.get_weight())?,
+            layers: Arc::clone(&self.layers),
+            final_norm: Arc::clone(&self.final_norm),
+            lm_head: Arc::clone(&self.lm_head),
+            caches: Arc::new(RwLock::new(None)), // Fresh empty caches
+            tokenizer: self.tokenizer.clone(),
+            fa_idx: self.fa_idx,
+            vision_encoder: None, // Not needed for training
+            image_processor: None,
+            spatial_merge_size: None,
+            vision_cache: Arc::new(Mutex::new(VisionCacheInner {
+                entries: HashMap::new(),
+                generation: 0,
+            })),
+        })
+    }
+
+    /// Extract all trainable parameters as a name->array map.
+    ///
+    /// Parameter naming convention matches HuggingFace format:
+    /// - `embedding.weight`
+    /// - Linear attention layers: `layers.{i}.linear_attn.{in_proj_qkvz,in_proj_ba,conv1d,norm,out_proj}.weight`
+    /// - Linear attention learnable: `layers.{i}.linear_attn.{a_log,dt_bias}`
+    /// - Full attention layers: `layers.{i}.self_attn.{q_proj,k_proj,v_proj,o_proj}.weight`
+    /// - Full attention norms: `layers.{i}.self_attn.{q_norm,k_norm}.weight`
+    /// - Dense MLP layers: `layers.{i}.mlp.{gate_proj,up_proj,down_proj}.weight`
+    /// - MoE layers:
+    ///   - `layers.{i}.mlp.gate.weight` (router)
+    ///   - `layers.{i}.mlp.switch_mlp.{gate_proj,up_proj,down_proj}.weight` (expert weights 3D)
+    ///   - `layers.{i}.mlp.shared_expert.{gate_proj,up_proj,down_proj}.weight`
+    ///   - `layers.{i}.mlp.shared_expert_gate.weight`
+    /// - All layers: `layers.{i}.{input_layernorm,post_attention_layernorm}.weight`
+    /// - `final_norm.weight`
+    /// - `lm_head.weight` (if not tied)
+    pub(crate) fn get_parameters_for_training(&self) -> HashMap<String, MxArray> {
+        use super::decoder_layer::{AttentionType, MLPType};
+
+        let mut params = HashMap::new();
+
+        let layers_guard = self
+            .layers
+            .read()
+            .expect("Failed to acquire layers read lock");
+        let final_norm_guard = self
+            .final_norm
+            .read()
+            .expect("Failed to acquire final_norm read lock");
+        let lm_head_guard = self
+            .lm_head
+            .read()
+            .expect("Failed to acquire lm_head read lock");
+
+        // Embedding
+        params.insert("embedding.weight".to_string(), self.embedding.get_weight());
+
+        // Transformer layers
+        for (i, layer) in layers_guard.iter().enumerate() {
+            let prefix = format!("layers.{}", i);
+
+            // Attention weights
+            match &layer.attn {
+                AttentionType::Linear(gdn) => {
+                    params.insert(
+                        format!("{}.linear_attn.in_proj_qkvz.weight", prefix),
+                        gdn.get_in_proj_qkvz_weight(),
+                    );
+                    params.insert(
+                        format!("{}.linear_attn.in_proj_ba.weight", prefix),
+                        gdn.get_in_proj_ba_weight(),
+                    );
+                    params.insert(
+                        format!("{}.linear_attn.conv1d.weight", prefix),
+                        gdn.get_conv1d_weight(),
+                    );
+                    params.insert(
+                        format!("{}.linear_attn.norm.weight", prefix),
+                        gdn.get_norm_weight(),
+                    );
+                    params.insert(
+                        format!("{}.linear_attn.out_proj.weight", prefix),
+                        gdn.get_out_proj_weight(),
+                    );
+                    params.insert(format!("{}.linear_attn.dt_bias", prefix), gdn.get_dt_bias());
+                    params.insert(format!("{}.linear_attn.a_log", prefix), gdn.get_a_log());
+                }
+                AttentionType::Full(attn) => {
+                    params.insert(
+                        format!("{}.self_attn.q_proj.weight", prefix),
+                        attn.get_q_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.k_proj.weight", prefix),
+                        attn.get_k_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.v_proj.weight", prefix),
+                        attn.get_v_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.o_proj.weight", prefix),
+                        attn.get_o_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.q_norm.weight", prefix),
+                        attn.get_q_norm_weight(),
+                    );
+                    params.insert(
+                        format!("{}.self_attn.k_norm.weight", prefix),
+                        attn.get_k_norm_weight(),
+                    );
+                }
+            }
+
+            // MLP weights — different for Dense vs MoE layers
+            match &layer.mlp {
+                MLPType::Dense(mlp) => {
+                    params.insert(
+                        format!("{}.mlp.gate_proj.weight", prefix),
+                        mlp.get_gate_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.mlp.up_proj.weight", prefix),
+                        mlp.get_up_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.mlp.down_proj.weight", prefix),
+                        mlp.get_down_proj_weight(),
+                    );
+                }
+                MLPType::MoE(moe) => {
+                    // Router gate
+                    params.insert(format!("{}.mlp.gate.weight", prefix), moe.get_gate_weight());
+                    // Expert weights (3D: [num_experts, out, in])
+                    let switch_mlp = moe.get_switch_mlp();
+                    params.insert(
+                        format!("{}.mlp.switch_mlp.gate_proj.weight", prefix),
+                        switch_mlp.get_gate_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.mlp.switch_mlp.up_proj.weight", prefix),
+                        switch_mlp.get_up_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.mlp.switch_mlp.down_proj.weight", prefix),
+                        switch_mlp.get_down_proj_weight(),
+                    );
+                    // Shared expert
+                    params.insert(
+                        format!("{}.mlp.shared_expert.gate_proj.weight", prefix),
+                        moe.get_shared_expert_gate_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.mlp.shared_expert.up_proj.weight", prefix),
+                        moe.get_shared_expert_up_proj_weight(),
+                    );
+                    params.insert(
+                        format!("{}.mlp.shared_expert.down_proj.weight", prefix),
+                        moe.get_shared_expert_down_proj_weight(),
+                    );
+                    // Shared expert gate
+                    params.insert(
+                        format!("{}.mlp.shared_expert_gate.weight", prefix),
+                        moe.get_shared_expert_gate_weight(),
+                    );
+                }
+            }
+
+            // Layer norms
+            params.insert(
+                format!("{}.input_layernorm.weight", prefix),
+                layer.get_input_layernorm_weight(),
+            );
+            params.insert(
+                format!("{}.post_attention_layernorm.weight", prefix),
+                layer.get_post_attention_layernorm_weight(),
+            );
+        }
+
+        // Final norm
+        params.insert(
+            "final_norm.weight".to_string(),
+            final_norm_guard.get_weight(),
+        );
+
+        // LM head (only if not tied)
+        if !self.config.tie_word_embeddings
+            && let Some(ref lm_head) = *lm_head_guard
+        {
+            params.insert("lm_head.weight".to_string(), lm_head.get_weight());
+        }
+
+        params
+    }
+
+    /// Apply gradients to model parameters using pre-fetched params.
+    /// SGD update: param = param - lr * grad.
+    pub(crate) fn apply_gradients_with_params(
+        &mut self,
+        gradients: HashMap<String, &MxArray>,
+        learning_rate: f64,
+        current_params: &HashMap<String, MxArray>,
+    ) -> Result<()> {
+        use crate::training_model::compute_sgd_updates;
+
+        // Compute updated parameters using shared SGD helper
+        let updated_params = compute_sgd_updates(&gradients, learning_rate, current_params)?;
+
+        // Acquire write locks
+        let mut layers = self.layers.write().map_err(|_| {
+            Error::new(
+                Status::GenericFailure,
+                "Failed to acquire layers write lock",
+            )
+        })?;
+        let mut final_norm = self.final_norm.write().map_err(|_| {
+            Error::new(
+                Status::GenericFailure,
+                "Failed to acquire final_norm write lock",
+            )
+        })?;
+        let mut lm_head = self.lm_head.write().map_err(|_| {
+            Error::new(
+                Status::GenericFailure,
+                "Failed to acquire lm_head write lock",
+            )
+        })?;
+
+        // Apply updates
+        for (name, updated_param) in updated_params.iter() {
+            if name == "lm_head.weight" {
+                if let Some(ref mut lm) = *lm_head {
+                    lm.set_weight(updated_param, "lm_head")?;
+                }
+            } else if name == "final_norm.weight" {
+                final_norm.set_weight(updated_param)?;
+            } else if name == "embedding.weight" {
+                self.embedding.set_weight(updated_param)?;
+            } else if name.starts_with("layers.") {
+                let parts: Vec<&str> = name.split('.').collect();
+                if parts.len() >= 3
+                    && let Ok(layer_idx) = parts[1].parse::<usize>()
+                    && layer_idx < layers.len()
+                {
+                    let layer = &mut layers[layer_idx];
+                    self.apply_layer_gradient(layer, name, updated_param)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn apply_layer_gradient(
+        &self,
+        layer: &mut super::decoder_layer::DecoderLayer,
+        name: &str,
+        updated_param: &MxArray,
+    ) -> Result<()> {
+        use super::decoder_layer::{AttentionType, MLPType};
+
+        if name.contains(".linear_attn.") {
+            if let AttentionType::Linear(ref mut gdn) = layer.attn {
+                if name.ends_with(".in_proj_qkvz.weight") {
+                    gdn.set_in_proj_qkvz_weight(updated_param)?;
+                } else if name.ends_with(".in_proj_ba.weight") {
+                    gdn.set_in_proj_ba_weight(updated_param)?;
+                } else if name.ends_with(".conv1d.weight") {
+                    gdn.set_conv1d_weight(updated_param)?;
+                } else if name.ends_with(".norm.weight") {
+                    gdn.set_norm_weight(updated_param)?;
+                } else if name.ends_with(".out_proj.weight") {
+                    gdn.set_out_proj_weight(updated_param)?;
+                } else if name.ends_with(".dt_bias") {
+                    gdn.set_dt_bias(updated_param);
+                } else if name.ends_with(".a_log") {
+                    gdn.set_a_log(updated_param)?;
+                }
+            }
+        } else if name.contains(".self_attn.") {
+            if let AttentionType::Full(ref mut attn) = layer.attn {
+                if name.ends_with(".q_proj.weight") {
+                    attn.set_q_proj_weight(updated_param)?;
+                } else if name.ends_with(".k_proj.weight") {
+                    attn.set_k_proj_weight(updated_param)?;
+                } else if name.ends_with(".v_proj.weight") {
+                    attn.set_v_proj_weight(updated_param)?;
+                } else if name.ends_with(".o_proj.weight") {
+                    attn.set_o_proj_weight(updated_param)?;
+                } else if name.ends_with(".q_norm.weight") {
+                    attn.set_q_norm_weight(updated_param)?;
+                } else if name.ends_with(".k_norm.weight") {
+                    attn.set_k_norm_weight(updated_param)?;
+                }
+            }
+        } else if name.contains(".mlp.") {
+            match &mut layer.mlp {
+                MLPType::Dense(mlp) => {
+                    if name.ends_with(".gate_proj.weight") {
+                        mlp.set_gate_proj_weight(updated_param)?;
+                    } else if name.ends_with(".up_proj.weight") {
+                        mlp.set_up_proj_weight(updated_param)?;
+                    } else if name.ends_with(".down_proj.weight") {
+                        mlp.set_down_proj_weight(updated_param)?;
+                    }
+                }
+                MLPType::MoE(moe) => {
+                    if name.ends_with(".mlp.gate.weight") {
+                        moe.set_gate_weight(updated_param)?;
+                    } else if name.contains(".mlp.switch_mlp.") {
+                        if name.ends_with(".gate_proj.weight") {
+                            moe.set_switch_mlp_gate_proj_weight(updated_param);
+                        } else if name.ends_with(".up_proj.weight") {
+                            moe.set_switch_mlp_up_proj_weight(updated_param);
+                        } else if name.ends_with(".down_proj.weight") {
+                            moe.set_switch_mlp_down_proj_weight(updated_param);
+                        }
+                    } else if name.contains(".mlp.shared_expert_gate.") {
+                        moe.set_shared_expert_gate_weight(updated_param)?;
+                    } else if name.contains(".mlp.shared_expert.") {
+                        if name.ends_with(".gate_proj.weight") {
+                            moe.set_shared_expert_gate_proj_weight(updated_param)?;
+                        } else if name.ends_with(".up_proj.weight") {
+                            moe.set_shared_expert_up_proj_weight(updated_param)?;
+                        } else if name.ends_with(".down_proj.weight") {
+                            moe.set_shared_expert_down_proj_weight(updated_param)?;
+                        }
+                    }
+                }
+            }
+        } else if name.ends_with(".input_layernorm.weight") {
+            layer.set_input_layernorm_weight(updated_param)?;
+        } else if name.ends_with(".post_attention_layernorm.weight") {
+            layer.set_post_attention_layernorm_weight(updated_param)?;
+        }
+
+        Ok(())
+    }
+
+    /// Tokenize messages using the model's chat template.
+    pub(crate) fn apply_chat_template_sync(
+        &self,
+        messages: &[ChatMessage],
+        add_generation_prompt: Option<bool>,
+        tools: Option<&[ToolDefinition]>,
+        enable_thinking: Option<bool>,
+    ) -> Result<Vec<u32>> {
+        let tokenizer = self.tokenizer.as_ref().ok_or_else(|| {
+            Error::from_reason("Tokenizer not loaded - call load_pretrained first")
+        })?;
+        tokenizer.apply_chat_template_sync(messages, add_generation_prompt, tools, enable_thinking)
+    }
+
+    /// Generate a single completion with logprob tracking (for GRPO training).
+    /// Uses the Rust forward path (NOT compiled C++) to ensure differentiability.
+    pub(crate) fn generate_for_training_sync(
+        &self,
+        input_ids: &MxArray,
+        config: Option<GenerationConfig>,
+    ) -> Result<GenerationResult> {
+        let config = config.unwrap_or_default();
+        let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
+
+        // Ensure caches exist
+        self.init_caches()?;
+
+        // Acquire locks
+        let embedding_weight = self.embedding.get_weight();
+        let mut layers_guard = self
+            .layers
+            .write()
+            .map_err(|_| Error::from_reason("Lock"))?;
+        let final_norm_guard = self
+            .final_norm
+            .read()
+            .map_err(|_| Error::from_reason("Lock"))?;
+        let lm_head_guard = self
+            .lm_head
+            .read()
+            .map_err(|_| Error::from_reason("Lock"))?;
+        let mut caches_guard = self
+            .caches
+            .write()
+            .map_err(|_| Error::from_reason("Lock"))?;
+
+        let fa_idx = self.fa_idx;
+        let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {
+            forward_inner(
+                ids,
+                &embedding_weight,
+                &mut layers_guard,
+                &mut caches_guard,
+                &final_norm_guard,
+                &lm_head_guard,
+                fa_idx,
+                None,
+            )
+        };
+
+        let result = crate::models::training_generate::generate_for_training_loop(
+            input_ids,
+            &config,
+            eos_token_id,
+            &mut forward_fn,
+        )?;
+
+        // Reset caches after generation
+        drop(layers_guard);
+        drop(final_norm_guard);
+        drop(lm_head_guard);
+        drop(caches_guard);
+        self.reset_caches()?;
+
+        Ok(result)
+    }
+
+    /// Generate a batch of completions for GRPO training.
+    pub(crate) fn generate_batch_for_training_sync(
+        &self,
+        prompt_arrays: &[MxArray],
+        group_size: usize,
+        config: Option<GenerationConfig>,
+    ) -> Result<BatchGenerationResult> {
+        let tokenizer = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?;
+
+        crate::models::training_generate::generate_batch_for_training_loop(
+            prompt_arrays,
+            group_size,
+            config,
+            tokenizer,
+            |prompt, cfg| self.generate_for_training_sync(prompt, cfg),
+        )
+    }
+
+    /// Decode token IDs to text.
+    pub(crate) fn decode_tokens_sync(&self, tokens: &MxArray) -> Result<String> {
+        let tokenizer = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?;
+        let token_ids = tokens.to_uint32()?;
+        tokenizer.decode_sync(&token_ids, true)
+    }
+
+    /// Calculate total memory size of all parameters in bytes.
+    pub(crate) fn calculate_memory_size(&self) -> usize {
+        let params = self.get_parameters_for_training();
+        params.values().map(|p| p.nbytes()).sum()
+    }
+
+    /// Save model weights and config to a directory.
+    pub(crate) fn save_model_sync(&self, path: &str) -> Result<()> {
+        use std::fs;
+
+        // Ensure directory exists
+        fs::create_dir_all(path)
+            .map_err(|e| Error::from_reason(format!("Failed to create directory: {}", e)))?;
+
+        // Save config.json
+        let config_json = serde_json::to_string_pretty(&self.config)
+            .map_err(|e| Error::from_reason(format!("Failed to serialize config: {}", e)))?;
+        fs::write(format!("{}/config.json", path), config_json)
+            .map_err(|e| Error::from_reason(format!("Failed to write config: {}", e)))?;
+
+        // Save weights as safetensors
+        let params = self.get_parameters_for_training();
+        crate::utils::safetensors::save_safetensors(
+            format!("{}/model.safetensors", path),
+            &params,
+            None,
+        )?;
+
+        Ok(())
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
+use futures::TryFutureExt;
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
@@ -1719,6 +1720,126 @@ impl Qwen3_5MoeModel {
         total += h;
         total
     }
+
+    /// Save the model weights and configuration to a directory.
+    ///
+    /// This saves:
+    /// - config.json: Model configuration (with model_type for detectModelType)
+    /// - weights.safetensors: Full model weights in SafeTensors format
+    /// - weights.mlx: Parameter metadata (for reference)
+    ///
+    /// # Arguments
+    /// * `save_path` - Directory to save the model
+    #[napi]
+    pub fn save_model<'env>(
+        &self,
+        env: &'env Env,
+        save_path: String,
+    ) -> Result<PromiseRaw<'env, ()>> {
+        let mut params = self.get_parameters_for_training()?;
+
+        // Include vision encoder weights when present (VLM models)
+        if let Some(ref vision_enc) = self.vision_encoder {
+            let vision_params = vision_enc.get_parameters();
+            params.extend(vision_params);
+        }
+
+        // Validate all parameters for NaN/Inf before saving
+        for (name, param) in params.iter() {
+            let data = param.to_float32()?;
+            let invalid_count = data
+                .iter()
+                .filter(|v| v.is_nan() || v.is_infinite())
+                .count();
+            if invalid_count > 0 {
+                return Err(napi::Error::new(
+                    Status::GenericFailure,
+                    format!(
+                        "Cannot save model: parameter '{}' contains {} NaN/Inf values. \
+                        Model weights are corrupted, likely due to training instability. \
+                        Consider reducing learning rate or using an earlier checkpoint.",
+                        name, invalid_count
+                    ),
+                ));
+            }
+        }
+
+        let params_clone: HashMap<String, MxArray> =
+            params.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+        // Create weights metadata (for reference)
+        let mut weights_metadata = serde_json::Map::new();
+        for (key, array) in params.iter() {
+            let shape_data = array.shape()?;
+            let shape: Vec<i64> = shape_data.as_ref().to_vec();
+            let dtype = array.dtype()?;
+
+            let mut param_info = serde_json::Map::new();
+            param_info.insert("shape".to_string(), serde_json::json!(shape));
+            param_info.insert("dtype".to_string(), serde_json::json!(dtype as i32));
+
+            weights_metadata.insert(key.clone(), serde_json::Value::Object(param_info));
+        }
+
+        // Serialize config and inject model_type for detectModelType
+        let config = self.get_config();
+        let mut config_value = serde_json::to_value(&config).map_err(|e| {
+            napi::Error::new(Status::GenericFailure, format!("Failed to serialize config: {e}"))
+        })?;
+        if let serde_json::Value::Object(ref mut map) = config_value {
+            map.insert("model_type".to_string(), serde_json::json!("qwen3_5_moe"));
+        }
+
+        let weights_json = serde_json::json!({
+            "version": "1.0",
+            "config": config_value,
+            "weights": weights_metadata,
+            "note": "Full weights are in weights.safetensors"
+        });
+
+        let promise = env.spawn_future(async move {
+            tokio::task::spawn_blocking(move || {
+                let path = std::path::Path::new(&save_path);
+                std::fs::create_dir_all(path)?;
+
+                info!("Saving model to {}", save_path);
+
+                // 1. Save configuration as JSON
+                let config_path = path.join("config.json");
+                let config_json = serde_json::to_string_pretty(&config_value)?;
+                std::fs::write(&config_path, config_json)?;
+                info!("Saved config.json");
+
+                // 2. Save full weights in SafeTensors format
+                let safetensors_path = path.join("weights.safetensors");
+                let metadata = Some(serde_json::json!({
+                    "format": "mlx-node",
+                    "version": "1.0"
+                }));
+                crate::utils::safetensors::save_safetensors(&safetensors_path, &params_clone, metadata)?;
+                info!("Saved weights.safetensors");
+
+                // 3. Save weights metadata (for reference)
+                let weights_str = serde_json::to_string_pretty(&weights_json)?;
+                let weights_path = path.join("weights.mlx");
+                std::fs::write(&weights_path, weights_str)?;
+                info!("Saved weights.mlx metadata");
+
+                Ok::<_, Error>(())
+            })
+            .map_err(|err| {
+                napi::Error::new(
+                    Status::GenericFailure,
+                    format!("Failed to save model: {}", err),
+                )
+            })
+            .await
+            .flatten()?;
+            Ok(())
+        })?;
+
+        Ok(promise)
+    }
 }
 
 /// Forward pass using already-acquired lock guards (no lock overhead).
@@ -2489,7 +2610,10 @@ impl Qwen3_5MoeModel {
     }
 
     /// Generate a single completion with logprob tracking (for GRPO training).
-    /// Uses the Rust forward path (NOT compiled C++) to ensure differentiability.
+    ///
+    /// Uses the C++ MoE forward path when available (~10x faster than Rust).
+    /// Generation does NOT need differentiability — gradients are computed separately
+    /// via the functional forward path in autograd Phase 2.
     pub(crate) fn generate_for_training_sync(
         &self,
         input_ids: &MxArray,
@@ -2497,6 +2621,18 @@ impl Qwen3_5MoeModel {
     ) -> Result<GenerationResult> {
         let config = config.unwrap_or_default();
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
+
+        // Check if C++ MoE path is available (weights loaded from safetensors)
+        let use_cpp = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+
+        // Try to acquire MoE compiled mutex (non-blocking, safe from sync context).
+        // If locked (concurrent generate() call), fall back to Rust path.
+        let compiled_lock = if use_cpp {
+            MOE_COMPILED_MUTEX.try_lock().ok()
+        } else {
+            None
+        };
+        let use_cpp = compiled_lock.is_some();
 
         // Ensure caches exist
         self.init_caches()?;
@@ -2521,31 +2657,142 @@ impl Qwen3_5MoeModel {
             .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
 
         let fa_idx = self.fa_idx;
-        let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {
-            forward_inner(
-                ids,
-                &embedding_weight,
-                &mut layers_guard,
-                &mut caches_guard,
-                &final_norm_guard,
-                &lm_head_guard,
-                fa_idx,
-                None,
-            )
+
+        // === Prefill (always uses Rust forward — runs once) ===
+        let logits = forward_inner(
+            input_ids,
+            &embedding_weight,
+            &mut layers_guard,
+            &mut caches_guard,
+            &final_norm_guard,
+            &lm_head_guard,
+            fa_idx,
+            None,
+        )?;
+        let seq_len = logits.shape_at(1)?;
+        let last_logits = logits.slice_axis(1, seq_len - 1, seq_len)?;
+        let last_logits = last_logits.squeeze(Some(&[1]))?;
+        let input_tokens = input_ids.to_uint32()?;
+
+        let result = if use_cpp {
+            // === C++ MoE decode path ===
+            let _moe_guard = MoeResetGuard;
+            let max_new_tokens = config.max_new_tokens.unwrap_or(100);
+            let prefill_len = seq_len as i32;
+            let max_kv_len = ((prefill_len + max_new_tokens + 255) / 256) * 256;
+            let num_layers = self.config.num_layers as usize;
+            let mut cache_ptrs: Vec<*mut mlx_sys::mlx_array> =
+                vec![std::ptr::null_mut(); num_layers * 2];
+            if let Some(ref caches) = *caches_guard {
+                for (i, cache) in caches.iter().enumerate() {
+                    let (p0, p1) = cache.export_ptrs();
+                    cache_ptrs[i * 2] = p0;
+                    cache_ptrs[i * 2 + 1] = p1;
+                }
+            }
+            let mlp_only: Vec<i32> = self
+                .config
+                .mlp_only_layers
+                .as_deref()
+                .unwrap_or(&[])
+                .to_vec();
+            // Drop locks not needed during C++ MoE decode
+            drop(layers_guard);
+            drop(final_norm_guard);
+            drop(lm_head_guard);
+            // Keep caches_guard alive through init_from_prefill so cache_ptrs remain valid
+            unsafe {
+                mlx_sys::mlx_qwen35_moe_init_from_prefill(
+                    self.config.num_layers,
+                    self.config.hidden_size,
+                    self.config.num_heads,
+                    self.config.num_kv_heads,
+                    self.config.head_dim,
+                    self.config.rope_theta as f32,
+                    self.config.rope_dims(),
+                    self.config.rms_norm_eps as f32,
+                    self.config.full_attention_interval,
+                    self.config.linear_num_key_heads,
+                    self.config.linear_num_value_heads,
+                    self.config.linear_key_head_dim,
+                    self.config.linear_value_head_dim,
+                    self.config.linear_conv_kernel_dim,
+                    if self.config.tie_word_embeddings {
+                        1
+                    } else {
+                        0
+                    },
+                    max_kv_len,
+                    1, // batch_size
+                    self.config.num_experts,
+                    self.config.num_experts_per_tok,
+                    if self.config.norm_topk_prob { 1 } else { 0 },
+                    self.config.decoder_sparse_step,
+                    if mlp_only.is_empty() {
+                        std::ptr::null()
+                    } else {
+                        mlp_only.as_ptr()
+                    },
+                    mlp_only.len() as i32,
+                    cache_ptrs.as_mut_ptr(),
+                    prefill_len,
+                );
+            }
+            // C++ has copied arrays into its own globals — safe to release
+            drop(caches_guard);
+
+            // Decode using C++ MoE forward with synchronous cache eval.
+            // Caches are eval'd BEFORE each forward call to ensure the previous step's
+            // caches are materialized, preventing O(N²) graph growth.
+            let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {
+                unsafe { mlx_sys::mlx_qwen35_moe_sync_eval_caches() };
+                let logits = forward_moe_cpp(ids, &embedding_weight)?;
+                // forward_moe_cpp returns [1, vocab] but training loop expects [1, 1, vocab]
+                let logits = logits.reshape(&[1, 1, -1])?;
+                Ok(logits)
+            };
+
+            crate::models::training_generate::generate_decode_loop_for_training(
+                &last_logits,
+                &input_tokens,
+                &config,
+                eos_token_id,
+                &mut forward_fn,
+            )?
+            // _moe_guard dropped here → mlx_qwen35_moe_reset()
+        } else {
+            // === Rust fallback decode path ===
+            let mut forward_fn = |ids: &MxArray| -> Result<MxArray> {
+                forward_inner(
+                    ids,
+                    &embedding_weight,
+                    &mut layers_guard,
+                    &mut caches_guard,
+                    &final_norm_guard,
+                    &lm_head_guard,
+                    fa_idx,
+                    None,
+                )
+            };
+
+            let result = crate::models::training_generate::generate_decode_loop_for_training(
+                &last_logits,
+                &input_tokens,
+                &config,
+                eos_token_id,
+                &mut forward_fn,
+            )?;
+
+            drop(layers_guard);
+            drop(final_norm_guard);
+            drop(lm_head_guard);
+            drop(caches_guard);
+
+            result
         };
 
-        let result = crate::models::training_generate::generate_for_training_loop(
-            input_ids,
-            &config,
-            eos_token_id,
-            &mut forward_fn,
-        )?;
-
-        // Reset caches after generation
-        drop(layers_guard);
-        drop(final_norm_guard);
-        drop(lm_head_guard);
-        drop(caches_guard);
+        // Drop compiled lock before reset_caches
+        drop(compiled_lock);
         self.reset_caches()?;
 
         Ok(result)

--- a/crates/mlx-core/src/models/qwen3_5_moe/sparse_moe.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/sparse_moe.rs
@@ -131,7 +131,33 @@ impl SparseMoeBlock {
         output.reshape(&[batch, seq_len, hidden_size])
     }
 
-    // ========== Weight accessors ==========
+    // ========== Weight getters (for training parameter extraction) ==========
+
+    pub fn get_gate_weight(&self) -> MxArray {
+        self.gate.get_weight()
+    }
+
+    pub fn get_switch_mlp(&self) -> &SwitchGLU {
+        &self.switch_mlp
+    }
+
+    pub fn get_shared_expert_gate_proj_weight(&self) -> MxArray {
+        self.shared_expert.get_gate_proj_weight()
+    }
+
+    pub fn get_shared_expert_up_proj_weight(&self) -> MxArray {
+        self.shared_expert.get_up_proj_weight()
+    }
+
+    pub fn get_shared_expert_down_proj_weight(&self) -> MxArray {
+        self.shared_expert.get_down_proj_weight()
+    }
+
+    pub fn get_shared_expert_gate_weight(&self) -> MxArray {
+        self.shared_expert_gate.get_weight()
+    }
+
+    // ========== Weight setters ==========
 
     pub fn set_gate_weight(&mut self, w: &MxArray) -> Result<()> {
         self.gate.set_weight(w, "gate")

--- a/crates/mlx-core/src/models/training_generate.rs
+++ b/crates/mlx-core/src/models/training_generate.rs
@@ -10,12 +10,14 @@ use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationRe
 use crate::sampling::{SamplingConfig, apply_repetition_penalty, check_repetition_cutoff, sample};
 use crate::tokenizer::Qwen3Tokenizer;
 
-/// Run autoregressive generation with logprob tracking for training.
+/// Decode-only generation loop with logprob tracking for training.
 ///
-/// Takes a `forward_fn` closure that maps input_ids -> logits,
-/// allowing different model architectures to share the same generation loop.
-pub(crate) fn generate_for_training_loop(
-    input_ids: &MxArray,
+/// Starts from pre-computed initial logits (after prefill) and runs autoregressive
+/// decoding. This allows callers to handle prefill separately — e.g. to initialize
+/// compiled C++ state between prefill and decode.
+pub(crate) fn generate_decode_loop_for_training(
+    initial_logits: &MxArray,
+    input_tokens: &[u32],
     config: &GenerationConfig,
     eos_token_id: Option<i32>,
     forward_fn: &mut dyn FnMut(&MxArray) -> Result<MxArray>,
@@ -39,21 +41,13 @@ pub(crate) fn generate_for_training_loop(
         min_p: Some(min_p),
     };
 
-    // Prefill: process input through model
-    let logits = forward_fn(input_ids)?;
-
-    // Get last token logits
-    let seq_len = logits.shape_at(1)?;
-    let last_logits = logits.slice_axis(1, seq_len - 1, seq_len)?;
-    let last_logits = last_logits.squeeze(Some(&[1]))?;
-
     // Track all generated tokens for repetition penalty
-    let mut all_tokens: Vec<u32> = input_ids.to_uint32()?.to_vec();
+    let mut all_tokens: Vec<u32> = input_tokens.to_vec();
     let mut generated_tokens: Vec<u32> = Vec::with_capacity(max_new_tokens as usize);
     let mut logprobs: Vec<f32> = Vec::with_capacity(max_new_tokens as usize);
     let mut finish_reason = "length".to_string();
 
-    let mut current_logits = last_logits;
+    let mut current_logits = initial_logits.clone();
 
     for _step in 0..max_new_tokens {
         // Apply repetition penalty

--- a/crates/mlx-core/src/models/training_generate.rs
+++ b/crates/mlx-core/src/models/training_generate.rs
@@ -1,0 +1,203 @@
+//! Shared training generation utilities for Qwen3.5 models.
+//!
+//! Provides a model-agnostic generation loop that can be parameterized by
+//! a forward function, avoiding duplication between Dense and MoE models.
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
+use crate::sampling::{SamplingConfig, apply_repetition_penalty, check_repetition_cutoff, sample};
+use crate::tokenizer::Qwen3Tokenizer;
+
+/// Run autoregressive generation with logprob tracking for training.
+///
+/// Takes a `forward_fn` closure that maps input_ids -> logits,
+/// allowing different model architectures to share the same generation loop.
+pub(crate) fn generate_for_training_loop(
+    input_ids: &MxArray,
+    config: &GenerationConfig,
+    eos_token_id: Option<i32>,
+    forward_fn: &mut dyn FnMut(&MxArray) -> Result<MxArray>,
+) -> Result<GenerationResult> {
+    let max_new_tokens = config.max_new_tokens.unwrap_or(100);
+    let temperature = config.temperature.unwrap_or(1.0);
+    let top_k = config.top_k.unwrap_or(0);
+    let top_p = config.top_p.unwrap_or(1.0);
+    let min_p = config.min_p.unwrap_or(0.0);
+    let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
+    let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+    let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
+    let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
+    let ngram_size = config.ngram_size.unwrap_or(64);
+    let return_logprobs = config.return_logprobs.unwrap_or(true);
+
+    let sampling_config = SamplingConfig {
+        temperature: Some(temperature),
+        top_k: Some(top_k),
+        top_p: Some(top_p),
+        min_p: Some(min_p),
+    };
+
+    // Prefill: process input through model
+    let logits = forward_fn(input_ids)?;
+
+    // Get last token logits
+    let seq_len = logits.shape_at(1)?;
+    let last_logits = logits.slice_axis(1, seq_len - 1, seq_len)?;
+    let last_logits = last_logits.squeeze(Some(&[1]))?;
+
+    // Track all generated tokens for repetition penalty
+    let mut all_tokens: Vec<u32> = input_ids.to_uint32()?.to_vec();
+    let mut generated_tokens: Vec<u32> = Vec::with_capacity(max_new_tokens as usize);
+    let mut logprobs: Vec<f32> = Vec::with_capacity(max_new_tokens as usize);
+    let mut finish_reason = "length".to_string();
+
+    let mut current_logits = last_logits;
+
+    for _step in 0..max_new_tokens {
+        // Apply repetition penalty
+        let penalized_logits = if repetition_penalty != 1.0 && !all_tokens.is_empty() {
+            let context_start = if all_tokens.len() > repetition_context_size as usize {
+                all_tokens.len() - repetition_context_size as usize
+            } else {
+                0
+            };
+            let context = &all_tokens[context_start..];
+            apply_repetition_penalty(&current_logits, context, repetition_penalty, None)?
+        } else {
+            current_logits.clone()
+        };
+
+        // Compute logprob if needed
+        if return_logprobs {
+            let logsumexp = penalized_logits.logsumexp(Some(&[-1]), Some(true))?;
+            let log_probs = penalized_logits.sub(&logsumexp)?;
+            // Sample first to know which token to get logprob for
+            let token = sample(&penalized_logits, Some(sampling_config))?;
+            token.eval();
+            let token_id = token.item_at_int32(0)? as u32;
+
+            let token_logprob =
+                log_probs.take(&MxArray::from_int32(&[token_id as i32], &[1])?, -1)?;
+            token_logprob.eval();
+            logprobs.push(token_logprob.item_at_float32(0)?);
+
+            // Check for EOS
+            if let Some(eos) = eos_token_id
+                && token_id == eos as u32
+            {
+                finish_reason = "eos".to_string();
+                generated_tokens.push(token_id);
+                all_tokens.push(token_id);
+                break;
+            }
+
+            // Check repetition cutoff
+            if check_repetition_cutoff(
+                &all_tokens,
+                max_consecutive_tokens,
+                max_ngram_repeats,
+                ngram_size,
+            )
+            .is_some()
+            {
+                finish_reason = "repetition".to_string();
+                break;
+            }
+
+            generated_tokens.push(token_id);
+            all_tokens.push(token_id);
+
+            // Forward next token
+            let token_input = MxArray::from_uint32(&[token_id], &[1, 1])?;
+            let next_logits = forward_fn(&token_input)?;
+            current_logits = next_logits.squeeze(Some(&[0, 1]))?;
+            current_logits.eval();
+        } else {
+            // No logprobs needed
+            let token = sample(&penalized_logits, Some(sampling_config))?;
+            token.eval();
+            let token_id = token.item_at_int32(0)? as u32;
+
+            if let Some(eos) = eos_token_id
+                && token_id == eos as u32
+            {
+                finish_reason = "eos".to_string();
+                generated_tokens.push(token_id);
+                all_tokens.push(token_id);
+                break;
+            }
+
+            generated_tokens.push(token_id);
+            all_tokens.push(token_id);
+
+            let token_input = MxArray::from_uint32(&[token_id], &[1, 1])?;
+            let next_logits = forward_fn(&token_input)?;
+            current_logits = next_logits.squeeze(Some(&[0, 1]))?;
+            current_logits.eval();
+        }
+    }
+
+    let num_tokens = generated_tokens.len();
+    let tokens_array = MxArray::from_uint32(&generated_tokens, &[generated_tokens.len() as i64])?;
+    let logprobs_array = MxArray::from_float32(&logprobs, &[logprobs.len() as i64])?;
+
+    Ok(GenerationResult {
+        text: String::new(),
+        tokens: tokens_array,
+        logprobs: logprobs_array,
+        finish_reason,
+        num_tokens,
+        first_token_elapsed_ms: None,
+    })
+}
+
+/// Batch generation wrapper for GRPO training.
+///
+/// Calls `generate_one` for each prompt/group combination, collecting results.
+pub(crate) fn generate_batch_for_training_loop(
+    prompt_arrays: &[MxArray],
+    group_size: usize,
+    config: Option<GenerationConfig>,
+    tokenizer: &Qwen3Tokenizer,
+    mut generate_one: impl FnMut(&MxArray, Option<GenerationConfig>) -> Result<GenerationResult>,
+) -> Result<BatchGenerationResult> {
+    let mut all_tokens: Vec<MxArray> = Vec::new();
+    let mut all_logprobs: Vec<MxArray> = Vec::new();
+    let mut all_texts: Vec<String> = Vec::new();
+    let mut all_finish_reasons: Vec<Vec<String>> = Vec::new();
+    let mut all_token_counts: Vec<Vec<u32>> = Vec::new();
+
+    for prompt in prompt_arrays {
+        let mut prompt_finish_reasons: Vec<String> = Vec::new();
+        let mut prompt_token_counts: Vec<u32> = Vec::new();
+
+        for _g in 0..group_size {
+            let result = generate_one(prompt, config.clone())?;
+
+            let text = tokenizer.decode_sync(&result.tokens.to_uint32()?, true)?;
+            all_texts.push(text);
+            prompt_token_counts.push(result.num_tokens as u32);
+            prompt_finish_reasons.push(result.finish_reason);
+            all_tokens.push(result.tokens);
+            all_logprobs.push(result.logprobs);
+
+            crate::array::heavy_cleanup();
+        }
+
+        all_finish_reasons.push(prompt_finish_reasons);
+        all_token_counts.push(prompt_token_counts);
+    }
+
+    let num_prompts = prompt_arrays.len();
+    Ok(BatchGenerationResult {
+        tokens: all_tokens,
+        logprobs: all_logprobs,
+        texts: all_texts,
+        finish_reasons: all_finish_reasons,
+        token_counts: all_token_counts,
+        num_prompts,
+        group_size: group_size as u32,
+    })
+}

--- a/crates/mlx-core/src/nn/normalization.rs
+++ b/crates/mlx-core/src/nn/normalization.rs
@@ -129,13 +129,7 @@ impl Clone for LayerNorm {
 }
 
 impl LayerNorm {
-    /// Create a LayerNorm layer from pre-loaded weights
-    ///
-    /// # Arguments
-    /// * `weight` - Scale parameter [dims]
-    /// * `bias` - Bias parameter [dims] (optional, defaults to zeros)
-    /// * `eps` - Small constant for numerical stability
-    /// Get the weight (scale) parameter
+    /// Get the weight (scale) parameter.
     pub fn get_weight(&self) -> MxArray {
         self.weight.clone()
     }

--- a/crates/mlx-core/src/nn/normalization.rs
+++ b/crates/mlx-core/src/nn/normalization.rs
@@ -135,6 +135,16 @@ impl LayerNorm {
     /// * `weight` - Scale parameter [dims]
     /// * `bias` - Bias parameter [dims] (optional, defaults to zeros)
     /// * `eps` - Small constant for numerical stability
+    /// Get the weight (scale) parameter
+    pub fn get_weight(&self) -> MxArray {
+        self.weight.clone()
+    }
+
+    /// Get the bias parameter
+    pub fn get_bias(&self) -> MxArray {
+        self.bias.clone()
+    }
+
     pub fn from_weights(
         weight: &MxArray,
         bias: Option<&MxArray>,

--- a/crates/mlx-core/src/sft/autograd.rs
+++ b/crates/mlx-core/src/sft/autograd.rs
@@ -49,6 +49,7 @@ pub(crate) fn compute_sft_loss_and_gradients(
     input_ids: &MxArray,
     labels: &MxArray,
     loss_config: SftLossConfig,
+    use_checkpointing: bool,
 ) -> Result<(f64, HashMap<String, MxArray>)> {
     // 1. Flatten parameters into ordered list (keep native dtype - bfloat16)
     let mut param_names: Vec<String> = model_params.keys().cloned().collect();
@@ -85,7 +86,7 @@ pub(crate) fn compute_sft_loss_and_gradients(
                 &config_clone,
                 &param_dict,
                 &input_ids_clone,
-                false,
+                use_checkpointing,
                 &mut ckpt_ctx.borrow_mut(),
             )?;
 

--- a/crates/mlx-core/src/sft/autograd.rs
+++ b/crates/mlx-core/src/sft/autograd.rs
@@ -73,6 +73,8 @@ pub(crate) fn compute_sft_loss_and_gradients(
         let loss_config_clone = loss_config.clone();
 
         // Define loss function for autograd
+        let ckpt_contexts = std::rc::Rc::new(std::cell::RefCell::new(autograd::CheckpointContexts::new()));
+        let ckpt_ctx = ckpt_contexts.clone();
         let loss_fn = move |params: &[MxArray]| -> Result<MxArray> {
             // Map params to structured dictionary
             let param_dict = param_manager::map_params_to_dict(params, &param_names_clone)?;
@@ -82,6 +84,8 @@ pub(crate) fn compute_sft_loss_and_gradients(
                 &config_clone,
                 &param_dict,
                 &input_ids_clone,
+                false,
+                &mut ckpt_ctx.borrow_mut(),
             )?;
 
             // Get shapes
@@ -129,6 +133,9 @@ pub(crate) fn compute_sft_loss_and_gradients(
             grad.eval();
         }
 
+        // Reclaim checkpoint contexts now that the graph is eval'd
+        ckpt_contexts.borrow_mut().reclaim();
+
         // Extract values before scope ends
         let loss_val = loss_array.item_at_float32(0)? as f64;
         let grads: HashMap<String, MxArray> = param_names
@@ -165,8 +172,10 @@ pub(crate) fn compute_token_accuracy(
     input_ids: &MxArray,
     labels: &MxArray,
 ) -> Result<f64> {
-    // Forward pass
-    let logits = functional::forward_functional_dispatch(model_type, model_params, input_ids)?;
+    // Forward pass (no checkpointing needed for validation — no backward pass)
+    let mut ckpt = autograd::CheckpointContexts::new();
+    let logits =
+        functional::forward_functional_dispatch(model_type, model_params, input_ids, false, &mut ckpt)?;
 
     // Get shapes
     let batch_size = logits.shape_at(0)?;

--- a/crates/mlx-core/src/sft/autograd.rs
+++ b/crates/mlx-core/src/sft/autograd.rs
@@ -73,7 +73,8 @@ pub(crate) fn compute_sft_loss_and_gradients(
         let loss_config_clone = loss_config.clone();
 
         // Define loss function for autograd
-        let ckpt_contexts = std::rc::Rc::new(std::cell::RefCell::new(autograd::CheckpointContexts::new()));
+        let ckpt_contexts =
+            std::rc::Rc::new(std::cell::RefCell::new(autograd::CheckpointContexts::new()));
         let ckpt_ctx = ckpt_contexts.clone();
         let loss_fn = move |params: &[MxArray]| -> Result<MxArray> {
             // Map params to structured dictionary
@@ -174,8 +175,13 @@ pub(crate) fn compute_token_accuracy(
 ) -> Result<f64> {
     // Forward pass (no checkpointing needed for validation — no backward pass)
     let mut ckpt = autograd::CheckpointContexts::new();
-    let logits =
-        functional::forward_functional_dispatch(model_type, model_params, input_ids, false, &mut ckpt)?;
+    let logits = functional::forward_functional_dispatch(
+        model_type,
+        model_params,
+        input_ids,
+        false,
+        &mut ckpt,
+    )?;
 
     // Get shapes
     let batch_size = logits.shape_at(0)?;

--- a/crates/mlx-core/src/sft/autograd.rs
+++ b/crates/mlx-core/src/sft/autograd.rs
@@ -20,9 +20,9 @@ use napi::bindgen_prelude::*;
 
 use crate::array::MxArray;
 use crate::autograd;
-use crate::models::qwen3::Qwen3Config;
 use crate::nn::Losses;
 use crate::param_manager;
+use crate::training_model::ModelType;
 use crate::utils::functional;
 
 use super::SftLossConfig;
@@ -43,8 +43,8 @@ use super::SftLossConfig;
 ///
 /// # Returns
 /// * `(loss_value, gradients)` - Scalar loss and gradients for each parameter
-pub fn compute_sft_loss_and_gradients(
-    model_config: &Qwen3Config,
+pub(crate) fn compute_sft_loss_and_gradients(
+    model_type: &ModelType,
     model_params: &HashMap<String, MxArray>,
     input_ids: &MxArray,
     labels: &MxArray,
@@ -69,7 +69,7 @@ pub fn compute_sft_loss_and_gradients(
         let param_names_clone = param_names.clone();
         let input_ids_clone = input_ids.clone();
         let labels_clone = labels.clone();
-        let config_clone = model_config.clone();
+        let config_clone = model_type.clone();
         let loss_config_clone = loss_config.clone();
 
         // Define loss function for autograd
@@ -78,8 +78,11 @@ pub fn compute_sft_loss_and_gradients(
             let param_dict = param_manager::map_params_to_dict(params, &param_names_clone)?;
 
             // Forward pass using functional implementation
-            let logits =
-                functional::qwen3_forward_functional(&config_clone, &param_dict, &input_ids_clone)?;
+            let logits = functional::forward_functional_dispatch(
+                &config_clone,
+                &param_dict,
+                &input_ids_clone,
+            )?;
 
             // Get shapes
             let batch_size = logits.shape_at(0)?;
@@ -156,14 +159,14 @@ pub fn compute_sft_loss_and_gradients(
 ///
 /// # Returns
 /// * Accuracy value between 0.0 and 1.0
-pub fn compute_token_accuracy(
-    model_config: &Qwen3Config,
+pub(crate) fn compute_token_accuracy(
+    model_type: &ModelType,
     model_params: &HashMap<String, MxArray>,
     input_ids: &MxArray,
     labels: &MxArray,
 ) -> Result<f64> {
     // Forward pass
-    let logits = functional::qwen3_forward_functional(model_config, model_params, input_ids)?;
+    let logits = functional::forward_functional_dispatch(model_type, model_params, input_ids)?;
 
     // Get shapes
     let batch_size = logits.shape_at(0)?;
@@ -207,8 +210,8 @@ pub fn compute_token_accuracy(
 /// Compute SFT loss only (no gradients)
 ///
 /// Useful for evaluation/validation without the overhead of gradient computation.
-pub fn compute_sft_loss_only(
-    model_config: &Qwen3Config,
+pub(crate) fn compute_sft_loss_only(
+    model_type: &ModelType,
     model_params: &HashMap<String, MxArray>,
     input_ids: &MxArray,
     labels: &MxArray,
@@ -218,7 +221,7 @@ pub fn compute_sft_loss_only(
     let param_dict: HashMap<String, MxArray> = model_params.clone();
 
     // Forward pass
-    let logits = functional::qwen3_forward_functional(model_config, &param_dict, input_ids)?;
+    let logits = functional::forward_functional_dispatch(model_type, &param_dict, input_ids)?;
 
     // Get shapes
     let batch_size = logits.shape_at(0)?;

--- a/crates/mlx-core/src/sft/autograd.rs
+++ b/crates/mlx-core/src/sft/autograd.rs
@@ -207,53 +207,6 @@ pub(crate) fn compute_token_accuracy(
     }
 }
 
-/// Compute SFT loss only (no gradients)
-///
-/// Useful for evaluation/validation without the overhead of gradient computation.
-pub(crate) fn compute_sft_loss_only(
-    model_type: &ModelType,
-    model_params: &HashMap<String, MxArray>,
-    input_ids: &MxArray,
-    labels: &MxArray,
-    loss_config: SftLossConfig,
-) -> Result<f64> {
-    // Build param dict
-    let param_dict: HashMap<String, MxArray> = model_params.clone();
-
-    // Forward pass
-    let logits = functional::forward_functional_dispatch(model_type, &param_dict, input_ids)?;
-
-    // Get shapes
-    let batch_size = logits.shape_at(0)?;
-    let seq_len = logits.shape_at(1)?;
-    let vocab_size = logits.shape_at(2)?;
-
-    // Shift for next-token prediction
-    let shift_logits = logits.slice(&[0, 0, 0], &[batch_size, seq_len - 1, vocab_size])?;
-    let shift_labels = labels.slice(&[0, 1], &[batch_size, seq_len])?;
-
-    // Reshape
-    let logits_flat = shift_logits.reshape(&[(batch_size) * (seq_len - 1), vocab_size])?;
-    let labels_flat = shift_labels.reshape(&[(batch_size) * (seq_len - 1)])?;
-
-    // Compute loss
-    let ignore_idx = loss_config.ignore_index.unwrap_or(-100);
-    let label_smoothing = loss_config.label_smoothing.unwrap_or(0.0);
-
-    let loss = Losses::cross_entropy(
-        &logits_flat,
-        &labels_flat,
-        None,
-        Some(ignore_idx),
-        Some(label_smoothing),
-    )?;
-
-    loss.eval();
-    let loss_value = loss.item_at_float32(0)? as f64;
-
-    Ok(loss_value)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mlx-core/src/sft/engine.rs
+++ b/crates/mlx-core/src/sft/engine.rs
@@ -339,7 +339,7 @@ impl SftTrainingEngine {
                     let model = model_arc.read().map_err(|_| {
                         Error::new(Status::GenericFailure, "Failed to acquire model read lock")
                     })?;
-                    model.get_parameters()
+                    model.get_parameters()?
                 };
 
                 // Build loss config
@@ -600,7 +600,7 @@ impl SftTrainingEngine {
                         let model = model_arc.read().map_err(|_| {
                             Error::new(Status::GenericFailure, "Failed to acquire model read lock")
                         })?;
-                        model.get_parameters()
+                        model.get_parameters()?
                     } else {
                         // Reuse params from start of step - no weights changed
                         params.clone()
@@ -715,7 +715,7 @@ impl SftTrainingEngine {
             let model = model_arc.read().map_err(|_| {
                 Error::new(Status::GenericFailure, "Failed to acquire model read lock")
             })?;
-            model.get_parameters()
+            model.get_parameters()?
         };
 
         // Apply weight decay to gradients if configured

--- a/crates/mlx-core/src/sft/engine.rs
+++ b/crates/mlx-core/src/sft/engine.rs
@@ -53,6 +53,9 @@ pub struct SftEngineConfig {
     /// boolean to CPU. When true, transfers the entire gradient tensor to CPU for detailed
     /// per-element analysis - useful for debugging but has significant performance overhead.
     pub verbose_nan_detection: Option<bool>,
+    /// Enable gradient checkpointing to reduce memory (default: true)
+    /// Trades ~30% more compute for O(1) layer memory instead of O(num_layers).
+    pub gradient_checkpointing: Option<bool>,
 }
 
 impl Default for SftEngineConfig {
@@ -69,6 +72,7 @@ impl Default for SftEngineConfig {
             emergency_save_threshold: Some(5),
             compute_accuracy: Some(false),
             verbose_nan_detection: Some(false),
+            gradient_checkpointing: Some(true),
         }
     }
 }
@@ -355,6 +359,7 @@ impl SftTrainingEngine {
                     &input_ids,
                     &labels,
                     loss_config,
+                    config.gradient_checkpointing.unwrap_or(true),
                 )?;
 
                 // Check for NaN/Inf in gradients BEFORE accumulation

--- a/crates/mlx-core/src/sft/engine.rs
+++ b/crates/mlx-core/src/sft/engine.rs
@@ -17,9 +17,12 @@ use tracing::{debug, info, warn};
 
 use crate::array::{MxArray, heavy_cleanup, synchronize_and_clear_cache};
 use crate::models::qwen3::{Qwen3Config, Qwen3Model};
+use crate::models::qwen3_5::model::Qwen3_5Model;
+use crate::models::qwen3_5_moe::model::Qwen3_5MoeModel;
 use crate::optimizers::GradientUtils;
 use crate::sft::SftLossConfig;
 use crate::sft::autograd::{compute_sft_loss_and_gradients, compute_token_accuracy};
+use crate::training_model::{ModelType, TrainableModel, TrainableModelEnum};
 
 /// Configuration for the SFT training engine
 #[napi(object)]
@@ -152,18 +155,18 @@ impl Default for EngineState {
 /// SFT Training Engine
 #[napi]
 pub struct SftTrainingEngine {
-    model: Arc<RwLock<Qwen3Model>>,
-    model_config: Qwen3Config,
+    model: Arc<RwLock<TrainableModelEnum>>,
+    model_type: ModelType,
     config: SftEngineConfig,
     state: Arc<RwLock<EngineState>>,
 }
 
 #[napi]
 impl SftTrainingEngine {
-    /// Create a new SFT training engine
+    /// Create a new SFT training engine from a Qwen3 model
     #[napi(constructor)]
     pub fn new(model: &Qwen3Model, config: SftEngineConfig) -> Result<Self> {
-        let model_config = model.get_config();
+        let model_type = ModelType::Qwen3(model.get_config());
 
         // Let MLX manage memory dynamically - no explicit cache limits
         // Previously set cache_limit which conflicted with other limit calls
@@ -171,8 +174,8 @@ impl SftTrainingEngine {
 
         info!(
             "Creating SFT training engine: {} layers, {} hidden, lr={}",
-            model_config.num_layers,
-            model_config.hidden_size,
+            model_type.num_layers(),
+            model_type.hidden_size(),
             config.learning_rate.unwrap_or(2e-5)
         );
 
@@ -181,8 +184,54 @@ impl SftTrainingEngine {
             // The model uses RwLock for interior mutability, so apply_gradients()
             // can acquire write locks without needing unique Arc ownership.
             // This eliminates the previous ~4GB memory overhead from deep cloning.
-            model: Arc::new(RwLock::new(model.clone_for_session()?)),
-            model_config,
+            model: Arc::new(RwLock::new(TrainableModelEnum::Qwen3(
+                model.clone_for_session()?,
+            ))),
+            model_type,
+            config,
+            state: Arc::new(RwLock::new(EngineState::default())),
+        })
+    }
+
+    /// Create a new SFT training engine from a Qwen3.5 dense model
+    #[napi(factory)]
+    pub fn from_qwen35(model: &Qwen3_5Model, config: SftEngineConfig) -> Result<Self> {
+        let model_type = ModelType::Qwen35Dense(model.get_config());
+
+        info!(
+            "Creating SFT training engine (Qwen3.5 Dense): {} layers, {} hidden, lr={}",
+            model_type.num_layers(),
+            model_type.hidden_size(),
+            config.learning_rate.unwrap_or(2e-5)
+        );
+
+        Ok(Self {
+            model: Arc::new(RwLock::new(TrainableModelEnum::Qwen35Dense(
+                model.clone_for_training()?,
+            ))),
+            model_type,
+            config,
+            state: Arc::new(RwLock::new(EngineState::default())),
+        })
+    }
+
+    /// Create a new SFT training engine from a Qwen3.5 MoE model
+    #[napi(factory)]
+    pub fn from_qwen35_moe(model: &Qwen3_5MoeModel, config: SftEngineConfig) -> Result<Self> {
+        let model_type = ModelType::Qwen35Moe(model.get_config());
+
+        info!(
+            "Creating SFT training engine (Qwen3.5 MoE): {} layers, {} hidden, lr={}",
+            model_type.num_layers(),
+            model_type.hidden_size(),
+            config.learning_rate.unwrap_or(2e-5)
+        );
+
+        Ok(Self {
+            model: Arc::new(RwLock::new(TrainableModelEnum::Qwen35Moe(
+                model.clone_for_training()?,
+            ))),
+            model_type,
             config,
             state: Arc::new(RwLock::new(EngineState::default())),
         })
@@ -276,7 +325,7 @@ impl SftTrainingEngine {
         // Clone Arcs for the blocking task
         let model_arc = Arc::clone(&self.model);
         let state_arc = Arc::clone(&self.state);
-        let model_config = self.model_config.clone();
+        let model_type = self.model_type.clone();
         let config = self.config.clone();
         let input_ids = input_ids.clone();
         let labels = labels.clone();
@@ -301,7 +350,7 @@ impl SftTrainingEngine {
 
                 // Compute loss and gradients
                 let (loss_value, gradients) = compute_sft_loss_and_gradients(
-                    &model_config,
+                    &model_type,
                     &params,
                     &input_ids,
                     &labels,
@@ -556,7 +605,7 @@ impl SftTrainingEngine {
                         // Reuse params from start of step - no weights changed
                         params.clone()
                     };
-                    match compute_token_accuracy(&model_config, &accuracy_params, &input_ids, &labels) {
+                    match compute_token_accuracy(&model_type, &accuracy_params, &input_ids, &labels) {
                         Ok(acc) => Some(acc),
                         Err(e) => {
                             warn!("Failed to compute accuracy: {}", e);
@@ -855,14 +904,20 @@ impl SftTrainingEngine {
         Ok(())
     }
 
-    /// Get the underlying model for checkpointing
+    /// Get the underlying Qwen3 model for checkpointing (only works for Qwen3 variant)
     #[napi]
     pub fn get_model(&self) -> Result<Qwen3Model> {
         let model = self
             .model
             .read()
             .map_err(|_| Error::new(Status::GenericFailure, "Lock error"))?;
-        model.clone_for_session()
+        match &*model {
+            TrainableModelEnum::Qwen3(m) => m.clone_for_session(),
+            _ => Err(Error::new(
+                Status::GenericFailure,
+                "get_model() only supports Qwen3 models. Use save_model() for other model types.",
+            )),
+        }
     }
 }
 

--- a/crates/mlx-core/src/sft/mod.rs
+++ b/crates/mlx-core/src/sft/mod.rs
@@ -13,6 +13,6 @@ pub mod engine;
 pub mod loss;
 
 // Re-export all public items
-pub use autograd::*;
+// autograd functions are pub(crate) - used directly by engine
 pub use engine::*;
 pub use loss::*;

--- a/crates/mlx-core/src/training_model.rs
+++ b/crates/mlx-core/src/training_model.rs
@@ -79,12 +79,12 @@ impl ModelType {
 
 /// Common training interface for all model families.
 ///
-/// This trait is Rust-internal only (not exposed via NAPI). All methods are synchronous
-/// to be compatible with `spawn_blocking` usage in engines.
+/// This trait is Rust-internal only (not exposed via NAPI). Methods that engines
+/// call through the trait during training steps. Methods like `clone_for_training`,
+/// `calculate_memory_size`, and `save_model_sync` exist on concrete model types
+/// but are NOT in this trait — engines call them on the concrete types before
+/// wrapping in `TrainableModelEnum`.
 pub(crate) trait TrainableModel: Send + Sync {
-    /// Get the model type (with config) for autograd dispatch.
-    fn model_type(&self) -> ModelType;
-
     /// Extract all trainable parameters as a name→array map.
     fn get_parameters(&self) -> HashMap<String, MxArray>;
 
@@ -95,9 +95,6 @@ pub(crate) trait TrainableModel: Send + Sync {
         lr: f64,
         params: &HashMap<String, MxArray>,
     ) -> Result<()>;
-
-    /// Create a cheap clone for training sessions (Arc-clone, fresh caches).
-    fn clone_for_training(&self) -> Result<TrainableModelEnum>;
 
     /// Tokenize messages using the model's chat template.
     fn apply_chat_template_sync(
@@ -125,12 +122,6 @@ pub(crate) trait TrainableModel: Send + Sync {
 
     /// Decode token IDs to text.
     fn decode_tokens_sync(&self, tokens: &MxArray) -> Result<String>;
-
-    /// Calculate total memory size of all parameters in bytes.
-    fn calculate_memory_size(&self) -> usize;
-
-    /// Save model weights and config to a directory.
-    fn save_model_sync(&self, path: &str) -> Result<()>;
 }
 
 /// Enum wrapping all trainable model types.
@@ -143,15 +134,6 @@ pub(crate) enum TrainableModelEnum {
 }
 
 impl TrainableModel for TrainableModelEnum {
-    // These two methods have non-uniform dispatch (different method names per variant)
-    fn model_type(&self) -> ModelType {
-        match self {
-            TrainableModelEnum::Qwen3(m) => ModelType::Qwen3(m.get_config()),
-            TrainableModelEnum::Qwen35Dense(m) => ModelType::Qwen35Dense(m.get_config()),
-            TrainableModelEnum::Qwen35Moe(m) => ModelType::Qwen35Moe(m.get_config()),
-        }
-    }
-
     fn get_parameters(&self) -> HashMap<String, MxArray> {
         match self {
             TrainableModelEnum::Qwen3(m) => m.get_parameters(),
@@ -160,19 +142,6 @@ impl TrainableModel for TrainableModelEnum {
         }
     }
 
-    fn clone_for_training(&self) -> Result<TrainableModelEnum> {
-        match self {
-            TrainableModelEnum::Qwen3(m) => Ok(TrainableModelEnum::Qwen3(m.clone_for_session()?)),
-            TrainableModelEnum::Qwen35Dense(m) => {
-                Ok(TrainableModelEnum::Qwen35Dense(m.clone_for_training()?))
-            }
-            TrainableModelEnum::Qwen35Moe(m) => {
-                Ok(TrainableModelEnum::Qwen35Moe(m.clone_for_training()?))
-            }
-        }
-    }
-
-    // All remaining methods have uniform dispatch (same method name on all variants)
     fn apply_gradients_with_params(
         &mut self,
         grads: HashMap<String, &MxArray>,
@@ -217,14 +186,6 @@ impl TrainableModel for TrainableModelEnum {
 
     fn decode_tokens_sync(&self, tokens: &MxArray) -> Result<String> {
         dispatch!(self, decode_tokens_sync(tokens))
-    }
-
-    fn calculate_memory_size(&self) -> usize {
-        dispatch!(self, calculate_memory_size())
-    }
-
-    fn save_model_sync(&self, path: &str) -> Result<()> {
-        dispatch!(self, save_model_sync(path))
     }
 }
 

--- a/crates/mlx-core/src/training_model.rs
+++ b/crates/mlx-core/src/training_model.rs
@@ -1,0 +1,269 @@
+/// Model-Agnostic Training Support
+///
+/// Provides a `TrainableModel` trait and `TrainableModelEnum` that allow the GRPO and SFT
+/// training engines to work with any supported model family (Qwen3, Qwen3.5 Dense, Qwen3.5 MoE).
+///
+/// ## Architecture
+///
+/// NAPI-RS cannot use trait objects or generics in `#[napi]` structs. We solve this with:
+/// 1. `TrainableModel` trait (Rust-only) defining the common training interface
+/// 2. `TrainableModelEnum` wrapping all model types, stored in engines
+/// 3. `ModelType` enum carrying config for functional forward passes in autograd
+use std::collections::HashMap;
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::models::qwen3::{
+    BatchGenerationResult, GenerationConfig, GenerationResult, Qwen3Config, Qwen3Model,
+};
+use crate::models::qwen3_5::Qwen3_5Config;
+use crate::models::qwen3_5::model::Qwen3_5Model;
+use crate::models::qwen3_5_moe::Qwen3_5MoeConfig;
+use crate::models::qwen3_5_moe::model::Qwen3_5MoeModel;
+use crate::tokenizer::{ChatMessage, ToolDefinition};
+
+/// Dispatch a field access across all ModelType config variants.
+macro_rules! config_field {
+    ($self:expr, $field:ident) => {
+        match $self {
+            ModelType::Qwen3(c) => c.$field,
+            ModelType::Qwen35Dense(c) => c.$field,
+            ModelType::Qwen35Moe(c) => c.$field,
+        }
+    };
+}
+
+/// Dispatch a method call across all TrainableModelEnum variants.
+macro_rules! dispatch {
+    ($self:expr, $method:ident ( $($arg:expr),* )) => {
+        match $self {
+            TrainableModelEnum::Qwen3(m) => m.$method($($arg),*),
+            TrainableModelEnum::Qwen35Dense(m) => m.$method($($arg),*),
+            TrainableModelEnum::Qwen35Moe(m) => m.$method($($arg),*),
+        }
+    };
+}
+
+/// Model type enum carrying the config needed for functional forward passes.
+///
+/// This is passed to autograd functions so they can dispatch to the correct
+/// functional forward pass implementation.
+#[derive(Clone)]
+pub(crate) enum ModelType {
+    Qwen3(Qwen3Config),
+    Qwen35Dense(Qwen3_5Config),
+    Qwen35Moe(Qwen3_5MoeConfig),
+}
+
+impl ModelType {
+    pub fn pad_token_id(&self) -> i32 {
+        config_field!(self, pad_token_id)
+    }
+    pub fn vocab_size(&self) -> i32 {
+        config_field!(self, vocab_size)
+    }
+    pub fn hidden_size(&self) -> i32 {
+        config_field!(self, hidden_size)
+    }
+    pub fn eos_token_id(&self) -> i32 {
+        config_field!(self, eos_token_id)
+    }
+    pub fn tie_word_embeddings(&self) -> bool {
+        config_field!(self, tie_word_embeddings)
+    }
+    pub fn num_layers(&self) -> i32 {
+        config_field!(self, num_layers)
+    }
+}
+
+/// Common training interface for all model families.
+///
+/// This trait is Rust-internal only (not exposed via NAPI). All methods are synchronous
+/// to be compatible with `spawn_blocking` usage in engines.
+pub(crate) trait TrainableModel: Send + Sync {
+    /// Get the model type (with config) for autograd dispatch.
+    fn model_type(&self) -> ModelType;
+
+    /// Extract all trainable parameters as a name→array map.
+    fn get_parameters(&self) -> HashMap<String, MxArray>;
+
+    /// Apply gradients using SGD: param = param - lr * grad.
+    fn apply_gradients_with_params(
+        &mut self,
+        grads: HashMap<String, &MxArray>,
+        lr: f64,
+        params: &HashMap<String, MxArray>,
+    ) -> Result<()>;
+
+    /// Create a cheap clone for training sessions (Arc-clone, fresh caches).
+    fn clone_for_training(&self) -> Result<TrainableModelEnum>;
+
+    /// Tokenize messages using the model's chat template.
+    fn apply_chat_template_sync(
+        &self,
+        messages: &[ChatMessage],
+        add_generation_prompt: Option<bool>,
+        tools: Option<&[ToolDefinition]>,
+        enable_thinking: Option<bool>,
+    ) -> Result<Vec<u32>>;
+
+    /// Generate a single completion with logprob tracking (for GRPO).
+    fn generate_for_training_sync(
+        &self,
+        input_ids: &MxArray,
+        config: Option<GenerationConfig>,
+    ) -> Result<GenerationResult>;
+
+    /// Generate a batch of completions (for GRPO).
+    fn generate_batch_for_training_sync(
+        &self,
+        prompt_arrays: &[MxArray],
+        group_size: usize,
+        config: Option<GenerationConfig>,
+    ) -> Result<BatchGenerationResult>;
+
+    /// Decode token IDs to text.
+    fn decode_tokens_sync(&self, tokens: &MxArray) -> Result<String>;
+
+    /// Calculate total memory size of all parameters in bytes.
+    fn calculate_memory_size(&self) -> usize;
+
+    /// Save model weights and config to a directory.
+    fn save_model_sync(&self, path: &str) -> Result<()>;
+}
+
+/// Enum wrapping all trainable model types.
+///
+/// Stored inside training engines to allow model-agnostic training.
+pub(crate) enum TrainableModelEnum {
+    Qwen3(Qwen3Model),
+    Qwen35Dense(Qwen3_5Model),
+    Qwen35Moe(Qwen3_5MoeModel),
+}
+
+impl TrainableModel for TrainableModelEnum {
+    // These two methods have non-uniform dispatch (different method names per variant)
+    fn model_type(&self) -> ModelType {
+        match self {
+            TrainableModelEnum::Qwen3(m) => ModelType::Qwen3(m.get_config()),
+            TrainableModelEnum::Qwen35Dense(m) => ModelType::Qwen35Dense(m.get_config()),
+            TrainableModelEnum::Qwen35Moe(m) => ModelType::Qwen35Moe(m.get_config()),
+        }
+    }
+
+    fn get_parameters(&self) -> HashMap<String, MxArray> {
+        match self {
+            TrainableModelEnum::Qwen3(m) => m.get_parameters(),
+            TrainableModelEnum::Qwen35Dense(m) => m.get_parameters_for_training(),
+            TrainableModelEnum::Qwen35Moe(m) => m.get_parameters_for_training(),
+        }
+    }
+
+    fn clone_for_training(&self) -> Result<TrainableModelEnum> {
+        match self {
+            TrainableModelEnum::Qwen3(m) => Ok(TrainableModelEnum::Qwen3(m.clone_for_session()?)),
+            TrainableModelEnum::Qwen35Dense(m) => {
+                Ok(TrainableModelEnum::Qwen35Dense(m.clone_for_training()?))
+            }
+            TrainableModelEnum::Qwen35Moe(m) => {
+                Ok(TrainableModelEnum::Qwen35Moe(m.clone_for_training()?))
+            }
+        }
+    }
+
+    // All remaining methods have uniform dispatch (same method name on all variants)
+    fn apply_gradients_with_params(
+        &mut self,
+        grads: HashMap<String, &MxArray>,
+        lr: f64,
+        params: &HashMap<String, MxArray>,
+    ) -> Result<()> {
+        dispatch!(self, apply_gradients_with_params(grads, lr, params))
+    }
+
+    fn apply_chat_template_sync(
+        &self,
+        messages: &[ChatMessage],
+        add_generation_prompt: Option<bool>,
+        tools: Option<&[ToolDefinition]>,
+        enable_thinking: Option<bool>,
+    ) -> Result<Vec<u32>> {
+        dispatch!(
+            self,
+            apply_chat_template_sync(messages, add_generation_prompt, tools, enable_thinking)
+        )
+    }
+
+    fn generate_for_training_sync(
+        &self,
+        input_ids: &MxArray,
+        config: Option<GenerationConfig>,
+    ) -> Result<GenerationResult> {
+        dispatch!(self, generate_for_training_sync(input_ids, config))
+    }
+
+    fn generate_batch_for_training_sync(
+        &self,
+        prompt_arrays: &[MxArray],
+        group_size: usize,
+        config: Option<GenerationConfig>,
+    ) -> Result<BatchGenerationResult> {
+        dispatch!(
+            self,
+            generate_batch_for_training_sync(prompt_arrays, group_size, config)
+        )
+    }
+
+    fn decode_tokens_sync(&self, tokens: &MxArray) -> Result<String> {
+        dispatch!(self, decode_tokens_sync(tokens))
+    }
+
+    fn calculate_memory_size(&self) -> usize {
+        dispatch!(self, calculate_memory_size())
+    }
+
+    fn save_model_sync(&self, path: &str) -> Result<()> {
+        dispatch!(self, save_model_sync(path))
+    }
+}
+
+/// Compute SGD parameter updates: param = param - lr * grad.
+///
+/// Shared helper used by all model implementations to avoid duplicating the
+/// update logic. Returns a map of parameter name → updated array with all
+/// values already eval'd.
+pub(crate) fn compute_sgd_updates(
+    gradients: &HashMap<String, &MxArray>,
+    learning_rate: f64,
+    current_params: &HashMap<String, MxArray>,
+) -> Result<HashMap<String, MxArray>> {
+    let lr_scalar_f32 = MxArray::full(&[], Either::A(learning_rate), None)?;
+    let mut updated_params: HashMap<String, MxArray> = HashMap::new();
+
+    for (name, grad) in gradients.iter() {
+        let param = current_params.get(name.as_str()).ok_or_else(|| {
+            Error::new(
+                Status::GenericFailure,
+                format!("Parameter '{}' not found", name),
+            )
+        })?;
+        let param_dtype = param.dtype()?;
+        let lr_scalar = lr_scalar_f32.astype(param_dtype)?;
+        let scaled_grad = lr_scalar.mul(grad)?;
+        let updated_param = param.sub(&scaled_grad)?;
+        let updated_param = if updated_param.dtype()? != param_dtype {
+            updated_param.astype(param_dtype)?
+        } else {
+            updated_param
+        };
+        updated_params.insert(name.clone(), updated_param);
+    }
+
+    // Batch eval all updated parameters
+    for param in updated_params.values() {
+        param.eval();
+    }
+
+    Ok(updated_params)
+}

--- a/crates/mlx-core/src/training_model.rs
+++ b/crates/mlx-core/src/training_model.rs
@@ -86,7 +86,7 @@ impl ModelType {
 /// wrapping in `TrainableModelEnum`.
 pub(crate) trait TrainableModel: Send + Sync {
     /// Extract all trainable parameters as a name→array map.
-    fn get_parameters(&self) -> HashMap<String, MxArray>;
+    fn get_parameters(&self) -> Result<HashMap<String, MxArray>>;
 
     /// Apply gradients using SGD: param = param - lr * grad.
     fn apply_gradients_with_params(
@@ -134,9 +134,9 @@ pub(crate) enum TrainableModelEnum {
 }
 
 impl TrainableModel for TrainableModelEnum {
-    fn get_parameters(&self) -> HashMap<String, MxArray> {
+    fn get_parameters(&self) -> Result<HashMap<String, MxArray>> {
         match self {
-            TrainableModelEnum::Qwen3(m) => m.get_parameters(),
+            TrainableModelEnum::Qwen3(m) => Ok(m.get_parameters()),
             TrainableModelEnum::Qwen35Dense(m) => m.get_parameters_for_training(),
             TrainableModelEnum::Qwen35Moe(m) => m.get_parameters_for_training(),
         }

--- a/crates/mlx-core/src/utils/functional.rs
+++ b/crates/mlx-core/src/utils/functional.rs
@@ -792,34 +792,29 @@ fn rms_norm_gated_functional(
     y_normed.mul(&z_activated)
 }
 
-/// Functional depthwise conv1d.
-/// weight: [channels, 1, kernel_size], input: [B, T, channels]
-/// Implements as a series of shifts and multiplies (differentiable).
+/// Functional depthwise conv1d using MLX's native conv1d (has VJP support).
+/// weight: [channels, kernel_size, 1] (MLX Conv1d format for depthwise)
+/// input: [B, T, channels]
+/// groups = channels (depthwise convolution)
 fn functional_depthwise_conv1d(
     input: &MxArray,
     weight: &MxArray,
     channels: i64,
-    kernel_size: i64,
+    _kernel_size: i64,
 ) -> Result<MxArray> {
-    let batch = input.shape_at(0)?;
-    let seq_len = input.shape_at(1)?;
-    let out_len = seq_len - kernel_size + 1;
-
-    // weight shape: [channels, 1, kernel_size] -> squeeze to [channels, kernel_size]
-    let w = weight.squeeze(Some(&[1]))?;
-
-    // For each kernel position k, slice input[:, k:k+out_len, :] and multiply by w[:, k]
-    let mut result = MxArray::zeros(&[batch, out_len, channels], Some(input.dtype()?))?;
-    for k in 0..kernel_size {
-        let input_slice = input.slice_axis(1, k, k + out_len)?; // [B, out_len, C]
-        let w_k = w.slice_axis(1, k, k + 1)?; // [C, 1]
-        let w_k = w_k.squeeze(Some(&[1]))?; // [C]
-        // Broadcast multiply: [B, out_len, C] * [C] -> [B, out_len, C]
-        let contribution = input_slice.mul(&w_k)?;
-        result = result.add(&contribution)?;
-    }
-
-    Ok(result)
+    // Use MLX's native conv1d which has proper VJP for autograd.
+    // Parameters: stride=1, padding=0, dilation=1, groups=channels (depthwise)
+    let handle = unsafe {
+        mlx_sys::mlx_conv1d(
+            input.as_raw_ptr(),
+            weight.as_raw_ptr(),
+            1,               // stride
+            0,               // padding (we prepend zeros manually)
+            1,               // dilation
+            channels as i32, // groups = channels for depthwise
+        )
+    };
+    MxArray::from_handle(handle, "functional_conv1d")
 }
 
 /// GatedDeltaNet functional forward (linear attention layer).
@@ -1145,13 +1140,15 @@ pub fn qwen3_5_forward_hidden_states(
     // Transformer blocks
     for layer_idx in 0..config.num_layers as usize {
         h = qwen3_5_block_functional(params, &h, config, layer_idx)?;
+        if layer_idx < 3 || layer_idx == config.num_layers as usize - 1 {}
     }
 
     // Final norm
     let final_norm_weight = params
         .get("final_norm.weight")
         .ok_or_else(|| Error::from_reason("Missing final_norm.weight"))?;
-    rms_norm_functional(&h, final_norm_weight, config.rms_norm_eps)
+    let result = rms_norm_functional(&h, final_norm_weight, config.rms_norm_eps)?;
+    Ok(result)
 }
 
 // ============================================

--- a/crates/mlx-core/src/utils/functional.rs
+++ b/crates/mlx-core/src/utils/functional.rs
@@ -788,7 +788,7 @@ fn rms_norm_gated_functional(
     eps: f64,
 ) -> Result<MxArray> {
     let y_normed = rms_norm_functional(y, weight, eps)?;
-    let z_activated = Activations::silu(z)?;
+    let z_activated = Activations::silu_for_autograd(z)?;
     y_normed.mul(&z_activated)
 }
 
@@ -888,8 +888,8 @@ fn gated_delta_net_functional(
         conv_out
     };
 
-    // SiLU activation
-    let conv_out = Activations::silu(&conv_out)?;
+    // SiLU activation (autograd-safe: tanh-based, avoids NaN gradients)
+    let conv_out = Activations::silu_for_autograd(&conv_out)?;
 
     // Split into q, k, v
     let q_flat = conv_out.slice_axis(2, 0, key_dim as i64)?;
@@ -1190,7 +1190,9 @@ fn functional_gather_sort(x: &MxArray, indices: &MxArray) -> Result<GatherSortRe
     let idx_sorted = flat_indices.take(&order, 0)?;
 
     let x_shape = x.shape()?;
-    let d = *x_shape.last().unwrap();
+    let d = *x_shape
+        .last()
+        .ok_or_else(|| Error::from_reason("gather_sort: x has empty shape"))?;
     let x_flat = x.reshape(&[-1, 1, d])?;
     let m_scalar = MxArray::scalar_int(m as i32)?;
     let token_indices = order.floor_divide(&m_scalar)?;
@@ -1284,13 +1286,15 @@ fn sparse_moe_functional(
         let idx = &sorted.idx_sorted;
         let gate_out = sorted.x_sorted.gather_mm(&gate_proj_t, idx, true)?;
         let up_out = sorted.x_sorted.gather_mm(&up_proj_t, idx, true)?;
-        let activated = Activations::swiglu(&gate_out, &up_out)?;
+        let gate_act = Activations::silu_for_autograd(&gate_out)?;
+        let activated = gate_act.mul(&up_out)?;
         let expert_out = activated.gather_mm(&down_proj_t, idx, true)?;
         functional_scatter_unsort(&expert_out, &sorted.inv_order, &[ne, k as i64])?
     } else {
         let gate_out = x_expanded.gather_mm(&gate_proj_t, &top_indices, false)?;
         let up_out = x_expanded.gather_mm(&up_proj_t, &top_indices, false)?;
-        let activated = Activations::swiglu(&gate_out, &up_out)?;
+        let gate_act = Activations::silu_for_autograd(&gate_out)?;
+        let activated = gate_act.mul(&up_out)?;
         activated.gather_mm(&down_proj_t, &top_indices, false)?
     };
 

--- a/crates/mlx-core/src/utils/functional.rs
+++ b/crates/mlx-core/src/utils/functional.rs
@@ -388,27 +388,31 @@ pub fn qwen3_forward_hidden_states_impl(
             let config_clone = config.clone();
             let layer = layer_idx;
 
-            let outputs = autograd::checkpoint_apply(inputs, move |arrays| {
-                let h_in = &arrays[0];
-                let layer_params: HashMap<String, MxArray> = names_clone
-                    .iter()
-                    .enumerate()
-                    .map(|(i, name)| (name.clone(), arrays[i + 1].clone()))
-                    .collect();
-                let block_params = get_layer_params(&layer_params, layer, &config_clone)?;
-                let h_out = transformer_block_functional(
-                    h_in,
-                    &block_params,
-                    config_clone.num_heads as u32,
-                    config_clone.num_kv_heads as u32,
-                    config_clone.head_dim as u32,
-                    config_clone.rope_theta,
-                    config_clone.use_qk_norm,
-                    config_clone.rms_norm_eps,
-                    0,
-                )?;
-                Ok(vec![h_out])
-            }, ckpt_contexts)?;
+            let outputs = autograd::checkpoint_apply(
+                inputs,
+                move |arrays| {
+                    let h_in = &arrays[0];
+                    let layer_params: HashMap<String, MxArray> = names_clone
+                        .iter()
+                        .enumerate()
+                        .map(|(i, name)| (name.clone(), arrays[i + 1].clone()))
+                        .collect();
+                    let block_params = get_layer_params(&layer_params, layer, &config_clone)?;
+                    let h_out = transformer_block_functional(
+                        h_in,
+                        &block_params,
+                        config_clone.num_heads as u32,
+                        config_clone.num_kv_heads as u32,
+                        config_clone.head_dim as u32,
+                        config_clone.rope_theta,
+                        config_clone.use_qk_norm,
+                        config_clone.rms_norm_eps,
+                        0,
+                    )?;
+                    Ok(vec![h_out])
+                },
+                ckpt_contexts,
+            )?;
 
             hidden_states = outputs.into_iter().next().unwrap();
         } else {
@@ -1218,17 +1222,21 @@ fn qwen3_5_block_checkpointed(
     let config_clone = config.clone();
     let layer = layer_idx;
 
-    let outputs = autograd::checkpoint_apply(inputs, move |arrays| {
-        // arrays[0] = hidden_states, arrays[1..] = layer params
-        let h_in = &arrays[0];
-        let layer_params: HashMap<String, MxArray> = names_clone
-            .iter()
-            .enumerate()
-            .map(|(i, name)| (name.clone(), arrays[i + 1].clone()))
-            .collect();
-        let h_out = qwen3_5_block_functional(&layer_params, h_in, &config_clone, layer)?;
-        Ok(vec![h_out])
-    }, ckpt_contexts)?;
+    let outputs = autograd::checkpoint_apply(
+        inputs,
+        move |arrays| {
+            // arrays[0] = hidden_states, arrays[1..] = layer params
+            let h_in = &arrays[0];
+            let layer_params: HashMap<String, MxArray> = names_clone
+                .iter()
+                .enumerate()
+                .map(|(i, name)| (name.clone(), arrays[i + 1].clone()))
+                .collect();
+            let h_out = qwen3_5_block_functional(&layer_params, h_in, &config_clone, layer)?;
+            Ok(vec![h_out])
+        },
+        ckpt_contexts,
+    )?;
 
     Ok(outputs.into_iter().next().unwrap())
 }
@@ -1544,17 +1552,26 @@ fn qwen3_5_moe_block_checkpointed(
     let dense_clone = dense_config.clone();
     let layer = layer_idx;
 
-    let outputs = autograd::checkpoint_apply(inputs, move |arrays| {
-        let h_in = &arrays[0];
-        let layer_params: HashMap<String, MxArray> = names_clone
-            .iter()
-            .enumerate()
-            .map(|(i, name)| (name.clone(), arrays[i + 1].clone()))
-            .collect();
-        let h_out =
-            qwen3_5_moe_block_functional(&layer_params, h_in, &config_clone, &dense_clone, layer)?;
-        Ok(vec![h_out])
-    }, ckpt_contexts)?;
+    let outputs = autograd::checkpoint_apply(
+        inputs,
+        move |arrays| {
+            let h_in = &arrays[0];
+            let layer_params: HashMap<String, MxArray> = names_clone
+                .iter()
+                .enumerate()
+                .map(|(i, name)| (name.clone(), arrays[i + 1].clone()))
+                .collect();
+            let h_out = qwen3_5_moe_block_functional(
+                &layer_params,
+                h_in,
+                &config_clone,
+                &dense_clone,
+                layer,
+            )?;
+            Ok(vec![h_out])
+        },
+        ckpt_contexts,
+    )?;
 
     Ok(outputs.into_iter().next().unwrap())
 }
@@ -1585,7 +1602,14 @@ pub fn qwen3_5_moe_forward_hidden_states_impl(
     let dense_config = config.to_dense_config();
     for layer_idx in 0..config.num_layers as usize {
         if use_checkpointing {
-            h = qwen3_5_moe_block_checkpointed(params, &h, config, &dense_config, layer_idx, ckpt_contexts)?;
+            h = qwen3_5_moe_block_checkpointed(
+                params,
+                &h,
+                config,
+                &dense_config,
+                layer_idx,
+                ckpt_contexts,
+            )?;
         } else {
             h = qwen3_5_moe_block_functional(params, &h, config, &dense_config, layer_idx)?;
         }
@@ -1609,8 +1633,13 @@ pub(crate) fn forward_functional_dispatch(
     use_checkpointing: bool,
     ckpt_contexts: &mut autograd::CheckpointContexts,
 ) -> Result<MxArray> {
-    let hidden_states =
-        forward_hidden_states_dispatch(model_type, params, input_ids, use_checkpointing, ckpt_contexts)?;
+    let hidden_states = forward_hidden_states_dispatch(
+        model_type,
+        params,
+        input_ids,
+        use_checkpointing,
+        ckpt_contexts,
+    )?;
     lm_head_functional(&hidden_states, params, model_type.tie_word_embeddings())
 }
 
@@ -1623,15 +1652,27 @@ pub(crate) fn forward_hidden_states_dispatch(
     ckpt_contexts: &mut autograd::CheckpointContexts,
 ) -> Result<MxArray> {
     match model_type {
-        ModelType::Qwen3(config) => {
-            qwen3_forward_hidden_states_impl(config, params, input_ids, use_checkpointing, ckpt_contexts)
-        }
-        ModelType::Qwen35Dense(config) => {
-            qwen3_5_forward_hidden_states_impl(config, params, input_ids, use_checkpointing, ckpt_contexts)
-        }
-        ModelType::Qwen35Moe(config) => {
-            qwen3_5_moe_forward_hidden_states_impl(config, params, input_ids, use_checkpointing, ckpt_contexts)
-        }
+        ModelType::Qwen3(config) => qwen3_forward_hidden_states_impl(
+            config,
+            params,
+            input_ids,
+            use_checkpointing,
+            ckpt_contexts,
+        ),
+        ModelType::Qwen35Dense(config) => qwen3_5_forward_hidden_states_impl(
+            config,
+            params,
+            input_ids,
+            use_checkpointing,
+            ckpt_contexts,
+        ),
+        ModelType::Qwen35Moe(config) => qwen3_5_moe_forward_hidden_states_impl(
+            config,
+            params,
+            input_ids,
+            use_checkpointing,
+            ckpt_contexts,
+        ),
     }
 }
 

--- a/crates/mlx-core/src/utils/functional.rs
+++ b/crates/mlx-core/src/utils/functional.rs
@@ -9,6 +9,7 @@
  * gradients through the entire forward pass from parameters to loss.
  */
 use crate::array::{MxArray, scaled_dot_product_attention};
+use crate::autograd;
 use crate::models::qwen3::Qwen3Config;
 use crate::models::qwen3_5::Qwen3_5Config;
 use crate::models::qwen3_5_moe::Qwen3_5MoeConfig;
@@ -347,6 +348,18 @@ pub fn qwen3_forward_hidden_states(
     params: &HashMap<String, MxArray>,
     input_ids: &MxArray,
 ) -> Result<MxArray> {
+    let mut ckpt = autograd::CheckpointContexts::new();
+    qwen3_forward_hidden_states_impl(config, params, input_ids, false, &mut ckpt)
+}
+
+/// Qwen3 forward with optional gradient checkpointing.
+pub fn qwen3_forward_hidden_states_impl(
+    config: &Qwen3Config,
+    params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+    use_checkpointing: bool,
+    ckpt_contexts: &mut autograd::CheckpointContexts,
+) -> Result<MxArray> {
     // 1. Embedding lookup
     let embedding_weight = params
         .get("embedding.weight")
@@ -357,21 +370,62 @@ pub fn qwen3_forward_hidden_states(
     // 2. Transformer layers
     let num_layers = config.num_layers as usize;
     for layer_idx in 0..num_layers {
-        // Get layer parameters
-        let layer_params = get_layer_params(params, layer_idx, config)?;
+        if use_checkpointing {
+            // Checkpointed path: collect layer params, wrap in checkpoint
+            let prefix = format!("layers.{}.", layer_idx);
+            let layer_param_names = collect_layer_param_names(params, &prefix);
 
-        // Forward through transformer block
-        hidden_states = transformer_block_functional(
-            &hidden_states,
-            &layer_params,
-            config.num_heads as u32,
-            config.num_kv_heads as u32,
-            config.head_dim as u32, // Use explicit head_dim from config (critical for Qwen3!)
-            config.rope_theta,
-            config.use_qk_norm,
-            config.rms_norm_eps,
-            0, // offset (no KV caching for training)
-        )?;
+            let mut inputs: Vec<&MxArray> = vec![&hidden_states];
+            for name in &layer_param_names {
+                inputs.push(
+                    params
+                        .get(name)
+                        .ok_or_else(|| Error::from_reason(format!("Missing {}", name)))?,
+                );
+            }
+
+            let names_clone = layer_param_names.clone();
+            let config_clone = config.clone();
+            let layer = layer_idx;
+
+            let outputs = autograd::checkpoint_apply(inputs, move |arrays| {
+                let h_in = &arrays[0];
+                let layer_params: HashMap<String, MxArray> = names_clone
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| (name.clone(), arrays[i + 1].clone()))
+                    .collect();
+                let block_params = get_layer_params(&layer_params, layer, &config_clone)?;
+                let h_out = transformer_block_functional(
+                    h_in,
+                    &block_params,
+                    config_clone.num_heads as u32,
+                    config_clone.num_kv_heads as u32,
+                    config_clone.head_dim as u32,
+                    config_clone.rope_theta,
+                    config_clone.use_qk_norm,
+                    config_clone.rms_norm_eps,
+                    0,
+                )?;
+                Ok(vec![h_out])
+            }, ckpt_contexts)?;
+
+            hidden_states = outputs.into_iter().next().unwrap();
+        } else {
+            // Standard path
+            let layer_params = get_layer_params(params, layer_idx, config)?;
+            hidden_states = transformer_block_functional(
+                &hidden_states,
+                &layer_params,
+                config.num_heads as u32,
+                config.num_kv_heads as u32,
+                config.head_dim as u32,
+                config.rope_theta,
+                config.use_qk_norm,
+                config.rms_norm_eps,
+                0,
+            )?;
+        }
     }
 
     // 3. Final layer norm
@@ -1125,11 +1179,77 @@ pub fn qwen3_5_forward_functional(
     lm_head_functional(&hidden_states, params, config.tie_word_embeddings)
 }
 
+/// Collect sorted parameter names that match a prefix (e.g., "layers.0.")
+fn collect_layer_param_names(params: &HashMap<String, MxArray>, prefix: &str) -> Vec<String> {
+    let mut names: Vec<String> = params
+        .keys()
+        .filter(|k| k.starts_with(prefix))
+        .cloned()
+        .collect();
+    names.sort();
+    names
+}
+
+/// Run a Qwen3.5 Dense block through gradient checkpointing.
+///
+/// Flattens [hidden_states, layer_param1, layer_param2, ...] into a single
+/// array vec for checkpoint, then reconstructs params inside the callback.
+fn qwen3_5_block_checkpointed(
+    params: &HashMap<String, MxArray>,
+    h: &MxArray,
+    config: &Qwen3_5Config,
+    layer_idx: usize,
+    ckpt_contexts: &mut autograd::CheckpointContexts,
+) -> Result<MxArray> {
+    let prefix = format!("layers.{}.", layer_idx);
+    let layer_param_names = collect_layer_param_names(params, &prefix);
+
+    // Build inputs: [hidden_states, param1, param2, ...]
+    let mut inputs: Vec<&MxArray> = vec![h];
+    for name in &layer_param_names {
+        inputs.push(
+            params
+                .get(name)
+                .ok_or_else(|| Error::from_reason(format!("Missing {}", name)))?,
+        );
+    }
+
+    let names_clone = layer_param_names.clone();
+    let config_clone = config.clone();
+    let layer = layer_idx;
+
+    let outputs = autograd::checkpoint_apply(inputs, move |arrays| {
+        // arrays[0] = hidden_states, arrays[1..] = layer params
+        let h_in = &arrays[0];
+        let layer_params: HashMap<String, MxArray> = names_clone
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), arrays[i + 1].clone()))
+            .collect();
+        let h_out = qwen3_5_block_functional(&layer_params, h_in, &config_clone, layer)?;
+        Ok(vec![h_out])
+    }, ckpt_contexts)?;
+
+    Ok(outputs.into_iter().next().unwrap())
+}
+
 /// Qwen3.5 Dense forward returning hidden states before LM head.
 pub fn qwen3_5_forward_hidden_states(
     config: &Qwen3_5Config,
     params: &HashMap<String, MxArray>,
     input_ids: &MxArray,
+) -> Result<MxArray> {
+    let mut ckpt = autograd::CheckpointContexts::new();
+    qwen3_5_forward_hidden_states_impl(config, params, input_ids, false, &mut ckpt)
+}
+
+/// Qwen3.5 Dense forward with optional gradient checkpointing.
+pub fn qwen3_5_forward_hidden_states_impl(
+    config: &Qwen3_5Config,
+    params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+    use_checkpointing: bool,
+    ckpt_contexts: &mut autograd::CheckpointContexts,
 ) -> Result<MxArray> {
     // Embedding
     let embed_weight = params
@@ -1137,10 +1257,17 @@ pub fn qwen3_5_forward_hidden_states(
         .ok_or_else(|| Error::from_reason("Missing embedding.weight"))?;
     let mut h = embedding_functional(embed_weight, input_ids)?;
 
-    // Transformer blocks
+    // Transformer blocks — NO eval() between layers!
+    // During value_and_grad tracing, eval() would materialize data without calling
+    // detach() (because is_tracer() is true), preventing checkpoint from freeing
+    // intermediates. The lazy graph is built here; the final eval() (outside tracing)
+    // processes it with proper detach, freeing each layer's intermediates in turn.
     for layer_idx in 0..config.num_layers as usize {
-        h = qwen3_5_block_functional(params, &h, config, layer_idx)?;
-        if layer_idx < 3 || layer_idx == config.num_layers as usize - 1 {}
+        if use_checkpointing {
+            h = qwen3_5_block_checkpointed(params, &h, config, layer_idx, ckpt_contexts)?;
+        } else {
+            h = qwen3_5_block_functional(params, &h, config, layer_idx)?;
+        }
     }
 
     // Final norm
@@ -1391,21 +1518,77 @@ pub fn qwen3_5_moe_forward_functional(
     lm_head_functional(&hidden_states, params, config.tie_word_embeddings)
 }
 
+/// Run a Qwen3.5 MoE block through gradient checkpointing.
+fn qwen3_5_moe_block_checkpointed(
+    params: &HashMap<String, MxArray>,
+    h: &MxArray,
+    config: &Qwen3_5MoeConfig,
+    dense_config: &Qwen3_5Config,
+    layer_idx: usize,
+    ckpt_contexts: &mut autograd::CheckpointContexts,
+) -> Result<MxArray> {
+    let prefix = format!("layers.{}.", layer_idx);
+    let layer_param_names = collect_layer_param_names(params, &prefix);
+
+    let mut inputs: Vec<&MxArray> = vec![h];
+    for name in &layer_param_names {
+        inputs.push(
+            params
+                .get(name)
+                .ok_or_else(|| Error::from_reason(format!("Missing {}", name)))?,
+        );
+    }
+
+    let names_clone = layer_param_names.clone();
+    let config_clone = config.clone();
+    let dense_clone = dense_config.clone();
+    let layer = layer_idx;
+
+    let outputs = autograd::checkpoint_apply(inputs, move |arrays| {
+        let h_in = &arrays[0];
+        let layer_params: HashMap<String, MxArray> = names_clone
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.clone(), arrays[i + 1].clone()))
+            .collect();
+        let h_out =
+            qwen3_5_moe_block_functional(&layer_params, h_in, &config_clone, &dense_clone, layer)?;
+        Ok(vec![h_out])
+    }, ckpt_contexts)?;
+
+    Ok(outputs.into_iter().next().unwrap())
+}
+
 /// Qwen3.5 MoE forward returning hidden states.
 pub fn qwen3_5_moe_forward_hidden_states(
     config: &Qwen3_5MoeConfig,
     params: &HashMap<String, MxArray>,
     input_ids: &MxArray,
 ) -> Result<MxArray> {
+    let mut ckpt = autograd::CheckpointContexts::new();
+    qwen3_5_moe_forward_hidden_states_impl(config, params, input_ids, false, &mut ckpt)
+}
+
+/// Qwen3.5 MoE forward with optional gradient checkpointing.
+pub fn qwen3_5_moe_forward_hidden_states_impl(
+    config: &Qwen3_5MoeConfig,
+    params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+    use_checkpointing: bool,
+    ckpt_contexts: &mut autograd::CheckpointContexts,
+) -> Result<MxArray> {
     let embed_weight = params
         .get("embedding.weight")
         .ok_or_else(|| Error::from_reason("Missing embedding.weight"))?;
     let mut h = embedding_functional(embed_weight, input_ids)?;
 
-    // Compute dense_config once (not per-layer) to avoid repeated allocation
     let dense_config = config.to_dense_config();
     for layer_idx in 0..config.num_layers as usize {
-        h = qwen3_5_moe_block_functional(params, &h, config, &dense_config, layer_idx)?;
+        if use_checkpointing {
+            h = qwen3_5_moe_block_checkpointed(params, &h, config, &dense_config, layer_idx, ckpt_contexts)?;
+        } else {
+            h = qwen3_5_moe_block_functional(params, &h, config, &dense_config, layer_idx)?;
+        }
     }
 
     let final_norm_weight = params
@@ -1423,25 +1606,31 @@ pub(crate) fn forward_functional_dispatch(
     model_type: &ModelType,
     params: &HashMap<String, MxArray>,
     input_ids: &MxArray,
+    use_checkpointing: bool,
+    ckpt_contexts: &mut autograd::CheckpointContexts,
 ) -> Result<MxArray> {
-    match model_type {
-        ModelType::Qwen3(config) => qwen3_forward_functional(config, params, input_ids),
-        ModelType::Qwen35Dense(config) => qwen3_5_forward_functional(config, params, input_ids),
-        ModelType::Qwen35Moe(config) => qwen3_5_moe_forward_functional(config, params, input_ids),
-    }
+    let hidden_states =
+        forward_hidden_states_dispatch(model_type, params, input_ids, use_checkpointing, ckpt_contexts)?;
+    lm_head_functional(&hidden_states, params, model_type.tie_word_embeddings())
 }
 
-/// Dispatch forward pass returning hidden states.
+/// Dispatch forward pass returning hidden states with optional checkpointing.
 pub(crate) fn forward_hidden_states_dispatch(
     model_type: &ModelType,
     params: &HashMap<String, MxArray>,
     input_ids: &MxArray,
+    use_checkpointing: bool,
+    ckpt_contexts: &mut autograd::CheckpointContexts,
 ) -> Result<MxArray> {
     match model_type {
-        ModelType::Qwen3(config) => qwen3_forward_hidden_states(config, params, input_ids),
-        ModelType::Qwen35Dense(config) => qwen3_5_forward_hidden_states(config, params, input_ids),
+        ModelType::Qwen3(config) => {
+            qwen3_forward_hidden_states_impl(config, params, input_ids, use_checkpointing, ckpt_contexts)
+        }
+        ModelType::Qwen35Dense(config) => {
+            qwen3_5_forward_hidden_states_impl(config, params, input_ids, use_checkpointing, ckpt_contexts)
+        }
         ModelType::Qwen35Moe(config) => {
-            qwen3_5_moe_forward_hidden_states(config, params, input_ids)
+            qwen3_5_moe_forward_hidden_states_impl(config, params, input_ids, use_checkpointing, ckpt_contexts)
         }
     }
 }

--- a/crates/mlx-core/src/utils/functional.rs
+++ b/crates/mlx-core/src/utils/functional.rs
@@ -10,7 +10,10 @@
  */
 use crate::array::{MxArray, scaled_dot_product_attention};
 use crate::models::qwen3::Qwen3Config;
+use crate::models::qwen3_5::Qwen3_5Config;
+use crate::models::qwen3_5_moe::Qwen3_5MoeConfig;
 use crate::nn::Activations;
+use crate::training_model::ModelType;
 use napi::bindgen_prelude::*;
 use std::collections::HashMap;
 
@@ -758,6 +761,688 @@ fn get_layer_params<'a>(
         input_norm_weight,
         post_attn_norm_weight,
     })
+}
+
+// ============================================
+// Qwen3.5 Dense Model Forward (Functional)
+// ============================================
+
+/// RMS normalization without learnable weight (functional version).
+fn rms_norm_no_weight_functional(x: &MxArray, eps: f64) -> Result<MxArray> {
+    let original_dtype = x.dtype()?;
+    let x_f32 = x.astype(crate::array::DType::Float32)?;
+    let squared = x_f32.square()?;
+    let mean_squared = squared.mean(Some(&[-1]), Some(true))?;
+    let variance_plus_eps = mean_squared.add_scalar(eps)?;
+    let sqrt_var = variance_plus_eps.sqrt()?;
+    let normalized = x_f32.div(&sqrt_var)?;
+    normalized.astype(original_dtype)
+}
+
+/// RMSNormGated functional: swiglu(z, rms_norm(y, weight))
+/// Implements: silu(z) * rms_norm(y) * weight
+fn rms_norm_gated_functional(
+    y: &MxArray,
+    z: &MxArray,
+    weight: &MxArray,
+    eps: f64,
+) -> Result<MxArray> {
+    let y_normed = rms_norm_functional(y, weight, eps)?;
+    let z_activated = Activations::silu(z)?;
+    y_normed.mul(&z_activated)
+}
+
+/// Functional depthwise conv1d.
+/// weight: [channels, 1, kernel_size], input: [B, T, channels]
+/// Implements as a series of shifts and multiplies (differentiable).
+fn functional_depthwise_conv1d(
+    input: &MxArray,
+    weight: &MxArray,
+    channels: i64,
+    kernel_size: i64,
+) -> Result<MxArray> {
+    let batch = input.shape_at(0)?;
+    let seq_len = input.shape_at(1)?;
+    let out_len = seq_len - kernel_size + 1;
+
+    // weight shape: [channels, 1, kernel_size] -> squeeze to [channels, kernel_size]
+    let w = weight.squeeze(Some(&[1]))?;
+
+    // For each kernel position k, slice input[:, k:k+out_len, :] and multiply by w[:, k]
+    let mut result = MxArray::zeros(&[batch, out_len, channels], Some(input.dtype()?))?;
+    for k in 0..kernel_size {
+        let input_slice = input.slice_axis(1, k, k + out_len)?; // [B, out_len, C]
+        let w_k = w.slice_axis(1, k, k + 1)?; // [C, 1]
+        let w_k = w_k.squeeze(Some(&[1]))?; // [C]
+        // Broadcast multiply: [B, out_len, C] * [C] -> [B, out_len, C]
+        let contribution = input_slice.mul(&w_k)?;
+        result = result.add(&contribution)?;
+    }
+
+    Ok(result)
+}
+
+/// GatedDeltaNet functional forward (linear attention layer).
+///
+/// Implements the full GDN pipeline: project -> conv1d -> gated_delta_update -> norm -> out_proj
+/// Uses `use_kernel=false` to ensure full differentiability for training.
+fn gated_delta_net_functional(
+    params: &HashMap<String, MxArray>,
+    x: &MxArray,
+    prefix: &str,
+    config: &Qwen3_5Config,
+) -> Result<MxArray> {
+    let batch = x.shape_at(0)?;
+    let seq_len = x.shape_at(1)?;
+
+    let num_k_heads = config.linear_num_key_heads;
+    let num_v_heads = config.linear_num_value_heads;
+    let key_head_dim = config.linear_key_head_dim;
+    let value_head_dim = config.linear_value_head_dim;
+    let key_dim = num_k_heads * key_head_dim;
+    let value_dim = num_v_heads * value_head_dim;
+    let conv_dim = key_dim * 2 + value_dim;
+    let conv_kernel_dim = config.linear_conv_kernel_dim;
+
+    // Project to qkvz
+    let qkvz_weight = params
+        .get(&format!("{}.in_proj_qkvz.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.in_proj_qkvz.weight", prefix)))?;
+    let qkvz = linear_functional(x, qkvz_weight, None)?;
+
+    // Project to ba
+    let ba_weight = params
+        .get(&format!("{}.in_proj_ba.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.in_proj_ba.weight", prefix)))?;
+    let ba = linear_functional(x, ba_weight, None)?;
+
+    // Split ba into b and a
+    let b = ba.slice_axis(2, 0, num_v_heads as i64)?;
+    let a = ba.slice_axis(2, num_v_heads as i64, (num_v_heads * 2) as i64)?;
+
+    // Split qkvz: qkv through conv, z bypasses
+    let qkv = qkvz.slice_axis(2, 0, conv_dim as i64)?;
+    let z = qkvz.slice_axis(2, conv_dim as i64, (key_dim * 2 + value_dim * 2) as i64)?;
+
+    // Conv1d: prepend zeros (no cache for training - full sequence)
+    let conv_weight = params
+        .get(&format!("{}.conv1d.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.conv1d.weight", prefix)))?;
+    let pad_len = (conv_kernel_dim - 1) as i64;
+    let zeros = MxArray::zeros(&[batch, pad_len, conv_dim as i64], Some(qkv.dtype()?))?;
+    let conv_input = MxArray::concatenate(&zeros, &qkv, 1)?;
+
+    // Depthwise conv1d: use functional matmul-based implementation
+    let conv_out = functional_depthwise_conv1d(
+        &conv_input,
+        conv_weight,
+        conv_dim as i64,
+        conv_kernel_dim as i64,
+    )?;
+
+    // Take last seq_len timesteps
+    let conv_out_len = conv_out.shape_at(1)?;
+    let conv_out = if conv_out_len > seq_len {
+        conv_out.slice_axis(1, conv_out_len - seq_len, conv_out_len)?
+    } else {
+        conv_out
+    };
+
+    // SiLU activation
+    let conv_out = Activations::silu(&conv_out)?;
+
+    // Split into q, k, v
+    let q_flat = conv_out.slice_axis(2, 0, key_dim as i64)?;
+    let k_flat = conv_out.slice_axis(2, key_dim as i64, (key_dim * 2) as i64)?;
+    let v_flat = conv_out.slice_axis(2, (key_dim * 2) as i64, conv_dim as i64)?;
+
+    // Reshape to head format
+    let q = q_flat.reshape(&[batch, seq_len, num_k_heads as i64, key_head_dim as i64])?;
+    let k = k_flat.reshape(&[batch, seq_len, num_k_heads as i64, key_head_dim as i64])?;
+    let v = v_flat.reshape(&[batch, seq_len, num_v_heads as i64, value_head_dim as i64])?;
+
+    // RMS norm scaling (no learnable weight)
+    let inv_scale = (key_head_dim as f64).powf(-0.5);
+    let q_normed = rms_norm_no_weight_functional(&q, 1e-6)?;
+    let k_normed = rms_norm_no_weight_functional(&k, 1e-6)?;
+    let q = q_normed.mul_scalar(inv_scale * inv_scale)?;
+    let k = k_normed.mul_scalar(inv_scale)?;
+
+    // Gated delta update (use_kernel=false for differentiability)
+    let a_log = params
+        .get(&format!("{}.a_log", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.a_log", prefix)))?;
+    let dt_bias = params
+        .get(&format!("{}.dt_bias", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.dt_bias", prefix)))?;
+
+    use crate::models::qwen3_5::gated_delta::gated_delta_update;
+    let (y, _state) = gated_delta_update(&q, &k, &v, &a, &b, a_log, dt_bias, None, None, false)?;
+
+    // Reshape z to per-head format
+    let z = z.reshape(&[batch, seq_len, num_v_heads as i64, value_head_dim as i64])?;
+
+    // RMSNormGated: applies swiglu(z, rms_norm(y))
+    let norm_weight = params
+        .get(&format!("{}.norm.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.norm.weight", prefix)))?;
+    let y_normed = rms_norm_gated_functional(&y, &z, norm_weight, config.rms_norm_eps)?;
+
+    // Flatten heads and output projection
+    let y_flat = y_normed.reshape(&[batch, seq_len, value_dim as i64])?;
+    let out_proj_weight = params
+        .get(&format!("{}.out_proj.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.out_proj.weight", prefix)))?;
+    linear_functional(&y_flat, out_proj_weight, None)
+}
+
+/// Qwen3.5 full attention with gating and partial RoPE (functional).
+fn qwen3_5_attention_functional(
+    params: &HashMap<String, MxArray>,
+    x: &MxArray,
+    prefix: &str,
+    config: &Qwen3_5Config,
+) -> Result<MxArray> {
+    let batch = x.shape_at(0)?;
+    let seq_len = x.shape_at(1)?;
+    let num_heads = config.num_heads;
+    let num_kv_heads = config.num_kv_heads;
+    let head_dim = config.head_dim;
+    let scale = (head_dim as f64).powf(-0.5);
+
+    // Q projection (2x width for gating)
+    let q_weight = params
+        .get(&format!("{}.q_proj.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.q_proj.weight", prefix)))?;
+    let q_proj_out = linear_functional(x, q_weight, None)?;
+
+    // Split into queries + gate per-head
+    let q_per_head =
+        q_proj_out.reshape(&[batch, seq_len, num_heads as i64, (head_dim * 2) as i64])?;
+    let queries = q_per_head.slice_axis(3, 0, head_dim as i64)?;
+    let gate = q_per_head.slice_axis(3, head_dim as i64, (head_dim * 2) as i64)?;
+    let gate = gate.reshape(&[batch, seq_len, (num_heads * head_dim) as i64])?;
+
+    // K, V projections
+    let k_weight = params
+        .get(&format!("{}.k_proj.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.k_proj.weight", prefix)))?;
+    let v_weight = params
+        .get(&format!("{}.v_proj.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.v_proj.weight", prefix)))?;
+    let keys = linear_functional(x, k_weight, None)?;
+    let values = linear_functional(x, v_weight, None)?;
+
+    let keys = keys.reshape(&[batch, seq_len, num_kv_heads as i64, head_dim as i64])?;
+    let values = values.reshape(&[batch, seq_len, num_kv_heads as i64, head_dim as i64])?;
+
+    // QK normalization
+    let q_norm_weight = params
+        .get(&format!("{}.q_norm.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.q_norm.weight", prefix)))?;
+    let k_norm_weight = params
+        .get(&format!("{}.k_norm.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.k_norm.weight", prefix)))?;
+    let queries = rms_norm_functional(&queries, q_norm_weight, config.rms_norm_eps)?;
+    let keys = rms_norm_functional(&keys, k_norm_weight, config.rms_norm_eps)?;
+
+    // Partial RoPE: only rotate rope_dims dimensions
+    let rope_dims = config.rope_dims();
+    let queries = apply_partial_rope(&queries, rope_dims as i64, config.rope_theta, 0)?;
+    let keys = apply_partial_rope(&keys, rope_dims as i64, config.rope_theta, 0)?;
+
+    // Transpose to [B, H, T, D] for SDPA
+    let queries = queries.transpose(Some(&[0, 2, 1, 3]))?;
+    let keys = keys.transpose(Some(&[0, 2, 1, 3]))?;
+    let values = values.transpose(Some(&[0, 2, 1, 3]))?;
+
+    // SDPA with causal mask (training: full sequence, no cache)
+    let output = if seq_len > 1 {
+        use crate::array::attention::scaled_dot_product_attention_causal;
+        scaled_dot_product_attention_causal(&queries, &keys, &values, scale)?
+    } else {
+        scaled_dot_product_attention(&queries, &keys, &values, scale, None)?
+    };
+
+    // Back to [B, T, H*D]
+    let output = output.transpose(Some(&[0, 2, 1, 3]))?;
+    let output = output.reshape(&[batch, seq_len, (num_heads * head_dim) as i64])?;
+
+    // Gate: output * sigmoid(gate)
+    let gate_sigmoid = Activations::sigmoid(&gate)?;
+    let gated_output = output.mul(&gate_sigmoid)?;
+
+    // Output projection
+    let o_weight = params
+        .get(&format!("{}.o_proj.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.o_proj.weight", prefix)))?;
+    linear_functional(&gated_output, o_weight, None)
+}
+
+/// Apply partial RoPE: only rotate the first `rope_dims` dimensions.
+/// Input shape: [B, T, H, D] (pre-transpose, heads in dim 2)
+fn apply_partial_rope(x: &MxArray, rope_dims: i64, theta: f64, offset: i32) -> Result<MxArray> {
+    let head_dim = x.shape_at(3)?;
+    if rope_dims >= head_dim {
+        // Full RoPE — transpose to [B, H, T, D], apply, transpose back
+        let x_t = x.transpose(Some(&[0, 2, 1, 3]))?;
+        let x_t = apply_rope(&x_t, head_dim as u32, theta, offset)?;
+        return x_t.transpose(Some(&[0, 2, 1, 3]));
+    }
+
+    // Split: rotated part + pass-through part
+    let x_rot = x.slice_axis(3, 0, rope_dims)?;
+    let x_pass = x.slice_axis(3, rope_dims, head_dim)?;
+
+    // Apply RoPE to rotated part only (transpose to [B, H, T, D] for apply_rope)
+    let x_rot = x_rot.transpose(Some(&[0, 2, 1, 3]))?;
+    let x_rot = apply_rope(&x_rot, rope_dims as u32, theta, offset)?;
+    let x_rot = x_rot.transpose(Some(&[0, 2, 1, 3]))?;
+
+    // Concatenate back along head_dim axis
+    MxArray::concatenate(&x_rot, &x_pass, 3)
+}
+
+/// Qwen3.5 dense decoder block (functional).
+fn qwen3_5_block_functional(
+    params: &HashMap<String, MxArray>,
+    x: &MxArray,
+    config: &Qwen3_5Config,
+    layer_idx: usize,
+) -> Result<MxArray> {
+    let prefix = format!("layers.{}", layer_idx);
+
+    // Pre-norm + attention
+    let input_norm_weight = params
+        .get(&format!("{}.input_layernorm.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.input_layernorm.weight", prefix)))?;
+    let normed = rms_norm_functional(x, input_norm_weight, config.rms_norm_eps)?;
+
+    let attn_out = if config.is_linear_layer(layer_idx) {
+        let attn_prefix = format!("{}.linear_attn", prefix);
+        gated_delta_net_functional(params, &normed, &attn_prefix, config)?
+    } else {
+        let attn_prefix = format!("{}.self_attn", prefix);
+        qwen3_5_attention_functional(params, &normed, &attn_prefix, config)?
+    };
+
+    // Residual
+    let h = x.add(&attn_out)?;
+
+    // Pre-norm + MLP
+    let post_norm_weight = params
+        .get(&format!("{}.post_attention_layernorm.weight", prefix))
+        .ok_or_else(|| {
+            Error::from_reason(format!(
+                "Missing {}.post_attention_layernorm.weight",
+                prefix
+            ))
+        })?;
+    let normed = rms_norm_functional(&h, post_norm_weight, config.rms_norm_eps)?;
+    let mlp_out = mlp_functional(
+        &normed,
+        params
+            .get(&format!("{}.mlp.gate_proj.weight", prefix))
+            .ok_or_else(|| {
+                Error::from_reason(format!("Missing {}.mlp.gate_proj.weight", prefix))
+            })?,
+        params
+            .get(&format!("{}.mlp.up_proj.weight", prefix))
+            .ok_or_else(|| Error::from_reason(format!("Missing {}.mlp.up_proj.weight", prefix)))?,
+        params
+            .get(&format!("{}.mlp.down_proj.weight", prefix))
+            .ok_or_else(|| {
+                Error::from_reason(format!("Missing {}.mlp.down_proj.weight", prefix))
+            })?,
+    )?;
+
+    h.add(&mlp_out)
+}
+
+/// Apply LM head to hidden states: linear projection + logit clamping.
+/// Shared by all model variants (Qwen3.5 Dense and MoE).
+fn lm_head_functional(
+    hidden_states: &MxArray,
+    params: &HashMap<String, MxArray>,
+    tie_word_embeddings: bool,
+) -> Result<MxArray> {
+    let logits = if tie_word_embeddings {
+        let embed_weight = params
+            .get("embedding.weight")
+            .ok_or_else(|| Error::from_reason("Missing embedding.weight"))?;
+        linear_functional(hidden_states, embed_weight, None)?
+    } else {
+        let lm_head_weight = params
+            .get("lm_head.weight")
+            .ok_or_else(|| Error::from_reason("Missing lm_head.weight"))?;
+        linear_functional(hidden_states, lm_head_weight, None)?
+    };
+    logits.clip(Some(-100.0), Some(100.0))
+}
+
+/// Full Qwen3.5 Dense forward pass returning logits (functional).
+pub fn qwen3_5_forward_functional(
+    config: &Qwen3_5Config,
+    params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+) -> Result<MxArray> {
+    let hidden_states = qwen3_5_forward_hidden_states(config, params, input_ids)?;
+    lm_head_functional(&hidden_states, params, config.tie_word_embeddings)
+}
+
+/// Qwen3.5 Dense forward returning hidden states before LM head.
+pub fn qwen3_5_forward_hidden_states(
+    config: &Qwen3_5Config,
+    params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+) -> Result<MxArray> {
+    // Embedding
+    let embed_weight = params
+        .get("embedding.weight")
+        .ok_or_else(|| Error::from_reason("Missing embedding.weight"))?;
+    let mut h = embedding_functional(embed_weight, input_ids)?;
+
+    // Transformer blocks
+    for layer_idx in 0..config.num_layers as usize {
+        h = qwen3_5_block_functional(params, &h, config, layer_idx)?;
+    }
+
+    // Final norm
+    let final_norm_weight = params
+        .get("final_norm.weight")
+        .ok_or_else(|| Error::from_reason("Missing final_norm.weight"))?;
+    rms_norm_functional(&h, final_norm_weight, config.rms_norm_eps)
+}
+
+// ============================================
+// Qwen3.5 MoE Model Forward (Functional)
+// ============================================
+
+/// Helper to get a parameter by prefix.suffix from the params map.
+fn get_param<'a>(
+    params: &'a HashMap<String, MxArray>,
+    prefix: &str,
+    suffix: &str,
+) -> Result<&'a MxArray> {
+    let key = format!("{}.{}", prefix, suffix);
+    params
+        .get(&key)
+        .ok_or_else(|| Error::from_reason(format!("Missing {}", key)))
+}
+
+struct GatherSortResult {
+    x_sorted: MxArray,
+    idx_sorted: MxArray,
+    inv_order: MxArray,
+}
+
+/// Sort tokens by expert assignment for efficient gather_mm.
+/// Replicates Python `_gather_sort` from mlx-lm switch_layers.py.
+fn functional_gather_sort(x: &MxArray, indices: &MxArray) -> Result<GatherSortResult> {
+    let idx_shape = indices.shape()?;
+    let m = *idx_shape
+        .last()
+        .ok_or_else(|| Error::from_reason("empty indices"))?;
+
+    let flat_indices = indices.reshape(&[-1])?;
+    let order = flat_indices.argsort(Some(-1))?;
+    let inv_order = order.argsort(Some(-1))?;
+    let idx_sorted = flat_indices.take(&order, 0)?;
+
+    let x_shape = x.shape()?;
+    let d = *x_shape.last().unwrap();
+    let x_flat = x.reshape(&[-1, 1, d])?;
+    let m_scalar = MxArray::scalar_int(m as i32)?;
+    let token_indices = order.floor_divide(&m_scalar)?;
+    let x_sorted = x_flat.take(&token_indices, 0)?;
+
+    Ok(GatherSortResult {
+        x_sorted,
+        idx_sorted,
+        inv_order,
+    })
+}
+
+/// Unsort gather_mm output back to original token order.
+fn functional_scatter_unsort(
+    x: &MxArray,
+    inv_order: &MxArray,
+    orig_shape: &[i64],
+) -> Result<MxArray> {
+    let unsorted = x.take(inv_order, 0)?;
+    let x_shape = unsorted.shape()?;
+    let mut new_shape = orig_shape.to_vec();
+    for &dim in &x_shape[1..] {
+        new_shape.push(dim);
+    }
+    unsorted.reshape(&new_shape)
+}
+
+/// Sparse MoE routing and expert computation (functional).
+///
+/// Uses `gather_mm` for efficient expert-indexed matmuls instead of looping
+/// over all experts. Only computes matmuls for the top-k routed experts per
+/// token (~16x speedup for 128 experts, top-8).
+///
+/// `gather_mm` has full VJP support in MLX, so this is fully differentiable.
+fn sparse_moe_functional(
+    params: &HashMap<String, MxArray>,
+    x: &MxArray,
+    prefix: &str,
+    config: &Qwen3_5MoeConfig,
+) -> Result<MxArray> {
+    let batch = x.shape_at(0)?;
+    let seq_len = x.shape_at(1)?;
+    let hidden_size = config.hidden_size as i64;
+    let num_experts = config.num_experts;
+    let num_experts_per_tok = config.num_experts_per_tok;
+    let ne = batch * seq_len;
+    let k = num_experts_per_tok;
+    let num_exp = num_experts as i64;
+
+    let x_flat = x.reshape(&[ne, hidden_size])?;
+
+    // Router: softmax(gate(x)) -> top-k
+    let gate_weight = get_param(params, prefix, "gate.weight")?;
+    let router_logits = linear_functional(&x_flat, gate_weight, None)?;
+    let router_weights = Activations::softmax(&router_logits, Some(-1))?;
+
+    // Top-k selection via argpartition
+    let top_indices_full = router_weights.argpartition(-k, Some(-1))?;
+    let top_indices = top_indices_full.slice_axis(1, num_exp - k as i64, num_exp)?;
+    let scores = router_weights.take_along_axis(&top_indices, -1)?;
+
+    // Normalize top-k weights
+    let scores = if config.norm_topk_prob {
+        let sum = scores.sum(Some(&[-1]), Some(true))?;
+        scores.div(&sum)?
+    } else {
+        scores
+    };
+
+    // Expert computation using gather_mm
+    let gate_proj_w = get_param(params, prefix, "switch_mlp.gate_proj.weight")?;
+    let up_proj_w = get_param(params, prefix, "switch_mlp.up_proj.weight")?;
+    let down_proj_w = get_param(params, prefix, "switch_mlp.down_proj.weight")?;
+
+    // Transpose weights: [E, out, in] -> [E, in, out] (gather_mm convention)
+    let gate_proj_t = gate_proj_w.transpose(Some(&[0, 2, 1]))?;
+    let up_proj_t = up_proj_w.transpose(Some(&[0, 2, 1]))?;
+    let down_proj_t = down_proj_w.transpose(Some(&[0, 2, 1]))?;
+
+    // Expand x for gather_mm: [ne, D] -> [ne, 1, 1, D]
+    let x_expanded = x_flat.reshape(&[ne, 1, 1, hidden_size])?;
+
+    // stop_gradient on indices (training: don't differentiate through discrete index selection)
+    let top_indices = top_indices.stop_gradient()?;
+
+    // Sort optimization (same threshold as stateful SwitchGLU in switch_glu.rs)
+    let do_sort = top_indices.size()? >= 64;
+
+    let y = if do_sort {
+        let sorted = functional_gather_sort(&x_expanded, &top_indices)?;
+        let idx = &sorted.idx_sorted;
+        let gate_out = sorted.x_sorted.gather_mm(&gate_proj_t, idx, true)?;
+        let up_out = sorted.x_sorted.gather_mm(&up_proj_t, idx, true)?;
+        let activated = Activations::swiglu(&gate_out, &up_out)?;
+        let expert_out = activated.gather_mm(&down_proj_t, idx, true)?;
+        functional_scatter_unsort(&expert_out, &sorted.inv_order, &[ne, k as i64])?
+    } else {
+        let gate_out = x_expanded.gather_mm(&gate_proj_t, &top_indices, false)?;
+        let up_out = x_expanded.gather_mm(&up_proj_t, &top_indices, false)?;
+        let activated = Activations::swiglu(&gate_out, &up_out)?;
+        activated.gather_mm(&down_proj_t, &top_indices, false)?
+    };
+
+    // Squeeze penultimate dim, weight by routing scores, sum over top-k
+    let y = y.squeeze(Some(&[-2]))?; // [ne, k, D]
+    let scores_expanded = scores.reshape(&[ne, k as i64, 1])?;
+    let expert_output = y.mul(&scores_expanded)?.sum(Some(&[1]), Some(false))?; // [ne, D]
+
+    // Shared expert (unchanged — dense MLP, always-on)
+    let shared_gate = get_param(params, prefix, "shared_expert.gate_proj.weight")?;
+    let shared_up = get_param(params, prefix, "shared_expert.up_proj.weight")?;
+    let shared_down = get_param(params, prefix, "shared_expert.down_proj.weight")?;
+    let shared_out = mlp_functional(&x_flat, shared_gate, shared_up, shared_down)?;
+
+    // Shared expert gate
+    let shared_expert_gate_weight = get_param(params, prefix, "shared_expert_gate.weight")?;
+    let gate_out = linear_functional(&x_flat, shared_expert_gate_weight, None)?;
+    let gate_sigmoid = Activations::sigmoid(&gate_out)?;
+    let shared_gated = shared_out.mul(&gate_sigmoid)?;
+
+    // Combine expert + shared
+    let combined = expert_output.add(&shared_gated)?;
+    combined.reshape(&[batch, seq_len, hidden_size])
+}
+
+/// Qwen3.5 MoE decoder block (functional).
+fn qwen3_5_moe_block_functional(
+    params: &HashMap<String, MxArray>,
+    x: &MxArray,
+    config: &Qwen3_5MoeConfig,
+    dense_config: &Qwen3_5Config,
+    layer_idx: usize,
+) -> Result<MxArray> {
+    let prefix = format!("layers.{}", layer_idx);
+
+    // Pre-norm + attention (same as dense)
+    let input_norm_weight = params
+        .get(&format!("{}.input_layernorm.weight", prefix))
+        .ok_or_else(|| Error::from_reason(format!("Missing {}.input_layernorm.weight", prefix)))?;
+    let normed = rms_norm_functional(x, input_norm_weight, config.rms_norm_eps)?;
+
+    let attn_out = if config.is_linear_layer(layer_idx) {
+        let attn_prefix = format!("{}.linear_attn", prefix);
+        gated_delta_net_functional(params, &normed, &attn_prefix, dense_config)?
+    } else {
+        let attn_prefix = format!("{}.self_attn", prefix);
+        qwen3_5_attention_functional(params, &normed, &attn_prefix, dense_config)?
+    };
+
+    let h = x.add(&attn_out)?;
+
+    // Pre-norm + MLP (MoE or dense depending on layer)
+    let post_norm_weight = params
+        .get(&format!("{}.post_attention_layernorm.weight", prefix))
+        .ok_or_else(|| {
+            Error::from_reason(format!(
+                "Missing {}.post_attention_layernorm.weight",
+                prefix
+            ))
+        })?;
+    let normed = rms_norm_functional(&h, post_norm_weight, config.rms_norm_eps)?;
+
+    let mlp_out = if config.is_moe_layer(layer_idx) {
+        let mlp_prefix = format!("{}.mlp", prefix);
+        sparse_moe_functional(params, &normed, &mlp_prefix, config)?
+    } else {
+        mlp_functional(
+            &normed,
+            params
+                .get(&format!("{}.mlp.gate_proj.weight", prefix))
+                .ok_or_else(|| {
+                    Error::from_reason(format!("Missing {}.mlp.gate_proj.weight", prefix))
+                })?,
+            params
+                .get(&format!("{}.mlp.up_proj.weight", prefix))
+                .ok_or_else(|| {
+                    Error::from_reason(format!("Missing {}.mlp.up_proj.weight", prefix))
+                })?,
+            params
+                .get(&format!("{}.mlp.down_proj.weight", prefix))
+                .ok_or_else(|| {
+                    Error::from_reason(format!("Missing {}.mlp.down_proj.weight", prefix))
+                })?,
+        )?
+    };
+
+    h.add(&mlp_out)
+}
+
+/// Full Qwen3.5 MoE forward pass returning logits (functional).
+pub fn qwen3_5_moe_forward_functional(
+    config: &Qwen3_5MoeConfig,
+    params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+) -> Result<MxArray> {
+    let hidden_states = qwen3_5_moe_forward_hidden_states(config, params, input_ids)?;
+    lm_head_functional(&hidden_states, params, config.tie_word_embeddings)
+}
+
+/// Qwen3.5 MoE forward returning hidden states.
+pub fn qwen3_5_moe_forward_hidden_states(
+    config: &Qwen3_5MoeConfig,
+    params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+) -> Result<MxArray> {
+    let embed_weight = params
+        .get("embedding.weight")
+        .ok_or_else(|| Error::from_reason("Missing embedding.weight"))?;
+    let mut h = embedding_functional(embed_weight, input_ids)?;
+
+    // Compute dense_config once (not per-layer) to avoid repeated allocation
+    let dense_config = config.to_dense_config();
+    for layer_idx in 0..config.num_layers as usize {
+        h = qwen3_5_moe_block_functional(params, &h, config, &dense_config, layer_idx)?;
+    }
+
+    let final_norm_weight = params
+        .get("final_norm.weight")
+        .ok_or_else(|| Error::from_reason("Missing final_norm.weight"))?;
+    rms_norm_functional(&h, final_norm_weight, config.rms_norm_eps)
+}
+
+// ============================================
+// Unified Model Dispatch (for autograd)
+// ============================================
+
+/// Dispatch functional forward pass based on model type.
+pub(crate) fn forward_functional_dispatch(
+    model_type: &ModelType,
+    params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+) -> Result<MxArray> {
+    match model_type {
+        ModelType::Qwen3(config) => qwen3_forward_functional(config, params, input_ids),
+        ModelType::Qwen35Dense(config) => qwen3_5_forward_functional(config, params, input_ids),
+        ModelType::Qwen35Moe(config) => qwen3_5_moe_forward_functional(config, params, input_ids),
+    }
+}
+
+/// Dispatch forward pass returning hidden states.
+pub(crate) fn forward_hidden_states_dispatch(
+    model_type: &ModelType,
+    params: &HashMap<String, MxArray>,
+    input_ids: &MxArray,
+) -> Result<MxArray> {
+    match model_type {
+        ModelType::Qwen3(config) => qwen3_forward_hidden_states(config, params, input_ids),
+        ModelType::Qwen35Dense(config) => qwen3_5_forward_hidden_states(config, params, input_ids),
+        ModelType::Qwen35Moe(config) => {
+            qwen3_5_moe_forward_hidden_states(config, params, input_ids)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/mlx-core/src/vision/encoder.rs
+++ b/crates/mlx-core/src/vision/encoder.rs
@@ -76,6 +76,26 @@ impl VisionAttention {
         })
     }
 
+    /// Get the QKV projection weight
+    pub fn get_qkv_weight(&self) -> MxArray {
+        self.qkv.get_weight()
+    }
+
+    /// Get the QKV projection bias
+    pub fn get_qkv_bias(&self) -> Option<MxArray> {
+        self.qkv.get_bias()
+    }
+
+    /// Get the output projection weight
+    pub fn get_out_proj_weight(&self) -> MxArray {
+        self.out_proj.get_weight()
+    }
+
+    /// Get the output projection bias
+    pub fn get_out_proj_bias(&self) -> Option<MxArray> {
+        self.out_proj.get_bias()
+    }
+
     /// Build attention mask from cumulative sequence lengths.
     ///
     /// Creates a mask where positions within the same sub-sequence can attend
@@ -249,6 +269,26 @@ impl VisionMLP {
         })
     }
 
+    /// Get fc1 weight
+    pub fn get_fc1_weight(&self) -> MxArray {
+        self.fc1.get_weight()
+    }
+
+    /// Get fc1 bias
+    pub fn get_fc1_bias(&self) -> Option<MxArray> {
+        self.fc1.get_bias()
+    }
+
+    /// Get fc2 weight
+    pub fn get_fc2_weight(&self) -> MxArray {
+        self.fc2.get_weight()
+    }
+
+    /// Get fc2 bias
+    pub fn get_fc2_bias(&self) -> Option<MxArray> {
+        self.fc2.get_bias()
+    }
+
     /// Forward pass with GELU activation
     ///
     /// # Arguments
@@ -301,6 +341,26 @@ impl VisionEncoderLayer {
                 fc2: mlp.fc2.clone(),
             }),
         }
+    }
+
+    /// Get the self-attention module
+    pub fn self_attn(&self) -> &VisionAttention {
+        &self.self_attn
+    }
+
+    /// Get the MLP module
+    pub fn mlp(&self) -> &VisionMLP {
+        &self.mlp
+    }
+
+    /// Get LayerNorm 1 (pre-attention)
+    pub fn layer_norm1(&self) -> &LayerNorm {
+        &self.layer_norm1
+    }
+
+    /// Get LayerNorm 2 (post-attention)
+    pub fn layer_norm2(&self) -> &LayerNorm {
+        &self.layer_norm2
     }
 
     /// Forward pass

--- a/crates/mlx-core/src/vision/projector.rs
+++ b/crates/mlx-core/src/vision/projector.rs
@@ -163,6 +163,21 @@ impl SpatialProjector {
         }
     }
 
+    /// Get the pre-norm LayerNorm
+    pub fn pre_norm(&self) -> &LayerNorm {
+        &self.pre_norm
+    }
+
+    /// Get the first linear layer
+    pub fn linear_1(&self) -> &Linear {
+        &self.linear_1
+    }
+
+    /// Get the second linear layer
+    pub fn linear_2(&self) -> &Linear {
+        &self.linear_2
+    }
+
     /// Get the spatial merge size
     pub fn spatial_merge_size(&self) -> u32 {
         self.spatial_merge_size

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -375,6 +375,7 @@ unsafe extern "C" {
     pub fn mlx_synchronize();
     pub fn mlx_clear_cache();
     pub fn mlx_compile_clear_cache() -> bool;
+    pub fn mlx_stop_gradient(a: *mut mlx_array) -> *mut mlx_array;
     pub fn mlx_compiled_categorical_sample(
         logits: *mut mlx_array,
         temperature: f32,

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -426,6 +426,16 @@ unsafe extern "C" {
         grad_handles: *mut *mut mlx_array,
     ) -> usize;
 
+    // Gradient checkpointing
+    pub fn mlx_checkpoint_apply(
+        layer_fn: LayerFunctionPtr,
+        context: *mut std::os::raw::c_void,
+        input_handles: *const *mut mlx_array,
+        input_count: usize,
+        output_handles: *mut *mut mlx_array,
+        max_outputs: usize,
+    ) -> usize;
+
     // Comparison operations
     pub fn mlx_array_equal(lhs: *mut mlx_array, rhs: *mut mlx_array) -> *mut mlx_array;
     pub fn mlx_array_not_equal(lhs: *mut mlx_array, rhs: *mut mlx_array) -> *mut mlx_array;
@@ -1038,6 +1048,9 @@ unsafe extern "C" {
     /// Eval next_token and all compiled cache arrays to prevent graph accumulation.
     pub fn mlx_qwen35_eval_token_and_compiled_caches(next_token: *mut mlx_array);
 
+    /// Synchronously eval all compiled cache arrays (for training decode loop).
+    pub fn mlx_qwen35_sync_eval_compiled_caches();
+
     /// Adjust the compiled offset by delta (for VLM rope_deltas).
     pub fn mlx_qwen35_compiled_adjust_offset(delta: i32);
 
@@ -1123,6 +1136,9 @@ unsafe extern "C" {
     /// Eval next_token and all MoE cache arrays to prevent graph accumulation.
     pub fn mlx_qwen35_moe_eval_token_and_caches(next_token: *mut mlx_array);
 
+    /// Synchronously eval all MoE cache arrays (for training decode loop).
+    pub fn mlx_qwen35_moe_sync_eval_caches();
+
     /// Reset MoE state.
     pub fn mlx_qwen35_moe_reset();
 
@@ -1147,3 +1163,12 @@ pub type LossFunctionPtr = extern "C" fn(
     input_count: usize,
     context: *mut std::os::raw::c_void,
 ) -> *mut mlx_array;
+
+// Checkpoint layer function type: takes inputs, writes outputs, returns count
+pub type LayerFunctionPtr = extern "C" fn(
+    inputs: *const *mut mlx_array,
+    input_count: usize,
+    outputs: *mut *mut mlx_array,
+    max_outputs: usize,
+    context: *mut std::os::raw::c_void,
+) -> usize;

--- a/crates/mlx-sys/src/mlx_autograd.cpp
+++ b/crates/mlx-sys/src/mlx_autograd.cpp
@@ -32,20 +32,28 @@ class LossFunctionWrapper {
 
   array operator()(const std::vector<array>& inputs) {
     // Convert arrays to mlx_array* handles for FFI boundary
-    // Note: This creates heap allocations but does NOT copy tensor data.
-    // MLX arrays use shared_ptr internally, so the "copy" is just a
-    // reference count increment (~16-24 bytes per array object).
     std::vector<mlx_array*> handles;
     handles.reserve(inputs.size());
     for (const auto& arr : inputs) {
-      // new array(arr) is a shallow copy - just copies the shared_ptr
       handles.push_back(reinterpret_cast<mlx_array*>(new array(arr)));
     }
 
-    // Call user function
-    mlx_array* loss_handle = fn_(handles.data(), handles.size(), context_);
+    // Call user function — the Rust callback may invoke MLX FFI functions
+    // that throw C++ exceptions (e.g., shape mismatches). We catch those
+    // here to prevent them from propagating through the Rust FFI boundary.
+    mlx_array* loss_handle = nullptr;
+    try {
+      loss_handle = fn_(handles.data(), handles.size(), context_);
+    } catch (const std::exception& e) {
+      // Clean up handles before rethrowing
+      for (auto* handle : handles) {
+        delete reinterpret_cast<array*>(handle);
+      }
+      std::cerr << "[MLX AUTOGRAD] Loss callback threw C++ exception: " << e.what() << std::endl;
+      throw;  // Rethrow to be caught by outer try/catch
+    }
 
-    // Clean up input handles - Rust callback copies these, so we own them
+    // Clean up input handles
     for (auto* handle : handles) {
       delete reinterpret_cast<array*>(handle);
     }
@@ -56,11 +64,7 @@ class LossFunctionWrapper {
       throw std::runtime_error("Loss function returned invalid handle");
     }
 
-    // Move the result to avoid an extra copy
     array result = std::move(*loss_ptr);
-
-    // Clean up the handle that Rust returned (via std::mem::forget)
-    // Rust prevents its drop to avoid double-free, so we must delete it here
     delete loss_ptr;
 
     return result;
@@ -195,16 +199,30 @@ extern "C" size_t mlx_value_and_gradients(LossFunctionPtr loss_fn,
   auto value_and_grad_fn = mlx::core::value_and_grad(loss_func, argnums);
 
   // Call with inputs
-  auto [value, gradients] = value_and_grad_fn(inputs);
+  std::vector<array> gradients;
+  array value = array(0.0f);
+  try {
+    auto result = value_and_grad_fn(inputs);
+    value = std::move(result.first);
+    gradients = std::move(result.second);
+  } catch (const std::exception& e) {
+    std::cerr << "[MLX AUTOGRAD ERROR] value_and_grad failed: " << e.what() << std::endl;
+    return 0;
+  }
 
   // Force evaluation AND synchronization to prevent command buffer overflow during training
   // eval() materializes the computation graph, synchronize() waits for GPU completion
   // This is critical for long training runs to avoid Metal GPU timeout and context leaks
-  value.eval();
-  for (auto& grad : gradients) {
-    grad.eval();
+  try {
+    value.eval();
+    for (auto& grad : gradients) {
+      grad.eval();
+    }
+    mlx::core::synchronize();  // Wait for GPU to finish before continuing
+  } catch (const std::exception& e) {
+    std::cerr << "[MLX AUTOGRAD ERROR] eval/sync failed: " << e.what() << std::endl;
+    return 0;
   }
-  mlx::core::synchronize();  // Wait for GPU to finish before continuing
 
   // Store loss value (for scalar functions, value is directly an array)
   *loss_handle = reinterpret_cast<mlx_array*>(new array(std::move(value)));

--- a/crates/mlx-sys/src/mlx_autograd.cpp
+++ b/crates/mlx-sys/src/mlx_autograd.cpp
@@ -198,7 +198,7 @@ extern "C" size_t mlx_value_and_gradients(LossFunctionPtr loss_fn,
   // Compute value and gradients using MLX with all argnums
   auto value_and_grad_fn = mlx::core::value_and_grad(loss_func, argnums);
 
-  // Call with inputs
+  // Call with inputs — this runs vjp: forward trace + backward graph construction
   std::vector<array> gradients;
   array value = array(0.0f);
   try {
@@ -210,15 +210,15 @@ extern "C" size_t mlx_value_and_gradients(LossFunctionPtr loss_fn,
     return 0;
   }
 
-  // Force evaluation AND synchronization to prevent command buffer overflow during training
-  // eval() materializes the computation graph, synchronize() waits for GPU completion
-  // This is critical for long training runs to avoid Metal GPU timeout and context leaks
+  // Force evaluation AND synchronization to prevent command buffer overflow
+  // Note: the Rust caller also evals, but doing it here ensures the graph is
+  // materialized before we extract handles (avoiding lazy-graph-across-FFI issues)
   try {
     value.eval();
     for (auto& grad : gradients) {
       grad.eval();
     }
-    mlx::core::synchronize();  // Wait for GPU to finish before continuing
+    mlx::core::synchronize();
   } catch (const std::exception& e) {
     std::cerr << "[MLX AUTOGRAD ERROR] eval/sync failed: " << e.what() << std::endl;
     return 0;
@@ -238,4 +238,150 @@ extern "C" size_t mlx_value_and_gradients(LossFunctionPtr loss_fn,
   }
 
   return gradients.size();
+}
+
+// ============================================================================
+// Gradient Checkpointing
+// ============================================================================
+
+// Layer function callback: takes array inputs, returns multiple array outputs
+// Returns: number of output arrays written to output_handles
+typedef size_t (*LayerFunctionPtr)(mlx_array* const* inputs,
+                                   size_t input_count,
+                                   mlx_array** outputs,
+                                   size_t max_outputs,
+                                   void* context);
+
+/**
+ * Wrap a layer function with MLX's checkpoint transform and call it.
+ *
+ * checkpoint() discards all intermediate activations during forward pass
+ * and recomputes them during backward pass. This trades compute for memory:
+ * only 1 layer's intermediates live at a time during backprop.
+ *
+ * @param layer_fn  Callback implementing the layer forward pass
+ * @param context   User context passed to layer_fn
+ * @param input_handles  Input arrays (hidden_states + layer parameters)
+ * @param input_count    Number of input arrays
+ * @param output_handles Pre-allocated output array handles
+ * @param max_outputs    Size of output_handles buffer
+ * @return Number of outputs written, or 0 on error
+ */
+extern "C" size_t mlx_checkpoint_apply(LayerFunctionPtr layer_fn,
+                                       void* context,
+                                       mlx_array* const* input_handles,
+                                       size_t input_count,
+                                       mlx_array** output_handles,
+                                       size_t max_outputs) {
+  if (!layer_fn || !input_handles || !output_handles || input_count == 0 ||
+      max_outputs == 0) {
+    return 0;
+  }
+
+  // Convert input handles to MLX arrays
+  std::vector<array> inputs;
+  inputs.reserve(input_count);
+  for (size_t i = 0; i < input_count; i++) {
+    auto arr = reinterpret_cast<array*>(input_handles[i]);
+    inputs.emplace_back(*arr);
+  }
+
+  // Create the layer function wrapper: vector<array> -> vector<array>
+  auto layer_wrapper =
+      [layer_fn, context](
+          const std::vector<array>& args) -> std::vector<array> {
+    // Convert to handles for FFI
+    std::vector<mlx_array*> handles;
+    handles.reserve(args.size());
+    for (const auto& arr : args) {
+      handles.push_back(reinterpret_cast<mlx_array*>(new array(arr)));
+    }
+
+    // Call the Rust layer function
+    constexpr size_t MAX_LAYER_OUTPUTS = 16;
+    mlx_array* out_handles[MAX_LAYER_OUTPUTS] = {};
+    size_t num_outputs = 0;
+
+    try {
+      num_outputs =
+          layer_fn(handles.data(), handles.size(), out_handles,
+                   MAX_LAYER_OUTPUTS, context);
+    } catch (const std::exception& e) {
+      for (auto* h : handles) {
+        delete reinterpret_cast<array*>(h);
+      }
+      throw;
+    }
+
+    // Clean up input handles
+    for (auto* h : handles) {
+      delete reinterpret_cast<array*>(h);
+    }
+
+    if (num_outputs == 0) {
+      throw std::runtime_error("Layer function returned 0 outputs");
+    }
+
+    // Convert output handles to arrays
+    std::vector<array> outputs;
+    outputs.reserve(num_outputs);
+    for (size_t i = 0; i < num_outputs; i++) {
+      auto* ptr = reinterpret_cast<array*>(out_handles[i]);
+      if (!ptr) {
+        throw std::runtime_error("Layer function returned null output handle");
+      }
+      outputs.push_back(std::move(*ptr));
+      delete ptr;
+    }
+
+    return outputs;
+  };
+
+  try {
+    // Memory-ordered checkpoint: like mlx::core::checkpoint but forces the eval
+    // topological sort to process layers sequentially (recompute + VJP for layer N
+    // before recomputing layer N-1).
+    //
+    // The problem with standard checkpoint: during backward eval, MLX's DFS-based
+    // topological sort follows V_0→V_1→...→V_23, collecting all recompute ops
+    // (D_i, R_i) before any VJPs. This puts all 24 layers' recomputed intermediates
+    // in memory simultaneously (24 × ~4.3GB = 104GB).
+    //
+    // Fix: in the custom VJP, wrap the recomputed primals with depends(..., cotangents)
+    // so the recompute for layer N depends on the cotangents (= VJPs from layer N+1).
+    // This forces the topological sort to process layer N+1's VJPs before layer N's
+    // recompute, giving the memory-efficient ordering:
+    //   D_23 → R_23 → V_23 → D_22 → R_22 → V_22 → ... → D_0 → R_0 → V_0
+    // Peak = 1 layer's intermediates ≈ 4.3GB instead of 104GB.
+    auto vjp_fun = [layer_wrapper](
+                       const std::vector<array>& primals,
+                       const std::vector<array>& cotangents,
+                       const std::vector<array>& outputs) -> std::vector<array> {
+      // depends(primals, outputs) ensures forward outputs evaluated before recompute
+      // depends(..., cotangents) ensures PREVIOUS layer's VJPs complete before THIS
+      // layer's recompute starts — this is the key ordering constraint
+      auto dep_primals = mlx::core::depends(primals, outputs);
+      auto dep_primals2 = mlx::core::depends(dep_primals, cotangents);
+      auto [__, vjps] = mlx::core::vjp(layer_wrapper, dep_primals2, cotangents);
+      return vjps;
+    };
+
+    auto checkpointed_fn = mlx::core::custom_vjp(layer_wrapper, vjp_fun);
+    auto outputs = checkpointed_fn(inputs);
+
+    if (outputs.size() > max_outputs) {
+      return 0;
+    }
+
+    for (size_t i = 0; i < outputs.size(); i++) {
+      output_handles[i] =
+          reinterpret_cast<mlx_array*>(new array(std::move(outputs[i])));
+    }
+
+    return outputs.size();
+  } catch (const std::exception& e) {
+    std::cerr << "[MLX CHECKPOINT] checkpoint_apply failed: " << e.what()
+              << std::endl;
+    return 0;
+  }
 }

--- a/crates/mlx-sys/src/mlx_misc_ops.cpp
+++ b/crates/mlx-sys/src/mlx_misc_ops.cpp
@@ -588,4 +588,16 @@ void mlx_compiled_sample_and_logprobs(
   *out_logprobs = reinterpret_cast<mlx_array*>(new array(std::move(original_logprobs)));
 }
 
+// Stop gradient: detach tensor from computation graph
+mlx_array* mlx_stop_gradient(mlx_array* a) {
+    try {
+        auto arr = reinterpret_cast<mlx::core::array*>(a);
+        auto result = mlx::core::stop_gradient(*arr);
+        return reinterpret_cast<mlx_array*>(new mlx::core::array(std::move(result)));
+    } catch (const std::exception& e) {
+        std::cerr << "mlx_stop_gradient error: " << e.what() << std::endl;
+        return nullptr;
+    }
+}
+
 }  // extern "C"

--- a/crates/mlx-sys/src/mlx_qwen35.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35.cpp
@@ -270,6 +270,24 @@ void mlx_qwen35_eval_token_and_compiled_caches(mlx_array* next_token_ptr) {
   }
 }
 
+void mlx_qwen35_sync_eval_compiled_caches() {
+  try {
+    if (g_compiled_caches.empty()) return;
+    std::vector<array> to_eval;
+    to_eval.reserve(g_compiled_caches.size());
+    for (const auto& c : g_compiled_caches) {
+      to_eval.push_back(c);
+    }
+    mlx::core::eval(std::move(to_eval));
+  } catch (const std::exception& e) {
+    fprintf(stderr, "[MLX] Exception in sync_eval_compiled_caches: %s\n", e.what());
+    fflush(stderr);
+  } catch (...) {
+    fprintf(stderr, "[MLX] Unknown exception in sync_eval_compiled_caches\n");
+    fflush(stderr);
+  }
+}
+
 void mlx_qwen35_compiled_adjust_offset(int delta) {
   g_offset_int += delta;
   g_compiled_offset = array(g_offset_int, mlx::core::int32);

--- a/crates/mlx-sys/src/mlx_qwen35_moe.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35_moe.cpp
@@ -759,6 +759,24 @@ void mlx_qwen35_moe_eval_token_and_caches(mlx_array* next_token_ptr) {
   }
 }
 
+void mlx_qwen35_moe_sync_eval_caches() {
+  try {
+    if (g_moe_caches.empty()) return;
+    std::vector<array> to_eval;
+    to_eval.reserve(g_moe_caches.size());
+    for (const auto& c : g_moe_caches) {
+      to_eval.push_back(c);
+    }
+    mlx::core::eval(std::move(to_eval));
+  } catch (const std::exception& e) {
+    fprintf(stderr, "[MLX] Exception in moe_sync_eval_caches: %s\n", e.what());
+    fflush(stderr);
+  } catch (...) {
+    fprintf(stderr, "[MLX] Unknown exception in moe_sync_eval_caches\n");
+    fflush(stderr);
+  }
+}
+
 // Reset MoE state
 void mlx_qwen35_moe_reset() {
   g_moe_caches.clear();

--- a/examples/measure-prompt.ts
+++ b/examples/measure-prompt.ts
@@ -1,0 +1,124 @@
+import { resolve } from 'node:path';
+import { execSync } from 'node:child_process';
+import { GRPOTrainer, type GRPOTrainerConfig } from '@mlx-node/trl';
+import { createToolDefinition } from '@mlx-node/lm';
+import { SYSTEM_PROMPT } from './sft/prompts';
+
+function showMemory(label: string) {
+  const pid = process.pid;
+  const psOut = execSync(`ps -o rss=,vsz= -p ${pid}`).toString().trim();
+  const [rssKB] = psOut.split(/\s+/).map(Number);
+  console.log(`[${label}] RSS: ${(rssKB / 1024 / 1024).toFixed(2)} GB`);
+}
+
+const lspTool = createToolDefinition(
+  'lsp',
+  'Query Octokit REST API documentation.',
+  {
+    method: { type: 'string', description: 'API method to query' },
+    kind: { type: 'string', enum: ['parameters', 'return'], description: 'What to query' },
+  },
+  ['method', 'kind'],
+);
+
+const runJsTool = createToolDefinition(
+  'run_js',
+  'Execute JavaScript code using Octokit.',
+  {
+    code: { type: 'string', description: 'JavaScript code to execute.' },
+  },
+  ['code'],
+);
+
+async function main() {
+  showMemory('start');
+
+  const modelPath = resolve(process.cwd(), '.cache/models/qwen3.5-0.8b-mlx-bf16');
+
+  // Match the actual training config from train-github-tool.ts
+  const config: GRPOTrainerConfig<string> = {
+    modelName: 'qwen3.5',
+    modelPath,
+    learningRate: 1e-6,
+    numEpochs: 1,
+    groupSize: 5, // actual config
+    batchSize: 2, // actual config
+    gradientAccumulationSteps: 1,
+    lmHeadChunkSize: 2,
+    forwardChunkSize: 1,
+    clipEpsilon: 0.2,
+    klCoef: 0.0,
+    maxCompletionLength: 1536, // actual config
+    temperature: 0.7,
+    topP: 0.9,
+    topK: 50,
+    repetitionPenalty: 1.1,
+    tools: [lspTool, runJsTool],
+    enableThinking: true,
+    lossType: 'grpo',
+    weightDecay: 0.01,
+    gradientClipNorm: 1.0,
+    logInterval: 1,
+    saveInterval: 999,
+    outputDir: resolve(process.cwd(), 'outputs/mem-test'),
+    logConsole: false,
+    logJsonl: false,
+    runName: 'mem-test',
+    device: 'metal',
+  };
+
+  console.log('Creating trainer...');
+  const trainer = await GRPOTrainer.create(config);
+  const engine = trainer.getNativeEngine();
+  showMemory('after model load');
+
+  // 2 prompts (batchSize=2)
+  const prompts = [
+    [
+      { role: 'system' as const, content: SYSTEM_PROMPT },
+      { role: 'user' as const, content: 'Show me the PR comments' },
+    ],
+    [
+      { role: 'system' as const, content: SYSTEM_PROMPT },
+      { role: 'user' as const, content: 'List all discussion comments on the current PR' },
+    ],
+  ];
+
+  // Phase 1: Generation (2 prompts × 5 group = 10 completions)
+  console.log('\n=== Phase 1: Generation (2 prompts × 5 group = 10 completions, max 1536 tokens) ===');
+  showMemory('before generation');
+  const t0 = Date.now();
+  const genResult = await engine.generateBatchForTraining(prompts);
+  const t1 = Date.now();
+  showMemory('after generation');
+  console.log(`Generation: ${genResult.completionTexts.length} completions in ${((t1 - t0) / 1000).toFixed(1)}s`);
+  console.log(`Completion lengths: ${genResult.completionLengths.join(', ')}`);
+  const maxLen = Math.max(...genResult.completionLengths);
+  const avgLen = genResult.completionLengths.reduce((a, b) => a + b, 0) / genResult.completionLengths.length;
+  console.log(`Max completion: ${maxLen}, Avg: ${avgLen.toFixed(0)}`);
+
+  // Phase 2: Training (autograd)
+  console.log('\n=== Phase 2: Autograd (10 completions, forwardChunkSize=1, lmHeadChunkSize=2) ===');
+  const rewards = new Array(genResult.completionTexts.length).fill(5.0);
+  showMemory('before trainStep');
+  const t2 = Date.now();
+  try {
+    const metrics = await engine.trainStepWithGenerations(prompts, rewards, genResult);
+    const t3 = Date.now();
+    showMemory('after trainStep');
+    console.log(`Training: loss=${metrics.loss.toFixed(4)}, time=${((t3 - t2) / 1000).toFixed(1)}s`);
+    console.log(`Peak metal: ${metrics.peakMemoryMb.toFixed(0)}MB, active: ${metrics.activeMemoryMb.toFixed(0)}MB`);
+    console.log(`Total tokens: ${metrics.totalTokens}`);
+  } catch (e) {
+    showMemory('after trainStep ERROR');
+    console.error(`Training failed: ${e}`);
+  }
+
+  showMemory('final');
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/examples/measure-prompt.ts
+++ b/examples/measure-prompt.ts
@@ -99,7 +99,7 @@ async function main() {
 
   // Phase 2: Training (autograd)
   console.log('\n=== Phase 2: Autograd (10 completions, forwardChunkSize=1, lmHeadChunkSize=2) ===');
-  const rewards = new Array(genResult.completionTexts.length).fill(5.0);
+  const rewards = Array.from({ length: genResult.completionTexts.length }, () => 5.0);
   showMemory('before trainStep');
   const t2 = Date.now();
   try {
@@ -111,7 +111,7 @@ async function main() {
     console.log(`Total tokens: ${metrics.totalTokens}`);
   } catch (e) {
     showMemory('after trainStep ERROR');
-    console.error(`Training failed: ${e}`);
+    console.error(`Training failed: ${String(e)}`);
   }
 
   showMemory('final');

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -239,6 +239,25 @@ export declare class GrpoTrainingEngine {
   get nanGradientCount(): number;
   /** Clear the emergency save flag (call after saving emergency checkpoint) */
   clearEmergencySaveFlag(): void;
+  /**
+   * Save optimizer state (moment tensors + step) to a SafeTensors file.
+   *
+   * The step counter is stored in the `__metadata__` field.
+   * Each parameter's first moment (m) and second moment (v) are stored as
+   * `{param_name}.m` and `{param_name}.v` tensors.
+   *
+   * No-op if the engine uses SGD (no optimizer state to save).
+   */
+  saveOptimizerState(path: string): void;
+  /**
+   * Load optimizer state (moment tensors + step) from a SafeTensors file.
+   *
+   * Restores the step counter from metadata and sets first/second moment
+   * tensors for each parameter found in the file.
+   *
+   * No-op if the engine uses SGD (no optimizer to restore).
+   */
+  loadOptimizerState(path: string): void;
 }
 export type GRPOTrainingEngine = GrpoTrainingEngine;
 
@@ -683,6 +702,18 @@ export declare class Qwen35Model {
   ): Promise<ChatStreamHandle>;
   /** Get the number of parameters in the model. */
   numParameters(): number;
+  /**
+   * Save the model weights and configuration to a directory.
+   *
+   * This saves:
+   * - config.json: Model configuration (with model_type for detectModelType)
+   * - weights.safetensors: Full model weights in SafeTensors format
+   * - weights.mlx: Parameter metadata (for reference)
+   *
+   * # Arguments
+   * * `save_path` - Directory to save the model
+   */
+  saveModel(savePath: string): Promise<undefined>;
 }
 export type Qwen3_5Model = Qwen35Model;
 
@@ -715,6 +746,18 @@ export declare class Qwen35MoeModel {
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
   numParameters(): number;
+  /**
+   * Save the model weights and configuration to a directory.
+   *
+   * This saves:
+   * - config.json: Model configuration (with model_type for detectModelType)
+   * - weights.safetensors: Full model weights in SafeTensors format
+   * - weights.mlx: Parameter metadata (for reference)
+   *
+   * # Arguments
+   * * `save_path` - Directory to save the model
+   */
+  saveModel(savePath: string): Promise<undefined>;
 }
 export type Qwen3_5MoeModel = Qwen35MoeModel;
 
@@ -2475,6 +2518,24 @@ export interface GrpoEngineConfig {
    * then expand KV cache for G completions).
    */
   useParallelBatchGeneration?: boolean;
+  /**
+   * Enable gradient checkpointing (default: true).
+   * When true, each transformer layer's activations are discarded during the forward
+   * pass and recomputed during backward, reducing peak memory from O(num_layers) to O(1)
+   * for intermediate states. For Qwen3.5 0.8B, this reduces autograd peak from ~105GB to ~11GB.
+   * The trade-off is ~30% more compute (one extra forward pass per layer during backward).
+   */
+  gradientCheckpointing?: boolean;
+  /** Optimizer type: "sgd" or "adamw" (default: "adamw") */
+  optimizerType?: string;
+  /** AdamW beta1 (default: 0.9) */
+  adamwBeta1?: number;
+  /** AdamW beta2 (default: 0.999) */
+  adamwBeta2?: number;
+  /** AdamW epsilon (default: 1e-8) */
+  adamwEps?: number;
+  /** Weight decay for AdamW (default: 0.01) */
+  weightDecay?: number;
 }
 
 /** Configuration for GRPO loss computation */

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -3111,6 +3111,11 @@ export interface SftEngineConfig {
    * per-element analysis - useful for debugging but has significant performance overhead.
    */
   verboseNanDetection?: boolean;
+  /**
+   * Enable gradient checkpointing to reduce memory (default: true)
+   * Trades ~30% more compute for O(1) layer memory instead of O(num_layers).
+   */
+  gradientCheckpointing?: boolean;
 }
 
 /** Metrics from a training epoch */

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -124,13 +124,17 @@ export declare class GenerationResult {
  */
 export declare class GrpoTrainingEngine {
   /**
-   * Create a new training engine from an existing model
+   * Create a new training engine from a Qwen3 model
    *
    * # Arguments
    * * `model` - The Qwen3 model to train (will be cloned internally)
    * * `config` - Engine configuration
    */
   constructor(model: Qwen3Model, config: GrpoEngineConfig);
+  /** Create a new training engine from a Qwen3.5 dense model */
+  static fromQwen35(model: Qwen3_5Model, config: GrpoEngineConfig): GrpoTrainingEngine;
+  /** Create a new training engine from a Qwen3.5 MoE model */
+  static fromQwen35Moe(model: Qwen3_5MoeModel, config: GrpoEngineConfig): GrpoTrainingEngine;
   /** Register a built-in reward function */
   registerBuiltinReward(config: BuiltinRewardConfig): void;
   /**
@@ -1408,8 +1412,12 @@ export declare class Qwen3Tokenizer {
 
 /** SFT Training Engine */
 export declare class SftTrainingEngine {
-  /** Create a new SFT training engine */
+  /** Create a new SFT training engine from a Qwen3 model */
   constructor(model: Qwen3Model, config: SftEngineConfig);
+  /** Create a new SFT training engine from a Qwen3.5 dense model */
+  static fromQwen35(model: Qwen35Model, config: SftEngineConfig): SftTrainingEngine;
+  /** Create a new SFT training engine from a Qwen3.5 MoE model */
+  static fromQwen35Moe(model: Qwen35MoeModel, config: SftEngineConfig): SftTrainingEngine;
   /** Run a single training step */
   trainStep(inputIds: MxArray, labels: MxArray): Promise<SftStepMetrics>;
   /** Get current step number */
@@ -1448,7 +1456,7 @@ export declare class SftTrainingEngine {
   reset(): void;
   /** Restore training state (for resuming from checkpoint) */
   restoreState(step: number, epoch: number): void;
-  /** Get the underlying model for checkpointing */
+  /** Get the underlying Qwen3 model for checkpointing (only works for Qwen3 variant) */
   getModel(): Qwen3Model;
 }
 

--- a/packages/lm/src/index.ts
+++ b/packages/lm/src/index.ts
@@ -46,7 +46,7 @@ export {
   getQwen3Config,
 } from './models/qwen3-configs';
 
-export { ModelLoader } from './models/model-loader';
+export { ModelLoader, detectModelType } from './models/model-loader';
 
 export { QWEN35_CONFIGS, getQwen35Config } from './models/qwen3_5-configs';
 

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -68,7 +68,7 @@ export class ModelLoader {
    * Note: This saves configuration and parameter metadata only.
    * For full model weight serialization, use safetensors or binary format.
    */
-  static saveModel(model: Qwen3Model, savePath: string): Promise<void> {
+  static saveModel(model: Qwen3Model | Qwen3_5Model | Qwen3_5MoeModel, savePath: string): Promise<void> {
     // Delegate to Rust implementation for efficient saving
     return model.saveModel(savePath);
   }
@@ -79,7 +79,7 @@ export async function detectModelType(modelPath: string): Promise<string> {
     const raw = await readFile(join(modelPath, 'config.json'), 'utf-8');
     const config = JSON.parse(raw);
     return config.model_type ?? 'qwen3';
-  } catch {
-    return 'qwen3';
+  } catch (e) {
+    throw new Error(`Cannot detect model type: config.json not found in ${modelPath}`);
   }
 }

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -74,7 +74,7 @@ export class ModelLoader {
   }
 }
 
-async function detectModelType(modelPath: string): Promise<string> {
+export async function detectModelType(modelPath: string): Promise<string> {
   try {
     const raw = await readFile(join(modelPath, 'config.json'), 'utf-8');
     const config = JSON.parse(raw);

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -79,7 +79,7 @@ export async function detectModelType(modelPath: string): Promise<string> {
     const raw = await readFile(join(modelPath, 'config.json'), 'utf-8');
     const config = JSON.parse(raw);
     return config.model_type ?? 'qwen3';
-  } catch (e) {
+  } catch {
     throw new Error(`Cannot detect model type: config.json not found in ${modelPath}`);
   }
 }

--- a/packages/trl/src/trainers/grpo-trainer.ts
+++ b/packages/trl/src/trainers/grpo-trainer.ts
@@ -225,6 +225,24 @@ export interface GRPOTrainerConfig<T = unknown> {
   useParallelBatchGeneration?: boolean;
 
   /**
+   * Enable gradient checkpointing (default: true).
+   * Discards intermediate activations during forward pass and recomputes during backward,
+   * reducing peak memory from O(num_layers) to O(1) for intermediate states.
+   * For Qwen3.5 0.8B, this reduces autograd peak from ~105GB to ~11GB.
+   * Trade-off: ~30% more compute (one extra forward pass per layer during backward).
+   */
+  gradientCheckpointing?: boolean;
+
+  /** Optimizer type: 'sgd' or 'adamw' (default: 'adamw') */
+  optimizerType?: 'sgd' | 'adamw';
+  /** AdamW beta1 (default: 0.9) */
+  adamwBeta1?: number;
+  /** AdamW beta2 (default: 0.999) */
+  adamwBeta2?: number;
+  /** AdamW epsilon (default: 1e-8) */
+  adamwEps?: number;
+
+  /**
    * Chunk size for vocabulary dimension in cross-entropy computation.
    * When computing logsumexp over large vocabularies (e.g., Qwen3's 151,936 tokens),
    * the computation is split into chunks of this size to reduce peak memory usage.
@@ -282,6 +300,8 @@ export interface TrainingState {
   timestamp: string;
   /** Dataset information for resume validation */
   dataset?: DatasetMetadata;
+  /** Whether optimizer state was saved alongside this checkpoint */
+  hasOptimizerState?: boolean;
 }
 
 /**
@@ -323,6 +343,7 @@ export const DEFAULT_GRPO_CONFIG: GRPOTrainerConfig = {
   logConsole: true,
   logJsonl: true,
   maxCheckpoints: 3,
+  lmHeadChunkSize: 2,
 };
 
 /**
@@ -523,6 +544,14 @@ export class GRPOTrainer<T = unknown> {
       vocabChunkSize: this.config.vocabChunkSize,
       // Parallel batch generation
       useParallelBatchGeneration: this.config.useParallelBatchGeneration,
+      // Gradient checkpointing
+      gradientCheckpointing: this.config.gradientCheckpointing,
+      // Optimizer
+      optimizerType: this.config.optimizerType,
+      adamwBeta1: this.config.adamwBeta1,
+      adamwBeta2: this.config.adamwBeta2,
+      adamwEps: this.config.adamwEps,
+      weightDecay: this.config.weightDecay,
     };
 
     if (model instanceof Qwen35Model) {
@@ -913,11 +942,6 @@ export class GRPOTrainer<T = unknown> {
     if (config.advantageNormalization === false) {
       throw new Error('advantageNormalization=false is not yet supported. Remove this option or set to true.');
     }
-    if (config.weightDecay !== undefined && config.weightDecay !== 0.01) {
-      throw new Error(
-        'Custom weightDecay is not yet implemented. Optimizer uses simple SGD. Remove weightDecay from config or use default (0.01).',
-      );
-    }
     if (config.rewardType === 'model') {
       throw new Error(
         'rewardType="model" is not implemented. Use rewardType="function" with a custom reward function.',
@@ -1033,6 +1057,17 @@ export class GRPOTrainer<T = unknown> {
           `Restored dataset metadata: size=${resumedState.dataset.size}, hash=${resumedState.dataset.contentHash}, ` +
             `${trainer.processedBatchIndices.size} processed batches`,
         );
+      }
+
+      // Restore optimizer state if available
+      if (resumedState.hasOptimizerState) {
+        const optimizerStatePath = join(modelPath, 'optimizer_state.safetensors');
+        try {
+          trainer.engine.loadOptimizerState(optimizerStatePath);
+          logger.info(`Restored optimizer state from checkpoint`);
+        } catch (e) {
+          logger.warn(`Failed to restore optimizer state: ${e}`);
+        }
       }
 
       // If resuming from a regular checkpoint (not emergency), track it as last known good
@@ -1866,13 +1901,8 @@ export class GRPOTrainer<T = unknown> {
     const statePath = join(checkpointPath, 'training_state.json');
     writeFileSync(statePath, JSON.stringify(state, null, 2));
 
-    // Save model weights (only Qwen3 has saveModel exposed via NAPI currently)
-    if (this.model instanceof Qwen3Model) {
-      await this.model.saveModel(checkpointPath);
-    } else {
-      // TODO: Add NAPI saveModel() for Qwen3.5 models
-      this.logger.warn('Checkpoint model weight saving not yet supported for Qwen3.5 models');
-    }
+    // Save model weights
+    await this.model.saveModel(checkpointPath);
 
     // Copy tokenizer files from original model path (required for loading checkpoints)
     const tokenizerSource = this.originalModelPath ?? this.config.modelPath;
@@ -1885,6 +1915,17 @@ export class GRPOTrainer<T = unknown> {
           copyFileSync(srcPath, destPath);
         }
       }
+    }
+
+    // Save optimizer state (AdamW moments + step counter)
+    try {
+      this.engine.saveOptimizerState(join(checkpointPath, 'optimizer_state.safetensors'));
+      state.hasOptimizerState = true;
+      // Re-write training_state.json with updated hasOptimizerState flag
+      writeFileSync(statePath, JSON.stringify(state, null, 2));
+    } catch (e) {
+      // Non-fatal: training can continue without optimizer state on resume
+      this.logger.warn(`Failed to save optimizer state: ${e}`);
     }
 
     this.logger.info(`Checkpoint saved: ${checkpointPath}`);

--- a/packages/trl/src/trainers/grpo-trainer.ts
+++ b/packages/trl/src/trainers/grpo-trainer.ts
@@ -1066,7 +1066,7 @@ export class GRPOTrainer<T = unknown> {
           trainer.engine.loadOptimizerState(optimizerStatePath);
           logger.info(`Restored optimizer state from checkpoint`);
         } catch (e) {
-          logger.warn(`Failed to restore optimizer state: ${e}`);
+          logger.warn(`Failed to restore optimizer state: ${String(e)}`);
         }
       }
 
@@ -1925,7 +1925,7 @@ export class GRPOTrainer<T = unknown> {
       writeFileSync(statePath, JSON.stringify(state, null, 2));
     } catch (e) {
       // Non-fatal: training can continue without optimizer state on resume
-      this.logger.warn(`Failed to save optimizer state: ${e}`);
+      this.logger.warn(`Failed to save optimizer state: ${String(e)}`);
     }
 
     this.logger.info(`Checkpoint saved: ${checkpointPath}`);

--- a/packages/trl/src/trainers/grpo-trainer.ts
+++ b/packages/trl/src/trainers/grpo-trainer.ts
@@ -529,8 +529,10 @@ export class GRPOTrainer<T = unknown> {
       this.engine = GrpoTrainingEngine.fromQwen35(model, engineConfig);
     } else if (model instanceof Qwen35MoeModel) {
       this.engine = GrpoTrainingEngine.fromQwen35Moe(model, engineConfig);
-    } else {
+    } else if (model instanceof Qwen3Model) {
       this.engine = new GrpoTrainingEngine(model, engineConfig);
+    } else {
+      throw new Error(`Unsupported model type: ${(model as object).constructor?.name ?? typeof model}`);
     }
 
     // Setup stdin handler if TUI mode
@@ -995,8 +997,10 @@ export class GRPOTrainer<T = unknown> {
       model = await Qwen35MoeModel.loadPretrained(modelPath);
     } else if (modelType === 'qwen3_5') {
       model = await Qwen35Model.loadPretrained(modelPath);
-    } else {
+    } else if (modelType === 'qwen3') {
       model = await Qwen3Model.loadPretrained(modelPath);
+    } else {
+      throw new Error(`Unsupported model_type "${modelType}" in ${modelPath}/config.json`);
     }
 
     logger.status('loading', `${modelName} loaded (${modelType})`);

--- a/packages/trl/src/trainers/grpo-trainer.ts
+++ b/packages/trl/src/trainers/grpo-trainer.ts
@@ -59,6 +59,8 @@ import {
   GrpoTrainingEngine,
   NativeRewardRegistry,
   Qwen3Model,
+  Qwen35Model,
+  Qwen35MoeModel,
   OutputStore,
   buildRewardOutputs,
   type GrpoEngineConfig,
@@ -69,6 +71,9 @@ import {
   type RewardOutput,
   type ToolDefinition,
 } from '@mlx-node/core';
+import { detectModelType } from '@mlx-node/lm';
+
+type TrainableModel = Qwen3Model | Qwen35Model | Qwen35MoeModel;
 
 import type { ChatMessage, DatasetExample, RewardFunction } from '../types';
 import { createTrainingLogger, type TrainingLogger } from './training-logger';
@@ -425,7 +430,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, errorMessage: st
  */
 export class GRPOTrainer<T = unknown> {
   private engine: GrpoTrainingEngine;
-  private model: Qwen3Model;
+  private model: TrainableModel;
   private config: GRPOTrainerConfig<T>;
   private rewardFn?: RewardFunction<T>;
   private currentEpoch: number = 0;
@@ -464,7 +469,7 @@ export class GRPOTrainer<T = unknown> {
    * @param model - Pre-loaded Qwen3 model
    * @param config - Training configuration
    */
-  constructor(model: Qwen3Model, config: Partial<GRPOTrainerConfig<T>> = {}, logger?: TrainingLogger) {
+  constructor(model: TrainableModel, config: Partial<GRPOTrainerConfig<T>> = {}, logger?: TrainingLogger) {
     // Auto-detect TUI mode from environment variable (set by mlx-train TUI)
     const tuiModeFromEnv = process.env.MLX_TUI_MODE === '1';
     if (tuiModeFromEnv && config.tuiMode === undefined) {
@@ -520,7 +525,13 @@ export class GRPOTrainer<T = unknown> {
       useParallelBatchGeneration: this.config.useParallelBatchGeneration,
     };
 
-    this.engine = new GrpoTrainingEngine(model, engineConfig);
+    if (model instanceof Qwen35Model) {
+      this.engine = GrpoTrainingEngine.fromQwen35(model, engineConfig);
+    } else if (model instanceof Qwen35MoeModel) {
+      this.engine = GrpoTrainingEngine.fromQwen35Moe(model, engineConfig);
+    } else {
+      this.engine = new GrpoTrainingEngine(model, engineConfig);
+    }
 
     // Setup stdin handler if TUI mode
     if (this.config.tuiMode) {
@@ -977,10 +988,18 @@ export class GRPOTrainer<T = unknown> {
     const modelName = modelPath.split('/').pop() ?? 'Unknown';
     logger.status('loading', `Loading ${modelName}...`);
 
-    // Load model from disk (checkpoint or original)
-    const model = await Qwen3Model.loadPretrained(modelPath);
+    // Detect model type and load appropriate model class
+    const modelType = await detectModelType(modelPath);
+    let model: TrainableModel;
+    if (modelType === 'qwen3_5_moe') {
+      model = await Qwen35MoeModel.loadPretrained(modelPath);
+    } else if (modelType === 'qwen3_5') {
+      model = await Qwen35Model.loadPretrained(modelPath);
+    } else {
+      model = await Qwen3Model.loadPretrained(modelPath);
+    }
 
-    logger.status('loading', `${modelName} loaded`);
+    logger.status('loading', `${modelName} loaded (${modelType})`);
 
     // Create trainer with the pre-created logger
     const trainer = new GRPOTrainer(model, config, logger);
@@ -1843,8 +1862,13 @@ export class GRPOTrainer<T = unknown> {
     const statePath = join(checkpointPath, 'training_state.json');
     writeFileSync(statePath, JSON.stringify(state, null, 2));
 
-    // Save model weights
-    await this.model.saveModel(checkpointPath);
+    // Save model weights (only Qwen3 has saveModel exposed via NAPI currently)
+    if (this.model instanceof Qwen3Model) {
+      await this.model.saveModel(checkpointPath);
+    } else {
+      // TODO: Add NAPI saveModel() for Qwen3.5 models
+      this.logger.warn('Checkpoint model weight saving not yet supported for Qwen3.5 models');
+    }
 
     // Copy tokenizer files from original model path (required for loading checkpoints)
     const tokenizerSource = this.originalModelPath ?? this.config.modelPath;

--- a/packages/trl/src/trainers/sft-config.ts
+++ b/packages/trl/src/trainers/sft-config.ts
@@ -36,6 +36,9 @@ export interface SFTTrainerConfig {
   log_jsonl: boolean;
   tui_mode: boolean;
 
+  // Memory optimization
+  gradient_checkpointing: boolean;
+
   // Misc
   seed: number;
   resume_from_checkpoint: string;
@@ -64,6 +67,8 @@ const DEFAULT_SFT_CONFIG: SFTTrainerConfig = Object.freeze({
   log_jsonl: true,
   tui_mode: false,
 
+  gradient_checkpointing: true,
+
   seed: 42,
   resume_from_checkpoint: '',
 });
@@ -90,6 +95,7 @@ const SFT_CONFIG_VALUE_TYPES: Record<SFTConfigKey, 'number' | 'boolean' | 'strin
   log_jsonl: 'boolean',
   tui_mode: 'boolean',
   seed: 'number',
+  gradient_checkpointing: 'boolean',
   resume_from_checkpoint: 'string',
 };
 

--- a/packages/trl/src/trainers/sft-trainer.ts
+++ b/packages/trl/src/trainers/sft-trainer.ts
@@ -141,8 +141,10 @@ export class SFTTrainer {
       this.engine = SftTrainingEngine.fromQwen35(model, engineConfig);
     } else if (model instanceof Qwen35MoeModel) {
       this.engine = SftTrainingEngine.fromQwen35Moe(model, engineConfig);
-    } else {
+    } else if (model instanceof Qwen3Model) {
       this.engine = new SftTrainingEngine(model, engineConfig);
+    } else {
+      throw new Error(`Unsupported model type: ${(model as object).constructor?.name ?? typeof model}`);
     }
 
     // Setup stdin handler if TUI mode
@@ -271,8 +273,10 @@ export class SFTTrainer {
       model = await Qwen35MoeModel.loadPretrained(modelPath);
     } else if (modelType === 'qwen3_5') {
       model = await Qwen35Model.loadPretrained(modelPath);
-    } else {
+    } else if (modelType === 'qwen3') {
       model = await Qwen3Model.loadPretrained(modelPath);
+    } else {
+      throw new Error(`Unsupported model_type "${modelType}" in ${modelPath}/config.json`);
     }
 
     const tokenizer = await Qwen3Tokenizer.fromPretrained(join(modelPath, 'tokenizer.json'));

--- a/packages/trl/src/trainers/sft-trainer.ts
+++ b/packages/trl/src/trainers/sft-trainer.ts
@@ -135,6 +135,7 @@ export class SFTTrainer {
       gradientClipNorm: this.config.max_grad_norm,
       weightDecay: this.config.weight_decay,
       labelSmoothing: this.config.label_smoothing,
+      gradientCheckpointing: this.config.gradient_checkpointing,
     };
 
     if (model instanceof Qwen35Model) {
@@ -552,14 +553,8 @@ export class SFTTrainer {
     const statePath = join(checkpointPath, 'training_state.json');
     writeFileSync(statePath, JSON.stringify(state, null, 2));
 
-    // Save model weights (only Qwen3 has getModel()/saveModel() exposed via NAPI currently)
-    if (this.model instanceof Qwen3Model) {
-      const trainedModel = this.engine.getModel();
-      await trainedModel.saveModel(checkpointPath);
-    } else {
-      // TODO: Add NAPI saveModel() for Qwen3.5 models
-      this.logger.warn('Checkpoint model weight saving not yet supported for Qwen3.5 models');
-    }
+    // Save model weights
+    await this.model.saveModel(checkpointPath);
 
     // Copy tokenizer files
     const tokenizerSource = this.originalModelPath ?? this.config.model_name;

--- a/packages/trl/src/trainers/sft-trainer.ts
+++ b/packages/trl/src/trainers/sft-trainer.ts
@@ -30,12 +30,17 @@ import * as readline from 'node:readline';
 import {
   SftTrainingEngine,
   Qwen3Model,
+  Qwen35Model,
+  Qwen35MoeModel,
   Qwen3Tokenizer,
   MxArray,
   type SftEngineConfig,
   type SftStepMetrics,
   type SftEpochMetrics,
 } from '@mlx-node/core';
+import { detectModelType } from '@mlx-node/lm';
+
+type TrainableModel = Qwen3Model | Qwen35Model | Qwen35MoeModel;
 
 import type { SFTTrainerConfig } from './sft-config';
 import { getDefaultSFTConfig, mergeSFTConfig } from './sft-config';
@@ -73,7 +78,7 @@ export interface SFTTrainStepResult {
  */
 export class SFTTrainer {
   private engine: SftTrainingEngine;
-  private model: Qwen3Model;
+  private model: TrainableModel;
   private tokenizer: Qwen3Tokenizer;
   private config: SFTTrainerConfig;
   private currentEpoch: number = 0;
@@ -97,7 +102,7 @@ export class SFTTrainer {
    * @param logger - Optional custom logger
    */
   constructor(
-    model: Qwen3Model,
+    model: TrainableModel,
     tokenizer: Qwen3Tokenizer,
     config: Partial<SFTTrainerConfig> = {},
     logger?: TrainingLogger,
@@ -132,7 +137,13 @@ export class SFTTrainer {
       labelSmoothing: this.config.label_smoothing,
     };
 
-    this.engine = new SftTrainingEngine(model, engineConfig);
+    if (model instanceof Qwen35Model) {
+      this.engine = SftTrainingEngine.fromQwen35(model, engineConfig);
+    } else if (model instanceof Qwen35MoeModel) {
+      this.engine = SftTrainingEngine.fromQwen35Moe(model, engineConfig);
+    } else {
+      this.engine = new SftTrainingEngine(model, engineConfig);
+    }
 
     // Setup stdin handler if TUI mode
     if (this.config.tui_mode) {
@@ -253,11 +264,20 @@ export class SFTTrainer {
     const modelName = parse(modelPath).base || 'Unknown';
     logger.status('loading', `Loading ${modelName}...`);
 
-    // Load model and tokenizer
-    const model = await Qwen3Model.loadPretrained(modelPath);
+    // Detect model type and load appropriate model class
+    const modelType = await detectModelType(modelPath);
+    let model: TrainableModel;
+    if (modelType === 'qwen3_5_moe') {
+      model = await Qwen35MoeModel.loadPretrained(modelPath);
+    } else if (modelType === 'qwen3_5') {
+      model = await Qwen35Model.loadPretrained(modelPath);
+    } else {
+      model = await Qwen3Model.loadPretrained(modelPath);
+    }
+
     const tokenizer = await Qwen3Tokenizer.fromPretrained(join(modelPath, 'tokenizer.json'));
 
-    logger.status('loading', `${modelName} loaded`);
+    logger.status('loading', `${modelName} loaded (${modelType})`);
 
     // Create trainer
     const trainer = new SFTTrainer(model, tokenizer, config, logger);
@@ -528,9 +548,14 @@ export class SFTTrainer {
     const statePath = join(checkpointPath, 'training_state.json');
     writeFileSync(statePath, JSON.stringify(state, null, 2));
 
-    // Save model weights (use trained model from engine, not original)
-    const trainedModel = this.engine.getModel();
-    await trainedModel.saveModel(checkpointPath);
+    // Save model weights (only Qwen3 has getModel()/saveModel() exposed via NAPI currently)
+    if (this.model instanceof Qwen3Model) {
+      const trainedModel = this.engine.getModel();
+      await trainedModel.saveModel(checkpointPath);
+    } else {
+      // TODO: Add NAPI saveModel() for Qwen3.5 models
+      this.logger.warn('Checkpoint model weight saving not yet supported for Qwen3.5 models');
+    }
 
     // Copy tokenizer files
     const tokenizerSource = this.originalModelPath ?? this.config.model_name;
@@ -609,8 +634,13 @@ export class SFTTrainer {
   /**
    * Get the underlying model for inference
    */
-  getModel(): Qwen3Model {
-    return this.engine.getModel();
+  getModel(): TrainableModel {
+    if (this.model instanceof Qwen3Model) {
+      return this.engine.getModel();
+    }
+    // For Qwen3.5 models, return the original model reference
+    // (engine.getModel() only supports Qwen3)
+    return this.model;
   }
 
   /**


### PR DESCRIPTION
The training system (GRPO + SFT) was hardcoded to Qwen3Model. This makes
all three model families trainable through a unified internal trait.

Architecture:
- TrainableModel trait + TrainableModelEnum for engine-level polymorphism
- ModelType enum for autograd dispatch to correct functional forward pass
- Per-model training methods (get_parameters, apply_gradients, generate)
- Functional forward passes for Qwen3.5 Dense (GDN + partial-RoPE attention)
  and MoE (gather_mm-based sparse expert routing)

Key changes:
- training_model.rs: TrainableModel trait, TrainableModelEnum, ModelType,
  compute_sgd_updates helper, dispatch macros
- training_generate.rs: shared generation loop parameterized by forward closure
- functional.rs: Qwen3.5 Dense/MoE functional forwards, gather_mm-based MoE
  (~16x fewer expert FLOPs vs per-expert loop), unified dispatch
- gated_delta.rs: use_kernel flag for ops-based differentiable GDN path
- Engine factories: GrpoTrainingEngine.fromQwen35/fromQwen35Moe,
  SftTrainingEngine.fromQwen35/fromQwen35Moe
- TypeScript trainers accept Qwen3 | Qwen35 | Qwen35Moe union type
- stop_gradient FFI binding for MoE routing index detachment

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core training/autograd and adds new unsafe FFI-backed paths (checkpointing, MoE ops) plus optimizer/state serialization; regressions could impact correctness, memory use, or training stability across multiple model families.
> 
> **Overview**
> **Model-agnostic training:** Refactors GRPO and SFT engines to train `Qwen3`, `Qwen3.5 Dense`, and `Qwen3.5 MoE` through a new internal `TrainableModel`/`TrainableModelEnum` plus `ModelType` for autograd functional-forward dispatch.
> 
> **Memory + autograd improvements:** Adds MLX gradient checkpointing support via new `checkpoint_apply`/`CheckpointContexts` (with tests), plumbs a `gradient_checkpointing` config flag through GRPO/SFT, and fixes chunked-gradient accumulation to `eval()` after each add to avoid retaining per-chunk graphs.
> 
> **Qwen3.5 training enablement:** Implements parameter extraction/apply-updates and training-generation paths for Qwen3.5 Dense/MoE (including shared generation utilities, kernel-vs-ops differentiable GDN path, and MoE helpers like `gather_mm` and `stop_gradient`), and adds model/optimizer save-load support (SafeTensors) for Qwen3.5 models plus AdamW optimizer state persistence/reset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 533fd55ea60cb44df66c25ddb1c69cc881ce8feb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gradient checkpointing for memory-efficient training workflows
  * Extended training support to Qwen 3.5 Dense and Qwen 3.5 MoE models
  * Introduced model persistence with `saveModel()` functionality
  * Added optimizer state save/load capabilities
  * Added AdamW optimizer support for training

<!-- end of auto-generated comment: release notes by coderabbit.ai -->