### PR TITLE
refactor: extract shared persistence and chat helpers

### DIFF
--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -14,7 +14,6 @@ use crate::sampling::{
 };
 use crate::tokenizer::Qwen3Tokenizer;
 use crate::tools;
-use crate::tools::ToolCallResult;
 
 use super::layer_cache::Qwen3_5LayerCache;
 use super::model::{ChatConfig, ChatResult};
@@ -128,9 +127,6 @@ pub(crate) fn compute_performance_metrics(
 pub(crate) fn finalize_chat_result(
     tokenizer: &Qwen3Tokenizer,
     generated_tokens: &[u32],
-    tokens: &[u32],
-    _expanded_tokens: Option<&[u32]>,
-    _has_images: bool,
     finish_reason: String,
     think_end_id: Option<u32>,
     think_end_str: Option<&str>,

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -234,32 +234,32 @@ pub(crate) fn verify_cache_prefix(
     cached_token_history: &[u32],
     cached_image_key: &Arc<RwLock<Option<u64>>>,
     has_caches: bool,
-) -> usize {
+) -> Result<usize> {
     if !reuse_cache {
-        return 0;
+        return Ok(0);
     }
     let cached = cached_token_history;
     if has_images {
-        let cached_img_key = cached_image_key.read().ok().and_then(|guard| *guard);
-        if let Some(cached_key) = cached_img_key
+        let cached_img_key_guard = cached_image_key
+            .read()
+            .map_err(|_| Error::from_reason("Failed to read cached image key"))?;
+        if let Some(cached_key) = *cached_img_key_guard
             && cached_key == image_cache_key
             && !cached.is_empty()
             && tokens_for_matching.len() >= cached.len()
             && tokens_for_matching[..cached.len()] == cached[..]
             && has_caches
         {
-            return cached.len();
+            return Ok(cached.len());
         }
-        0
+        Ok(0)
+    } else if !cached.is_empty()
+        && tokens.len() >= cached.len()
+        && tokens[..cached.len()] == cached[..]
+        && has_caches
+    {
+        Ok(cached.len())
     } else {
-        if !cached.is_empty()
-            && tokens.len() >= cached.len()
-            && tokens[..cached.len()] == cached[..]
-            && has_caches
-        {
-            cached.len()
-        } else {
-            0
-        }
+        Ok(0)
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -1,0 +1,269 @@
+//! Shared chat/decode infrastructure for Qwen3.5 Dense and MoE models.
+//!
+//! Extracts identical boilerplate from `chat()` and `chat_stream()` methods
+//! across both model variants: config extraction, penalty application,
+//! performance metrics, result finalization, and cache management.
+
+use std::sync::{Arc, RwLock};
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::sampling::{
+    SamplingConfig, apply_frequency_penalty, apply_presence_penalty, apply_repetition_penalty,
+};
+use crate::tokenizer::Qwen3Tokenizer;
+use crate::tools;
+use crate::tools::ToolCallResult;
+
+use super::layer_cache::Qwen3_5LayerCache;
+use super::model::{ChatConfig, ChatResult};
+
+/// Extracted chat parameters with defaults applied.
+pub(crate) struct ChatParams {
+    pub max_new_tokens: i32,
+    pub repetition_penalty: f64,
+    pub repetition_context_size: i32,
+    pub presence_penalty: f64,
+    pub presence_context_size: i32,
+    pub frequency_penalty: f64,
+    pub frequency_context_size: i32,
+    pub max_consecutive_tokens: i32,
+    pub max_ngram_repeats: i32,
+    pub ngram_size: i32,
+    pub sampling_config: Option<SamplingConfig>,
+    pub report_performance: bool,
+    pub reuse_cache: bool,
+}
+
+/// Extract ChatConfig fields into flat variables with defaults.
+pub(crate) fn extract_chat_params(config: &ChatConfig) -> ChatParams {
+    ChatParams {
+        max_new_tokens: config.max_new_tokens.unwrap_or(2048),
+        repetition_penalty: config.repetition_penalty.unwrap_or(1.0),
+        repetition_context_size: config.repetition_context_size.unwrap_or(256),
+        presence_penalty: config.presence_penalty.unwrap_or(0.0),
+        presence_context_size: config.presence_context_size.unwrap_or(20),
+        frequency_penalty: config.frequency_penalty.unwrap_or(0.0),
+        frequency_context_size: config.frequency_context_size.unwrap_or(20),
+        max_consecutive_tokens: config.max_consecutive_tokens.unwrap_or(16),
+        max_ngram_repeats: config.max_ngram_repeats.unwrap_or(3),
+        ngram_size: config.ngram_size.unwrap_or(64),
+        sampling_config: Some(SamplingConfig {
+            temperature: config.temperature,
+            top_k: config.top_k,
+            top_p: config.top_p,
+            min_p: config.min_p,
+        }),
+        report_performance: config.report_performance.unwrap_or(false),
+        reuse_cache: config.reuse_cache.unwrap_or(true),
+    }
+}
+
+/// Apply repetition + presence + frequency penalties to logits.
+pub(crate) fn apply_all_penalties(
+    mut logits: MxArray,
+    token_history: &[u32],
+    params: &ChatParams,
+) -> Result<MxArray> {
+    if params.repetition_penalty != 1.0 && !token_history.is_empty() {
+        logits = apply_repetition_penalty(
+            &logits,
+            token_history,
+            params.repetition_penalty,
+            Some(params.repetition_context_size),
+        )?;
+    }
+    if params.presence_penalty != 0.0 {
+        logits = apply_presence_penalty(
+            &logits,
+            token_history,
+            params.presence_penalty,
+            Some(params.presence_context_size),
+        )?;
+    }
+    if params.frequency_penalty != 0.0 {
+        logits = apply_frequency_penalty(
+            &logits,
+            token_history,
+            params.frequency_penalty,
+            Some(params.frequency_context_size),
+        )?;
+    }
+    Ok(logits)
+}
+
+/// Compute TTFT / prefill tok/s / decode tok/s performance metrics.
+pub(crate) fn compute_performance_metrics(
+    generation_start: Option<std::time::Instant>,
+    first_token_instant: Option<std::time::Instant>,
+    prefill_tokens_len: usize,
+    generated_tokens_len: usize,
+) -> Option<crate::profiling::PerformanceMetrics> {
+    let (gen_start, first_tok) = match (generation_start, first_token_instant) {
+        (Some(gs), Some(ft)) => (gs, ft),
+        _ => return None,
+    };
+    let generation_end = std::time::Instant::now();
+    let actual_prefill_toks = prefill_tokens_len as f64;
+    let gen_toks = generated_tokens_len as f64;
+    let ttft_ms = first_tok.duration_since(gen_start).as_secs_f64() * 1000.0;
+    let decode_ms = generation_end.duration_since(first_tok).as_secs_f64() * 1000.0;
+    Some(crate::profiling::PerformanceMetrics {
+        ttft_ms,
+        prefill_tokens_per_second: if ttft_ms > 0.0 {
+            actual_prefill_toks / (ttft_ms / 1000.0)
+        } else {
+            0.0
+        },
+        decode_tokens_per_second: if decode_ms > 0.0 && gen_toks > 1.0 {
+            (gen_toks - 1.0) / (decode_ms / 1000.0)
+        } else {
+            0.0
+        },
+    })
+}
+
+/// Decode tokens, parse thinking/tool_calls, build ChatResult.
+pub(crate) fn finalize_chat_result(
+    tokenizer: &Qwen3Tokenizer,
+    generated_tokens: &[u32],
+    tokens: &[u32],
+    _expanded_tokens: Option<&[u32]>,
+    _has_images: bool,
+    finish_reason: String,
+    think_end_id: Option<u32>,
+    think_end_str: Option<&str>,
+    performance: Option<crate::profiling::PerformanceMetrics>,
+) -> Result<ChatResult> {
+    let text = tokenizer
+        .decode_sync(generated_tokens, true)
+        .unwrap_or_else(|e| {
+            tracing::warn!("Failed to decode generated tokens: {}", e);
+            String::new()
+        });
+
+    let num_tokens = generated_tokens.len() as u32;
+
+    let think_tag = if tools::has_think_end_token(generated_tokens, think_end_id) {
+        think_end_str
+    } else {
+        None
+    };
+    let (clean_text, tool_calls, thinking) = tools::split_at_think_end(&text, think_tag);
+
+    // If we have valid tool calls, override finish reason
+    let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
+        "tool_calls".to_string()
+    } else {
+        finish_reason
+    };
+
+    Ok(ChatResult {
+        text: clean_text,
+        tool_calls,
+        thinking,
+        num_tokens,
+        finish_reason,
+        raw_text: text,
+        performance,
+    })
+}
+
+/// Save or clear cache state after generation.
+pub(crate) fn save_cache_state(
+    reuse_cache: bool,
+    has_images: bool,
+    generated_tokens: &[u32],
+    finish_reason: &str,
+    tokens: &[u32],
+    expanded_tokens: Option<&[u32]>,
+    image_cache_key: u64,
+    cached_token_history_arc: &Arc<RwLock<Vec<u32>>>,
+    cached_image_key_arc: &Arc<RwLock<Option<u64>>>,
+    cached_rope_deltas_arc: &Arc<RwLock<Option<i32>>>,
+    caches_arc: &Arc<RwLock<Option<Vec<Qwen3_5LayerCache>>>>,
+) -> Result<()> {
+    if reuse_cache {
+        let mut full_history = if has_images {
+            expanded_tokens.unwrap_or(tokens).to_vec()
+        } else {
+            tokens.to_vec()
+        };
+        // Only include tokens that were actually forwarded through the model.
+        // When stopped at max_tokens ("length"), the last token was never forwarded
+        // (the pipelined loop skips forward on the final step).
+        let history_tokens = if finish_reason == "length" && !generated_tokens.is_empty() {
+            &generated_tokens[..generated_tokens.len() - 1]
+        } else {
+            generated_tokens
+        };
+        full_history.extend_from_slice(history_tokens);
+        if let Ok(mut th) = cached_token_history_arc.write() {
+            *th = full_history;
+        }
+        if let Ok(mut ik) = cached_image_key_arc.write() {
+            *ik = if has_images {
+                Some(image_cache_key)
+            } else {
+                None
+            };
+        }
+    } else {
+        // reuseCache: false — clear all cache state to free GPU memory
+        if let Ok(mut cg) = caches_arc.write() {
+            *cg = None;
+        }
+        if let Ok(mut th) = cached_token_history_arc.write() {
+            th.clear();
+        }
+        if let Ok(mut ik) = cached_image_key_arc.write() {
+            *ik = None;
+        }
+        if let Ok(mut rd) = cached_rope_deltas_arc.write() {
+            *rd = None;
+        }
+    }
+    Ok(())
+}
+
+/// Verify cache prefix match for reuse. Returns the number of cached tokens
+/// that match the current input (0 if no match).
+pub(crate) fn verify_cache_prefix(
+    reuse_cache: bool,
+    has_images: bool,
+    tokens: &[u32],
+    tokens_for_matching: &[u32],
+    image_cache_key: u64,
+    cached_token_history: &[u32],
+    cached_image_key: &Arc<RwLock<Option<u64>>>,
+    has_caches: bool,
+) -> usize {
+    if !reuse_cache {
+        return 0;
+    }
+    let cached = cached_token_history;
+    if has_images {
+        let cached_img_key = cached_image_key.read().ok().and_then(|guard| *guard);
+        if let Some(cached_key) = cached_img_key
+            && cached_key == image_cache_key
+            && !cached.is_empty()
+            && tokens_for_matching.len() >= cached.len()
+            && tokens_for_matching[..cached.len()] == cached[..]
+            && has_caches
+        {
+            return cached.len();
+        }
+        0
+    } else {
+        if !cached.is_empty()
+            && tokens.len() >= cached.len()
+            && tokens[..cached.len()] == cached[..]
+            && has_caches
+        {
+            cached.len()
+        } else {
+            0
+        }
+    }
+}

--- a/crates/mlx-core/src/models/qwen3_5/mod.rs
+++ b/crates/mlx-core/src/models/qwen3_5/mod.rs
@@ -1,5 +1,6 @@
 pub mod arrays_cache;
 pub mod attention;
+pub(crate) mod chat_common;
 pub mod config;
 pub mod decoder_layer;
 pub mod gated_delta;
@@ -7,6 +8,7 @@ pub mod gated_delta_net;
 pub mod layer_cache;
 pub mod model;
 pub mod persistence;
+pub(crate) mod persistence_common;
 pub mod processing;
 pub mod prompt_cache;
 pub mod quantized_linear;

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -23,8 +23,8 @@ use crate::tools;
 use crate::tools::ToolCallResult;
 
 use super::chat_common::{
-    self, ChatParams, apply_all_penalties, compute_performance_metrics, extract_chat_params,
-    finalize_chat_result, save_cache_state, verify_cache_prefix,
+    apply_all_penalties, compute_performance_metrics, extract_chat_params, finalize_chat_result,
+    save_cache_state, verify_cache_prefix,
 };
 use super::config::Qwen3_5Config;
 use super::decoder_layer::DecoderLayer;
@@ -1060,42 +1060,16 @@ impl Qwen3_5Model {
             let cached_token_history_guard = cached_token_history_arc
                 .read()
                 .map_err(|_| Error::from_reason("Failed to read cached token history"))?;
-            let cached_prefix_len = if reuse_cache {
-                let cached = &*cached_token_history_guard;
-                if has_images {
-                    // VLM: check image_cache_key matches AND expanded token prefix matches
-                    let cached_img_key = cached_image_key_arc
-                        .read()
-                        .map_err(|_| Error::from_reason("Failed to read cached image key"))?;
-                    if let Some(cached_key) = *cached_img_key {
-                        if cached_key == current_image_cache_key
-                            && !cached.is_empty()
-                            && expanded_tokens.len() >= cached.len()
-                            && expanded_tokens[..cached.len()] == cached[..]
-                            && caches_guard.is_some()
-                        {
-                            cached.len()
-                        } else {
-                            0
-                        }
-                    } else {
-                        0
-                    }
-                } else {
-                    // Text-only: existing logic unchanged
-                    if !cached.is_empty()
-                        && tokens.len() >= cached.len()
-                        && tokens[..cached.len()] == cached[..]
-                        && caches_guard.is_some()
-                    {
-                        cached.len()
-                    } else {
-                        0
-                    }
-                }
-            } else {
-                0
-            };
+            let cached_prefix_len = verify_cache_prefix(
+                reuse_cache,
+                has_images,
+                &tokens,
+                &expanded_tokens,
+                current_image_cache_key,
+                &cached_token_history_guard,
+                &cached_image_key_arc,
+                caches_guard.is_some(),
+            );
             drop(cached_token_history_guard);
 
             let prefill_tokens = if cached_prefix_len > 0 {
@@ -1573,9 +1547,6 @@ impl Qwen3_5Model {
             finalize_chat_result(
                 &tokenizer_for_decode,
                 &generated_tokens,
-                &tokens,
-                Some(&expanded_tokens),
-                has_images,
                 finish_reason,
                 think_end_id,
                 think_end_str.as_deref(),

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1069,7 +1069,7 @@ impl Qwen3_5Model {
                 &cached_token_history_guard,
                 &cached_image_key_arc,
                 caches_guard.is_some(),
-            );
+            )?;
             drop(cached_token_history_guard);
 
             let prefill_tokens = if cached_prefix_len > 0 {

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -22,6 +22,10 @@ use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::tools;
 use crate::tools::ToolCallResult;
 
+use super::chat_common::{
+    self, ChatParams, apply_all_penalties, compute_performance_metrics, extract_chat_params,
+    finalize_chat_result, save_cache_state, verify_cache_prefix,
+};
 use super::config::Qwen3_5Config;
 use super::decoder_layer::DecoderLayer;
 use super::layer_cache::Qwen3_5LayerCache;
@@ -1014,22 +1018,8 @@ impl Qwen3_5Model {
                 enable_thinking,
             )?;
 
-            let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
-            let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
-            let repetition_context_size = config.repetition_context_size.unwrap_or(256);
-            let presence_penalty = config.presence_penalty.unwrap_or(0.0);
-            let presence_context_size = config.presence_context_size.unwrap_or(20);
-            let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
-            let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-            let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-            let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-            let ngram_size = config.ngram_size.unwrap_or(64);
-            let sampling_config = Some(SamplingConfig {
-                temperature: config.temperature,
-                top_k: config.top_k,
-                top_p: config.top_p,
-                min_p: config.min_p,
-            });
+            let p = extract_chat_params(&config);
+            let max_new_tokens = p.max_new_tokens;
 
             let mut layers_guard = layers_arc
                 .write()
@@ -1270,32 +1260,9 @@ impl Qwen3_5Model {
             let mut token_history: Vec<u32> = tokens.clone();
 
             // Apply repetition penalty to prefill logits
-            if repetition_penalty != 1.0 && !token_history.is_empty() {
-                last_logits = apply_repetition_penalty(
-                    &last_logits,
-                    &token_history,
-                    repetition_penalty,
-                    Some(repetition_context_size),
-                )?;
-            }
-            if presence_penalty != 0.0 {
-                last_logits = apply_presence_penalty(
-                    &last_logits,
-                    &token_history,
-                    presence_penalty,
-                    Some(presence_context_size),
-                )?;
-            }
-            if frequency_penalty != 0.0 {
-                last_logits = apply_frequency_penalty(
-                    &last_logits,
-                    &token_history,
-                    frequency_penalty,
-                    Some(frequency_context_size),
-                )?;
-            }
+            last_logits = apply_all_penalties(last_logits, &token_history, &p)?;
 
-            let mut y = sample(&last_logits, sampling_config)?;
+            let mut y = sample(&last_logits, p.sampling_config)?;
             MxArray::async_eval_arrays(&[&y]);
 
             let _compiled_guard = if use_compiled {
@@ -1394,34 +1361,11 @@ impl Qwen3_5Model {
                         profiler.end();
 
                         profiler.begin("rep_penalty");
-                        if repetition_penalty != 1.0 {
-                            logits = apply_repetition_penalty(
-                                &logits,
-                                &token_history,
-                                repetition_penalty,
-                                Some(repetition_context_size),
-                            )?;
-                        }
-                        if presence_penalty != 0.0 {
-                            logits = apply_presence_penalty(
-                                &logits,
-                                &token_history,
-                                presence_penalty,
-                                Some(presence_context_size),
-                            )?;
-                        }
-                        if frequency_penalty != 0.0 {
-                            logits = apply_frequency_penalty(
-                                &logits,
-                                &token_history,
-                                frequency_penalty,
-                                Some(frequency_context_size),
-                            )?;
-                        }
+                        logits = apply_all_penalties(logits, &token_history, &p)?;
                         profiler.end();
 
                         profiler.begin("sample");
-                        let next_token = sample(&logits, sampling_config)?;
+                        let next_token = sample(&logits, p.sampling_config)?;
                         profiler.end();
 
                         profiler.begin("eval_caches");
@@ -1442,7 +1386,7 @@ impl Qwen3_5Model {
                     let token_id = y.item_at_int32(0)? as u32;
                     profiler.end();
                     profiler.mark_first_token();
-                    if report_perf && first_token_instant.is_none() {
+                    if p.report_performance && first_token_instant.is_none() {
                         first_token_instant = Some(std::time::Instant::now());
                     }
 
@@ -1456,9 +1400,9 @@ impl Qwen3_5Model {
 
                     if let Some(reason) = check_repetition_cutoff(
                         &generated_tokens,
-                        max_consecutive_tokens,
-                        max_ngram_repeats,
-                        ngram_size,
+                        p.max_consecutive_tokens,
+                        p.max_ngram_repeats,
+                        p.ngram_size,
                     ) {
                         finish_reason = reason.to_string();
                         break;
@@ -1539,34 +1483,11 @@ impl Qwen3_5Model {
                         profiler.end();
 
                         profiler.begin("rep_penalty");
-                        if repetition_penalty != 1.0 {
-                            logits = apply_repetition_penalty(
-                                &logits,
-                                &token_history,
-                                repetition_penalty,
-                                Some(repetition_context_size),
-                            )?;
-                        }
-                        if presence_penalty != 0.0 {
-                            logits = apply_presence_penalty(
-                                &logits,
-                                &token_history,
-                                presence_penalty,
-                                Some(presence_context_size),
-                            )?;
-                        }
-                        if frequency_penalty != 0.0 {
-                            logits = apply_frequency_penalty(
-                                &logits,
-                                &token_history,
-                                frequency_penalty,
-                                Some(frequency_context_size),
-                            )?;
-                        }
+                        logits = apply_all_penalties(logits, &token_history, &p)?;
                         profiler.end();
 
                         profiler.begin("sample");
-                        let next_token = sample(&logits, sampling_config)?;
+                        let next_token = sample(&logits, p.sampling_config)?;
                         profiler.end();
 
                         profiler.begin("async_eval");
@@ -1585,7 +1506,7 @@ impl Qwen3_5Model {
                     let token_id = y.item_at_int32(0)? as u32;
                     profiler.end();
                     profiler.mark_first_token();
-                    if report_perf && first_token_instant.is_none() {
+                    if p.report_performance && first_token_instant.is_none() {
                         first_token_instant = Some(std::time::Instant::now());
                     }
 
@@ -1599,9 +1520,9 @@ impl Qwen3_5Model {
 
                     if let Some(reason) = check_repetition_cutoff(
                         &generated_tokens,
-                        max_consecutive_tokens,
-                        max_ngram_repeats,
-                        ngram_size,
+                        p.max_consecutive_tokens,
+                        p.max_ngram_repeats,
+                        p.ngram_size,
                     ) {
                         finish_reason = reason.to_string();
                         break;
@@ -1627,106 +1548,39 @@ impl Qwen3_5Model {
             // _compiled_guard dropped here (if Some), calling mlx_qwen35_compiled_reset()
 
             // === Save token history and image key for cache reuse on next call ===
-            if reuse_cache {
-                let mut full_history = if has_images {
-                    expanded_tokens.clone()
-                } else {
-                    tokens.clone()
-                };
-                // Only include tokens that were actually forwarded through the model.
-                // When stopped at max_tokens ("length"), the last token was never forwarded
-                // (the pipelined loop skips forward on the final step).
-                let history_tokens = if finish_reason == "length" && !generated_tokens.is_empty() {
-                    &generated_tokens[..generated_tokens.len() - 1]
-                } else {
-                    &generated_tokens
-                };
-                full_history.extend_from_slice(history_tokens);
-                if let Ok(mut th) = cached_token_history_arc.write() {
-                    *th = full_history;
-                }
-                if let Ok(mut ik) = cached_image_key_arc.write() {
-                    *ik = if has_images {
-                        Some(current_image_cache_key)
-                    } else {
-                        None
-                    };
-                }
-            } else {
-                // reuseCache: false — clear all cache state to free GPU memory
-                if let Ok(mut cg) = caches_arc.write() {
-                    *cg = None;
-                }
-                if let Ok(mut th) = cached_token_history_arc.write() {
-                    th.clear();
-                }
-                if let Ok(mut ik) = cached_image_key_arc.write() {
-                    *ik = None;
-                }
-                if let Ok(mut rd) = cached_rope_deltas_arc.write() {
-                    *rd = None;
-                }
-            }
+            save_cache_state(
+                p.reuse_cache,
+                has_images,
+                &generated_tokens,
+                &finish_reason,
+                &tokens,
+                Some(&expanded_tokens),
+                current_image_cache_key,
+                &cached_token_history_arc,
+                &cached_image_key_arc,
+                &cached_rope_deltas_arc,
+                &caches_arc,
+            )?;
 
-            // Decode text
-            let text = tokenizer_for_decode
-                .decode_sync(&generated_tokens, true)
-                .unwrap_or_else(|e| {
-                    warn!("Failed to decode generated tokens: {}", e);
-                    String::new()
-                });
+            // Compute performance metrics
+            let performance = compute_performance_metrics(
+                generation_start,
+                first_token_instant,
+                prefill_tokens.len(),
+                generated_tokens.len(),
+            );
 
-            let num_tokens = generated_tokens.len() as u32;
-
-            let think_tag = if tools::has_think_end_token(&generated_tokens, think_end_id) {
-                think_end_str.as_deref()
-            } else {
-                None
-            };
-            let (clean_text, tool_calls, thinking) = tools::split_at_think_end(&text, think_tag);
-
-            // If we have valid tool calls, override finish reason
-            let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
-                "tool_calls".to_string()
-            } else {
-                finish_reason
-            };
-
-            // Compute performance metrics if requested
-            let performance = if let (Some(gen_start), Some(first_tok)) =
-                (generation_start, first_token_instant)
-            {
-                let generation_end = std::time::Instant::now();
-                let actual_prefill_toks = prefill_tokens.len() as f64;
-                let gen_toks = generated_tokens.len() as f64;
-                let ttft_ms = first_tok.duration_since(gen_start).as_secs_f64() * 1000.0;
-                let decode_ms = generation_end.duration_since(first_tok).as_secs_f64() * 1000.0;
-                Some(crate::profiling::PerformanceMetrics {
-                    ttft_ms,
-                    prefill_tokens_per_second: if ttft_ms > 0.0 {
-                        actual_prefill_toks / (ttft_ms / 1000.0)
-                    } else {
-                        0.0
-                    },
-                    decode_tokens_per_second: if decode_ms > 0.0 && gen_toks > 1.0 {
-                        (gen_toks - 1.0) / (decode_ms / 1000.0)
-                    } else {
-                        0.0
-                    },
-                })
-            } else {
-                None
-            };
-
-            Ok(ChatResult {
-                text: clean_text,
-                tool_calls,
-                thinking,
-                num_tokens,
+            finalize_chat_result(
+                &tokenizer_for_decode,
+                &generated_tokens,
+                &tokens,
+                Some(&expanded_tokens),
+                has_images,
                 finish_reason,
-                raw_text: text,
+                think_end_id,
+                think_end_str.as_deref(),
                 performance,
-            })
+            )
         })
         .await
         .map_err(|e| Error::from_reason(format!("Chat task failed: {}", e)))?

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -11,9 +11,12 @@ use tracing::{info, warn};
 use crate::array::{DType, MxArray};
 use crate::nn::LayerNorm;
 use crate::tokenizer::Qwen3Tokenizer;
-use crate::utils::safetensors::load_safetensors_lazy;
 use crate::vision::encoder::{VisionAttention, VisionEncoderLayer, VisionMLP};
 use crate::vision::projector::SpatialProjector;
+
+use super::persistence_common::{
+    dequant_fp8_weights, get_config_bool, get_config_f64, get_config_i32, load_all_safetensors,
+};
 
 use super::config::Qwen3_5Config;
 use super::decoder_layer::AttentionType;
@@ -24,157 +27,6 @@ use super::quantized_linear::{
     is_quantized_checkpoint, try_build_mxfp8_quantized_linear, try_build_quantized_linear,
 };
 use super::vision::{Qwen3_5VisionConfig, Qwen3_5VisionEncoder};
-
-/// Load all safetensors files from a directory (supports sharded checkpoints).
-/// Uses MLX's native mmap-backed lazy loader — arrays are backed by deferred disk
-/// reads and data is only materialized on eval. This makes loading near-instant
-/// regardless of model size (vs the eager reader which took 3-4 min for 29GB).
-fn load_all_safetensors(dir: &Path) -> Result<HashMap<String, MxArray>> {
-    let single_path = if dir.join("weights.safetensors").exists() {
-        Some(dir.join("weights.safetensors"))
-    } else if dir.join("model.safetensors").exists() {
-        Some(dir.join("model.safetensors"))
-    } else {
-        None
-    };
-
-    if let Some(path) = single_path {
-        info!("Loading weights from: {} (mmap)", path.display());
-        let mut params = load_safetensors_lazy(&path)?;
-
-        // Also load vision.safetensors if present (VLM models)
-        let vision_path = dir.join("vision.safetensors");
-        if vision_path.exists() {
-            info!(
-                "Loading vision weights from: {} (mmap)",
-                vision_path.display()
-            );
-            let vision_params = load_safetensors_lazy(&vision_path)?;
-            info!("Loaded {} vision tensors", vision_params.len());
-            params.extend(vision_params);
-        }
-
-        return Ok(params);
-    }
-
-    let mut shard_files: Vec<std::path::PathBuf> = Vec::new();
-    let entries = fs::read_dir(dir)
-        .map_err(|e| Error::from_reason(format!("Failed to read model directory: {}", e)))?;
-
-    for entry in entries {
-        let entry = entry
-            .map_err(|e| Error::from_reason(format!("Failed to read directory entry: {}", e)))?;
-        let name = entry.file_name().to_string_lossy().to_string();
-        let is_shard = (name.starts_with("model-") || name.starts_with("model.safetensors-"))
-            && name.ends_with(".safetensors")
-            && name.contains("-of-");
-        if is_shard {
-            shard_files.push(entry.path());
-        }
-    }
-
-    if shard_files.is_empty() {
-        return Err(Error::from_reason(format!(
-            "No safetensors files found in {}",
-            dir.display()
-        )));
-    }
-
-    shard_files.sort();
-    info!(
-        "Loading {} sharded safetensors files (mmap)",
-        shard_files.len()
-    );
-
-    let mut all_params: HashMap<String, MxArray> = HashMap::new();
-    for shard_path in &shard_files {
-        info!("  Loading shard: {} (mmap)", shard_path.display());
-        let shard_params = load_safetensors_lazy(shard_path)?;
-        all_params.extend(shard_params);
-    }
-
-    Ok(all_params)
-}
-
-/// FP8 E4M3 block-wise dequantization: weight * scale_inv with block_size=128
-fn dequant_fp8(weight: &MxArray, scale_inv: &MxArray, target_dtype: DType) -> Result<MxArray> {
-    let weight = weight.from_fp8(target_dtype)?;
-
-    let shape = weight.shape()?;
-    let shape_ref = shape.as_ref();
-
-    if shape_ref.len() < 2 {
-        return weight.mul(scale_inv)?.astype(target_dtype);
-    }
-
-    let m = shape_ref[0] as usize;
-    let n = shape_ref[1] as usize;
-    let bs: usize = 128;
-
-    let pad_bottom = (bs - (m % bs)) % bs;
-    let pad_side = (bs - (n % bs)) % bs;
-
-    let weight = if pad_bottom > 0 || pad_side > 0 {
-        weight.pad(&[0, pad_bottom as i32, 0, pad_side as i32], 0.0)?
-    } else {
-        weight
-    };
-
-    let m_padded = m + pad_bottom;
-    let n_padded = n + pad_side;
-    let weight = weight.reshape(&[
-        (m_padded / bs) as i64,
-        bs as i64,
-        (n_padded / bs) as i64,
-        bs as i64,
-    ])?;
-
-    let scale = scale_inv.expand_dims(1)?.expand_dims(3)?;
-    let weight = weight.mul(&scale)?;
-
-    let weight = weight.reshape(&[m_padded as i64, n_padded as i64])?;
-    let weight = if pad_bottom > 0 || pad_side > 0 {
-        weight.slice(&[0, 0], &[m as i64, n as i64])?
-    } else {
-        weight
-    };
-
-    weight.astype(target_dtype)
-}
-
-/// Dequantize all FP8 weight pairs in-place.
-fn dequant_fp8_weights(params: &mut HashMap<String, MxArray>, target_dtype: DType) -> Result<()> {
-    let scale_keys: Vec<String> = params
-        .keys()
-        .filter(|k| k.ends_with("weight_scale_inv"))
-        .cloned()
-        .collect();
-
-    if scale_keys.is_empty() {
-        return Ok(());
-    }
-
-    info!(
-        "Dequantizing {} FP8 weight pairs to {:?}",
-        scale_keys.len(),
-        target_dtype
-    );
-
-    for scale_key in scale_keys {
-        let weight_key = scale_key.replace("_scale_inv", "");
-        let scale_inv = params
-            .remove(&scale_key)
-            .expect("scale_key must exist in params");
-        if let Some(weight) = params.remove(&weight_key) {
-            let dequantized = dequant_fp8(&weight, &scale_inv, target_dtype)?;
-            // Eval immediately to prevent lazy chain accumulation (OOM with many FP8 pairs)
-            dequantized.eval();
-            params.insert(weight_key, dequantized);
-        }
-    }
-
-    Ok(())
-}
 
 /// Sanitize weights from HuggingFace format (dense variant).
 ///
@@ -831,7 +683,7 @@ pub async fn load(model_path: &str) -> Result<Qwen3_5Model> {
         );
 
         // Load all weights
-        let raw_params = load_all_safetensors(path)?;
+        let raw_params = load_all_safetensors(path, true)?;
         info!("Loaded {} raw tensors", raw_params.len());
 
         // Check for vision weights and split if present
@@ -1082,50 +934,12 @@ fn register_weights_with_cpp(params: &HashMap<String, MxArray>, model_id: u64) {
 fn parse_config(raw: &Value) -> Result<Qwen3_5Config> {
     let text_cfg = raw.get("text_config");
 
-    let get_i32 = |keys: &[&str], default: i32| -> i32 {
-        for key in keys {
-            if let Some(tc) = text_cfg
-                && let Some(v) = tc[key].as_i64()
-            {
-                return v as i32;
-            }
-            if let Some(v) = raw[key].as_i64() {
-                return v as i32;
-            }
-        }
-        default
-    };
+    let gi = |keys: &[&str], default: i32| get_config_i32(raw, text_cfg, keys, default);
+    let gf = |keys: &[&str], default: f64| get_config_f64(raw, text_cfg, keys, default);
+    let gb = |keys: &[&str], default: bool| get_config_bool(raw, text_cfg, keys, default);
 
-    let get_f64 = |keys: &[&str], default: f64| -> f64 {
-        for key in keys {
-            if let Some(tc) = text_cfg
-                && let Some(v) = tc[key].as_f64()
-            {
-                return v;
-            }
-            if let Some(v) = raw[key].as_f64() {
-                return v;
-            }
-        }
-        default
-    };
-
-    let get_bool = |keys: &[&str], default: bool| -> bool {
-        for key in keys {
-            if let Some(tc) = text_cfg
-                && let Some(v) = tc[key].as_bool()
-            {
-                return v;
-            }
-            if let Some(v) = raw[key].as_bool() {
-                return v;
-            }
-        }
-        default
-    };
-
-    let hidden_size = get_i32(&["hidden_size"], 0);
-    let num_heads = get_i32(&["num_attention_heads", "num_heads"], 0);
+    let hidden_size = gi(&["hidden_size"], 0);
+    let num_heads = gi(&["num_attention_heads", "num_heads"], 0);
 
     let head_dim = text_cfg
         .and_then(|tc| tc["head_dim"].as_i64())
@@ -1145,17 +959,17 @@ fn parse_config(raw: &Value) -> Result<Qwen3_5Config> {
 
     let partial_rotary_factor = rope_obj
         .and_then(|rp| rp["partial_rotary_factor"].as_f64())
-        .unwrap_or_else(|| get_f64(&["partial_rotary_factor"], 0.25));
+        .unwrap_or_else(|| gf(&["partial_rotary_factor"], 0.25));
 
     let rope_theta = rope_obj
         .and_then(|rp| rp["rope_theta"].as_f64())
-        .unwrap_or_else(|| get_f64(&["rope_theta"], 100_000.0));
+        .unwrap_or_else(|| gf(&["rope_theta"], 100_000.0));
 
-    let bos_token_id = get_i32(&["bos_token_id"], 151643);
-    let num_layers = get_i32(&["num_hidden_layers", "num_layers"], 0);
-    let intermediate_size = get_i32(&["intermediate_size"], 0);
-    let num_kv_heads = get_i32(&["num_key_value_heads", "num_kv_heads"], 8);
-    let vocab_size = get_i32(&["vocab_size"], 151936);
+    let bos_token_id = gi(&["bos_token_id"], 151643);
+    let num_layers = gi(&["num_hidden_layers", "num_layers"], 0);
+    let intermediate_size = gi(&["intermediate_size"], 0);
+    let num_kv_heads = gi(&["num_key_value_heads", "num_kv_heads"], 8);
+    let vocab_size = gi(&["vocab_size"], 151936);
 
     if hidden_size <= 0 {
         return Err(Error::from_reason(format!(
@@ -1201,21 +1015,21 @@ fn parse_config(raw: &Value) -> Result<Qwen3_5Config> {
         num_heads,
         num_kv_heads,
         intermediate_size,
-        rms_norm_eps: get_f64(&["rms_norm_eps"], 1e-6),
+        rms_norm_eps: gf(&["rms_norm_eps"], 1e-6),
         head_dim,
-        tie_word_embeddings: get_bool(&["tie_word_embeddings"], false),
-        attention_bias: get_bool(&["attention_bias"], false),
-        max_position_embeddings: get_i32(&["max_position_embeddings"], 131072),
-        pad_token_id: get_i32(&["pad_token_id"], bos_token_id),
-        eos_token_id: get_i32(&["eos_token_id"], 151645),
+        tie_word_embeddings: gb(&["tie_word_embeddings"], false),
+        attention_bias: gb(&["attention_bias"], false),
+        max_position_embeddings: gi(&["max_position_embeddings"], 131072),
+        pad_token_id: gi(&["pad_token_id"], bos_token_id),
+        eos_token_id: gi(&["eos_token_id"], 151645),
         bos_token_id,
 
-        linear_num_value_heads: get_i32(&["linear_num_value_heads"], 64),
-        linear_num_key_heads: get_i32(&["linear_num_key_heads"], 16),
-        linear_key_head_dim: get_i32(&["linear_key_head_dim"], 192),
-        linear_value_head_dim: get_i32(&["linear_value_head_dim"], 128),
-        linear_conv_kernel_dim: get_i32(&["linear_conv_kernel_dim"], 4),
-        full_attention_interval: get_i32(&["full_attention_interval"], 4),
+        linear_num_value_heads: gi(&["linear_num_value_heads"], 64),
+        linear_num_key_heads: gi(&["linear_num_key_heads"], 16),
+        linear_key_head_dim: gi(&["linear_key_head_dim"], 192),
+        linear_value_head_dim: gi(&["linear_value_head_dim"], 128),
+        linear_conv_kernel_dim: gi(&["linear_conv_kernel_dim"], 4),
+        full_attention_interval: gi(&["full_attention_interval"], 4),
         partial_rotary_factor,
         rope_theta,
     })

--- a/crates/mlx-core/src/models/qwen3_5/persistence_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence_common.rs
@@ -1,0 +1,250 @@
+//! Shared persistence utilities for Qwen3.5 Dense and MoE models.
+//!
+//! Contains functions that are identical between the two model variants:
+//! safetensors loading, FP8 dequantization, and config parsing helpers.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use napi::bindgen_prelude::*;
+use serde_json::Value;
+use tracing::info;
+
+use crate::array::{DType, MxArray};
+use crate::utils::safetensors::load_safetensors_lazy;
+
+/// Load all safetensors files from a directory (supports sharded checkpoints).
+/// Uses MLX's native mmap-backed lazy loader — arrays are backed by deferred disk
+/// reads and data is only materialized on eval. This makes loading near-instant
+/// and memory is only allocated when weights are actually used.
+///
+/// When `load_vision` is true, also loads `vision.safetensors` if present (for VLM models).
+pub(crate) fn load_all_safetensors(
+    dir: &Path,
+    load_vision: bool,
+) -> Result<HashMap<String, MxArray>> {
+    let single_path = if dir.join("weights.safetensors").exists() {
+        Some(dir.join("weights.safetensors"))
+    } else if dir.join("model.safetensors").exists() {
+        Some(dir.join("model.safetensors"))
+    } else {
+        None
+    };
+
+    if let Some(path) = single_path {
+        info!("Loading weights from: {} (mmap)", path.display());
+        let mut params = load_safetensors_lazy(&path)?;
+
+        // Also load vision.safetensors if present (VLM models)
+        if load_vision {
+            let vision_path = dir.join("vision.safetensors");
+            if vision_path.exists() {
+                info!(
+                    "Loading vision weights from: {} (mmap)",
+                    vision_path.display()
+                );
+                let vision_params = load_safetensors_lazy(&vision_path)?;
+                info!("Loaded {} vision tensors", vision_params.len());
+                params.extend(vision_params);
+            }
+        }
+
+        return Ok(params);
+    }
+
+    let mut shard_files: Vec<std::path::PathBuf> = Vec::new();
+    let entries = fs::read_dir(dir)
+        .map_err(|e| Error::from_reason(format!("Failed to read model directory: {}", e)))?;
+
+    for entry in entries {
+        let entry = entry
+            .map_err(|e| Error::from_reason(format!("Failed to read directory entry: {}", e)))?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        let is_shard = (name.starts_with("model-") || name.starts_with("model.safetensors-"))
+            && name.ends_with(".safetensors")
+            && name.contains("-of-");
+        if is_shard {
+            shard_files.push(entry.path());
+        }
+    }
+
+    if shard_files.is_empty() {
+        return Err(Error::from_reason(format!(
+            "No safetensors files found in {}",
+            dir.display()
+        )));
+    }
+
+    shard_files.sort();
+    info!(
+        "Loading {} sharded safetensors files (mmap)",
+        shard_files.len()
+    );
+
+    let mut all_params: HashMap<String, MxArray> = HashMap::new();
+    for shard_path in &shard_files {
+        info!("  Loading shard: {} (mmap)", shard_path.display());
+        let shard_params = load_safetensors_lazy(shard_path)?;
+        all_params.extend(shard_params);
+    }
+
+    Ok(all_params)
+}
+
+/// FP8 E4M3 block-wise dequantization: weight * scale_inv with block_size=128
+///
+/// Handles both 2D [out, in] and 1D [n] weights.
+/// 1. from_fp8(weight) → target dtype
+/// 2. Pad to 128-block alignment
+/// 3. Reshape into blocks, multiply by scale_inv
+/// 4. Unpad and return as target dtype
+pub(crate) fn dequant_fp8(
+    weight: &MxArray,
+    scale_inv: &MxArray,
+    target_dtype: DType,
+) -> Result<MxArray> {
+    let weight = weight.from_fp8(target_dtype)?;
+
+    let shape = weight.shape()?;
+    let shape_ref = shape.as_ref();
+
+    if shape_ref.len() < 2 {
+        // 1D weight (e.g. bias): just scale directly
+        return weight.mul(scale_inv)?.astype(target_dtype);
+    }
+
+    let m = shape_ref[0] as usize;
+    let n = shape_ref[1] as usize;
+    let bs: usize = 128;
+
+    let pad_bottom = (bs - (m % bs)) % bs;
+    let pad_side = (bs - (n % bs)) % bs;
+
+    let weight = if pad_bottom > 0 || pad_side > 0 {
+        weight.pad(&[0, pad_bottom as i32, 0, pad_side as i32], 0.0)?
+    } else {
+        weight
+    };
+
+    let m_padded = m + pad_bottom;
+    let n_padded = n + pad_side;
+    let weight = weight.reshape(&[
+        (m_padded / bs) as i64,
+        bs as i64,
+        (n_padded / bs) as i64,
+        bs as i64,
+    ])?;
+
+    let scale = scale_inv.expand_dims(1)?.expand_dims(3)?;
+    let weight = weight.mul(&scale)?;
+
+    let weight = weight.reshape(&[m_padded as i64, n_padded as i64])?;
+    let weight = if pad_bottom > 0 || pad_side > 0 {
+        weight.slice(&[0, 0], &[m as i64, n as i64])?
+    } else {
+        weight
+    };
+
+    weight.astype(target_dtype)
+}
+
+/// Dequantize all FP8 weight pairs in-place.
+/// Finds all `*weight_scale_inv` keys, dequantizes the corresponding weight,
+/// removes scale_inv keys, and replaces weights with dequantized versions.
+pub(crate) fn dequant_fp8_weights(
+    params: &mut HashMap<String, MxArray>,
+    target_dtype: DType,
+) -> Result<()> {
+    let scale_keys: Vec<String> = params
+        .keys()
+        .filter(|k| k.ends_with("weight_scale_inv"))
+        .cloned()
+        .collect();
+
+    if scale_keys.is_empty() {
+        return Ok(());
+    }
+
+    info!(
+        "Dequantizing {} FP8 weight pairs to {:?}",
+        scale_keys.len(),
+        target_dtype
+    );
+
+    for scale_key in scale_keys {
+        let weight_key = scale_key.replace("_scale_inv", "");
+        let scale_inv = params
+            .remove(&scale_key)
+            .expect("scale_key must exist in params");
+        if let Some(weight) = params.remove(&weight_key) {
+            let dequantized = dequant_fp8(&weight, &scale_inv, target_dtype)?;
+            // Eval immediately to prevent lazy chain accumulation (OOM with ~31K FP8 pairs)
+            dequantized.eval();
+            params.insert(weight_key, dequantized);
+        }
+    }
+
+    Ok(())
+}
+
+/// Helper to read an i32 config value, checking `text_config` first, then root.
+/// Tries each key in order, returning the first match or the default.
+pub(crate) fn get_config_i32(
+    raw: &Value,
+    text_cfg: Option<&Value>,
+    keys: &[&str],
+    default: i32,
+) -> i32 {
+    for key in keys {
+        if let Some(tc) = text_cfg
+            && let Some(v) = tc[key].as_i64()
+        {
+            return v as i32;
+        }
+        if let Some(v) = raw[key].as_i64() {
+            return v as i32;
+        }
+    }
+    default
+}
+
+/// Helper to read an f64 config value, checking `text_config` first, then root.
+pub(crate) fn get_config_f64(
+    raw: &Value,
+    text_cfg: Option<&Value>,
+    keys: &[&str],
+    default: f64,
+) -> f64 {
+    for key in keys {
+        if let Some(tc) = text_cfg
+            && let Some(v) = tc[key].as_f64()
+        {
+            return v;
+        }
+        if let Some(v) = raw[key].as_f64() {
+            return v;
+        }
+    }
+    default
+}
+
+/// Helper to read a bool config value, checking `text_config` first, then root.
+pub(crate) fn get_config_bool(
+    raw: &Value,
+    text_cfg: Option<&Value>,
+    keys: &[&str],
+    default: bool,
+) -> bool {
+    for key in keys {
+        if let Some(tc) = text_cfg
+            && let Some(v) = tc[key].as_bool()
+        {
+            return v;
+        }
+        if let Some(v) = raw[key].as_bool() {
+            return v;
+        }
+    }
+    default
+}

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -24,7 +24,7 @@ use crate::array::mask::create_causal_mask;
 use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
 use crate::models::qwen3_5::chat_common::{
     apply_all_penalties, compute_performance_metrics, extract_chat_params, finalize_chat_result,
-    save_cache_state,
+    save_cache_state, verify_cache_prefix,
 };
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::sampling::{
@@ -856,42 +856,16 @@ impl Qwen3_5MoeModel {
             let cached_token_history_guard = cached_token_history_arc
                 .read()
                 .map_err(|_| Error::from_reason("Failed to read cached token history"))?;
-            let cached_prefix_len = if reuse_cache {
-                let cached = &*cached_token_history_guard;
-                if has_images {
-                    // VLM: also check that image_cache_key matches
-                    let cached_img_key = cached_image_key_arc
-                        .read()
-                        .map_err(|_| Error::from_reason("Failed to read cached image key"))?;
-                    if let Some(cached_key) = *cached_img_key {
-                        if cached_key == image_cache_key
-                            && !cached.is_empty()
-                            && tokens_for_matching.len() >= cached.len()
-                            && tokens_for_matching[..cached.len()] == cached[..]
-                            && caches_guard.is_some()
-                        {
-                            cached.len()
-                        } else {
-                            0
-                        }
-                    } else {
-                        0
-                    }
-                } else {
-                    // Text-only: existing logic
-                    if !cached.is_empty()
-                        && tokens.len() >= cached.len()
-                        && tokens[..cached.len()] == cached[..]
-                        && caches_guard.is_some()
-                    {
-                        cached.len()
-                    } else {
-                        0
-                    }
-                }
-            } else {
-                0
-            };
+            let cached_prefix_len = verify_cache_prefix(
+                reuse_cache,
+                has_images,
+                &tokens,
+                tokens_for_matching,
+                image_cache_key,
+                &cached_token_history_guard,
+                &cached_image_key_arc,
+                caches_guard.is_some(),
+            );
             drop(cached_token_history_guard);
 
             let prefill_tokens = if cached_prefix_len > 0 {
@@ -1379,9 +1353,6 @@ impl Qwen3_5MoeModel {
             finalize_chat_result(
                 &tokenizer_for_decode,
                 &generated_tokens,
-                &tokens,
-                expanded_tokens.as_deref(),
-                has_images,
                 finish_reason,
                 think_end_id,
                 think_end_str.as_deref(),

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -865,7 +865,7 @@ impl Qwen3_5MoeModel {
                 &cached_token_history_guard,
                 &cached_image_key_arc,
                 caches_guard.is_some(),
-            );
+            )?;
             drop(cached_token_history_guard);
 
             let prefill_tokens = if cached_prefix_len > 0 {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -22,6 +22,10 @@ use super::quantized_linear::LinearProj;
 use crate::array::MxArray;
 use crate::array::mask::create_causal_mask;
 use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
+use crate::models::qwen3_5::chat_common::{
+    apply_all_penalties, compute_performance_metrics, extract_chat_params, finalize_chat_result,
+    save_cache_state,
+};
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::sampling::{
     SamplingConfig, apply_frequency_penalty, apply_presence_penalty, apply_repetition_penalty,
@@ -810,22 +814,8 @@ impl Qwen3_5MoeModel {
                 enable_thinking,
             )?;
 
-            let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
-            let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
-            let repetition_context_size = config.repetition_context_size.unwrap_or(256);
-            let presence_penalty = config.presence_penalty.unwrap_or(0.0);
-            let presence_context_size = config.presence_context_size.unwrap_or(20);
-            let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
-            let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-            let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-            let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-            let ngram_size = config.ngram_size.unwrap_or(64);
-            let sampling_config = Some(SamplingConfig {
-                temperature: config.temperature,
-                top_k: config.top_k,
-                top_p: config.top_p,
-                min_p: config.min_p,
-            });
+            let p = extract_chat_params(&config);
+            let max_new_tokens = p.max_new_tokens;
 
             let mut layers_guard = layers_arc
                 .write()
@@ -1076,32 +1066,9 @@ impl Qwen3_5MoeModel {
             profiler.end_prefill();
 
             // Apply repetition penalty to prefill logits
-            if repetition_penalty != 1.0 && !token_history.is_empty() {
-                last_logits = apply_repetition_penalty(
-                    &last_logits,
-                    &token_history,
-                    repetition_penalty,
-                    Some(repetition_context_size),
-                )?;
-            }
-            if presence_penalty != 0.0 {
-                last_logits = apply_presence_penalty(
-                    &last_logits,
-                    &token_history,
-                    presence_penalty,
-                    Some(presence_context_size),
-                )?;
-            }
-            if frequency_penalty != 0.0 {
-                last_logits = apply_frequency_penalty(
-                    &last_logits,
-                    &token_history,
-                    frequency_penalty,
-                    Some(frequency_context_size),
-                )?;
-            }
+            last_logits = apply_all_penalties(last_logits, &token_history, &p)?;
 
-            let mut y = sample(&last_logits, sampling_config)?;
+            let mut y = sample(&last_logits, p.sampling_config)?;
             MxArray::async_eval_arrays(&[&y]);
 
             if use_cpp {
@@ -1204,34 +1171,11 @@ impl Qwen3_5MoeModel {
                         profiler.end();
 
                         profiler.begin("rep_penalty");
-                        if repetition_penalty != 1.0 {
-                            logits = apply_repetition_penalty(
-                                &logits,
-                                &token_history,
-                                repetition_penalty,
-                                Some(repetition_context_size),
-                            )?;
-                        }
-                        if presence_penalty != 0.0 {
-                            logits = apply_presence_penalty(
-                                &logits,
-                                &token_history,
-                                presence_penalty,
-                                Some(presence_context_size),
-                            )?;
-                        }
-                        if frequency_penalty != 0.0 {
-                            logits = apply_frequency_penalty(
-                                &logits,
-                                &token_history,
-                                frequency_penalty,
-                                Some(frequency_context_size),
-                            )?;
-                        }
+                        logits = apply_all_penalties(logits, &token_history, &p)?;
                         profiler.end();
 
                         profiler.begin("sample");
-                        let next_token = sample(&logits, sampling_config)?;
+                        let next_token = sample(&logits, p.sampling_config)?;
                         profiler.end();
 
                         profiler.begin("eval_caches");
@@ -1252,7 +1196,7 @@ impl Qwen3_5MoeModel {
                     let token_id = y.item_at_int32(0)? as u32;
                     profiler.end();
                     profiler.mark_first_token();
-                    if report_perf && first_token_instant.is_none() {
+                    if p.report_performance && first_token_instant.is_none() {
                         first_token_instant = Some(std::time::Instant::now());
                     }
 
@@ -1266,9 +1210,9 @@ impl Qwen3_5MoeModel {
 
                     if let Some(reason) = check_repetition_cutoff(
                         &generated_tokens,
-                        max_consecutive_tokens,
-                        max_ngram_repeats,
-                        ngram_size,
+                        p.max_consecutive_tokens,
+                        p.max_ngram_repeats,
+                        p.ngram_size,
                     ) {
                         finish_reason = reason.to_string();
                         break;
@@ -1343,34 +1287,11 @@ impl Qwen3_5MoeModel {
                         profiler.end();
 
                         profiler.begin("rep_penalty");
-                        if repetition_penalty != 1.0 {
-                            logits = apply_repetition_penalty(
-                                &logits,
-                                &token_history,
-                                repetition_penalty,
-                                Some(repetition_context_size),
-                            )?;
-                        }
-                        if presence_penalty != 0.0 {
-                            logits = apply_presence_penalty(
-                                &logits,
-                                &token_history,
-                                presence_penalty,
-                                Some(presence_context_size),
-                            )?;
-                        }
-                        if frequency_penalty != 0.0 {
-                            logits = apply_frequency_penalty(
-                                &logits,
-                                &token_history,
-                                frequency_penalty,
-                                Some(frequency_context_size),
-                            )?;
-                        }
+                        logits = apply_all_penalties(logits, &token_history, &p)?;
                         profiler.end();
 
                         profiler.begin("sample");
-                        let next_token = sample(&logits, sampling_config)?;
+                        let next_token = sample(&logits, p.sampling_config)?;
                         profiler.end();
 
                         profiler.begin("async_eval");
@@ -1391,7 +1312,7 @@ impl Qwen3_5MoeModel {
                     let token_id = y.item_at_int32(0)? as u32;
                     profiler.end();
                     profiler.mark_first_token();
-                    if report_perf && first_token_instant.is_none() {
+                    if p.report_performance && first_token_instant.is_none() {
                         first_token_instant = Some(std::time::Instant::now());
                     }
 
@@ -1405,9 +1326,9 @@ impl Qwen3_5MoeModel {
 
                     if let Some(reason) = check_repetition_cutoff(
                         &generated_tokens,
-                        max_consecutive_tokens,
-                        max_ngram_repeats,
-                        ngram_size,
+                        p.max_consecutive_tokens,
+                        p.max_ngram_repeats,
+                        p.ngram_size,
                     ) {
                         finish_reason = reason.to_string();
                         break;
@@ -1434,108 +1355,38 @@ impl Qwen3_5MoeModel {
                 drop(lm_head_guard);
             }
 
-            // === Save token history and image key for cache reuse on next call ===
-            if reuse_cache {
-                // For VLM, save the expanded token history (with image placeholders)
-                let mut full_history = if let Some(ref et) = expanded_tokens {
-                    et.clone()
-                } else {
-                    tokens.clone()
-                };
-                // Only include tokens that were actually forwarded through the model.
-                // When stopped at max_tokens ("length"), the last token was never forwarded
-                // (the pipelined loop skips forward on the final step).
-                let history_tokens = if finish_reason == "length" && !generated_tokens.is_empty() {
-                    &generated_tokens[..generated_tokens.len() - 1]
-                } else {
-                    &generated_tokens
-                };
-                full_history.extend_from_slice(history_tokens);
-                if let Ok(mut th) = cached_token_history_arc.write() {
-                    *th = full_history;
-                }
-                // Save image cache key (Some for VLM, None for text-only)
-                if let Ok(mut ik) = cached_image_key_arc.write() {
-                    *ik = if has_images {
-                        Some(image_cache_key)
-                    } else {
-                        None
-                    };
-                }
-            } else {
-                // reuseCache: false — clear all cache state to free GPU memory
-                if let Ok(mut cg) = caches_arc.write() {
-                    *cg = None;
-                }
-                if let Ok(mut th) = cached_token_history_arc.write() {
-                    th.clear();
-                }
-                if let Ok(mut ik) = cached_image_key_arc.write() {
-                    *ik = None;
-                }
-                if let Ok(mut rd) = cached_rope_deltas_arc.write() {
-                    *rd = None;
-                }
-            }
+            save_cache_state(
+                p.reuse_cache,
+                has_images,
+                &generated_tokens,
+                &finish_reason,
+                &tokens,
+                expanded_tokens.as_deref(),
+                image_cache_key,
+                &cached_token_history_arc,
+                &cached_image_key_arc,
+                &cached_rope_deltas_arc,
+                &caches_arc,
+            )?;
 
-            // Compute performance metrics if requested
-            let performance = if let (Some(gen_start), Some(first_tok)) =
-                (generation_start, first_token_instant)
-            {
-                let generation_end = std::time::Instant::now();
-                let actual_prefill_toks = prefill_tokens.len() as f64;
-                let gen_tokens = generated_tokens.len() as f64;
-                let ttft_ms = first_tok.duration_since(gen_start).as_secs_f64() * 1000.0;
-                let decode_ms = generation_end.duration_since(first_tok).as_secs_f64() * 1000.0;
-                Some(crate::profiling::PerformanceMetrics {
-                    ttft_ms,
-                    prefill_tokens_per_second: if ttft_ms > 0.0 {
-                        actual_prefill_toks / (ttft_ms / 1000.0)
-                    } else {
-                        0.0
-                    },
-                    decode_tokens_per_second: if decode_ms > 0.0 && gen_tokens > 1.0 {
-                        (gen_tokens - 1.0) / (decode_ms / 1000.0)
-                    } else {
-                        0.0
-                    },
-                })
-            } else {
-                None
-            };
+            let performance = compute_performance_metrics(
+                generation_start,
+                first_token_instant,
+                prefill_tokens.len(),
+                generated_tokens.len(),
+            );
 
-            let text = tokenizer_for_decode
-                .decode_sync(&generated_tokens, true)
-                .unwrap_or_else(|e| {
-                    warn!("Failed to decode generated tokens: {}", e);
-                    String::new()
-                });
-
-            let num_tokens = generated_tokens.len() as u32;
-
-            let think_tag = if tools::has_think_end_token(&generated_tokens, think_end_id) {
-                think_end_str.as_deref()
-            } else {
-                None
-            };
-            let (clean_text, tool_calls, thinking) = tools::split_at_think_end(&text, think_tag);
-
-            // If we have valid tool calls, override finish reason
-            let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
-                "tool_calls".to_string()
-            } else {
-                finish_reason
-            };
-
-            Ok(ChatResult {
-                text: clean_text,
-                tool_calls,
-                thinking,
-                num_tokens,
+            finalize_chat_result(
+                &tokenizer_for_decode,
+                &generated_tokens,
+                &tokens,
+                expanded_tokens.as_deref(),
+                has_images,
                 finish_reason,
-                raw_text: text,
+                think_end_id,
+                think_end_str.as_deref(),
                 performance,
-            })
+            )
         })
         .await
         .map_err(|e| Error::from_reason(format!("Chat task failed: {}", e)))?

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -9,10 +9,12 @@ use tracing::{info, warn};
 
 use crate::array::{DType, MxArray};
 use crate::models::qwen3_5::persistence::{load_vision_weights, parse_vision_config};
+use crate::models::qwen3_5::persistence_common::{
+    dequant_fp8_weights, get_config_bool, get_config_f64, get_config_i32, load_all_safetensors,
+};
 use crate::models::qwen3_5::processing::Qwen35VLImageProcessor;
 use crate::models::qwen3_5::vision::Qwen3_5VisionEncoder;
 use crate::tokenizer::Qwen3Tokenizer;
-use crate::utils::safetensors::load_safetensors_lazy;
 
 use super::config::Qwen3_5MoeConfig;
 use super::decoder_layer::{AttentionType, MLPType};
@@ -24,150 +26,6 @@ use super::quantized_linear::{
     try_build_quantized_linear,
 };
 use super::switch_glu::SwitchGLU;
-
-/// Load all safetensors files from a directory.
-/// Uses MLX's native mmap-backed lazy loader for near-instant loading.
-fn load_all_safetensors(dir: &Path) -> Result<HashMap<String, MxArray>> {
-    let single_path = if dir.join("weights.safetensors").exists() {
-        Some(dir.join("weights.safetensors"))
-    } else if dir.join("model.safetensors").exists() {
-        Some(dir.join("model.safetensors"))
-    } else {
-        None
-    };
-
-    if let Some(path) = single_path {
-        info!("Loading weights from: {} (mmap)", path.display());
-        return load_safetensors_lazy(&path);
-    }
-
-    let mut shard_files: Vec<std::path::PathBuf> = Vec::new();
-    let entries = fs::read_dir(dir)
-        .map_err(|e| Error::from_reason(format!("Failed to read model directory: {}", e)))?;
-
-    for entry in entries {
-        let entry = entry
-            .map_err(|e| Error::from_reason(format!("Failed to read directory entry: {}", e)))?;
-        let name = entry.file_name().to_string_lossy().to_string();
-        let is_shard = (name.starts_with("model-") || name.starts_with("model.safetensors-"))
-            && name.ends_with(".safetensors")
-            && name.contains("-of-");
-        if is_shard {
-            shard_files.push(entry.path());
-        }
-    }
-
-    if shard_files.is_empty() {
-        return Err(Error::from_reason(format!(
-            "No safetensors files found in {}",
-            dir.display()
-        )));
-    }
-
-    shard_files.sort();
-    info!(
-        "Loading {} sharded safetensors files (mmap)",
-        shard_files.len()
-    );
-
-    let mut all_params: HashMap<String, MxArray> = HashMap::new();
-    for shard_path in &shard_files {
-        info!("  Loading shard: {} (mmap)", shard_path.display());
-        let shard_params = load_safetensors_lazy(shard_path)?;
-        all_params.extend(shard_params);
-    }
-
-    Ok(all_params)
-}
-
-/// FP8 E4M3 block-wise dequantization: weight * scale_inv with block_size=128
-///
-/// Handles both 2D [out, in] and 1D [n] weights.
-/// 1. from_fp8(weight) → target dtype
-/// 2. Pad to 128-block alignment
-/// 3. Reshape into blocks, multiply by scale_inv
-/// 4. Unpad and return as target dtype
-fn dequant_fp8(weight: &MxArray, scale_inv: &MxArray, target_dtype: DType) -> Result<MxArray> {
-    let weight = weight.from_fp8(target_dtype)?;
-
-    let shape = weight.shape()?;
-    let shape_ref = shape.as_ref();
-
-    if shape_ref.len() < 2 {
-        // 1D weight (e.g. bias): just scale directly
-        return weight.mul(scale_inv)?.astype(target_dtype);
-    }
-
-    let m = shape_ref[0] as usize;
-    let n = shape_ref[1] as usize;
-    let bs: usize = 128;
-
-    let pad_bottom = (bs - (m % bs)) % bs;
-    let pad_side = (bs - (n % bs)) % bs;
-
-    let weight = if pad_bottom > 0 || pad_side > 0 {
-        weight.pad(&[0, pad_bottom as i32, 0, pad_side as i32], 0.0)?
-    } else {
-        weight
-    };
-
-    let m_padded = m + pad_bottom;
-    let n_padded = n + pad_side;
-    let weight = weight.reshape(&[
-        (m_padded / bs) as i64,
-        bs as i64,
-        (n_padded / bs) as i64,
-        bs as i64,
-    ])?;
-
-    let scale = scale_inv.expand_dims(1)?.expand_dims(3)?;
-    let weight = weight.mul(&scale)?;
-
-    let weight = weight.reshape(&[m_padded as i64, n_padded as i64])?;
-    let weight = if pad_bottom > 0 || pad_side > 0 {
-        weight.slice(&[0, 0], &[m as i64, n as i64])?
-    } else {
-        weight
-    };
-
-    weight.astype(target_dtype)
-}
-
-/// Dequantize all FP8 weight pairs in-place.
-/// Finds all `*weight_scale_inv` keys, dequantizes the corresponding weight,
-/// removes scale_inv keys, and replaces weights with dequantized versions.
-fn dequant_fp8_weights(params: &mut HashMap<String, MxArray>, target_dtype: DType) -> Result<()> {
-    let scale_keys: Vec<String> = params
-        .keys()
-        .filter(|k| k.ends_with("weight_scale_inv"))
-        .cloned()
-        .collect();
-
-    if scale_keys.is_empty() {
-        return Ok(());
-    }
-
-    info!(
-        "Dequantizing {} FP8 weight pairs to {:?}",
-        scale_keys.len(),
-        target_dtype
-    );
-
-    for scale_key in scale_keys {
-        let weight_key = scale_key.replace("_scale_inv", "");
-        let scale_inv = params
-            .remove(&scale_key)
-            .expect("scale_key must exist in params");
-        if let Some(weight) = params.remove(&weight_key) {
-            let dequantized = dequant_fp8(&weight, &scale_inv, target_dtype)?;
-            // Eval immediately to prevent lazy chain accumulation (OOM with ~31K FP8 pairs)
-            dequantized.eval();
-            params.insert(weight_key, dequantized);
-        }
-    }
-
-    Ok(())
-}
 
 /// Sanitize weights from HuggingFace format.
 fn sanitize_weights(
@@ -971,7 +829,7 @@ pub async fn load(model_path: &str) -> Result<Qwen3_5MoeModel> {
             config.num_layers, config.hidden_size, config.num_experts, config.num_experts_per_tok
         );
 
-        let raw_params = load_all_safetensors(path)?;
+        let raw_params = load_all_safetensors(path, false)?;
         info!("Loaded {} raw tensors", raw_params.len());
 
         // Check for vision weights and split if present
@@ -1138,50 +996,12 @@ pub async fn load(model_path: &str) -> Result<Qwen3_5MoeModel> {
 fn parse_config(raw: &Value) -> Result<Qwen3_5MoeConfig> {
     let text_cfg = raw.get("text_config");
 
-    let get_i32 = |keys: &[&str], default: i32| -> i32 {
-        for key in keys {
-            if let Some(tc) = text_cfg
-                && let Some(v) = tc[key].as_i64()
-            {
-                return v as i32;
-            }
-            if let Some(v) = raw[key].as_i64() {
-                return v as i32;
-            }
-        }
-        default
-    };
+    let gi = |keys: &[&str], default: i32| get_config_i32(raw, text_cfg, keys, default);
+    let gf = |keys: &[&str], default: f64| get_config_f64(raw, text_cfg, keys, default);
+    let gb = |keys: &[&str], default: bool| get_config_bool(raw, text_cfg, keys, default);
 
-    let get_f64 = |keys: &[&str], default: f64| -> f64 {
-        for key in keys {
-            if let Some(tc) = text_cfg
-                && let Some(v) = tc[key].as_f64()
-            {
-                return v;
-            }
-            if let Some(v) = raw[key].as_f64() {
-                return v;
-            }
-        }
-        default
-    };
-
-    let get_bool = |keys: &[&str], default: bool| -> bool {
-        for key in keys {
-            if let Some(tc) = text_cfg
-                && let Some(v) = tc[key].as_bool()
-            {
-                return v;
-            }
-            if let Some(v) = raw[key].as_bool() {
-                return v;
-            }
-        }
-        default
-    };
-
-    let hidden_size = get_i32(&["hidden_size"], 0);
-    let num_heads = get_i32(&["num_attention_heads", "num_heads"], 0);
+    let hidden_size = gi(&["hidden_size"], 0);
+    let num_heads = gi(&["num_attention_heads", "num_heads"], 0);
 
     let head_dim = text_cfg
         .and_then(|tc| tc["head_dim"].as_i64())
@@ -1201,21 +1021,21 @@ fn parse_config(raw: &Value) -> Result<Qwen3_5MoeConfig> {
 
     let partial_rotary_factor = rope_obj
         .and_then(|rp| rp["partial_rotary_factor"].as_f64())
-        .unwrap_or_else(|| get_f64(&["partial_rotary_factor"], 0.25));
+        .unwrap_or_else(|| gf(&["partial_rotary_factor"], 0.25));
 
     let rope_theta = rope_obj
         .and_then(|rp| rp["rope_theta"].as_f64())
-        .unwrap_or_else(|| get_f64(&["rope_theta"], 100_000.0));
+        .unwrap_or_else(|| gf(&["rope_theta"], 100_000.0));
 
-    let bos_token_id = get_i32(&["bos_token_id"], 151643);
-    let num_layers = get_i32(&["num_hidden_layers", "num_layers"], 0);
-    let intermediate_size = get_i32(&["intermediate_size"], 0);
-    let num_kv_heads = get_i32(&["num_key_value_heads", "num_kv_heads"], 8);
-    let vocab_size = get_i32(&["vocab_size"], 151936);
+    let bos_token_id = gi(&["bos_token_id"], 151643);
+    let num_layers = gi(&["num_hidden_layers", "num_layers"], 0);
+    let intermediate_size = gi(&["intermediate_size"], 0);
+    let num_kv_heads = gi(&["num_key_value_heads", "num_kv_heads"], 8);
+    let vocab_size = gi(&["vocab_size"], 151936);
 
-    let num_experts = get_i32(&["num_experts"], 0);
-    let num_experts_per_tok = get_i32(&["num_experts_per_tok"], 1);
-    let moe_i = get_i32(&["moe_intermediate_size"], 0);
+    let num_experts = gi(&["num_experts"], 0);
+    let num_experts_per_tok = gi(&["num_experts_per_tok"], 1);
+    let moe_i = gi(&["moe_intermediate_size"], 0);
 
     if hidden_size <= 0 {
         return Err(Error::from_reason(format!(
@@ -1249,33 +1069,33 @@ fn parse_config(raw: &Value) -> Result<Qwen3_5MoeConfig> {
         num_heads,
         num_kv_heads,
         intermediate_size,
-        rms_norm_eps: get_f64(&["rms_norm_eps"], 1e-6),
+        rms_norm_eps: gf(&["rms_norm_eps"], 1e-6),
         head_dim,
-        tie_word_embeddings: get_bool(&["tie_word_embeddings"], false),
-        attention_bias: get_bool(&["attention_bias"], false),
-        max_position_embeddings: get_i32(&["max_position_embeddings"], 131072),
-        pad_token_id: get_i32(&["pad_token_id"], bos_token_id),
-        eos_token_id: get_i32(&["eos_token_id"], 151645),
+        tie_word_embeddings: gb(&["tie_word_embeddings"], false),
+        attention_bias: gb(&["attention_bias"], false),
+        max_position_embeddings: gi(&["max_position_embeddings"], 131072),
+        pad_token_id: gi(&["pad_token_id"], bos_token_id),
+        eos_token_id: gi(&["eos_token_id"], 151645),
         bos_token_id,
 
-        linear_num_value_heads: get_i32(&["linear_num_value_heads"], 64),
-        linear_num_key_heads: get_i32(&["linear_num_key_heads"], 16),
-        linear_key_head_dim: get_i32(&["linear_key_head_dim"], 192),
-        linear_value_head_dim: get_i32(&["linear_value_head_dim"], 128),
-        linear_conv_kernel_dim: get_i32(&["linear_conv_kernel_dim"], 4),
-        full_attention_interval: get_i32(&["full_attention_interval"], 4),
+        linear_num_value_heads: gi(&["linear_num_value_heads"], 64),
+        linear_num_key_heads: gi(&["linear_num_key_heads"], 16),
+        linear_key_head_dim: gi(&["linear_key_head_dim"], 192),
+        linear_value_head_dim: gi(&["linear_value_head_dim"], 128),
+        linear_conv_kernel_dim: gi(&["linear_conv_kernel_dim"], 4),
+        full_attention_interval: gi(&["full_attention_interval"], 4),
         partial_rotary_factor,
         rope_theta,
 
         num_experts,
         num_experts_per_tok,
-        decoder_sparse_step: get_i32(&["decoder_sparse_step"], 1),
+        decoder_sparse_step: gi(&["decoder_sparse_step"], 1),
         shared_expert_intermediate_size: {
-            let v = get_i32(&["shared_expert_intermediate_size"], 0);
+            let v = gi(&["shared_expert_intermediate_size"], 0);
             if v > 0 { Some(v) } else { None }
         },
         moe_intermediate_size: { if moe_i > 0 { Some(moe_i) } else { None } },
-        norm_topk_prob: get_bool(&["norm_topk_prob"], true),
+        norm_topk_prob: gb(&["norm_topk_prob"], true),
         mlp_only_layers: text_cfg
             .and_then(|tc| tc["mlp_only_layers"].as_array())
             .or_else(|| raw["mlp_only_layers"].as_array())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it touches token generation loops, cache reuse behavior, and weight loading/dequantization paths; behavior should be identical but regressions could affect output, performance metrics, or memory usage.
> 
> **Overview**
> Extracts duplicated Qwen3.5 `chat()`/generation boilerplate into `chat_common.rs`, centralizing config defaulting (`extract_chat_params`), penalty application (`apply_all_penalties`), cache prefix checks and save/clear logic, performance metric computation, and final `ChatResult` assembly.
> 
> Extracts duplicated persistence helpers into `persistence_common.rs`, including safetensors loading (with optional `vision.safetensors`), FP8 dequantization, and JSON config getters; dense and MoE persistence now call these shared functions (notably `load_all_safetensors(path, load_vision)` and `get_config_*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 811744ab1876a695e293e808eb19d770504fcc30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->