### PR TITLE
fix: cleanup Codex review issues

### DIFF
--- a/crates/mlx-core/src/models/paddleocr_vl/model.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/model.rs
@@ -934,6 +934,19 @@ impl VLModel {
                     let logits = lm_guard.forward_fused(&input_embeds, &decode_pos)?;
                     let mut next_logits = logits.squeeze(Some(&[0, 1]))?;
 
+                    // Append the previous token to all_tokens BEFORE applying penalties,
+                    // so the penalty functions see the most recent token.
+                    token.eval();
+                    let token_value = token.item_at_int32(0)? as u32;
+                    generated_tokens.push(token_value);
+                    all_tokens.push(token_value);
+
+                    if return_logprobs && let Some(ref lp) = logprobs_arr {
+                        lp.eval();
+                        let token_logprob = lp.item_at_float32(token_value as usize)?;
+                        generated_logprobs.push(token_logprob);
+                    }
+
                     if repetition_penalty != 1.0 {
                         next_logits = apply_repetition_penalty(
                             &next_logits,
@@ -979,17 +992,8 @@ impl VLModel {
                     MxArray::async_eval_arrays(&[&next_tok]);
                 }
 
-                token.eval();
-                let token_value = token.item_at_int32(0)? as u32;
-
-                generated_tokens.push(token_value);
-                all_tokens.push(token_value);
-
-                if return_logprobs && let Some(ref lp) = logprobs_arr {
-                    lp.eval();
-                    let token_logprob = lp.item_at_float32(token_value as usize)?;
-                    generated_logprobs.push(token_logprob);
-                }
+                // Token was already evaluated and pushed above (before penalties)
+                let token_value = *all_tokens.last().unwrap();
 
                 if token_value == eos_token_id as u32 {
                     finish_reason = "stop";
@@ -1647,6 +1651,27 @@ impl VLModel {
             // Sample next tokens [active_batch, 1, vocab] -> [active_batch, vocab]
             let next_logits = logits.squeeze(Some(&[1]))?;
 
+            // Append previous tokens to item_all_tokens BEFORE applying penalties,
+            // so the penalty functions see the most recent token.
+            current_tokens.eval();
+            let token_values_for_push = current_tokens.to_int32()?;
+            if return_logprobs
+                && let Some(ref lp_vec) = current_logprobs {
+                    for (local_idx, &global_idx) in active_indices.iter().enumerate() {
+                        let tv = token_values_for_push[local_idx] as u32;
+                        if let Some(ref lp) = lp_vec[global_idx] {
+                            lp.eval();
+                            let token_logprob = lp.item_at_float32(tv as usize)?;
+                            generated_logprobs[global_idx].push(token_logprob);
+                        }
+                    }
+                }
+            for (local_idx, &global_idx) in active_indices.iter().enumerate() {
+                let tv = token_values_for_push[local_idx] as u32;
+                generated_tokens[global_idx].push(tv);
+                item_all_tokens[global_idx].push(tv);
+            }
+
             // Apply repetition penalty per item
             let mut next_logits = if repetition_penalty != 1.0 {
                 let mut rows = Vec::with_capacity(active_indices.len());
@@ -1705,29 +1730,12 @@ impl VLModel {
                 (sample(&next_logits, Some(sampling_config))?, None)
             };
 
-            // --- Phase 2: Extract CURRENT tokens and CURRENT logprobs (aligned pair) ---
-            current_tokens.eval();
-            let token_values = current_tokens.to_int32()?;
-
-            // Extract logprobs for current tokens
-            if return_logprobs && let Some(ref lp_vec) = current_logprobs {
-                for (local_idx, &global_idx) in active_indices.iter().enumerate() {
-                    let token_value = token_values[local_idx] as u32;
-                    if let Some(ref lp) = lp_vec[global_idx] {
-                        lp.eval();
-                        let token_logprob = lp.item_at_float32(token_value as usize)?;
-                        generated_logprobs[global_idx].push(token_logprob);
-                    }
-                }
-            }
-
-            // Track deactivations
+            // --- Phase 2: Check EOS and deactivation for current tokens ---
+            // (Tokens were already extracted and pushed before penalties above)
             let mut to_deactivate: Vec<(usize, String)> = Vec::new();
 
-            for (local_idx, &global_idx) in active_indices.iter().enumerate() {
-                let token_value = token_values[local_idx] as u32;
-                generated_tokens[global_idx].push(token_value);
-                item_all_tokens[global_idx].push(token_value);
+            for (local_idx, &_global_idx) in active_indices.iter().enumerate() {
+                let token_value = token_values_for_push[local_idx] as u32;
 
                 // Check EOS
                 if token_value == eos_token_id as u32 {

--- a/crates/mlx-core/src/models/paddleocr_vl/model.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/model.rs
@@ -1655,17 +1655,16 @@ impl VLModel {
             // so the penalty functions see the most recent token.
             current_tokens.eval();
             let token_values_for_push = current_tokens.to_int32()?;
-            if return_logprobs
-                && let Some(ref lp_vec) = current_logprobs {
-                    for (local_idx, &global_idx) in active_indices.iter().enumerate() {
-                        let tv = token_values_for_push[local_idx] as u32;
-                        if let Some(ref lp) = lp_vec[global_idx] {
-                            lp.eval();
-                            let token_logprob = lp.item_at_float32(tv as usize)?;
-                            generated_logprobs[global_idx].push(token_logprob);
-                        }
+            if return_logprobs && let Some(ref lp_vec) = current_logprobs {
+                for (local_idx, &global_idx) in active_indices.iter().enumerate() {
+                    let tv = token_values_for_push[local_idx] as u32;
+                    if let Some(ref lp) = lp_vec[global_idx] {
+                        lp.eval();
+                        let token_logprob = lp.item_at_float32(tv as usize)?;
+                        generated_logprobs[global_idx].push(token_logprob);
                     }
                 }
+            }
             for (local_idx, &global_idx) in active_indices.iter().enumerate() {
                 let tv = token_values_for_push[local_idx] as u32;
                 generated_tokens[global_idx].push(tv);

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -566,7 +566,13 @@ impl Qwen3Model {
             )
         })?;
 
-        self.forward_paged_with_cache(input_ids, slot_mapping, seq_ids, positions, &paged_cache_guard)
+        self.forward_paged_with_cache(
+            input_ids,
+            slot_mapping,
+            seq_ids,
+            positions,
+            &paged_cache_guard,
+        )
     }
 
     /// Internal paged forward pass that accepts an already-locked cache reference.
@@ -992,37 +998,48 @@ impl Qwen3Model {
             let mut logit_arr = MxArray::from_float32(logit_slice, &[1, 1, vocab_size])?;
 
             if let Some((prompt, generated)) = scheduler_guard.get_penalty_context(seq_id) {
-                    // Build penalty context from the tail of prompt+generated,
-                    // bounded by the largest context_size to cap allocation.
-                    let max_ctx = repetition_context_size
-                        .unwrap_or(256)
-                        .max(presence_context_size.unwrap_or(20))
-                        .max(frequency_context_size.unwrap_or(20)) as usize;
-                    let total = prompt.len() + generated.len();
-                    let skip = total.saturating_sub(max_ctx);
-                    let prompt_skip = skip.min(prompt.len());
-                    let ctx: Vec<u32> = prompt[prompt_skip..].iter()
-                        .chain(generated.iter())
-                        .copied()
-                        .collect();
-                    if !ctx.is_empty() {
-                        if repetition_penalty != 1.0 {
-                            logit_arr = crate::sampling::apply_repetition_penalty(
-                                &logit_arr, &ctx, repetition_penalty, repetition_context_size,
-                            )?;
-                        }
-                        if presence_penalty != 0.0 {
-                            logit_arr = crate::sampling::apply_presence_penalty(
-                                &logit_arr, &ctx, presence_penalty, presence_context_size,
-                            )?;
-                        }
-                        if frequency_penalty != 0.0 {
-                            logit_arr = crate::sampling::apply_frequency_penalty(
-                                &logit_arr, &ctx, frequency_penalty, frequency_context_size,
-                            )?;
-                        }
+                // Build penalty context from the tail of prompt+generated,
+                // bounded by the largest context_size to cap allocation.
+                let max_ctx = repetition_context_size
+                    .unwrap_or(256)
+                    .max(presence_context_size.unwrap_or(20))
+                    .max(frequency_context_size.unwrap_or(20))
+                    as usize;
+                let total = prompt.len() + generated.len();
+                let skip = total.saturating_sub(max_ctx);
+                let prompt_skip = skip.min(prompt.len());
+                let ctx: Vec<u32> = prompt[prompt_skip..]
+                    .iter()
+                    .chain(generated.iter())
+                    .copied()
+                    .collect();
+                if !ctx.is_empty() {
+                    if repetition_penalty != 1.0 {
+                        logit_arr = crate::sampling::apply_repetition_penalty(
+                            &logit_arr,
+                            &ctx,
+                            repetition_penalty,
+                            repetition_context_size,
+                        )?;
+                    }
+                    if presence_penalty != 0.0 {
+                        logit_arr = crate::sampling::apply_presence_penalty(
+                            &logit_arr,
+                            &ctx,
+                            presence_penalty,
+                            presence_context_size,
+                        )?;
+                    }
+                    if frequency_penalty != 0.0 {
+                        logit_arr = crate::sampling::apply_frequency_penalty(
+                            &logit_arr,
+                            &ctx,
+                            frequency_penalty,
+                            frequency_context_size,
+                        )?;
                     }
                 }
+            }
 
             let (next_token_arr, logprobs_arr) =
                 crate::sampling::sample_and_logprobs(&logit_arr, Some(sampling_config))?;
@@ -1034,19 +1051,18 @@ impl Qwen3Model {
             let is_eos = next_token == eos_token_id as u32;
             let mut finish_reason_override: Option<&'static str> = None;
 
-            if !is_eos
-                && let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id) {
-                    let mut history = gen_tokens.to_vec();
-                    history.push(next_token);
-                    if let Some(reason) = crate::sampling::check_repetition_cutoff(
-                        &history,
-                        max_consecutive_tokens,
-                        max_ngram_repeats,
-                        ngram_size,
-                    ) {
-                        finish_reason_override = Some(reason);
-                    }
+            if !is_eos && let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id) {
+                let mut history = gen_tokens.to_vec();
+                history.push(next_token);
+                if let Some(reason) = crate::sampling::check_repetition_cutoff(
+                    &history,
+                    max_consecutive_tokens,
+                    max_ngram_repeats,
+                    ngram_size,
+                ) {
+                    finish_reason_override = Some(reason);
                 }
+            }
 
             // Check if this token hits the length limit
             if finish_reason_override.is_none()
@@ -1162,28 +1178,40 @@ impl Qwen3Model {
                     let max_ctx = repetition_context_size
                         .unwrap_or(256)
                         .max(presence_context_size.unwrap_or(20))
-                        .max(frequency_context_size.unwrap_or(20)) as usize;
+                        .max(frequency_context_size.unwrap_or(20))
+                        as usize;
                     let total = prompt.len() + generated.len();
                     let skip = total.saturating_sub(max_ctx);
                     let prompt_skip = skip.min(prompt.len());
-                    let ctx: Vec<u32> = prompt[prompt_skip..].iter()
-                        .chain(generated.iter())
+                    let gen_skip = skip.saturating_sub(prompt.len());
+                    let ctx: Vec<u32> = prompt[prompt_skip..]
+                        .iter()
+                        .chain(generated[gen_skip..].iter())
                         .copied()
                         .collect();
                     if !ctx.is_empty() {
                         if repetition_penalty != 1.0 {
                             logit_arr = crate::sampling::apply_repetition_penalty(
-                                &logit_arr, &ctx, repetition_penalty, repetition_context_size,
+                                &logit_arr,
+                                &ctx,
+                                repetition_penalty,
+                                repetition_context_size,
                             )?;
                         }
                         if presence_penalty != 0.0 {
                             logit_arr = crate::sampling::apply_presence_penalty(
-                                &logit_arr, &ctx, presence_penalty, presence_context_size,
+                                &logit_arr,
+                                &ctx,
+                                presence_penalty,
+                                presence_context_size,
                             )?;
                         }
                         if frequency_penalty != 0.0 {
                             logit_arr = crate::sampling::apply_frequency_penalty(
-                                &logit_arr, &ctx, frequency_penalty, frequency_context_size,
+                                &logit_arr,
+                                &ctx,
+                                frequency_penalty,
+                                frequency_context_size,
                             )?;
                         }
                     }
@@ -1199,19 +1227,18 @@ impl Qwen3Model {
                 let is_eos = next_token == eos_token_id as u32;
                 let mut finish_reason_override: Option<&'static str> = None;
 
-                if !is_eos
-                    && let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id) {
-                        let mut history = gen_tokens.to_vec();
-                        history.push(next_token);
-                        if let Some(reason) = crate::sampling::check_repetition_cutoff(
-                            &history,
-                            max_consecutive_tokens,
-                            max_ngram_repeats,
-                            ngram_size,
-                        ) {
-                            finish_reason_override = Some(reason);
-                        }
+                if !is_eos && let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id) {
+                    let mut history = gen_tokens.to_vec();
+                    history.push(next_token);
+                    if let Some(reason) = crate::sampling::check_repetition_cutoff(
+                        &history,
+                        max_consecutive_tokens,
+                        max_ngram_repeats,
+                        ngram_size,
+                    ) {
+                        finish_reason_override = Some(reason);
                     }
+                }
 
                 // Check if this token hits the length limit
                 if finish_reason_override.is_none()

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -856,16 +856,19 @@ impl Qwen3Model {
         };
         let eos_token_id = config.eos_token_id.unwrap_or(self.config.eos_token_id);
 
-        // Penalty config (previously ignored in paged path)
+        // Penalty config — defaults match the normal (non-paged) generation path
         let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
-        let repetition_context_size = config.repetition_context_size.map(|v| v);
+        let repetition_context_size = Some(config.repetition_context_size.unwrap_or(256));
         let presence_penalty = config.presence_penalty.unwrap_or(0.0);
-        let presence_context_size = config.presence_context_size.map(|v| v);
+        let presence_context_size = Some(config.presence_context_size.unwrap_or(20));
         let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
-        let frequency_context_size = config.frequency_context_size.map(|v| v);
+        let frequency_context_size = Some(config.frequency_context_size.unwrap_or(20));
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
+
+        // Track per-sequence finish reason overrides (e.g. "repetition")
+        let mut finish_reason_overrides: HashMap<u32, String> = HashMap::new();
 
         // Separate batch into prefill and decode sequences
         let mut prefill_indices: Vec<usize> = Vec::new();
@@ -1086,13 +1089,14 @@ impl Qwen3Model {
                 let logit_slice = &logits_data[start..end];
                 let mut logit_arr = MxArray::from_float32(logit_slice, &[1, 1, vocab_size])?;
 
-                // Apply penalties using the sequence's generated token history
-                if let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id)
-                    && !gen_tokens.is_empty() {
+                // Apply penalties using the full context (prompt + generated tokens),
+                // matching the non-paged generation path's behavior.
+                if let Some(penalty_ctx) = scheduler_guard.get_penalty_context(seq_id)
+                    && !penalty_ctx.is_empty() {
                         if repetition_penalty != 1.0 {
                             logit_arr = crate::sampling::apply_repetition_penalty(
                                 &logit_arr,
-                                gen_tokens,
+                                &penalty_ctx,
                                 repetition_penalty,
                                 repetition_context_size,
                             )?;
@@ -1100,7 +1104,7 @@ impl Qwen3Model {
                         if presence_penalty != 0.0 {
                             logit_arr = crate::sampling::apply_presence_penalty(
                                 &logit_arr,
-                                gen_tokens,
+                                &penalty_ctx,
                                 presence_penalty,
                                 presence_context_size,
                             )?;
@@ -1108,7 +1112,7 @@ impl Qwen3Model {
                         if frequency_penalty != 0.0 {
                             logit_arr = crate::sampling::apply_frequency_penalty(
                                 &logit_arr,
-                                gen_tokens,
+                                &penalty_ctx,
                                 frequency_penalty,
                                 frequency_context_size,
                             )?;
@@ -1122,25 +1126,28 @@ impl Qwen3Model {
                 logprobs_arr.eval();
                 let next_token = next_token_arr.item_at_int32(0)? as u32;
                 let logprob = logprobs_arr.item_at_float32(next_token as usize)? as f64;
-                let mut is_finished = next_token == eos_token_id as u32;
+                let is_eos = next_token == eos_token_id as u32;
+                let mut finish_reason_override: Option<String> = None;
 
                 // Check repetition cutoff (after the token is known)
-                if !is_finished
+                if !is_eos
                     && let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id) {
-                        // Build temp history with the new token appended
                         let mut history = gen_tokens.to_vec();
                         history.push(next_token);
-                        if crate::sampling::check_repetition_cutoff(
+                        if let Some(reason) = crate::sampling::check_repetition_cutoff(
                             &history,
                             max_consecutive_tokens,
                             max_ngram_repeats,
                             ngram_size,
-                        )
-                        .is_some()
-                        {
-                            is_finished = true;
+                        ) {
+                            finish_reason_override = Some(reason.to_string());
                         }
                     }
+
+                let is_finished = is_eos || finish_reason_override.is_some();
+                if let Some(ref reason) = finish_reason_override {
+                    finish_reason_overrides.insert(seq_id, reason.clone());
+                }
 
                 outputs.push(PagedTokenOutput {
                     seq_id,
@@ -1159,6 +1166,7 @@ impl Qwen3Model {
                 seq_id: o.seq_id,
                 token: o.token,
                 is_eos: o.is_finished,
+                finish_reason_override: finish_reason_overrides.get(&o.seq_id).cloned(),
             })
             .collect();
         scheduler_guard

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -878,7 +878,7 @@ impl Qwen3Model {
         let ngram_size = config.ngram_size.unwrap_or(64);
 
         // Track per-sequence finish reason overrides (e.g. "repetition")
-        let mut finish_reason_overrides: HashMap<u32, String> = HashMap::new();
+        let mut finish_reason_overrides: HashMap<u32, &'static str> = HashMap::new();
 
         // Separate batch into prefill and decode sequences
         let mut prefill_indices: Vec<usize> = Vec::new();
@@ -1031,7 +1031,7 @@ impl Qwen3Model {
             let next_token = next_token_arr.item_at_int32(0)? as u32;
             let logprob = logprobs_arr.item_at_float32(next_token as usize)? as f64;
             let is_eos = next_token == eos_token_id as u32;
-            let mut finish_reason_override: Option<String> = None;
+            let mut finish_reason_override: Option<&'static str> = None;
 
             // Check repetition cutoff on the first token too
             if !is_eos
@@ -1044,7 +1044,7 @@ impl Qwen3Model {
                         max_ngram_repeats,
                         ngram_size,
                     ) {
-                        finish_reason_override = Some(reason.to_string());
+                        finish_reason_override = Some(reason);
                     }
                 }
 
@@ -1053,12 +1053,12 @@ impl Qwen3Model {
                 && !is_eos
                 && scheduler_guard.would_hit_length_limit(seq_id)
             {
-                finish_reason_override = Some("length".to_string());
+                finish_reason_override = Some("length");
             }
 
             let is_finished = is_eos || finish_reason_override.is_some();
-            if let Some(ref reason) = finish_reason_override {
-                finish_reason_overrides.insert(seq_id, reason.clone());
+            if let Some(reason) = finish_reason_override {
+                finish_reason_overrides.insert(seq_id, reason);
             }
 
             outputs.push(PagedTokenOutput {
@@ -1196,7 +1196,7 @@ impl Qwen3Model {
                 let next_token = next_token_arr.item_at_int32(0)? as u32;
                 let logprob = logprobs_arr.item_at_float32(next_token as usize)? as f64;
                 let is_eos = next_token == eos_token_id as u32;
-                let mut finish_reason_override: Option<String> = None;
+                let mut finish_reason_override: Option<&'static str> = None;
 
                 // Check repetition cutoff (after the token is known)
                 if !is_eos
@@ -1209,7 +1209,7 @@ impl Qwen3Model {
                             max_ngram_repeats,
                             ngram_size,
                         ) {
-                            finish_reason_override = Some(reason.to_string());
+                            finish_reason_override = Some(reason);
                         }
                     }
 
@@ -1218,7 +1218,7 @@ impl Qwen3Model {
                     && !is_eos
                     && scheduler_guard.would_hit_length_limit(seq_id)
                 {
-                    finish_reason_override = Some("length".to_string());
+                    finish_reason_override = Some("length");
                 }
 
                 let is_finished = is_eos || finish_reason_override.is_some();
@@ -1240,7 +1240,7 @@ impl Qwen3Model {
         let token_outputs: Vec<_> = outputs
             .iter()
             .map(|o| {
-                let override_reason = finish_reason_overrides.get(&o.seq_id).cloned();
+                let override_reason = finish_reason_overrides.get(&o.seq_id).copied();
                 crate::transformer::TokenOutput {
                     seq_id: o.seq_id,
                     token: o.token,

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::iter;
 use std::sync::{Arc, RwLock};
+use tokio::sync::Mutex as TokioMutex;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -141,6 +142,10 @@ pub struct Qwen3Model {
     cached_cache_idx: Arc<RwLock<i32>>,
     /// Token history for prefix verification
     cached_token_history: Arc<RwLock<Vec<u32>>>,
+    /// Serializes cache state access: held during the entire chat() lifecycle
+    /// (both prefix-match reads and post-generation writes) to prevent concurrent
+    /// chat()/reset_cache() from splicing state across conversations.
+    generation_lock: Arc<TokioMutex<()>>,
 }
 
 #[napi]
@@ -244,6 +249,7 @@ impl Qwen3Model {
             cached_kv_values: Arc::new(RwLock::new(Vec::new())),
             cached_cache_idx: Arc::new(RwLock::new(0)),
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
+            generation_lock: Arc::new(TokioMutex::new(())),
         })
     }
 
@@ -251,6 +257,9 @@ impl Qwen3Model {
     /// Call this when starting a new conversation to ensure a full prefill.
     #[napi]
     pub fn reset_cache(&self) -> Result<()> {
+        let _guard = self.generation_lock.try_lock().map_err(|_| {
+            Error::from_reason("Cannot reset cache while generation is in progress")
+        })?;
         self.cached_kv_keys
             .write()
             .map_err(|_| Error::from_reason("Poisoned lock"))?
@@ -376,6 +385,9 @@ impl Qwen3Model {
             }
         }
         // Also clear cached chat state so next chat() does a full prefill
+        let _guard = self.generation_lock.try_lock().map_err(|_| {
+            Error::from_reason("Cannot reset KV cache while generation is in progress")
+        })?;
         self.cached_kv_keys
             .write()
             .map_err(|_| Error::from_reason("Poisoned lock"))?
@@ -1359,6 +1371,7 @@ impl Qwen3Model {
             cached_kv_values: Arc::new(RwLock::new(Vec::new())),
             cached_cache_idx: Arc::new(RwLock::new(0)),
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
+            generation_lock: Arc::new(TokioMutex::new(())),
         })
     }
 
@@ -5545,6 +5558,11 @@ impl Qwen3Model {
                 format!("Chat template task failed: {}", e),
             )
         })??;
+
+        // Hold generation lock for the entire cache-read + generation + cache-write lifecycle.
+        // This prevents concurrent chat()/reset_cache() from splicing state across conversations.
+        let gen_lock = self.generation_lock.clone();
+        let _gen_guard = gen_lock.lock().await;
 
         // === Cache reuse: prefix verification ===
         let (initial_kv_keys, initial_kv_values, initial_cache_idx, prefill_input_ids) =

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -866,7 +866,6 @@ impl Qwen3Model {
         };
         let eos_token_id = config.eos_token_id.unwrap_or(self.config.eos_token_id);
 
-        // Penalty config — defaults match the normal (non-paged) generation path
         let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
         let repetition_context_size = Some(config.repetition_context_size.unwrap_or(256));
         let presence_penalty = config.presence_penalty.unwrap_or(0.0);
@@ -877,7 +876,6 @@ impl Qwen3Model {
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
 
-        // Track per-sequence finish reason overrides (e.g. "repetition")
         let mut finish_reason_overrides: HashMap<u32, &'static str> = HashMap::new();
 
         // Separate batch into prefill and decode sequences
@@ -993,33 +991,36 @@ impl Qwen3Model {
             let logit_slice = &logits_data[start..end];
             let mut logit_arr = MxArray::from_float32(logit_slice, &[1, 1, vocab_size])?;
 
-            // Apply penalties against prompt tokens before sampling the first token,
-            // matching the non-paged generation path's behavior.
-            if let Some(penalty_ctx) = scheduler_guard.get_penalty_context(seq_id)
-                && !penalty_ctx.is_empty() {
-                    if repetition_penalty != 1.0 {
-                        logit_arr = crate::sampling::apply_repetition_penalty(
-                            &logit_arr,
-                            &penalty_ctx,
-                            repetition_penalty,
-                            repetition_context_size,
-                        )?;
-                    }
-                    if presence_penalty != 0.0 {
-                        logit_arr = crate::sampling::apply_presence_penalty(
-                            &logit_arr,
-                            &penalty_ctx,
-                            presence_penalty,
-                            presence_context_size,
-                        )?;
-                    }
-                    if frequency_penalty != 0.0 {
-                        logit_arr = crate::sampling::apply_frequency_penalty(
-                            &logit_arr,
-                            &penalty_ctx,
-                            frequency_penalty,
-                            frequency_context_size,
-                        )?;
+            if let Some((prompt, generated)) = scheduler_guard.get_penalty_context(seq_id) {
+                    // Build penalty context from the tail of prompt+generated,
+                    // bounded by the largest context_size to cap allocation.
+                    let max_ctx = repetition_context_size
+                        .unwrap_or(256)
+                        .max(presence_context_size.unwrap_or(20))
+                        .max(frequency_context_size.unwrap_or(20)) as usize;
+                    let total = prompt.len() + generated.len();
+                    let skip = total.saturating_sub(max_ctx);
+                    let prompt_skip = skip.min(prompt.len());
+                    let ctx: Vec<u32> = prompt[prompt_skip..].iter()
+                        .chain(generated.iter())
+                        .copied()
+                        .collect();
+                    if !ctx.is_empty() {
+                        if repetition_penalty != 1.0 {
+                            logit_arr = crate::sampling::apply_repetition_penalty(
+                                &logit_arr, &ctx, repetition_penalty, repetition_context_size,
+                            )?;
+                        }
+                        if presence_penalty != 0.0 {
+                            logit_arr = crate::sampling::apply_presence_penalty(
+                                &logit_arr, &ctx, presence_penalty, presence_context_size,
+                            )?;
+                        }
+                        if frequency_penalty != 0.0 {
+                            logit_arr = crate::sampling::apply_frequency_penalty(
+                                &logit_arr, &ctx, frequency_penalty, frequency_context_size,
+                            )?;
+                        }
                     }
                 }
 
@@ -1033,7 +1034,6 @@ impl Qwen3Model {
             let is_eos = next_token == eos_token_id as u32;
             let mut finish_reason_override: Option<&'static str> = None;
 
-            // Check repetition cutoff on the first token too
             if !is_eos
                 && let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id) {
                     let mut history = gen_tokens.to_vec();
@@ -1158,35 +1158,36 @@ impl Qwen3Model {
                 let logit_slice = &logits_data[start..end];
                 let mut logit_arr = MxArray::from_float32(logit_slice, &[1, 1, vocab_size])?;
 
-                // Apply penalties using the full context (prompt + generated tokens),
-                // matching the non-paged generation path's behavior.
-                if let Some(penalty_ctx) = scheduler_guard.get_penalty_context(seq_id)
-                    && !penalty_ctx.is_empty() {
+                if let Some((prompt, generated)) = scheduler_guard.get_penalty_context(seq_id) {
+                    let max_ctx = repetition_context_size
+                        .unwrap_or(256)
+                        .max(presence_context_size.unwrap_or(20))
+                        .max(frequency_context_size.unwrap_or(20)) as usize;
+                    let total = prompt.len() + generated.len();
+                    let skip = total.saturating_sub(max_ctx);
+                    let prompt_skip = skip.min(prompt.len());
+                    let ctx: Vec<u32> = prompt[prompt_skip..].iter()
+                        .chain(generated.iter())
+                        .copied()
+                        .collect();
+                    if !ctx.is_empty() {
                         if repetition_penalty != 1.0 {
                             logit_arr = crate::sampling::apply_repetition_penalty(
-                                &logit_arr,
-                                &penalty_ctx,
-                                repetition_penalty,
-                                repetition_context_size,
+                                &logit_arr, &ctx, repetition_penalty, repetition_context_size,
                             )?;
                         }
                         if presence_penalty != 0.0 {
                             logit_arr = crate::sampling::apply_presence_penalty(
-                                &logit_arr,
-                                &penalty_ctx,
-                                presence_penalty,
-                                presence_context_size,
+                                &logit_arr, &ctx, presence_penalty, presence_context_size,
                             )?;
                         }
                         if frequency_penalty != 0.0 {
                             logit_arr = crate::sampling::apply_frequency_penalty(
-                                &logit_arr,
-                                &penalty_ctx,
-                                frequency_penalty,
-                                frequency_context_size,
+                                &logit_arr, &ctx, frequency_penalty, frequency_context_size,
                             )?;
                         }
                     }
+                }
 
                 let (next_token_arr, logprobs_arr) =
                     crate::sampling::sample_and_logprobs(&logit_arr, Some(sampling_config))?;
@@ -1198,7 +1199,6 @@ impl Qwen3Model {
                 let is_eos = next_token == eos_token_id as u32;
                 let mut finish_reason_override: Option<&'static str> = None;
 
-                // Check repetition cutoff (after the token is known)
                 if !is_eos
                     && let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id) {
                         let mut history = gen_tokens.to_vec();
@@ -1236,7 +1236,6 @@ impl Qwen3Model {
             }
         }
 
-        // Update scheduler with outputs (handles prefill→decode transition)
         let token_outputs: Vec<_> = outputs
             .iter()
             .map(|o| {

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -873,11 +873,11 @@ impl Qwen3Model {
         let eos_token_id = config.eos_token_id.unwrap_or(self.config.eos_token_id);
 
         let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
-        let repetition_context_size = Some(config.repetition_context_size.unwrap_or(256));
+        let repetition_context_size = config.repetition_context_size.unwrap_or(256);
         let presence_penalty = config.presence_penalty.unwrap_or(0.0);
-        let presence_context_size = Some(config.presence_context_size.unwrap_or(20));
+        let presence_context_size = config.presence_context_size.unwrap_or(20);
         let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
-        let frequency_context_size = Some(config.frequency_context_size.unwrap_or(20));
+        let frequency_context_size = config.frequency_context_size.unwrap_or(20);
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
@@ -1001,10 +1001,8 @@ impl Qwen3Model {
                 // Build penalty context from the tail of prompt+generated,
                 // bounded by the largest context_size to cap allocation.
                 let max_ctx = repetition_context_size
-                    .unwrap_or(256)
-                    .max(presence_context_size.unwrap_or(20))
-                    .max(frequency_context_size.unwrap_or(20))
-                    as usize;
+                    .max(presence_context_size)
+                    .max(frequency_context_size) as usize;
                 let total = prompt.len() + generated.len();
                 let skip = total.saturating_sub(max_ctx);
                 let prompt_skip = skip.min(prompt.len());
@@ -1019,7 +1017,7 @@ impl Qwen3Model {
                             &logit_arr,
                             &ctx,
                             repetition_penalty,
-                            repetition_context_size,
+                            Some(repetition_context_size),
                         )?;
                     }
                     if presence_penalty != 0.0 {
@@ -1027,7 +1025,7 @@ impl Qwen3Model {
                             &logit_arr,
                             &ctx,
                             presence_penalty,
-                            presence_context_size,
+                            Some(presence_context_size),
                         )?;
                     }
                     if frequency_penalty != 0.0 {
@@ -1035,7 +1033,7 @@ impl Qwen3Model {
                             &logit_arr,
                             &ctx,
                             frequency_penalty,
-                            frequency_context_size,
+                            Some(frequency_context_size),
                         )?;
                     }
                 }
@@ -1176,10 +1174,8 @@ impl Qwen3Model {
 
                 if let Some((prompt, generated)) = scheduler_guard.get_penalty_context(seq_id) {
                     let max_ctx = repetition_context_size
-                        .unwrap_or(256)
-                        .max(presence_context_size.unwrap_or(20))
-                        .max(frequency_context_size.unwrap_or(20))
-                        as usize;
+                        .max(presence_context_size)
+                        .max(frequency_context_size) as usize;
                     let total = prompt.len() + generated.len();
                     let skip = total.saturating_sub(max_ctx);
                     let prompt_skip = skip.min(prompt.len());
@@ -1195,7 +1191,7 @@ impl Qwen3Model {
                                 &logit_arr,
                                 &ctx,
                                 repetition_penalty,
-                                repetition_context_size,
+                                Some(repetition_context_size),
                             )?;
                         }
                         if presence_penalty != 0.0 {
@@ -1203,7 +1199,7 @@ impl Qwen3Model {
                                 &logit_arr,
                                 &ctx,
                                 presence_penalty,
-                                presence_context_size,
+                                Some(presence_context_size),
                             )?;
                         }
                         if frequency_penalty != 0.0 {
@@ -1211,7 +1207,7 @@ impl Qwen3Model {
                                 &logit_arr,
                                 &ctx,
                                 frequency_penalty,
-                                frequency_context_size,
+                                Some(frequency_context_size),
                             )?;
                         }
                     }
@@ -1249,8 +1245,8 @@ impl Qwen3Model {
                 }
 
                 let is_finished = is_eos || finish_reason_override.is_some();
-                if let Some(ref reason) = finish_reason_override {
-                    finish_reason_overrides.insert(seq_id, reason.clone());
+                if let Some(reason) = finish_reason_override {
+                    finish_reason_overrides.insert(seq_id, reason);
                 }
 
                 outputs.push(PagedTokenOutput {

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -778,6 +778,11 @@ impl Qwen3Model {
         max_new_tokens: u32,
         priority: Option<i32>,
     ) -> Result<u32> {
+        if max_new_tokens == 0 {
+            return Err(napi::Error::from_reason(
+                "max_new_tokens must be > 0 for paged generation",
+            ));
+        }
         let scheduler = self
             .scheduler
             .as_ref()
@@ -981,7 +986,37 @@ impl Qwen3Model {
             }
 
             let logit_slice = &logits_data[start..end];
-            let logit_arr = MxArray::from_float32(logit_slice, &[1, 1, vocab_size])?;
+            let mut logit_arr = MxArray::from_float32(logit_slice, &[1, 1, vocab_size])?;
+
+            // Apply penalties against prompt tokens before sampling the first token,
+            // matching the non-paged generation path's behavior.
+            if let Some(penalty_ctx) = scheduler_guard.get_penalty_context(seq_id)
+                && !penalty_ctx.is_empty() {
+                    if repetition_penalty != 1.0 {
+                        logit_arr = crate::sampling::apply_repetition_penalty(
+                            &logit_arr,
+                            &penalty_ctx,
+                            repetition_penalty,
+                            repetition_context_size,
+                        )?;
+                    }
+                    if presence_penalty != 0.0 {
+                        logit_arr = crate::sampling::apply_presence_penalty(
+                            &logit_arr,
+                            &penalty_ctx,
+                            presence_penalty,
+                            presence_context_size,
+                        )?;
+                    }
+                    if frequency_penalty != 0.0 {
+                        logit_arr = crate::sampling::apply_frequency_penalty(
+                            &logit_arr,
+                            &penalty_ctx,
+                            frequency_penalty,
+                            frequency_context_size,
+                        )?;
+                    }
+                }
 
             let (next_token_arr, logprobs_arr) =
                 crate::sampling::sample_and_logprobs(&logit_arr, Some(sampling_config))?;
@@ -990,7 +1025,28 @@ impl Qwen3Model {
             logprobs_arr.eval();
             let next_token = next_token_arr.item_at_int32(0)? as u32;
             let logprob = logprobs_arr.item_at_float32(next_token as usize)? as f64;
-            let is_finished = next_token == eos_token_id as u32;
+            let is_eos = next_token == eos_token_id as u32;
+            let mut finish_reason_override: Option<String> = None;
+
+            // Check repetition cutoff on the first token too
+            if !is_eos
+                && let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id) {
+                    let mut history = gen_tokens.to_vec();
+                    history.push(next_token);
+                    if let Some(reason) = crate::sampling::check_repetition_cutoff(
+                        &history,
+                        max_consecutive_tokens,
+                        max_ngram_repeats,
+                        ngram_size,
+                    ) {
+                        finish_reason_override = Some(reason.to_string());
+                    }
+                }
+
+            let is_finished = is_eos || finish_reason_override.is_some();
+            if let Some(ref reason) = finish_reason_override {
+                finish_reason_overrides.insert(seq_id, reason.clone());
+            }
 
             outputs.push(PagedTokenOutput {
                 seq_id,

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -558,11 +558,6 @@ impl Qwen3Model {
             )
         })?;
 
-        // Embedding lookup: [num_seqs, 1] -> [num_seqs, 1, hidden_dim]
-        let mut hidden_states = self.embedding.forward(input_ids)?;
-        let num_seqs = hidden_states.shape_at(0)?;
-        let seq_len = hidden_states.shape_at(1)?;
-
         // Acquire read lock for paged cache
         let paged_cache_guard = paged_cache.read().map_err(|_| {
             Error::new(
@@ -570,6 +565,25 @@ impl Qwen3Model {
                 "Failed to acquire paged cache read lock",
             )
         })?;
+
+        self.forward_paged_with_cache(input_ids, slot_mapping, seq_ids, positions, &paged_cache_guard)
+    }
+
+    /// Internal paged forward pass that accepts an already-locked cache reference.
+    /// This avoids deadlock when called from step_paged_generation() which already
+    /// holds a write lock on the same paged_cache RwLock.
+    fn forward_paged_with_cache(
+        &self,
+        input_ids: &MxArray,
+        slot_mapping: &MxArray,
+        seq_ids: Vec<u32>,
+        positions: &MxArray,
+        paged_cache_guard: &mlx_paged_attn::PagedKVCache,
+    ) -> Result<MxArray> {
+        // Embedding lookup: [num_seqs, 1] -> [num_seqs, 1, hidden_dim]
+        let mut hidden_states = self.embedding.forward(input_ids)?;
+        let num_seqs = hidden_states.shape_at(0)?;
+        let seq_len = hidden_states.shape_at(1)?;
 
         // Acquire read locks for model components
         let layers_guard = self.layers.read().map_err(|_| {
@@ -598,7 +612,7 @@ impl Qwen3Model {
         for (layer_idx, layer) in layers_guard.iter().enumerate() {
             hidden_states = layer.forward_paged_metal(
                 &hidden_states,
-                &paged_cache_guard,
+                paged_cache_guard,
                 layer_idx as u32,
                 slot_mapping,
                 &seq_ids,
@@ -842,6 +856,17 @@ impl Qwen3Model {
         };
         let eos_token_id = config.eos_token_id.unwrap_or(self.config.eos_token_id);
 
+        // Penalty config (previously ignored in paged path)
+        let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
+        let repetition_context_size = config.repetition_context_size.map(|v| v);
+        let presence_penalty = config.presence_penalty.unwrap_or(0.0);
+        let presence_context_size = config.presence_context_size.map(|v| v);
+        let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
+        let frequency_context_size = config.frequency_context_size.map(|v| v);
+        let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
+        let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
+        let ngram_size = config.ngram_size.unwrap_or(64);
+
         // Separate batch into prefill and decode sequences
         let mut prefill_indices: Vec<usize> = Vec::new();
         let mut decode_indices: Vec<usize> = Vec::new();
@@ -1028,12 +1053,14 @@ impl Qwen3Model {
             let slot_mapping_arr =
                 MxArray::from_int64(&slot_mapping, &[slot_mapping.len() as i64])?;
 
-            // Run paged attention forward pass (now takes seq_ids instead of block_tables/context_lens)
-            let logits = self.forward_paged(
+            // Run paged attention forward pass using the already-held write guard
+            // (avoids deadlock — forward_paged() would try to read-lock the same RwLock)
+            let logits = self.forward_paged_with_cache(
                 &input_ids,
                 &slot_mapping_arr,
                 decode_seq_ids.clone(),
                 &positions_arr,
+                &cache_guard,
             )?;
 
             // Sample from logits
@@ -1057,7 +1084,36 @@ impl Qwen3Model {
                 }
 
                 let logit_slice = &logits_data[start..end];
-                let logit_arr = MxArray::from_float32(logit_slice, &[1, 1, vocab_size])?;
+                let mut logit_arr = MxArray::from_float32(logit_slice, &[1, 1, vocab_size])?;
+
+                // Apply penalties using the sequence's generated token history
+                if let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id)
+                    && !gen_tokens.is_empty() {
+                        if repetition_penalty != 1.0 {
+                            logit_arr = crate::sampling::apply_repetition_penalty(
+                                &logit_arr,
+                                gen_tokens,
+                                repetition_penalty,
+                                repetition_context_size,
+                            )?;
+                        }
+                        if presence_penalty != 0.0 {
+                            logit_arr = crate::sampling::apply_presence_penalty(
+                                &logit_arr,
+                                gen_tokens,
+                                presence_penalty,
+                                presence_context_size,
+                            )?;
+                        }
+                        if frequency_penalty != 0.0 {
+                            logit_arr = crate::sampling::apply_frequency_penalty(
+                                &logit_arr,
+                                gen_tokens,
+                                frequency_penalty,
+                                frequency_context_size,
+                            )?;
+                        }
+                    }
 
                 let (next_token_arr, logprobs_arr) =
                     crate::sampling::sample_and_logprobs(&logit_arr, Some(sampling_config))?;
@@ -1066,7 +1122,25 @@ impl Qwen3Model {
                 logprobs_arr.eval();
                 let next_token = next_token_arr.item_at_int32(0)? as u32;
                 let logprob = logprobs_arr.item_at_float32(next_token as usize)? as f64;
-                let is_finished = next_token == eos_token_id as u32;
+                let mut is_finished = next_token == eos_token_id as u32;
+
+                // Check repetition cutoff (after the token is known)
+                if !is_finished
+                    && let Some(gen_tokens) = scheduler_guard.get_generated_tokens(seq_id) {
+                        // Build temp history with the new token appended
+                        let mut history = gen_tokens.to_vec();
+                        history.push(next_token);
+                        if crate::sampling::check_repetition_cutoff(
+                            &history,
+                            max_consecutive_tokens,
+                            max_ngram_repeats,
+                            ngram_size,
+                        )
+                        .is_some()
+                        {
+                            is_finished = true;
+                        }
+                    }
 
                 outputs.push(PagedTokenOutput {
                     seq_id,

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -369,6 +369,9 @@ impl Qwen3Model {
     /// Clears cached key-value states. Call this between different generation sequences.
     #[napi]
     pub fn reset_kv_caches(&self) -> Result<()> {
+        let _guard = self.generation_lock.try_lock().map_err(|_| {
+            Error::from_reason("Cannot reset KV cache while generation is in progress")
+        })?;
         if let Some(caches) = self
             .kv_caches
             .write()
@@ -384,10 +387,6 @@ impl Qwen3Model {
                 cache.reset();
             }
         }
-        // Also clear cached chat state so next chat() does a full prefill
-        let _guard = self.generation_lock.try_lock().map_err(|_| {
-            Error::from_reason("Cannot reset KV cache while generation is in progress")
-        })?;
         self.cached_kv_keys
             .write()
             .map_err(|_| Error::from_reason("Poisoned lock"))?

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -1048,9 +1048,15 @@ impl Qwen3Model {
                     }
                 }
 
-            // Also check if this token hits the length limit
-            let hits_length = scheduler_guard.would_hit_length_limit(seq_id);
-            let is_finished = is_eos || finish_reason_override.is_some() || hits_length;
+            // Check if this token hits the length limit
+            if finish_reason_override.is_none()
+                && !is_eos
+                && scheduler_guard.would_hit_length_limit(seq_id)
+            {
+                finish_reason_override = Some("length".to_string());
+            }
+
+            let is_finished = is_eos || finish_reason_override.is_some();
             if let Some(ref reason) = finish_reason_override {
                 finish_reason_overrides.insert(seq_id, reason.clone());
             }
@@ -1207,9 +1213,15 @@ impl Qwen3Model {
                         }
                     }
 
-                // Also check if this token hits the length limit
-                let hits_length = scheduler_guard.would_hit_length_limit(seq_id);
-                let is_finished = is_eos || finish_reason_override.is_some() || hits_length;
+                // Check if this token hits the length limit
+                if finish_reason_override.is_none()
+                    && !is_eos
+                    && scheduler_guard.would_hit_length_limit(seq_id)
+                {
+                    finish_reason_override = Some("length".to_string());
+                }
+
+                let is_finished = is_eos || finish_reason_override.is_some();
                 if let Some(ref reason) = finish_reason_override {
                     finish_reason_overrides.insert(seq_id, reason.clone());
                 }
@@ -1227,11 +1239,16 @@ impl Qwen3Model {
         // Update scheduler with outputs (handles prefill→decode transition)
         let token_outputs: Vec<_> = outputs
             .iter()
-            .map(|o| crate::transformer::TokenOutput {
-                seq_id: o.seq_id,
-                token: o.token,
-                is_eos: o.is_finished,
-                finish_reason_override: finish_reason_overrides.get(&o.seq_id).cloned(),
+            .map(|o| {
+                let override_reason = finish_reason_overrides.get(&o.seq_id).cloned();
+                crate::transformer::TokenOutput {
+                    seq_id: o.seq_id,
+                    token: o.token,
+                    // is_eos should only be true for actual EOS tokens, not for
+                    // length/repetition stops — those flow through finish_reason_override.
+                    is_eos: o.is_finished && override_reason.is_none(),
+                    finish_reason_override: override_reason,
+                }
             })
             .collect();
         scheduler_guard

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -5698,19 +5698,18 @@ impl Qwen3Model {
             None
         };
 
-        // Apply chat template with tools and encode in a blocking task.
-        // Return both the token IDs (Vec<u32>) and the MxArray for prefix matching.
+        // Hold generation lock for the entire cache-read + generation + cache-write lifecycle.
+        let gen_lock = self.generation_lock.clone();
+        let _gen_guard = gen_lock.lock().await;
+
         let tokenizer_clone = tokenizer.clone();
         let (token_ids_vec, input_ids) = napi::bindgen_prelude::spawn_blocking(move || {
-            // Use the tokenizer's apply_chat_template_sync method which handles Jinja2 + tools
             let token_ids = tokenizer_clone.apply_chat_template_sync(
                 &messages,
                 Some(true),
                 tools.as_deref(),
                 enable_thinking,
             )?;
-
-            // Create MxArray from token IDs
             let arr = MxArray::from_uint32(&token_ids, &[1, token_ids.len() as i64])?;
             Ok::<(Vec<u32>, MxArray), napi::Error>((token_ids, arr))
         })
@@ -5721,11 +5720,6 @@ impl Qwen3Model {
                 format!("Chat template task failed: {}", e),
             )
         })??;
-
-        // Hold generation lock for the entire cache-read + generation + cache-write lifecycle.
-        // This prevents concurrent chat()/reset_cache() from splicing state across conversations.
-        let gen_lock = self.generation_lock.clone();
-        let _gen_guard = gen_lock.lock().await;
 
         // === Cache reuse: prefix verification ===
         let (initial_kv_keys, initial_kv_values, initial_cache_idx, prefill_input_ids) =

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -783,6 +783,11 @@ impl Qwen3Model {
                 "max_new_tokens must be > 0 for paged generation",
             ));
         }
+        if prompt_tokens.is_empty() {
+            return Err(napi::Error::from_reason(
+                "prompt_tokens must not be empty for paged generation",
+            ));
+        }
         let scheduler = self
             .scheduler
             .as_ref()
@@ -1043,7 +1048,9 @@ impl Qwen3Model {
                     }
                 }
 
-            let is_finished = is_eos || finish_reason_override.is_some();
+            // Also check if this token hits the length limit
+            let hits_length = scheduler_guard.would_hit_length_limit(seq_id);
+            let is_finished = is_eos || finish_reason_override.is_some() || hits_length;
             if let Some(ref reason) = finish_reason_override {
                 finish_reason_overrides.insert(seq_id, reason.clone());
             }
@@ -1200,7 +1207,9 @@ impl Qwen3Model {
                         }
                     }
 
-                let is_finished = is_eos || finish_reason_override.is_some();
+                // Also check if this token hits the length limit
+                let hits_length = scheduler_guard.would_hit_length_limit(seq_id);
+                let is_finished = is_eos || finish_reason_override.is_some() || hits_length;
                 if let Some(ref reason) = finish_reason_override {
                     finish_reason_overrides.insert(seq_id, reason.clone());
                 }

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -77,6 +77,21 @@ pub(crate) static QWEN35_MODEL_ID_COUNTER: AtomicU64 = AtomicU64::new(1); // 0 =
 /// between has_weight() / get_weight() in linear_proj().
 pub(crate) static COMPILED_WEIGHTS_RWLOCK: std::sync::RwLock<()> = std::sync::RwLock::new(());
 
+/// Acquire the compiled weight read lock and verify model ownership in one step.
+/// Returns `Some(guard)` if this model owns the compiled weights, `None` otherwise.
+/// The guard must be held for the lifetime of the compiled decode to prevent
+/// concurrent model loads from swapping weights mid-generation.
+pub(crate) fn acquire_compiled_weight_guard(
+    model_id: u64,
+) -> Option<std::sync::RwLockReadGuard<'static, ()>> {
+    let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
+    if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
+        Some(guard)
+    } else {
+        None
+    }
+}
+
 /// Process-wide mutex serializing the dense compiled forward lifecycle.
 ///
 /// The C++ compiled decode path uses process-wide globals (`g_compiled_caches`,
@@ -559,20 +574,8 @@ impl Qwen3_5Model {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
-            // Re-validate compiled path under weight lock. The read lock prevents
-            // concurrent model loads from mutating the C++ weight map mid-decode.
-            let mut _weight_guard = None;
-            let use_compiled = if use_compiled {
-                let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
-                if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
-                    _weight_guard = Some(guard);
-                    true
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
+            let _weight_guard = if use_compiled { acquire_compiled_weight_guard(model_id) } else { None };
+            let use_compiled = _weight_guard.is_some();
 
             // Acquire all locks ONCE for the entire prefill+decode sequence
             let mut layers_guard = layers_arc
@@ -3439,20 +3442,8 @@ impl Qwen3_5Model {
         };
         let use_compiled = compiled_lock.is_some();
 
-        // Acquire weight read lock to prevent concurrent model loads from
-        // swapping weights during compiled decode. Re-validate model ID under lock.
-        let mut _weight_guard = None;
-        let use_compiled = if use_compiled {
-            let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
-            if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
-                _weight_guard = Some(guard);
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
+        let _weight_guard = if use_compiled { acquire_compiled_weight_guard(model_id) } else { None };
+        let use_compiled = _weight_guard.is_some();
 
         // Ensure caches exist
         self.init_caches()?;

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -366,6 +366,16 @@ impl Qwen3_5Model {
             .write()
             .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
         *caches_guard = Some(caches);
+        // Clear reuse state so stale history doesn't cause a false cache hit
+        if let Ok(mut th) = self.cached_token_history.write() {
+            th.clear();
+        }
+        if let Ok(mut ik) = self.cached_image_key.write() {
+            *ik = None;
+        }
+        if let Ok(mut rd) = self.cached_rope_deltas.write() {
+            *rd = None;
+        }
         Ok(())
     }
 
@@ -2001,9 +2011,8 @@ impl Qwen3_5Model {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
-                    // Use the HF tokenizer's incremental DecodeStream for correct
-                    // streaming with ByteLevel BPE decoders.
                     let mut decode_stream = tokenizer_for_decode.inner().decode_stream(true);
+                    let mut streamed_text_len: usize = 0;
 
                     let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
                     let generation_stream = Stream::new(DeviceType::Gpu);
@@ -2272,6 +2281,7 @@ impl Qwen3_5Model {
                                 .ok()
                                 .flatten()
                                 .unwrap_or_default();
+                            streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2418,6 +2428,7 @@ impl Qwen3_5Model {
                                 .ok()
                                 .flatten()
                                 .unwrap_or_default();
+                            streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2506,13 +2517,31 @@ impl Qwen3_5Model {
                         }
                     }
 
-                    // Decode full text for final chunk
                     let text = tokenizer_for_decode
                         .decode_sync(&generated_tokens, true)
                         .unwrap_or_else(|e| {
                             warn!("Failed to decode generated tokens: {}", e);
                             String::new()
                         });
+
+                    // Flush any residual bytes buffered by DecodeStream that
+                    // weren't emitted as intermediate chunks.
+                    if text.len() > streamed_text_len {
+                        let residual = text[streamed_text_len..].to_string();
+                        callback.call(
+                            Ok(ChatStreamChunk {
+                                text: residual,
+                                done: false,
+                                finish_reason: None,
+                                tool_calls: None,
+                                thinking: None,
+                                num_tokens: None,
+                                raw_text: None,
+                                performance: None,
+                            }),
+                            ThreadsafeFunctionCallMode::NonBlocking,
+                        );
+                    }
 
                     let num_tokens = generated_tokens.len() as u32;
 

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2011,7 +2011,7 @@ impl Qwen3_5Model {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
-                    let mut decode_stream = tokenizer_for_decode.inner().decode_stream(true);
+                    let mut decode_stream = Some(tokenizer_for_decode.inner().decode_stream(true));
                     let mut streamed_text_len: usize = 0;
 
                     let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
@@ -2276,11 +2276,38 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            let token_text = decode_stream
-                                .step(token_id)
-                                .ok()
-                                .flatten()
-                                .unwrap_or_default();
+                            // Use DecodeStream for correct incremental decoding.
+                            // On InvalidPrefix error, fall back to full-decode diff.
+                            let token_text = if let Some(ref mut ds) = decode_stream {
+                                match ds.step(token_id) {
+                                    Ok(Some(text)) => text,
+                                    Ok(None) => String::new(),
+                                    Err(_) => {
+                                        // Stream state is broken — fall back to full decode
+                                        decode_stream = None;
+                                        let full = tokenizer_for_decode
+                                            .decode_sync(&generated_tokens, true)
+                                            .unwrap_or_default();
+                                        let delta = if full.len() > streamed_text_len {
+                                            full[streamed_text_len..].to_string()
+                                        } else {
+                                            String::new()
+                                        };
+                                        delta
+                                    }
+                                }
+                            } else {
+                                // Fallback mode: full-decode diff
+                                let full = tokenizer_for_decode
+                                    .decode_sync(&generated_tokens, true)
+                                    .unwrap_or_default();
+                                let delta = if full.len() > streamed_text_len {
+                                    full[streamed_text_len..].to_string()
+                                } else {
+                                    String::new()
+                                };
+                                delta
+                            };
                             streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
@@ -2423,11 +2450,38 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            let token_text = decode_stream
-                                .step(token_id)
-                                .ok()
-                                .flatten()
-                                .unwrap_or_default();
+                            // Use DecodeStream for correct incremental decoding.
+                            // On InvalidPrefix error, fall back to full-decode diff.
+                            let token_text = if let Some(ref mut ds) = decode_stream {
+                                match ds.step(token_id) {
+                                    Ok(Some(text)) => text,
+                                    Ok(None) => String::new(),
+                                    Err(_) => {
+                                        // Stream state is broken — fall back to full decode
+                                        decode_stream = None;
+                                        let full = tokenizer_for_decode
+                                            .decode_sync(&generated_tokens, true)
+                                            .unwrap_or_default();
+                                        let delta = if full.len() > streamed_text_len {
+                                            full[streamed_text_len..].to_string()
+                                        } else {
+                                            String::new()
+                                        };
+                                        delta
+                                    }
+                                }
+                            } else {
+                                // Fallback mode: full-decode diff
+                                let full = tokenizer_for_decode
+                                    .decode_sync(&generated_tokens, true)
+                                    .unwrap_or_default();
+                                let delta = if full.len() > streamed_text_len {
+                                    full[streamed_text_len..].to_string()
+                                } else {
+                                    String::new()
+                                };
+                                delta
+                            };
                             streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -397,6 +397,7 @@ impl Qwen3_5Model {
             self.config.num_layers as usize,
             image_key,
             rope_deltas,
+            self.model_id,
         ))
     }
 
@@ -421,6 +422,11 @@ impl Qwen3_5Model {
                 cache.num_layers(),
                 self.config.num_layers
             )));
+        }
+        if cache.model_id() != self.model_id {
+            return Err(Error::from_reason(
+                "Cache was created by a different model instance (different checkpoint or config)",
+            ));
         }
         let restored_caches = cache.take_caches().ok_or_else(|| {
             Error::from_reason("PromptCache is empty (already consumed or disposed)")

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2011,7 +2011,7 @@ impl Qwen3_5Model {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
-                    let mut decode_stream = Some(tokenizer_for_decode.inner().decode_stream(true));
+                    let mut decode_stream = tokenizer_for_decode.inner().decode_stream(true);
                     let mut streamed_text_len: usize = 0;
 
                     let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
@@ -2277,36 +2277,27 @@ impl Qwen3_5Model {
                             }
 
                             // Use DecodeStream for correct incremental decoding.
-                            // On InvalidPrefix error, fall back to full-decode diff.
-                            let token_text = if let Some(ref mut ds) = decode_stream {
-                                match ds.step(token_id) {
-                                    Ok(Some(text)) => text,
-                                    Ok(None) => String::new(),
-                                    Err(_) => {
-                                        // Stream state is broken — fall back to full decode
-                                        decode_stream = None;
-                                        let full = tokenizer_for_decode
-                                            .decode_sync(&generated_tokens, true)
-                                            .unwrap_or_default();
-                                        let delta = if full.len() > streamed_text_len {
-                                            full[streamed_text_len..].to_string()
-                                        } else {
-                                            String::new()
-                                        };
-                                        delta
+                            // On InvalidPrefix, recreate stream and replay all tokens
+                            // to re-establish correct detokenization state.
+                            let token_text = match decode_stream.step(token_id) {
+                                Ok(Some(text)) => text,
+                                Ok(None) => String::new(),
+                                Err(_) => {
+                                    let mut new_ds = tokenizer_for_decode.inner().decode_stream(true);
+                                    let mut replayed = String::new();
+                                    for &tid in &generated_tokens {
+                                        if let Ok(Some(t)) = new_ds.step(tid) {
+                                            replayed.push_str(&t);
+                                        }
                                     }
+                                    decode_stream = new_ds;
+                                    let delta = if replayed.len() > streamed_text_len {
+                                        replayed[streamed_text_len..].to_string()
+                                    } else {
+                                        String::new()
+                                    };
+                                    delta
                                 }
-                            } else {
-                                // Fallback mode: full-decode diff
-                                let full = tokenizer_for_decode
-                                    .decode_sync(&generated_tokens, true)
-                                    .unwrap_or_default();
-                                let delta = if full.len() > streamed_text_len {
-                                    full[streamed_text_len..].to_string()
-                                } else {
-                                    String::new()
-                                };
-                                delta
                             };
                             streamed_text_len += token_text.len();
                             callback.call(
@@ -2451,36 +2442,27 @@ impl Qwen3_5Model {
                             }
 
                             // Use DecodeStream for correct incremental decoding.
-                            // On InvalidPrefix error, fall back to full-decode diff.
-                            let token_text = if let Some(ref mut ds) = decode_stream {
-                                match ds.step(token_id) {
-                                    Ok(Some(text)) => text,
-                                    Ok(None) => String::new(),
-                                    Err(_) => {
-                                        // Stream state is broken — fall back to full decode
-                                        decode_stream = None;
-                                        let full = tokenizer_for_decode
-                                            .decode_sync(&generated_tokens, true)
-                                            .unwrap_or_default();
-                                        let delta = if full.len() > streamed_text_len {
-                                            full[streamed_text_len..].to_string()
-                                        } else {
-                                            String::new()
-                                        };
-                                        delta
+                            // On InvalidPrefix, recreate stream and replay all tokens
+                            // to re-establish correct detokenization state.
+                            let token_text = match decode_stream.step(token_id) {
+                                Ok(Some(text)) => text,
+                                Ok(None) => String::new(),
+                                Err(_) => {
+                                    let mut new_ds = tokenizer_for_decode.inner().decode_stream(true);
+                                    let mut replayed = String::new();
+                                    for &tid in &generated_tokens {
+                                        if let Ok(Some(t)) = new_ds.step(tid) {
+                                            replayed.push_str(&t);
+                                        }
                                     }
+                                    decode_stream = new_ds;
+                                    let delta = if replayed.len() > streamed_text_len {
+                                        replayed[streamed_text_len..].to_string()
+                                    } else {
+                                        String::new()
+                                    };
+                                    delta
                                 }
-                            } else {
-                                // Fallback mode: full-decode diff
-                                let full = tokenizer_for_decode
-                                    .decode_sync(&generated_tokens, true)
-                                    .unwrap_or_default();
-                                let delta = if full.len() > streamed_text_len {
-                                    full[streamed_text_len..].to_string()
-                                } else {
-                                    String::new()
-                                };
-                                delta
                             };
                             streamed_text_len += token_text.len();
                             callback.call(

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -66,9 +66,9 @@ pub(crate) fn compute_image_cache_key(all_images: &[Vec<u8>]) -> u64 {
 }
 
 /// Monotonically incrementing counter for assigning unique model IDs.
-/// Each Qwen3_5Model instance gets its own ID so the C++ compiled path gate
-/// can verify that the global weight map belongs to the calling model.
-static DENSE_MODEL_ID_COUNTER: AtomicU64 = AtomicU64::new(1); // 0 = no model
+/// Shared by BOTH dense and MoE models — the C++ weight map is shared,
+/// so IDs must be globally unique across all Qwen3.5 model variants.
+pub(crate) static QWEN35_MODEL_ID_COUNTER: AtomicU64 = AtomicU64::new(1); // 0 = no model
 
 /// Process-wide mutex serializing the dense compiled forward lifecycle.
 ///
@@ -318,7 +318,7 @@ impl Qwen3_5Model {
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
-            model_id: DENSE_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            model_id: QWEN35_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
     }
 
@@ -1924,6 +1924,11 @@ impl Qwen3_5Model {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
+                    // Track decoded text length for incremental delta streaming.
+                    // Single-token decode can mis-handle multibyte UTF-8, byte-fallback,
+                    // and whitespace-prefix tokens. Instead, decode the full sequence
+                    // and emit only the new characters each step.
+                    let mut prev_decoded_len: usize = 0;
 
                     let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
                     let generation_stream = Stream::new(DeviceType::Gpu);
@@ -2187,10 +2192,18 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Decode and stream this token
-                            let token_text = tokenizer_for_decode
-                                .decode_sync(&[token_id], true)
+                            // Incremental delta decode: decode the full sequence so far
+                            // and emit only the new characters. This correctly handles
+                            // multibyte UTF-8, byte-fallback, and whitespace-prefix tokens.
+                            let full_text = tokenizer_for_decode
+                                .decode_sync(&generated_tokens, true)
                                 .unwrap_or_default();
+                            let token_text = if full_text.len() > prev_decoded_len {
+                                full_text[prev_decoded_len..].to_string()
+                            } else {
+                                String::new()
+                            };
+                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2332,10 +2345,18 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Decode and stream this token
-                            let token_text = tokenizer_for_decode
-                                .decode_sync(&[token_id], true)
+                            // Incremental delta decode: decode the full sequence so far
+                            // and emit only the new characters. This correctly handles
+                            // multibyte UTF-8, byte-fallback, and whitespace-prefix tokens.
+                            let full_text = tokenizer_for_decode
+                                .decode_sync(&generated_tokens, true)
                                 .unwrap_or_default();
+                            let token_text = if full_text.len() > prev_decoded_len {
+                                full_text[prev_decoded_len..].to_string()
+                            } else {
+                                String::new()
+                            };
+                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -3035,7 +3056,7 @@ impl Qwen3_5Model {
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
-            model_id: DENSE_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            model_id: QWEN35_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
     }
 

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -352,6 +352,15 @@ impl Qwen3_5Model {
     /// Initialize caches for incremental generation.
     #[napi]
     pub fn init_caches(&self) -> Result<()> {
+        let _guard = self.generation_lock.try_lock().map_err(|_| {
+            Error::from_reason("Cannot init caches while generation is in progress")
+        })?;
+        self.init_caches_inner()
+    }
+
+    /// Init caches without checking the generation lock (for internal use
+    /// by generate_for_training_sync which already holds the lock).
+    fn init_caches_inner(&self) -> Result<()> {
         let caches = (0..self.config.num_layers as usize)
             .map(|i| {
                 if self.config.is_linear_layer(i) {
@@ -366,16 +375,7 @@ impl Qwen3_5Model {
             .write()
             .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
         *caches_guard = Some(caches);
-        // Clear reuse state so stale history doesn't cause a false cache hit
-        if let Ok(mut th) = self.cached_token_history.write() {
-            th.clear();
-        }
-        if let Ok(mut ik) = self.cached_image_key.write() {
-            *ik = None;
-        }
-        if let Ok(mut rd) = self.cached_rope_deltas.write() {
-            *rd = None;
-        }
+        self.clear_reuse_state();
         Ok(())
     }
 
@@ -385,6 +385,11 @@ impl Qwen3_5Model {
         let _guard = self.generation_lock.try_lock().map_err(|_| {
             Error::from_reason("Cannot reset caches while generation is in progress")
         })?;
+        self.reset_caches_inner()
+    }
+
+    /// Reset caches without checking the generation lock.
+    fn reset_caches_inner(&self) -> Result<()> {
         let mut caches_guard = self
             .caches
             .write()
@@ -395,15 +400,21 @@ impl Qwen3_5Model {
             }
         }
         *caches_guard = None;
-        // Also clear token history so next chat() does a full prefill
+        self.clear_reuse_state();
+        Ok(())
+    }
+
+    /// Clear cached token history, image key, and rope deltas.
+    fn clear_reuse_state(&self) {
         if let Ok(mut th) = self.cached_token_history.write() {
             th.clear();
         }
-        // Clear cached rope deltas so next VLM prefill recomputes them
+        if let Ok(mut ik) = self.cached_image_key.write() {
+            *ik = None;
+        }
         if let Ok(mut rd) = self.cached_rope_deltas.write() {
             *rd = None;
         }
-        Ok(())
     }
 
     /// Take the KV cache from the model, returning a `PromptCache` handle.
@@ -3466,8 +3477,7 @@ impl Qwen3_5Model {
         };
         let use_compiled = _weight_guard.is_some();
 
-        // Ensure caches exist
-        self.init_caches()?;
+        self.init_caches_inner()?;
 
         // Acquire locks
         let embedding_weight = self.embedding.get_weight();
@@ -3607,9 +3617,9 @@ impl Qwen3_5Model {
             result
         };
 
-        // Drop compiled lock before reset_caches
         drop(compiled_lock);
-        self.reset_caches()?;
+        // Use inner variant — we already hold the generation lock
+        self.reset_caches_inner()?;
 
         Ok(result)
     }

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -70,6 +70,13 @@ pub(crate) fn compute_image_cache_key(all_images: &[Vec<u8>]) -> u64 {
 /// so IDs must be globally unique across all Qwen3.5 model variants.
 pub(crate) static QWEN35_MODEL_ID_COUNTER: AtomicU64 = AtomicU64::new(1); // 0 = no model
 
+/// RwLock protecting the C++ global weight map against concurrent mutation.
+/// Write-locked during weight registration (model load), read-locked during
+/// compiled inference. This prevents a concurrent model load from swapping
+/// weights underneath an in-flight compiled decode, and eliminates the TOCTOU
+/// between has_weight() / get_weight() in linear_proj().
+pub(crate) static COMPILED_WEIGHTS_RWLOCK: std::sync::RwLock<()> = std::sync::RwLock::new(());
+
 /// Process-wide mutex serializing the dense compiled forward lifecycle.
 ///
 /// The C++ compiled decode path uses process-wide globals (`g_compiled_caches`,
@@ -530,6 +537,21 @@ impl Qwen3_5Model {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
+            // Re-validate compiled path under weight lock. The read lock prevents
+            // concurrent model loads from mutating the C++ weight map mid-decode.
+            let mut _weight_guard = None;
+            let use_compiled = if use_compiled {
+                let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
+                if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
+                    _weight_guard = Some(guard);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
             // Acquire all locks ONCE for the entire prefill+decode sequence
             let mut layers_guard = layers_arc
                 .write()
@@ -914,6 +936,20 @@ impl Qwen3_5Model {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
+            // Re-validate compiled path under weight lock.
+            let mut _weight_guard = None;
+            let use_compiled = if use_compiled {
+                let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
+                if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
+                    _weight_guard = Some(guard);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
             let mut first_token_instant: Option<std::time::Instant> = None;
 
             let tool_defs = config.tools.as_deref();
@@ -1117,7 +1153,7 @@ impl Qwen3_5Model {
                         let input_ids =
                             MxArray::from_uint32(final_tokens, &[1, final_tokens.len() as i64])?;
 
-                        let (logits, rope_deltas) = vlm_prefill(
+                        let (logits, rope_deltas, vlm_compiled) = vlm_prefill(
                             &input_ids,
                             image_cache_key,
                             processed,
@@ -1141,7 +1177,7 @@ impl Qwen3_5Model {
                         }
 
                         let vlm_seq_len = final_tokens.len() as i64;
-                        (logits, vlm_seq_len, use_compiled)
+                        (logits, vlm_seq_len, vlm_compiled)
                     } else {
                         return Err(Error::from_reason(
                             "VLM prefill requested but vision encoder/processor not loaded",
@@ -1752,6 +1788,20 @@ impl Qwen3_5Model {
             let callback_err = callback.clone();
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
+                    // Re-validate compiled path under weight lock.
+                    let mut _weight_guard = None;
+                    let use_compiled = if use_compiled {
+                        let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
+                        if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
+                            _weight_guard = Some(guard);
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
+
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = config.enable_thinking;
                     let tokens = tokenizer.apply_chat_template_sync(
@@ -1963,7 +2013,7 @@ impl Qwen3_5Model {
                                     &[1, final_tokens.len() as i64],
                                 )?;
 
-                                let (logits, rope_deltas) = vlm_prefill(
+                                let (logits, rope_deltas, vlm_compiled) = vlm_prefill(
                                     &input_ids,
                                     image_cache_key,
                                     processed,
@@ -1987,7 +2037,7 @@ impl Qwen3_5Model {
                                 }
 
                                 let vlm_seq_len = final_tokens.len() as i64;
-                                (logits, vlm_seq_len, use_compiled)
+                                (logits, vlm_seq_len, vlm_compiled)
                             } else {
                                 return Err(Error::from_reason(
                                     "VLM prefill requested but vision encoder/processor not loaded",
@@ -3354,6 +3404,21 @@ impl Qwen3_5Model {
         };
         let use_compiled = compiled_lock.is_some();
 
+        // Acquire weight read lock to prevent concurrent model loads from
+        // swapping weights during compiled decode. Re-validate model ID under lock.
+        let mut _weight_guard = None;
+        let use_compiled = if use_compiled {
+            let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
+            if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
+                _weight_guard = Some(guard);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
         // Ensure caches exist
         self.init_caches()?;
 
@@ -3826,7 +3891,7 @@ fn vlm_prefill(
     generation_stream: Stream,
     vision_cache: &VisionCache,
     model_id: u64,
-) -> Result<(MxArray, i64)> {
+) -> Result<(MxArray, i64, bool)> {
     use crate::array::clear_cache;
 
     let (inputs_embeds, position_ids, rope_deltas) = vlm_prepare_vision_features(
@@ -3843,7 +3908,7 @@ fn vlm_prefill(
     // === STEP 4: Prefill with M-RoPE ===
     let use_compiled = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
-    let (last_logits, _seq_len) = if use_compiled {
+    let (last_logits, _seq_len, compiled_init_done) = if use_compiled {
         // C++ VLM prefill: runs all layers in one FFI call with M-RoPE
         use mlx_sys as sys;
 
@@ -3942,7 +4007,7 @@ fn vlm_prefill(
 
         let logits = MxArray::from_handle(output_ptr, "vlm_cpp_prefill")?;
         // logits is already [1, vocab] from C++ prefill
-        (logits, seq_len_i32 as i64)
+        (logits, seq_len_i32 as i64, true) // compiled init done
     } else {
         // Rust fallback prefill (when C++ weights not loaded, e.g. test models)
         // Init fresh caches
@@ -4001,10 +4066,10 @@ fn vlm_prefill(
         let seq_len = logits.shape_at(1)?;
         let last_logits = logits.slice_axis(1, seq_len - 1, seq_len)?;
         let last_logits = last_logits.squeeze(Some(&[1]))?;
-        (last_logits, seq_len)
+        (last_logits, seq_len, false) // compiled init NOT done
     };
 
-    Ok((last_logits, rope_deltas))
+    Ok((last_logits, rope_deltas, compiled_init_done))
 }
 
 /// Shared VLM prefill steps 1-3: vision cache lookup, vision encoder,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -444,9 +444,10 @@ impl Qwen3_5Model {
         &self,
         cache: &mut crate::models::qwen3_5::prompt_cache::PromptCache,
     ) -> Result<()> {
-        let _guard = self.generation_lock.try_lock().map_err(|_| {
-            Error::from_reason("Cannot set cache while generation is in progress")
-        })?;
+        let _guard = self
+            .generation_lock
+            .try_lock()
+            .map_err(|_| Error::from_reason("Cannot set cache while generation is in progress"))?;
         if cache.model_type() != "qwen3_5" {
             return Err(Error::from_reason(format!(
                 "Cache type '{}' doesn't match model type 'qwen3_5'",
@@ -584,7 +585,11 @@ impl Qwen3_5Model {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
-            let _weight_guard = if use_compiled { acquire_compiled_weight_guard(model_id) } else { None };
+            let _weight_guard = if use_compiled {
+                acquire_compiled_weight_guard(model_id)
+            } else {
+                None
+            };
             let use_compiled = _weight_guard.is_some();
 
             // Acquire all locks ONCE for the entire prefill+decode sequence
@@ -1131,7 +1136,8 @@ impl Qwen3_5Model {
             // Zero-delta guard: if entire prompt was cached (exact same input repeated),
             // reset caches and do a full re-prefill. GDN recurrence state cannot be
             // rewound, so full re-prefill is the only correct approach for Qwen3.5.
-            let prefill_tokens = if prefill_tokens.is_empty() {
+            // Also reset cached_prefix_len so VLM routing correctly triggers vlm_prefill.
+            let (prefill_tokens, cached_prefix_len) = if prefill_tokens.is_empty() {
                 info!("Zero-delta cache hit: resetting caches for full re-prefill");
                 if let Some(ref mut caches) = *caches_guard {
                     for cache in caches.iter_mut() {
@@ -1148,13 +1154,14 @@ impl Qwen3_5Model {
                     })
                     .collect();
                 *caches_guard = Some(new_caches);
-                if has_images {
+                let tokens = if has_images {
                     expanded_tokens.clone()
                 } else {
                     tokens.clone()
-                }
+                };
+                (tokens, 0)
             } else {
-                prefill_tokens
+                (prefill_tokens, cached_prefix_len)
             };
 
             let eos_id = model_config.eos_token_id as u32;
@@ -1867,7 +1874,6 @@ impl Qwen3_5Model {
                         min_p: config.min_p,
                     });
 
-
                     let mut layers_guard = layers_arc
                         .write()
                         .map_err(|_| Error::from_reason("Failed to acquire layers write lock"))?;
@@ -1981,8 +1987,8 @@ impl Qwen3_5Model {
                         tokens.clone()
                     };
 
-                    // Zero-delta guard: if entire prompt was cached, reset and re-prefill.
-                    let prefill_tokens = if prefill_tokens.is_empty() {
+                    // Zero-delta guard: also reset cached_prefix_len for VLM routing.
+                    let (prefill_tokens, cached_prefix_len) = if prefill_tokens.is_empty() {
                         info!("Zero-delta cache hit: resetting caches for full re-prefill");
                         if let Some(ref mut caches) = *caches_guard {
                             for cache in caches.iter_mut() {
@@ -1999,13 +2005,14 @@ impl Qwen3_5Model {
                             })
                             .collect();
                         *caches_guard = Some(new_caches);
-                        if has_images {
+                        let tokens = if has_images {
                             expanded_tokens.clone()
                         } else {
                             tokens.clone()
-                        }
+                        };
+                        (tokens, 0)
                     } else {
-                        prefill_tokens
+                        (prefill_tokens, cached_prefix_len)
                     };
 
                     let eos_id = model_config.eos_token_id as u32;
@@ -2276,29 +2283,13 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Use DecodeStream for correct incremental decoding.
-                            // On InvalidPrefix, recreate stream and replay all tokens
-                            // to re-establish correct detokenization state.
-                            let token_text = match decode_stream.step(token_id) {
-                                Ok(Some(text)) => text,
-                                Ok(None) => String::new(),
-                                Err(_) => {
-                                    let mut new_ds = tokenizer_for_decode.inner().decode_stream(true);
-                                    let mut replayed = String::new();
-                                    for &tid in &generated_tokens {
-                                        if let Ok(Some(t)) = new_ds.step(tid) {
-                                            replayed.push_str(&t);
-                                        }
-                                    }
-                                    decode_stream = new_ds;
-                                    let delta = if replayed.len() > streamed_text_len {
-                                        replayed[streamed_text_len..].to_string()
-                                    } else {
-                                        String::new()
-                                    };
-                                    delta
-                                }
-                            };
+                            let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
+                                &mut decode_stream,
+                                tokenizer_for_decode.inner(),
+                                token_id,
+                                &generated_tokens,
+                                streamed_text_len,
+                            );
                             streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
@@ -2441,29 +2432,13 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Use DecodeStream for correct incremental decoding.
-                            // On InvalidPrefix, recreate stream and replay all tokens
-                            // to re-establish correct detokenization state.
-                            let token_text = match decode_stream.step(token_id) {
-                                Ok(Some(text)) => text,
-                                Ok(None) => String::new(),
-                                Err(_) => {
-                                    let mut new_ds = tokenizer_for_decode.inner().decode_stream(true);
-                                    let mut replayed = String::new();
-                                    for &tid in &generated_tokens {
-                                        if let Ok(Some(t)) = new_ds.step(tid) {
-                                            replayed.push_str(&t);
-                                        }
-                                    }
-                                    decode_stream = new_ds;
-                                    let delta = if replayed.len() > streamed_text_len {
-                                        replayed[streamed_text_len..].to_string()
-                                    } else {
-                                        String::new()
-                                    };
-                                    delta
-                                }
-                            };
+                            let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
+                                &mut decode_stream,
+                                tokenizer_for_decode.inner(),
+                                token_id,
+                                &generated_tokens,
+                                streamed_text_len,
+                            );
                             streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
@@ -3484,7 +3459,11 @@ impl Qwen3_5Model {
         };
         let use_compiled = compiled_lock.is_some();
 
-        let _weight_guard = if use_compiled { acquire_compiled_weight_guard(model_id) } else { None };
+        let _weight_guard = if use_compiled {
+            acquire_compiled_weight_guard(model_id)
+        } else {
+            None
+        };
         let use_compiled = _weight_guard.is_some();
 
         // Ensure caches exist

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2001,7 +2001,9 @@ impl Qwen3_5Model {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
-                    let mut prev_decoded_len: usize = 0;
+                    // Use the HF tokenizer's incremental DecodeStream for correct
+                    // streaming with ByteLevel BPE decoders.
+                    let mut decode_stream = tokenizer_for_decode.inner().decode_stream(true);
 
                     let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
                     let generation_stream = Stream::new(DeviceType::Gpu);
@@ -2265,17 +2267,11 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Decode full sequence and emit delta. ByteLevel BPE
-                            // decoders need full context for correct output.
-                            let full_text = tokenizer_for_decode
-                                .decode_sync(&generated_tokens, true)
+                            let token_text = decode_stream
+                                .step(token_id)
+                                .ok()
+                                .flatten()
                                 .unwrap_or_default();
-                            let token_text = if full_text.len() > prev_decoded_len {
-                                full_text[prev_decoded_len..].to_string()
-                            } else {
-                                String::new()
-                            };
-                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2417,17 +2413,11 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Decode full sequence and emit delta. ByteLevel BPE
-                            // decoders need full context for correct output.
-                            let full_text = tokenizer_for_decode
-                                .decode_sync(&generated_tokens, true)
+                            let token_text = decode_stream
+                                .step(token_id)
+                                .ok()
+                                .flatten()
                                 .unwrap_or_default();
-                            let token_text = if full_text.len() > prev_decoded_len {
-                                full_text[prev_decoded_len..].to_string()
-                            } else {
-                                String::new()
-                            };
-                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use futures::TryFutureExt;
@@ -64,6 +64,11 @@ pub(crate) fn compute_image_cache_key(all_images: &[Vec<u8>]) -> u64 {
     let individual_hashes: Vec<u64> = all_images.iter().map(|img| hash_image_bytes(img)).collect();
     combine_image_hashes(&individual_hashes)
 }
+
+/// Monotonically incrementing counter for assigning unique model IDs.
+/// Each Qwen3_5Model instance gets its own ID so the C++ compiled path gate
+/// can verify that the global weight map belongs to the calling model.
+static DENSE_MODEL_ID_COUNTER: AtomicU64 = AtomicU64::new(1); // 0 = no model
 
 /// Process-wide mutex serializing the dense compiled forward lifecycle.
 ///
@@ -255,6 +260,10 @@ pub struct Qwen3_5Model {
     /// Without this, the compiled decode path starts with wrong RoPE positions
     /// when VLM prefill is skipped on Turn 2+.
     cached_rope_deltas: Arc<RwLock<Option<i32>>>,
+    /// Unique model instance ID for compiled path ownership.
+    /// The C++ global weight map is shared across all models — this ID ensures
+    /// inference only uses the compiled path when the weights belong to this model.
+    pub(crate) model_id: u64,
 }
 
 #[napi]
@@ -309,6 +318,7 @@ impl Qwen3_5Model {
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
+            model_id: DENSE_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
     }
 
@@ -506,10 +516,11 @@ impl Qwen3_5Model {
         let tokenizer = self.tokenizer.clone();
 
         let prompt_tokens = prompt_tokens.clone();
+        let model_id = self.model_id;
 
-        // Check if compiled path will be used (C++ weights loaded from safetensors).
+        // Check if compiled path will be used (C++ weights belong to this model).
         // Must be checked before spawn_blocking so we can acquire the mutex in async context.
-        let use_compiled = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+        let use_compiled = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
         // Serialize compiled lifecycle — prevents concurrent C++ global corruption
         let _compiled_lock = if use_compiled {
@@ -880,9 +891,10 @@ impl Qwen3_5Model {
         };
         let spatial_merge_size = self.spatial_merge_size;
         let vision_cache = self.vision_cache.clone();
+        let model_id = self.model_id;
 
-        // Check if compiled path will be used (C++ weights loaded from safetensors).
-        let use_compiled = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+        // Check if compiled path will be used (C++ weights belong to this model).
+        let use_compiled = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
         // Capture start time BEFORE compiled mutex + spawn_blocking so TTFT
         // reflects the full user-perceived latency (mutex wait + thread dispatch
@@ -1044,6 +1056,35 @@ impl Qwen3_5Model {
                 tokens.clone()
             };
 
+            // Zero-delta guard: if entire prompt was cached (exact same input repeated),
+            // reset caches and do a full re-prefill. GDN recurrence state cannot be
+            // rewound, so full re-prefill is the only correct approach for Qwen3.5.
+            let prefill_tokens = if prefill_tokens.is_empty() {
+                info!("Zero-delta cache hit: resetting caches for full re-prefill");
+                if let Some(ref mut caches) = *caches_guard {
+                    for cache in caches.iter_mut() {
+                        cache.reset();
+                    }
+                }
+                let new_caches = (0..model_config.num_layers as usize)
+                    .map(|i| {
+                        if model_config.is_linear_layer(i) {
+                            Qwen3_5LayerCache::new_linear()
+                        } else {
+                            Qwen3_5LayerCache::new_full_attention()
+                        }
+                    })
+                    .collect();
+                *caches_guard = Some(new_caches);
+                if has_images {
+                    expanded_tokens.clone()
+                } else {
+                    tokens.clone()
+                }
+            } else {
+                prefill_tokens
+            };
+
             let eos_id = model_config.eos_token_id as u32;
             let mut generated_tokens: Vec<u32> = Vec::new();
             let mut finish_reason = String::from("length");
@@ -1091,6 +1132,7 @@ impl Qwen3_5Model {
                             max_new_tokens,
                             generation_stream,
                             &vision_cache,
+                            model_id,
                         )?;
 
                         // Save rope_deltas for cache reuse on subsequent turns
@@ -1677,9 +1719,10 @@ impl Qwen3_5Model {
         };
         let spatial_merge_size = self.spatial_merge_size;
         let vision_cache_stream = self.vision_cache.clone();
+        let model_id = self.model_id;
 
-        // Check if compiled path will be used (C++ weights loaded from safetensors).
-        let use_compiled = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+        // Check if compiled path will be used (C++ weights belong to this model).
+        let use_compiled = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
         // Capture start time BEFORE compiled mutex + spawn_blocking so TTFT
         // reflects the full user-perceived latency.
@@ -1851,6 +1894,33 @@ impl Qwen3_5Model {
                         tokens.clone()
                     };
 
+                    // Zero-delta guard: if entire prompt was cached, reset and re-prefill.
+                    let prefill_tokens = if prefill_tokens.is_empty() {
+                        info!("Zero-delta cache hit: resetting caches for full re-prefill");
+                        if let Some(ref mut caches) = *caches_guard {
+                            for cache in caches.iter_mut() {
+                                cache.reset();
+                            }
+                        }
+                        let new_caches = (0..model_config.num_layers as usize)
+                            .map(|i| {
+                                if model_config.is_linear_layer(i) {
+                                    Qwen3_5LayerCache::new_linear()
+                                } else {
+                                    Qwen3_5LayerCache::new_full_attention()
+                                }
+                            })
+                            .collect();
+                        *caches_guard = Some(new_caches);
+                        if has_images {
+                            expanded_tokens.clone()
+                        } else {
+                            tokens.clone()
+                        }
+                    } else {
+                        prefill_tokens
+                    };
+
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
@@ -1903,6 +1973,7 @@ impl Qwen3_5Model {
                                     max_new_tokens,
                                     generation_stream,
                                     &vision_cache_stream,
+                                    model_id,
                                 )?;
 
                                 // Save rope_deltas for cache reuse on subsequent turns
@@ -2964,6 +3035,7 @@ impl Qwen3_5Model {
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
+            model_id: DENSE_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
     }
 
@@ -3247,9 +3319,10 @@ impl Qwen3_5Model {
     ) -> Result<GenerationResult> {
         let config = config.unwrap_or_default();
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
+        let model_id = self.model_id;
 
-        // Check if compiled path is available (C++ weights loaded from safetensors)
-        let use_compiled = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+        // Check if compiled path is available (C++ weights belong to this model)
+        let use_compiled = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
         // Try to acquire compiled mutex (non-blocking, safe from sync context).
         // If locked (concurrent generate() call), fall back to Rust path.
@@ -3731,6 +3804,7 @@ fn vlm_prefill(
     max_new_tokens: i32,
     generation_stream: Stream,
     vision_cache: &VisionCache,
+    model_id: u64,
 ) -> Result<(MxArray, i64)> {
     use crate::array::clear_cache;
 
@@ -3746,7 +3820,7 @@ fn vlm_prefill(
     )?;
 
     // === STEP 4: Prefill with M-RoPE ===
-    let use_compiled = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+    let use_compiled = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
     let (last_logits, _seq_len) = if use_compiled {
         // C++ VLM prefill: runs all layers in one FFI call with M-RoPE

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -900,6 +900,7 @@ impl Qwen3_5Model {
         let reuse_cache = config.reuse_cache.unwrap_or(true);
 
         let gen_lock = self.generation_lock.clone();
+        let _gen_guard = gen_lock.lock().await;
 
         let tokenizer = self
             .tokenizer
@@ -1003,11 +1004,6 @@ impl Qwen3_5Model {
                 top_p: config.top_p,
                 min_p: config.min_p,
             });
-
-            // Acquire generation lock AFTER tokenization (which is pure CPU work
-            // that doesn't need cache protection). blocking_lock() is safe here
-            // since we're inside spawn_blocking.
-            let _gen_guard = gen_lock.blocking_lock();
 
             let mut layers_guard = layers_arc
                 .write()
@@ -1746,15 +1742,14 @@ impl Qwen3_5Model {
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 
-        let gen_lock = self.generation_lock.clone();
+        // Use lock_owned() so the guard is 'static and can be moved into tokio::spawn.
+        let gen_guard = Arc::clone(&self.generation_lock).lock_owned().await;
 
-        // Tokenize messages using chat template
         let tokenizer = self
             .tokenizer
             .clone()
             .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?;
 
-        // Detect images in messages
         let has_images = messages
             .iter()
             .any(|m| m.images.as_ref().is_some_and(|imgs| !imgs.is_empty()));
@@ -1814,6 +1809,7 @@ impl Qwen3_5Model {
         let callback = Arc::new(callback);
 
         tokio::spawn(async move {
+            let _gen_guard = gen_guard;
             let _compiled_lock = compiled_lock;
 
             let callback_err = callback.clone();
@@ -1861,7 +1857,6 @@ impl Qwen3_5Model {
                         min_p: config.min_p,
                     });
 
-                    let _gen_guard = gen_lock.blocking_lock();
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -2006,6 +2001,7 @@ impl Qwen3_5Model {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
+                    let mut prev_decoded_len: usize = 0;
 
                     let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
                     let generation_stream = Stream::new(DeviceType::Gpu);
@@ -2269,30 +2265,17 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Incremental delta decode: decode a bounded tail of the
-                            // sequence and diff against the previous decode. Avoids O(n²)
-                            // total cost for long generations while correctly handling
-                            // multibyte UTF-8 and byte-fallback tokens.
-                            let token_text = {
-                                const TAIL: usize = 64;
-                                let n = generated_tokens.len();
-                                let start = n.saturating_sub(TAIL);
-                                let cur = tokenizer_for_decode
-                                    .decode_sync(&generated_tokens[start..], true)
-                                    .unwrap_or_default();
-                                let prev = if n > 1 {
-                                    tokenizer_for_decode
-                                        .decode_sync(&generated_tokens[start..n - 1], true)
-                                        .unwrap_or_default()
-                                } else {
-                                    String::new()
-                                };
-                                if cur.len() > prev.len() {
-                                    cur[prev.len()..].to_string()
-                                } else {
-                                    String::new()
-                                }
+                            // Decode full sequence and emit delta. ByteLevel BPE
+                            // decoders need full context for correct output.
+                            let full_text = tokenizer_for_decode
+                                .decode_sync(&generated_tokens, true)
+                                .unwrap_or_default();
+                            let token_text = if full_text.len() > prev_decoded_len {
+                                full_text[prev_decoded_len..].to_string()
+                            } else {
+                                String::new()
                             };
+                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2434,30 +2417,17 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Incremental delta decode: decode a bounded tail of the
-                            // sequence and diff against the previous decode. Avoids O(n²)
-                            // total cost for long generations while correctly handling
-                            // multibyte UTF-8 and byte-fallback tokens.
-                            let token_text = {
-                                const TAIL: usize = 64;
-                                let n = generated_tokens.len();
-                                let start = n.saturating_sub(TAIL);
-                                let cur = tokenizer_for_decode
-                                    .decode_sync(&generated_tokens[start..], true)
-                                    .unwrap_or_default();
-                                let prev = if n > 1 {
-                                    tokenizer_for_decode
-                                        .decode_sync(&generated_tokens[start..n - 1], true)
-                                        .unwrap_or_default()
-                                } else {
-                                    String::new()
-                                };
-                                if cur.len() > prev.len() {
-                                    cur[prev.len()..].to_string()
-                                } else {
-                                    String::new()
-                                }
+                            // Decode full sequence and emit delta. ByteLevel BPE
+                            // decoders need full context for correct output.
+                            let full_text = tokenizer_for_decode
+                                .decode_sync(&generated_tokens, true)
+                                .unwrap_or_default();
+                            let token_text = if full_text.len() > prev_decoded_len {
+                                full_text[prev_decoded_len..].to_string()
+                            } else {
+                                String::new()
                             };
+                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -271,6 +271,10 @@ pub struct Qwen3_5Model {
     /// The C++ global weight map is shared across all models — this ID ensures
     /// inference only uses the compiled path when the weights belong to this model.
     pub(crate) model_id: u64,
+    /// Serializes cache state access: held during the entire chat()/chatStream()/generate()
+    /// lifecycle. Cache API methods (reset_caches, take_cache, set_cache) use try_lock
+    /// and return an error if generation is in-flight.
+    generation_lock: Arc<TokioMutex<()>>,
 }
 
 #[napi]
@@ -326,6 +330,7 @@ impl Qwen3_5Model {
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
             model_id: QWEN35_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            generation_lock: Arc::new(TokioMutex::new(())),
         })
     }
 
@@ -352,6 +357,9 @@ impl Qwen3_5Model {
     /// Reset all caches.
     #[napi]
     pub fn reset_caches(&self) -> Result<()> {
+        let _guard = self.generation_lock.try_lock().map_err(|_| {
+            Error::from_reason("Cannot reset caches while generation is in progress")
+        })?;
         let mut caches_guard = self
             .caches
             .write()
@@ -380,6 +388,7 @@ impl Qwen3_5Model {
     /// before the next `chat()` call for incremental prefill.
     #[napi]
     pub fn take_cache(&self) -> Option<crate::models::qwen3_5::prompt_cache::PromptCache> {
+        let _guard = self.generation_lock.try_lock().ok()?;
         let mut caches_guard = self.caches.write().ok()?;
         let token_history_guard = self.cached_token_history.read().ok()?;
         let caches = caches_guard.take()?;
@@ -410,6 +419,9 @@ impl Qwen3_5Model {
         &self,
         cache: &mut crate::models::qwen3_5::prompt_cache::PromptCache,
     ) -> Result<()> {
+        let _guard = self.generation_lock.try_lock().map_err(|_| {
+            Error::from_reason("Cannot set cache while generation is in progress")
+        })?;
         if cache.model_type() != "qwen3_5" {
             return Err(Error::from_reason(format!(
                 "Cache type '{}' doesn't match model type 'qwen3_5'",
@@ -518,6 +530,10 @@ impl Qwen3_5Model {
                 batch_size
             )));
         }
+
+        // Hold generation lock for the entire cache-read + generation + cache-write lifecycle.
+        let gen_lock = self.generation_lock.clone();
+        let _gen_guard = gen_lock.lock().await;
 
         // Clone Arcs and data needed for the closure
         let embedding_weight = self.embedding.get_weight();
@@ -879,6 +895,10 @@ impl Qwen3_5Model {
         });
 
         let reuse_cache = config.reuse_cache.unwrap_or(true);
+
+        // Hold generation lock for the entire lifecycle.
+        let gen_lock = self.generation_lock.clone();
+        let _gen_guard = gen_lock.lock().await;
 
         // Tokenize messages using chat template
         let tokenizer = self
@@ -1722,6 +1742,10 @@ impl Qwen3_5Model {
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 
+        // Hold generation lock for the entire lifecycle.
+        // Use lock_owned() so the guard is 'static and can be moved into tokio::spawn.
+        let gen_guard = Arc::clone(&self.generation_lock).lock_owned().await;
+
         // Tokenize messages using chat template
         let tokenizer = self
             .tokenizer
@@ -1788,7 +1812,8 @@ impl Qwen3_5Model {
         let callback = Arc::new(callback);
 
         tokio::spawn(async move {
-            // Hold the compiled lock for the duration of generation
+            // Hold both locks for the duration of generation
+            let _gen_guard = gen_guard;
             let _compiled_lock = compiled_lock;
 
             let callback_err = callback.clone();
@@ -3113,6 +3138,7 @@ impl Qwen3_5Model {
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
             model_id: QWEN35_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            generation_lock: Arc::new(TokioMutex::new(())),
         })
     }
 
@@ -3397,6 +3423,9 @@ impl Qwen3_5Model {
         let config = config.unwrap_or_default();
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
         let model_id = self.model_id;
+
+        // Hold generation lock (blocking — called from spawn_blocking context).
+        let _gen_guard = self.generation_lock.blocking_lock();
 
         // Check if compiled path is available (C++ weights belong to this model)
         let use_compiled = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -899,11 +899,8 @@ impl Qwen3_5Model {
 
         let reuse_cache = config.reuse_cache.unwrap_or(true);
 
-        // Hold generation lock for the entire lifecycle.
         let gen_lock = self.generation_lock.clone();
-        let _gen_guard = gen_lock.lock().await;
 
-        // Tokenize messages using chat template
         let tokenizer = self
             .tokenizer
             .clone()
@@ -1002,12 +999,16 @@ impl Qwen3_5Model {
             let ngram_size = config.ngram_size.unwrap_or(64);
             let sampling_config = Some(SamplingConfig {
                 temperature: config.temperature,
-                top_k: config.top_k, // Qwen3.5 recommends top_k=20
+                top_k: config.top_k,
                 top_p: config.top_p,
                 min_p: config.min_p,
             });
 
-            // Acquire all locks ONCE for the entire prefill+decode sequence
+            // Acquire generation lock AFTER tokenization (which is pure CPU work
+            // that doesn't need cache protection). blocking_lock() is safe here
+            // since we're inside spawn_blocking.
+            let _gen_guard = gen_lock.blocking_lock();
+
             let mut layers_guard = layers_arc
                 .write()
                 .map_err(|_| Error::from_reason("Failed to acquire layers write lock"))?;
@@ -1745,9 +1746,7 @@ impl Qwen3_5Model {
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 
-        // Hold generation lock for the entire lifecycle.
-        // Use lock_owned() so the guard is 'static and can be moved into tokio::spawn.
-        let gen_guard = Arc::clone(&self.generation_lock).lock_owned().await;
+        let gen_lock = self.generation_lock.clone();
 
         // Tokenize messages using chat template
         let tokenizer = self
@@ -1815,8 +1814,6 @@ impl Qwen3_5Model {
         let callback = Arc::new(callback);
 
         tokio::spawn(async move {
-            // Hold both locks for the duration of generation
-            let _gen_guard = gen_guard;
             let _compiled_lock = compiled_lock;
 
             let callback_err = callback.clone();
@@ -1864,7 +1861,8 @@ impl Qwen3_5Model {
                         min_p: config.min_p,
                     });
 
-                    // Acquire all locks ONCE for the entire prefill+decode sequence
+                    let _gen_guard = gen_lock.blocking_lock();
+
                     let mut layers_guard = layers_arc
                         .write()
                         .map_err(|_| Error::from_reason("Failed to acquire layers write lock"))?;
@@ -2008,11 +2006,6 @@ impl Qwen3_5Model {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
-                    // Track decoded text length for incremental delta streaming.
-                    // Single-token decode can mis-handle multibyte UTF-8, byte-fallback,
-                    // and whitespace-prefix tokens. Instead, decode the full sequence
-                    // and emit only the new characters each step.
-                    let mut prev_decoded_len: usize = 0;
 
                     let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
                     let generation_stream = Stream::new(DeviceType::Gpu);
@@ -2276,18 +2269,30 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Incremental delta decode: decode the full sequence so far
-                            // and emit only the new characters. This correctly handles
-                            // multibyte UTF-8, byte-fallback, and whitespace-prefix tokens.
-                            let full_text = tokenizer_for_decode
-                                .decode_sync(&generated_tokens, true)
-                                .unwrap_or_default();
-                            let token_text = if full_text.len() > prev_decoded_len {
-                                full_text[prev_decoded_len..].to_string()
-                            } else {
-                                String::new()
+                            // Incremental delta decode: decode a bounded tail of the
+                            // sequence and diff against the previous decode. Avoids O(n²)
+                            // total cost for long generations while correctly handling
+                            // multibyte UTF-8 and byte-fallback tokens.
+                            let token_text = {
+                                const TAIL: usize = 64;
+                                let n = generated_tokens.len();
+                                let start = n.saturating_sub(TAIL);
+                                let cur = tokenizer_for_decode
+                                    .decode_sync(&generated_tokens[start..], true)
+                                    .unwrap_or_default();
+                                let prev = if n > 1 {
+                                    tokenizer_for_decode
+                                        .decode_sync(&generated_tokens[start..n - 1], true)
+                                        .unwrap_or_default()
+                                } else {
+                                    String::new()
+                                };
+                                if cur.len() > prev.len() {
+                                    cur[prev.len()..].to_string()
+                                } else {
+                                    String::new()
+                                }
                             };
-                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2429,18 +2434,30 @@ impl Qwen3_5Model {
                                 break;
                             }
 
-                            // Incremental delta decode: decode the full sequence so far
-                            // and emit only the new characters. This correctly handles
-                            // multibyte UTF-8, byte-fallback, and whitespace-prefix tokens.
-                            let full_text = tokenizer_for_decode
-                                .decode_sync(&generated_tokens, true)
-                                .unwrap_or_default();
-                            let token_text = if full_text.len() > prev_decoded_len {
-                                full_text[prev_decoded_len..].to_string()
-                            } else {
-                                String::new()
+                            // Incremental delta decode: decode a bounded tail of the
+                            // sequence and diff against the previous decode. Avoids O(n²)
+                            // total cost for long generations while correctly handling
+                            // multibyte UTF-8 and byte-fallback tokens.
+                            let token_text = {
+                                const TAIL: usize = 64;
+                                let n = generated_tokens.len();
+                                let start = n.saturating_sub(TAIL);
+                                let cur = tokenizer_for_decode
+                                    .decode_sync(&generated_tokens[start..], true)
+                                    .unwrap_or_default();
+                                let prev = if n > 1 {
+                                    tokenizer_for_decode
+                                        .decode_sync(&generated_tokens[start..n - 1], true)
+                                        .unwrap_or_default()
+                                } else {
+                                    String::new()
+                                };
+                                if cur.len() > prev.len() {
+                                    cur[prev.len()..].to_string()
+                                } else {
+                                    String::new()
+                                }
                             };
-                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -955,6 +955,7 @@ pub async fn load(model_path: &str) -> Result<Qwen3_5Model> {
             info!("Skipping C++ compiled path for quantized model (using Rust quantized_matmul)");
             // Clear stale weights so a previously-loaded non-quantized model's weights
             // don't trick this model into the compiled path via weight_count > 0.
+            let _guard = super::model::COMPILED_WEIGHTS_RWLOCK.write().unwrap();
             unsafe { mlx_sys::mlx_qwen35_clear_weights() };
         }
 
@@ -1012,6 +1013,11 @@ pub async fn load(model_path: &str) -> Result<Qwen3_5Model> {
 /// a partially-populated weight map with the new model's ID.
 fn register_weights_with_cpp(params: &HashMap<String, MxArray>, model_id: u64) {
     use mlx_sys as sys;
+
+    // Write-lock the weight RwLock for the entire registration.
+    // This blocks any in-flight compiled inference from reading weights
+    // until registration is complete and model_id is set.
+    let _guard = super::model::COMPILED_WEIGHTS_RWLOCK.write().unwrap();
 
     unsafe { sys::mlx_qwen35_clear_weights() };
 

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -950,9 +950,12 @@ pub async fn load(model_path: &str) -> Result<Qwen3_5Model> {
         // Register weights with C++ compiled forward pass (dense-only).
         // Skip for quantized models — C++ path uses dense matmul, not quantized_matmul.
         if !is_quantized_checkpoint(&params) && !is_mxfp8_checkpoint(&params) {
-            register_weights_with_cpp(&params);
+            register_weights_with_cpp(&params, model.model_id);
         } else {
             info!("Skipping C++ compiled path for quantized model (using Rust quantized_matmul)");
+            // Clear stale weights so a previously-loaded non-quantized model's weights
+            // don't trick this model into the compiled path via weight_count > 0.
+            unsafe { mlx_sys::mlx_qwen35_clear_weights() };
         }
 
         // Materialize all mmap-backed weight arrays so the first inference
@@ -1005,7 +1008,9 @@ pub async fn load(model_path: &str) -> Result<Qwen3_5Model> {
 }
 
 /// Register all sanitized weights with the C++ fused forward pass.
-fn register_weights_with_cpp(params: &HashMap<String, MxArray>) {
+/// Sets model_id AFTER all weights are stored — ensures no inference sees
+/// a partially-populated weight map with the new model's ID.
+fn register_weights_with_cpp(params: &HashMap<String, MxArray>, model_id: u64) {
     use mlx_sys as sys;
 
     unsafe { sys::mlx_qwen35_clear_weights() };
@@ -1061,6 +1066,10 @@ fn register_weights_with_cpp(params: &HashMap<String, MxArray>) {
 
     let count = unsafe { sys::mlx_qwen35_weight_count() };
     info!("Registered {} weights with C++ fused forward pass", count);
+
+    // Set model ID AFTER all weights are stored. This ordering ensures no
+    // inference sees a partially-populated map with the new model's ID.
+    unsafe { sys::mlx_qwen35_set_model_id(model_id) };
 }
 
 /// Parse Qwen3.5 dense config from JSON.

--- a/crates/mlx-core/src/models/qwen3_5/prompt_cache.rs
+++ b/crates/mlx-core/src/models/qwen3_5/prompt_cache.rs
@@ -24,6 +24,9 @@ pub struct PromptCache {
     pub(crate) image_cache_key: Option<u64>,
     /// Rope deltas from VLM prefill (None for text-only)
     pub(crate) rope_deltas: Option<i32>,
+    /// Model instance ID — prevents restoring cache into a different checkpoint.
+    /// Each Qwen3_5Model/MoeModel instance gets a unique ID from a shared counter.
+    pub(crate) model_id: u64,
 }
 
 #[napi]
@@ -59,6 +62,7 @@ impl PromptCache {
         num_layers: usize,
         image_cache_key: Option<u64>,
         rope_deltas: Option<i32>,
+        model_id: u64,
     ) -> Self {
         Self {
             caches: Some(caches),
@@ -67,6 +71,7 @@ impl PromptCache {
             num_layers,
             image_cache_key,
             rope_deltas,
+            model_id,
         }
     }
 
@@ -92,5 +97,9 @@ impl PromptCache {
 
     pub(crate) fn rope_deltas(&self) -> Option<i32> {
         self.rope_deltas
+    }
+
+    pub(crate) fn model_id(&self) -> u64 {
+        self.model_id
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1803,7 +1803,7 @@ impl Qwen3_5MoeModel {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
-                    let mut decode_stream = tokenizer_for_decode.inner().decode_stream(true);
+                    let mut decode_stream = Some(tokenizer_for_decode.inner().decode_stream(true));
                     let mut streamed_text_len: usize = 0;
 
                     // Track token history for repetition penalty
@@ -2088,11 +2088,34 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            let token_text = decode_stream
-                                .step(token_id)
-                                .ok()
-                                .flatten()
-                                .unwrap_or_default();
+                            let token_text = if let Some(ref mut ds) = decode_stream {
+                                match ds.step(token_id) {
+                                    Ok(Some(text)) => text,
+                                    Ok(None) => String::new(),
+                                    Err(_) => {
+                                        decode_stream = None;
+                                        let full = tokenizer_for_decode
+                                            .decode_sync(&generated_tokens, true)
+                                            .unwrap_or_default();
+                                        let delta = if full.len() > streamed_text_len {
+                                            full[streamed_text_len..].to_string()
+                                        } else {
+                                            String::new()
+                                        };
+                                        delta
+                                    }
+                                }
+                            } else {
+                                let full = tokenizer_for_decode
+                                    .decode_sync(&generated_tokens, true)
+                                    .unwrap_or_default();
+                                let delta = if full.len() > streamed_text_len {
+                                    full[streamed_text_len..].to_string()
+                                } else {
+                                    String::new()
+                                };
+                                delta
+                            };
                             streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
@@ -2236,11 +2259,34 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            let token_text = decode_stream
-                                .step(token_id)
-                                .ok()
-                                .flatten()
-                                .unwrap_or_default();
+                            let token_text = if let Some(ref mut ds) = decode_stream {
+                                match ds.step(token_id) {
+                                    Ok(Some(text)) => text,
+                                    Ok(None) => String::new(),
+                                    Err(_) => {
+                                        decode_stream = None;
+                                        let full = tokenizer_for_decode
+                                            .decode_sync(&generated_tokens, true)
+                                            .unwrap_or_default();
+                                        let delta = if full.len() > streamed_text_len {
+                                            full[streamed_text_len..].to_string()
+                                        } else {
+                                            String::new()
+                                        };
+                                        delta
+                                    }
+                                }
+                            } else {
+                                let full = tokenizer_for_decode
+                                    .decode_sync(&generated_tokens, true)
+                                    .unwrap_or_default();
+                                let delta = if full.len() > streamed_text_len {
+                                    full[streamed_text_len..].to_string()
+                                } else {
+                                    String::new()
+                                };
+                                delta
+                            };
                             streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -120,6 +120,8 @@ pub struct Qwen3_5MoeModel {
     cached_rope_deltas: Arc<RwLock<Option<i32>>>,
     /// Unique model instance ID for compiled path ownership.
     pub(crate) model_id: u64,
+    /// Serializes cache state access during generation.
+    generation_lock: Arc<TokioMutex<()>>,
 }
 
 #[napi]
@@ -173,6 +175,7 @@ impl Qwen3_5MoeModel {
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
             model_id: QWEN35_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            generation_lock: Arc::new(TokioMutex::new(())),
         })
     }
 
@@ -183,6 +186,7 @@ impl Qwen3_5MoeModel {
     /// before the next `chat()` call for incremental prefill.
     #[napi]
     pub fn take_cache(&self) -> Option<crate::models::qwen3_5::prompt_cache::PromptCache> {
+        let _guard = self.generation_lock.try_lock().ok()?;
         let mut caches_guard = self.caches.write().ok()?;
         let token_history_guard = self.cached_token_history.read().ok()?;
         let caches = caches_guard.take()?;
@@ -213,6 +217,9 @@ impl Qwen3_5MoeModel {
         &self,
         cache: &mut crate::models::qwen3_5::prompt_cache::PromptCache,
     ) -> Result<()> {
+        let _guard = self.generation_lock.try_lock().map_err(|_| {
+            Error::from_reason("Cannot set cache while generation is in progress")
+        })?;
         if cache.model_type() != "qwen3_5_moe" {
             return Err(Error::from_reason(format!(
                 "Cache type '{}' doesn't match model type 'qwen3_5_moe'",
@@ -274,6 +281,9 @@ impl Qwen3_5MoeModel {
 
     #[napi]
     pub fn reset_caches(&self) -> Result<()> {
+        let _guard = self.generation_lock.try_lock().map_err(|_| {
+            Error::from_reason("Cannot reset caches while generation is in progress")
+        })?;
         let mut caches_guard = self
             .caches
             .write()
@@ -344,6 +354,10 @@ impl Qwen3_5MoeModel {
                 batch_size
             )));
         }
+
+        // Hold generation lock for the entire lifecycle.
+        let gen_lock = self.generation_lock.clone();
+        let _gen_guard = gen_lock.lock().await;
 
         let embedding_weight = self.embedding.get_weight();
         let layers_arc = self.layers.clone();
@@ -706,6 +720,11 @@ impl Qwen3_5MoeModel {
         });
 
         let reuse_cache = config.reuse_cache.unwrap_or(true);
+
+        // Hold generation lock for the entire lifecycle.
+        let gen_lock = self.generation_lock.clone();
+        let _gen_guard = gen_lock.lock().await;
+
         let tokenizer = self
             .tokenizer
             .clone()
@@ -1557,6 +1576,10 @@ impl Qwen3_5MoeModel {
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 
+        // Hold generation lock for the entire lifecycle.
+        // Use lock_owned() so the guard is 'static and can be moved into tokio::spawn.
+        let gen_guard = Arc::clone(&self.generation_lock).lock_owned().await;
+
         let tokenizer = self
             .tokenizer
             .clone()
@@ -1621,7 +1644,8 @@ impl Qwen3_5MoeModel {
         let callback = Arc::new(callback);
 
         tokio::spawn(async move {
-            // Hold the MoE lock for the duration of generation
+            // Hold both locks for the duration of generation
+            let _gen_guard = gen_guard;
             let _moe_lock = moe_lock;
 
             let callback_err = callback.clone();
@@ -2988,6 +3012,7 @@ impl Qwen3_5MoeModel {
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
             model_id: QWEN35_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            generation_lock: Arc::new(TokioMutex::new(())),
         })
     }
 
@@ -3345,6 +3370,9 @@ impl Qwen3_5MoeModel {
         let config = config.unwrap_or_default();
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
         let model_id = self.model_id;
+
+        // Hold generation lock (blocking — called from spawn_blocking context).
+        let _gen_guard = self.generation_lock.blocking_lock();
 
         // Check if C++ MoE path is available (weights belong to this model)
         let use_cpp = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -200,6 +200,7 @@ impl Qwen3_5MoeModel {
             self.config.num_layers as usize,
             image_key,
             rope_deltas,
+            self.model_id,
         ))
     }
 
@@ -224,6 +225,11 @@ impl Qwen3_5MoeModel {
                 cache.num_layers(),
                 self.config.num_layers
             )));
+        }
+        if cache.model_id() != self.model_id {
+            return Err(Error::from_reason(
+                "Cache was created by a different model instance (different checkpoint or config)",
+            ));
         }
         let restored_caches = cache.take_caches().ok_or_else(|| {
             Error::from_reason("PromptCache is empty (already consumed or disposed)")

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -38,7 +38,9 @@ use super::persistence;
 
 // Import the shared model ID counter from the dense module — dense and MoE
 // share the same C++ weight map, so IDs must be globally unique.
-use crate::models::qwen3_5::model::{COMPILED_WEIGHTS_RWLOCK, QWEN35_MODEL_ID_COUNTER};
+use crate::models::qwen3_5::model::{
+    QWEN35_MODEL_ID_COUNTER, acquire_compiled_weight_guard,
+};
 
 /// Process-wide mutex serializing the MoE compiled forward lifecycle.
 ///
@@ -381,19 +383,8 @@ impl Qwen3_5MoeModel {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
-            // Re-validate compiled path under weight lock.
-            let mut _weight_guard = None;
-            let use_cpp = if use_cpp {
-                let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
-                if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
-                    _weight_guard = Some(guard);
-                    true
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
+            let _weight_guard = if use_cpp { acquire_compiled_weight_guard(model_id) } else { None };
+            let use_cpp = _weight_guard.is_some();
 
             // Acquire all locks ONCE for the entire prefill+decode sequence
             let mut layers_guard = layers_arc
@@ -784,19 +775,8 @@ impl Qwen3_5MoeModel {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
-            // Re-validate compiled path under weight lock.
-            let mut _weight_guard = None;
-            let use_cpp = if use_cpp {
-                let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
-                if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
-                    _weight_guard = Some(guard);
-                    true
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
+            let _weight_guard = if use_cpp { acquire_compiled_weight_guard(model_id) } else { None };
+            let use_cpp = _weight_guard.is_some();
 
             let tool_defs = config.tools.as_deref();
             let enable_thinking = config.enable_thinking;
@@ -1651,19 +1631,8 @@ impl Qwen3_5MoeModel {
             let callback_err = callback.clone();
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
-                    // Re-validate compiled path under weight lock.
-                    let mut _weight_guard = None;
-                    let use_cpp = if use_cpp {
-                        let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
-                        if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
-                            _weight_guard = Some(guard);
-                            true
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    };
+                    let _weight_guard = if use_cpp { acquire_compiled_weight_guard(model_id) } else { None };
+                    let use_cpp = _weight_guard.is_some();
 
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = config.enable_thinking;
@@ -3386,19 +3355,8 @@ impl Qwen3_5MoeModel {
         };
         let use_cpp = compiled_lock.is_some();
 
-        // Acquire weight read lock to prevent concurrent model loads.
-        let mut _weight_guard = None;
-        let use_cpp = if use_cpp {
-            let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
-            if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
-                _weight_guard = Some(guard);
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
+        let _weight_guard = if use_cpp { acquire_compiled_weight_guard(model_id) } else { None };
+        let use_cpp = _weight_guard.is_some();
 
         // Ensure caches exist
         self.init_caches()?;

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1803,7 +1803,7 @@ impl Qwen3_5MoeModel {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
-                    let mut decode_stream = Some(tokenizer_for_decode.inner().decode_stream(true));
+                    let mut decode_stream = tokenizer_for_decode.inner().decode_stream(true);
                     let mut streamed_text_len: usize = 0;
 
                     // Track token history for repetition penalty
@@ -2088,33 +2088,25 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            let token_text = if let Some(ref mut ds) = decode_stream {
-                                match ds.step(token_id) {
-                                    Ok(Some(text)) => text,
-                                    Ok(None) => String::new(),
-                                    Err(_) => {
-                                        decode_stream = None;
-                                        let full = tokenizer_for_decode
-                                            .decode_sync(&generated_tokens, true)
-                                            .unwrap_or_default();
-                                        let delta = if full.len() > streamed_text_len {
-                                            full[streamed_text_len..].to_string()
-                                        } else {
-                                            String::new()
-                                        };
-                                        delta
+                            let token_text = match decode_stream.step(token_id) {
+                                Ok(Some(text)) => text,
+                                Ok(None) => String::new(),
+                                Err(_) => {
+                                    let mut new_ds = tokenizer_for_decode.inner().decode_stream(true);
+                                    let mut replayed = String::new();
+                                    for &tid in &generated_tokens {
+                                        if let Ok(Some(t)) = new_ds.step(tid) {
+                                            replayed.push_str(&t);
+                                        }
                                     }
+                                    decode_stream = new_ds;
+                                    let delta = if replayed.len() > streamed_text_len {
+                                        replayed[streamed_text_len..].to_string()
+                                    } else {
+                                        String::new()
+                                    };
+                                    delta
                                 }
-                            } else {
-                                let full = tokenizer_for_decode
-                                    .decode_sync(&generated_tokens, true)
-                                    .unwrap_or_default();
-                                let delta = if full.len() > streamed_text_len {
-                                    full[streamed_text_len..].to_string()
-                                } else {
-                                    String::new()
-                                };
-                                delta
                             };
                             streamed_text_len += token_text.len();
                             callback.call(
@@ -2259,33 +2251,25 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            let token_text = if let Some(ref mut ds) = decode_stream {
-                                match ds.step(token_id) {
-                                    Ok(Some(text)) => text,
-                                    Ok(None) => String::new(),
-                                    Err(_) => {
-                                        decode_stream = None;
-                                        let full = tokenizer_for_decode
-                                            .decode_sync(&generated_tokens, true)
-                                            .unwrap_or_default();
-                                        let delta = if full.len() > streamed_text_len {
-                                            full[streamed_text_len..].to_string()
-                                        } else {
-                                            String::new()
-                                        };
-                                        delta
+                            let token_text = match decode_stream.step(token_id) {
+                                Ok(Some(text)) => text,
+                                Ok(None) => String::new(),
+                                Err(_) => {
+                                    let mut new_ds = tokenizer_for_decode.inner().decode_stream(true);
+                                    let mut replayed = String::new();
+                                    for &tid in &generated_tokens {
+                                        if let Ok(Some(t)) = new_ds.step(tid) {
+                                            replayed.push_str(&t);
+                                        }
                                     }
+                                    decode_stream = new_ds;
+                                    let delta = if replayed.len() > streamed_text_len {
+                                        replayed[streamed_text_len..].to_string()
+                                    } else {
+                                        String::new()
+                                    };
+                                    delta
                                 }
-                            } else {
-                                let full = tokenizer_for_decode
-                                    .decode_sync(&generated_tokens, true)
-                                    .unwrap_or_default();
-                                let delta = if full.len() > streamed_text_len {
-                                    full[streamed_text_len..].to_string()
-                                } else {
-                                    String::new()
-                                };
-                                delta
                             };
                             streamed_text_len += token_text.len();
                             callback.call(

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -38,9 +38,7 @@ use super::persistence;
 
 // Import the shared model ID counter from the dense module — dense and MoE
 // share the same C++ weight map, so IDs must be globally unique.
-use crate::models::qwen3_5::model::{
-    QWEN35_MODEL_ID_COUNTER, acquire_compiled_weight_guard,
-};
+use crate::models::qwen3_5::model::{QWEN35_MODEL_ID_COUNTER, acquire_compiled_weight_guard};
 
 /// Process-wide mutex serializing the MoE compiled forward lifecycle.
 ///
@@ -219,9 +217,10 @@ impl Qwen3_5MoeModel {
         &self,
         cache: &mut crate::models::qwen3_5::prompt_cache::PromptCache,
     ) -> Result<()> {
-        let _guard = self.generation_lock.try_lock().map_err(|_| {
-            Error::from_reason("Cannot set cache while generation is in progress")
-        })?;
+        let _guard = self
+            .generation_lock
+            .try_lock()
+            .map_err(|_| Error::from_reason("Cannot set cache while generation is in progress"))?;
         if cache.model_type() != "qwen3_5_moe" {
             return Err(Error::from_reason(format!(
                 "Cache type '{}' doesn't match model type 'qwen3_5_moe'",
@@ -393,7 +392,11 @@ impl Qwen3_5MoeModel {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
-            let _weight_guard = if use_cpp { acquire_compiled_weight_guard(model_id) } else { None };
+            let _weight_guard = if use_cpp {
+                acquire_compiled_weight_guard(model_id)
+            } else {
+                None
+            };
             let use_cpp = _weight_guard.is_some();
 
             // Acquire all locks ONCE for the entire prefill+decode sequence
@@ -783,7 +786,11 @@ impl Qwen3_5MoeModel {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
-            let _weight_guard = if use_cpp { acquire_compiled_weight_guard(model_id) } else { None };
+            let _weight_guard = if use_cpp {
+                acquire_compiled_weight_guard(model_id)
+            } else {
+                None
+            };
             let use_cpp = _weight_guard.is_some();
 
             let tool_defs = config.tools.as_deref();
@@ -918,9 +925,8 @@ impl Qwen3_5MoeModel {
                 tokens.clone()
             };
 
-            // Zero-delta guard: if entire prompt was cached, reset and re-prefill.
-            // GDN recurrence state cannot be rewound.
-            let prefill_tokens = if prefill_tokens.is_empty() {
+            // Zero-delta guard: also reset cached_prefix_len for VLM routing.
+            let (prefill_tokens, cached_prefix_len) = if prefill_tokens.is_empty() {
                 info!("Zero-delta cache hit: resetting caches for full re-prefill");
                 if let Some(ref mut caches) = *caches_guard {
                     for cache in caches.iter_mut() {
@@ -937,13 +943,14 @@ impl Qwen3_5MoeModel {
                     })
                     .collect();
                 *caches_guard = Some(new_caches);
-                if has_images {
+                let tokens = if has_images {
                     expanded_tokens.as_ref().unwrap_or(&tokens).clone()
                 } else {
                     tokens.clone()
-                }
+                };
+                (tokens, 0)
             } else {
-                prefill_tokens
+                (prefill_tokens, cached_prefix_len)
             };
 
             let eos_id = model_config.eos_token_id as u32;
@@ -1162,11 +1169,12 @@ impl Qwen3_5MoeModel {
                 // correction gets overwritten.
                 if has_images
                     && let Ok(rd) = cached_rope_deltas_arc.read()
-                        && let Some(delta) = *rd {
-                            unsafe {
-                                mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
-                            }
-                        }
+                    && let Some(delta) = *rd
+                {
+                    unsafe {
+                        mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
+                    }
+                }
 
                 // For text-only conversations, clear any stale cached rope deltas
                 if !has_images && let Ok(mut rd) = cached_rope_deltas_arc.write() {
@@ -1634,7 +1642,11 @@ impl Qwen3_5MoeModel {
             let callback_err = callback.clone();
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
-                    let _weight_guard = if use_cpp { acquire_compiled_weight_guard(model_id) } else { None };
+                    let _weight_guard = if use_cpp {
+                        acquire_compiled_weight_guard(model_id)
+                    } else {
+                        None
+                    };
                     let use_cpp = _weight_guard.is_some();
 
                     let tool_defs = config.tools.as_deref();
@@ -1662,8 +1674,6 @@ impl Qwen3_5MoeModel {
                         top_p: config.top_p,
                         min_p: config.min_p,
                     });
-
-
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -1773,8 +1783,8 @@ impl Qwen3_5MoeModel {
                         tokens.clone()
                     };
 
-                    // Zero-delta guard: if entire prompt was cached, reset and re-prefill.
-                    let prefill_tokens = if prefill_tokens.is_empty() {
+                    // Zero-delta guard: also reset cached_prefix_len for VLM routing.
+                    let (prefill_tokens, cached_prefix_len) = if prefill_tokens.is_empty() {
                         info!("Zero-delta cache hit: resetting caches for full re-prefill");
                         if let Some(ref mut caches) = *caches_guard {
                             for cache in caches.iter_mut() {
@@ -1791,13 +1801,14 @@ impl Qwen3_5MoeModel {
                             })
                             .collect();
                         *caches_guard = Some(new_caches);
-                        if has_images {
+                        let tokens = if has_images {
                             expanded_tokens.as_ref().unwrap_or(&tokens).clone()
                         } else {
                             tokens.clone()
-                        }
+                        };
+                        (tokens, 0)
                     } else {
-                        prefill_tokens
+                        (prefill_tokens, cached_prefix_len)
                     };
 
                     let eos_id = model_config.eos_token_id as u32;
@@ -2024,11 +2035,12 @@ impl Qwen3_5MoeModel {
                         // Apply M-RoPE offset correction AFTER init_from_prefill.
                         if has_images
                             && let Ok(rd) = cached_rope_deltas_arc.read()
-                                && let Some(delta) = *rd {
-                                    unsafe {
-                                        mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
-                                    }
-                                }
+                            && let Some(delta) = *rd
+                        {
+                            unsafe {
+                                mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
+                            }
+                        }
 
                         // For text-only conversations, clear any stale cached rope deltas
                         if !has_images && let Ok(mut rd) = cached_rope_deltas_arc.write() {
@@ -2088,26 +2100,13 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            let token_text = match decode_stream.step(token_id) {
-                                Ok(Some(text)) => text,
-                                Ok(None) => String::new(),
-                                Err(_) => {
-                                    let mut new_ds = tokenizer_for_decode.inner().decode_stream(true);
-                                    let mut replayed = String::new();
-                                    for &tid in &generated_tokens {
-                                        if let Ok(Some(t)) = new_ds.step(tid) {
-                                            replayed.push_str(&t);
-                                        }
-                                    }
-                                    decode_stream = new_ds;
-                                    let delta = if replayed.len() > streamed_text_len {
-                                        replayed[streamed_text_len..].to_string()
-                                    } else {
-                                        String::new()
-                                    };
-                                    delta
-                                }
-                            };
+                            let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
+                                &mut decode_stream,
+                                tokenizer_for_decode.inner(),
+                                token_id,
+                                &generated_tokens,
+                                streamed_text_len,
+                            );
                             streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
@@ -2251,26 +2250,13 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            let token_text = match decode_stream.step(token_id) {
-                                Ok(Some(text)) => text,
-                                Ok(None) => String::new(),
-                                Err(_) => {
-                                    let mut new_ds = tokenizer_for_decode.inner().decode_stream(true);
-                                    let mut replayed = String::new();
-                                    for &tid in &generated_tokens {
-                                        if let Ok(Some(t)) = new_ds.step(tid) {
-                                            replayed.push_str(&t);
-                                        }
-                                    }
-                                    decode_stream = new_ds;
-                                    let delta = if replayed.len() > streamed_text_len {
-                                        replayed[streamed_text_len..].to_string()
-                                    } else {
-                                        String::new()
-                                    };
-                                    delta
-                                }
-                            };
+                            let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
+                                &mut decode_stream,
+                                tokenizer_for_decode.inner(),
+                                token_id,
+                                &generated_tokens,
+                                streamed_text_len,
+                            );
                             streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
@@ -3394,7 +3380,11 @@ impl Qwen3_5MoeModel {
         };
         let use_cpp = compiled_lock.is_some();
 
-        let _weight_guard = if use_cpp { acquire_compiled_weight_guard(model_id) } else { None };
+        let _weight_guard = if use_cpp {
+            acquire_compiled_weight_guard(model_id)
+        } else {
+            None
+        };
         let use_cpp = _weight_guard.is_some();
 
         // Ensure caches exist

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -263,6 +263,13 @@ impl Qwen3_5MoeModel {
 
     #[napi]
     pub fn init_caches(&self) -> Result<()> {
+        let _guard = self.generation_lock.try_lock().map_err(|_| {
+            Error::from_reason("Cannot init caches while generation is in progress")
+        })?;
+        self.init_caches_inner()
+    }
+
+    fn init_caches_inner(&self) -> Result<()> {
         let caches = (0..self.config.num_layers as usize)
             .map(|i| {
                 if self.config.is_linear_layer(i) {
@@ -277,16 +284,7 @@ impl Qwen3_5MoeModel {
             .write()
             .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
         *caches_guard = Some(caches);
-        // Clear reuse state so stale history doesn't cause a false cache hit
-        if let Ok(mut th) = self.cached_token_history.write() {
-            th.clear();
-        }
-        if let Ok(mut ik) = self.cached_image_key.write() {
-            *ik = None;
-        }
-        if let Ok(mut rd) = self.cached_rope_deltas.write() {
-            *rd = None;
-        }
+        self.clear_reuse_state();
         Ok(())
     }
 
@@ -295,6 +293,10 @@ impl Qwen3_5MoeModel {
         let _guard = self.generation_lock.try_lock().map_err(|_| {
             Error::from_reason("Cannot reset caches while generation is in progress")
         })?;
+        self.reset_caches_inner()
+    }
+
+    fn reset_caches_inner(&self) -> Result<()> {
         let mut caches_guard = self
             .caches
             .write()
@@ -305,14 +307,20 @@ impl Qwen3_5MoeModel {
             }
         }
         *caches_guard = None;
-        // Also clear token history so next chat() does a full prefill
+        self.clear_reuse_state();
+        Ok(())
+    }
+
+    fn clear_reuse_state(&self) {
         if let Ok(mut th) = self.cached_token_history.write() {
             th.clear();
+        }
+        if let Ok(mut ik) = self.cached_image_key.write() {
+            *ik = None;
         }
         if let Ok(mut rd) = self.cached_rope_deltas.write() {
             *rd = None;
         }
-        Ok(())
     }
 
     #[napi]
@@ -3387,8 +3395,7 @@ impl Qwen3_5MoeModel {
         };
         let use_cpp = _weight_guard.is_some();
 
-        // Ensure caches exist
-        self.init_caches()?;
+        self.init_caches_inner()?;
 
         // Acquire locks
         let embedding_weight = self.embedding.get_weight();
@@ -3544,9 +3551,8 @@ impl Qwen3_5MoeModel {
             result
         };
 
-        // Drop compiled lock before reset_caches
         drop(compiled_lock);
-        self.reset_caches()?;
+        self.reset_caches_inner()?;
 
         Ok(result)
     }

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1793,7 +1793,7 @@ impl Qwen3_5MoeModel {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
-                    let mut prev_decoded_len: usize = 0;
+                    let mut decode_stream = tokenizer_for_decode.inner().decode_stream(true);
 
                     // Track token history for repetition penalty
                     let mut token_history: Vec<u32> = if let Some(ref et) = expanded_tokens {
@@ -2077,17 +2077,11 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            // Decode full sequence and emit delta. ByteLevel BPE
-                            // decoders need full context for correct output.
-                            let full_text = tokenizer_for_decode
-                                .decode_sync(&generated_tokens, true)
+                            let token_text = decode_stream
+                                .step(token_id)
+                                .ok()
+                                .flatten()
                                 .unwrap_or_default();
-                            let token_text = if full_text.len() > prev_decoded_len {
-                                full_text[prev_decoded_len..].to_string()
-                            } else {
-                                String::new()
-                            };
-                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2230,17 +2224,11 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            // Decode full sequence and emit delta. ByteLevel BPE
-                            // decoders need full context for correct output.
-                            let full_text = tokenizer_for_decode
-                                .decode_sync(&generated_tokens, true)
+                            let token_text = decode_stream
+                                .step(token_id)
+                                .ok()
+                                .flatten()
                                 .unwrap_or_default();
-                            let token_text = if full_text.len() > prev_decoded_len {
-                                full_text[prev_decoded_len..].to_string()
-                            } else {
-                                String::new()
-                            };
-                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use futures::TryFutureExt;
@@ -37,6 +37,9 @@ use super::layer_cache::Qwen3_5LayerCache;
 use super::persistence;
 
 /// Maximum number of entries in the vision encoder cache before LRU eviction.
+/// Monotonically incrementing counter for MoE model instance IDs.
+static MOE_MODEL_ID_COUNTER: AtomicU64 = AtomicU64::new(1); // 0 = no model
+
 /// Process-wide mutex serializing the MoE compiled forward lifecycle.
 ///
 /// The C++ MoE forward path uses process-wide globals (separate from dense).
@@ -115,6 +118,8 @@ pub struct Qwen3_5MoeModel {
     cached_image_key: Arc<RwLock<Option<u64>>>,
     /// Rope deltas from VLM prefill, for cache reuse M-RoPE correction
     cached_rope_deltas: Arc<RwLock<Option<i32>>>,
+    /// Unique model instance ID for compiled path ownership.
+    pub(crate) model_id: u64,
 }
 
 #[napi]
@@ -167,6 +172,7 @@ impl Qwen3_5MoeModel {
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
+            model_id: MOE_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
     }
 
@@ -342,9 +348,10 @@ impl Qwen3_5MoeModel {
         let tokenizer = self.tokenizer.clone();
         let fa_idx = self.fa_idx;
         let prompt_tokens = prompt_tokens.clone();
+        let model_id = self.model_id;
 
-        // Check if C++ MoE path will be used (weights loaded from safetensors).
-        let use_cpp = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+        // Check if C++ MoE path will be used (weights belong to this model).
+        let use_cpp = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
         // Serialize MoE compiled lifecycle — prevents concurrent C++ global corruption
         let _moe_lock = if use_cpp {
@@ -716,9 +723,10 @@ impl Qwen3_5MoeModel {
         };
         let spatial_merge_size = self.spatial_merge_size;
         let vision_cache = self.vision_cache.clone();
+        let model_id = self.model_id;
 
-        // Check if C++ MoE path will be used (weights loaded from safetensors).
-        let use_cpp = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+        // Check if C++ MoE path will be used (weights belong to this model).
+        let use_cpp = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
         // Capture start time BEFORE mutex + spawn_blocking so TTFT
         // reflects the full user-perceived latency.
@@ -868,6 +876,34 @@ impl Qwen3_5MoeModel {
                     .collect();
                 *caches_guard = Some(new_caches);
                 tokens.clone()
+            };
+
+            // Zero-delta guard: if entire prompt was cached, reset and re-prefill.
+            // GDN recurrence state cannot be rewound.
+            let prefill_tokens = if prefill_tokens.is_empty() {
+                info!("Zero-delta cache hit: resetting caches for full re-prefill");
+                if let Some(ref mut caches) = *caches_guard {
+                    for cache in caches.iter_mut() {
+                        cache.reset();
+                    }
+                }
+                let new_caches = (0..model_config.num_layers as usize)
+                    .map(|i| {
+                        if model_config.is_linear_layer(i) {
+                            Qwen3_5LayerCache::new_linear()
+                        } else {
+                            Qwen3_5LayerCache::new_full_attention()
+                        }
+                    })
+                    .collect();
+                *caches_guard = Some(new_caches);
+                if has_images {
+                    expanded_tokens.as_ref().unwrap_or(&tokens).clone()
+                } else {
+                    tokens.clone()
+                }
+            } else {
+                prefill_tokens
             };
 
             let eos_id = model_config.eos_token_id as u32;
@@ -1532,9 +1568,10 @@ impl Qwen3_5MoeModel {
         };
         let spatial_merge_size = self.spatial_merge_size;
         let vision_cache_stream = self.vision_cache.clone();
+        let model_id = self.model_id;
 
-        // Check if C++ MoE path will be used (weights loaded from safetensors).
-        let use_cpp = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+        // Check if C++ MoE path will be used (weights belong to this model).
+        let use_cpp = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
         // Capture start time BEFORE mutex + spawn_blocking so TTFT
         // reflects the full user-perceived latency.
@@ -1697,6 +1734,33 @@ impl Qwen3_5MoeModel {
                             .collect();
                         *caches_guard = Some(new_caches);
                         tokens.clone()
+                    };
+
+                    // Zero-delta guard: if entire prompt was cached, reset and re-prefill.
+                    let prefill_tokens = if prefill_tokens.is_empty() {
+                        info!("Zero-delta cache hit: resetting caches for full re-prefill");
+                        if let Some(ref mut caches) = *caches_guard {
+                            for cache in caches.iter_mut() {
+                                cache.reset();
+                            }
+                        }
+                        let new_caches = (0..model_config.num_layers as usize)
+                            .map(|i| {
+                                if model_config.is_linear_layer(i) {
+                                    Qwen3_5LayerCache::new_linear()
+                                } else {
+                                    Qwen3_5LayerCache::new_full_attention()
+                                }
+                            })
+                            .collect();
+                        *caches_guard = Some(new_caches);
+                        if has_images {
+                            expanded_tokens.as_ref().unwrap_or(&tokens).clone()
+                        } else {
+                            tokens.clone()
+                        }
+                    } else {
+                        prefill_tokens
                     };
 
                     let eos_id = model_config.eos_token_id as u32;
@@ -2875,6 +2939,7 @@ impl Qwen3_5MoeModel {
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
+            model_id: MOE_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
     }
 
@@ -3231,9 +3296,10 @@ impl Qwen3_5MoeModel {
     ) -> Result<GenerationResult> {
         let config = config.unwrap_or_default();
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
+        let model_id = self.model_id;
 
-        // Check if C++ MoE path is available (weights loaded from safetensors)
-        let use_cpp = unsafe { mlx_sys::mlx_qwen35_weight_count() } > 0;
+        // Check if C++ MoE path is available (weights belong to this model)
+        let use_cpp = unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id;
 
         // Try to acquire MoE compiled mutex (non-blocking, safe from sync context).
         // If locked (concurrent generate() call), fall back to Rust path.

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -38,7 +38,7 @@ use super::persistence;
 
 // Import the shared model ID counter from the dense module — dense and MoE
 // share the same C++ weight map, so IDs must be globally unique.
-use crate::models::qwen3_5::model::QWEN35_MODEL_ID_COUNTER;
+use crate::models::qwen3_5::model::{COMPILED_WEIGHTS_RWLOCK, QWEN35_MODEL_ID_COUNTER};
 
 /// Process-wide mutex serializing the MoE compiled forward lifecycle.
 ///
@@ -361,6 +361,20 @@ impl Qwen3_5MoeModel {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
+            // Re-validate compiled path under weight lock.
+            let mut _weight_guard = None;
+            let use_cpp = if use_cpp {
+                let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
+                if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
+                    _weight_guard = Some(guard);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
             // Acquire all locks ONCE for the entire prefill+decode sequence
             let mut layers_guard = layers_arc
                 .write()
@@ -745,6 +759,20 @@ impl Qwen3_5MoeModel {
         };
 
         napi::bindgen_prelude::spawn_blocking(move || {
+            // Re-validate compiled path under weight lock.
+            let mut _weight_guard = None;
+            let use_cpp = if use_cpp {
+                let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
+                if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
+                    _weight_guard = Some(guard);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
             let tool_defs = config.tools.as_deref();
             let enable_thinking = config.enable_thinking;
             let tokens = tokenizer.apply_chat_template_sync(
@@ -989,13 +1017,6 @@ impl Qwen3_5MoeModel {
                     &vision_cache,
                 )?;
 
-                // Adjust RoPE offset for VLM M-RoPE position correction
-                if rope_deltas != 0 && use_cpp {
-                    unsafe {
-                        mlx_sys::mlx_qwen35_moe_adjust_offset(rope_deltas as i32);
-                    }
-                }
-
                 // Save rope_deltas for cache reuse on subsequent turns
                 if let Ok(mut rd) = cached_rope_deltas_arc.write() {
                     *rd = Some(rope_deltas as i32);
@@ -1124,17 +1145,16 @@ impl Qwen3_5MoeModel {
                 // C++ has copied arrays into its own globals — safe to release
                 drop(caches_guard);
 
-                // Reapply rope_deltas from the original VLM prefill
-                // (VLM cache reuse skips vlm_prefill, so C++ offset is unset)
+                // Apply M-RoPE offset correction AFTER init_from_prefill (which sets
+                // g_moe_offset_int = prefill_len). Must come after, not before, or the
+                // correction gets overwritten.
                 if has_images
-                    && cached_prefix_len > 0
                     && let Ok(rd) = cached_rope_deltas_arc.read()
-                    && let Some(delta) = *rd
-                {
-                    unsafe {
-                        mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
-                    }
-                }
+                        && let Some(delta) = *rd {
+                            unsafe {
+                                mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
+                            }
+                        }
 
                 // For text-only conversations, clear any stale cached rope deltas
                 if !has_images && let Ok(mut rd) = cached_rope_deltas_arc.write() {
@@ -1601,6 +1621,20 @@ impl Qwen3_5MoeModel {
             let callback_err = callback.clone();
             let result =
                 napi::bindgen_prelude::spawn_blocking(move || -> std::result::Result<(), Error> {
+                    // Re-validate compiled path under weight lock.
+                    let mut _weight_guard = None;
+                    let use_cpp = if use_cpp {
+                        let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
+                        if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
+                            _weight_guard = Some(guard);
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
+
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = config.enable_thinking;
                     let tokens = tokenizer.apply_chat_template_sync(
@@ -1854,13 +1888,6 @@ impl Qwen3_5MoeModel {
                             &vision_cache_stream,
                         )?;
 
-                        // Adjust RoPE offset for VLM M-RoPE position correction
-                        if rope_deltas != 0 && use_cpp {
-                            unsafe {
-                                mlx_sys::mlx_qwen35_moe_adjust_offset(rope_deltas as i32);
-                            }
-                        }
-
                         // Save rope_deltas for cache reuse on subsequent turns
                         if let Ok(mut rd) = cached_rope_deltas_arc.write() {
                             *rd = Some(rope_deltas as i32);
@@ -1991,17 +2018,14 @@ impl Qwen3_5MoeModel {
                         // C++ has copied arrays into its own globals — safe to release
                         drop(caches_guard);
 
-                        // Reapply rope_deltas from the original VLM prefill
-                        // (VLM cache reuse skips vlm_prefill, so C++ offset is unset)
+                        // Apply M-RoPE offset correction AFTER init_from_prefill.
                         if has_images
-                            && cached_prefix_len > 0
                             && let Ok(rd) = cached_rope_deltas_arc.read()
-                            && let Some(delta) = *rd
-                        {
-                            unsafe {
-                                mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
-                            }
-                        }
+                                && let Some(delta) = *rd {
+                                    unsafe {
+                                        mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
+                                    }
+                                }
 
                         // For text-only conversations, clear any stale cached rope deltas
                         if !has_images && let Ok(mut rd) = cached_rope_deltas_arc.write() {
@@ -3327,6 +3351,20 @@ impl Qwen3_5MoeModel {
             None
         };
         let use_cpp = compiled_lock.is_some();
+
+        // Acquire weight read lock to prevent concurrent model loads.
+        let mut _weight_guard = None;
+        let use_cpp = if use_cpp {
+            let guard = COMPILED_WEIGHTS_RWLOCK.read().unwrap();
+            if unsafe { mlx_sys::mlx_qwen35_get_model_id() } == model_id {
+                _weight_guard = Some(guard);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
 
         // Ensure caches exist
         self.init_caches()?;

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -713,13 +713,13 @@ impl Qwen3_5MoeModel {
         let reuse_cache = config.reuse_cache.unwrap_or(true);
 
         let gen_lock = self.generation_lock.clone();
+        let _gen_guard = gen_lock.lock().await;
 
         let tokenizer = self
             .tokenizer
             .clone()
             .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?;
 
-        // Detect images in messages
         let has_images = messages
             .iter()
             .any(|m| m.images.as_ref().is_some_and(|imgs| !imgs.is_empty()));
@@ -801,8 +801,6 @@ impl Qwen3_5MoeModel {
                 top_p: config.top_p,
                 min_p: config.min_p,
             });
-
-            let _gen_guard = gen_lock.blocking_lock();
 
             let mut layers_guard = layers_arc
                 .write()
@@ -1555,14 +1553,13 @@ impl Qwen3_5MoeModel {
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 
-        let gen_lock = self.generation_lock.clone();
+        let gen_guard = Arc::clone(&self.generation_lock).lock_owned().await;
 
         let tokenizer = self
             .tokenizer
             .clone()
             .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?;
 
-        // Detect images in messages
         let has_images = messages
             .iter()
             .any(|m| m.images.as_ref().is_some_and(|imgs| !imgs.is_empty()));
@@ -1621,6 +1618,7 @@ impl Qwen3_5MoeModel {
         let callback = Arc::new(callback);
 
         tokio::spawn(async move {
+            let _gen_guard = gen_guard;
             let _moe_lock = moe_lock;
 
             let callback_err = callback.clone();
@@ -1655,7 +1653,7 @@ impl Qwen3_5MoeModel {
                         min_p: config.min_p,
                     });
 
-                    let _gen_guard = gen_lock.blocking_lock();
+
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -1795,6 +1793,7 @@ impl Qwen3_5MoeModel {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
+                    let mut prev_decoded_len: usize = 0;
 
                     // Track token history for repetition penalty
                     let mut token_history: Vec<u32> = if let Some(ref et) = expanded_tokens {
@@ -2078,27 +2077,17 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            // Incremental delta decode with bounded tail window.
-                            let token_text = {
-                                const TAIL: usize = 64;
-                                let n = generated_tokens.len();
-                                let start = n.saturating_sub(TAIL);
-                                let cur = tokenizer_for_decode
-                                    .decode_sync(&generated_tokens[start..], true)
-                                    .unwrap_or_default();
-                                let prev = if n > 1 {
-                                    tokenizer_for_decode
-                                        .decode_sync(&generated_tokens[start..n - 1], true)
-                                        .unwrap_or_default()
-                                } else {
-                                    String::new()
-                                };
-                                if cur.len() > prev.len() {
-                                    cur[prev.len()..].to_string()
-                                } else {
-                                    String::new()
-                                }
+                            // Decode full sequence and emit delta. ByteLevel BPE
+                            // decoders need full context for correct output.
+                            let full_text = tokenizer_for_decode
+                                .decode_sync(&generated_tokens, true)
+                                .unwrap_or_default();
+                            let token_text = if full_text.len() > prev_decoded_len {
+                                full_text[prev_decoded_len..].to_string()
+                            } else {
+                                String::new()
                             };
+                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2241,27 +2230,17 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            // Incremental delta decode with bounded tail window.
-                            let token_text = {
-                                const TAIL: usize = 64;
-                                let n = generated_tokens.len();
-                                let start = n.saturating_sub(TAIL);
-                                let cur = tokenizer_for_decode
-                                    .decode_sync(&generated_tokens[start..], true)
-                                    .unwrap_or_default();
-                                let prev = if n > 1 {
-                                    tokenizer_for_decode
-                                        .decode_sync(&generated_tokens[start..n - 1], true)
-                                        .unwrap_or_default()
-                                } else {
-                                    String::new()
-                                };
-                                if cur.len() > prev.len() {
-                                    cur[prev.len()..].to_string()
-                                } else {
-                                    String::new()
-                                }
+                            // Decode full sequence and emit delta. ByteLevel BPE
+                            // decoders need full context for correct output.
+                            let full_text = tokenizer_for_decode
+                                .decode_sync(&generated_tokens, true)
+                                .unwrap_or_default();
+                            let token_text = if full_text.len() > prev_decoded_len {
+                                full_text[prev_decoded_len..].to_string()
+                            } else {
+                                String::new()
                             };
+                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -278,6 +278,16 @@ impl Qwen3_5MoeModel {
             .write()
             .map_err(|_| Error::from_reason("Failed to acquire caches write lock"))?;
         *caches_guard = Some(caches);
+        // Clear reuse state so stale history doesn't cause a false cache hit
+        if let Ok(mut th) = self.cached_token_history.write() {
+            th.clear();
+        }
+        if let Ok(mut ik) = self.cached_image_key.write() {
+            *ik = None;
+        }
+        if let Ok(mut rd) = self.cached_rope_deltas.write() {
+            *rd = None;
+        }
         Ok(())
     }
 
@@ -1794,6 +1804,7 @@ impl Qwen3_5MoeModel {
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
                     let mut decode_stream = tokenizer_for_decode.inner().decode_stream(true);
+                    let mut streamed_text_len: usize = 0;
 
                     // Track token history for repetition penalty
                     let mut token_history: Vec<u32> = if let Some(ref et) = expanded_tokens {
@@ -2082,6 +2093,7 @@ impl Qwen3_5MoeModel {
                                 .ok()
                                 .flatten()
                                 .unwrap_or_default();
+                            streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2229,6 +2241,7 @@ impl Qwen3_5MoeModel {
                                 .ok()
                                 .flatten()
                                 .unwrap_or_default();
+                            streamed_text_len += token_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2350,13 +2363,30 @@ impl Qwen3_5MoeModel {
                         None
                     };
 
-                    // Decode full text for final chunk
                     let text = tokenizer_for_decode
                         .decode_sync(&generated_tokens, true)
                         .unwrap_or_else(|e| {
                             warn!("Failed to decode generated tokens: {}", e);
                             String::new()
                         });
+
+                    // Flush residual bytes buffered by DecodeStream
+                    if text.len() > streamed_text_len {
+                        let residual = text[streamed_text_len..].to_string();
+                        callback.call(
+                            Ok(ChatStreamChunk {
+                                text: residual,
+                                done: false,
+                                finish_reason: None,
+                                tool_calls: None,
+                                thinking: None,
+                                num_tokens: None,
+                                raw_text: None,
+                                performance: None,
+                            }),
+                            ThreadsafeFunctionCallMode::NonBlocking,
+                        );
+                    }
 
                     let num_tokens = generated_tokens.len() as u32;
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -712,9 +712,7 @@ impl Qwen3_5MoeModel {
 
         let reuse_cache = config.reuse_cache.unwrap_or(true);
 
-        // Hold generation lock for the entire lifecycle.
         let gen_lock = self.generation_lock.clone();
-        let _gen_guard = gen_lock.lock().await;
 
         let tokenizer = self
             .tokenizer
@@ -799,12 +797,13 @@ impl Qwen3_5MoeModel {
             let ngram_size = config.ngram_size.unwrap_or(64);
             let sampling_config = Some(SamplingConfig {
                 temperature: config.temperature,
-                top_k: config.top_k, // Qwen3.5 recommends top_k=20
+                top_k: config.top_k,
                 top_p: config.top_p,
                 min_p: config.min_p,
             });
 
-            // Acquire all locks ONCE for the entire prefill+decode sequence
+            let _gen_guard = gen_lock.blocking_lock();
+
             let mut layers_guard = layers_arc
                 .write()
                 .map_err(|_| Error::from_reason("Failed to acquire layers write lock"))?;
@@ -1556,9 +1555,7 @@ impl Qwen3_5MoeModel {
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 
-        // Hold generation lock for the entire lifecycle.
-        // Use lock_owned() so the guard is 'static and can be moved into tokio::spawn.
-        let gen_guard = Arc::clone(&self.generation_lock).lock_owned().await;
+        let gen_lock = self.generation_lock.clone();
 
         let tokenizer = self
             .tokenizer
@@ -1624,8 +1621,6 @@ impl Qwen3_5MoeModel {
         let callback = Arc::new(callback);
 
         tokio::spawn(async move {
-            // Hold both locks for the duration of generation
-            let _gen_guard = gen_guard;
             let _moe_lock = moe_lock;
 
             let callback_err = callback.clone();
@@ -1660,7 +1655,8 @@ impl Qwen3_5MoeModel {
                         min_p: config.min_p,
                     });
 
-                    // Acquire all locks ONCE for the entire prefill+decode sequence
+                    let _gen_guard = gen_lock.blocking_lock();
+
                     let mut layers_guard = layers_arc
                         .write()
                         .map_err(|_| Error::from_reason("Failed to acquire layers write lock"))?;
@@ -1799,8 +1795,6 @@ impl Qwen3_5MoeModel {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
-                    // Track decoded text length for incremental delta streaming.
-                    let mut prev_decoded_len: usize = 0;
 
                     // Track token history for repetition penalty
                     let mut token_history: Vec<u32> = if let Some(ref et) = expanded_tokens {
@@ -2084,18 +2078,27 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            // Incremental delta decode: decode the full sequence so far
-                            // and emit only the new characters. This correctly handles
-                            // multibyte UTF-8, byte-fallback, and whitespace-prefix tokens.
-                            let full_text = tokenizer_for_decode
-                                .decode_sync(&generated_tokens, true)
-                                .unwrap_or_default();
-                            let token_text = if full_text.len() > prev_decoded_len {
-                                full_text[prev_decoded_len..].to_string()
-                            } else {
-                                String::new()
+                            // Incremental delta decode with bounded tail window.
+                            let token_text = {
+                                const TAIL: usize = 64;
+                                let n = generated_tokens.len();
+                                let start = n.saturating_sub(TAIL);
+                                let cur = tokenizer_for_decode
+                                    .decode_sync(&generated_tokens[start..], true)
+                                    .unwrap_or_default();
+                                let prev = if n > 1 {
+                                    tokenizer_for_decode
+                                        .decode_sync(&generated_tokens[start..n - 1], true)
+                                        .unwrap_or_default()
+                                } else {
+                                    String::new()
+                                };
+                                if cur.len() > prev.len() {
+                                    cur[prev.len()..].to_string()
+                                } else {
+                                    String::new()
+                                }
                             };
-                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2238,18 +2241,27 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            // Incremental delta decode: decode the full sequence so far
-                            // and emit only the new characters. This correctly handles
-                            // multibyte UTF-8, byte-fallback, and whitespace-prefix tokens.
-                            let full_text = tokenizer_for_decode
-                                .decode_sync(&generated_tokens, true)
-                                .unwrap_or_default();
-                            let token_text = if full_text.len() > prev_decoded_len {
-                                full_text[prev_decoded_len..].to_string()
-                            } else {
-                                String::new()
+                            // Incremental delta decode with bounded tail window.
+                            let token_text = {
+                                const TAIL: usize = 64;
+                                let n = generated_tokens.len();
+                                let start = n.saturating_sub(TAIL);
+                                let cur = tokenizer_for_decode
+                                    .decode_sync(&generated_tokens[start..], true)
+                                    .unwrap_or_default();
+                                let prev = if n > 1 {
+                                    tokenizer_for_decode
+                                        .decode_sync(&generated_tokens[start..n - 1], true)
+                                        .unwrap_or_default()
+                                } else {
+                                    String::new()
+                                };
+                                if cur.len() > prev.len() {
+                                    cur[prev.len()..].to_string()
+                                } else {
+                                    String::new()
+                                }
                             };
-                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use futures::TryFutureExt;
@@ -36,9 +36,9 @@ use super::decoder_layer::DecoderLayer;
 use super::layer_cache::Qwen3_5LayerCache;
 use super::persistence;
 
-/// Maximum number of entries in the vision encoder cache before LRU eviction.
-/// Monotonically incrementing counter for MoE model instance IDs.
-static MOE_MODEL_ID_COUNTER: AtomicU64 = AtomicU64::new(1); // 0 = no model
+// Import the shared model ID counter from the dense module — dense and MoE
+// share the same C++ weight map, so IDs must be globally unique.
+use crate::models::qwen3_5::model::QWEN35_MODEL_ID_COUNTER;
 
 /// Process-wide mutex serializing the MoE compiled forward lifecycle.
 ///
@@ -172,7 +172,7 @@ impl Qwen3_5MoeModel {
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
-            model_id: MOE_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            model_id: QWEN35_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
     }
 
@@ -1766,6 +1766,8 @@ impl Qwen3_5MoeModel {
                     let eos_id = model_config.eos_token_id as u32;
                     let mut generated_tokens: Vec<u32> = Vec::new();
                     let mut finish_reason = String::from("length");
+                    // Track decoded text length for incremental delta streaming.
+                    let mut prev_decoded_len: usize = 0;
 
                     // Track token history for repetition penalty
                     let mut token_history: Vec<u32> = if let Some(ref et) = expanded_tokens {
@@ -2059,10 +2061,18 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            // Decode and stream this token
-                            let token_text = tokenizer_for_decode
-                                .decode_sync(&[token_id], true)
+                            // Incremental delta decode: decode the full sequence so far
+                            // and emit only the new characters. This correctly handles
+                            // multibyte UTF-8, byte-fallback, and whitespace-prefix tokens.
+                            let full_text = tokenizer_for_decode
+                                .decode_sync(&generated_tokens, true)
                                 .unwrap_or_default();
+                            let token_text = if full_text.len() > prev_decoded_len {
+                                full_text[prev_decoded_len..].to_string()
+                            } else {
+                                String::new()
+                            };
+                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2205,10 +2215,18 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
-                            // Decode and stream this token
-                            let token_text = tokenizer_for_decode
-                                .decode_sync(&[token_id], true)
+                            // Incremental delta decode: decode the full sequence so far
+                            // and emit only the new characters. This correctly handles
+                            // multibyte UTF-8, byte-fallback, and whitespace-prefix tokens.
+                            let full_text = tokenizer_for_decode
+                                .decode_sync(&generated_tokens, true)
                                 .unwrap_or_default();
+                            let token_text = if full_text.len() > prev_decoded_len {
+                                full_text[prev_decoded_len..].to_string()
+                            } else {
+                                String::new()
+                            };
+                            prev_decoded_len = full_text.len();
                             callback.call(
                                 Ok(ChatStreamChunk {
                                     text: token_text,
@@ -2939,7 +2957,7 @@ impl Qwen3_5MoeModel {
             cached_token_history: Arc::new(RwLock::new(Vec::new())),
             cached_image_key: Arc::new(RwLock::new(None)),
             cached_rope_deltas: Arc::new(RwLock::new(None)),
-            model_id: MOE_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
+            model_id: QWEN35_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
         })
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -1294,6 +1294,11 @@ fn register_moe_weights_with_cpp(params: &HashMap<String, MxArray>, model_id: u6
     use mlx_sys as sys;
     use std::ffi::CString;
 
+    // Write-lock the weight RwLock for the entire registration.
+    let _guard = crate::models::qwen3_5::model::COMPILED_WEIGHTS_RWLOCK
+        .write()
+        .unwrap();
+
     // Clear weights (shared map)
     unsafe { sys::mlx_qwen35_clear_weights() };
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -1084,7 +1084,7 @@ pub async fn load(model_path: &str) -> Result<Qwen3_5MoeModel> {
 
         // Register weights with C++ MoE forward pass.
         // Works for both quantized and unquantized models (C++ detects quantization at init).
-        register_moe_weights_with_cpp(&params);
+        register_moe_weights_with_cpp(&params, model.model_id);
 
         // Materialize all mmap-backed weight arrays so the first inference
         // prefill timing is not inflated by lazy disk reads.
@@ -1289,7 +1289,8 @@ fn parse_config(raw: &Value) -> Result<Qwen3_5MoeConfig> {
 
 /// Register all sanitized weights with the C++ MoE forward pass.
 /// Uses the same shared g_weights map as the dense path (mlx_qwen35_store_weight).
-fn register_moe_weights_with_cpp(params: &HashMap<String, MxArray>) {
+/// Sets model_id AFTER all weights are stored.
+fn register_moe_weights_with_cpp(params: &HashMap<String, MxArray>, model_id: u64) {
     use mlx_sys as sys;
     use std::ffi::CString;
 
@@ -1312,4 +1313,7 @@ fn register_moe_weights_with_cpp(params: &HashMap<String, MxArray>) {
 
     let count = unsafe { sys::mlx_qwen35_weight_count() };
     info!("Registered {} weights with C++ MoE forward pass", count);
+
+    // Set model ID AFTER all weights are stored.
+    unsafe { sys::mlx_qwen35_set_model_id(model_id) };
 }

--- a/crates/mlx-core/src/models/training_generate.rs
+++ b/crates/mlx-core/src/models/training_generate.rs
@@ -110,21 +110,21 @@ pub(crate) fn generate_decode_loop_for_training(
                 break;
             }
 
-            // Check repetition cutoff
-            if check_repetition_cutoff(
+            // Append BEFORE repetition check (matches inference loop ordering).
+            // check_repetition_cutoff inspects the tail of the token list,
+            // so the just-sampled token must be present.
+            generated_tokens.push(token_id);
+            all_tokens.push(token_id);
+
+            if let Some(reason) = check_repetition_cutoff(
                 &all_tokens,
                 max_consecutive_tokens,
                 max_ngram_repeats,
                 ngram_size,
-            )
-            .is_some()
-            {
-                finish_reason = "repetition".to_string();
+            ) {
+                finish_reason = reason.to_string();
                 break;
             }
-
-            generated_tokens.push(token_id);
-            all_tokens.push(token_id);
 
             // Forward next token
             let token_input = MxArray::from_uint32(&[token_id], &[1, 1])?;
@@ -146,8 +146,19 @@ pub(crate) fn generate_decode_loop_for_training(
                 break;
             }
 
+            // Append BEFORE repetition check.
             generated_tokens.push(token_id);
             all_tokens.push(token_id);
+
+            if let Some(reason) = check_repetition_cutoff(
+                &all_tokens,
+                max_consecutive_tokens,
+                max_ngram_repeats,
+                ngram_size,
+            ) {
+                finish_reason = reason.to_string();
+                break;
+            }
 
             let token_input = MxArray::from_uint32(&[token_id], &[1, 1])?;
             let next_logits = forward_fn(&token_input)?;

--- a/crates/mlx-core/src/tokenizer.rs
+++ b/crates/mlx-core/src/tokenizer.rs
@@ -1028,6 +1028,11 @@ impl Qwen3Tokenizer {
             .map_err(|e| Error::from_reason(format!("Failed to decode tokens: {}", e)))
     }
 
+    /// Get a reference to the inner tokenizer for creating a DecodeStream.
+    pub(crate) fn inner(&self) -> &tokenizers::Tokenizer {
+        &self.tokenizer
+    }
+
     /// Apply chat template synchronously (for internal use by chat())
     ///
     /// This is a synchronous version of apply_chat_template for use in blocking tasks.

--- a/crates/mlx-core/src/tokenizer.rs
+++ b/crates/mlx-core/src/tokenizer.rs
@@ -1033,6 +1033,45 @@ impl Qwen3Tokenizer {
         &self.tokenizer
     }
 
+    /// Step the decode stream with error recovery. On InvalidPrefix,
+    /// recreates the stream, replays all generated tokens, and returns
+    /// the delta since `streamed_text_len`.
+    pub(crate) fn step_decode_stream<'a>(
+        decode_stream: &mut tokenizers::DecodeStream<
+            'a,
+            tokenizers::ModelWrapper,
+            tokenizers::NormalizerWrapper,
+            tokenizers::PreTokenizerWrapper,
+            tokenizers::PostProcessorWrapper,
+            tokenizers::DecoderWrapper,
+        >,
+        tokenizer: &'a tokenizers::Tokenizer,
+        token_id: u32,
+        generated_tokens: &[u32],
+        streamed_text_len: usize,
+    ) -> String {
+        match decode_stream.step(token_id) {
+            Ok(Some(text)) => text,
+            Ok(None) => String::new(),
+            Err(_) => {
+                // Recreate stream and replay all tokens to recover state
+                let mut new_ds = tokenizer.decode_stream(true);
+                let mut replayed = String::new();
+                for &tid in generated_tokens {
+                    if let Ok(Some(t)) = new_ds.step(tid) {
+                        replayed.push_str(&t);
+                    }
+                }
+                *decode_stream = new_ds;
+                if replayed.len() > streamed_text_len {
+                    replayed[streamed_text_len..].to_string()
+                } else {
+                    String::new()
+                }
+            }
+        }
+    }
+
     /// Apply chat template synchronously (for internal use by chat())
     ///
     /// This is a synchronous version of apply_chat_template for use in blocking tasks.

--- a/crates/mlx-paged-attn/src/scheduler.rs
+++ b/crates/mlx-paged-attn/src/scheduler.rs
@@ -198,6 +198,14 @@ impl ContinuousBatchingScheduler {
             .map(|seq| seq.generated_tokens.as_slice())
     }
 
+    /// Check if adding one more token would hit or exceed max_new_tokens for a sequence.
+    /// Used by the model to set is_finished on the last token so clients see it immediately.
+    pub fn would_hit_length_limit(&self, seq_id: u32) -> bool {
+        self.running
+            .get(&seq_id)
+            .is_some_and(|seq| seq.generated_tokens.len() + 1 >= seq.max_new_tokens as usize)
+    }
+
     /// Add a new request to the waiting queue
     pub fn add_request(&mut self, request: PendingRequest) {
         // Insert based on priority (higher priority first)
@@ -380,10 +388,9 @@ impl ContinuousBatchingScheduler {
                 seq.generated_tokens.push(output.token);
                 seq.position += 1;
 
-                // Extend cache for the new token
-                cache.extend_sequence(output.seq_id, 1)?;
-
-                // Check for completion
+                // Check for completion BEFORE extending cache —
+                // avoids allocating a block for a nonexistent next token
+                // when the sequence ends exactly on a block boundary.
                 let should_stop = output.is_eos
                     || output.finish_reason_override.is_some()
                     || output.token == eos_token
@@ -410,6 +417,9 @@ impl ContinuousBatchingScheduler {
 
                     // Free memory
                     cache.remove_sequence(output.seq_id)?;
+                } else {
+                    // Only extend cache if sequence continues generating
+                    cache.extend_sequence(output.seq_id, 1)?;
                 }
             }
         }
@@ -623,6 +633,7 @@ mod tests {
                     seq_id,
                     token: 100,
                     is_eos: false,
+                    finish_reason_override: None,
                 }],
                 &mut cache,
             )
@@ -638,6 +649,7 @@ mod tests {
                     seq_id,
                     token: 101,
                     is_eos: false,
+                    finish_reason_override: None,
                 }],
                 &mut cache,
             )
@@ -649,6 +661,7 @@ mod tests {
                     seq_id,
                     token: 102,
                     is_eos: false,
+                    finish_reason_override: None,
                 }],
                 &mut cache,
             )
@@ -691,6 +704,7 @@ mod tests {
                     seq_id,
                     token: 999,
                     is_eos: true,
+                    finish_reason_override: None,
                 }],
                 &mut cache,
             )
@@ -780,6 +794,7 @@ mod tests {
                         seq_id,
                         token: 100,
                         is_eos: false,
+                        finish_reason_override: None,
                     }],
                     &mut cache,
                 )

--- a/crates/mlx-paged-attn/src/scheduler.rs
+++ b/crates/mlx-paged-attn/src/scheduler.rs
@@ -178,17 +178,13 @@ impl ContinuousBatchingScheduler {
         }
     }
 
-    /// Get the full penalty context (prompt + generated tokens) for an active sequence.
-    /// Used by the model to apply repetition/presence/frequency penalties during sampling.
-    /// Includes prompt tokens so penalties are conditioned on the full context,
-    /// matching the behavior of the non-paged generation path.
-    pub fn get_penalty_context(&self, seq_id: u32) -> Option<Vec<u32>> {
-        self.running.get(&seq_id).map(|seq| {
-            let mut ctx = Vec::with_capacity(seq.prompt_tokens.len() + seq.generated_tokens.len());
-            ctx.extend_from_slice(&seq.prompt_tokens);
-            ctx.extend_from_slice(&seq.generated_tokens);
-            ctx
-        })
+    /// Get the penalty context slices (prompt, generated) for an active sequence.
+    /// Returns borrowed slices to avoid per-step allocation. Callers pass both
+    /// to penalty functions which accept &[u32].
+    pub fn get_penalty_context(&self, seq_id: u32) -> Option<(&[u32], &[u32])> {
+        self.running
+            .get(&seq_id)
+            .map(|seq| (seq.prompt_tokens.as_slice(), seq.generated_tokens.as_slice()))
     }
 
     /// Get just the generated token history for an active sequence.
@@ -384,7 +380,6 @@ impl ContinuousBatchingScheduler {
                     seq.is_prefill = false;
                 }
 
-                // Add generated token
                 seq.generated_tokens.push(output.token);
                 seq.position += 1;
 

--- a/crates/mlx-paged-attn/src/scheduler.rs
+++ b/crates/mlx-paged-attn/src/scheduler.rs
@@ -371,11 +371,8 @@ impl ContinuousBatchingScheduler {
         outputs: Vec<TokenOutput>,
         cache: &mut PagedKVCache,
     ) -> Result<(), String> {
-        let eos_token = self.config.eos_token_id.unwrap_or(151645);
-
         for output in outputs {
             if let Some(seq) = self.running.get_mut(&output.seq_id) {
-                // Transition from prefill to decode
                 if seq.is_prefill {
                     seq.is_prefill = false;
                 }
@@ -383,18 +380,18 @@ impl ContinuousBatchingScheduler {
                 seq.generated_tokens.push(output.token);
                 seq.position += 1;
 
-                // Check for completion BEFORE extending cache —
-                // avoids allocating a block for a nonexistent next token
-                // when the sequence ends exactly on a block boundary.
+                // The model sets is_eos and finish_reason_override based on
+                // the per-call GenerationConfig.eos_token_id. The scheduler
+                // does NOT duplicate the EOS check — that would use the stale
+                // construction-time config and ignore per-call overrides.
                 let should_stop = output.is_eos
                     || output.finish_reason_override.is_some()
-                    || output.token == eos_token
                     || seq.generated_tokens.len() >= seq.max_new_tokens as usize;
 
                 if should_stop {
                     let finish_reason = if let Some(reason) = output.finish_reason_override {
                         reason
-                    } else if output.is_eos || output.token == eos_token {
+                    } else if output.is_eos {
                         "stop"
                     } else {
                         "length"

--- a/crates/mlx-paged-attn/src/scheduler.rs
+++ b/crates/mlx-paged-attn/src/scheduler.rs
@@ -182,9 +182,12 @@ impl ContinuousBatchingScheduler {
     /// Returns borrowed slices to avoid per-step allocation. Callers pass both
     /// to penalty functions which accept &[u32].
     pub fn get_penalty_context(&self, seq_id: u32) -> Option<(&[u32], &[u32])> {
-        self.running
-            .get(&seq_id)
-            .map(|seq| (seq.prompt_tokens.as_slice(), seq.generated_tokens.as_slice()))
+        self.running.get(&seq_id).map(|seq| {
+            (
+                seq.prompt_tokens.as_slice(),
+                seq.generated_tokens.as_slice(),
+            )
+        })
     }
 
     /// Get just the generated token history for an active sequence.

--- a/crates/mlx-paged-attn/src/scheduler.rs
+++ b/crates/mlx-paged-attn/src/scheduler.rs
@@ -52,6 +52,8 @@ pub struct ActiveSequence {
     pub seq_id: u32,
     /// Original request ID
     pub request_id: String,
+    /// Original prompt token IDs (for penalty context)
+    pub prompt_tokens: Vec<u32>,
     /// Tokens generated so far
     pub generated_tokens: Vec<u32>,
     /// Maximum tokens to generate
@@ -107,6 +109,9 @@ pub struct TokenOutput {
     pub token: u32,
     /// Whether this token is an EOS token
     pub is_eos: bool,
+    /// Override finish reason (e.g. "repetition"). When set, takes precedence
+    /// over the default EOS/length logic in process_outputs.
+    pub finish_reason_override: Option<String>,
 }
 
 /// Scheduler configuration
@@ -173,8 +178,20 @@ impl ContinuousBatchingScheduler {
         }
     }
 
-    /// Get the generated token history for an active sequence.
+    /// Get the full penalty context (prompt + generated tokens) for an active sequence.
     /// Used by the model to apply repetition/presence/frequency penalties during sampling.
+    /// Includes prompt tokens so penalties are conditioned on the full context,
+    /// matching the behavior of the non-paged generation path.
+    pub fn get_penalty_context(&self, seq_id: u32) -> Option<Vec<u32>> {
+        self.running.get(&seq_id).map(|seq| {
+            let mut ctx = Vec::with_capacity(seq.prompt_tokens.len() + seq.generated_tokens.len());
+            ctx.extend_from_slice(&seq.prompt_tokens);
+            ctx.extend_from_slice(&seq.generated_tokens);
+            ctx
+        })
+    }
+
+    /// Get just the generated token history for an active sequence.
     pub fn get_generated_tokens(&self, seq_id: u32) -> Option<&[u32]> {
         self.running
             .get(&seq_id)
@@ -277,6 +294,7 @@ impl ContinuousBatchingScheduler {
                     let seq = ActiveSequence {
                         seq_id, // Use cache's seq_id, not our own counter
                         request_id: request.request_id.clone(),
+                        prompt_tokens: request.prompt_tokens.clone(),
                         generated_tokens: Vec::new(),
                         max_new_tokens: request.max_new_tokens,
                         prompt_len,
@@ -367,11 +385,14 @@ impl ContinuousBatchingScheduler {
 
                 // Check for completion
                 let should_stop = output.is_eos
+                    || output.finish_reason_override.is_some()
                     || output.token == eos_token
                     || seq.generated_tokens.len() >= seq.max_new_tokens as usize;
 
                 if should_stop {
-                    let finish_reason = if output.is_eos || output.token == eos_token {
+                    let finish_reason = if let Some(ref reason) = output.finish_reason_override {
+                        reason.as_str()
+                    } else if output.is_eos || output.token == eos_token {
                         "stop"
                     } else {
                         "length"

--- a/crates/mlx-paged-attn/src/scheduler.rs
+++ b/crates/mlx-paged-attn/src/scheduler.rs
@@ -173,6 +173,14 @@ impl ContinuousBatchingScheduler {
         }
     }
 
+    /// Get the generated token history for an active sequence.
+    /// Used by the model to apply repetition/presence/frequency penalties during sampling.
+    pub fn get_generated_tokens(&self, seq_id: u32) -> Option<&[u32]> {
+        self.running
+            .get(&seq_id)
+            .map(|seq| seq.generated_tokens.as_slice())
+    }
+
     /// Add a new request to the waiting queue
     pub fn add_request(&mut self, request: PendingRequest) {
         // Insert based on priority (higher priority first)

--- a/crates/mlx-paged-attn/src/scheduler.rs
+++ b/crates/mlx-paged-attn/src/scheduler.rs
@@ -111,7 +111,7 @@ pub struct TokenOutput {
     pub is_eos: bool,
     /// Override finish reason (e.g. "repetition"). When set, takes precedence
     /// over the default EOS/length logic in process_outputs.
-    pub finish_reason_override: Option<String>,
+    pub finish_reason_override: Option<&'static str>,
 }
 
 /// Scheduler configuration
@@ -397,8 +397,8 @@ impl ContinuousBatchingScheduler {
                     || seq.generated_tokens.len() >= seq.max_new_tokens as usize;
 
                 if should_stop {
-                    let finish_reason = if let Some(ref reason) = output.finish_reason_override {
-                        reason.as_str()
+                    let finish_reason = if let Some(reason) = output.finish_reason_override {
+                        reason
                     } else if output.is_eos || output.token == eos_token {
                         "stop"
                     } else {

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -1011,6 +1011,13 @@ unsafe extern "C-unwind" {
     /// Get the number of stored weights (for debugging)
     pub fn mlx_qwen35_weight_count() -> usize;
 
+    /// Set the active model ID (called after all weights are stored).
+    /// Inference checks this against its own model_id to avoid cross-model contamination.
+    pub fn mlx_qwen35_set_model_id(id: u64);
+
+    /// Get the active model ID. Returns 0 if no model has registered weights.
+    pub fn mlx_qwen35_get_model_id() -> u64;
+
     /// Initialize compiled forward pass from post-prefill caches.
     /// Call once after prefill, before decode loop.
     /// cache_arrays: [num_layers * 2] non-null pointers to prefill cache arrays.

--- a/crates/mlx-sys/src/mlx_qwen35.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35.cpp
@@ -117,9 +117,10 @@ void mlx_qwen35_store_weight(const char* name, mlx_array* weight) {
   auto& arr = *reinterpret_cast<array*>(weight);
   std::string key(name);
   g_weights().insert_or_assign(key, arr);
-  // Pre-compute transpose only for weights accessed via get_weight_t() / linear_proj().
-  // Norm weights, A_log, dt_bias, conv1d, scales, biases are only accessed via get_weight().
-  if (key.size() >= 7 && key.compare(key.size() - 7, 7, ".weight") == 0) {
+  // Pre-compute 2D transpose only for weights accessed via get_weight_t() / linear_proj().
+  // Gate to ndim==2 to exclude 3D MoE expert tensors (those use get_weight_t3d instead).
+  if (key.size() >= 7 && key.compare(key.size() - 7, 7, ".weight") == 0
+      && arr.ndim() == 2) {
     g_weight_transposes().insert_or_assign(key, transpose(arr));
   }
 }

--- a/crates/mlx-sys/src/mlx_qwen35.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35.cpp
@@ -113,20 +113,32 @@ static std::vector<array> qwen35_decode_fn(const std::vector<array>& inputs) {
 extern "C" {
 
 void mlx_qwen35_store_weight(const char* name, mlx_array* weight) {
-  std::lock_guard<std::mutex> lock(g_weights_mutex());
+  std::unique_lock<std::shared_mutex> lock(g_weights_mutex());
   auto& arr = *reinterpret_cast<array*>(weight);
-  g_weights().insert_or_assign(std::string(name), arr);
+  std::string key(name);
+  g_weights().insert_or_assign(key, arr);
+  // Pre-compute transpose so get_weight_t() is a pure read (no lazy mutation).
+  g_weight_transposes().insert_or_assign(key, transpose(arr));
 }
 
 void mlx_qwen35_clear_weights() {
-  std::lock_guard<std::mutex> lock(g_weights_mutex());
+  std::unique_lock<std::shared_mutex> lock(g_weights_mutex());
   g_weights().clear();
   g_weight_transposes().clear();
+  g_active_model_id().store(0, std::memory_order_release);
 }
 
 size_t mlx_qwen35_weight_count() {
-  std::lock_guard<std::mutex> lock(g_weights_mutex());
+  std::shared_lock<std::shared_mutex> lock(g_weights_mutex());
   return g_weights().size();
+}
+
+void mlx_qwen35_set_model_id(uint64_t id) {
+  g_active_model_id().store(id, std::memory_order_release);
+}
+
+uint64_t mlx_qwen35_get_model_id() {
+  return g_active_model_id().load(std::memory_order_acquire);
 }
 
 void mlx_qwen35_compiled_init_from_prefill(

--- a/crates/mlx-sys/src/mlx_qwen35.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35.cpp
@@ -117,12 +117,12 @@ void mlx_qwen35_store_weight(const char* name, mlx_array* weight) {
   auto& arr = *reinterpret_cast<array*>(weight);
   std::string key(name);
   g_weights().insert_or_assign(key, arr);
-  // Pre-compute 2D transpose only for weights actually consumed via get_weight_t().
-  // These are: *_proj.weight (attention/MLP projections via linear_proj()),
-  // embedding.weight, and lm_head.weight. Skip vision encoder weights and
-  // other 2D tensors (norm, A_log, dt_bias, scales, biases) that only use get_weight().
+  // Pre-compute 2D transpose only for weights consumed via get_weight_t() / linear_proj().
+  // Match: any key containing "_proj" (covers q_proj, k_proj, v_proj, o_proj, out_proj,
+  // gate_proj, up_proj, down_proj, in_proj_qkvz, in_proj_ba, etc.), plus embedding/lm_head.
+  // Excludes vision encoder weights, norm weights, A_log, dt_bias, scales, biases.
   if (arr.ndim() == 2 && (
-      key.find("_proj.weight") != std::string::npos ||
+      key.find("_proj") != std::string::npos ||
       key == "embedding.weight" ||
       key == "lm_head.weight")) {
     g_weight_transposes().insert_or_assign(key, transpose(arr));

--- a/crates/mlx-sys/src/mlx_qwen35.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35.cpp
@@ -117,10 +117,14 @@ void mlx_qwen35_store_weight(const char* name, mlx_array* weight) {
   auto& arr = *reinterpret_cast<array*>(weight);
   std::string key(name);
   g_weights().insert_or_assign(key, arr);
-  // Pre-compute 2D transpose only for weights accessed via get_weight_t() / linear_proj().
-  // Gate to ndim==2 to exclude 3D MoE expert tensors (those use get_weight_t3d instead).
-  if (key.size() >= 7 && key.compare(key.size() - 7, 7, ".weight") == 0
-      && arr.ndim() == 2) {
+  // Pre-compute 2D transpose only for weights actually consumed via get_weight_t().
+  // These are: *_proj.weight (attention/MLP projections via linear_proj()),
+  // embedding.weight, and lm_head.weight. Skip vision encoder weights and
+  // other 2D tensors (norm, A_log, dt_bias, scales, biases) that only use get_weight().
+  if (arr.ndim() == 2 && (
+      key.find("_proj.weight") != std::string::npos ||
+      key == "embedding.weight" ||
+      key == "lm_head.weight")) {
     g_weight_transposes().insert_or_assign(key, transpose(arr));
   }
 }

--- a/crates/mlx-sys/src/mlx_qwen35.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35.cpp
@@ -117,8 +117,11 @@ void mlx_qwen35_store_weight(const char* name, mlx_array* weight) {
   auto& arr = *reinterpret_cast<array*>(weight);
   std::string key(name);
   g_weights().insert_or_assign(key, arr);
-  // Pre-compute transpose so get_weight_t() is a pure read (no lazy mutation).
-  g_weight_transposes().insert_or_assign(key, transpose(arr));
+  // Pre-compute transpose only for weights accessed via get_weight_t() / linear_proj().
+  // Norm weights, A_log, dt_bias, conv1d, scales, biases are only accessed via get_weight().
+  if (key.size() >= 7 && key.compare(key.size() - 7, 7, ".weight") == 0) {
+    g_weight_transposes().insert_or_assign(key, transpose(arr));
+  }
 }
 
 void mlx_qwen35_clear_weights() {

--- a/crates/mlx-sys/src/mlx_qwen35_common.h
+++ b/crates/mlx-sys/src/mlx_qwen35_common.h
@@ -46,21 +46,24 @@ inline std::atomic<uint64_t>& g_active_model_id() {
   return instance;
 }
 
-inline const array& get_weight(const std::string& name) {
+// Returns by VALUE (refcount bump) so the caller's copy survives even if a
+// concurrent writer clears the map. MLX arrays are refcounted handles — cheap to copy.
+inline array get_weight(const std::string& name) {
   std::shared_lock<std::shared_mutex> lock(g_weights_mutex());
   auto it = g_weights().find(name);
   if (it == g_weights().end()) {
     throw std::runtime_error("Weight not found: " + name);
   }
-  return it->second;
+  return it->second;  // copy under lock
 }
 
 // Pure read — transposes are pre-computed during weight registration.
-inline const array& get_weight_t(const std::string& name) {
+// Returns by VALUE for same reason as get_weight().
+inline array get_weight_t(const std::string& name) {
   std::shared_lock<std::shared_mutex> lock(g_weights_mutex());
   auto it = g_weight_transposes().find(name);
   if (it != g_weight_transposes().end()) {
-    return it->second;
+    return it->second;  // copy under lock
   }
   throw std::runtime_error("Transpose not found for weight: " + name);
 }
@@ -94,8 +97,8 @@ inline int infer_affine_bits(const array& w, const array& scales, int group_size
 inline array linear_proj(const array& x, const std::string& prefix) {
   std::string scales_key = prefix + ".scales";
   if (has_weight(scales_key)) {
-    const auto& w = get_weight(prefix + ".weight");
-    const auto& scales = get_weight(scales_key);
+    auto w = get_weight(prefix + ".weight");
+    auto scales = get_weight(scales_key);
     std::string biases_key = prefix + ".biases";
     std::optional<array> biases = std::nullopt;
     if (has_weight(biases_key)) {
@@ -418,7 +421,7 @@ inline GDNPureResult gdn_pure_fn(
   int keep = cfg.linear_conv_kernel_dim - 1;
   auto new_conv_state = slice(conv_input, {0, total_len - keep, 0}, {B, total_len, conv_dim});
 
-  const auto& conv_w = get_weight(pfx + "conv1d.weight");
+  auto conv_w = get_weight(pfx + "conv1d.weight");
   auto conv_out = mlx::core::conv1d(conv_input, conv_w, 1, 0, 1, conv_dim);
 
   // SiLU — compiled
@@ -442,8 +445,8 @@ inline GDNPureResult gdn_pure_fn(
 
   // Beta, g
   auto beta_3d = reshape(sigmoid(b), {B, 1, cfg.linear_num_v_heads});
-  const auto& a_log  = get_weight(pfx + "A_log");
-  const auto& dt_b   = get_weight(pfx + "dt_bias");
+  auto a_log  = get_weight(pfx + "A_log");
+  auto dt_b   = get_weight(pfx + "dt_bias");
   auto g_3d = reshape(fused_compute_g(a_log, a, dt_b), {B, 1, cfg.linear_num_v_heads});
 
   // Metal kernel
@@ -451,7 +454,7 @@ inline GDNPureResult gdn_pure_fn(
 
   // RMSNorm gating
   auto z_h = reshape(z, {B, 1, cfg.linear_num_v_heads, cfg.linear_value_head_dim});
-  const auto& nw = get_weight(pfx + "norm.weight");
+  auto nw = get_weight(pfx + "norm.weight");
   auto y_normed = fast::rms_norm(y, nw, cfg.rms_norm_eps);
   y_normed = compiled_silu_mul()({z_h, y_normed})[0];
 
@@ -679,7 +682,7 @@ inline GDNPureResult gdn_prefill_fn(
   int total_len = pad_len + T;
   auto new_conv_state = slice(conv_input, {0, total_len - pad_len, 0}, {B, total_len, conv_dim});
 
-  const auto& conv_w = get_weight(pfx + "conv1d.weight");
+  auto conv_w = get_weight(pfx + "conv1d.weight");
   auto conv_out = mlx::core::conv1d(conv_input, conv_w, 1, 0, 1, conv_dim);  // [B, T, conv_dim]
 
   // SiLU — compiled
@@ -703,8 +706,8 @@ inline GDNPureResult gdn_prefill_fn(
 
   // Beta, g — reshape b/a from [B*T, Hv] to [B, T, Hv]
   auto beta_3d = reshape(sigmoid(b), {B, T, cfg.linear_num_v_heads});
-  const auto& a_log = get_weight(pfx + "A_log");
-  const auto& dt_b  = get_weight(pfx + "dt_bias");
+  auto a_log = get_weight(pfx + "A_log");
+  auto dt_b  = get_weight(pfx + "dt_bias");
   // fused_compute_g works on flat tensors [B*T, Hv]
   auto g_flat = fused_compute_g(a_log, a, dt_b);
   auto g_3d = reshape(g_flat, {B, T, cfg.linear_num_v_heads});
@@ -718,7 +721,7 @@ inline GDNPureResult gdn_prefill_fn(
 
   // RMSNorm gating — z is [B*T, value_dim], reshape to [B, T, Hv, Dv]
   auto z_h = reshape(z, {B, T, cfg.linear_num_v_heads, cfg.linear_value_head_dim});
-  const auto& nw = get_weight(pfx + "norm.weight");
+  auto nw = get_weight(pfx + "norm.weight");
   auto y_normed = fast::rms_norm(y, nw, cfg.rms_norm_eps);
   y_normed = compiled_silu_mul()({z_h, y_normed})[0];
 

--- a/crates/mlx-sys/src/mlx_qwen35_common.h
+++ b/crates/mlx-sys/src/mlx_qwen35_common.h
@@ -14,7 +14,8 @@
 
 #include <string>
 #include <unordered_map>
-#include <mutex>
+#include <shared_mutex>
+#include <atomic>
 
 namespace qwen35_common {
 
@@ -27,8 +28,8 @@ inline std::unordered_map<std::string, array>& g_weights() {
   return instance;
 }
 
-inline std::mutex& g_weights_mutex() {
-  static std::mutex instance;
+inline std::shared_mutex& g_weights_mutex() {
+  static std::shared_mutex instance;
   return instance;
 }
 
@@ -37,7 +38,16 @@ inline std::unordered_map<std::string, array>& g_weight_transposes() {
   return instance;
 }
 
+// Model identity: atomic counter set after all weights are stored.
+// Inference checks this against its own model_id to avoid using another model's weights.
+// Value 0 means no model has registered weights.
+inline std::atomic<uint64_t>& g_active_model_id() {
+  static std::atomic<uint64_t> instance{0};
+  return instance;
+}
+
 inline const array& get_weight(const std::string& name) {
+  std::shared_lock<std::shared_mutex> lock(g_weights_mutex());
   auto it = g_weights().find(name);
   if (it == g_weights().end()) {
     throw std::runtime_error("Weight not found: " + name);
@@ -45,18 +55,18 @@ inline const array& get_weight(const std::string& name) {
   return it->second;
 }
 
+// Pure read — transposes are pre-computed during weight registration.
 inline const array& get_weight_t(const std::string& name) {
+  std::shared_lock<std::shared_mutex> lock(g_weights_mutex());
   auto it = g_weight_transposes().find(name);
   if (it != g_weight_transposes().end()) {
     return it->second;
   }
-  const auto& w = get_weight(name);
-  auto wt = transpose(w);
-  auto [inserted_it, _] = g_weight_transposes().emplace(name, std::move(wt));
-  return inserted_it->second;
+  throw std::runtime_error("Transpose not found for weight: " + name);
 }
 
 inline bool has_weight(const std::string& name) {
+  std::shared_lock<std::shared_mutex> lock(g_weights_mutex());
   return g_weights().count(name) > 0;
 }
 

--- a/crates/mlx-sys/src/mlx_qwen35_moe.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35_moe.cpp
@@ -75,16 +75,13 @@ static std::vector<DenseMLPQuantInfo> g_dense_quant;  // per-layer dense MLP qua
 // Cached 3D transposes for expert weights [E,out,in] → [E,in,out]
 static std::unordered_map<std::string, array> g_weight_transposes_3d;
 
+// Pure read — 3D transposes are pre-computed in mlx_qwen35_moe_init_from_prefill.
 const array& get_weight_t3d(const std::string& name) {
   auto it = g_weight_transposes_3d.find(name);
   if (it != g_weight_transposes_3d.end()) {
     return it->second;
   }
-  const auto& w = get_weight(name);
-  // [E, out, in] → [E, in, out]
-  auto wt = transpose(w, {0, 2, 1});
-  auto [inserted_it, _] = g_weight_transposes_3d.emplace(name, std::move(wt));
-  return inserted_it->second;
+  throw std::runtime_error("3D transpose not found for weight: " + name);
 }
 
 // =====================================================================
@@ -659,8 +656,17 @@ void mlx_qwen35_moe_init_from_prefill(
     g_moe_offset_int = prefill_offset;
     g_moe_inited = true;
 
-    // Clear 3D transpose cache
+    // Pre-compute 3D transposes for all expert weights [E,out,in] → [E,in,out].
+    // This eliminates lazy mutation in get_weight_t3d() during inference.
     g_weight_transposes_3d.clear();
+    {
+      std::shared_lock<std::shared_mutex> lock(g_weights_mutex());
+      for (const auto& [name, w] : g_weights()) {
+        if (w.ndim() == 3) {
+          g_weight_transposes_3d.insert_or_assign(name, transpose(w, {0, 2, 1}));
+        }
+      }
+    }
 
     // Break the lazy RNG split chain
     auto rng_key = mlx::core::random::KeySequence::default_().next();

--- a/crates/mlx-sys/src/mlx_qwen35_moe.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35_moe.cpp
@@ -76,10 +76,11 @@ static std::vector<DenseMLPQuantInfo> g_dense_quant;  // per-layer dense MLP qua
 static std::unordered_map<std::string, array> g_weight_transposes_3d;
 
 // Pure read — 3D transposes are pre-computed in mlx_qwen35_moe_init_from_prefill.
-const array& get_weight_t3d(const std::string& name) {
+// Returns by VALUE so the caller's copy survives concurrent map mutations.
+array get_weight_t3d(const std::string& name) {
   auto it = g_weight_transposes_3d.find(name);
   if (it != g_weight_transposes_3d.end()) {
-    return it->second;
+    return it->second;  // copy (refcount bump)
   }
   throw std::runtime_error("3D transpose not found for weight: " + name);
 }
@@ -94,8 +95,8 @@ array quantized_linear_forward(
     const std::string& prefix,
     int gs, int bits,
     const std::string& mode) {
-  const auto& w = get_weight(prefix + ".weight");
-  const auto& scales = get_weight(prefix + ".scales");
+  auto w = get_weight(prefix + ".weight");
+  auto scales = get_weight(prefix + ".scales");
   std::optional<array> biases = std::nullopt;
   if (has_weight(prefix + ".biases")) {
     biases = get_weight(prefix + ".biases");
@@ -143,8 +144,8 @@ array switch_linear_fwd(
     bool sorted,
     bool is_quant, int /*gs_hint*/, int /*bits_hint*/, const std::string& /*mode_hint*/) {
   if (is_quant && has_weight(prefix + ".scales")) {
-    const auto& w = get_weight(prefix + ".weight");
-    const auto& scales = get_weight(prefix + ".scales");
+    auto w = get_weight(prefix + ".weight");
+    auto scales = get_weight(prefix + ".scales");
     std::optional<array> biases = std::nullopt;
     if (has_weight(prefix + ".biases")) {
       biases = get_weight(prefix + ".biases");
@@ -611,8 +612,8 @@ void mlx_qwen35_moe_init_from_prefill(
         return {true, 32, 8, "mxfp8"};
       }
       // Affine: infer bits from weight/scales shape ratio
-      const auto& w = get_weight(prefix + ".weight");
-      const auto& scales = get_weight(prefix + ".scales");
+      auto w = get_weight(prefix + ".weight");
+      auto scales = get_weight(prefix + ".scales");
       int bits = infer_affine_bits(w, scales, 64);
       return {true, 64, bits, "affine"};
     };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,10 @@ export default defineConfig({
       typeAware: true,
     },
   },
+  staged: {
+    '*': ['vp check --fix'],
+    "*.rs": ["cargo fmt --all --"]
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes generation control flow, cache locking, and the C++/Rust boundary for compiled Qwen3.5 weights; mistakes could cause deadlocks, cross-request state leakage, or incorrect stopping behavior.
> 
> **Overview**
> Fixes token accounting so repetition/presence/frequency penalties and repetition cutoffs see the *most recently sampled token* (updates `paddleocr_vl` generation loops and `training_generate`).
> 
> Hardens Qwen3/Qwen3.5 (dense + MoE) cache reuse and compiled inference against concurrency: adds per-model `generation_lock` to serialize `chat()`/`generate()` vs cache reset/take/set, introduces globally-unique `model_id` for compiled weight ownership, and gates compiled paths behind a weight read lock plus model-id checks.
> 
> Improves paged generation correctness by validating requests, adding per-sequence penalty context + finish-reason overrides through the scheduler, applying penalties during prefill/decode sampling, avoiding an RwLock deadlock via `forward_paged_with_cache`, and making stop/length/repetition termination propagate accurately.
> 
> Switches `chatStream` token decoding to an incremental decode stream with recovery and final residual flush, and updates the C++ weight store to use a shared mutex, precompute transposes at registration, and expose `mlx_qwen35_set/get_model_id()` FFI APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8160136b46d0d7e338035850a5486e402fd681ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->