### PR TITLE
feat: add Harrier embedding model (microsoft/harrier-oss-v1)

### DIFF
--- a/__test__/models/harrier-detection.test.ts
+++ b/__test__/models/harrier-detection.test.ts
@@ -1,0 +1,85 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { detectModelType } from '@mlx-node/lm';
+import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
+
+describe.sequential('Harrier Model Detection', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `harrier-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should detect Qwen3Model architecture as harrier', async () => {
+    await writeFile(
+      join(tempDir, 'config.json'),
+      JSON.stringify({
+        model_type: 'qwen3',
+        architectures: ['Qwen3Model'],
+        hidden_size: 1024,
+      }),
+    );
+
+    const modelType = await detectModelType(tempDir);
+    expect(modelType).toBe('harrier');
+  });
+
+  it('should detect Qwen3ForCausalLM as qwen3', async () => {
+    await writeFile(
+      join(tempDir, 'config.json'),
+      JSON.stringify({
+        model_type: 'qwen3',
+        architectures: ['Qwen3ForCausalLM'],
+        hidden_size: 1024,
+      }),
+    );
+
+    const modelType = await detectModelType(tempDir);
+    expect(modelType).toBe('qwen3');
+  });
+
+  it('should default to qwen3 when architectures is absent', async () => {
+    await writeFile(
+      join(tempDir, 'config.json'),
+      JSON.stringify({
+        model_type: 'qwen3',
+        hidden_size: 1024,
+      }),
+    );
+
+    const modelType = await detectModelType(tempDir);
+    expect(modelType).toBe('qwen3');
+  });
+
+  it('should detect qwen3_5 model type directly', async () => {
+    await writeFile(
+      join(tempDir, 'config.json'),
+      JSON.stringify({
+        model_type: 'qwen3_5',
+        hidden_size: 4096,
+      }),
+    );
+
+    const modelType = await detectModelType(tempDir);
+    expect(modelType).toBe('qwen3_5');
+  });
+
+  it('should throw on unsupported model_type', async () => {
+    await writeFile(
+      join(tempDir, 'config.json'),
+      JSON.stringify({
+        model_type: 'llama',
+        hidden_size: 4096,
+      }),
+    );
+
+    await expect(detectModelType(tempDir)).rejects.toThrow('Unsupported model_type');
+  });
+});

--- a/__test__/models/harrier.test.ts
+++ b/__test__/models/harrier.test.ts
@@ -54,14 +54,24 @@ describe.sequential('HarrierModel', () => {
       const model = new HarrierModel(TINY_CONFIG);
       const numParams = model.numParameters();
       expect(numParams).toBeGreaterThan(0);
-
-      // Rough calculation for tiny config:
-      // embedding: 1000 * 128 = 128,000
-      // Per layer: attn(4*32*128 + 2*32*128 + 2*32*128 + 128*4*32) + mlp(512*128*3) + norms(128*2) + qk_norms(32*2)
-      // = 16384 + 8192 + 8192 + 16384 + 196608 + 256 + 64 = 246,080 per layer
-      // final_norm: 128
-      // Total: 128000 + 2*246080 + 128 = 620,288
       expect(numParams).toBe(620288);
+    });
+
+    it('should default useQkNorm to true (Qwen3 architectural requirement)', () => {
+      // When useQkNorm is not explicitly set, it should default to true
+      // because the underlying Qwen3 backbone always uses QK normalization
+      const config = {
+        ...TINY_CONFIG,
+        useQkNorm: true, // Qwen3 default
+      };
+      const model = new HarrierModel(config);
+      expect(model.getConfig().useQkNorm).toBe(true);
+    });
+
+    it('should return empty prompts map for programmatically created model', () => {
+      const model = new HarrierModel(TINY_CONFIG);
+      const prompts = model.getPrompts();
+      expect(Object.keys(prompts)).toHaveLength(0);
     });
   });
 
@@ -89,7 +99,6 @@ describe.sequential('HarrierModel', () => {
       const hidden = model.forward(inputIds);
 
       const lastDim = hidden.shape()[2];
-      // Should be hidden_size (128), not vocab_size (1000)
       expect(lastDim).toBe(BigInt(TINY_CONFIG.hiddenSize));
       expect(lastDim).not.toBe(BigInt(TINY_CONFIG.vocabSize));
     });
@@ -102,6 +111,41 @@ describe.sequential('HarrierModel', () => {
         const hidden = model.forward(inputIds);
         expect(hidden.shape()[1]).toBe(BigInt(seqLen));
       }
+    });
+  });
+
+  describe('L2 Normalization (via forward + manual pooling)', () => {
+    it('should produce non-zero hidden states suitable for normalization', () => {
+      const model = new HarrierModel(TINY_CONFIG);
+      const inputIds = MxArray.randint(shape(1, 3), 0, TINY_CONFIG.vocabSize);
+      const hidden = model.forward(inputIds);
+
+      // Extract last token hidden state: [1, 1, hidden_size]
+      const lastToken = hidden.slice(
+        BigInt64Array.from([0n, 2n, 0n]),
+        BigInt64Array.from([1n, 3n, BigInt(TINY_CONFIG.hiddenSize)]),
+      );
+
+      // Compute L2 norm manually: sqrt(sum(x^2))
+      const sq = lastToken.square();
+      const sumSq = sq.sum(Int32Array.from([-1]), true);
+      const norm = sumSq.sqrt();
+
+      // Norm should be positive (model produces non-trivial output)
+      const normVals = norm.toFloat32();
+      expect(normVals[0]).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Tokenizer requirement', () => {
+    it('should reject encode() without tokenizer', async () => {
+      const model = new HarrierModel(TINY_CONFIG);
+      await expect(model.encode('hello')).rejects.toThrow('Tokenizer not loaded');
+    });
+
+    it('should reject encodeBatch() without tokenizer', async () => {
+      const model = new HarrierModel(TINY_CONFIG);
+      await expect(model.encodeBatch(['hello'])).rejects.toThrow('Tokenizer not loaded');
     });
   });
 });

--- a/__test__/models/harrier.test.ts
+++ b/__test__/models/harrier.test.ts
@@ -1,0 +1,107 @@
+import { HarrierModel, MxArray } from '@mlx-node/core';
+import { describe, it, expect } from 'vite-plus/test';
+
+import { shape } from '../test-utils';
+
+// Tiny config for fast unit tests (not real model sizes)
+const TINY_CONFIG = {
+  vocabSize: 1000,
+  hiddenSize: 128,
+  numLayers: 2,
+  numHeads: 4,
+  numKeyValueHeads: 2,
+  headDim: 32,
+  intermediateSize: 512,
+  rmsNormEps: 1e-6,
+  ropeTheta: 1_000_000.0,
+  maxPositionEmbeddings: 512,
+  useQkNorm: true,
+};
+
+// Harrier 0.6B config (for config correctness tests)
+const HARRIER_0_6B_CONFIG = {
+  vocabSize: 151936,
+  hiddenSize: 1024,
+  numLayers: 28,
+  numHeads: 16,
+  numKeyValueHeads: 8,
+  headDim: 128,
+  intermediateSize: 3072,
+  rmsNormEps: 1e-6,
+  ropeTheta: 1_000_000.0,
+  maxPositionEmbeddings: 32768,
+  useQkNorm: true,
+};
+
+describe.sequential('HarrierModel', () => {
+  describe('Model Instantiation', () => {
+    it('should create model from tiny config', () => {
+      const model = new HarrierModel(TINY_CONFIG);
+      expect(model).toBeDefined();
+      expect(model.getConfig().hiddenSize).toBe(128);
+      expect(model.getConfig().numLayers).toBe(2);
+    });
+
+    it('should create model from 0.6B config', () => {
+      const model = new HarrierModel(HARRIER_0_6B_CONFIG);
+      expect(model).toBeDefined();
+      expect(model.getConfig().hiddenSize).toBe(1024);
+      expect(model.getConfig().numLayers).toBe(28);
+      expect(model.getConfig().numKeyValueHeads).toBe(8);
+    });
+
+    it('should report correct number of parameters', () => {
+      const model = new HarrierModel(TINY_CONFIG);
+      const numParams = model.numParameters();
+      expect(numParams).toBeGreaterThan(0);
+
+      // Rough calculation for tiny config:
+      // embedding: 1000 * 128 = 128,000
+      // Per layer: attn(4*32*128 + 2*32*128 + 2*32*128 + 128*4*32) + mlp(512*128*3) + norms(128*2) + qk_norms(32*2)
+      // = 16384 + 8192 + 8192 + 16384 + 196608 + 256 + 64 = 246,080 per layer
+      // final_norm: 128
+      // Total: 128000 + 2*246080 + 128 = 620,288
+      expect(numParams).toBe(620288);
+    });
+  });
+
+  describe('Forward Pass', () => {
+    it('should return hidden states with shape [batch, seq_len, hidden_size]', () => {
+      const model = new HarrierModel(TINY_CONFIG);
+
+      const batchSize = 1;
+      const seqLen = 5;
+      const inputIds = MxArray.randint(shape(batchSize, seqLen), 0, TINY_CONFIG.vocabSize);
+
+      const hidden = model.forward(inputIds);
+      expect(hidden).toBeDefined();
+
+      const outputShape = hidden.shape();
+      expect(outputShape[0]).toBe(BigInt(batchSize));
+      expect(outputShape[1]).toBe(BigInt(seqLen));
+      expect(outputShape[2]).toBe(BigInt(TINY_CONFIG.hiddenSize));
+    });
+
+    it('should return hidden_size dim, NOT vocab_size dim (not logits)', () => {
+      const model = new HarrierModel(TINY_CONFIG);
+
+      const inputIds = MxArray.randint(shape(1, 3), 0, TINY_CONFIG.vocabSize);
+      const hidden = model.forward(inputIds);
+
+      const lastDim = hidden.shape()[2];
+      // Should be hidden_size (128), not vocab_size (1000)
+      expect(lastDim).toBe(BigInt(TINY_CONFIG.hiddenSize));
+      expect(lastDim).not.toBe(BigInt(TINY_CONFIG.vocabSize));
+    });
+
+    it('should handle different sequence lengths', () => {
+      const model = new HarrierModel(TINY_CONFIG);
+
+      for (const seqLen of [1, 10, 50]) {
+        const inputIds = MxArray.randint(shape(1, seqLen), 0, TINY_CONFIG.vocabSize);
+        const hidden = model.forward(inputIds);
+        expect(hidden.shape()[1]).toBe(BigInt(seqLen));
+      }
+    });
+  });
+});

--- a/__test__/models/harrier.test.ts
+++ b/__test__/models/harrier.test.ts
@@ -57,14 +57,15 @@ describe.sequential('HarrierModel', () => {
       expect(numParams).toBe(620288);
     });
 
-    it('should default useQkNorm to true (Qwen3 architectural requirement)', () => {
-      // When useQkNorm is not explicitly set, it should default to true
-      // because the underlying Qwen3 backbone always uses QK normalization
-      const config = {
-        ...TINY_CONFIG,
-        useQkNorm: true, // Qwen3 default
-      };
-      const model = new HarrierModel(config);
+    it('should default useQkNorm to true when omitted', () => {
+      // useQkNorm is optional — Qwen3 always uses QK normalization
+      const { useQkNorm: _, ...configWithoutQkNorm } = TINY_CONFIG;
+      const model = new HarrierModel(configWithoutQkNorm as any);
+      expect(model.getConfig().useQkNorm).toBe(true);
+    });
+
+    it('should accept explicit useQkNorm value', () => {
+      const model = new HarrierModel({ ...TINY_CONFIG, useQkNorm: true });
       expect(model.getConfig().useQkNorm).toBe(true);
     });
 

--- a/crates/mlx-core/src/models/harrier/config.rs
+++ b/crates/mlx-core/src/models/harrier/config.rs
@@ -37,9 +37,9 @@ pub struct HarrierConfig {
     #[serde(default = "default_max_position_embeddings")]
     pub max_position_embeddings: i32,
     pub head_dim: i32,
-    /// Qwen3 always uses QK normalization. Omit or pass null to use the
-    /// default (true). Explicitly passing false is allowed but produces
-    /// a model incompatible with published Harrier weights.
+    /// Qwen3 always uses QK normalization. Omit to use the default (true).
+    /// Explicitly passing false is allowed but produces a model incompatible
+    /// with published Harrier weights.
     #[serde(default = "default_use_qk_norm")]
     pub use_qk_norm: Option<bool>,
     pub vocab_size: i32,

--- a/crates/mlx-core/src/models/harrier/config.rs
+++ b/crates/mlx-core/src/models/harrier/config.rs
@@ -12,6 +12,11 @@ fn default_max_position_embeddings() -> i32 {
     32768
 }
 
+/// Qwen3 always uses QK normalization.
+fn default_use_qk_norm() -> bool {
+    true
+}
+
 /// Configuration for Harrier embedding model (Qwen3 backbone).
 ///
 /// Only includes backbone dimensions needed for encoding.
@@ -33,7 +38,7 @@ pub struct HarrierConfig {
     #[serde(default = "default_max_position_embeddings")]
     pub max_position_embeddings: i32,
     pub head_dim: i32,
-    #[serde(default)]
+    #[serde(default = "default_use_qk_norm")]
     pub use_qk_norm: bool,
     pub vocab_size: i32,
 }

--- a/crates/mlx-core/src/models/harrier/config.rs
+++ b/crates/mlx-core/src/models/harrier/config.rs
@@ -1,0 +1,39 @@
+use napi_derive::napi;
+
+fn default_rope_theta() -> f64 {
+    1_000_000.0
+}
+
+fn default_rms_norm_eps() -> f64 {
+    1e-6
+}
+
+fn default_max_position_embeddings() -> i32 {
+    32768
+}
+
+/// Configuration for Harrier embedding model (Qwen3 backbone).
+///
+/// Only includes backbone dimensions needed for encoding.
+/// No generation fields (token IDs, paged attention, etc.).
+#[napi(object)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct HarrierConfig {
+    pub hidden_size: i32,
+    #[serde(alias = "num_hidden_layers")]
+    pub num_layers: i32,
+    #[serde(alias = "num_attention_heads")]
+    pub num_heads: i32,
+    pub num_key_value_heads: i32,
+    pub intermediate_size: i32,
+    #[serde(default = "default_rms_norm_eps")]
+    pub rms_norm_eps: f64,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f64,
+    #[serde(default = "default_max_position_embeddings")]
+    pub max_position_embeddings: i32,
+    pub head_dim: i32,
+    #[serde(default)]
+    pub use_qk_norm: bool,
+    pub vocab_size: i32,
+}

--- a/crates/mlx-core/src/models/harrier/config.rs
+++ b/crates/mlx-core/src/models/harrier/config.rs
@@ -12,9 +12,8 @@ fn default_max_position_embeddings() -> i32 {
     32768
 }
 
-/// Qwen3 always uses QK normalization.
-fn default_use_qk_norm() -> bool {
-    true
+fn default_use_qk_norm() -> Option<bool> {
+    Some(true)
 }
 
 /// Configuration for Harrier embedding model (Qwen3 backbone).
@@ -38,7 +37,10 @@ pub struct HarrierConfig {
     #[serde(default = "default_max_position_embeddings")]
     pub max_position_embeddings: i32,
     pub head_dim: i32,
+    /// Qwen3 always uses QK normalization. Omit or pass null to use the
+    /// default (true). Explicitly passing false is allowed but produces
+    /// a model incompatible with published Harrier weights.
     #[serde(default = "default_use_qk_norm")]
-    pub use_qk_norm: bool,
+    pub use_qk_norm: Option<bool>,
     pub vocab_size: i32,
 }

--- a/crates/mlx-core/src/models/harrier/mod.rs
+++ b/crates/mlx-core/src/models/harrier/mod.rs
@@ -1,0 +1,6 @@
+mod config;
+mod model;
+mod persistence;
+
+pub use config::*;
+pub use model::*;

--- a/crates/mlx-core/src/models/harrier/model.rs
+++ b/crates/mlx-core/src/models/harrier/model.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use napi::bindgen_prelude::*;
@@ -22,6 +23,9 @@ pub struct HarrierModel {
     pub(crate) layers: Vec<TransformerBlock>,
     pub(crate) final_norm: RMSNorm,
     pub(crate) tokenizer: Option<Arc<Qwen3Tokenizer>>,
+    /// Named prompt presets loaded from config_sentence_transformers.json.
+    /// Keys are task names (e.g. "web_search_query"), values are full prefix strings.
+    pub(crate) prompts: HashMap<String, String>,
 }
 
 #[napi]
@@ -53,6 +57,7 @@ impl HarrierModel {
             layers,
             final_norm,
             tokenizer: None,
+            prompts: HashMap::new(),
         })
     }
 
@@ -71,17 +76,21 @@ impl HarrierModel {
     /// Encode a single text into a normalized embedding vector.
     ///
     /// Tokenizes the text, runs the forward pass, applies last-token pooling,
-    /// and L2-normalizes the result.
+    /// and L2-normalizes the result. Truncates to `max_position_embeddings`.
     ///
     /// # Arguments
     /// * `text` - Input text to encode
-    /// * `instruction` - Optional task instruction to prepend (for queries)
+    /// * `instruction` - Optional task instruction prefix or preset name
+    ///   (e.g. `"web_search_query"` resolves to the full Harrier prompt).
+    ///   Pass `null` for documents/passages that need no instruction.
     ///
     /// # Returns
     /// * Embedding vector, shape: [hidden_size]
     #[napi]
     pub async fn encode(&self, text: String, instruction: Option<String>) -> Result<MxArray> {
         let tokenizer = self.require_tokenizer()?.clone();
+        let instruction = instruction.map(|i| self.resolve_instruction(i));
+        let max_tokens = self.config.max_position_embeddings as usize;
         let config_hidden = self.config.hidden_size;
 
         let embedding = self.embedding.clone();
@@ -94,7 +103,10 @@ impl HarrierModel {
                 None => text,
             };
 
-            let token_ids = tokenizer.encode_sync(&full_text, Some(true))?;
+            let mut token_ids = tokenizer.encode_sync(&full_text, Some(true))?;
+            if token_ids.len() > max_tokens {
+                token_ids.truncate(max_tokens);
+            }
             let seq_len = token_ids.len();
             let input = MxArray::from_uint32(&token_ids, &[1, seq_len as i64])?;
 
@@ -114,11 +126,14 @@ impl HarrierModel {
     /// Encode a batch of texts into normalized embedding vectors.
     ///
     /// Each text is independently tokenized and encoded (no padding needed
-    /// since each goes through its own forward pass).
+    /// since each goes through its own forward pass). Truncates each text
+    /// to `max_position_embeddings`.
     ///
     /// # Arguments
     /// * `texts` - Input texts to encode
-    /// * `instruction` - Optional task instruction to prepend to each text
+    /// * `instruction` - Optional task instruction prefix or preset name
+    ///   (e.g. `"web_search_query"` resolves to the full Harrier prompt).
+    ///   Pass `null` for documents/passages that need no instruction.
     ///
     /// # Returns
     /// * Embedding matrix, shape: [batch_size, hidden_size]
@@ -129,6 +144,8 @@ impl HarrierModel {
         instruction: Option<String>,
     ) -> Result<MxArray> {
         let tokenizer = self.require_tokenizer()?.clone();
+        let instruction = instruction.map(|i| self.resolve_instruction(i));
+        let max_tokens = self.config.max_position_embeddings as usize;
         let config_hidden = self.config.hidden_size;
 
         let embedding = self.embedding.clone();
@@ -144,7 +161,10 @@ impl HarrierModel {
                     None => text,
                 };
 
-                let token_ids = tokenizer.encode_sync(&full_text, Some(true))?;
+                let mut token_ids = tokenizer.encode_sync(&full_text, Some(true))?;
+                if token_ids.len() > max_tokens {
+                    token_ids.truncate(max_tokens);
+                }
                 let seq_len = token_ids.len();
                 let input = MxArray::from_uint32(&token_ids, &[1, seq_len as i64])?;
 
@@ -173,6 +193,16 @@ impl HarrierModel {
     #[napi]
     pub fn get_config(&self) -> HarrierConfig {
         self.config.clone()
+    }
+
+    /// Get available prompt presets loaded from config_sentence_transformers.json.
+    ///
+    /// Returns a map of task name -> full instruction prefix.
+    /// Pass a task name to `encode()`/`encodeBatch()` as the `instruction` parameter
+    /// to use a preset instead of a raw prefix string.
+    #[napi]
+    pub fn get_prompts(&self) -> HashMap<String, String> {
+        self.prompts.clone()
     }
 
     /// Get the total number of model parameters.
@@ -206,10 +236,7 @@ impl HarrierModel {
     }
 
     /// Apply loaded parameters to the model.
-    pub(crate) fn load_parameters(
-        &mut self,
-        params: &std::collections::HashMap<String, MxArray>,
-    ) -> Result<()> {
+    pub(crate) fn load_parameters(&mut self, params: &HashMap<String, MxArray>) -> Result<()> {
         if let Some(w) = params.get("embedding.weight") {
             self.embedding.set_weight(w)?;
         } else {
@@ -295,6 +322,15 @@ impl HarrierModel {
             )
         })
     }
+
+    /// If `instruction` matches a loaded prompt name, return the full prefix.
+    /// Otherwise return it as-is (the caller passed a raw prefix string).
+    fn resolve_instruction(&self, instruction: String) -> String {
+        self.prompts
+            .get(&instruction)
+            .cloned()
+            .unwrap_or(instruction)
+    }
 }
 
 /// Shared forward pass: embedding -> transformer layers -> final norm.
@@ -327,12 +363,128 @@ fn l2_normalize(x: &MxArray) -> Result<MxArray> {
 }
 
 fn set_required(
-    params: &std::collections::HashMap<String, MxArray>,
+    params: &HashMap<String, MxArray>,
     name: &str,
     setter: impl FnOnce(&MxArray) -> Result<()>,
 ) -> Result<()> {
     match params.get(name) {
         Some(w) => setter(w),
         None => Err(Error::from_reason(format!("{} not found", name))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_values(arr: &MxArray) -> Vec<f32> {
+        arr.eval();
+        arr.to_float32().unwrap().to_vec()
+    }
+
+    fn get_shape(arr: &MxArray) -> Vec<i64> {
+        arr.shape().unwrap().to_vec()
+    }
+
+    #[test]
+    fn test_l2_normalize_produces_unit_vector() {
+        // [3, 4, 0] has L2 norm = 5, so normalized = [0.6, 0.8, 0.0]
+        let x = MxArray::from_float32(&[3.0, 4.0, 0.0], &[3]).unwrap();
+        let normed = l2_normalize(&x).unwrap();
+        let vals = get_values(&normed);
+
+        assert!((vals[0] - 0.6).abs() < 1e-5);
+        assert!((vals[1] - 0.8).abs() < 1e-5);
+        assert!(vals[2].abs() < 1e-5);
+
+        // Check the result actually has unit norm
+        let norm_sq: f32 = vals.iter().map(|v| v * v).sum();
+        assert!((norm_sq - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_l2_normalize_handles_zero_vector() {
+        // Zero vector should not produce NaN (clip(1e-12) prevents div-by-zero)
+        let x = MxArray::from_float32(&[0.0, 0.0, 0.0], &[3]).unwrap();
+        let normed = l2_normalize(&x).unwrap();
+        let vals = get_values(&normed);
+
+        for v in &vals {
+            assert!(!v.is_nan(), "L2 normalize of zero vector produced NaN");
+        }
+    }
+
+    #[test]
+    fn test_l2_normalize_2d_normalizes_per_row() {
+        // Two rows: [3,4] (norm=5) and [0,1] (norm=1)
+        let x = MxArray::from_float32(&[3.0, 4.0, 0.0, 1.0], &[2, 2]).unwrap();
+        let normed = l2_normalize(&x).unwrap();
+        let vals = get_values(&normed);
+
+        // Row 0: [0.6, 0.8]
+        assert!((vals[0] - 0.6).abs() < 1e-5);
+        assert!((vals[1] - 0.8).abs() < 1e-5);
+        // Row 1: [0.0, 1.0]
+        assert!(vals[2].abs() < 1e-5);
+        assert!((vals[3] - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_last_token_pool_extracts_final_position() {
+        // [1, 3, 4] tensor: 3 tokens, 4-dim hidden states
+        let data: Vec<f32> = (0..12).map(|i| i as f32).collect();
+        let x = MxArray::from_float32(&data, &[1, 3, 4]).unwrap();
+        let pooled = last_token_pool(&x, 3, 4).unwrap();
+
+        assert_eq!(get_shape(&pooled), vec![1, 1, 4]);
+        // Last token (index 2): values [8, 9, 10, 11]
+        let vals = get_values(&pooled);
+        assert_eq!(vals, vec![8.0, 9.0, 10.0, 11.0]);
+    }
+
+    #[test]
+    fn test_last_token_pool_single_token() {
+        let x = MxArray::from_float32(&[1.0, 2.0], &[1, 1, 2]).unwrap();
+        let pooled = last_token_pool(&x, 1, 2).unwrap();
+
+        assert_eq!(get_shape(&pooled), vec![1, 1, 2]);
+        assert_eq!(get_values(&pooled), vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_resolve_instruction_with_known_prompt() {
+        let mut prompts = HashMap::new();
+        prompts.insert(
+            "web_search_query".to_string(),
+            "Instruct: search\nQuery: ".to_string(),
+        );
+
+        let config = HarrierConfig {
+            hidden_size: 64,
+            num_layers: 1,
+            num_heads: 2,
+            num_key_value_heads: 1,
+            intermediate_size: 128,
+            rms_norm_eps: 1e-6,
+            rope_theta: 1_000_000.0,
+            max_position_embeddings: 512,
+            head_dim: 32,
+            use_qk_norm: false,
+            vocab_size: 100,
+        };
+
+        let mut model = HarrierModel::new(config).unwrap();
+        model.prompts = prompts;
+
+        // Named prompt resolves to full prefix
+        assert_eq!(
+            model.resolve_instruction("web_search_query".to_string()),
+            "Instruct: search\nQuery: "
+        );
+        // Unknown name passes through as-is
+        assert_eq!(
+            model.resolve_instruction("Instruct: custom\nQuery: ".to_string()),
+            "Instruct: custom\nQuery: "
+        );
     }
 }

--- a/crates/mlx-core/src/models/harrier/model.rs
+++ b/crates/mlx-core/src/models/harrier/model.rs
@@ -98,7 +98,7 @@ impl HarrierModel {
         let config_hidden = self.config.hidden_size;
 
         let embedding = self.embedding.clone();
-        let layers: Vec<_> = self.layers.iter().cloned().collect();
+        let layers: Vec<_> = self.layers.to_vec();
         let final_norm = self.final_norm.clone();
 
         napi::bindgen_prelude::spawn_blocking(move || {
@@ -151,7 +151,7 @@ impl HarrierModel {
         let config_hidden = self.config.hidden_size;
 
         let embedding = self.embedding.clone();
-        let layers: Vec<_> = self.layers.iter().cloned().collect();
+        let layers: Vec<_> = self.layers.to_vec();
         let final_norm = self.final_norm.clone();
 
         napi::bindgen_prelude::spawn_blocking(move || {

--- a/crates/mlx-core/src/models/harrier/model.rs
+++ b/crates/mlx-core/src/models/harrier/model.rs
@@ -31,7 +31,11 @@ pub struct HarrierModel {
 #[napi]
 impl HarrierModel {
     #[napi(constructor)]
-    pub fn new(config: HarrierConfig) -> Result<Self> {
+    pub fn new(mut config: HarrierConfig) -> Result<Self> {
+        // Resolve use_qk_norm default — Qwen3 always uses QK normalization
+        let use_qk_norm = config.use_qk_norm.unwrap_or(true);
+        config.use_qk_norm = Some(use_qk_norm);
+
         let embedding = Embedding::new(config.vocab_size as u32, config.hidden_size as u32)?;
 
         let layers = (0..config.num_layers)
@@ -43,7 +47,7 @@ impl HarrierModel {
                     config.intermediate_size as u32,
                     config.rms_norm_eps,
                     Some(config.rope_theta),
-                    Some(config.use_qk_norm),
+                    Some(use_qk_norm),
                     Some(config.head_dim as u32),
                 )
             })
@@ -221,7 +225,7 @@ impl HarrierModel {
             + (hidden * heads * head_dim);
         let mlp_params = inter * hidden * 3;
         let norm_params = hidden * 2;
-        let qk_norm_params = if self.config.use_qk_norm {
+        let qk_norm_params = if self.config.use_qk_norm.unwrap_or(true) {
             head_dim * 2
         } else {
             0
@@ -264,7 +268,7 @@ impl HarrierModel {
                 |w| attn.set_o_proj_weight(w),
             )?;
 
-            if self.config.use_qk_norm {
+            if self.config.use_qk_norm.unwrap_or(true) {
                 set_required(
                     params,
                     &format!("{}.self_attn.q_norm.weight", prefix),
@@ -518,7 +522,7 @@ mod tests {
             rope_theta: 1_000_000.0,
             max_position_embeddings: 512,
             head_dim: 32,
-            use_qk_norm: false,
+            use_qk_norm: None,
             vocab_size: 100,
         };
 

--- a/crates/mlx-core/src/models/harrier/model.rs
+++ b/crates/mlx-core/src/models/harrier/model.rs
@@ -1,0 +1,358 @@
+use std::sync::Arc;
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use tracing::info;
+
+use crate::array::MxArray;
+use crate::nn::{Embedding, RMSNorm};
+use crate::tokenizer::Qwen3Tokenizer;
+use crate::transformer::TransformerBlock;
+
+use super::HarrierConfig;
+
+/// Harrier embedding model (Qwen3 backbone for text embeddings).
+///
+/// Uses last-token pooling and L2 normalization to produce fixed-size
+/// embedding vectors from variable-length text inputs.
+#[napi]
+pub struct HarrierModel {
+    pub(crate) config: HarrierConfig,
+    pub(crate) embedding: Embedding,
+    pub(crate) layers: Vec<TransformerBlock>,
+    pub(crate) final_norm: RMSNorm,
+    pub(crate) tokenizer: Option<Arc<Qwen3Tokenizer>>,
+}
+
+#[napi]
+impl HarrierModel {
+    #[napi(constructor)]
+    pub fn new(config: HarrierConfig) -> Result<Self> {
+        let embedding = Embedding::new(config.vocab_size as u32, config.hidden_size as u32)?;
+
+        let layers = (0..config.num_layers)
+            .map(|_| {
+                TransformerBlock::new(
+                    config.hidden_size as u32,
+                    config.num_heads as u32,
+                    config.num_key_value_heads as u32,
+                    config.intermediate_size as u32,
+                    config.rms_norm_eps,
+                    Some(config.rope_theta),
+                    Some(config.use_qk_norm),
+                    Some(config.head_dim as u32),
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let final_norm = RMSNorm::new(config.hidden_size as u32, Some(config.rms_norm_eps))?;
+
+        Ok(Self {
+            config,
+            embedding,
+            layers,
+            final_norm,
+            tokenizer: None,
+        })
+    }
+
+    /// Forward pass returning hidden states (no lm_head projection).
+    ///
+    /// # Arguments
+    /// * `input_ids` - Token IDs, shape: [batch_size, seq_len]
+    ///
+    /// # Returns
+    /// * Hidden states, shape: [batch_size, seq_len, hidden_size]
+    #[napi]
+    pub fn forward(&self, input_ids: &MxArray) -> Result<MxArray> {
+        let mut hidden_states = self.embedding.forward(input_ids)?;
+
+        for layer in &self.layers {
+            hidden_states = layer.forward(&hidden_states, None, None)?;
+        }
+
+        self.final_norm.forward(&hidden_states)
+    }
+
+    /// Encode a single text into a normalized embedding vector.
+    ///
+    /// Tokenizes the text, runs the forward pass, applies last-token pooling,
+    /// and L2-normalizes the result.
+    ///
+    /// # Arguments
+    /// * `text` - Input text to encode
+    /// * `instruction` - Optional task instruction to prepend (for queries)
+    ///
+    /// # Returns
+    /// * Embedding vector, shape: [hidden_size]
+    #[napi]
+    pub async fn encode(&self, text: String, instruction: Option<String>) -> Result<MxArray> {
+        let tokenizer = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| {
+                Error::from_reason(
+                    "Tokenizer not loaded. Use HarrierModel.load() to load a model with tokenizer.",
+                )
+            })?
+            .clone();
+        let config_hidden = self.config.hidden_size;
+
+        // Collect model references for spawn_blocking
+        let embedding = self.embedding.clone();
+        let layers: Vec<_> = self.layers.iter().cloned().collect();
+        let final_norm = self.final_norm.clone();
+
+        napi::bindgen_prelude::spawn_blocking(move || {
+            let full_text = match instruction {
+                Some(instr) => format!("{}{}", instr, text),
+                None => text,
+            };
+
+            let token_ids = tokenizer.encode_sync(&full_text, Some(true))?;
+            let seq_len = token_ids.len();
+            let input = MxArray::from_uint32(&token_ids, &[1, seq_len as i64])?;
+
+            // Forward pass
+            let mut hidden_states = embedding.forward(&input)?;
+            for layer in &layers {
+                hidden_states = layer.forward(&hidden_states, None, None)?;
+            }
+            hidden_states = final_norm.forward(&hidden_states)?;
+
+            // Last-token pooling: take the last token's hidden state
+            let pooled = hidden_states.slice(
+                &[0, seq_len as i64 - 1, 0],
+                &[1, seq_len as i64, config_hidden as i64],
+            )?;
+            let pooled = pooled.reshape(&[config_hidden as i64])?;
+
+            // L2 normalization
+            l2_normalize(&pooled)
+        })
+        .await
+        .map_err(|e| Error::from_reason(format!("encode failed: {}", e)))?
+    }
+
+    /// Encode a batch of texts into normalized embedding vectors.
+    ///
+    /// Each text is independently tokenized and encoded (no padding needed
+    /// since each goes through its own forward pass).
+    ///
+    /// # Arguments
+    /// * `texts` - Input texts to encode
+    /// * `instruction` - Optional task instruction to prepend to each text
+    ///
+    /// # Returns
+    /// * Embedding matrix, shape: [batch_size, hidden_size]
+    #[napi]
+    pub async fn encode_batch(
+        &self,
+        texts: Vec<String>,
+        instruction: Option<String>,
+    ) -> Result<MxArray> {
+        let tokenizer = self
+            .tokenizer
+            .as_ref()
+            .ok_or_else(|| {
+                Error::from_reason(
+                    "Tokenizer not loaded. Use HarrierModel.load() to load a model with tokenizer.",
+                )
+            })?
+            .clone();
+        let config_hidden = self.config.hidden_size;
+
+        let embedding = self.embedding.clone();
+        let layers: Vec<_> = self.layers.iter().cloned().collect();
+        let final_norm = self.final_norm.clone();
+
+        napi::bindgen_prelude::spawn_blocking(move || {
+            let mut all_embeddings: Vec<MxArray> = Vec::with_capacity(texts.len());
+
+            for text in texts {
+                let full_text = match &instruction {
+                    Some(instr) => format!("{}{}", instr, text),
+                    None => text,
+                };
+
+                let token_ids = tokenizer.encode_sync(&full_text, Some(true))?;
+                let seq_len = token_ids.len();
+                let input = MxArray::from_uint32(&token_ids, &[1, seq_len as i64])?;
+
+                // Forward pass
+                let mut hidden_states = embedding.forward(&input)?;
+                for layer in &layers {
+                    hidden_states = layer.forward(&hidden_states, None, None)?;
+                }
+                hidden_states = final_norm.forward(&hidden_states)?;
+
+                // Last-token pooling
+                let pooled = hidden_states.slice(
+                    &[0, seq_len as i64 - 1, 0],
+                    &[1, seq_len as i64, config_hidden as i64],
+                )?;
+                let pooled = pooled.reshape(&[1, config_hidden as i64])?;
+
+                // L2 normalize
+                let normalized = l2_normalize(&pooled)?;
+                all_embeddings.push(normalized);
+            }
+
+            // Stack: concatenate along dim 0
+            if all_embeddings.is_empty() {
+                return Err(Error::from_reason("Cannot encode empty batch"));
+            }
+
+            let mut result = all_embeddings.remove(0);
+            for emb in all_embeddings {
+                result = MxArray::concatenate(&result, &emb, 0)?;
+            }
+            result.eval();
+            Ok(result)
+        })
+        .await
+        .map_err(|e| Error::from_reason(format!("encode_batch failed: {}", e)))?
+    }
+
+    /// Get the model configuration.
+    #[napi]
+    pub fn get_config(&self) -> HarrierConfig {
+        self.config.clone()
+    }
+
+    /// Get the total number of model parameters.
+    #[napi]
+    pub fn num_parameters(&self) -> i64 {
+        let vocab = self.config.vocab_size as i64;
+        let hidden = self.config.hidden_size as i64;
+        let inter = self.config.intermediate_size as i64;
+        let heads = self.config.num_heads as i64;
+        let kv_heads = self.config.num_key_value_heads as i64;
+        let head_dim = self.config.head_dim as i64;
+        let n_layers = self.config.num_layers as i64;
+
+        let embedding_params = vocab * hidden;
+        let final_norm_params = hidden;
+
+        // Per layer: q_proj + k_proj + v_proj + o_proj + gate + up + down + 2 norms
+        let attn_params = (heads * head_dim * hidden) // q_proj
+            + (kv_heads * head_dim * hidden)           // k_proj
+            + (kv_heads * head_dim * hidden)           // v_proj
+            + (hidden * heads * head_dim); // o_proj
+        let mlp_params = inter * hidden * 3; // gate + up + down
+        let norm_params = hidden * 2; // input_layernorm + post_attention_layernorm
+        let qk_norm_params = if self.config.use_qk_norm {
+            head_dim * 2
+        } else {
+            0
+        };
+        let layer_params = attn_params + mlp_params + norm_params + qk_norm_params;
+
+        embedding_params + final_norm_params + n_layers * layer_params
+    }
+
+    /// Apply loaded parameters to the model.
+    pub(crate) fn load_parameters(
+        &mut self,
+        params: &std::collections::HashMap<String, MxArray>,
+    ) -> Result<()> {
+        // Embedding
+        if let Some(w) = params.get("embedding.weight") {
+            self.embedding.set_weight(w)?;
+        } else {
+            return Err(Error::from_reason("embedding.weight not found"));
+        }
+
+        // Transformer layers
+        for (i, layer) in self.layers.iter_mut().enumerate() {
+            let prefix = format!("layers.{}", i);
+
+            let attn = &mut layer.self_attn;
+            set_required(
+                params,
+                &format!("{}.self_attn.q_proj.weight", prefix),
+                |w| attn.set_q_proj_weight(w),
+            )?;
+            set_required(
+                params,
+                &format!("{}.self_attn.k_proj.weight", prefix),
+                |w| attn.set_k_proj_weight(w),
+            )?;
+            set_required(
+                params,
+                &format!("{}.self_attn.v_proj.weight", prefix),
+                |w| attn.set_v_proj_weight(w),
+            )?;
+            set_required(
+                params,
+                &format!("{}.self_attn.o_proj.weight", prefix),
+                |w| attn.set_o_proj_weight(w),
+            )?;
+
+            if self.config.use_qk_norm {
+                set_required(
+                    params,
+                    &format!("{}.self_attn.q_norm.weight", prefix),
+                    |w| attn.set_q_norm_weight(w),
+                )?;
+                set_required(
+                    params,
+                    &format!("{}.self_attn.k_norm.weight", prefix),
+                    |w| attn.set_k_norm_weight(w),
+                )?;
+            }
+
+            let mlp = &mut layer.mlp;
+            set_required(params, &format!("{}.mlp.gate_proj.weight", prefix), |w| {
+                mlp.set_gate_proj_weight(w)
+            })?;
+            set_required(params, &format!("{}.mlp.up_proj.weight", prefix), |w| {
+                mlp.set_up_proj_weight(w)
+            })?;
+            set_required(params, &format!("{}.mlp.down_proj.weight", prefix), |w| {
+                mlp.set_down_proj_weight(w)
+            })?;
+
+            set_required(params, &format!("{}.input_layernorm.weight", prefix), |w| {
+                layer.set_input_layernorm_weight(w)
+            })?;
+            set_required(
+                params,
+                &format!("{}.post_attention_layernorm.weight", prefix),
+                |w| layer.set_post_attention_layernorm_weight(w),
+            )?;
+        }
+
+        // Final norm
+        if let Some(w) = params.get("final_norm.weight") {
+            self.final_norm.set_weight(w)?;
+        } else {
+            return Err(Error::from_reason("final_norm.weight not found"));
+        }
+
+        info!(
+            "Loaded {} layers into HarrierModel ({} hidden)",
+            self.config.num_layers, self.config.hidden_size
+        );
+        Ok(())
+    }
+}
+
+/// L2-normalize an array along the last axis.
+fn l2_normalize(x: &MxArray) -> Result<MxArray> {
+    let norm = x.square()?.sum(Some(&[-1]), Some(true))?.sqrt()?;
+    let norm = norm.clip(Some(1e-12), None)?;
+    x.div(&norm)
+}
+
+/// Helper to set a required parameter or return an error.
+fn set_required(
+    params: &std::collections::HashMap<String, MxArray>,
+    name: &str,
+    setter: impl FnOnce(&MxArray) -> Result<()>,
+) -> Result<()> {
+    match params.get(name) {
+        Some(w) => setter(w),
+        None => Err(Error::from_reason(format!("{} not found", name))),
+    }
+}

--- a/crates/mlx-core/src/models/harrier/model.rs
+++ b/crates/mlx-core/src/models/harrier/model.rs
@@ -104,9 +104,7 @@ impl HarrierModel {
             };
 
             let mut token_ids = tokenizer.encode_sync(&full_text, Some(true))?;
-            if token_ids.len() > max_tokens {
-                token_ids.truncate(max_tokens);
-            }
+            truncate_preserving_tail(&mut token_ids, max_tokens);
             let seq_len = token_ids.len();
             let input = MxArray::from_uint32(&token_ids, &[1, seq_len as i64])?;
 
@@ -162,9 +160,7 @@ impl HarrierModel {
                 };
 
                 let mut token_ids = tokenizer.encode_sync(&full_text, Some(true))?;
-                if token_ids.len() > max_tokens {
-                    token_ids.truncate(max_tokens);
-                }
+                truncate_preserving_tail(&mut token_ids, max_tokens);
                 let seq_len = token_ids.len();
                 let input = MxArray::from_uint32(&token_ids, &[1, seq_len as i64])?;
 
@@ -355,6 +351,20 @@ fn last_token_pool(hidden_states: &MxArray, seq_len: usize, hidden_size: i32) ->
     )
 }
 
+/// Truncate token sequence to `max_len` while preserving the trailing token.
+///
+/// Harrier pools the final token, which is the special end-of-sequence token
+/// added by `add_special_tokens=true`. Naive truncation would drop it, causing
+/// the model to pool a content token instead — deviating from the training recipe.
+/// This keeps the first `max_len - 1` tokens plus the original tail token.
+fn truncate_preserving_tail(token_ids: &mut Vec<u32>, max_len: usize) {
+    if token_ids.len() > max_len && max_len > 0 {
+        let tail = *token_ids.last().unwrap();
+        token_ids.truncate(max_len);
+        *token_ids.last_mut().unwrap() = tail;
+    }
+}
+
 /// L2-normalize an array along the last axis.
 fn l2_normalize(x: &MxArray) -> Result<MxArray> {
     let norm = x.square()?.sum(Some(&[-1]), Some(true))?.sqrt()?;
@@ -449,6 +459,45 @@ mod tests {
 
         assert_eq!(get_shape(&pooled), vec![1, 1, 2]);
         assert_eq!(get_values(&pooled), vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_truncate_preserving_tail_keeps_special_token() {
+        // Reproduces the reviewer's scenario: content tokens + trailing EOS (151643)
+        let mut ids = vec![14990, 23811, 23811, 23811, 151643];
+        truncate_preserving_tail(&mut ids, 3);
+        // First 2 content tokens + EOS preserved at end
+        assert_eq!(ids, vec![14990, 23811, 151643]);
+    }
+
+    #[test]
+    fn test_truncate_preserving_tail_noop_under_limit() {
+        let mut ids = vec![1, 2, 3];
+        truncate_preserving_tail(&mut ids, 5);
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_truncate_preserving_tail_noop_at_exact_limit() {
+        let mut ids = vec![1, 2, 3];
+        truncate_preserving_tail(&mut ids, 3);
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_truncate_preserving_tail_to_single_token() {
+        // Even truncating to 1 should preserve the tail special token
+        let mut ids = vec![1, 2, 3, 151643];
+        truncate_preserving_tail(&mut ids, 1);
+        assert_eq!(ids, vec![151643]);
+    }
+
+    #[test]
+    fn test_truncate_preserving_tail_to_two_tokens() {
+        let mut ids = vec![100, 200, 300, 400, 151643];
+        truncate_preserving_tail(&mut ids, 2);
+        // First content token + tail special token
+        assert_eq!(ids, vec![100, 151643]);
     }
 
     #[test]

--- a/crates/mlx-core/src/models/harrier/model.rs
+++ b/crates/mlx-core/src/models/harrier/model.rs
@@ -65,13 +65,7 @@ impl HarrierModel {
     /// * Hidden states, shape: [batch_size, seq_len, hidden_size]
     #[napi]
     pub fn forward(&self, input_ids: &MxArray) -> Result<MxArray> {
-        let mut hidden_states = self.embedding.forward(input_ids)?;
-
-        for layer in &self.layers {
-            hidden_states = layer.forward(&hidden_states, None, None)?;
-        }
-
-        self.final_norm.forward(&hidden_states)
+        forward_inner(&self.embedding, &self.layers, &self.final_norm, input_ids)
     }
 
     /// Encode a single text into a normalized embedding vector.
@@ -87,18 +81,9 @@ impl HarrierModel {
     /// * Embedding vector, shape: [hidden_size]
     #[napi]
     pub async fn encode(&self, text: String, instruction: Option<String>) -> Result<MxArray> {
-        let tokenizer = self
-            .tokenizer
-            .as_ref()
-            .ok_or_else(|| {
-                Error::from_reason(
-                    "Tokenizer not loaded. Use HarrierModel.load() to load a model with tokenizer.",
-                )
-            })?
-            .clone();
+        let tokenizer = self.require_tokenizer()?.clone();
         let config_hidden = self.config.hidden_size;
 
-        // Collect model references for spawn_blocking
         let embedding = self.embedding.clone();
         let layers: Vec<_> = self.layers.iter().cloned().collect();
         let final_norm = self.final_norm.clone();
@@ -113,22 +98,14 @@ impl HarrierModel {
             let seq_len = token_ids.len();
             let input = MxArray::from_uint32(&token_ids, &[1, seq_len as i64])?;
 
-            // Forward pass
-            let mut hidden_states = embedding.forward(&input)?;
-            for layer in &layers {
-                hidden_states = layer.forward(&hidden_states, None, None)?;
-            }
-            hidden_states = final_norm.forward(&hidden_states)?;
+            let hidden_states = forward_inner(&embedding, &layers, &final_norm, &input)?;
 
-            // Last-token pooling: take the last token's hidden state
-            let pooled = hidden_states.slice(
-                &[0, seq_len as i64 - 1, 0],
-                &[1, seq_len as i64, config_hidden as i64],
-            )?;
+            let pooled = last_token_pool(&hidden_states, seq_len, config_hidden)?;
             let pooled = pooled.reshape(&[config_hidden as i64])?;
 
-            // L2 normalization
-            l2_normalize(&pooled)
+            let result = l2_normalize(&pooled)?;
+            result.eval();
+            Ok(result)
         })
         .await
         .map_err(|e| Error::from_reason(format!("encode failed: {}", e)))?
@@ -151,15 +128,7 @@ impl HarrierModel {
         texts: Vec<String>,
         instruction: Option<String>,
     ) -> Result<MxArray> {
-        let tokenizer = self
-            .tokenizer
-            .as_ref()
-            .ok_or_else(|| {
-                Error::from_reason(
-                    "Tokenizer not loaded. Use HarrierModel.load() to load a model with tokenizer.",
-                )
-            })?
-            .clone();
+        let tokenizer = self.require_tokenizer()?.clone();
         let config_hidden = self.config.hidden_size;
 
         let embedding = self.embedding.clone();
@@ -179,34 +148,20 @@ impl HarrierModel {
                 let seq_len = token_ids.len();
                 let input = MxArray::from_uint32(&token_ids, &[1, seq_len as i64])?;
 
-                // Forward pass
-                let mut hidden_states = embedding.forward(&input)?;
-                for layer in &layers {
-                    hidden_states = layer.forward(&hidden_states, None, None)?;
-                }
-                hidden_states = final_norm.forward(&hidden_states)?;
+                let hidden_states = forward_inner(&embedding, &layers, &final_norm, &input)?;
 
-                // Last-token pooling
-                let pooled = hidden_states.slice(
-                    &[0, seq_len as i64 - 1, 0],
-                    &[1, seq_len as i64, config_hidden as i64],
-                )?;
+                let pooled = last_token_pool(&hidden_states, seq_len, config_hidden)?;
                 let pooled = pooled.reshape(&[1, config_hidden as i64])?;
 
-                // L2 normalize
-                let normalized = l2_normalize(&pooled)?;
-                all_embeddings.push(normalized);
+                all_embeddings.push(l2_normalize(&pooled)?);
             }
 
-            // Stack: concatenate along dim 0
             if all_embeddings.is_empty() {
                 return Err(Error::from_reason("Cannot encode empty batch"));
             }
 
-            let mut result = all_embeddings.remove(0);
-            for emb in all_embeddings {
-                result = MxArray::concatenate(&result, &emb, 0)?;
-            }
+            let refs: Vec<&MxArray> = all_embeddings.iter().collect();
+            let result = MxArray::concatenate_many(refs, Some(0))?;
             result.eval();
             Ok(result)
         })
@@ -234,13 +189,12 @@ impl HarrierModel {
         let embedding_params = vocab * hidden;
         let final_norm_params = hidden;
 
-        // Per layer: q_proj + k_proj + v_proj + o_proj + gate + up + down + 2 norms
-        let attn_params = (heads * head_dim * hidden) // q_proj
-            + (kv_heads * head_dim * hidden)           // k_proj
-            + (kv_heads * head_dim * hidden)           // v_proj
-            + (hidden * heads * head_dim); // o_proj
-        let mlp_params = inter * hidden * 3; // gate + up + down
-        let norm_params = hidden * 2; // input_layernorm + post_attention_layernorm
+        let attn_params = (heads * head_dim * hidden)
+            + (kv_heads * head_dim * hidden)
+            + (kv_heads * head_dim * hidden)
+            + (hidden * heads * head_dim);
+        let mlp_params = inter * hidden * 3;
+        let norm_params = hidden * 2;
         let qk_norm_params = if self.config.use_qk_norm {
             head_dim * 2
         } else {
@@ -256,14 +210,12 @@ impl HarrierModel {
         &mut self,
         params: &std::collections::HashMap<String, MxArray>,
     ) -> Result<()> {
-        // Embedding
         if let Some(w) = params.get("embedding.weight") {
             self.embedding.set_weight(w)?;
         } else {
             return Err(Error::from_reason("embedding.weight not found"));
         }
 
-        // Transformer layers
         for (i, layer) in self.layers.iter_mut().enumerate() {
             let prefix = format!("layers.{}", i);
 
@@ -323,7 +275,6 @@ impl HarrierModel {
             )?;
         }
 
-        // Final norm
         if let Some(w) = params.get("final_norm.weight") {
             self.final_norm.set_weight(w)?;
         } else {
@@ -336,6 +287,36 @@ impl HarrierModel {
         );
         Ok(())
     }
+
+    fn require_tokenizer(&self) -> Result<&Arc<Qwen3Tokenizer>> {
+        self.tokenizer.as_ref().ok_or_else(|| {
+            Error::from_reason(
+                "Tokenizer not loaded. Use HarrierModel.load() to load a model with tokenizer.",
+            )
+        })
+    }
+}
+
+/// Shared forward pass: embedding -> transformer layers -> final norm.
+fn forward_inner(
+    embedding: &Embedding,
+    layers: &[TransformerBlock],
+    final_norm: &RMSNorm,
+    input_ids: &MxArray,
+) -> Result<MxArray> {
+    let mut hidden_states = embedding.forward(input_ids)?;
+    for layer in layers {
+        hidden_states = layer.forward(&hidden_states, None, None)?;
+    }
+    final_norm.forward(&hidden_states)
+}
+
+/// Extract the last token's hidden state from the full sequence output.
+fn last_token_pool(hidden_states: &MxArray, seq_len: usize, hidden_size: i32) -> Result<MxArray> {
+    hidden_states.slice(
+        &[0, seq_len as i64 - 1, 0],
+        &[1, seq_len as i64, hidden_size as i64],
+    )
 }
 
 /// L2-normalize an array along the last axis.
@@ -345,7 +326,6 @@ fn l2_normalize(x: &MxArray) -> Result<MxArray> {
     x.div(&norm)
 }
 
-/// Helper to set a required parameter or return an error.
 fn set_required(
     params: &std::collections::HashMap<String, MxArray>,
     name: &str,

--- a/crates/mlx-core/src/models/harrier/persistence.rs
+++ b/crates/mlx-core/src/models/harrier/persistence.rs
@@ -22,6 +22,7 @@ impl HarrierModel {
     /// - config.json (model configuration)
     /// - model.safetensors or weights.safetensors (weights)
     /// - tokenizer.json (tokenizer)
+    /// - config_sentence_transformers.json (optional, prompt presets)
     #[napi]
     pub fn load<'env>(
         env: &'env Env,
@@ -48,7 +49,6 @@ fn load_impl(model_path: &str) -> Result<HarrierModel> {
         )));
     }
 
-    // Parse config
     let config_path = path.join("config.json");
     if !config_path.exists() {
         return Err(Error::from_reason(format!(
@@ -66,15 +66,12 @@ fn load_impl(model_path: &str) -> Result<HarrierModel> {
         config.num_layers, config.hidden_size, config.num_heads
     );
 
-    // Load weights
     let mut param_map = load_all_safetensors(path, false)?;
     info!("Loaded {} tensors from SafeTensors", param_map.len());
 
-    // Map HuggingFace names to internal names
     let mapped_params = map_hf_names(&mut param_map);
     info!("Mapped {} parameters", mapped_params.len());
 
-    // Load tokenizer
     let tokenizer_path = path.join("tokenizer.json");
     if !tokenizer_path.exists() {
         return Err(Error::from_reason(format!(
@@ -84,12 +81,20 @@ fn load_impl(model_path: &str) -> Result<HarrierModel> {
     }
     let tokenizer = Qwen3Tokenizer::load_from_file_sync(tokenizer_path.to_str().unwrap())?;
 
-    // Create model and apply weights
+    let prompts = load_prompts(path);
+    if !prompts.is_empty() {
+        info!(
+            "Loaded {} prompt presets: {:?}",
+            prompts.len(),
+            prompts.keys().collect::<Vec<_>>()
+        );
+    }
+
     let mut model = HarrierModel::new(config)?;
     model.load_parameters(&mapped_params)?;
     model.tokenizer = Some(Arc::new(tokenizer));
+    model.prompts = prompts;
 
-    // Materialize all mmap-backed arrays
     for array in mapped_params.values() {
         array.eval();
     }
@@ -139,10 +144,32 @@ fn parse_config(raw: &Value) -> Result<HarrierConfig> {
     })
 }
 
+/// Load prompt presets from config_sentence_transformers.json if present.
+///
+/// Format: `{ "prompts": { "task_name": "Instruct: ...\nQuery: " } }`
+fn load_prompts(model_dir: &Path) -> HashMap<String, String> {
+    let prompts_path = model_dir.join("config_sentence_transformers.json");
+    let data = match fs::read_to_string(&prompts_path) {
+        Ok(d) => d,
+        Err(_) => return HashMap::new(),
+    };
+    let json: Value = match serde_json::from_str(&data) {
+        Ok(v) => v,
+        Err(_) => return HashMap::new(),
+    };
+
+    let mut prompts = HashMap::new();
+    if let Some(obj) = json["prompts"].as_object() {
+        for (key, val) in obj {
+            if let Some(s) = val.as_str() {
+                prompts.insert(key.clone(), s.to_string());
+            }
+        }
+    }
+    prompts
+}
+
 /// Map HuggingFace parameter names to internal names.
-/// model.embed_tokens.weight -> embedding.weight
-/// model.layers.N.* -> layers.N.*
-/// model.norm.weight -> final_norm.weight
 fn map_hf_names(params: &mut HashMap<String, MxArray>) -> HashMap<String, MxArray> {
     let mut mapped = HashMap::new();
 

--- a/crates/mlx-core/src/models/harrier/persistence.rs
+++ b/crates/mlx-core/src/models/harrier/persistence.rs
@@ -136,10 +136,12 @@ fn parse_config(raw: &Value) -> Result<HarrierConfig> {
             .or_else(|| raw["maxPositionEmbeddings"].as_i64())
             .unwrap_or(32768) as i32,
         head_dim,
-        use_qk_norm: raw["use_qk_norm"]
-            .as_bool()
-            .or_else(|| raw["useQkNorm"].as_bool())
-            .unwrap_or(true),
+        use_qk_norm: Some(
+            raw["use_qk_norm"]
+                .as_bool()
+                .or_else(|| raw["useQkNorm"].as_bool())
+                .unwrap_or(true),
+        ),
         vocab_size: get_i32(raw, &["vocab_size", "vocabSize"])?,
     })
 }

--- a/crates/mlx-core/src/models/harrier/persistence.rs
+++ b/crates/mlx-core/src/models/harrier/persistence.rs
@@ -121,7 +121,15 @@ fn parse_config(raw: &Value) -> Result<HarrierConfig> {
         hidden_size,
         num_layers: get_i32(raw, &["num_hidden_layers", "num_layers", "numLayers"])?,
         num_heads,
-        num_key_value_heads: get_i32(raw, &["num_key_value_heads", "num_kv_heads", "numKvHeads"])?,
+        num_key_value_heads: get_i32(
+            raw,
+            &[
+                "num_key_value_heads",
+                "numKeyValueHeads",
+                "num_kv_heads",
+                "numKvHeads",
+            ],
+        )?,
         intermediate_size: get_i32(raw, &["intermediate_size", "intermediateSize"])?,
         rms_norm_eps: raw["rms_norm_eps"]
             .as_f64()

--- a/crates/mlx-core/src/models/harrier/persistence.rs
+++ b/crates/mlx-core/src/models/harrier/persistence.rs
@@ -1,0 +1,182 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use serde_json::Value;
+use tracing::info;
+
+use crate::array::MxArray;
+use crate::models::qwen3_5::persistence_common::load_all_safetensors;
+use crate::tokenizer::Qwen3Tokenizer;
+
+use super::{HarrierConfig, HarrierModel};
+
+#[napi]
+impl HarrierModel {
+    /// Load a Harrier embedding model from a directory.
+    ///
+    /// Expects the standard HuggingFace layout:
+    /// - config.json (model configuration)
+    /// - model.safetensors or weights.safetensors (weights)
+    /// - tokenizer.json (tokenizer)
+    #[napi]
+    pub fn load<'env>(
+        env: &'env Env,
+        model_path: String,
+    ) -> Result<PromiseRaw<'env, HarrierModel>> {
+        env.spawn_future_with_callback(
+            async move {
+                napi::bindgen_prelude::spawn_blocking(move || load_impl(&model_path))
+                    .await
+                    .map_err(|e| Error::from_reason(format!("HarrierModel::load failed: {}", e)))?
+            },
+            |_env, model| Ok(model),
+        )
+    }
+}
+
+fn load_impl(model_path: &str) -> Result<HarrierModel> {
+    let path = Path::new(model_path);
+
+    if !path.exists() {
+        return Err(Error::from_reason(format!(
+            "Model path does not exist: {}",
+            model_path
+        )));
+    }
+
+    // Parse config
+    let config_path = path.join("config.json");
+    if !config_path.exists() {
+        return Err(Error::from_reason(format!(
+            "Config file not found: {}",
+            config_path.display()
+        )));
+    }
+
+    let config_data = fs::read_to_string(&config_path)?;
+    let raw: Value = serde_json::from_str(&config_data)?;
+    let config = parse_config(&raw)?;
+
+    info!(
+        "HarrierModel config: {} layers, {} hidden, {} heads",
+        config.num_layers, config.hidden_size, config.num_heads
+    );
+
+    // Load weights
+    let mut param_map = load_all_safetensors(path, false)?;
+    info!("Loaded {} tensors from SafeTensors", param_map.len());
+
+    // Map HuggingFace names to internal names
+    let mapped_params = map_hf_names(&mut param_map);
+    info!("Mapped {} parameters", mapped_params.len());
+
+    // Load tokenizer
+    let tokenizer_path = path.join("tokenizer.json");
+    if !tokenizer_path.exists() {
+        return Err(Error::from_reason(format!(
+            "Tokenizer file not found: {}",
+            tokenizer_path.display()
+        )));
+    }
+    let tokenizer = Qwen3Tokenizer::load_from_file_sync(tokenizer_path.to_str().unwrap())?;
+
+    // Create model and apply weights
+    let mut model = HarrierModel::new(config)?;
+    model.load_parameters(&mapped_params)?;
+    model.tokenizer = Some(Arc::new(tokenizer));
+
+    // Materialize all mmap-backed arrays
+    for array in mapped_params.values() {
+        array.eval();
+    }
+
+    info!(
+        "HarrierModel loaded successfully ({} parameters)",
+        model.num_parameters()
+    );
+    Ok(model)
+}
+
+/// Parse HarrierConfig from raw JSON, supporting both HuggingFace and internal naming.
+fn parse_config(raw: &Value) -> Result<HarrierConfig> {
+    let hidden_size = get_i32(raw, &["hidden_size", "hiddenSize"])?;
+    let num_heads = get_i32(raw, &["num_attention_heads", "num_heads", "numHeads"])?;
+
+    let head_dim = raw["head_dim"]
+        .as_i64()
+        .or_else(|| raw["headDim"].as_i64())
+        .map(|v| v as i32)
+        .unwrap_or(hidden_size / num_heads);
+
+    Ok(HarrierConfig {
+        hidden_size,
+        num_layers: get_i32(raw, &["num_hidden_layers", "num_layers", "numLayers"])?,
+        num_heads,
+        num_key_value_heads: get_i32(raw, &["num_key_value_heads", "num_kv_heads", "numKvHeads"])?,
+        intermediate_size: get_i32(raw, &["intermediate_size", "intermediateSize"])?,
+        rms_norm_eps: raw["rms_norm_eps"]
+            .as_f64()
+            .or_else(|| raw["rmsNormEps"].as_f64())
+            .unwrap_or(1e-6),
+        rope_theta: raw["rope_theta"]
+            .as_f64()
+            .or_else(|| raw["ropeTheta"].as_f64())
+            .unwrap_or(1_000_000.0),
+        max_position_embeddings: raw["max_position_embeddings"]
+            .as_i64()
+            .or_else(|| raw["maxPositionEmbeddings"].as_i64())
+            .unwrap_or(32768) as i32,
+        head_dim,
+        use_qk_norm: raw["use_qk_norm"]
+            .as_bool()
+            .or_else(|| raw["useQkNorm"].as_bool())
+            .unwrap_or(true),
+        vocab_size: get_i32(raw, &["vocab_size", "vocabSize"])?,
+    })
+}
+
+/// Map HuggingFace parameter names to internal names.
+/// model.embed_tokens.weight -> embedding.weight
+/// model.layers.N.* -> layers.N.*
+/// model.norm.weight -> final_norm.weight
+fn map_hf_names(params: &mut HashMap<String, MxArray>) -> HashMap<String, MxArray> {
+    let mut mapped = HashMap::new();
+
+    for (name, array) in params.drain() {
+        let mapped_name = if let Some(stripped) = name.strip_prefix("model.") {
+            if stripped == "embed_tokens.weight" {
+                "embedding.weight".to_string()
+            } else if stripped.starts_with("embed_tokens.") {
+                stripped.replace("embed_tokens", "embedding")
+            } else if stripped == "norm.weight" {
+                "final_norm.weight".to_string()
+            } else {
+                stripped.to_string()
+            }
+        } else if name == "lm_head.weight" {
+            // Skip lm_head if present — embedding model doesn't use it
+            continue;
+        } else {
+            name
+        };
+        mapped.insert(mapped_name, array);
+    }
+
+    mapped
+}
+
+fn get_i32(raw: &Value, keys: &[&str]) -> Result<i32> {
+    for key in keys {
+        if let Some(v) = raw[key].as_i64() {
+            return Ok(v as i32);
+        }
+    }
+    Err(Error::from_reason(format!(
+        "Missing required config field: {}",
+        keys[0]
+    )))
+}

--- a/crates/mlx-core/src/models/mod.rs
+++ b/crates/mlx-core/src/models/mod.rs
@@ -3,6 +3,7 @@
  *
  * Contains all model implementations.
  */
+pub mod harrier;
 pub mod paddleocr_vl;
 pub mod pp_doc_ori;
 pub mod pp_doc_unwarp;

--- a/examples/lm.ts
+++ b/examples/lm.ts
@@ -14,7 +14,7 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
-import { QianfanOCRModel } from '@mlx-node/core';
+import { HarrierModel, QianfanOCRModel } from '@mlx-node/core';
 import type { ChatResult } from '@mlx-node/lm';
 import { loadModel, Qwen3Model } from '@mlx-node/lm';
 
@@ -34,7 +34,12 @@ const MODEL_PATH = resolve(process.cwd(), '.cache', 'models', modelName);
 console.log(`Loading model from: ${MODEL_PATH}`);
 if (imagePath) console.log(`Image: ${imagePath}`);
 
-const model = await loadModel(MODEL_PATH);
+const loadedModel = await loadModel(MODEL_PATH);
+if (loadedModel instanceof HarrierModel) {
+  console.error('This example is for generative models, not embedding models.');
+  process.exit(1);
+}
+const model = loadedModel;
 const isQwen3 = model instanceof Qwen3Model;
 const isQianfan = model instanceof QianfanOCRModel;
 const modelArch = isQianfan ? 'Qianfan-OCR' : isQwen3 ? 'Qwen3' : 'Qwen3.5';

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -744,6 +744,7 @@ module.exports.DocUnwarpModel = nativeBinding.DocUnwarpModel;
 module.exports.GenerationResult = nativeBinding.GenerationResult;
 module.exports.GrpoTrainingEngine = nativeBinding.GrpoTrainingEngine;
 module.exports.GRPOTrainingEngine = nativeBinding.GRPOTrainingEngine;
+module.exports.HarrierModel = nativeBinding.HarrierModel;
 module.exports.MxArray = nativeBinding.MxArray;
 module.exports.NativeRewardRegistry = nativeBinding.NativeRewardRegistry;
 module.exports.OutputStore = nativeBinding.OutputStore;

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -261,6 +261,67 @@ export declare class GrpoTrainingEngine {
 }
 export type GRPOTrainingEngine = GrpoTrainingEngine;
 
+/**
+ * Harrier embedding model (Qwen3 backbone for text embeddings).
+ *
+ * Uses last-token pooling and L2 normalization to produce fixed-size
+ * embedding vectors from variable-length text inputs.
+ */
+export declare class HarrierModel {
+  constructor(config: HarrierConfig);
+  /**
+   * Forward pass returning hidden states (no lm_head projection).
+   *
+   * # Arguments
+   * * `input_ids` - Token IDs, shape: [batch_size, seq_len]
+   *
+   * # Returns
+   * * Hidden states, shape: [batch_size, seq_len, hidden_size]
+   */
+  forward(inputIds: MxArray): MxArray;
+  /**
+   * Encode a single text into a normalized embedding vector.
+   *
+   * Tokenizes the text, runs the forward pass, applies last-token pooling,
+   * and L2-normalizes the result.
+   *
+   * # Arguments
+   * * `text` - Input text to encode
+   * * `instruction` - Optional task instruction to prepend (for queries)
+   *
+   * # Returns
+   * * Embedding vector, shape: [hidden_size]
+   */
+  encode(text: string, instruction?: string | undefined | null): Promise<MxArray>;
+  /**
+   * Encode a batch of texts into normalized embedding vectors.
+   *
+   * Each text is independently tokenized and encoded (no padding needed
+   * since each goes through its own forward pass).
+   *
+   * # Arguments
+   * * `texts` - Input texts to encode
+   * * `instruction` - Optional task instruction to prepend to each text
+   *
+   * # Returns
+   * * Embedding matrix, shape: [batch_size, hidden_size]
+   */
+  encodeBatch(texts: Array<string>, instruction?: string | undefined | null): Promise<MxArray>;
+  /** Get the model configuration. */
+  getConfig(): HarrierConfig;
+  /** Get the total number of model parameters. */
+  numParameters(): number;
+  /**
+   * Load a Harrier embedding model from a directory.
+   *
+   * Expects the standard HuggingFace layout:
+   * - config.json (model configuration)
+   * - model.safetensors or weights.safetensors (weights)
+   * - tokenizer.json (tokenizer)
+   */
+  static load(modelPath: string): Promise<HarrierModel>;
+}
+
 export declare class MxArray {
   equal(other: MxArray): MxArray;
   notEqual(other: MxArray): MxArray;
@@ -2746,6 +2807,26 @@ export interface GrpoLossConfig {
    * Recommended: 65536 for Qwen3 (vocab=151936) splits into 3 chunks
    */
   vocabChunkSize?: number;
+}
+
+/**
+ * Configuration for Harrier embedding model (Qwen3 backbone).
+ *
+ * Only includes backbone dimensions needed for encoding.
+ * No generation fields (token IDs, paged attention, etc.).
+ */
+export interface HarrierConfig {
+  hiddenSize: number;
+  numLayers: number;
+  numHeads: number;
+  numKeyValueHeads: number;
+  intermediateSize: number;
+  rmsNormEps: number;
+  ropeTheta: number;
+  maxPositionEmbeddings: number;
+  headDim: number;
+  useQkNorm: boolean;
+  vocabSize: number;
 }
 
 /** InternViT vision encoder configuration */

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -283,11 +283,13 @@ export declare class HarrierModel {
    * Encode a single text into a normalized embedding vector.
    *
    * Tokenizes the text, runs the forward pass, applies last-token pooling,
-   * and L2-normalizes the result.
+   * and L2-normalizes the result. Truncates to `max_position_embeddings`.
    *
    * # Arguments
    * * `text` - Input text to encode
-   * * `instruction` - Optional task instruction to prepend (for queries)
+   * * `instruction` - Optional task instruction prefix or preset name
+   *   (e.g. `"web_search_query"` resolves to the full Harrier prompt).
+   *   Pass `null` for documents/passages that need no instruction.
    *
    * # Returns
    * * Embedding vector, shape: [hidden_size]
@@ -297,11 +299,14 @@ export declare class HarrierModel {
    * Encode a batch of texts into normalized embedding vectors.
    *
    * Each text is independently tokenized and encoded (no padding needed
-   * since each goes through its own forward pass).
+   * since each goes through its own forward pass). Truncates each text
+   * to `max_position_embeddings`.
    *
    * # Arguments
    * * `texts` - Input texts to encode
-   * * `instruction` - Optional task instruction to prepend to each text
+   * * `instruction` - Optional task instruction prefix or preset name
+   *   (e.g. `"web_search_query"` resolves to the full Harrier prompt).
+   *   Pass `null` for documents/passages that need no instruction.
    *
    * # Returns
    * * Embedding matrix, shape: [batch_size, hidden_size]
@@ -309,6 +314,14 @@ export declare class HarrierModel {
   encodeBatch(texts: Array<string>, instruction?: string | undefined | null): Promise<MxArray>;
   /** Get the model configuration. */
   getConfig(): HarrierConfig;
+  /**
+   * Get available prompt presets loaded from config_sentence_transformers.json.
+   *
+   * Returns a map of task name -> full instruction prefix.
+   * Pass a task name to `encode()`/`encodeBatch()` as the `instruction` parameter
+   * to use a preset instead of a raw prefix string.
+   */
+  getPrompts(): Record<string, string>;
   /** Get the total number of model parameters. */
   numParameters(): number;
   /**
@@ -318,6 +331,7 @@ export declare class HarrierModel {
    * - config.json (model configuration)
    * - model.safetensors or weights.safetensors (weights)
    * - tokenizer.json (tokenizer)
+   * - config_sentence_transformers.json (optional, prompt presets)
    */
   static load(modelPath: string): Promise<HarrierModel>;
 }

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -2839,7 +2839,12 @@ export interface HarrierConfig {
   ropeTheta: number;
   maxPositionEmbeddings: number;
   headDim: number;
-  useQkNorm: boolean;
+  /**
+   * Qwen3 always uses QK normalization. Omit or pass null to use the
+   * default (true). Explicitly passing false is allowed but produces
+   * a model incompatible with published Harrier weights.
+   */
+  useQkNorm?: boolean;
   vocabSize: number;
 }
 

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -2840,9 +2840,9 @@ export interface HarrierConfig {
   maxPositionEmbeddings: number;
   headDim: number;
   /**
-   * Qwen3 always uses QK normalization. Omit or pass null to use the
-   * default (true). Explicitly passing false is allowed but produces
-   * a model incompatible with published Harrier weights.
+   * Qwen3 always uses QK normalization. Omit to use the default (true).
+   * Explicitly passing false is allowed but produces a model incompatible
+   * with published Harrier weights.
    */
   useQkNorm?: boolean;
   vocabSize: number;

--- a/packages/lm/src/index.ts
+++ b/packages/lm/src/index.ts
@@ -15,6 +15,10 @@
 
 // Model classes (for inference)
 export { Qwen3Model, Qwen3Tokenizer } from '@mlx-node/core';
+
+// Embedding models
+export { HarrierModel } from '@mlx-node/core';
+export type { HarrierConfig } from '@mlx-node/core';
 export { Qwen35Model, Qwen35Model as Qwen3_5Model } from './stream.js';
 export type { Qwen35Config, Qwen35GenerationConfig, Qwen35GenerationResult } from '@mlx-node/core';
 
@@ -51,7 +55,7 @@ export {
 export { loadModel, detectModelType, type ModelType } from './models/model-loader.js';
 
 // Interfaces
-export type { TrainableModel, LoadableModel } from './interfaces.js';
+export type { TrainableModel, LoadableModel, EmbeddingModel } from './interfaces.js';
 
 export { QWEN35_CONFIGS, getQwen35Config } from './models/qwen3_5-configs.js';
 

--- a/packages/lm/src/interfaces.ts
+++ b/packages/lm/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { Qwen3Model, Qwen35Model, Qwen35MoeModel, QianfanOCRModel } from '@mlx-node/core';
+import type { HarrierModel, Qwen3Model, Qwen35Model, Qwen35MoeModel, QianfanOCRModel } from '@mlx-node/core';
 
 /**
  * Union of all model classes that can be used with training engines.
@@ -8,7 +8,13 @@ import type { Qwen3Model, Qwen35Model, Qwen35MoeModel, QianfanOCRModel } from '@
 export type TrainableModel = Qwen3Model | Qwen35Model | Qwen35MoeModel;
 
 /**
- * Union of all model classes that loadModel can return.
- * Includes both trainable models and inference-only models (e.g. VLMs).
+ * Union of all embedding model classes.
+ * These models encode text into fixed-size embedding vectors.
  */
-export type LoadableModel = TrainableModel | QianfanOCRModel;
+export type EmbeddingModel = HarrierModel;
+
+/**
+ * Union of all model classes that loadModel can return.
+ * Includes trainable models, inference-only models, and embedding models.
+ */
+export type LoadableModel = TrainableModel | QianfanOCRModel | EmbeddingModel;

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -7,14 +7,21 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { Qwen3Model, QianfanOCRModel } from '@mlx-node/core';
+import { HarrierModel, Qwen3Model, QianfanOCRModel } from '@mlx-node/core';
 
 import type { LoadableModel, TrainableModel } from '../interfaces.js';
 import { Qwen35Model, Qwen35MoeModel } from '../stream.js';
 
-export type ModelType = 'qwen3' | 'qwen3_5' | 'qwen3_5_moe' | 'internvl_chat' | 'qianfan-ocr';
+export type ModelType = 'qwen3' | 'qwen3_5' | 'qwen3_5_moe' | 'internvl_chat' | 'qianfan-ocr' | 'harrier';
 
-const SUPPORTED_MODEL_TYPES = new Set<ModelType>(['qwen3', 'qwen3_5', 'qwen3_5_moe', 'internvl_chat', 'qianfan-ocr']);
+const SUPPORTED_MODEL_TYPES = new Set<ModelType>([
+  'qwen3',
+  'qwen3_5',
+  'qwen3_5_moe',
+  'internvl_chat',
+  'qianfan-ocr',
+  'harrier',
+]);
 
 /**
  * Load a model from disk, auto-detecting architecture from config.json.
@@ -32,6 +39,8 @@ export async function loadModel(modelPath: string): Promise<LoadableModel> {
       return Qwen35Model.load(modelPath) as unknown as Promise<TrainableModel>;
     case 'qwen3':
       return Qwen3Model.load(modelPath);
+    case 'harrier':
+      return HarrierModel.load(modelPath) as unknown as Promise<LoadableModel>;
     case 'internvl_chat':
     case 'qianfan-ocr':
       return QianfanOCRModel.load(modelPath) as unknown as Promise<LoadableModel>;
@@ -42,7 +51,16 @@ export async function detectModelType(modelPath: string): Promise<ModelType> {
   try {
     const raw = await readFile(join(modelPath, 'config.json'), 'utf-8');
     const config = JSON.parse(raw);
-    const modelType = config.model_type ?? 'qwen3';
+    let modelType: ModelType = config.model_type ?? 'qwen3';
+
+    // Detect embedding models: Qwen3 backbone with base architecture (no ForCausalLM)
+    if (modelType === 'qwen3') {
+      const architectures: string[] = config.architectures ?? [];
+      if (architectures.includes('Qwen3Model') && !architectures.includes('Qwen3ForCausalLM')) {
+        modelType = 'harrier';
+      }
+    }
+
     if (!SUPPORTED_MODEL_TYPES.has(modelType)) {
       throw new Error(`Unsupported model_type "${modelType}" in ${modelPath}/config.json`);
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new native model type and updates model auto-detection/loading logic, which could affect how some `qwen3` checkpoints are classified and loaded. Most risk is around config parsing/weight name mapping and runtime compatibility rather than broad refactors.
> 
> **Overview**
> Introduces a new **Harrier embedding model** (Qwen3 backbone) in `mlx-core`, including `HarrierConfig`, `HarrierModel` APIs (`forward`, `encode`, `encodeBatch`), last-token pooling + L2 normalization, and a `load()` path that reads HF-style `config.json`, loads SafeTensors weights (with HF->internal key mapping), loads `tokenizer.json`, and optionally loads prompt presets from `config_sentence_transformers.json`.
> 
> Extends `@mlx-node/lm` to **detect and load Harrier models** via `detectModelType()`/`loadModel()` by treating `model_type: "qwen3"` + `architectures: ["Qwen3Model"]` (without `Qwen3ForCausalLM`) as `harrier`, exports `HarrierModel/HarrierConfig`, updates the `LoadableModel` typing, and guards the `examples/lm.ts` generative-chat example from running on embedding models.
> 
> Adds unit tests covering Harrier detection, basic model instantiation/forward-shapes, tokenizer-required errors, and internal helpers like truncation preserving the trailing EOS token and normalization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 273fd47ed55d0541ff9d92dd759fa7b704f27028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->