### PR TITLE
feat: stop generation on </tool_call> token when tools are active

### DIFF
--- a/__test__/tokenization/qwen3-tokenizer.test.ts
+++ b/__test__/tokenization/qwen3-tokenizer.test.ts
@@ -382,6 +382,62 @@ describe('Qwen3Tokenizer', () => {
     });
   });
 
+  describe('Tool Message Template Rendering', () => {
+    it('should not double-wrap tool response with plain content', async () => {
+      const messages: ChatMessage[] = [{ role: 'tool', content: '{"temperature": 22}' }];
+      const tokens = await tokenizer.applyChatTemplate(messages, false);
+      const formatted = await tokenizer.decode(tokens, false);
+      // Should contain exactly ONE <tool_response> wrapping (from template), not two
+      const count = (formatted.match(/<tool_response>/g) || []).length;
+      expect(count).toBe(1);
+    });
+
+    it('should double-wrap if content already has tool_response tags', async () => {
+      // This is the bug that formatToolResponse + role:'tool' caused
+      const messages: ChatMessage[] = [{ role: 'tool', content: '<tool_response>\n{"temp": 22}\n</tool_response>' }];
+      const tokens = await tokenizer.applyChatTemplate(messages, false);
+      const formatted = await tokenizer.decode(tokens, false);
+      // Two <tool_response> occurrences — the template added another wrapper
+      const count = (formatted.match(/<tool_response>/g) || []).length;
+      expect(count).toBe(2);
+    });
+
+    it('should group consecutive tool messages under one user block', async () => {
+      const messages: ChatMessage[] = [
+        { role: 'tool', content: '{"result": "sunny"}' },
+        { role: 'tool', content: '{"result": "14:00"}' },
+      ];
+      const tokens = await tokenizer.applyChatTemplate(messages, false);
+      const formatted = await tokenizer.decode(tokens, false);
+      // Should have only ONE <|im_start|>user ... <|im_end|> block
+      const imStartCount = (formatted.match(/<\|im_start\|>user/g) || []).length;
+      expect(imStartCount).toBe(1);
+      // But TWO <tool_response> blocks
+      const toolResponseCount = (formatted.match(/<tool_response>/g) || []).length;
+      expect(toolResponseCount).toBe(2);
+    });
+
+    it('should render assistant message with tool_calls', async () => {
+      const messages: ChatMessage[] = [
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            {
+              name: 'get_weather',
+              arguments: '{"city": "Tokyo"}',
+            },
+          ],
+        },
+      ];
+      const tokens = await tokenizer.applyChatTemplate(messages, false);
+      const formatted = await tokenizer.decode(tokens, false);
+      expect(formatted).toContain('<tool_call>');
+      expect(formatted).toContain('get_weather');
+      expect(formatted).toContain('Tokyo');
+    });
+  });
+
   describe('Edge Cases', () => {
     it('should handle very long text', async () => {
       const longText = 'Hello '.repeat(1000);

--- a/__test__/tools/chat.test.ts
+++ b/__test__/tools/chat.test.ts
@@ -188,6 +188,73 @@ describe('Error Status Values', () => {
   });
 });
 
+describe('formatToolResponse removal', () => {
+  it('formatToolResponse should not be exported', async () => {
+    const lm = await import('@mlx-node/lm');
+    expect('formatToolResponse' in lm).toBe(false);
+  });
+});
+
+describe('ToolCallResult to ToolCall conversion', () => {
+  it('should convert ToolCallResult arguments to ToolCall arguments', () => {
+    // ToolCallResult has arguments as an object
+    const result: ToolCallResult = {
+      id: 'call_abc123',
+      name: 'get_weather',
+      arguments: { city: 'Tokyo', units: 'celsius' },
+      status: 'ok' as const,
+      rawContent: '{"name": "get_weather", "arguments": {"city": "Tokyo", "units": "celsius"}}',
+    };
+
+    // Convert to ToolCall format (arguments as JSON string)
+    const toolCall = {
+      id: result.id,
+      name: result.name,
+      arguments: typeof result.arguments === 'string' ? result.arguments : JSON.stringify(result.arguments),
+    };
+
+    expect(toolCall.arguments).toBe('{"city":"Tokyo","units":"celsius"}');
+    expect(typeof toolCall.arguments).toBe('string');
+
+    // Verify round-trip: parse back to object
+    const parsed = JSON.parse(toolCall.arguments);
+    expect(parsed.city).toBe('Tokyo');
+    expect(parsed.units).toBe('celsius');
+  });
+
+  it('should handle multiple tool calls in result', () => {
+    const toolCalls: ToolCallResult[] = [
+      {
+        id: 'call_1',
+        name: 'get_weather',
+        arguments: { city: 'Tokyo' },
+        status: 'ok' as const,
+        rawContent: '{"name": "get_weather", "arguments": {"city": "Tokyo"}}',
+      },
+      {
+        id: 'call_2',
+        name: 'get_time',
+        arguments: { timezone: 'JST' },
+        status: 'ok' as const,
+        rawContent: '{"name": "get_time", "arguments": {"timezone": "JST"}}',
+      },
+    ];
+
+    const validCalls = toolCalls.filter((tc) => tc.status === 'ok');
+    expect(validCalls.length).toBe(2);
+
+    const converted = validCalls.map((tc) => ({
+      id: tc.id,
+      name: tc.name,
+      arguments: typeof tc.arguments === 'string' ? tc.arguments : JSON.stringify(tc.arguments),
+    }));
+
+    expect(converted[0].name).toBe('get_weather');
+    expect(converted[1].name).toBe('get_time');
+    expect(JSON.parse(converted[0].arguments)).toEqual({ city: 'Tokyo' });
+  });
+});
+
 describe('Thinking Content Extraction', () => {
   it('thinking field type is string | null', () => {
     // Verify the thinking field can be string or null

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -812,47 +812,42 @@ pub(crate) fn build_qwen35_recipe(
 
 /// Build the "unsloth" quantization recipe for Qwen3.5 hybrid models.
 ///
-/// Based on Unsloth's GGUF benchmark findings for Qwen3.5's hybrid
+/// MLX affine equivalent of Unsloth Dynamic 2.0 (UD) GGUF quantization.
+/// Based on Unsloth's per-tensor 99.9% KLD analysis for Qwen3.5's hybrid
 /// GatedDeltaNet (linear attention/SSM) + full attention architecture:
 /// (https://unsloth.ai/docs/models/qwen3.5/gguf-benchmarks)
 ///
-/// Key findings from Unsloth's per-tensor 99.9% KLD analysis (sorted worst→best):
+/// ## GGUF Equivalence
 ///
-/// **Most sensitive — AWQ-correctable (quantize at 5-bit with imatrix):**
-/// - `attn_qkv` (`self_attn.q/k/v_proj`): KLD ~1.5-2.9 — AWQ via input_layernorm
-/// - `attn_gate` (`linear_attn.in_proj_z`): "performs poorly with MXFP4" — AWQ via input_layernorm
-/// - `linear_attn.in_proj_qkv`: KLD ~2.9 — AWQ via input_layernorm
+/// | `--q-bits` | GGUF Equivalent    | Size (35B-A3B) |
+/// |------------|--------------------|----------------|
+/// | 3          | `UD-Q3_K_XL` 16 GB | ~17 GB         |
+/// | 4          | `UD-Q4_K_XL` 19 GB | ~20 GB         |
 ///
-/// **Most sensitive — NOT AWQ-correctable (keep bf16):**
-/// - `ssm_out` (`linear_attn.out_proj`): KLD ~6.0 at q2_k — no preceding norm
-/// - `self_attn.o_proj`: KLD ~1.5 — no preceding norm
+/// Size difference (~1 GB) is format-level: GGUF K-quants pack scales within
+/// blocks, while MLX affine stores separate scales+biases per group (~2 GB
+/// metadata overhead).
 ///
-/// - `ssm_beta`, `ssm_alpha` (`in_proj_a/b`): degrade significantly with low bits
-///   (already excluded by `should_quantize()` since they lack `.weight` suffix)
+/// ## Per-Tensor Bit Assignments (default_bits = N)
 ///
-/// NOTE: imatrix is **required** for this recipe — without AWQ pre-scaling,
-/// affine quantization of attention/SSM at 5-bit would have noticeable quality loss.
+/// | Weight                  | Bits    | GGUF Type  | Rationale                         |
+/// |-------------------------|---------|------------|-----------------------------------|
+/// | `embed_tokens`          | N+2     | Q5_K/Q6_K  | KLD ~0.15 — very low sensitivity  |
+/// | `lm_head`               | N+3     | Q6_K/Q8_0  | KLD ~0.05 — safest tensor         |
+/// | `self_attn.q/k/v_proj`  | N+2     | Q5_K/Q6_K  | KLD ~1.5-2.9, AWQ via layernorm   |
+/// | `linear_attn.in_proj_*` | N+2     | Q5_K/Q6_K  | KLD ~2.9, AWQ via layernorm       |
+/// | `self_attn.o_proj`      | bf16    | bf16       | KLD ~1.5, NOT AWQ-correctable     |
+/// | `linear_attn.out_proj`  | bf16    | bf16       | KLD ~6.0, worst tensor by far     |
+/// | `down_proj`             | N+1     | Q4_K/Q5_K  | "slightly more sensitive" than FFN |
+/// | `gate_proj`, `up_proj`  | N       | Q3_K/Q4_K  | "generally ok" at low bits        |
+/// | Router gates            | 8       | Q8_0       | Standard for MoE routing          |
+/// | GDN params (A_log, etc) | bf16    | bf16       | Excluded by `should_quantize()`   |
 ///
-/// **Moderate sensitivity (default_bits + 1):**
-/// - `ffn_down` (`down_proj`): "slightly more sensitive" than other FFN weights
+/// ## AWQ Pre-Scaling
 ///
-/// **Safe to quantize aggressively (default bits = 3-bit):**
-/// - `ffn_up`, `ffn_gate`: "generally ok to quantize to 3-bit"
-/// - "leaving ffn_* (down, up, gate) at around iq3_xxs seems to be best compromise"
-///
-/// **Very low sensitivity (quantize at 5-6 bit):**
-/// - `token_embedding`: KLD ~0.15 at q5_k — among the least sensitive tensors
-/// - `output-tensor` (lm_head): KLD ~0.05 at q5_k — the safest tensor to quantize
-///
-/// **Always 8-bit:**
-/// - Router gates: standard for MoE routing accuracy
-///
-/// This recipe matches Unsloth Dynamic 2.0's approach of quantizing important
-/// layers at higher bits (5-bit with imatrix) while aggressively quantizing
-/// FFN weights to 3-bit. Requires imatrix for near-lossless quality.
-/// Embeddings and lm_head are quantized at higher precision (5-6 bit) following
-/// llama.cpp's standard practice — they're dequantized at load time since the
-/// model accesses them every token (savings come from smaller file on disk).
+/// imatrix is **required** — attention/SSM weights fed by input_layernorm can
+/// be AWQ-corrected (layernorm absorbs inverse scales), but o_proj and out_proj
+/// have no preceding norm and must stay bf16.
 pub(crate) fn build_unsloth_recipe(
     default_bits: i32,
     default_group_size: i32,
@@ -872,7 +867,7 @@ pub(crate) fn build_unsloth_recipe(
     let down_proj_bits = snap_bits(default_bits + 1);
     let embed_bits = snap_bits(default_bits + 2);
     let lm_head_bits = snap_bits(default_bits + 3);
-    let attn_ssm_bits = snap_bits(default_bits + 2); // 5-bit for attention/SSM (Q5_K equivalent)
+    let attn_ssm_bits = snap_bits(default_bits + 2);
     let gs = default_group_size;
 
     Box::new(move |key: &str| -> QuantDecision {
@@ -945,7 +940,7 @@ pub(crate) fn build_unsloth_recipe(
             };
         }
 
-        // Everything else (ffn_gate_proj, ffn_up_proj, etc.) → default bits (3-bit)
+        // Everything else (ffn_gate_proj, ffn_up_proj, etc.) → default bits
         QuantDecision::Default
     })
 }

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -5638,6 +5638,7 @@ impl Qwen3Model {
         let prompt_token_count = actual_prefill_count;
         let config = gen_config.unwrap_or_default();
 
+        let tool_call_start_id = tokenizer.tool_call_start_id();
         let tool_call_end_id = tokenizer.tool_call_end_id();
 
         let embedding_weight = self.embedding.get_weight();
@@ -5891,6 +5892,7 @@ impl Qwen3Model {
             // Decode loop
             const DECODE_CLEANUP_INTERVAL: i32 = 256;
             let one_arr = MxArray::from_int32(&[1], &[1])?;
+            let mut tool_call_stop_after: Option<u32> = None;
 
             for step in 0..max_new_tokens {
                 let _stream_ctx = StreamContext::new(generation_stream);
@@ -5910,9 +5912,19 @@ impl Qwen3Model {
 
                 generated_tokens.push(token_value);
 
-                if has_tools && tool_call_end_id.is_some_and(|id| id == token_value) {
-                    finish_reason = "stop";
-                    break;
+                if has_tools {
+                    if tool_call_end_id.is_some_and(|id| id == token_value) {
+                        tool_call_stop_after = Some(2);
+                    } else if let Some(remaining) = tool_call_stop_after {
+                        if tool_call_start_id.is_some_and(|id| id == token_value) {
+                            tool_call_stop_after = None;
+                        } else if remaining == 0 {
+                            finish_reason = "stop";
+                            break;
+                        } else {
+                            tool_call_stop_after = Some(remaining - 1);
+                        }
+                    }
                 }
 
                 if return_logprobs && let Some(ref lp) = logprobs_arr {

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -5482,6 +5482,7 @@ impl Qwen3Model {
 
         // Extract tools, enable_thinking, report_performance, and reuse_cache from config
         let tools = config.as_ref().and_then(|c| c.tools.clone());
+        let has_tools = tools.is_some();
         let enable_thinking = config.as_ref().and_then(|c| c.enable_thinking);
         let report_perf = config
             .as_ref()
@@ -5636,6 +5637,8 @@ impl Qwen3Model {
         // Generate tokens using the internal generate method with optional cache state
         let prompt_token_count = actual_prefill_count;
         let config = gen_config.unwrap_or_default();
+
+        let tool_call_end_id = tokenizer.tool_call_end_id();
 
         let embedding_weight = self.embedding.get_weight();
         let layers_arc = self.layers.clone();
@@ -5906,6 +5909,11 @@ impl Qwen3Model {
                 }
 
                 generated_tokens.push(token_value);
+
+                if has_tools && tool_call_end_id.is_some_and(|id| id == token_value) {
+                    finish_reason = "stop";
+                    break;
+                }
 
                 if return_logprobs && let Some(ref lp) = logprobs_arr {
                     lp.eval();

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -5482,7 +5482,6 @@ impl Qwen3Model {
 
         // Extract tools, enable_thinking, report_performance, and reuse_cache from config
         let tools = config.as_ref().and_then(|c| c.tools.clone());
-        let has_tools = tools.is_some();
         let enable_thinking = config.as_ref().and_then(|c| c.enable_thinking);
         let report_perf = config
             .as_ref()
@@ -5637,9 +5636,6 @@ impl Qwen3Model {
         // Generate tokens using the internal generate method with optional cache state
         let prompt_token_count = actual_prefill_count;
         let config = gen_config.unwrap_or_default();
-
-        let tool_call_start_id = tokenizer.tool_call_start_id();
-        let tool_call_end_id = tokenizer.tool_call_end_id();
 
         let embedding_weight = self.embedding.get_weight();
         let layers_arc = self.layers.clone();
@@ -5892,8 +5888,6 @@ impl Qwen3Model {
             // Decode loop
             const DECODE_CLEANUP_INTERVAL: i32 = 256;
             let one_arr = MxArray::from_int32(&[1], &[1])?;
-            let mut tool_call_stop_after: Option<u32> = None;
-
             for step in 0..max_new_tokens {
                 let _stream_ctx = StreamContext::new(generation_stream);
 
@@ -5933,21 +5927,6 @@ impl Qwen3Model {
                 {
                     finish_reason = "stop";
                     break;
-                }
-
-                if has_tools {
-                    if tool_call_end_id.is_some_and(|id| id == token_value) {
-                        tool_call_stop_after = Some(4);
-                    } else if let Some(remaining) = tool_call_stop_after {
-                        if tool_call_start_id.is_some_and(|id| id == token_value) {
-                            tool_call_stop_after = None;
-                        } else if remaining == 0 {
-                            finish_reason = "stop";
-                            break;
-                        } else {
-                            tool_call_stop_after = Some(remaining - 1);
-                        }
-                    }
                 }
 
                 // Forward pass with just the new token

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -5912,21 +5912,6 @@ impl Qwen3Model {
 
                 generated_tokens.push(token_value);
 
-                if has_tools {
-                    if tool_call_end_id.is_some_and(|id| id == token_value) {
-                        tool_call_stop_after = Some(2);
-                    } else if let Some(remaining) = tool_call_stop_after {
-                        if tool_call_start_id.is_some_and(|id| id == token_value) {
-                            tool_call_stop_after = None;
-                        } else if remaining == 0 {
-                            finish_reason = "stop";
-                            break;
-                        } else {
-                            tool_call_stop_after = Some(remaining - 1);
-                        }
-                    }
-                }
-
                 if return_logprobs && let Some(ref lp) = logprobs_arr {
                     lp.eval();
                     let token_logprob = lp.item_at_float32(token_value as usize)?;
@@ -5948,6 +5933,21 @@ impl Qwen3Model {
                 {
                     finish_reason = "stop";
                     break;
+                }
+
+                if has_tools {
+                    if tool_call_end_id.is_some_and(|id| id == token_value) {
+                        tool_call_stop_after = Some(4);
+                    } else if let Some(remaining) = tool_call_stop_after {
+                        if tool_call_start_id.is_some_and(|id| id == token_value) {
+                            tool_call_stop_after = None;
+                        } else if remaining == 0 {
+                            finish_reason = "stop";
+                            break;
+                        } else {
+                            tool_call_stop_after = Some(remaining - 1);
+                        }
+                    }
                 }
 
                 // Forward pass with just the new token

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1321,21 +1321,6 @@ impl Qwen3_5Model {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
-                    if has_tools {
-                        if tool_call_end_id.is_some_and(|id| id == token_id) {
-                            tool_call_stop_after = Some(2);
-                        } else if let Some(remaining) = tool_call_stop_after {
-                            if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                tool_call_stop_after = None;
-                            } else if remaining == 0 {
-                                finish_reason = String::from("stop");
-                                break;
-                            } else {
-                                tool_call_stop_after = Some(remaining - 1);
-                            }
-                        }
-                    }
-
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
                         break;
@@ -1349,6 +1334,21 @@ impl Qwen3_5Model {
                     ) {
                         finish_reason = reason.to_string();
                         break;
+                    }
+
+                    if has_tools {
+                        if tool_call_end_id.is_some_and(|id| id == token_id) {
+                            tool_call_stop_after = Some(4);
+                        } else if let Some(remaining) = tool_call_stop_after {
+                            if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                tool_call_stop_after = None;
+                            } else if remaining == 0 {
+                                finish_reason = String::from("stop");
+                                break;
+                            } else {
+                                tool_call_stop_after = Some(remaining - 1);
+                            }
+                        }
                     }
 
                     match next_y {
@@ -1480,21 +1480,6 @@ impl Qwen3_5Model {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
-                    if has_tools {
-                        if tool_call_end_id.is_some_and(|id| id == token_id) {
-                            tool_call_stop_after = Some(2);
-                        } else if let Some(remaining) = tool_call_stop_after {
-                            if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                tool_call_stop_after = None;
-                            } else if remaining == 0 {
-                                finish_reason = String::from("stop");
-                                break;
-                            } else {
-                                tool_call_stop_after = Some(remaining - 1);
-                            }
-                        }
-                    }
-
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
                         break;
@@ -1508,6 +1493,21 @@ impl Qwen3_5Model {
                     ) {
                         finish_reason = reason.to_string();
                         break;
+                    }
+
+                    if has_tools {
+                        if tool_call_end_id.is_some_and(|id| id == token_id) {
+                            tool_call_stop_after = Some(4);
+                        } else if let Some(remaining) = tool_call_stop_after {
+                            if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                tool_call_stop_after = None;
+                            } else if remaining == 0 {
+                                finish_reason = String::from("stop");
+                                break;
+                            } else {
+                                tool_call_stop_after = Some(remaining - 1);
+                            }
+                        }
                     }
 
                     profiler.step();
@@ -2173,21 +2173,6 @@ impl Qwen3_5Model {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
-                            if has_tools {
-                                if tool_call_end_id.is_some_and(|id| id == token_id) {
-                                    tool_call_stop_after = Some(2);
-                                } else if let Some(remaining) = tool_call_stop_after {
-                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                        tool_call_stop_after = None;
-                                    } else if remaining == 0 {
-                                        finish_reason = String::from("stop");
-                                        break;
-                                    } else {
-                                        tool_call_stop_after = Some(remaining - 1);
-                                    }
-                                }
-                            }
-
                             if token_id == eos_id {
                                 finish_reason = String::from("stop");
                                 break;
@@ -2201,6 +2186,21 @@ impl Qwen3_5Model {
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
+                            }
+
+                            if has_tools {
+                                if tool_call_end_id.is_some_and(|id| id == token_id) {
+                                    tool_call_stop_after = Some(4);
+                                } else if let Some(remaining) = tool_call_stop_after {
+                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                        tool_call_stop_after = None;
+                                    } else if remaining == 0 {
+                                        finish_reason = String::from("stop");
+                                        break;
+                                    } else {
+                                        tool_call_stop_after = Some(remaining - 1);
+                                    }
+                                }
                             }
 
                             match next_y {
@@ -2334,21 +2334,6 @@ impl Qwen3_5Model {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
-                            if has_tools {
-                                if tool_call_end_id.is_some_and(|id| id == token_id) {
-                                    tool_call_stop_after = Some(2);
-                                } else if let Some(remaining) = tool_call_stop_after {
-                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                        tool_call_stop_after = None;
-                                    } else if remaining == 0 {
-                                        finish_reason = String::from("stop");
-                                        break;
-                                    } else {
-                                        tool_call_stop_after = Some(remaining - 1);
-                                    }
-                                }
-                            }
-
                             if token_id == eos_id {
                                 finish_reason = String::from("stop");
                                 break;
@@ -2362,6 +2347,21 @@ impl Qwen3_5Model {
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
+                            }
+
+                            if has_tools {
+                                if tool_call_end_id.is_some_and(|id| id == token_id) {
+                                    tool_call_stop_after = Some(4);
+                                } else if let Some(remaining) = tool_call_stop_after {
+                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                        tool_call_stop_after = None;
+                                    } else if remaining == 0 {
+                                        finish_reason = String::from("stop");
+                                        break;
+                                    } else {
+                                        tool_call_stop_after = Some(remaining - 1);
+                                    }
+                                }
                             }
 
                             match next_y {

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -904,9 +904,6 @@ impl Qwen3_5Model {
         napi::bindgen_prelude::spawn_blocking(move || {
             let mut first_token_instant: Option<std::time::Instant> = None;
 
-            let has_tools = config.tools.is_some();
-            let tool_call_start_id = tokenizer.tool_call_start_id();
-            let tool_call_end_id = tokenizer.tool_call_end_id();
             let tool_defs = config.tools.as_deref();
             let enable_thinking = config.enable_thinking;
             let tokens = tokenizer.apply_chat_template_sync(
@@ -1253,7 +1250,6 @@ impl Qwen3_5Model {
 
                 // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                 profiler.set_label("chat_compiled");
-                let mut tool_call_stop_after: Option<u32> = None;
 
                 for step in 0..max_new_tokens {
                     // Build and submit graph for step N+1 before waiting for N
@@ -1336,21 +1332,6 @@ impl Qwen3_5Model {
                         break;
                     }
 
-                    if has_tools {
-                        if tool_call_end_id.is_some_and(|id| id == token_id) {
-                            tool_call_stop_after = Some(4);
-                        } else if let Some(remaining) = tool_call_stop_after {
-                            if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                tool_call_stop_after = None;
-                            } else if remaining == 0 {
-                                finish_reason = String::from("stop");
-                                break;
-                            } else {
-                                tool_call_stop_after = Some(remaining - 1);
-                            }
-                        }
-                    }
-
                     match next_y {
                         Some(next) => y = next,
                         None => break,
@@ -1401,7 +1382,6 @@ impl Qwen3_5Model {
                 // Rust fallback decode loop — pipelined like mlx-lm:
                 // Build next step's graph before blocking on current token.
                 profiler.set_label("chat_rust");
-                let mut tool_call_stop_after: Option<u32> = None;
 
                 // Kick off first token's async eval
                 MxArray::async_eval_arrays(&[&y]);
@@ -1493,21 +1473,6 @@ impl Qwen3_5Model {
                     ) {
                         finish_reason = reason.to_string();
                         break;
-                    }
-
-                    if has_tools {
-                        if tool_call_end_id.is_some_and(|id| id == token_id) {
-                            tool_call_stop_after = Some(4);
-                        } else if let Some(remaining) = tool_call_stop_after {
-                            if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                tool_call_stop_after = None;
-                            } else if remaining == 0 {
-                                finish_reason = String::from("stop");
-                                break;
-                            } else {
-                                tool_call_stop_after = Some(remaining - 1);
-                            }
-                        }
                     }
 
                     profiler.step();
@@ -1744,9 +1709,6 @@ impl Qwen3_5Model {
             let callback_err = callback.clone();
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
-                    let has_tools = config.tools.is_some();
-                    let tool_call_start_id = tokenizer.tool_call_start_id();
-                    let tool_call_end_id = tokenizer.tool_call_end_id();
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = config.enable_thinking;
                     let tokens = tokenizer.apply_chat_template_sync(
@@ -2102,7 +2064,6 @@ impl Qwen3_5Model {
 
                         // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("chat_stream_compiled");
-                        let mut tool_call_stop_after: Option<u32> = None;
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
@@ -2188,21 +2149,6 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            if has_tools {
-                                if tool_call_end_id.is_some_and(|id| id == token_id) {
-                                    tool_call_stop_after = Some(4);
-                                } else if let Some(remaining) = tool_call_stop_after {
-                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                        tool_call_stop_after = None;
-                                    } else if remaining == 0 {
-                                        finish_reason = String::from("stop");
-                                        break;
-                                    } else {
-                                        tool_call_stop_after = Some(remaining - 1);
-                                    }
-                                }
-                            }
-
                             match next_y {
                                 Some(next) => y = next,
                                 None => break,
@@ -2254,7 +2200,6 @@ impl Qwen3_5Model {
                     } else {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("chat_stream_rust");
-                        let mut tool_call_stop_after: Option<u32> = None;
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
@@ -2347,21 +2292,6 @@ impl Qwen3_5Model {
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
-                            }
-
-                            if has_tools {
-                                if tool_call_end_id.is_some_and(|id| id == token_id) {
-                                    tool_call_stop_after = Some(4);
-                                } else if let Some(remaining) = tool_call_stop_after {
-                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                        tool_call_stop_after = None;
-                                    } else if remaining == 0 {
-                                        finish_reason = String::from("stop");
-                                        break;
-                                    } else {
-                                        tool_call_stop_after = Some(remaining - 1);
-                                    }
-                                }
                             }
 
                             match next_y {

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -904,6 +904,8 @@ impl Qwen3_5Model {
         napi::bindgen_prelude::spawn_blocking(move || {
             let mut first_token_instant: Option<std::time::Instant> = None;
 
+            let has_tools = config.tools.is_some();
+            let tool_call_end_id = tokenizer.tool_call_end_id();
             let tool_defs = config.tools.as_deref();
             let enable_thinking = config.enable_thinking;
             let tokens = tokenizer.apply_chat_template_sync(
@@ -1317,6 +1319,11 @@ impl Qwen3_5Model {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
+                    if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
+                        finish_reason = String::from("stop");
+                        break;
+                    }
+
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
                         break;
@@ -1459,6 +1466,11 @@ impl Qwen3_5Model {
 
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
+
+                    if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
+                        finish_reason = String::from("stop");
+                        break;
+                    }
 
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
@@ -1709,6 +1721,8 @@ impl Qwen3_5Model {
             let callback_err = callback.clone();
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
+                    let has_tools = config.tools.is_some();
+                    let tool_call_end_id = tokenizer.tool_call_end_id();
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = config.enable_thinking;
                     let tokens = tokenizer.apply_chat_template_sync(
@@ -2134,6 +2148,11 @@ impl Qwen3_5Model {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
+                            if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
+                                finish_reason = String::from("stop");
+                                break;
+                            }
+
                             if token_id == eos_id {
                                 finish_reason = String::from("stop");
                                 break;
@@ -2278,6 +2297,11 @@ impl Qwen3_5Model {
                                 }),
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
+
+                            if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
+                                finish_reason = String::from("stop");
+                                break;
+                            }
 
                             if token_id == eos_id {
                                 finish_reason = String::from("stop");

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -905,6 +905,7 @@ impl Qwen3_5Model {
             let mut first_token_instant: Option<std::time::Instant> = None;
 
             let has_tools = config.tools.is_some();
+            let tool_call_start_id = tokenizer.tool_call_start_id();
             let tool_call_end_id = tokenizer.tool_call_end_id();
             let tool_defs = config.tools.as_deref();
             let enable_thinking = config.enable_thinking;
@@ -1252,6 +1253,7 @@ impl Qwen3_5Model {
 
                 // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                 profiler.set_label("chat_compiled");
+                let mut tool_call_stop_after: Option<u32> = None;
 
                 for step in 0..max_new_tokens {
                     // Build and submit graph for step N+1 before waiting for N
@@ -1319,9 +1321,19 @@ impl Qwen3_5Model {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
-                    if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
-                        finish_reason = String::from("stop");
-                        break;
+                    if has_tools {
+                        if tool_call_end_id.is_some_and(|id| id == token_id) {
+                            tool_call_stop_after = Some(2);
+                        } else if let Some(remaining) = tool_call_stop_after {
+                            if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                tool_call_stop_after = None;
+                            } else if remaining == 0 {
+                                finish_reason = String::from("stop");
+                                break;
+                            } else {
+                                tool_call_stop_after = Some(remaining - 1);
+                            }
+                        }
                     }
 
                     if token_id == eos_id {
@@ -1389,6 +1401,7 @@ impl Qwen3_5Model {
                 // Rust fallback decode loop — pipelined like mlx-lm:
                 // Build next step's graph before blocking on current token.
                 profiler.set_label("chat_rust");
+                let mut tool_call_stop_after: Option<u32> = None;
 
                 // Kick off first token's async eval
                 MxArray::async_eval_arrays(&[&y]);
@@ -1467,9 +1480,19 @@ impl Qwen3_5Model {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
-                    if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
-                        finish_reason = String::from("stop");
-                        break;
+                    if has_tools {
+                        if tool_call_end_id.is_some_and(|id| id == token_id) {
+                            tool_call_stop_after = Some(2);
+                        } else if let Some(remaining) = tool_call_stop_after {
+                            if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                tool_call_stop_after = None;
+                            } else if remaining == 0 {
+                                finish_reason = String::from("stop");
+                                break;
+                            } else {
+                                tool_call_stop_after = Some(remaining - 1);
+                            }
+                        }
                     }
 
                     if token_id == eos_id {
@@ -1722,6 +1745,7 @@ impl Qwen3_5Model {
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
                     let has_tools = config.tools.is_some();
+                    let tool_call_start_id = tokenizer.tool_call_start_id();
                     let tool_call_end_id = tokenizer.tool_call_end_id();
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = config.enable_thinking;
@@ -2078,6 +2102,7 @@ impl Qwen3_5Model {
 
                         // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("chat_stream_compiled");
+                        let mut tool_call_stop_after: Option<u32> = None;
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
@@ -2148,9 +2173,19 @@ impl Qwen3_5Model {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
-                            if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
-                                finish_reason = String::from("stop");
-                                break;
+                            if has_tools {
+                                if tool_call_end_id.is_some_and(|id| id == token_id) {
+                                    tool_call_stop_after = Some(2);
+                                } else if let Some(remaining) = tool_call_stop_after {
+                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                        tool_call_stop_after = None;
+                                    } else if remaining == 0 {
+                                        finish_reason = String::from("stop");
+                                        break;
+                                    } else {
+                                        tool_call_stop_after = Some(remaining - 1);
+                                    }
+                                }
                             }
 
                             if token_id == eos_id {
@@ -2219,6 +2254,7 @@ impl Qwen3_5Model {
                     } else {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("chat_stream_rust");
+                        let mut tool_call_stop_after: Option<u32> = None;
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
@@ -2298,9 +2334,19 @@ impl Qwen3_5Model {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
-                            if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
-                                finish_reason = String::from("stop");
-                                break;
+                            if has_tools {
+                                if tool_call_end_id.is_some_and(|id| id == token_id) {
+                                    tool_call_stop_after = Some(2);
+                                } else if let Some(remaining) = tool_call_stop_after {
+                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                        tool_call_stop_after = None;
+                                    } else if remaining == 0 {
+                                        finish_reason = String::from("stop");
+                                        break;
+                                    } else {
+                                        tool_call_stop_after = Some(remaining - 1);
+                                    }
+                                }
                             }
 
                             if token_id == eos_id {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -738,6 +738,7 @@ impl Qwen3_5MoeModel {
 
         napi::bindgen_prelude::spawn_blocking(move || {
             let has_tools = config.tools.is_some();
+            let tool_call_start_id = tokenizer.tool_call_start_id();
             let tool_call_end_id = tokenizer.tool_call_end_id();
             let tool_defs = config.tools.as_deref();
             let enable_thinking = config.enable_thinking;
@@ -1113,6 +1114,7 @@ impl Qwen3_5MoeModel {
                 // Rep penalty uses token_history as-of graph build time (one
                 // token behind), matching Python mlx-lm's pipelining behavior.
                 profiler.set_label("moe_chat_compiled");
+                let mut tool_call_stop_after: Option<u32> = None;
 
                 for step in 0..max_new_tokens {
                     // Build and submit graph for step N+1 before waiting for N
@@ -1178,9 +1180,19 @@ impl Qwen3_5MoeModel {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
-                    if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
-                        finish_reason = String::from("stop");
-                        break;
+                    if has_tools {
+                        if tool_call_end_id.is_some_and(|id| id == token_id) {
+                            tool_call_stop_after = Some(2);
+                        } else if let Some(remaining) = tool_call_stop_after {
+                            if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                tool_call_stop_after = None;
+                            } else if remaining == 0 {
+                                finish_reason = String::from("stop");
+                                break;
+                            } else {
+                                tool_call_stop_after = Some(remaining - 1);
+                            }
+                        }
                     }
 
                     if token_id == eos_id {
@@ -1248,6 +1260,7 @@ impl Qwen3_5MoeModel {
             } else {
                 // Rust fallback decode loop (pipelined)
                 profiler.set_label("moe_chat_rust");
+                let mut tool_call_stop_after: Option<u32> = None;
 
                 for step in 0..max_new_tokens {
                     // Build and submit graph for step N+1 before waiting for N
@@ -1323,9 +1336,19 @@ impl Qwen3_5MoeModel {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
-                    if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
-                        finish_reason = String::from("stop");
-                        break;
+                    if has_tools {
+                        if tool_call_end_id.is_some_and(|id| id == token_id) {
+                            tool_call_stop_after = Some(2);
+                        } else if let Some(remaining) = tool_call_stop_after {
+                            if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                tool_call_stop_after = None;
+                            } else if remaining == 0 {
+                                finish_reason = String::from("stop");
+                                break;
+                            } else {
+                                tool_call_stop_after = Some(remaining - 1);
+                            }
+                        }
                     }
 
                     if token_id == eos_id {
@@ -1579,6 +1602,7 @@ impl Qwen3_5MoeModel {
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
                     let has_tools = config.tools.is_some();
+                    let tool_call_start_id = tokenizer.tool_call_start_id();
                     let tool_call_end_id = tokenizer.tool_call_end_id();
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = config.enable_thinking;
@@ -1960,6 +1984,7 @@ impl Qwen3_5MoeModel {
 
                         // C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("moe_chat_stream_compiled");
+                        let mut tool_call_stop_after: Option<u32> = None;
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
@@ -2029,9 +2054,19 @@ impl Qwen3_5MoeModel {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
-                            if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
-                                finish_reason = String::from("stop");
-                                break;
+                            if has_tools {
+                                if tool_call_end_id.is_some_and(|id| id == token_id) {
+                                    tool_call_stop_after = Some(2);
+                                } else if let Some(remaining) = tool_call_stop_after {
+                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                        tool_call_stop_after = None;
+                                    } else if remaining == 0 {
+                                        finish_reason = String::from("stop");
+                                        break;
+                                    } else {
+                                        tool_call_stop_after = Some(remaining - 1);
+                                    }
+                                }
                             }
 
                             if token_id == eos_id {
@@ -2101,6 +2136,7 @@ impl Qwen3_5MoeModel {
                     } else {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("moe_chat_stream_rust");
+                        let mut tool_call_stop_after: Option<u32> = None;
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
@@ -2180,9 +2216,19 @@ impl Qwen3_5MoeModel {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
-                            if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
-                                finish_reason = String::from("stop");
-                                break;
+                            if has_tools {
+                                if tool_call_end_id.is_some_and(|id| id == token_id) {
+                                    tool_call_stop_after = Some(2);
+                                } else if let Some(remaining) = tool_call_stop_after {
+                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                        tool_call_stop_after = None;
+                                    } else if remaining == 0 {
+                                        finish_reason = String::from("stop");
+                                        break;
+                                    } else {
+                                        tool_call_stop_after = Some(remaining - 1);
+                                    }
+                                }
                             }
 
                             if token_id == eos_id {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1180,21 +1180,6 @@ impl Qwen3_5MoeModel {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
-                    if has_tools {
-                        if tool_call_end_id.is_some_and(|id| id == token_id) {
-                            tool_call_stop_after = Some(2);
-                        } else if let Some(remaining) = tool_call_stop_after {
-                            if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                tool_call_stop_after = None;
-                            } else if remaining == 0 {
-                                finish_reason = String::from("stop");
-                                break;
-                            } else {
-                                tool_call_stop_after = Some(remaining - 1);
-                            }
-                        }
-                    }
-
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
                         break;
@@ -1208,6 +1193,21 @@ impl Qwen3_5MoeModel {
                     ) {
                         finish_reason = reason.to_string();
                         break;
+                    }
+
+                    if has_tools {
+                        if tool_call_end_id.is_some_and(|id| id == token_id) {
+                            tool_call_stop_after = Some(4);
+                        } else if let Some(remaining) = tool_call_stop_after {
+                            if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                tool_call_stop_after = None;
+                            } else if remaining == 0 {
+                                finish_reason = String::from("stop");
+                                break;
+                            } else {
+                                tool_call_stop_after = Some(remaining - 1);
+                            }
+                        }
                     }
 
                     match next_y {
@@ -1336,21 +1336,6 @@ impl Qwen3_5MoeModel {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
-                    if has_tools {
-                        if tool_call_end_id.is_some_and(|id| id == token_id) {
-                            tool_call_stop_after = Some(2);
-                        } else if let Some(remaining) = tool_call_stop_after {
-                            if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                tool_call_stop_after = None;
-                            } else if remaining == 0 {
-                                finish_reason = String::from("stop");
-                                break;
-                            } else {
-                                tool_call_stop_after = Some(remaining - 1);
-                            }
-                        }
-                    }
-
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
                         break;
@@ -1364,6 +1349,21 @@ impl Qwen3_5MoeModel {
                     ) {
                         finish_reason = reason.to_string();
                         break;
+                    }
+
+                    if has_tools {
+                        if tool_call_end_id.is_some_and(|id| id == token_id) {
+                            tool_call_stop_after = Some(4);
+                        } else if let Some(remaining) = tool_call_stop_after {
+                            if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                tool_call_stop_after = None;
+                            } else if remaining == 0 {
+                                finish_reason = String::from("stop");
+                                break;
+                            } else {
+                                tool_call_stop_after = Some(remaining - 1);
+                            }
+                        }
                     }
 
                     match next_y {
@@ -2054,21 +2054,6 @@ impl Qwen3_5MoeModel {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
-                            if has_tools {
-                                if tool_call_end_id.is_some_and(|id| id == token_id) {
-                                    tool_call_stop_after = Some(2);
-                                } else if let Some(remaining) = tool_call_stop_after {
-                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                        tool_call_stop_after = None;
-                                    } else if remaining == 0 {
-                                        finish_reason = String::from("stop");
-                                        break;
-                                    } else {
-                                        tool_call_stop_after = Some(remaining - 1);
-                                    }
-                                }
-                            }
-
                             if token_id == eos_id {
                                 finish_reason = String::from("stop");
                                 break;
@@ -2082,6 +2067,21 @@ impl Qwen3_5MoeModel {
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
+                            }
+
+                            if has_tools {
+                                if tool_call_end_id.is_some_and(|id| id == token_id) {
+                                    tool_call_stop_after = Some(4);
+                                } else if let Some(remaining) = tool_call_stop_after {
+                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                        tool_call_stop_after = None;
+                                    } else if remaining == 0 {
+                                        finish_reason = String::from("stop");
+                                        break;
+                                    } else {
+                                        tool_call_stop_after = Some(remaining - 1);
+                                    }
+                                }
                             }
 
                             match next_y {
@@ -2216,21 +2216,6 @@ impl Qwen3_5MoeModel {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
-                            if has_tools {
-                                if tool_call_end_id.is_some_and(|id| id == token_id) {
-                                    tool_call_stop_after = Some(2);
-                                } else if let Some(remaining) = tool_call_stop_after {
-                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                        tool_call_stop_after = None;
-                                    } else if remaining == 0 {
-                                        finish_reason = String::from("stop");
-                                        break;
-                                    } else {
-                                        tool_call_stop_after = Some(remaining - 1);
-                                    }
-                                }
-                            }
-
                             if token_id == eos_id {
                                 finish_reason = String::from("stop");
                                 break;
@@ -2244,6 +2229,21 @@ impl Qwen3_5MoeModel {
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
+                            }
+
+                            if has_tools {
+                                if tool_call_end_id.is_some_and(|id| id == token_id) {
+                                    tool_call_stop_after = Some(4);
+                                } else if let Some(remaining) = tool_call_stop_after {
+                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
+                                        tool_call_stop_after = None;
+                                    } else if remaining == 0 {
+                                        finish_reason = String::from("stop");
+                                        break;
+                                    } else {
+                                        tool_call_stop_after = Some(remaining - 1);
+                                    }
+                                }
                             }
 
                             match next_y {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -737,9 +737,6 @@ impl Qwen3_5MoeModel {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
-            let has_tools = config.tools.is_some();
-            let tool_call_start_id = tokenizer.tool_call_start_id();
-            let tool_call_end_id = tokenizer.tool_call_end_id();
             let tool_defs = config.tools.as_deref();
             let enable_thinking = config.enable_thinking;
             let tokens = tokenizer.apply_chat_template_sync(
@@ -1114,8 +1111,6 @@ impl Qwen3_5MoeModel {
                 // Rep penalty uses token_history as-of graph build time (one
                 // token behind), matching Python mlx-lm's pipelining behavior.
                 profiler.set_label("moe_chat_compiled");
-                let mut tool_call_stop_after: Option<u32> = None;
-
                 for step in 0..max_new_tokens {
                     // Build and submit graph for step N+1 before waiting for N
                     let next_y = if step + 1 < max_new_tokens {
@@ -1195,21 +1190,6 @@ impl Qwen3_5MoeModel {
                         break;
                     }
 
-                    if has_tools {
-                        if tool_call_end_id.is_some_and(|id| id == token_id) {
-                            tool_call_stop_after = Some(4);
-                        } else if let Some(remaining) = tool_call_stop_after {
-                            if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                tool_call_stop_after = None;
-                            } else if remaining == 0 {
-                                finish_reason = String::from("stop");
-                                break;
-                            } else {
-                                tool_call_stop_after = Some(remaining - 1);
-                            }
-                        }
-                    }
-
                     match next_y {
                         Some(next) => y = next,
                         None => break,
@@ -1260,8 +1240,6 @@ impl Qwen3_5MoeModel {
             } else {
                 // Rust fallback decode loop (pipelined)
                 profiler.set_label("moe_chat_rust");
-                let mut tool_call_stop_after: Option<u32> = None;
-
                 for step in 0..max_new_tokens {
                     // Build and submit graph for step N+1 before waiting for N
                     let next_y = if step + 1 < max_new_tokens {
@@ -1349,21 +1327,6 @@ impl Qwen3_5MoeModel {
                     ) {
                         finish_reason = reason.to_string();
                         break;
-                    }
-
-                    if has_tools {
-                        if tool_call_end_id.is_some_and(|id| id == token_id) {
-                            tool_call_stop_after = Some(4);
-                        } else if let Some(remaining) = tool_call_stop_after {
-                            if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                tool_call_stop_after = None;
-                            } else if remaining == 0 {
-                                finish_reason = String::from("stop");
-                                break;
-                            } else {
-                                tool_call_stop_after = Some(remaining - 1);
-                            }
-                        }
                     }
 
                     match next_y {
@@ -1601,9 +1564,6 @@ impl Qwen3_5MoeModel {
             let callback_err = callback.clone();
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
-                    let has_tools = config.tools.is_some();
-                    let tool_call_start_id = tokenizer.tool_call_start_id();
-                    let tool_call_end_id = tokenizer.tool_call_end_id();
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = config.enable_thinking;
                     let tokens = tokenizer.apply_chat_template_sync(
@@ -1984,7 +1944,6 @@ impl Qwen3_5MoeModel {
 
                         // C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("moe_chat_stream_compiled");
-                        let mut tool_call_stop_after: Option<u32> = None;
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
@@ -2069,21 +2028,6 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            if has_tools {
-                                if tool_call_end_id.is_some_and(|id| id == token_id) {
-                                    tool_call_stop_after = Some(4);
-                                } else if let Some(remaining) = tool_call_stop_after {
-                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                        tool_call_stop_after = None;
-                                    } else if remaining == 0 {
-                                        finish_reason = String::from("stop");
-                                        break;
-                                    } else {
-                                        tool_call_stop_after = Some(remaining - 1);
-                                    }
-                                }
-                            }
-
                             match next_y {
                                 Some(next) => y = next,
                                 None => break,
@@ -2136,7 +2080,6 @@ impl Qwen3_5MoeModel {
                     } else {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("moe_chat_stream_rust");
-                        let mut tool_call_stop_after: Option<u32> = None;
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
@@ -2229,21 +2172,6 @@ impl Qwen3_5MoeModel {
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
-                            }
-
-                            if has_tools {
-                                if tool_call_end_id.is_some_and(|id| id == token_id) {
-                                    tool_call_stop_after = Some(4);
-                                } else if let Some(remaining) = tool_call_stop_after {
-                                    if tool_call_start_id.is_some_and(|id| id == token_id) {
-                                        tool_call_stop_after = None;
-                                    } else if remaining == 0 {
-                                        finish_reason = String::from("stop");
-                                        break;
-                                    } else {
-                                        tool_call_stop_after = Some(remaining - 1);
-                                    }
-                                }
                             }
 
                             match next_y {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -737,6 +737,8 @@ impl Qwen3_5MoeModel {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
+            let has_tools = config.tools.is_some();
+            let tool_call_end_id = tokenizer.tool_call_end_id();
             let tool_defs = config.tools.as_deref();
             let enable_thinking = config.enable_thinking;
             let tokens = tokenizer.apply_chat_template_sync(
@@ -1176,6 +1178,11 @@ impl Qwen3_5MoeModel {
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
 
+                    if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
+                        finish_reason = String::from("stop");
+                        break;
+                    }
+
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
                         break;
@@ -1315,6 +1322,11 @@ impl Qwen3_5MoeModel {
 
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
+
+                    if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
+                        finish_reason = String::from("stop");
+                        break;
+                    }
 
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
@@ -1566,6 +1578,8 @@ impl Qwen3_5MoeModel {
             let callback_err = callback.clone();
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
+                    let has_tools = config.tools.is_some();
+                    let tool_call_end_id = tokenizer.tool_call_end_id();
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = config.enable_thinking;
                     let tokens = tokenizer.apply_chat_template_sync(
@@ -2015,6 +2029,11 @@ impl Qwen3_5MoeModel {
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
 
+                            if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
+                                finish_reason = String::from("stop");
+                                break;
+                            }
+
                             if token_id == eos_id {
                                 finish_reason = String::from("stop");
                                 break;
@@ -2160,6 +2179,11 @@ impl Qwen3_5MoeModel {
                                 }),
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
+
+                            if has_tools && tool_call_end_id.is_some_and(|id| id == token_id) {
+                                finish_reason = String::from("stop");
+                                break;
+                            }
 
                             if token_id == eos_id {
                                 finish_reason = String::from("stop");

--- a/crates/mlx-core/src/tokenizer.rs
+++ b/crates/mlx-core/src/tokenizer.rs
@@ -48,6 +48,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::Arc;
 use tokenizers::{EncodeInput, Encoding, Tokenizer};
+use tracing::warn;
 
 /// Special token IDs for Qwen3 models
 const ENDOFTEXT_TOKEN_ID: u32 = 151643;
@@ -162,6 +163,8 @@ pub struct Qwen3Tokenizer {
     think_end_id: Option<u32>,
     /// The actual think-end string (e.g., `"</think>"` or `"</longcat_think>"`).
     think_end_str: Option<String>,
+    /// Token ID for `<tool_call>` (None if not in vocabulary).
+    tool_call_start_id: Option<u32>,
     /// Token ID for `</tool_call>` (None if not in vocabulary).
     tool_call_end_id: Option<u32>,
 }
@@ -192,7 +195,8 @@ impl Qwen3Tokenizer {
                 let chat_template = Self::load_chat_template(&tokenizer_path);
 
                 let (think_end_id, think_end_str) = Self::detect_think_end(&tokenizer);
-                let tool_call_end_id = Self::detect_tool_call_end(&tokenizer);
+                let (tool_call_start_id, tool_call_end_id) =
+                    Self::detect_tool_call_tokens(&tokenizer);
 
                 Ok(Self {
                     tokenizer: Arc::new(tokenizer),
@@ -202,6 +206,7 @@ impl Qwen3Tokenizer {
                     chat_template,
                     think_end_id,
                     think_end_str,
+                    tool_call_start_id,
                     tool_call_end_id,
                 })
             })
@@ -279,7 +284,7 @@ impl Qwen3Tokenizer {
         let chat_template = Self::load_chat_template(tokenizer_path.to_string_lossy().as_ref());
 
         let (think_end_id, think_end_str) = Self::detect_think_end(&tokenizer);
-        let tool_call_end_id = Self::detect_tool_call_end(&tokenizer);
+        let (tool_call_start_id, tool_call_end_id) = Self::detect_tool_call_tokens(&tokenizer);
 
         Ok(Self {
             tokenizer: Arc::new(tokenizer),
@@ -289,6 +294,7 @@ impl Qwen3Tokenizer {
             chat_template,
             think_end_id,
             think_end_str,
+            tool_call_start_id,
             tool_call_end_id,
         })
     }
@@ -855,9 +861,13 @@ impl Qwen3Tokenizer {
                         params_obj.insert("type".to_string(), serde_json::json!(params.r#type));
                         if let Some(props) = &params.properties {
                             // Parse the JSON string to include it properly
-                            if let Ok(props_val) = serde_json::from_str::<serde_json::Value>(props)
-                            {
-                                params_obj.insert("properties".to_string(), props_val);
+                            match serde_json::from_str::<serde_json::Value>(props) {
+                                Ok(props_val) => {
+                                    params_obj.insert("properties".to_string(), props_val);
+                                }
+                                Err(e) => {
+                                    warn!("Failed to parse tool properties JSON: {}", e);
+                                }
                             }
                         }
                         if let Some(req) = &params.required {
@@ -892,8 +902,10 @@ impl Qwen3Tokenizer {
                                 call_obj.insert("id".to_string(), serde_json::json!(id));
                             }
                             call_obj.insert("name".to_string(), serde_json::json!(tc.name));
-                            call_obj
-                                .insert("arguments".to_string(), serde_json::json!(tc.arguments));
+                            let args_value =
+                                serde_json::from_str::<serde_json::Value>(&tc.arguments)
+                                    .unwrap_or_else(|_| serde_json::json!(tc.arguments));
+                            call_obj.insert("arguments".to_string(), args_value);
                             serde_json::Value::Object(call_obj)
                         })
                         .collect();
@@ -994,7 +1006,7 @@ impl Qwen3Tokenizer {
         let chat_template = Self::load_chat_template(tokenizer_path);
 
         let (think_end_id, think_end_str) = Self::detect_think_end(&tokenizer);
-        let tool_call_end_id = Self::detect_tool_call_end(&tokenizer);
+        let (tool_call_start_id, tool_call_end_id) = Self::detect_tool_call_tokens(&tokenizer);
 
         Ok(Self {
             tokenizer: Arc::new(tokenizer),
@@ -1004,6 +1016,7 @@ impl Qwen3Tokenizer {
             chat_template,
             think_end_id,
             think_end_str,
+            tool_call_start_id,
             tool_call_end_id,
         })
     }
@@ -1075,6 +1088,7 @@ impl Clone for Qwen3Tokenizer {
             chat_template: self.chat_template.clone(),
             think_end_id: self.think_end_id,
             think_end_str: self.think_end_str.clone(),
+            tool_call_start_id: self.tool_call_start_id,
             tool_call_end_id: self.tool_call_end_id,
         }
     }
@@ -1103,13 +1117,20 @@ impl Qwen3Tokenizer {
         self.think_end_str.as_deref()
     }
 
-    /// Detect tool-call-end token from tokenizer vocabulary.
-    fn detect_tool_call_end(tokenizer: &Tokenizer) -> Option<u32> {
+    /// Detect tool-call start/end tokens from tokenizer vocabulary.
+    fn detect_tool_call_tokens(tokenizer: &Tokenizer) -> (Option<u32>, Option<u32>) {
         let vocab = tokenizer.get_vocab(true);
-        vocab.get("</tool_call>").copied()
+        let start = vocab.get("<tool_call>").copied();
+        let end = vocab.get("</tool_call>").copied();
+        (start, end)
     }
 
-    /// Get the tool-call-end token ID, if the tokenizer has tool calling support.
+    /// Get the `<tool_call>` start token ID.
+    pub fn tool_call_start_id(&self) -> Option<u32> {
+        self.tool_call_start_id
+    }
+
+    /// Get the `</tool_call>` end token ID.
     pub fn tool_call_end_id(&self) -> Option<u32> {
         self.tool_call_end_id
     }

--- a/crates/mlx-core/src/tokenizer.rs
+++ b/crates/mlx-core/src/tokenizer.rs
@@ -163,10 +163,6 @@ pub struct Qwen3Tokenizer {
     think_end_id: Option<u32>,
     /// The actual think-end string (e.g., `"</think>"` or `"</longcat_think>"`).
     think_end_str: Option<String>,
-    /// Token ID for `<tool_call>` (None if not in vocabulary).
-    tool_call_start_id: Option<u32>,
-    /// Token ID for `</tool_call>` (None if not in vocabulary).
-    tool_call_end_id: Option<u32>,
 }
 
 #[napi]
@@ -195,8 +191,6 @@ impl Qwen3Tokenizer {
                 let chat_template = Self::load_chat_template(&tokenizer_path);
 
                 let (think_end_id, think_end_str) = Self::detect_think_end(&tokenizer);
-                let (tool_call_start_id, tool_call_end_id) =
-                    Self::detect_tool_call_tokens(&tokenizer);
 
                 Ok(Self {
                     tokenizer: Arc::new(tokenizer),
@@ -206,8 +200,6 @@ impl Qwen3Tokenizer {
                     chat_template,
                     think_end_id,
                     think_end_str,
-                    tool_call_start_id,
-                    tool_call_end_id,
                 })
             })
             .await
@@ -284,7 +276,6 @@ impl Qwen3Tokenizer {
         let chat_template = Self::load_chat_template(tokenizer_path.to_string_lossy().as_ref());
 
         let (think_end_id, think_end_str) = Self::detect_think_end(&tokenizer);
-        let (tool_call_start_id, tool_call_end_id) = Self::detect_tool_call_tokens(&tokenizer);
 
         Ok(Self {
             tokenizer: Arc::new(tokenizer),
@@ -294,8 +285,6 @@ impl Qwen3Tokenizer {
             chat_template,
             think_end_id,
             think_end_str,
-            tool_call_start_id,
-            tool_call_end_id,
         })
     }
 
@@ -1006,7 +995,6 @@ impl Qwen3Tokenizer {
         let chat_template = Self::load_chat_template(tokenizer_path);
 
         let (think_end_id, think_end_str) = Self::detect_think_end(&tokenizer);
-        let (tool_call_start_id, tool_call_end_id) = Self::detect_tool_call_tokens(&tokenizer);
 
         Ok(Self {
             tokenizer: Arc::new(tokenizer),
@@ -1016,8 +1004,6 @@ impl Qwen3Tokenizer {
             chat_template,
             think_end_id,
             think_end_str,
-            tool_call_start_id,
-            tool_call_end_id,
         })
     }
 
@@ -1088,8 +1074,6 @@ impl Clone for Qwen3Tokenizer {
             chat_template: self.chat_template.clone(),
             think_end_id: self.think_end_id,
             think_end_str: self.think_end_str.clone(),
-            tool_call_start_id: self.tool_call_start_id,
-            tool_call_end_id: self.tool_call_end_id,
         }
     }
 }
@@ -1115,24 +1099,6 @@ impl Qwen3Tokenizer {
     /// Get the think-end string (e.g., `"</think>"` or `"</longcat_think>"`).
     pub fn think_end_str(&self) -> Option<&str> {
         self.think_end_str.as_deref()
-    }
-
-    /// Detect tool-call start/end tokens from tokenizer vocabulary.
-    fn detect_tool_call_tokens(tokenizer: &Tokenizer) -> (Option<u32>, Option<u32>) {
-        let vocab = tokenizer.get_vocab(true);
-        let start = vocab.get("<tool_call>").copied();
-        let end = vocab.get("</tool_call>").copied();
-        (start, end)
-    }
-
-    /// Get the `<tool_call>` start token ID.
-    pub fn tool_call_start_id(&self) -> Option<u32> {
-        self.tool_call_start_id
-    }
-
-    /// Get the `</tool_call>` end token ID.
-    pub fn tool_call_end_id(&self) -> Option<u32> {
-        self.tool_call_end_id
     }
 }
 

--- a/crates/mlx-core/src/tokenizer.rs
+++ b/crates/mlx-core/src/tokenizer.rs
@@ -162,6 +162,8 @@ pub struct Qwen3Tokenizer {
     think_end_id: Option<u32>,
     /// The actual think-end string (e.g., `"</think>"` or `"</longcat_think>"`).
     think_end_str: Option<String>,
+    /// Token ID for `</tool_call>` (None if not in vocabulary).
+    tool_call_end_id: Option<u32>,
 }
 
 #[napi]
@@ -190,6 +192,7 @@ impl Qwen3Tokenizer {
                 let chat_template = Self::load_chat_template(&tokenizer_path);
 
                 let (think_end_id, think_end_str) = Self::detect_think_end(&tokenizer);
+                let tool_call_end_id = Self::detect_tool_call_end(&tokenizer);
 
                 Ok(Self {
                     tokenizer: Arc::new(tokenizer),
@@ -199,6 +202,7 @@ impl Qwen3Tokenizer {
                     chat_template,
                     think_end_id,
                     think_end_str,
+                    tool_call_end_id,
                 })
             })
             .await
@@ -275,6 +279,7 @@ impl Qwen3Tokenizer {
         let chat_template = Self::load_chat_template(tokenizer_path.to_string_lossy().as_ref());
 
         let (think_end_id, think_end_str) = Self::detect_think_end(&tokenizer);
+        let tool_call_end_id = Self::detect_tool_call_end(&tokenizer);
 
         Ok(Self {
             tokenizer: Arc::new(tokenizer),
@@ -284,6 +289,7 @@ impl Qwen3Tokenizer {
             chat_template,
             think_end_id,
             think_end_str,
+            tool_call_end_id,
         })
     }
 
@@ -988,6 +994,7 @@ impl Qwen3Tokenizer {
         let chat_template = Self::load_chat_template(tokenizer_path);
 
         let (think_end_id, think_end_str) = Self::detect_think_end(&tokenizer);
+        let tool_call_end_id = Self::detect_tool_call_end(&tokenizer);
 
         Ok(Self {
             tokenizer: Arc::new(tokenizer),
@@ -997,6 +1004,7 @@ impl Qwen3Tokenizer {
             chat_template,
             think_end_id,
             think_end_str,
+            tool_call_end_id,
         })
     }
 
@@ -1067,6 +1075,7 @@ impl Clone for Qwen3Tokenizer {
             chat_template: self.chat_template.clone(),
             think_end_id: self.think_end_id,
             think_end_str: self.think_end_str.clone(),
+            tool_call_end_id: self.tool_call_end_id,
         }
     }
 }
@@ -1092,6 +1101,17 @@ impl Qwen3Tokenizer {
     /// Get the think-end string (e.g., `"</think>"` or `"</longcat_think>"`).
     pub fn think_end_str(&self) -> Option<&str> {
         self.think_end_str.as_deref()
+    }
+
+    /// Detect tool-call-end token from tokenizer vocabulary.
+    fn detect_tool_call_end(tokenizer: &Tokenizer) -> Option<u32> {
+        let vocab = tokenizer.get_vocab(true);
+        vocab.get("</tool_call>").copied()
+    }
+
+    /// Get the tool-call-end token ID, if the tokenizer has tool calling support.
+    pub fn tool_call_end_id(&self) -> Option<u32> {
+        self.tool_call_end_id
     }
 }
 

--- a/crates/mlx-core/src/tools/mod.rs
+++ b/crates/mlx-core/src/tools/mod.rs
@@ -1125,4 +1125,124 @@ console.log(x + y)"
         assert!(code.contains("const y = 2"));
         assert!(code.contains("console.log"));
     }
+
+    // ---- Critical tool call code paths ----
+
+    #[test]
+    fn test_parse_multiple_json_tool_calls_with_text() {
+        // Two JSON-format tool calls (Qwen3 style) with leading text
+        let text = r#"Let me check both.
+<tool_call>
+{"name": "get_weather", "arguments": {"city": "Tokyo"}}
+</tool_call>
+<tool_call>
+{"name": "get_weather", "arguments": {"city": "Paris"}}
+</tool_call>"#;
+        let (clean, calls) = parse_tool_calls(text);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[1].name, "get_weather");
+        assert_eq!(calls[0].status, "ok");
+        assert_eq!(calls[1].status, "ok");
+        assert_eq!(calls[0].arguments["city"], "Tokyo");
+        assert_eq!(calls[1].arguments["city"], "Paris");
+        assert_eq!(clean.trim(), "Let me check both.");
+    }
+
+    #[test]
+    fn test_parse_multiple_function_tool_calls_different_names() {
+        // Two function-format tool calls (Qwen3.5 style) with different function names
+        let text = r#"<tool_call>
+<function=get_weather>
+<parameter=city>Tokyo</parameter>
+</function>
+</tool_call>
+<tool_call>
+<function=get_time>
+<parameter=timezone>JST</parameter>
+</function>
+</tool_call>"#;
+        let (clean, calls) = parse_tool_calls(text);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[1].name, "get_time");
+        assert_eq!(calls[0].status, "ok");
+        assert_eq!(calls[1].status, "ok");
+        assert_eq!(calls[0].arguments["city"], "Tokyo");
+        assert_eq!(calls[1].arguments["timezone"], "JST");
+        assert!(clean.trim().is_empty());
+    }
+
+    #[test]
+    fn test_parse_generation_output_multiple_tools_with_thinking() {
+        // Thinking block followed by multiple JSON tool calls
+        let text = r#"<think>I need to check both cities.</think>
+<tool_call>
+{"name": "get_weather", "arguments": {"city": "Tokyo"}}
+</tool_call>
+<tool_call>
+{"name": "get_weather", "arguments": {"city": "Paris"}}
+</tool_call>"#;
+        let (clean, calls, thinking) = parse_generation_output(text);
+        assert_eq!(calls.len(), 2);
+        assert!(thinking.is_some());
+        assert_eq!(thinking.unwrap().trim(), "I need to check both cities.");
+        assert!(clean.trim().is_empty());
+    }
+
+    #[test]
+    fn test_split_at_think_end_with_multiple_tools() {
+        // Simulate Qwen3.5 path: thinking prefix (no opening <think> tag) then tool calls.
+        // The chat template injects `<think>\n` as a prefix so the generated text
+        // starts with thinking content followed by `</think>`.
+        let text = r#"I need weather data.
+</think>
+
+<tool_call>
+{"name": "get_weather", "arguments": {"city": "Tokyo"}}
+</tool_call>
+<tool_call>
+{"name": "get_weather", "arguments": {"city": "Paris"}}
+</tool_call>"#;
+        let (clean, calls, thinking) = split_at_think_end(text, Some("</think>"));
+        assert_eq!(calls.len(), 2);
+        assert!(thinking.is_some());
+        assert_eq!(thinking.unwrap().trim(), "I need weather data.");
+        assert!(clean.trim().is_empty());
+    }
+
+    #[test]
+    fn test_parse_unclosed_tool_call() {
+        // Truncated by max_tokens — no closing </tool_call> tag
+        let text = r#"<tool_call>
+{"name": "get_weather", "arguments": {"city": "Tok"#;
+        let (clean, calls) = parse_tool_calls(text);
+        assert_eq!(calls.len(), 0); // No complete tool call
+        assert_eq!(clean, text); // Text preserved as-is
+    }
+
+    #[test]
+    fn test_parse_tool_call_with_trailing_hallucination() {
+        // Model generates a tool call then hallucinates a response
+        let text = r#"<tool_call>
+{"name": "get_weather", "arguments": {"city": "Tokyo"}}
+</tool_call>
+The weather in Tokyo is sunny."#;
+        let (clean, calls) = parse_tool_calls(text);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "get_weather");
+        assert_eq!(calls[0].status, "ok");
+        // The trailing hallucinated text remains in clean text
+        assert!(clean.contains("The weather in Tokyo is sunny."));
+    }
+
+    #[test]
+    fn test_parse_empty_tool_call() {
+        // Empty tool_call block — recognized as a tag pair but no parseable format inside
+        let text = "<tool_call></tool_call>";
+        let (_, calls) = parse_tool_calls(text);
+        // Empty content doesn't start with '{', contain '<function=', or '<name>',
+        // so classify_and_parse_tool_call returns None — no tool call produced.
+        assert_eq!(calls.len(), 0);
+    }
 }

--- a/examples/grpo/train-github-tool.ts
+++ b/examples/grpo/train-github-tool.ts
@@ -65,17 +65,6 @@ import { initLspService, executeToolCall, type LspService } from './lsp';
 // Helper Functions
 // ============================================================================
 
-/**
- * Format a tool response for inclusion in a message.
- * Creates a properly formatted tool response string wrapped in `<tool_response>` tags.
- */
-function formatToolResponse(content: unknown): string {
-  const contentStr = typeof content === 'string' ? content : JSON.stringify(content);
-  return `<tool_response>
-${contentStr}
-</tool_response>`;
-}
-
 // ============================================================================
 // Constants
 // ============================================================================
@@ -673,7 +662,7 @@ async function main() {
             // Execute LSP tool and generate second turn
             stepLspCalls++;
             const lspResult = executeLspTool(toolCall.arguments as { method?: string; kind?: string });
-            const toolResponse = formatToolResponse(lspResult);
+            const toolResponse = typeof lspResult === 'string' ? lspResult : JSON.stringify(lspResult);
 
             // Build extended conversation for second turn
             const promptIdx = Math.floor(j / groupSize);

--- a/examples/tool-use-example.ts
+++ b/examples/tool-use-example.ts
@@ -23,8 +23,8 @@
 
 import { resolve } from 'node:path';
 
-import { Qwen35Model } from '@mlx-node/core';
-import { formatToolResponse, createToolDefinition } from '@mlx-node/lm';
+import { Qwen35Model, type ChatMessage } from '@mlx-node/core';
+import { createToolDefinition } from '@mlx-node/lm';
 
 // Get model path from CLI args, environment, or default
 const DEFAULT_MODEL_PATH = resolve(process.cwd(), '.cache', 'models', 'qwen3.5-4B-mlx-bf16');
@@ -97,7 +97,7 @@ async function runToolConversation(model: Qwen35Model, userPrompt: string) {
   console.log(`User: ${userPrompt}`);
   console.log('='.repeat(75));
 
-  let messages = [{ role: 'user', content: userPrompt }];
+  let messages: ChatMessage[] = [{ role: 'user', content: userPrompt }];
 
   // Use chat() API - returns ChatResult with structured tool calls and thinking
   console.log('\n[->] Generating response with tools...');
@@ -115,42 +115,51 @@ async function runToolConversation(model: Qwen35Model, userPrompt: string) {
   console.log(`[INFO] Finish reason: ${result.finishReason}`);
 
   // Check for tool calls - they're already parsed!
-  if (result.toolCalls.length > 0) {
-    console.log(`\n[TOOL] Found ${result.toolCalls.length} tool call(s):`);
+  const validCalls = result.toolCalls.filter((tc) => tc.status === 'ok');
+  if (validCalls.length > 0) {
+    console.log(`\n[TOOL] Found ${validCalls.length} tool call(s):`);
 
+    // Add the assistant message with all tool calls
+    messages = [
+      ...messages,
+      {
+        role: 'assistant',
+        content: result.text,
+        toolCalls: validCalls.map((tc) => ({
+          id: tc.id,
+          name: tc.name,
+          arguments: typeof tc.arguments === 'string' ? tc.arguments : JSON.stringify(tc.arguments),
+        })),
+      },
+    ];
+
+    // Execute each tool call and append results as role: 'tool' messages
+    for (const call of validCalls) {
+      console.log(`   - ${call.name}(${JSON.stringify(call.arguments)})`);
+
+      const toolResult = await executeTool(call.name, call.arguments as Record<string, unknown>);
+      const displayResult = toolResult.length > 200 ? toolResult.substring(0, 200) + '...' : toolResult;
+      console.log(`   [<-] ${displayResult}`);
+
+      messages = [...messages, { role: 'tool', content: toolResult, toolCallId: call.id }];
+    }
+
+    // Generate final response with all tool results
+    console.log('\n[->] Generating final response...');
+    const finalResult = await model.chat(messages, {
+      tools,
+      maxNewTokens: 2048,
+      temperature: 0.9,
+    });
+
+    if (finalResult.thinking) {
+      console.log(`\n[THINK] ${finalResult.thinking}`);
+    }
+    console.log(`\n[AI] Final response: ${finalResult.text}`);
+
+    // Log any parsing errors
     for (const call of result.toolCalls) {
-      if (call.status === 'ok') {
-        // Arguments are already a JS object - no JSON.parse needed!
-        console.log(`   - ${call.name}(${JSON.stringify(call.arguments)})`);
-        console.log(`     ID: ${call.id}`);
-
-        // Execute the tool
-        const toolResult = await executeTool(call.name, call.arguments as Record<string, unknown>);
-        const displayResult = toolResult.length > 200 ? toolResult.substring(0, 200) + '...' : toolResult;
-        console.log(`\n[<-] Tool result: ${displayResult}`);
-
-        // Continue conversation with tool result
-        messages = [
-          ...messages,
-          { role: 'assistant', content: result.rawText }, // Use rawText to preserve tool_call tags
-          { role: 'user', content: formatToolResponse(toolResult) },
-        ];
-
-        // Generate final response using chat() API
-        console.log('\n[->] Generating final response...');
-        const finalResult = await model.chat(messages, {
-          tools,
-          maxNewTokens: 2048,
-          temperature: 0.9,
-        });
-
-        // Show thinking if model reasoned through the tool result
-        if (finalResult.thinking) {
-          console.log(`\n[THINK] ${finalResult.thinking}`);
-        }
-        console.log(`\n[AI] Final response: ${finalResult.text}`);
-      } else {
-        // Handle parsing errors gracefully
+      if (call.status !== 'ok') {
         console.log(`   [WARN] ${call.name || '(unknown)'}: ${call.status} - ${call.error}`);
       }
     }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -141,14 +141,41 @@ Auto-detected from `config.json` when not specified:
 
 #### Quantization Recipes
 
-| Recipe      | Description                        |
-| ----------- | ---------------------------------- |
-| `mixed_2_6` | 2-bit embeddings, 6-bit layers     |
-| `mixed_3_4` | 3-bit embeddings, 4-bit layers     |
-| `mixed_3_6` | 3-bit embeddings, 6-bit layers     |
-| `mixed_4_6` | 4-bit embeddings, 6-bit layers     |
-| `qwen3_5`   | Optimized for Qwen3.5 architecture |
-| `unsloth`   | Unsloth dynamic quantization       |
+| Recipe      | Description                                     |
+| ----------- | ----------------------------------------------- |
+| `mixed_2_6` | 2-bit base, 6-bit sensitive layers              |
+| `mixed_3_4` | 3-bit base, 4-bit sensitive layers              |
+| `mixed_3_6` | 3-bit base, 6-bit sensitive layers              |
+| `mixed_4_6` | 4-bit base, 6-bit sensitive layers              |
+| `qwen3_5`   | Optimized for Qwen3.5 hybrid architecture       |
+| `unsloth`   | Unsloth Dynamic 2.0 (requires `--imatrix-path`) |
+
+#### Unsloth Recipe
+
+MLX affine equivalent of [Unsloth Dynamic 2.0](https://unsloth.ai/docs/models/qwen3.5/gguf-benchmarks) (UD) GGUF quantization. Designed for Qwen3.5's hybrid GatedDeltaNet + full attention architecture. Requires imatrix for AWQ pre-scaling of attention/SSM weights.
+
+```bash
+# UD-Q3_K_XL equivalent (~17 GB for 35B-A3B)
+mlx convert -i ./model -o ./model-q3 -q --q-bits 3 --q-recipe unsloth --imatrix-path ./imatrix.gguf
+
+# UD-Q4_K_XL equivalent (~20 GB for 35B-A3B)
+mlx convert -i ./model -o ./model-q4 -q --q-bits 4 --q-recipe unsloth --imatrix-path ./imatrix.gguf
+```
+
+Per-tensor bit assignments (N = `--q-bits`):
+
+| Weight                      | Bits | Rationale                                         |
+| --------------------------- | ---- | ------------------------------------------------- |
+| `gate_proj`, `up_proj`      | N    | Bulk of MoE expert params, safe at low bits       |
+| `down_proj`                 | N+1  | Slightly more sensitive than other FFN weights    |
+| `embed_tokens`              | N+2  | Very low KLD sensitivity (~0.15)                  |
+| `self_attn.q/k/v_proj`      | N+2  | AWQ-correctable via input_layernorm               |
+| `linear_attn.in_proj_qkv/z` | N+2  | AWQ-correctable via input_layernorm               |
+| `lm_head`                   | N+3  | Safest tensor (KLD ~0.05)                         |
+| Router gates                | 8    | Standard for MoE routing accuracy                 |
+| `self_attn.o_proj`          | bf16 | No preceding norm — not AWQ-correctable           |
+| `linear_attn.out_proj`      | bf16 | Worst tensor (KLD ~6.0) — not AWQ-correctable     |
+| GDN params (`A_log`, etc.)  | bf16 | Recurrent state params, errors compound over time |
 
 ## Examples
 

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -134,7 +134,8 @@ async function getModelFiles(modelName: string, accessToken?: string, globPatter
         file.path.endsWith('.safetensors') ||
         file.path.endsWith('.json') ||
         file.path.endsWith('.pdiparams') ||
-        file.path.endsWith('.yml')
+        file.path.endsWith('.yml') ||
+        file.path.endsWith('.gguf')
       ) {
         filesToDownload.push(file);
         if (file.size) {

--- a/packages/lm/README.md
+++ b/packages/lm/README.md
@@ -50,7 +50,7 @@ Breaking out of the loop automatically cancels generation.
 OpenAI-compatible function calling with `createToolDefinition`:
 
 ```typescript
-import { loadModel, createToolDefinition, formatToolResponse } from '@mlx-node/lm';
+import { loadModel, createToolDefinition } from '@mlx-node/lm';
 
 const model = await loadModel('./models/Qwen3-0.6B');
 
@@ -67,17 +67,27 @@ const tools = [
 
 const result = model.chat([{ role: 'user', content: 'What is the weather in Tokyo?' }], { tools });
 
-// If the model calls a tool, execute it and continue
-if (result.toolCalls?.length) {
-  const toolResult = executeMyTool(result.toolCalls[0]);
-  const followUp = model.chat(
-    [
-      ...messages,
-      { role: 'assistant', content: result.rawText },
-      { role: 'tool', content: formatToolResponse(toolResult) },
-    ],
-    { tools },
-  );
+// If the model calls tools, execute them and continue
+const validCalls = result.toolCalls?.filter((tc) => tc.status === 'ok') ?? [];
+if (validCalls.length) {
+  // Add assistant message with structured tool calls
+  const toolMessages = [
+    {
+      role: 'assistant',
+      content: result.text,
+      toolCalls: validCalls.map((tc) => ({
+        id: tc.id,
+        name: tc.name,
+        arguments: JSON.stringify(tc.arguments),
+      })),
+    },
+    // Execute each tool and add results as role: 'tool' messages
+    ...validCalls.map((tc) => ({
+      role: 'tool' as const,
+      content: JSON.stringify(executeMyTool(tc)),
+    })),
+  ];
+  const followUp = model.chat([...messages, ...toolMessages], { tools });
 }
 ```
 
@@ -179,8 +189,6 @@ function createToolDefinition(
   properties?: Record<string, FunctionParameterProperty>,
   required?: string[],
 ): ToolDefinition;
-
-function formatToolResponse(content: string): string;
 ```
 
 ### Functions
@@ -188,7 +196,6 @@ function formatToolResponse(content: string): string;
 | Function                 | Description                                          |
 | ------------------------ | ---------------------------------------------------- |
 | `createToolDefinition()` | Create an OpenAI-compatible tool definition          |
-| `formatToolResponse()`   | Wrap tool output in `<tool_response>` tags           |
 | `detectModelType()`      | Read `config.json` and return the `model_type` field |
 | `enableProfiling()`      | Start profiling with auto-report on exit             |
 | `disableProfiling()`     | Stop profiling and write JSON report                 |

--- a/packages/lm/src/tools/index.ts
+++ b/packages/lm/src/tools/index.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```typescript
- * import { createToolDefinition, formatToolResponse } from '@mlx-node/lm';
+ * import { createToolDefinition } from '@mlx-node/lm';
  *
  * const weatherTool = createToolDefinition(
  *   'get_weather',
@@ -19,8 +19,8 @@
  * for (const call of result.toolCalls) {
  *   if (call.status === 'ok') {
  *     const toolResult = await executeMyTool(call.name, call.arguments);
- *     // Continue conversation with tool result
- *     messages.push({ role: 'user', content: formatToolResponse(toolResult) });
+ *     // Use role: 'tool' — the Jinja2 template wraps content in <tool_response> tags
+ *     messages.push({ role: 'tool', content: JSON.stringify(toolResult) });
  *   }
  * }
  * ```

--- a/packages/lm/src/tools/types.ts
+++ b/packages/lm/src/tools/types.ts
@@ -212,30 +212,3 @@ export function createToolDefinition(
     },
   };
 }
-
-/**
- * Format a tool response for inclusion in a message
- *
- * Creates a properly formatted tool response string that can be used
- * in tool messages when continuing a conversation after a tool call.
- *
- * @param content - The response content (will be JSON stringified if object)
- * @returns Formatted tool response string wrapped in `<tool_response>` tags
- *
- * @example
- * ```typescript
- * // After executing a tool call from model.chat()
- * const toolResult = await executeMyTool(call.arguments);
- * const responseMessage = {
- *   role: 'user',
- *   content: formatToolResponse(toolResult)
- * };
- * const finalResult = await model.chat([...messages, responseMessage]);
- * ```
- */
-export function formatToolResponse(content: unknown): string {
-  const contentStr = typeof content === 'string' ? content : JSON.stringify(content);
-  // Qwen3/3.5 expects <tool_response> XML wrapping for tool results.
-  // Other model families may require a different format.
-  return `<tool_response>\n${contentStr}\n</tool_response>`;
-}


### PR DESCRIPTION
Previously, tool call detection was entirely post-hoc: the model generated all tokens until EOS, then <tool_call> tags were parsed from the complete text. This wasted tokens and allowed the model to hallucinate tool results after </tool_call>, creating loops.

Now, when tools are provided in ChatConfig, the decode loop checks each generated token against the </tool_call> token ID and breaks immediately when detected. The post-hoc parser still runs to extract structured ToolCallResult data and override finish_reason to "tool_calls".

Changes:
- Add tool_call_end_id detection to Qwen3Tokenizer (mirrors think_end_id)
- Insert early-stop check in 9 decode loops across Qwen3, Qwen3.5 Dense, and Qwen3.5 MoE (chat + chatStream, compiled + Rust variants)
- Gated on has_tools to avoid false stops when no tools are provided

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a small breaking API change (`formatToolResponse` removal) and updated tool-call/tool-response formatting that can affect downstream tool-calling conversations and prompt serialization.
> 
> **Overview**
> Updates tool-calling to rely on `role: 'tool'` messages (template-wrapped) rather than manually injecting `<tool_response>` wrappers, removing the exported `formatToolResponse` helper and updating examples/docs/tests accordingly.
> 
> Improves chat-template JSON serialization by parsing `tool_calls[].arguments` as JSON when possible (falling back to a string) and logging a warning when tool `parameters.properties` JSON fails to parse; adds extensive parser/test coverage for multiple tool calls, thinking+tools combinations, and template rendering edge cases.
> 
> Separately, expands CLI model download to include `.gguf` files and clarifies/extends documentation for the `unsloth` quantization recipe.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85725af20f61c343321ad0bd635d86b3716f9e54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->