### PR TITLE
feat: add presence_penalty and frequency_penalty support

### DIFF
--- a/crates/mlx-core/src/grpo/engine.rs
+++ b/crates/mlx-core/src/grpo/engine.rs
@@ -96,6 +96,12 @@ pub struct GRPOEngineConfig {
     pub top_k: Option<i32>,
     /// Repetition penalty (default: 1.1)
     pub repetition_penalty: Option<f64>,
+    /// Presence penalty (0.0 = disabled). Subtracts a flat penalty from logits of any
+    /// token that appeared at least once in context.
+    pub presence_penalty: Option<f64>,
+    /// Frequency penalty (0.0 = disabled). Subtracts penalty * occurrence_count from
+    /// logits of each token in context.
+    pub frequency_penalty: Option<f64>,
 
     // === NaN gradient protection ===
     /// Maximum allowed NaN gradient occurrences before stopping training (default: 100)
@@ -191,6 +197,8 @@ impl Default for GRPOEngineConfig {
             top_p: Some(0.95),
             top_k: None,
             repetition_penalty: Some(1.1),
+            presence_penalty: None,
+            frequency_penalty: None,
             max_nan_gradients: Some(100),
             emergency_save_threshold: Some(5),
             verbose_nan_detection: Some(false),
@@ -695,6 +703,10 @@ impl GRPOTrainingEngine {
             min_p: None,
             repetition_penalty: config.repetition_penalty,
             repetition_context_size: Some(256),
+            presence_penalty: config.presence_penalty,
+            presence_context_size: None,
+            frequency_penalty: config.frequency_penalty,
+            frequency_context_size: None,
             max_consecutive_tokens: Some(16),
             max_ngram_repeats: Some(8),
             ngram_size: Some(3),
@@ -1133,6 +1145,10 @@ impl GRPOTrainingEngine {
             min_p: None,
             repetition_penalty: config.repetition_penalty,
             repetition_context_size: Some(256),
+            presence_penalty: config.presence_penalty,
+            presence_context_size: None,
+            frequency_penalty: config.frequency_penalty,
+            frequency_context_size: None,
             max_consecutive_tokens: Some(16),
             max_ngram_repeats: Some(8),
             ngram_size: Some(3),
@@ -1740,6 +1756,10 @@ impl GRPOTrainingEngine {
             min_p: None,
             repetition_penalty: config.repetition_penalty,
             repetition_context_size: Some(256),
+            presence_penalty: config.presence_penalty,
+            presence_context_size: None,
+            frequency_penalty: config.frequency_penalty,
+            frequency_context_size: None,
             max_consecutive_tokens: Some(16),
             max_ngram_repeats: Some(8),
             ngram_size: Some(3),

--- a/crates/mlx-core/src/models/paddleocr_vl/chat.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/chat.rs
@@ -57,6 +57,20 @@ pub struct VLMChatConfig {
     /// Repetition penalty (default: 1.5)
     pub repetition_penalty: Option<f64>,
 
+    /// Presence penalty (0.0 = disabled). Subtracts a flat penalty from logits of any
+    /// token that appeared at least once in context. Matches OpenAI API semantics.
+    pub presence_penalty: Option<f64>,
+
+    /// Number of recent tokens to consider for presence penalty (default: 20)
+    pub presence_context_size: Option<i32>,
+
+    /// Frequency penalty (0.0 = disabled). Subtracts penalty * occurrence_count from
+    /// logits of each token in context. Matches OpenAI API semantics.
+    pub frequency_penalty: Option<f64>,
+
+    /// Number of recent tokens to consider for frequency penalty (default: 20)
+    pub frequency_context_size: Option<i32>,
+
     /// Whether to return log probabilities (default: false)
     pub return_logprobs: Option<bool>,
 }
@@ -70,6 +84,10 @@ impl Default for VLMChatConfig {
             top_k: Some(0),
             top_p: Some(1.0),
             repetition_penalty: Some(1.5), // Reduce repetitive text generation
+            presence_penalty: None,
+            presence_context_size: None,
+            frequency_penalty: None,
+            frequency_context_size: None,
             return_logprobs: Some(false),
         }
     }

--- a/crates/mlx-core/src/models/paddleocr_vl/model.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/model.rs
@@ -14,7 +14,10 @@ use crate::models::paddleocr_vl::processing::{ImageProcessor, ImageProcessorConf
 use crate::models::paddleocr_vl::vision::PaddleOCRVisionModel;
 use crate::models::qwen3::{GenerationConfig, GenerationResult};
 use crate::nn::LayerNorm;
-use crate::sampling::{SamplingConfig, apply_repetition_penalty, sample, sample_and_logprobs};
+use crate::sampling::{
+    SamplingConfig, apply_frequency_penalty, apply_presence_penalty, apply_repetition_penalty,
+    sample, sample_and_logprobs,
+};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::Qwen3Tokenizer;
 use crate::utils::safetensors::SafeTensorsFile;
@@ -118,6 +121,14 @@ impl VLModel {
                 top_k: c.top_k.or(default_config.top_k),
                 top_p: c.top_p.or(default_config.top_p),
                 repetition_penalty: c.repetition_penalty.or(default_config.repetition_penalty),
+                presence_penalty: c.presence_penalty.or(default_config.presence_penalty),
+                presence_context_size: c
+                    .presence_context_size
+                    .or(default_config.presence_context_size),
+                frequency_penalty: c.frequency_penalty.or(default_config.frequency_penalty),
+                frequency_context_size: c
+                    .frequency_context_size
+                    .or(default_config.frequency_context_size),
                 return_logprobs: c.return_logprobs.or(default_config.return_logprobs),
             },
             None => default_config,
@@ -195,6 +206,10 @@ impl VLModel {
                     min_p: None,
                     repetition_penalty: config.repetition_penalty,
                     repetition_context_size: None,
+                    presence_penalty: config.presence_penalty,
+                    presence_context_size: config.presence_context_size,
+                    frequency_penalty: config.frequency_penalty,
+                    frequency_context_size: config.frequency_context_size,
                     max_consecutive_tokens: None,
                     max_ngram_repeats: None,
                     ngram_size: None,
@@ -708,6 +723,10 @@ impl VLModel {
             let min_p = config.min_p.unwrap_or(0.0);
             let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
             let repetition_context_size = config.repetition_context_size.unwrap_or(20);
+            let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+            let presence_context_size = config.presence_context_size.unwrap_or(20);
+            let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+            let frequency_context_size = config.frequency_context_size.unwrap_or(20);
             let eos_token_id = config.eos_token_id.unwrap_or(model_config.eos_token_id);
             let return_logprobs = config.return_logprobs.unwrap_or(false);
 
@@ -848,6 +867,22 @@ impl VLModel {
                     Some(repetition_context_size),
                 )?;
             }
+            if presence_penalty != 0.0 {
+                last_logits = apply_presence_penalty(
+                    &last_logits,
+                    &all_tokens,
+                    presence_penalty,
+                    Some(presence_context_size),
+                )?;
+            }
+            if frequency_penalty != 0.0 {
+                last_logits = apply_frequency_penalty(
+                    &last_logits,
+                    &all_tokens,
+                    frequency_penalty,
+                    Some(frequency_context_size),
+                )?;
+            }
 
             // Sample first token
             let (mut token, mut logprobs_arr): (MxArray, Option<MxArray>) = if return_logprobs {
@@ -905,6 +940,22 @@ impl VLModel {
                             &all_tokens,
                             repetition_penalty,
                             Some(repetition_context_size),
+                        )?;
+                    }
+                    if presence_penalty != 0.0 {
+                        next_logits = apply_presence_penalty(
+                            &next_logits,
+                            &all_tokens,
+                            presence_penalty,
+                            Some(presence_context_size),
+                        )?;
+                    }
+                    if frequency_penalty != 0.0 {
+                        next_logits = apply_frequency_penalty(
+                            &next_logits,
+                            &all_tokens,
+                            frequency_penalty,
+                            Some(frequency_context_size),
                         )?;
                     }
 
@@ -1099,6 +1150,10 @@ impl VLModel {
                 top_k: base.top_k,
                 top_p: base.top_p,
                 repetition_penalty: base.repetition_penalty,
+                presence_penalty: base.presence_penalty,
+                presence_context_size: base.presence_context_size,
+                frequency_penalty: base.frequency_penalty,
+                frequency_context_size: base.frequency_context_size,
                 return_logprobs: base.return_logprobs,
             });
             let result = self.chat(item.messages.clone(), c).await?;
@@ -1114,6 +1169,14 @@ impl VLModel {
                 top_k: c.top_k.or(default_config.top_k),
                 top_p: c.top_p.or(default_config.top_p),
                 repetition_penalty: c.repetition_penalty.or(default_config.repetition_penalty),
+                presence_penalty: c.presence_penalty.or(default_config.presence_penalty),
+                presence_context_size: c
+                    .presence_context_size
+                    .or(default_config.presence_context_size),
+                frequency_penalty: c.frequency_penalty.or(default_config.frequency_penalty),
+                frequency_context_size: c
+                    .frequency_context_size
+                    .or(default_config.frequency_context_size),
                 return_logprobs: c.return_logprobs.or(default_config.return_logprobs),
             },
             None => default_config,
@@ -1138,6 +1201,10 @@ impl VLModel {
                 min_p: None,
                 repetition_penalty: config.repetition_penalty,
                 repetition_context_size: None,
+                presence_penalty: config.presence_penalty,
+                presence_context_size: config.presence_context_size,
+                frequency_penalty: config.frequency_penalty,
+                frequency_context_size: config.frequency_context_size,
                 max_consecutive_tokens: None,
                 max_ngram_repeats: None,
                 ngram_size: None,
@@ -1281,6 +1348,10 @@ impl VLModel {
         let min_p = config.min_p.unwrap_or(0.0);
         let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
         let repetition_context_size = config.repetition_context_size.unwrap_or(20);
+        let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+        let presence_context_size = config.presence_context_size.unwrap_or(20);
+        let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+        let frequency_context_size = config.frequency_context_size.unwrap_or(20);
         let eos_token_id = config.eos_token_id.unwrap_or(model_config.eos_token_id);
         let return_logprobs = config.return_logprobs.unwrap_or(false);
 
@@ -1383,14 +1454,32 @@ impl VLModel {
 
             // Apply repetition penalty to first token (matches single-item generate())
             let input_tokens = input_ids.to_uint32()?;
-            if repetition_penalty != 1.0 {
+            {
                 let all_tokens: Vec<u32> = input_tokens.to_vec();
-                last_logits = apply_repetition_penalty(
-                    &last_logits,
-                    &all_tokens,
-                    repetition_penalty,
-                    Some(repetition_context_size),
-                )?;
+                if repetition_penalty != 1.0 {
+                    last_logits = apply_repetition_penalty(
+                        &last_logits,
+                        &all_tokens,
+                        repetition_penalty,
+                        Some(repetition_context_size),
+                    )?;
+                }
+                if presence_penalty != 0.0 {
+                    last_logits = apply_presence_penalty(
+                        &last_logits,
+                        &all_tokens,
+                        presence_penalty,
+                        Some(presence_context_size),
+                    )?;
+                }
+                if frequency_penalty != 0.0 {
+                    last_logits = apply_frequency_penalty(
+                        &last_logits,
+                        &all_tokens,
+                        frequency_penalty,
+                        Some(frequency_context_size),
+                    )?;
+                }
             }
 
             let (first_token, first_logprobs) = if return_logprobs {
@@ -1559,7 +1648,7 @@ impl VLModel {
             let next_logits = logits.squeeze(Some(&[1]))?;
 
             // Apply repetition penalty per item
-            let next_logits = if repetition_penalty != 1.0 {
+            let mut next_logits = if repetition_penalty != 1.0 {
                 let mut rows = Vec::with_capacity(active_indices.len());
                 for (local_idx, &global_idx) in active_indices.iter().enumerate() {
                     let row = next_logits.slice_axis(0, local_idx as i64, local_idx as i64 + 1)?;
@@ -1577,6 +1666,36 @@ impl VLModel {
             } else {
                 next_logits
             };
+            if presence_penalty != 0.0 {
+                let mut rows = Vec::with_capacity(active_indices.len());
+                for (local_idx, &global_idx) in active_indices.iter().enumerate() {
+                    let row = next_logits.slice_axis(0, local_idx as i64, local_idx as i64 + 1)?;
+                    let row = row.squeeze(Some(&[0]))?;
+                    rows.push(apply_presence_penalty(
+                        &row,
+                        &item_all_tokens[global_idx],
+                        presence_penalty,
+                        Some(presence_context_size),
+                    )?);
+                }
+                let row_refs: Vec<&MxArray> = rows.iter().collect();
+                next_logits = MxArray::stack(row_refs, Some(0))?;
+            }
+            if frequency_penalty != 0.0 {
+                let mut rows = Vec::with_capacity(active_indices.len());
+                for (local_idx, &global_idx) in active_indices.iter().enumerate() {
+                    let row = next_logits.slice_axis(0, local_idx as i64, local_idx as i64 + 1)?;
+                    let row = row.squeeze(Some(&[0]))?;
+                    rows.push(apply_frequency_penalty(
+                        &row,
+                        &item_all_tokens[global_idx],
+                        frequency_penalty,
+                        Some(frequency_context_size),
+                    )?);
+                }
+                let row_refs: Vec<&MxArray> = rows.iter().collect();
+                next_logits = MxArray::stack(row_refs, Some(0))?;
+            }
 
             // Sample next tokens (with logprobs if requested)
             let (mut next_tokens, mut next_logprobs) = if return_logprobs {

--- a/crates/mlx-core/src/models/qwen3/generation.rs
+++ b/crates/mlx-core/src/models/qwen3/generation.rs
@@ -33,6 +33,20 @@ pub struct GenerationConfig {
     /// Matches mlx-lm default. Larger values catch longer patterns but use more memory
     pub repetition_context_size: Option<i32>,
 
+    /// Presence penalty (0.0 = disabled). Subtracts a flat penalty from logits of any
+    /// token that appeared at least once in context. Matches OpenAI API semantics.
+    pub presence_penalty: Option<f64>,
+
+    /// Number of recent tokens to consider for presence penalty (default: 20)
+    pub presence_context_size: Option<i32>,
+
+    /// Frequency penalty (0.0 = disabled). Subtracts penalty * occurrence_count from
+    /// logits of each token in context. Matches OpenAI API semantics.
+    pub frequency_penalty: Option<f64>,
+
+    /// Number of recent tokens to consider for frequency penalty (default: 20)
+    pub frequency_context_size: Option<i32>,
+
     /// Stop if same token repeats this many times consecutively (default: 16)
     /// Set to 0 to disable. Prevents OOM from degenerate repetitive generation.
     pub max_consecutive_tokens: Option<i32>,
@@ -95,6 +109,10 @@ impl Default for GenerationConfig {
             min_p: Some(0.0),
             repetition_penalty: Some(1.0),
             repetition_context_size: Some(20),
+            presence_penalty: None,
+            presence_context_size: None,
+            frequency_penalty: None,
+            frequency_context_size: None,
             max_consecutive_tokens: Some(16),
             max_ngram_repeats: Some(3),
             ngram_size: Some(64),

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -5196,8 +5196,11 @@ impl Qwen3Model {
                     // Extract logits
                     let mut next_last_logits = logits.squeeze(Some(&[0, 1]))?;
 
-                    // Apply repetition penalty with COMPLETE token history
+                    // Apply penalties with COMPLETE token history
                     // generated_tokens now includes the current token (added above)
+                    if repetition_penalty != 1.0
+                        || presence_penalty != 0.0
+                        || frequency_penalty != 0.0
                     {
                         let mut all_tokens =
                             Vec::with_capacity(input_tokens.len() + generated_tokens.len());

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -17,7 +17,8 @@ use crate::array::{
 use crate::grpo::{advantages::compute_advantages, autograd::compute_loss_and_gradients_autograd};
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::sampling::{
-    SamplingConfig, apply_repetition_penalty, check_repetition_cutoff, sample, sample_and_logprobs,
+    SamplingConfig, apply_frequency_penalty, apply_presence_penalty, apply_repetition_penalty,
+    check_repetition_cutoff, sample, sample_and_logprobs,
 };
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
@@ -1501,6 +1502,10 @@ impl Qwen3Model {
         let min_p = config.min_p.unwrap_or(0.0);
         let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
         let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+        let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+        let presence_context_size = config.presence_context_size.unwrap_or(20);
+        let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+        let frequency_context_size = config.frequency_context_size.unwrap_or(20);
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
@@ -1712,6 +1717,22 @@ impl Qwen3Model {
                 Some(repetition_context_size),
             )?;
         }
+        if presence_penalty != 0.0 {
+            last_logits = apply_presence_penalty(
+                &last_logits,
+                &input_tokens,
+                presence_penalty,
+                Some(presence_context_size),
+            )?;
+        }
+        if frequency_penalty != 0.0 {
+            last_logits = apply_frequency_penalty(
+                &last_logits,
+                &input_tokens,
+                frequency_penalty,
+                Some(frequency_context_size),
+            )?;
+        }
 
         // Sample first token
         let (mut token, mut logprobs_arr) = if return_logprobs {
@@ -1829,6 +1850,29 @@ impl Qwen3Model {
             } else {
                 next_last_logits
             };
+            {
+                let context_tokens: Vec<u32> = input_tokens
+                    .iter()
+                    .copied()
+                    .chain(generated_tokens.iter().copied())
+                    .collect();
+                if presence_penalty != 0.0 {
+                    last_logits = apply_presence_penalty(
+                        &last_logits,
+                        &context_tokens,
+                        presence_penalty,
+                        Some(presence_context_size),
+                    )?;
+                }
+                if frequency_penalty != 0.0 {
+                    last_logits = apply_frequency_penalty(
+                        &last_logits,
+                        &context_tokens,
+                        frequency_penalty,
+                        Some(frequency_context_size),
+                    )?;
+                }
+            }
 
             // Sample next token
             let (next_tok, next_lp) = if return_logprobs {
@@ -1937,6 +1981,10 @@ impl Qwen3Model {
         let min_p = config.min_p.unwrap_or(0.0);
         let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
         let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+        let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+        let presence_context_size = config.presence_context_size.unwrap_or(20);
+        let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+        let frequency_context_size = config.frequency_context_size.unwrap_or(20);
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
@@ -2091,7 +2139,7 @@ impl Qwen3Model {
             .squeeze(Some(&[0, 1]))?;
 
         // Apply repetition penalty to first token
-        let last_logits = if repetition_penalty != 1.0 && !input_tokens.is_empty() {
+        let mut last_logits = if repetition_penalty != 1.0 && !input_tokens.is_empty() {
             apply_repetition_penalty(
                 &last_logits,
                 &input_tokens,
@@ -2101,6 +2149,22 @@ impl Qwen3Model {
         } else {
             last_logits
         };
+        if presence_penalty != 0.0 {
+            last_logits = apply_presence_penalty(
+                &last_logits,
+                &input_tokens,
+                presence_penalty,
+                Some(presence_context_size),
+            )?;
+        }
+        if frequency_penalty != 0.0 {
+            last_logits = apply_frequency_penalty(
+                &last_logits,
+                &input_tokens,
+                frequency_penalty,
+                Some(frequency_context_size),
+            )?;
+        }
 
         // Sample first token
         let first_token_result = sample_and_logprobs(&last_logits, Some(sampling_config))?;
@@ -2395,6 +2459,10 @@ impl Qwen3Model {
         let min_p = config.min_p.unwrap_or(0.0);
         let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
         let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+        let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+        let presence_context_size = config.presence_context_size.unwrap_or(20);
+        let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+        let frequency_context_size = config.frequency_context_size.unwrap_or(20);
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
@@ -2620,7 +2688,7 @@ impl Qwen3Model {
             let batch_logits = last_logits.repeat_along_axis(0, group_size as i32)?;
 
             // Apply repetition penalty to initial logits
-            let batch_logits = if repetition_penalty != 1.0 && !prompt_tokens.is_empty() {
+            let mut batch_logits = if repetition_penalty != 1.0 && !prompt_tokens.is_empty() {
                 self.apply_batch_repetition_penalty(
                     &batch_logits,
                     &vec![prompt_tokens.clone(); group_size],
@@ -2630,6 +2698,41 @@ impl Qwen3Model {
             } else {
                 batch_logits
             };
+            {
+                let histories = vec![prompt_tokens.clone(); group_size];
+                if presence_penalty != 0.0 {
+                    let mut rows = Vec::with_capacity(group_size);
+                    for (i, ctx) in histories.iter().enumerate().take(group_size) {
+                        let row = batch_logits
+                            .slice_axis(0, i as i64, (i + 1) as i64)?
+                            .squeeze(Some(&[0]))?;
+                        rows.push(apply_presence_penalty(
+                            &row,
+                            ctx,
+                            presence_penalty,
+                            Some(presence_context_size),
+                        )?);
+                    }
+                    let refs: Vec<&MxArray> = rows.iter().collect();
+                    batch_logits = MxArray::stack(refs, Some(0))?;
+                }
+                if frequency_penalty != 0.0 {
+                    let mut rows = Vec::with_capacity(group_size);
+                    for (i, ctx) in histories.iter().enumerate().take(group_size) {
+                        let row = batch_logits
+                            .slice_axis(0, i as i64, (i + 1) as i64)?
+                            .squeeze(Some(&[0]))?;
+                        rows.push(apply_frequency_penalty(
+                            &row,
+                            ctx,
+                            frequency_penalty,
+                            Some(frequency_context_size),
+                        )?);
+                    }
+                    let refs: Vec<&MxArray> = rows.iter().collect();
+                    batch_logits = MxArray::stack(refs, Some(0))?;
+                }
+            }
 
             // === BATCHED DECODE STATE ===
             // Track per-sequence state
@@ -2871,7 +2974,7 @@ impl Qwen3Model {
                 let next_last_logits = next_logits.squeeze(Some(&[1]))?;
 
                 // Apply repetition penalty
-                let next_last_logits = if repetition_penalty != 1.0 {
+                let mut next_last_logits = if repetition_penalty != 1.0 {
                     self.apply_batch_repetition_penalty(
                         &next_last_logits,
                         &token_histories,
@@ -2881,6 +2984,41 @@ impl Qwen3Model {
                 } else {
                     next_last_logits
                 };
+                {
+                    let batch_size = token_histories.len();
+                    if presence_penalty != 0.0 {
+                        let mut rows = Vec::with_capacity(batch_size);
+                        for (i, ctx) in token_histories.iter().enumerate().take(batch_size) {
+                            let row = next_last_logits
+                                .slice_axis(0, i as i64, (i + 1) as i64)?
+                                .squeeze(Some(&[0]))?;
+                            rows.push(apply_presence_penalty(
+                                &row,
+                                ctx,
+                                presence_penalty,
+                                Some(presence_context_size),
+                            )?);
+                        }
+                        let refs: Vec<&MxArray> = rows.iter().collect();
+                        next_last_logits = MxArray::stack(refs, Some(0))?;
+                    }
+                    if frequency_penalty != 0.0 {
+                        let mut rows = Vec::with_capacity(batch_size);
+                        for (i, ctx) in token_histories.iter().enumerate().take(batch_size) {
+                            let row = next_last_logits
+                                .slice_axis(0, i as i64, (i + 1) as i64)?
+                                .squeeze(Some(&[0]))?;
+                            rows.push(apply_frequency_penalty(
+                                &row,
+                                ctx,
+                                frequency_penalty,
+                                Some(frequency_context_size),
+                            )?);
+                        }
+                        let refs: Vec<&MxArray> = rows.iter().collect();
+                        next_last_logits = MxArray::stack(refs, Some(0))?;
+                    }
+                }
 
                 // Sample next tokens
                 let (next_tokens, next_lp) = if return_logprobs {
@@ -3010,6 +3148,10 @@ impl Qwen3Model {
         let min_p = config.min_p.unwrap_or(0.0);
         let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
         let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+        let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+        let presence_context_size = config.presence_context_size.unwrap_or(20);
+        let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+        let frequency_context_size = config.frequency_context_size.unwrap_or(20);
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
@@ -3258,6 +3400,41 @@ impl Qwen3Model {
         } else {
             last_logits
         };
+        {
+            let batch_size = token_histories.len();
+            if presence_penalty != 0.0 {
+                let mut rows = Vec::with_capacity(batch_size);
+                for (i, ctx) in token_histories.iter().enumerate().take(batch_size) {
+                    let row = current_logits
+                        .slice_axis(0, i as i64, (i + 1) as i64)?
+                        .squeeze(Some(&[0]))?;
+                    rows.push(apply_presence_penalty(
+                        &row,
+                        ctx,
+                        presence_penalty,
+                        Some(presence_context_size),
+                    )?);
+                }
+                let refs: Vec<&MxArray> = rows.iter().collect();
+                current_logits = MxArray::stack(refs, Some(0))?;
+            }
+            if frequency_penalty != 0.0 {
+                let mut rows = Vec::with_capacity(batch_size);
+                for (i, ctx) in token_histories.iter().enumerate().take(batch_size) {
+                    let row = current_logits
+                        .slice_axis(0, i as i64, (i + 1) as i64)?
+                        .squeeze(Some(&[0]))?;
+                    rows.push(apply_frequency_penalty(
+                        &row,
+                        ctx,
+                        frequency_penalty,
+                        Some(frequency_context_size),
+                    )?);
+                }
+                let refs: Vec<&MxArray> = rows.iter().collect();
+                current_logits = MxArray::stack(refs, Some(0))?;
+            }
+        }
 
         // Sample first tokens
         let (mut current_tokens, mut current_logprobs_arr) = if return_logprobs {
@@ -3471,6 +3648,41 @@ impl Qwen3Model {
             } else {
                 next_logits
             };
+            {
+                let batch_size = active_histories.len();
+                if presence_penalty != 0.0 {
+                    let mut rows = Vec::with_capacity(batch_size);
+                    for (i, ctx) in active_histories.iter().enumerate().take(batch_size) {
+                        let row = current_logits
+                            .slice_axis(0, i as i64, (i + 1) as i64)?
+                            .squeeze(Some(&[0]))?;
+                        rows.push(apply_presence_penalty(
+                            &row,
+                            ctx,
+                            presence_penalty,
+                            Some(presence_context_size),
+                        )?);
+                    }
+                    let refs: Vec<&MxArray> = rows.iter().collect();
+                    current_logits = MxArray::stack(refs, Some(0))?;
+                }
+                if frequency_penalty != 0.0 {
+                    let mut rows = Vec::with_capacity(batch_size);
+                    for (i, ctx) in active_histories.iter().enumerate().take(batch_size) {
+                        let row = current_logits
+                            .slice_axis(0, i as i64, (i + 1) as i64)?
+                            .squeeze(Some(&[0]))?;
+                        rows.push(apply_frequency_penalty(
+                            &row,
+                            ctx,
+                            frequency_penalty,
+                            Some(frequency_context_size),
+                        )?);
+                    }
+                    let refs: Vec<&MxArray> = rows.iter().collect();
+                    current_logits = MxArray::stack(refs, Some(0))?;
+                }
+            }
 
             // Sample next tokens
             let (next_toks, next_lp) = if return_logprobs {
@@ -4646,6 +4858,10 @@ impl Qwen3Model {
         let min_p = config.min_p.unwrap_or(0.0);
         let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
         let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+        let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+        let presence_context_size = config.presence_context_size.unwrap_or(20);
+        let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+        let frequency_context_size = config.frequency_context_size.unwrap_or(20);
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
@@ -4874,6 +5090,22 @@ impl Qwen3Model {
                     Some(repetition_context_size),
                 )?;
             }
+            if presence_penalty != 0.0 {
+                last_logits = apply_presence_penalty(
+                    &last_logits,
+                    &input_tokens,
+                    presence_penalty,
+                    Some(presence_context_size),
+                )?;
+            }
+            if frequency_penalty != 0.0 {
+                last_logits = apply_frequency_penalty(
+                    &last_logits,
+                    &input_tokens,
+                    frequency_penalty,
+                    Some(frequency_context_size),
+                )?;
+            }
 
             // Sample first token
             let (mut token, mut logprobs) = if return_logprobs {
@@ -4973,17 +5205,35 @@ impl Qwen3Model {
 
                     // Apply repetition penalty with COMPLETE token history
                     // generated_tokens now includes the current token (added above)
-                    if repetition_penalty != 1.0 {
+                    {
                         let mut all_tokens =
                             Vec::with_capacity(input_tokens.len() + generated_tokens.len());
                         all_tokens.extend_from_slice(&input_tokens);
                         all_tokens.extend_from_slice(&generated_tokens);
-                        next_last_logits = apply_repetition_penalty(
-                            &next_last_logits,
-                            &all_tokens,
-                            repetition_penalty,
-                            Some(repetition_context_size),
-                        )?;
+                        if repetition_penalty != 1.0 {
+                            next_last_logits = apply_repetition_penalty(
+                                &next_last_logits,
+                                &all_tokens,
+                                repetition_penalty,
+                                Some(repetition_context_size),
+                            )?;
+                        }
+                        if presence_penalty != 0.0 {
+                            next_last_logits = apply_presence_penalty(
+                                &next_last_logits,
+                                &all_tokens,
+                                presence_penalty,
+                                Some(presence_context_size),
+                            )?;
+                        }
+                        if frequency_penalty != 0.0 {
+                            next_last_logits = apply_frequency_penalty(
+                                &next_last_logits,
+                                &all_tokens,
+                                frequency_penalty,
+                                Some(frequency_context_size),
+                            )?;
+                        }
                     }
 
                     // Sample
@@ -5252,6 +5502,10 @@ impl Qwen3Model {
             min_p: c.min_p,
             repetition_penalty: c.repetition_penalty,
             repetition_context_size: c.repetition_context_size,
+            presence_penalty: c.presence_penalty,
+            presence_context_size: c.presence_context_size,
+            frequency_penalty: c.frequency_penalty,
+            frequency_context_size: c.frequency_context_size,
             max_consecutive_tokens: c.max_consecutive_tokens,
             max_ngram_repeats: c.max_ngram_repeats,
             ngram_size: c.ngram_size,
@@ -5405,6 +5659,10 @@ impl Qwen3Model {
             let min_p = config.min_p.unwrap_or(0.0);
             let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
             let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+            let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+            let presence_context_size = config.presence_context_size.unwrap_or(20);
+            let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+            let frequency_context_size = config.frequency_context_size.unwrap_or(20);
             let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
             let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
             let ngram_size = config.ngram_size.unwrap_or(64);
@@ -5605,6 +5863,22 @@ impl Qwen3Model {
                     Some(repetition_context_size),
                 )?;
             }
+            if presence_penalty != 0.0 {
+                last_logits = apply_presence_penalty(
+                    &last_logits,
+                    &token_ids_vec,
+                    presence_penalty,
+                    Some(presence_context_size),
+                )?;
+            }
+            if frequency_penalty != 0.0 {
+                last_logits = apply_frequency_penalty(
+                    &last_logits,
+                    &token_ids_vec,
+                    frequency_penalty,
+                    Some(frequency_context_size),
+                )?;
+            }
 
             // Sample first token
             let (mut token, mut logprobs_arr) = if return_logprobs {
@@ -5694,6 +5968,29 @@ impl Qwen3Model {
                 } else {
                     next_last_logits
                 };
+                {
+                    let context_tokens: Vec<u32> = token_ids_vec
+                        .iter()
+                        .copied()
+                        .chain(generated_tokens.iter().copied())
+                        .collect();
+                    if presence_penalty != 0.0 {
+                        last_logits = apply_presence_penalty(
+                            &last_logits,
+                            &context_tokens,
+                            presence_penalty,
+                            Some(presence_context_size),
+                        )?;
+                    }
+                    if frequency_penalty != 0.0 {
+                        last_logits = apply_frequency_penalty(
+                            &last_logits,
+                            &context_tokens,
+                            frequency_penalty,
+                            Some(frequency_context_size),
+                        )?;
+                    }
+                }
 
                 let (next_tok, next_lp) = if return_logprobs {
                     let (tok, lp) = sample_and_logprobs(&last_logits, Some(sampling_config))?;

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -1850,7 +1850,7 @@ impl Qwen3Model {
             } else {
                 next_last_logits
             };
-            {
+            if presence_penalty != 0.0 || frequency_penalty != 0.0 {
                 let context_tokens: Vec<u32> = input_tokens
                     .iter()
                     .copied()
@@ -5968,7 +5968,7 @@ impl Qwen3Model {
                 } else {
                     next_last_logits
                 };
-                {
+                if presence_penalty != 0.0 || frequency_penalty != 0.0 {
                     let context_tokens: Vec<u32> = token_ids_vec
                         .iter()
                         .copied()

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -1833,29 +1833,22 @@ impl Qwen3Model {
             // Extract last token logits (shape: [1, 1, vocab_size] -> [vocab_size])
             let next_last_logits = next_logits.slice_axis(1, 0, 1)?.squeeze(Some(&[0, 1]))?;
 
-            // Apply repetition penalty if enabled
-            last_logits = if repetition_penalty != 1.0 {
-                // Build context from input + generated tokens
+            // Apply penalties
+            last_logits = next_last_logits;
+            if repetition_penalty != 1.0 || presence_penalty != 0.0 || frequency_penalty != 0.0 {
                 let context_tokens: Vec<u32> = input_tokens
                     .iter()
                     .copied()
                     .chain(generated_tokens.iter().copied())
                     .collect();
-                apply_repetition_penalty(
-                    &next_last_logits,
-                    &context_tokens,
-                    repetition_penalty,
-                    Some(repetition_context_size),
-                )?
-            } else {
-                next_last_logits
-            };
-            if presence_penalty != 0.0 || frequency_penalty != 0.0 {
-                let context_tokens: Vec<u32> = input_tokens
-                    .iter()
-                    .copied()
-                    .chain(generated_tokens.iter().copied())
-                    .collect();
+                if repetition_penalty != 1.0 {
+                    last_logits = apply_repetition_penalty(
+                        &last_logits,
+                        &context_tokens,
+                        repetition_penalty,
+                        Some(repetition_context_size),
+                    )?;
+                }
                 if presence_penalty != 0.0 {
                     last_logits = apply_presence_penalty(
                         &last_logits,
@@ -5953,27 +5946,22 @@ impl Qwen3Model {
 
                 let next_last_logits = next_logits.slice_axis(1, 0, 1)?.squeeze(Some(&[0, 1]))?;
 
-                last_logits = if repetition_penalty != 1.0 {
+                last_logits = next_last_logits;
+                if repetition_penalty != 1.0 || presence_penalty != 0.0 || frequency_penalty != 0.0
+                {
                     let context_tokens: Vec<u32> = token_ids_vec
                         .iter()
                         .copied()
                         .chain(generated_tokens.iter().copied())
                         .collect();
-                    apply_repetition_penalty(
-                        &next_last_logits,
-                        &context_tokens,
-                        repetition_penalty,
-                        Some(repetition_context_size),
-                    )?
-                } else {
-                    next_last_logits
-                };
-                if presence_penalty != 0.0 || frequency_penalty != 0.0 {
-                    let context_tokens: Vec<u32> = token_ids_vec
-                        .iter()
-                        .copied()
-                        .chain(generated_tokens.iter().copied())
-                        .collect();
+                    if repetition_penalty != 1.0 {
+                        last_logits = apply_repetition_penalty(
+                            &last_logits,
+                            &context_tokens,
+                            repetition_penalty,
+                            Some(repetition_context_size),
+                        )?;
+                    }
                     if presence_penalty != 0.0 {
                         last_logits = apply_presence_penalty(
                             &last_logits,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -13,7 +13,10 @@ use tracing::{info, warn};
 use crate::array::MxArray;
 use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
 use crate::nn::{Embedding, Linear, RMSNorm};
-use crate::sampling::{SamplingConfig, apply_repetition_penalty, check_repetition_cutoff, sample};
+use crate::sampling::{
+    SamplingConfig, apply_frequency_penalty, apply_presence_penalty, apply_repetition_penalty,
+    check_repetition_cutoff, sample,
+};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::tools;
@@ -131,6 +134,20 @@ pub struct ChatConfig {
     /// Size of the context window for repetition penalty (default: 256)
     #[napi(ts_type = "number | undefined")]
     pub repetition_context_size: Option<i32>,
+    /// Presence penalty (0.0 = disabled). Subtracts a flat penalty from logits of any
+    /// token that appeared at least once in context. Matches OpenAI API semantics.
+    #[napi(ts_type = "number | undefined")]
+    pub presence_penalty: Option<f64>,
+    /// Number of recent tokens to consider for presence penalty (default: 20)
+    #[napi(ts_type = "number | undefined")]
+    pub presence_context_size: Option<i32>,
+    /// Frequency penalty (0.0 = disabled). Subtracts penalty * occurrence_count from
+    /// logits of each token in context. Matches OpenAI API semantics.
+    #[napi(ts_type = "number | undefined")]
+    pub frequency_penalty: Option<f64>,
+    /// Number of recent tokens to consider for frequency penalty (default: 20)
+    #[napi(ts_type = "number | undefined")]
+    pub frequency_context_size: Option<i32>,
     /// Max consecutive identical tokens before stopping (default: 16, 0 = disabled)
     #[napi(ts_type = "number | undefined")]
     pub max_consecutive_tokens: Option<i32>,
@@ -809,6 +826,10 @@ impl Qwen3_5Model {
             min_p: None,
             repetition_penalty: None,
             repetition_context_size: None,
+            presence_penalty: None,
+            presence_context_size: None,
+            frequency_penalty: None,
+            frequency_context_size: None,
             max_consecutive_tokens: None,
             max_ngram_repeats: None,
             ngram_size: None,
@@ -895,6 +916,10 @@ impl Qwen3_5Model {
             let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
             let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
             let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+            let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+            let presence_context_size = config.presence_context_size.unwrap_or(20);
+            let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+            let frequency_context_size = config.frequency_context_size.unwrap_or(20);
             let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
             let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
             let ngram_size = config.ngram_size.unwrap_or(64);
@@ -1121,6 +1146,22 @@ impl Qwen3_5Model {
                     Some(repetition_context_size),
                 )?;
             }
+            if presence_penalty != 0.0 {
+                last_logits = apply_presence_penalty(
+                    &last_logits,
+                    &token_history,
+                    presence_penalty,
+                    Some(presence_context_size),
+                )?;
+            }
+            if frequency_penalty != 0.0 {
+                last_logits = apply_frequency_penalty(
+                    &last_logits,
+                    &token_history,
+                    frequency_penalty,
+                    Some(frequency_context_size),
+                )?;
+            }
 
             let mut y = sample(&last_logits, sampling_config)?;
             MxArray::async_eval_arrays(&[&y]);
@@ -1227,6 +1268,22 @@ impl Qwen3_5Model {
                                 &token_history,
                                 repetition_penalty,
                                 Some(repetition_context_size),
+                            )?;
+                        }
+                        if presence_penalty != 0.0 {
+                            logits = apply_presence_penalty(
+                                &logits,
+                                &token_history,
+                                presence_penalty,
+                                Some(presence_context_size),
+                            )?;
+                        }
+                        if frequency_penalty != 0.0 {
+                            logits = apply_frequency_penalty(
+                                &logits,
+                                &token_history,
+                                frequency_penalty,
+                                Some(frequency_context_size),
                             )?;
                         }
                         profiler.end();
@@ -1356,6 +1413,22 @@ impl Qwen3_5Model {
                                 &token_history,
                                 repetition_penalty,
                                 Some(repetition_context_size),
+                            )?;
+                        }
+                        if presence_penalty != 0.0 {
+                            logits = apply_presence_penalty(
+                                &logits,
+                                &token_history,
+                                presence_penalty,
+                                Some(presence_context_size),
+                            )?;
+                        }
+                        if frequency_penalty != 0.0 {
+                            logits = apply_frequency_penalty(
+                                &logits,
+                                &token_history,
+                                frequency_penalty,
+                                Some(frequency_context_size),
                             )?;
                         }
                         profiler.end();
@@ -1549,6 +1622,10 @@ impl Qwen3_5Model {
             min_p: None,
             repetition_penalty: None,
             repetition_context_size: None,
+            presence_penalty: None,
+            presence_context_size: None,
+            frequency_penalty: None,
+            frequency_context_size: None,
             max_consecutive_tokens: None,
             max_ngram_repeats: None,
             ngram_size: None,
@@ -1646,6 +1723,10 @@ impl Qwen3_5Model {
                     let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
                     let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
                     let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+                    let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+                    let presence_context_size = config.presence_context_size.unwrap_or(20);
+                    let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+                    let frequency_context_size = config.frequency_context_size.unwrap_or(20);
                     let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
                     let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
                     let ngram_size = config.ngram_size.unwrap_or(64);
@@ -1879,6 +1960,22 @@ impl Qwen3_5Model {
                             Some(repetition_context_size),
                         )?;
                     }
+                    if presence_penalty != 0.0 {
+                        last_logits = apply_presence_penalty(
+                            &last_logits,
+                            &token_history,
+                            presence_penalty,
+                            Some(presence_context_size),
+                        )?;
+                    }
+                    if frequency_penalty != 0.0 {
+                        last_logits = apply_frequency_penalty(
+                            &last_logits,
+                            &token_history,
+                            frequency_penalty,
+                            Some(frequency_context_size),
+                        )?;
+                    }
 
                     let mut y = sample(&last_logits, sampling_config)?;
                     MxArray::async_eval_arrays(&[&y]);
@@ -1979,6 +2076,22 @@ impl Qwen3_5Model {
                                         &token_history,
                                         repetition_penalty,
                                         Some(repetition_context_size),
+                                    )?;
+                                }
+                                if presence_penalty != 0.0 {
+                                    logits = apply_presence_penalty(
+                                        &logits,
+                                        &token_history,
+                                        presence_penalty,
+                                        Some(presence_context_size),
+                                    )?;
+                                }
+                                if frequency_penalty != 0.0 {
+                                    logits = apply_frequency_penalty(
+                                        &logits,
+                                        &token_history,
+                                        frequency_penalty,
+                                        Some(frequency_context_size),
                                     )?;
                                 }
                                 let next_token = sample(&logits, sampling_config)?;
@@ -2108,6 +2221,22 @@ impl Qwen3_5Model {
                                         &token_history,
                                         repetition_penalty,
                                         Some(repetition_context_size),
+                                    )?;
+                                }
+                                if presence_penalty != 0.0 {
+                                    logits = apply_presence_penalty(
+                                        &logits,
+                                        &token_history,
+                                        presence_penalty,
+                                        Some(presence_context_size),
+                                    )?;
+                                }
+                                if frequency_penalty != 0.0 {
+                                    logits = apply_frequency_penalty(
+                                        &logits,
+                                        &token_history,
+                                        frequency_penalty,
+                                        Some(frequency_context_size),
                                     )?;
                                 }
                                 let next_token = sample(&logits, sampling_config)?;

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -23,7 +23,10 @@ use crate::array::MxArray;
 use crate::array::mask::create_causal_mask;
 use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
 use crate::nn::{Embedding, Linear, RMSNorm};
-use crate::sampling::{SamplingConfig, apply_repetition_penalty, check_repetition_cutoff, sample};
+use crate::sampling::{
+    SamplingConfig, apply_frequency_penalty, apply_presence_penalty, apply_repetition_penalty,
+    check_repetition_cutoff, sample,
+};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::tools;
@@ -662,6 +665,10 @@ impl Qwen3_5MoeModel {
             min_p: None,
             repetition_penalty: None,
             repetition_context_size: None,
+            presence_penalty: None,
+            presence_context_size: None,
+            frequency_penalty: None,
+            frequency_context_size: None,
             max_consecutive_tokens: None,
             max_ngram_repeats: None,
             ngram_size: None,
@@ -742,6 +749,10 @@ impl Qwen3_5MoeModel {
             let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
             let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
             let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+            let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+            let presence_context_size = config.presence_context_size.unwrap_or(20);
+            let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+            let frequency_context_size = config.frequency_context_size.unwrap_or(20);
             let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
             let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
             let ngram_size = config.ngram_size.unwrap_or(64);
@@ -989,6 +1000,22 @@ impl Qwen3_5MoeModel {
                     Some(repetition_context_size),
                 )?;
             }
+            if presence_penalty != 0.0 {
+                last_logits = apply_presence_penalty(
+                    &last_logits,
+                    &token_history,
+                    presence_penalty,
+                    Some(presence_context_size),
+                )?;
+            }
+            if frequency_penalty != 0.0 {
+                last_logits = apply_frequency_penalty(
+                    &last_logits,
+                    &token_history,
+                    frequency_penalty,
+                    Some(frequency_context_size),
+                )?;
+            }
 
             let mut y = sample(&last_logits, sampling_config)?;
             MxArray::async_eval_arrays(&[&y]);
@@ -1100,6 +1127,22 @@ impl Qwen3_5MoeModel {
                                 &token_history,
                                 repetition_penalty,
                                 Some(repetition_context_size),
+                            )?;
+                        }
+                        if presence_penalty != 0.0 {
+                            logits = apply_presence_penalty(
+                                &logits,
+                                &token_history,
+                                presence_penalty,
+                                Some(presence_context_size),
+                            )?;
+                        }
+                        if frequency_penalty != 0.0 {
+                            logits = apply_frequency_penalty(
+                                &logits,
+                                &token_history,
+                                frequency_penalty,
+                                Some(frequency_context_size),
                             )?;
                         }
                         profiler.end();
@@ -1224,6 +1267,22 @@ impl Qwen3_5MoeModel {
                                 &token_history,
                                 repetition_penalty,
                                 Some(repetition_context_size),
+                            )?;
+                        }
+                        if presence_penalty != 0.0 {
+                            logits = apply_presence_penalty(
+                                &logits,
+                                &token_history,
+                                presence_penalty,
+                                Some(presence_context_size),
+                            )?;
+                        }
+                        if frequency_penalty != 0.0 {
+                            logits = apply_frequency_penalty(
+                                &logits,
+                                &token_history,
+                                frequency_penalty,
+                                Some(frequency_context_size),
                             )?;
                         }
                         profiler.end();
@@ -1422,6 +1481,10 @@ impl Qwen3_5MoeModel {
             min_p: None,
             repetition_penalty: None,
             repetition_context_size: None,
+            presence_penalty: None,
+            presence_context_size: None,
+            frequency_penalty: None,
+            frequency_context_size: None,
             max_consecutive_tokens: None,
             max_ngram_repeats: None,
             ngram_size: None,
@@ -1515,6 +1578,10 @@ impl Qwen3_5MoeModel {
                     let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
                     let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
                     let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+                    let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+                    let presence_context_size = config.presence_context_size.unwrap_or(20);
+                    let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+                    let frequency_context_size = config.frequency_context_size.unwrap_or(20);
                     let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
                     let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
                     let ngram_size = config.ngram_size.unwrap_or(64);
@@ -1772,6 +1839,22 @@ impl Qwen3_5MoeModel {
                             Some(repetition_context_size),
                         )?;
                     }
+                    if presence_penalty != 0.0 {
+                        last_logits = apply_presence_penalty(
+                            &last_logits,
+                            &token_history,
+                            presence_penalty,
+                            Some(presence_context_size),
+                        )?;
+                    }
+                    if frequency_penalty != 0.0 {
+                        last_logits = apply_frequency_penalty(
+                            &last_logits,
+                            &token_history,
+                            frequency_penalty,
+                            Some(frequency_context_size),
+                        )?;
+                    }
 
                     let mut y = sample(&last_logits, sampling_config)?;
                     MxArray::async_eval_arrays(&[&y]);
@@ -1874,6 +1957,22 @@ impl Qwen3_5MoeModel {
                                         &token_history,
                                         repetition_penalty,
                                         Some(repetition_context_size),
+                                    )?;
+                                }
+                                if presence_penalty != 0.0 {
+                                    logits = apply_presence_penalty(
+                                        &logits,
+                                        &token_history,
+                                        presence_penalty,
+                                        Some(presence_context_size),
+                                    )?;
+                                }
+                                if frequency_penalty != 0.0 {
+                                    logits = apply_frequency_penalty(
+                                        &logits,
+                                        &token_history,
+                                        frequency_penalty,
+                                        Some(frequency_context_size),
                                     )?;
                                 }
                                 let next_token = sample(&logits, sampling_config)?;
@@ -2004,6 +2103,22 @@ impl Qwen3_5MoeModel {
                                         &token_history,
                                         repetition_penalty,
                                         Some(repetition_context_size),
+                                    )?;
+                                }
+                                if presence_penalty != 0.0 {
+                                    logits = apply_presence_penalty(
+                                        &logits,
+                                        &token_history,
+                                        presence_penalty,
+                                        Some(presence_context_size),
+                                    )?;
+                                }
+                                if frequency_penalty != 0.0 {
+                                    logits = apply_frequency_penalty(
+                                        &logits,
+                                        &token_history,
+                                        frequency_penalty,
+                                        Some(frequency_context_size),
                                     )?;
                                 }
                                 let next_token = sample(&logits, sampling_config)?;

--- a/crates/mlx-core/src/models/training_generate.rs
+++ b/crates/mlx-core/src/models/training_generate.rs
@@ -7,7 +7,10 @@ use napi::bindgen_prelude::*;
 
 use crate::array::MxArray;
 use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
-use crate::sampling::{SamplingConfig, apply_repetition_penalty, check_repetition_cutoff, sample};
+use crate::sampling::{
+    SamplingConfig, apply_frequency_penalty, apply_presence_penalty, apply_repetition_penalty,
+    check_repetition_cutoff, sample,
+};
 use crate::tokenizer::Qwen3Tokenizer;
 
 /// Decode-only generation loop with logprob tracking for training.
@@ -29,6 +32,10 @@ pub(crate) fn generate_decode_loop_for_training(
     let min_p = config.min_p.unwrap_or(0.0);
     let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
     let repetition_context_size = config.repetition_context_size.unwrap_or(256);
+    let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+    let presence_context_size = config.presence_context_size.unwrap_or(20);
+    let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+    let frequency_context_size = config.frequency_context_size.unwrap_or(20);
     let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
     let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
     let ngram_size = config.ngram_size.unwrap_or(64);
@@ -51,7 +58,7 @@ pub(crate) fn generate_decode_loop_for_training(
 
     for _step in 0..max_new_tokens {
         // Apply repetition penalty
-        let penalized_logits = if repetition_penalty != 1.0 && !all_tokens.is_empty() {
+        let mut penalized_logits = if repetition_penalty != 1.0 && !all_tokens.is_empty() {
             let context_start = if all_tokens.len() > repetition_context_size as usize {
                 all_tokens.len() - repetition_context_size as usize
             } else {
@@ -62,6 +69,22 @@ pub(crate) fn generate_decode_loop_for_training(
         } else {
             current_logits.clone()
         };
+        if presence_penalty != 0.0 {
+            penalized_logits = apply_presence_penalty(
+                &penalized_logits,
+                &all_tokens,
+                presence_penalty,
+                Some(presence_context_size),
+            )?;
+        }
+        if frequency_penalty != 0.0 {
+            penalized_logits = apply_frequency_penalty(
+                &penalized_logits,
+                &all_tokens,
+                frequency_penalty,
+                Some(frequency_context_size),
+            )?;
+        }
 
         // Compute logprob if needed
         if return_logprobs {

--- a/crates/mlx-core/src/sampling.rs
+++ b/crates/mlx-core/src/sampling.rs
@@ -402,6 +402,82 @@ pub(crate) fn sample_and_logprobs(
     Ok((token, logprobs))
 }
 
+/// Shared context for penalty functions: validates inputs, slices to recent tokens,
+/// and filters invalid IDs.
+///
+/// Returns `None` if no penalty should be applied (empty/invalid tokens).
+struct PenaltyContext {
+    /// The axis to operate on (last axis)
+    last_axis: i32,
+    /// Number of dimensions (1 or 2)
+    ndim: usize,
+    /// Valid token IDs after filtering (within vocab range, from recent context)
+    valid_tokens: Vec<u32>,
+}
+
+impl PenaltyContext {
+    /// Build an index MxArray from token IDs, shaped to match logit ndim.
+    fn make_indices(&self, token_ids: &[u32]) -> Result<MxArray> {
+        if self.ndim == 1 {
+            MxArray::from_uint32(token_ids, &[token_ids.len() as i64])
+        } else {
+            MxArray::from_uint32(token_ids, &[1, token_ids.len() as i64])
+        }
+    }
+}
+
+fn prepare_penalty_context(
+    logits: &MxArray,
+    tokens: &[u32],
+    context_size: i32,
+) -> Result<Option<PenaltyContext>> {
+    if tokens.is_empty() {
+        return Ok(None);
+    }
+
+    if context_size <= 0 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!("context_size must be positive, got {}", context_size),
+        ));
+    }
+
+    // Take last context_size tokens
+    let start_idx = tokens.len().saturating_sub(context_size as usize);
+    let recent_tokens = &tokens[start_idx..];
+
+    if recent_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    let ndim = logits.ndim()? as usize;
+    if ndim == 0 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            "expected logits with shape [vocab_size] or [batch, vocab_size], got scalar"
+                .to_string(),
+        ));
+    }
+
+    let vocab_size = logits.shape_at((ndim - 1) as u32)?;
+
+    let valid_tokens: Vec<u32> = recent_tokens
+        .iter()
+        .filter(|&&id| (id as i64) < vocab_size)
+        .copied()
+        .collect();
+
+    if valid_tokens.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(PenaltyContext {
+        last_axis: ndim as i32 - 1,
+        ndim,
+        valid_tokens,
+    }))
+}
+
 /// Apply repetition penalty to logits
 ///
 /// Reduces the probability of tokens that have recently appeared in the generated sequence.
@@ -420,24 +496,12 @@ pub(crate) fn sample_and_logprobs(
 /// For each token in the recent history (last context_size tokens):
 /// - If logit < 0: multiply by penalty (make more negative)
 /// - If logit ≥ 0: divide by penalty (reduce magnitude)
-///
-/// This asymmetric treatment ensures:
-/// - Already unlikely tokens (negative logits) become even more unlikely
-/// - Already likely tokens (positive logits) become less likely
-///
-/// # Example
-/// ```
-/// // With penalty=1.5:
-/// // Token 42 has logit=2.0 → becomes 2.0/1.5 = 1.33 (reduced)
-/// // Token 100 has logit=-1.0 → becomes -1.0*1.5 = -1.5 (more negative)
-/// ```
 pub(crate) fn apply_repetition_penalty(
     logits: &MxArray,
     tokens: &[u32],
     penalty: f64,
     context_size: Option<i32>,
 ) -> Result<MxArray> {
-    // Validate penalty
     if penalty <= 0.0 {
         return Err(Error::new(
             Status::InvalidArg,
@@ -445,89 +509,133 @@ pub(crate) fn apply_repetition_penalty(
         ));
     }
 
-    // If penalty is 1.0, no effect - just return a reference (no copy needed)
     if (penalty - 1.0).abs() < 1e-10 {
         return Ok(logits.clone());
     }
 
-    // If no tokens to penalize, return as-is
-    if tokens.is_empty() {
-        return Ok(logits.clone());
-    }
-
-    let context_size = context_size.unwrap_or(20);
-    if context_size <= 0 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            format!("context_size must be positive, got {}", context_size),
-        ));
-    }
-
-    // Take last context_size tokens
-    let start_idx = if tokens.len() > context_size as usize {
-        tokens.len() - context_size as usize
-    } else {
-        0
-    };
-    let recent_tokens = &tokens[start_idx..];
-
-    // If no tokens after filtering, return as-is
-    if recent_tokens.is_empty() {
-        return Ok(logits.clone());
-    }
-
-    // OPTIMIZED: Get ndim and vocab_size without copying entire shape
-    let ndim = logits.ndim()? as usize;
-    if ndim == 0 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "apply_repetition_penalty: expected logits with shape [vocab_size] or [batch, vocab_size], got scalar"
-                .to_string(),
-        ));
-    }
-
-    let vocab_size = logits.shape_at((ndim - 1) as u32)?;
-
-    // Filter out invalid token IDs
-    let valid_tokens: Vec<u32> = recent_tokens
-        .iter()
-        .filter(|&&id| (id as i64) < vocab_size)
-        .copied()
-        .collect();
-
-    if valid_tokens.is_empty() {
-        return Ok(logits.clone());
-    }
-
-    // Create index array for gathering/scattering
-    let ndim_val = logits.ndim()?;
-    let last_axis = ndim_val as i32 - 1;
-
-    // For put_along_axis, indices must have the same ndim as the source array.
-    // 1D: indices shape [num_tokens], 2D: indices shape [1, num_tokens] (broadcasts over batch)
-    let indices = if ndim_val == 1 {
-        MxArray::from_uint32(&valid_tokens, &[valid_tokens.len() as i64])?
-    } else {
-        MxArray::from_uint32(&valid_tokens, &[1, valid_tokens.len() as i64])?
+    let ctx = match prepare_penalty_context(logits, tokens, context_size.unwrap_or(20))? {
+        Some(ctx) => ctx,
+        None => return Ok(logits.clone()),
     };
 
-    // Gather logits at the penalized token positions (vectorized, 1 FFI call)
-    let gathered = logits.take_along_axis(&indices, last_axis)?;
+    let indices = ctx.make_indices(&ctx.valid_tokens)?;
 
-    // Apply penalty to gathered values (vectorized, 4 FFI calls)
+    // Gather logits at the penalized token positions
+    let gathered = logits.take_along_axis(&indices, ctx.last_axis)?;
+
+    // Asymmetric penalty: divide positive logits, multiply negative logits
     let zero = MxArray::scalar_float(0.0)?;
     let is_negative = gathered.less(&zero)?;
     let penalized_positive = gathered.div_scalar(penalty)?;
     let penalized_negative = gathered.mul_scalar(penalty)?;
     let penalized = is_negative.where_(&penalized_negative, &penalized_positive)?;
 
-    // Scatter penalized values back in ONE operation (1 FFI call)
-    // put_along_axis(self, indices, values, axis) is equivalent to:
-    //   result = self.copy(); result[..., indices] = values
-    // This replaces the previous loop of ~N slice_assign_axis calls.
-    let result = logits.put_along_axis(&indices, &penalized, last_axis)?;
+    logits.put_along_axis(&indices, &penalized, ctx.last_axis)
+}
 
-    Ok(result)
+/// Apply presence penalty to logits
+///
+/// Subtracts a flat penalty from logits of any token that appeared at least once
+/// in the context window. Matches OpenAI API `presence_penalty` semantics.
+///
+/// Reference: mlx-lm/mlx_lm/sample_utils.py:make_presence_penalty
+///
+/// # Arguments
+/// * `logits` - Input logits [vocab_size] or [batch, vocab_size]
+/// * `tokens` - Previously generated tokens (token IDs)
+/// * `penalty` - Additive penalty to subtract (0.0 = disabled, recommended: 0.0-2.0)
+/// * `context_size` - Maximum number of recent tokens to consider (default: 20)
+pub(crate) fn apply_presence_penalty(
+    logits: &MxArray,
+    tokens: &[u32],
+    penalty: f64,
+    context_size: Option<i32>,
+) -> Result<MxArray> {
+    if penalty.abs() < 1e-10 {
+        return Ok(logits.clone());
+    }
+
+    let ctx = match prepare_penalty_context(logits, tokens, context_size.unwrap_or(20))? {
+        Some(ctx) => ctx,
+        None => return Ok(logits.clone()),
+    };
+
+    // Deduplicate tokens — presence is binary (one or five occurrences = same penalty)
+    let unique: Vec<u32> = {
+        let mut seen = std::collections::HashSet::new();
+        ctx.valid_tokens
+            .iter()
+            .filter(|id| seen.insert(**id))
+            .copied()
+            .collect()
+    };
+
+    let indices = ctx.make_indices(&unique)?;
+    let gathered = logits.take_along_axis(&indices, ctx.last_axis)?;
+    let penalized = gathered.sub_scalar(penalty)?;
+
+    logits.put_along_axis(&indices, &penalized, ctx.last_axis)
+}
+
+/// Apply frequency penalty to logits
+///
+/// Subtracts a penalty proportional to how many times each token appeared in the
+/// context window. Matches OpenAI API `frequency_penalty` semantics.
+///
+/// Reference: mlx-lm/mlx_lm/sample_utils.py:make_frequency_penalty
+///
+/// # Arguments
+/// * `logits` - Input logits [vocab_size] or [batch, vocab_size]
+/// * `tokens` - Previously generated tokens (token IDs)
+/// * `penalty` - Additive penalty per occurrence (0.0 = disabled, recommended: 0.0-2.0)
+/// * `context_size` - Maximum number of recent tokens to consider (default: 20)
+pub(crate) fn apply_frequency_penalty(
+    logits: &MxArray,
+    tokens: &[u32],
+    penalty: f64,
+    context_size: Option<i32>,
+) -> Result<MxArray> {
+    if penalty.abs() < 1e-10 {
+        return Ok(logits.clone());
+    }
+
+    let ctx = match prepare_penalty_context(logits, tokens, context_size.unwrap_or(20))? {
+        Some(ctx) => ctx,
+        None => return Ok(logits.clone()),
+    };
+
+    // Count frequency of each token on CPU — O(context_size), max ~256 iterations
+    let mut freq_map = std::collections::HashMap::new();
+    for &id in &ctx.valid_tokens {
+        *freq_map.entry(id).or_insert(0u32) += 1;
+    }
+
+    // For tokens that appear once, use sub_scalar (same as presence penalty).
+    // For mixed frequencies, build a per-token penalty array.
+    let unique_ids: Vec<u32> = freq_map.keys().copied().collect();
+    let all_single = freq_map.values().all(|&c| c == 1);
+
+    let indices = ctx.make_indices(&unique_ids)?;
+    let gathered = logits.take_along_axis(&indices, ctx.last_axis)?;
+
+    let penalized = if all_single {
+        // All tokens appear once — flat subtract like presence penalty
+        gathered.sub_scalar(penalty)?
+    } else {
+        // Mixed frequencies — per-token penalty array
+        let freq_penalties: Vec<f32> = unique_ids
+            .iter()
+            .map(|id| freq_map[id] as f32 * penalty as f32)
+            .collect();
+        let penalty_array = if ctx.ndim == 1 {
+            MxArray::from_float32(&freq_penalties, &[freq_penalties.len() as i64])?
+        } else {
+            MxArray::from_float32(&freq_penalties, &[1, freq_penalties.len() as i64])?
+        };
+        gathered.sub(&penalty_array)?
+    };
+
+    logits.put_along_axis(&indices, &penalized, ctx.last_axis)
 }
 
 /// Check if generation has fallen into a repetitive loop.
@@ -611,17 +719,18 @@ pub(crate) fn check_repetition_cutoff(
     None
 }
 
-// Unit tests for repetition_penalty (pub(crate) function) remain here
+// Unit tests for penalty functions (pub(crate) functions) remain here
 // Public API tests have been moved to node/tests/sampling_tests.rs
+
+#[cfg(test)]
+fn assert_close(a: f32, b: f32, tolerance: f32) {
+    assert!((a - b).abs() < tolerance, "Expected {}, got {}", b, a);
+}
 
 #[cfg(test)]
 mod repetition_penalty_tests {
     use super::*;
     use crate::array::MxArray;
-
-    fn assert_close(a: f32, b: f32, tolerance: f32) {
-        assert!((a - b).abs() < tolerance, "Expected {}, got {}", b, a);
-    }
 
     #[test]
     fn test_apply_penalty_to_positive_logits() {
@@ -878,5 +987,210 @@ mod repetition_penalty_tests {
         assert_close(result_data[2], 6.0, 1e-5); // Unchanged
         assert_close(result_data[3], 4.0, 1e-5); // 8.0 / 2.0 = 4.0
         assert_close(result_data[4], 5.0, 1e-5); // 10.0 / 2.0 = 5.0
+    }
+}
+
+#[cfg(test)]
+mod presence_penalty_tests {
+    use super::*;
+    use crate::array::MxArray;
+
+    #[test]
+    fn test_basic_presence_penalty() {
+        let logits = MxArray::from_float32(&[1.0f32, 2.0, 3.0, 4.0, 5.0], &[5]).unwrap();
+        let tokens = vec![1, 3];
+        let penalty = 1.5;
+
+        let result = apply_presence_penalty(&logits, &tokens, penalty, None).unwrap();
+        result.eval();
+        let data = result.to_float32().unwrap();
+
+        assert_close(data[0], 1.0, 1e-5); // Unchanged
+        assert_close(data[1], 0.5, 1e-5); // 2.0 - 1.5 = 0.5
+        assert_close(data[2], 3.0, 1e-5); // Unchanged
+        assert_close(data[3], 2.5, 1e-5); // 4.0 - 1.5 = 2.5
+        assert_close(data[4], 5.0, 1e-5); // Unchanged
+    }
+
+    #[test]
+    fn test_deduplication() {
+        // Token 1 appears 3 times, but presence penalty should only subtract once
+        let logits = MxArray::from_float32(&[1.0f32, 10.0, 3.0], &[3]).unwrap();
+        let tokens = vec![1, 1, 1];
+        let penalty = 2.0;
+
+        let result = apply_presence_penalty(&logits, &tokens, penalty, None).unwrap();
+        result.eval();
+        let data = result.to_float32().unwrap();
+
+        assert_close(data[0], 1.0, 1e-5); // Unchanged
+        assert_close(data[1], 8.0, 1e-5); // 10.0 - 2.0 = 8.0 (subtracted once, not 3x)
+        assert_close(data[2], 3.0, 1e-5); // Unchanged
+    }
+
+    #[test]
+    fn test_zero_disabled() {
+        let logits = MxArray::from_float32(&[1.0f32, 2.0, 3.0], &[3]).unwrap();
+        let tokens = vec![0, 1, 2];
+
+        let result = apply_presence_penalty(&logits, &tokens, 0.0, None).unwrap();
+        result.eval();
+        let data = result.to_float32().unwrap();
+        let orig = logits.to_float32().unwrap();
+
+        for i in 0..data.len() {
+            assert_close(data[i], orig[i], 1e-5);
+        }
+    }
+
+    #[test]
+    fn test_context_size() {
+        let logits = MxArray::from_float32(&[1.0f32, 2.0, 3.0, 4.0, 5.0], &[5]).unwrap();
+        let tokens = vec![0, 1, 2, 3, 4];
+        let penalty = 1.0;
+
+        let result = apply_presence_penalty(&logits, &tokens, penalty, Some(2)).unwrap();
+        result.eval();
+        let data = result.to_float32().unwrap();
+
+        // Only last 2 tokens (3, 4) should be penalized
+        assert_close(data[0], 1.0, 1e-5);
+        assert_close(data[1], 2.0, 1e-5);
+        assert_close(data[2], 3.0, 1e-5);
+        assert_close(data[3], 3.0, 1e-5); // 4.0 - 1.0 = 3.0
+        assert_close(data[4], 4.0, 1e-5); // 5.0 - 1.0 = 4.0
+    }
+
+    #[test]
+    fn test_batch_2d() {
+        let logits = MxArray::from_float32(
+            &[
+                1.0f32, 2.0, 3.0, 4.0, // Batch 0
+                5.0, 6.0, 7.0, 8.0, // Batch 1
+            ],
+            &[2, 4],
+        )
+        .unwrap();
+        let tokens = vec![1, 3];
+        let penalty = 1.0;
+
+        let result = apply_presence_penalty(&logits, &tokens, penalty, None).unwrap();
+        result.eval();
+        let data = result.to_float32().unwrap();
+
+        // Batch 0
+        assert_close(data[0], 1.0, 1e-5);
+        assert_close(data[1], 1.0, 1e-5); // 2.0 - 1.0
+        assert_close(data[2], 3.0, 1e-5);
+        assert_close(data[3], 3.0, 1e-5); // 4.0 - 1.0
+
+        // Batch 1
+        assert_close(data[4], 5.0, 1e-5);
+        assert_close(data[5], 5.0, 1e-5); // 6.0 - 1.0
+        assert_close(data[6], 7.0, 1e-5);
+        assert_close(data[7], 7.0, 1e-5); // 8.0 - 1.0
+    }
+}
+
+#[cfg(test)]
+mod frequency_penalty_tests {
+    use super::*;
+    use crate::array::MxArray;
+
+    #[test]
+    fn test_basic_frequency_penalty() {
+        // Token 1 appears 3x → penalty = 3 * 1.0 = 3.0
+        // Token 2 appears 1x → penalty = 1 * 1.0 = 1.0
+        let logits = MxArray::from_float32(&[1.0f32, 10.0, 5.0, 4.0], &[4]).unwrap();
+        let tokens = vec![1, 1, 1, 2];
+        let penalty = 1.0;
+
+        let result = apply_frequency_penalty(&logits, &tokens, penalty, None).unwrap();
+        result.eval();
+        let data = result.to_float32().unwrap();
+
+        assert_close(data[0], 1.0, 1e-5); // Unchanged
+        assert_close(data[1], 7.0, 1e-5); // 10.0 - 3*1.0 = 7.0
+        assert_close(data[2], 4.0, 1e-5); // 5.0 - 1*1.0 = 4.0
+        assert_close(data[3], 4.0, 1e-5); // Unchanged
+    }
+
+    #[test]
+    fn test_single_occurrence_matches_presence() {
+        // With all unique tokens, frequency penalty = presence penalty
+        let logits = MxArray::from_float32(&[1.0f32, 2.0, 3.0, 4.0], &[4]).unwrap();
+        let tokens = vec![1, 3];
+        let penalty = 1.5;
+
+        let freq_result = apply_frequency_penalty(&logits, &tokens, penalty, None).unwrap();
+        freq_result.eval();
+        let freq_data = freq_result.to_float32().unwrap();
+
+        let pres_result = apply_presence_penalty(&logits, &tokens, penalty, None).unwrap();
+        pres_result.eval();
+        let pres_data = pres_result.to_float32().unwrap();
+
+        for i in 0..freq_data.len() {
+            assert_close(freq_data[i], pres_data[i], 1e-5);
+        }
+    }
+
+    #[test]
+    fn test_zero_disabled() {
+        let logits = MxArray::from_float32(&[1.0f32, 2.0, 3.0], &[3]).unwrap();
+        let tokens = vec![0, 0, 0, 1, 2];
+
+        let result = apply_frequency_penalty(&logits, &tokens, 0.0, None).unwrap();
+        result.eval();
+        let data = result.to_float32().unwrap();
+        let orig = logits.to_float32().unwrap();
+
+        for i in 0..data.len() {
+            assert_close(data[i], orig[i], 1e-5);
+        }
+    }
+
+    #[test]
+    fn test_context_size() {
+        // Tokens: [0, 0, 0, 1, 1], context_size=2 → only [1, 1]
+        let logits = MxArray::from_float32(&[1.0f32, 10.0, 3.0], &[3]).unwrap();
+        let tokens = vec![0, 0, 0, 1, 1];
+        let penalty = 1.0;
+
+        let result = apply_frequency_penalty(&logits, &tokens, penalty, Some(2)).unwrap();
+        result.eval();
+        let data = result.to_float32().unwrap();
+
+        assert_close(data[0], 1.0, 1e-5); // Token 0 not in last 2
+        assert_close(data[1], 8.0, 1e-5); // 10.0 - 2*1.0 = 8.0 (token 1 appears 2x)
+        assert_close(data[2], 3.0, 1e-5); // Unchanged
+    }
+
+    #[test]
+    fn test_batch_2d() {
+        let logits = MxArray::from_float32(
+            &[
+                1.0f32, 10.0, 3.0, // Batch 0
+                4.0, 20.0, 6.0, // Batch 1
+            ],
+            &[2, 3],
+        )
+        .unwrap();
+        let tokens = vec![1, 1]; // Token 1 appears 2x
+        let penalty = 2.0;
+
+        let result = apply_frequency_penalty(&logits, &tokens, penalty, None).unwrap();
+        result.eval();
+        let data = result.to_float32().unwrap();
+
+        // Batch 0: token 1 penalized by 2*2.0=4.0
+        assert_close(data[0], 1.0, 1e-5);
+        assert_close(data[1], 6.0, 1e-5); // 10.0 - 4.0 = 6.0
+        assert_close(data[2], 3.0, 1e-5);
+
+        // Batch 1: same penalty
+        assert_close(data[3], 4.0, 1e-5);
+        assert_close(data[4], 16.0, 1e-5); // 20.0 - 4.0 = 16.0
+        assert_close(data[5], 6.0, 1e-5);
     }
 }

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -1972,6 +1972,20 @@ export interface ChatConfig {
   repetitionPenalty?: number | undefined;
   /** Size of the context window for repetition penalty (default: 256) */
   repetitionContextSize?: number | undefined;
+  /**
+   * Presence penalty (0.0 = disabled). Subtracts a flat penalty from logits of any
+   * token that appeared at least once in context. Matches OpenAI API semantics.
+   */
+  presencePenalty?: number | undefined;
+  /** Number of recent tokens to consider for presence penalty (default: 20) */
+  presenceContextSize?: number | undefined;
+  /**
+   * Frequency penalty (0.0 = disabled). Subtracts penalty * occurrence_count from
+   * logits of each token in context. Matches OpenAI API semantics.
+   */
+  frequencyPenalty?: number | undefined;
+  /** Number of recent tokens to consider for frequency penalty (default: 20) */
+  frequencyContextSize?: number | undefined;
   /** Max consecutive identical tokens before stopping (default: 16, 0 = disabled) */
   maxConsecutiveTokens?: number | undefined;
   /** Max n-gram repetitions before stopping (default: 3, 0 = disabled) */
@@ -2334,6 +2348,20 @@ export interface GenerationConfig {
    */
   repetitionContextSize?: number;
   /**
+   * Presence penalty (0.0 = disabled). Subtracts a flat penalty from logits of any
+   * token that appeared at least once in context. Matches OpenAI API semantics.
+   */
+  presencePenalty?: number;
+  /** Number of recent tokens to consider for presence penalty (default: 20) */
+  presenceContextSize?: number;
+  /**
+   * Frequency penalty (0.0 = disabled). Subtracts penalty * occurrence_count from
+   * logits of each token in context. Matches OpenAI API semantics.
+   */
+  frequencyPenalty?: number;
+  /** Number of recent tokens to consider for frequency penalty (default: 20) */
+  frequencyContextSize?: number;
+  /**
    * Stop if same token repeats this many times consecutively (default: 16)
    * Set to 0 to disable. Prevents OOM from degenerate repetitive generation.
    */
@@ -2526,6 +2554,16 @@ export interface GrpoEngineConfig {
   topK?: number;
   /** Repetition penalty (default: 1.1) */
   repetitionPenalty?: number;
+  /**
+   * Presence penalty (0.0 = disabled). Subtracts a flat penalty from logits of any
+   * token that appeared at least once in context.
+   */
+  presencePenalty?: number;
+  /**
+   * Frequency penalty (0.0 = disabled). Subtracts penalty * occurrence_count from
+   * logits of each token in context.
+   */
+  frequencyPenalty?: number;
   /**
    * Maximum allowed NaN gradient occurrences before stopping training (default: 100)
    * When exceeded, training will stop with an error to prevent model corruption.
@@ -3462,6 +3500,20 @@ export interface VlmChatConfig {
   topP?: number;
   /** Repetition penalty (default: 1.5) */
   repetitionPenalty?: number;
+  /**
+   * Presence penalty (0.0 = disabled). Subtracts a flat penalty from logits of any
+   * token that appeared at least once in context. Matches OpenAI API semantics.
+   */
+  presencePenalty?: number;
+  /** Number of recent tokens to consider for presence penalty (default: 20) */
+  presenceContextSize?: number;
+  /**
+   * Frequency penalty (0.0 = disabled). Subtracts penalty * occurrence_count from
+   * logits of each token in context. Matches OpenAI API semantics.
+   */
+  frequencyPenalty?: number;
+  /** Number of recent tokens to consider for frequency penalty (default: 20) */
+  frequencyContextSize?: number;
   /** Whether to return log probabilities (default: false) */
   returnLogprobs?: boolean;
 }

--- a/packages/trl/src/trainers/grpo-trainer.ts
+++ b/packages/trl/src/trainers/grpo-trainer.ts
@@ -122,6 +122,10 @@ export interface GRPOTrainerConfig<T = unknown> {
   topP?: number;
   topK?: number;
   repetitionPenalty?: number;
+  /** Presence penalty (0.0 = disabled). Subtracts a flat penalty from logits of any token in context. */
+  presencePenalty?: number;
+  /** Frequency penalty (0.0 = disabled). Subtracts penalty * count for each token in context. */
+  frequencyPenalty?: number;
 
   // Tool calling (for tool-use training)
   /**
@@ -533,6 +537,8 @@ export class GRPOTrainer<T = unknown> {
       topP: this.config.topP,
       topK: this.config.topK,
       repetitionPenalty: this.config.repetitionPenalty,
+      presencePenalty: this.config.presencePenalty,
+      frequencyPenalty: this.config.frequencyPenalty,
       // Tool calling support
       tools: this.config.tools,
       enableThinking: this.config.enableThinking,


### PR DESCRIPTION
Add two new additive penalty types matching OpenAI API semantics and mlx-lm's implementation, as recommended by the Qwen3.5 model card (presence_penalty=1.5 for repetition prevention).

- presence_penalty: subtracts a flat penalty from logits of any token that appeared at least once in context (binary, deduplicates tokens)
- frequency_penalty: subtracts penalty proportional to occurrence count in context (uses HashMap frequency counting)

Both default to 0.0 (disabled) with zero overhead when not used. Default context_size is 20, matching mlx-lm.

Wired into all generation loops across Qwen3, Qwen3.5 Dense/MoE, PaddleOCR-VL, training generate, and GRPO engine. Added to ChatConfig, GenerationConfig, VLMChatConfig, and GRPOEngineConfig structs.

Includes 11 new unit tests and a shared prepare_penalty_context helper that eliminates duplication across all three penalty functions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core token sampling logic and multiple generation loops, so incorrect penalty application could alter model outputs or performance; defaults are disabled which limits blast radius.
> 
> **Overview**
> Adds OpenAI-style *additive* `presence_penalty` and `frequency_penalty` controls (with configurable context windows) and wires them through `GenerationConfig`, `ChatConfig`, `VLMChatConfig`, and `GRPOEngineConfig`, including TS type exports and TRL GRPO trainer plumbing.
> 
> Implements new `apply_presence_penalty` and `apply_frequency_penalty` in `sampling.rs` via a shared `prepare_penalty_context` helper, refactors `apply_repetition_penalty` to reuse it, and applies the new penalties throughout Qwen3/Qwen3.5 (dense + MoE), PaddleOCR-VL generation loops, training generation utilities, and GRPO generation config construction. Adds unit tests covering the new penalty behaviors (deduplication, frequency counting, context size, and 1D/2D logits).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 416f6bbff06325e6369d8ef57051410ab1bb54d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->