### PR TITLE
feat: add reasoning control flow for Qwen3.5 models

### DIFF
--- a/crates/mlx-core/src/models/qianfan_ocr/model.rs
+++ b/crates/mlx-core/src/models/qianfan_ocr/model.rs
@@ -207,7 +207,6 @@ impl QianfanOCRModel {
             max_ngram_repeats: None,
             ngram_size: None,
             tools: None,
-            enable_thinking: None,
             thinking_token_budget: None,
             include_reasoning: None,
             reasoning_effort: None,
@@ -229,7 +228,10 @@ impl QianfanOCRModel {
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
-        let enable_thinking = config.enable_thinking.unwrap_or(false);
+        let enable_thinking = config
+            .reasoning_effort
+            .as_deref()
+            .is_some_and(|e| !matches!(e, "none" | "low"));
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 
@@ -635,7 +637,6 @@ impl QianfanOCRModel {
             max_ngram_repeats: None,
             ngram_size: None,
             tools: None,
-            enable_thinking: None,
             thinking_token_budget: None,
             include_reasoning: None,
             reasoning_effort: None,
@@ -657,7 +658,10 @@ impl QianfanOCRModel {
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
-        let enable_thinking = config.enable_thinking.unwrap_or(false);
+        let enable_thinking = config
+            .reasoning_effort
+            .as_deref()
+            .is_some_and(|e| !matches!(e, "none" | "low"));
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 

--- a/crates/mlx-core/src/models/qianfan_ocr/model.rs
+++ b/crates/mlx-core/src/models/qianfan_ocr/model.rs
@@ -228,10 +228,8 @@ impl QianfanOCRModel {
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
-        let enable_thinking = config
-            .reasoning_effort
-            .as_deref()
-            .is_some_and(|e| !matches!(e, "none" | "low"));
+        let enable_thinking =
+            crate::models::qwen3_5::chat_common::resolve_enable_thinking(&config).unwrap_or(false);
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 
@@ -658,10 +656,8 @@ impl QianfanOCRModel {
         let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
         let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
         let ngram_size = config.ngram_size.unwrap_or(64);
-        let enable_thinking = config
-            .reasoning_effort
-            .as_deref()
-            .is_some_and(|e| !matches!(e, "none" | "low"));
+        let enable_thinking =
+            crate::models::qwen3_5::chat_common::resolve_enable_thinking(&config).unwrap_or(false);
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
 

--- a/crates/mlx-core/src/models/qianfan_ocr/model.rs
+++ b/crates/mlx-core/src/models/qianfan_ocr/model.rs
@@ -208,6 +208,9 @@ impl QianfanOCRModel {
             ngram_size: None,
             tools: None,
             enable_thinking: None,
+            thinking_token_budget: None,
+            include_reasoning: None,
+            reasoning_effort: None,
             report_performance: None,
             reuse_cache: None,
         });
@@ -633,6 +636,9 @@ impl QianfanOCRModel {
             ngram_size: None,
             tools: None,
             enable_thinking: None,
+            thinking_token_budget: None,
+            include_reasoning: None,
+            reasoning_effort: None,
             report_performance: None,
             reuse_cache: None,
         });
@@ -899,6 +905,7 @@ impl QianfanOCRModel {
                                 num_tokens: None,
                                 raw_text: None,
                                 performance: None,
+                                is_reasoning: None,
                             });
 
                             // Check repetition cutoff (after emit so token is streamed)
@@ -1024,6 +1031,7 @@ impl QianfanOCRModel {
                             num_tokens: Some(generated_tokens.len() as u32),
                             raw_text: Some(raw_decoded),
                             performance,
+                            is_reasoning: None,
                         });
 
                         Ok(())

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -5680,7 +5680,9 @@ impl Qwen3Model {
 
         // Extract tools, enable_thinking, report_performance, and reuse_cache from config
         let tools = config.as_ref().and_then(|c| c.tools.clone());
-        let enable_thinking = config.as_ref().and_then(|c| c.enable_thinking);
+        let enable_thinking = config
+            .as_ref()
+            .and_then(crate::models::qwen3_5::chat_common::resolve_enable_thinking);
         let report_perf = config
             .as_ref()
             .and_then(|c| c.report_performance)

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -147,13 +147,15 @@ impl ReasoningTracker {
             return true; // </think> itself is part of reasoning
         }
 
-        self.thinking_token_count += 1;
+        // Check budget BEFORE incrementing so budget=0 triggers on the
+        // very first thinking token (distinct from budget=1).
         if let Some(budget) = self.budget
             && self.thinking_token_count >= budget
             && !self.end_scheduled
         {
             self.force_think_end = true;
         }
+        self.thinking_token_count += 1;
         true
     }
 
@@ -441,34 +443,54 @@ mod tests {
 
     #[test]
     fn test_tracker_budget_enforcement() {
+        // Budget=3: allows exactly 3 thinking tokens before triggering.
+        // Budget is checked BEFORE incrementing count.
         let mut tracker = ReasoningTracker::new(true, Some(3), Some(THINK_END_ID));
-        assert!(tracker.observe_token(100)); // count=1
+        assert!(tracker.observe_token(100)); // check 0<3, count→1
         assert!(!tracker.should_force_think_end());
-        assert!(tracker.observe_token(200)); // count=2
+        assert!(tracker.observe_token(200)); // check 1<3, count→2
         assert!(!tracker.should_force_think_end());
-        assert!(tracker.observe_token(300)); // count=3 >= budget
+        assert!(tracker.observe_token(300)); // check 2<3, count→3
+        assert!(!tracker.should_force_think_end());
+        assert!(tracker.observe_token(400)); // check 3>=3 → force! count→4
         assert!(tracker.should_force_think_end());
         assert_eq!(tracker.forced_token_id(), THINK_END_ID);
     }
 
     #[test]
     fn test_tracker_budget_zero() {
+        // Budget=0: triggers on the very first thinking token (before incrementing).
         let mut tracker = ReasoningTracker::new(true, Some(0), Some(THINK_END_ID));
-        // First token pushes count to 1, which >= 0
-        assert!(tracker.observe_token(100));
+        assert!(tracker.observe_token(100)); // check 0>=0 → force!
         assert!(tracker.should_force_think_end());
+    }
+
+    #[test]
+    fn test_tracker_budget_zero_vs_one() {
+        // Budget=0 and budget=1 must produce different behavior.
+        let mut t0 = ReasoningTracker::new(true, Some(0), Some(THINK_END_ID));
+        assert!(t0.observe_token(100));
+        assert!(t0.should_force_think_end()); // triggers after 1st token
+
+        let mut t1 = ReasoningTracker::new(true, Some(1), Some(THINK_END_ID));
+        assert!(t1.observe_token(100));
+        assert!(!t1.should_force_think_end()); // NOT yet after 1st token
+        assert!(t1.observe_token(200));
+        assert!(t1.should_force_think_end()); // triggers after 2nd token
     }
 
     #[test]
     fn test_tracker_budget_clears_on_think_end() {
         let mut tracker = ReasoningTracker::new(true, Some(2), Some(THINK_END_ID));
-        assert!(tracker.observe_token(100)); // count=1
-        assert!(tracker.observe_token(200)); // count=2 >= budget
+        assert!(tracker.observe_token(100)); // count→1
+        assert!(tracker.observe_token(200)); // check 1<2, count→2
+        assert!(!tracker.should_force_think_end());
+        assert!(tracker.observe_token(300)); // check 2>=2 → force! count→3
         assert!(tracker.should_force_think_end());
         // When the forced think_end token is generated:
         assert!(tracker.observe_token(THINK_END_ID)); // transitions to content
         assert!(!tracker.should_force_think_end()); // force cleared
-        assert!(!tracker.observe_token(300)); // now content
+        assert!(!tracker.observe_token(400)); // now content
     }
 
     #[test]
@@ -477,17 +499,18 @@ mod tests {
         // the pipeline extracts an over-budget token before the forced </think>
         // arrives. The tracker must NOT re-trigger forcing.
         let mut tracker = ReasoningTracker::new(true, Some(3), Some(THINK_END_ID));
-        tracker.observe_token(100); // count=1
-        tracker.observe_token(200); // count=2
-        tracker.observe_token(300); // count=3 >= budget → force=true
+        tracker.observe_token(100); // count→1
+        tracker.observe_token(200); // count→2
+        tracker.observe_token(300); // count→3
+        tracker.observe_token(400); // check 3>=3 → force=true, count→4
 
         // Phase A of step N+1: consume the force flag
         assert!(tracker.should_force_think_end()); // returns true, sets end_scheduled
         assert!(!tracker.should_force_think_end()); // already consumed — must be false
 
         // Phase B of step N+1: the pipeline extracts the over-budget token (not </think>)
-        assert!(tracker.observe_token(400)); // still reasoning, count=4
-        // Must NOT re-trigger forcing despite count(4) >= budget(3)
+        assert!(tracker.observe_token(500)); // still reasoning, count→5
+        // Must NOT re-trigger forcing despite count(5) >= budget(3)
         assert!(!tracker.should_force_think_end());
 
         // Phase B of step N+2: the forced </think> token is finally extracted
@@ -495,7 +518,7 @@ mod tests {
         assert!(!tracker.should_force_think_end());
 
         // Phase B of step N+3: normal content token
-        assert!(!tracker.observe_token(500)); // content
+        assert!(!tracker.observe_token(600)); // content
     }
 
     #[test]

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -33,6 +33,8 @@ pub(crate) struct ChatParams {
     pub sampling_config: Option<SamplingConfig>,
     pub report_performance: bool,
     pub reuse_cache: bool,
+    pub thinking_token_budget: Option<i32>,
+    pub include_reasoning: bool,
 }
 
 /// Extract ChatConfig fields into flat variables with defaults.
@@ -56,6 +58,8 @@ pub(crate) fn extract_chat_params(config: &ChatConfig) -> ChatParams {
         }),
         report_performance: config.report_performance.unwrap_or(false),
         reuse_cache: config.reuse_cache.unwrap_or(true),
+        thinking_token_budget: config.thinking_token_budget,
+        include_reasoning: config.include_reasoning.unwrap_or(true),
     }
 }
 
@@ -90,6 +94,73 @@ pub(crate) fn apply_all_penalties(
         )?;
     }
     Ok(logits)
+}
+
+/// Tracks reasoning vs content state during token-by-token generation.
+///
+/// For Qwen3.5: the template injects `<think>\n` when thinking is enabled.
+/// The model generates thinking tokens, then emits `</think>` (think_end_id),
+/// then generates content. This tracker detects the transition at the TOKEN
+/// level — no text parsing needed during decoding.
+pub(crate) struct ReasoningTracker {
+    in_thinking: bool,
+    thinking_token_count: i32,
+    budget: Option<i32>,
+    think_end_id: Option<u32>,
+    force_think_end: bool,
+}
+
+impl ReasoningTracker {
+    /// Create a new tracker.
+    ///
+    /// `starts_in_thinking`: true when the template injected `<think>\n` (thinking enabled).
+    /// `budget`: maximum thinking tokens before forcing `</think>`. None = unlimited.
+    /// `think_end_id`: token ID for `</think>` from the tokenizer vocabulary.
+    pub fn new(starts_in_thinking: bool, budget: Option<i32>, think_end_id: Option<u32>) -> Self {
+        Self {
+            in_thinking: starts_in_thinking,
+            thinking_token_count: 0,
+            budget,
+            think_end_id,
+            force_think_end: false,
+        }
+    }
+
+    /// Process a generated token. Returns whether this token is reasoning content.
+    ///
+    /// Call AFTER extracting the token ID from the GPU each decode step.
+    pub fn observe_token(&mut self, token_id: u32) -> bool {
+        if !self.in_thinking {
+            return false;
+        }
+
+        if self.think_end_id == Some(token_id) {
+            self.in_thinking = false;
+            self.force_think_end = false;
+            return true; // </think> itself is part of reasoning
+        }
+
+        self.thinking_token_count += 1;
+        if let Some(budget) = self.budget {
+            if self.thinking_token_count >= budget {
+                self.force_think_end = true;
+            }
+        }
+        true
+    }
+
+    /// Whether the next token should be forced to think_end_id.
+    ///
+    /// Check this BEFORE building the next decode step's graph.
+    pub fn should_force_think_end(&self) -> bool {
+        self.force_think_end && self.think_end_id.is_some()
+    }
+
+    /// The think_end token ID to force. Only valid when `should_force_think_end()` is true.
+    pub fn forced_token_id(&self) -> u32 {
+        self.think_end_id
+            .expect("should_force_think_end was true but think_end_id is None")
+    }
 }
 
 /// Compute TTFT / prefill tok/s / decode tok/s performance metrics.
@@ -131,6 +202,7 @@ pub(crate) fn finalize_chat_result(
     think_end_id: Option<u32>,
     think_end_str: Option<&str>,
     performance: Option<crate::profiling::PerformanceMetrics>,
+    include_reasoning: bool,
 ) -> Result<ChatResult> {
     let text = tokenizer
         .decode_sync(generated_tokens, true)
@@ -147,6 +219,9 @@ pub(crate) fn finalize_chat_result(
         None
     };
     let (clean_text, tool_calls, thinking) = tools::split_at_think_end(&text, think_tag);
+
+    // Suppress reasoning if not requested
+    let thinking = if include_reasoning { thinking } else { None };
 
     // If we have valid tool calls, override finish reason
     let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
@@ -261,5 +336,88 @@ pub(crate) fn verify_cache_prefix(
         Ok(cached.len())
     } else {
         Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const THINK_END_ID: u32 = 151668; // example </think> token ID
+
+    #[test]
+    fn test_tracker_starts_in_thinking() {
+        let mut tracker = ReasoningTracker::new(true, None, Some(THINK_END_ID));
+        assert!(tracker.observe_token(100)); // reasoning
+        assert!(tracker.observe_token(200)); // reasoning
+        assert!(!tracker.should_force_think_end());
+    }
+
+    #[test]
+    fn test_tracker_transitions_on_think_end() {
+        let mut tracker = ReasoningTracker::new(true, None, Some(THINK_END_ID));
+        assert!(tracker.observe_token(100)); // reasoning
+        assert!(tracker.observe_token(THINK_END_ID)); // </think> is still reasoning
+        assert!(!tracker.observe_token(300)); // now content
+        assert!(!tracker.observe_token(400)); // still content
+    }
+
+    #[test]
+    fn test_tracker_starts_in_content() {
+        let mut tracker = ReasoningTracker::new(false, None, Some(THINK_END_ID));
+        assert!(!tracker.observe_token(100));
+        assert!(!tracker.observe_token(200));
+        assert!(!tracker.should_force_think_end());
+    }
+
+    #[test]
+    fn test_tracker_budget_enforcement() {
+        let mut tracker = ReasoningTracker::new(true, Some(3), Some(THINK_END_ID));
+        assert!(tracker.observe_token(100)); // count=1
+        assert!(!tracker.should_force_think_end());
+        assert!(tracker.observe_token(200)); // count=2
+        assert!(!tracker.should_force_think_end());
+        assert!(tracker.observe_token(300)); // count=3 >= budget
+        assert!(tracker.should_force_think_end());
+        assert_eq!(tracker.forced_token_id(), THINK_END_ID);
+    }
+
+    #[test]
+    fn test_tracker_budget_zero() {
+        let mut tracker = ReasoningTracker::new(true, Some(0), Some(THINK_END_ID));
+        // First token pushes count to 1, which >= 0
+        assert!(tracker.observe_token(100));
+        assert!(tracker.should_force_think_end());
+    }
+
+    #[test]
+    fn test_tracker_budget_clears_on_think_end() {
+        let mut tracker = ReasoningTracker::new(true, Some(2), Some(THINK_END_ID));
+        assert!(tracker.observe_token(100)); // count=1
+        assert!(tracker.observe_token(200)); // count=2 >= budget
+        assert!(tracker.should_force_think_end());
+        // When the forced think_end token is generated:
+        assert!(tracker.observe_token(THINK_END_ID)); // transitions to content
+        assert!(!tracker.should_force_think_end()); // force cleared
+        assert!(!tracker.observe_token(300)); // now content
+    }
+
+    #[test]
+    fn test_tracker_no_budget() {
+        let mut tracker = ReasoningTracker::new(true, None, Some(THINK_END_ID));
+        for i in 0..1000 {
+            assert!(tracker.observe_token(i));
+            assert!(!tracker.should_force_think_end());
+        }
+    }
+
+    #[test]
+    fn test_tracker_no_think_end_id() {
+        let mut tracker = ReasoningTracker::new(true, Some(5), None);
+        // Without think_end_id, should_force_think_end is always false
+        for i in 0..100 {
+            tracker.observe_token(i);
+            assert!(!tracker.should_force_think_end());
+        }
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -209,39 +209,32 @@ pub(crate) fn compute_performance_metrics(
     })
 }
 
-/// Decode tokens, parse thinking/tool_calls, build ChatResult.
+/// Shared finalization: parse thinking + tool calls from decoded text.
 ///
-/// `starts_in_thinking`: whether generation began inside a reasoning block.
-/// When false (no-thinking mode), all text is treated as content regardless of
-/// any literal `</think>` tokens that may appear.
-pub(crate) fn finalize_chat_result(
-    tokenizer: &Qwen3Tokenizer,
+/// Three-way branching based on the request's reasoning state:
+/// 1. `!thinking_enabled`: no-thinking mode — all text is content, no reasoning parsing.
+/// 2. `thinking_enabled` + `</think>` token confirmed: split at token-confirmed boundary.
+/// 3. `thinking_enabled` + no `</think>` token + `think_end_id` exists: truncated generation.
+/// 4. `thinking_enabled` + no `think_end_id` in vocab: text-level fallback via `split_at_think_end`.
+///
+/// `include_reasoning`: when false, thinking field is suppressed (set to None).
+pub(crate) fn parse_thinking_and_tools(
+    text: &str,
     generated_tokens: &[u32],
-    finish_reason: String,
+    thinking_enabled: bool,
     think_end_id: Option<u32>,
     think_end_str: Option<&str>,
-    performance: Option<crate::profiling::PerformanceMetrics>,
     include_reasoning: bool,
-    starts_in_thinking: bool,
-) -> Result<ChatResult> {
-    let text = tokenizer
-        .decode_sync(generated_tokens, true)
-        .unwrap_or_else(|e| {
-            tracing::warn!("Failed to decode generated tokens: {}", e);
-            String::new()
-        });
-
-    let num_tokens = generated_tokens.len() as u32;
-
-    let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
+) -> (String, Vec<tools::ToolCallResult>, Option<String>) {
+    let (clean_text, tool_calls, thinking) = if !thinking_enabled {
         // No-thinking mode: all text is content, passed through verbatim.
         // Any literal <think> tags are normal model output, not markup.
-        let (clean, calls) = tools::parse_tool_calls(&text);
+        let (clean, calls) = tools::parse_tool_calls(text);
         (clean, calls, None)
     } else if tools::has_think_end_token(generated_tokens, think_end_id) {
         // Thinking mode with confirmed </think>: split at token boundary.
-        tools::split_at_think_end(&text, think_end_str)
-    } else {
+        tools::split_at_think_end(text, think_end_str)
+    } else if think_end_id.is_some() {
         // Thinking mode, truncated (no </think> before EOS/max_tokens):
         // entire output is reasoning, no content.
         let thinking_text = text.trim();
@@ -258,10 +251,46 @@ pub(crate) fn finalize_chat_result(
             Some(thinking_text.to_string())
         };
         (String::new(), vec![], thinking)
+    } else {
+        // No think_end_id in vocab — cannot do token-level detection.
+        // Fall back to text-level parsing via split_at_think_end(None).
+        tools::split_at_think_end(text, None)
     };
 
     // Suppress reasoning if not requested
     let thinking = if include_reasoning { thinking } else { None };
+
+    (clean_text, tool_calls, thinking)
+}
+
+/// Decode tokens, parse thinking/tool_calls, build ChatResult.
+pub(crate) fn finalize_chat_result(
+    tokenizer: &Qwen3Tokenizer,
+    generated_tokens: &[u32],
+    finish_reason: String,
+    think_end_id: Option<u32>,
+    think_end_str: Option<&str>,
+    performance: Option<crate::profiling::PerformanceMetrics>,
+    include_reasoning: bool,
+    thinking_enabled: bool,
+) -> Result<ChatResult> {
+    let text = tokenizer
+        .decode_sync(generated_tokens, true)
+        .unwrap_or_else(|e| {
+            tracing::warn!("Failed to decode generated tokens: {}", e);
+            String::new()
+        });
+
+    let num_tokens = generated_tokens.len() as u32;
+
+    let (clean_text, tool_calls, thinking) = parse_thinking_and_tools(
+        &text,
+        generated_tokens,
+        thinking_enabled,
+        think_end_id,
+        think_end_str,
+        include_reasoning,
+    );
 
     // If we have valid tool calls, override finish reason
     let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -433,7 +433,6 @@ pub(crate) fn verify_cache_prefix(
 ///
 /// `F`: forward pass — takes (input_ids [1,1], embedding_weight) → Result<(logits, needs_squeeze)>.
 /// `E`: eval step — takes (next_token, logits, budget_forced) → schedules async eval.
-#[allow(dead_code)]
 pub(crate) struct DecodeOps<F, E>
 where
     F: FnMut(&MxArray, &MxArray) -> Result<(MxArray, bool)>,
@@ -455,7 +454,6 @@ where
 ///
 /// The optional `streaming:` block adds callback emission, cancellation,
 /// incremental detokenization, and is_reasoning tagging.
-#[allow(unused_macros)]
 macro_rules! decode_loop {
     (
         ops: $ops:expr,
@@ -600,7 +598,6 @@ macro_rules! decode_loop {
     }};
 }
 
-#[allow(unused_imports)]
 pub(crate) use decode_loop;
 
 #[cfg(test)]

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -59,11 +59,9 @@ pub(crate) fn extract_chat_params(config: &ChatConfig) -> ChatParams {
         report_performance: config.report_performance.unwrap_or(false),
         reuse_cache: config.reuse_cache.unwrap_or(true),
         thinking_token_budget: config.thinking_token_budget,
-        include_reasoning: config.include_reasoning.unwrap_or_else(|| {
-            // reasoning_effort == "none" implies include_reasoning = false
-            // unless explicitly overridden by the include_reasoning field
-            !matches!(config.reasoning_effort.as_deref(), Some("none"))
-        }),
+        include_reasoning: config
+            .include_reasoning
+            .unwrap_or(!matches!(config.reasoning_effort.as_deref(), Some("none"))),
     }
 }
 
@@ -150,10 +148,11 @@ impl ReasoningTracker {
         }
 
         self.thinking_token_count += 1;
-        if let Some(budget) = self.budget {
-            if self.thinking_token_count >= budget && !self.end_scheduled {
-                self.force_think_end = true;
-            }
+        if let Some(budget) = self.budget
+            && self.thinking_token_count >= budget
+            && !self.end_scheduled
+        {
+            self.force_think_end = true;
         }
         true
     }

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -211,6 +211,10 @@ pub(crate) fn compute_performance_metrics(
 }
 
 /// Decode tokens, parse thinking/tool_calls, build ChatResult.
+///
+/// `starts_in_thinking`: whether generation began inside a reasoning block.
+/// When false (no-thinking mode), all text is treated as content regardless of
+/// any literal `</think>` tokens that may appear.
 pub(crate) fn finalize_chat_result(
     tokenizer: &Qwen3Tokenizer,
     generated_tokens: &[u32],
@@ -219,6 +223,7 @@ pub(crate) fn finalize_chat_result(
     think_end_str: Option<&str>,
     performance: Option<crate::profiling::PerformanceMetrics>,
     include_reasoning: bool,
+    starts_in_thinking: bool,
 ) -> Result<ChatResult> {
     let text = tokenizer
         .decode_sync(generated_tokens, true)
@@ -229,7 +234,12 @@ pub(crate) fn finalize_chat_result(
 
     let num_tokens = generated_tokens.len() as u32;
 
-    let think_tag = if tools::has_think_end_token(generated_tokens, think_end_id) {
+    // Only attempt think splitting when generation started inside a reasoning
+    // block. In no-thinking mode the prompt already closed the think block,
+    // so any literal </think> in the output is normal content.
+    let think_tag = if starts_in_thinking
+        && tools::has_think_end_token(generated_tokens, think_end_id)
+    {
         think_end_str
     } else {
         None

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -235,10 +235,9 @@ pub(crate) fn finalize_chat_result(
     let num_tokens = generated_tokens.len() as u32;
 
     let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
-        // No-thinking mode: all text is content. Strip think markup for
-        // old-template compatibility, but treat content as normal text.
-        let stripped = tools::strip_think_markup(&text);
-        let (clean, calls) = tools::parse_tool_calls(&stripped);
+        // No-thinking mode: all text is content, passed through verbatim.
+        // Any literal <think> tags are normal model output, not markup.
+        let (clean, calls) = tools::parse_tool_calls(&text);
         (clean, calls, None)
     } else if tools::has_think_end_token(generated_tokens, think_end_id) {
         // Thinking mode with confirmed </think>: split at token boundary.

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -50,6 +50,13 @@ pub(crate) fn resolve_enable_thinking(config: &ChatConfig) -> Option<bool> {
     }
 }
 
+/// Resolve `include_reasoning` from config, with `reasoning_effort: "none"` default.
+pub(crate) fn resolve_include_reasoning(config: &ChatConfig) -> bool {
+    config
+        .include_reasoning
+        .unwrap_or(!matches!(config.reasoning_effort.as_deref(), Some("none")))
+}
+
 /// Extract ChatConfig fields into flat variables with defaults.
 pub(crate) fn extract_chat_params(config: &ChatConfig) -> ChatParams {
     ChatParams {
@@ -72,9 +79,7 @@ pub(crate) fn extract_chat_params(config: &ChatConfig) -> ChatParams {
         report_performance: config.report_performance.unwrap_or(false),
         reuse_cache: config.reuse_cache.unwrap_or(true),
         thinking_token_budget: config.thinking_token_budget,
-        include_reasoning: config
-            .include_reasoning
-            .unwrap_or(!matches!(config.reasoning_effort.as_deref(), Some("none"))),
+        include_reasoning: resolve_include_reasoning(config),
     }
 }
 

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -232,7 +232,7 @@ pub(crate) fn compute_performance_metrics(
 
 /// Shared finalization: parse thinking + tool calls from decoded text.
 ///
-/// Three-way branching based on the request's reasoning state:
+/// Four-way branching based on the request's reasoning state:
 /// 1. `!thinking_enabled`: no-thinking mode — all text is content, no reasoning parsing.
 /// 2. `thinking_enabled` + `</think>` token confirmed: split at token-confirmed boundary.
 /// 3. `thinking_enabled` + no `</think>` token + `think_end_id` exists: truncated generation.

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -122,12 +122,15 @@ impl ReasoningTracker {
     /// `budget`: maximum thinking tokens before forcing `</think>`. None = unlimited.
     /// `think_end_id`: token ID for `</think>` from the tokenizer vocabulary.
     pub fn new(starts_in_thinking: bool, budget: Option<i32>, think_end_id: Option<u32>) -> Self {
+        // Budget=0 means "no thinking tokens at all" — force </think> immediately
+        // on the first decode step, before any thinking token is generated.
+        let force_immediately = starts_in_thinking && budget == Some(0) && think_end_id.is_some();
         Self {
             in_thinking: starts_in_thinking,
             thinking_token_count: 0,
             budget,
             think_end_id,
-            force_think_end: false,
+            force_think_end: force_immediately,
             end_scheduled: false,
         }
     }
@@ -147,15 +150,13 @@ impl ReasoningTracker {
             return true; // </think> itself is part of reasoning
         }
 
-        // Check budget BEFORE incrementing so budget=0 triggers on the
-        // very first thinking token (distinct from budget=1).
+        self.thinking_token_count += 1;
         if let Some(budget) = self.budget
             && self.thinking_token_count >= budget
             && !self.end_scheduled
         {
             self.force_think_end = true;
         }
-        self.thinking_token_count += 1;
         true
     }
 
@@ -443,54 +444,48 @@ mod tests {
 
     #[test]
     fn test_tracker_budget_enforcement() {
-        // Budget=3: allows exactly 3 thinking tokens before triggering.
-        // Budget is checked BEFORE incrementing count.
+        // Budget=3: allows exactly 3 thinking tokens, then forces on the 3rd.
         let mut tracker = ReasoningTracker::new(true, Some(3), Some(THINK_END_ID));
-        assert!(tracker.observe_token(100)); // check 0<3, count→1
+        assert!(tracker.observe_token(100)); // count→1
         assert!(!tracker.should_force_think_end());
-        assert!(tracker.observe_token(200)); // check 1<3, count→2
+        assert!(tracker.observe_token(200)); // count→2
         assert!(!tracker.should_force_think_end());
-        assert!(tracker.observe_token(300)); // check 2<3, count→3
-        assert!(!tracker.should_force_think_end());
-        assert!(tracker.observe_token(400)); // check 3>=3 → force! count→4
+        assert!(tracker.observe_token(300)); // count→3, 3>=3 → force!
         assert!(tracker.should_force_think_end());
         assert_eq!(tracker.forced_token_id(), THINK_END_ID);
     }
 
     #[test]
     fn test_tracker_budget_zero() {
-        // Budget=0: triggers on the very first thinking token (before incrementing).
+        // Budget=0: force is set in new() — triggers BEFORE any thinking token.
         let mut tracker = ReasoningTracker::new(true, Some(0), Some(THINK_END_ID));
-        assert!(tracker.observe_token(100)); // check 0>=0 → force!
-        assert!(tracker.should_force_think_end());
+        assert!(tracker.should_force_think_end()); // immediate, no observe needed
     }
 
     #[test]
     fn test_tracker_budget_zero_vs_one() {
-        // Budget=0 and budget=1 must produce different behavior.
+        // Budget=0: force immediately (0 thinking tokens allowed).
         let mut t0 = ReasoningTracker::new(true, Some(0), Some(THINK_END_ID));
-        assert!(t0.observe_token(100));
-        assert!(t0.should_force_think_end()); // triggers after 1st token
+        assert!(t0.should_force_think_end()); // before any observe
 
+        // Budget=1: allows exactly 1 thinking token before forcing.
         let mut t1 = ReasoningTracker::new(true, Some(1), Some(THINK_END_ID));
-        assert!(t1.observe_token(100));
-        assert!(!t1.should_force_think_end()); // NOT yet after 1st token
-        assert!(t1.observe_token(200));
-        assert!(t1.should_force_think_end()); // triggers after 2nd token
+        assert!(!t1.should_force_think_end()); // not yet
+        assert!(t1.observe_token(100)); // count→1, 1>=1 → force!
+        assert!(t1.should_force_think_end()); // triggers after 1st token
     }
 
     #[test]
     fn test_tracker_budget_clears_on_think_end() {
         let mut tracker = ReasoningTracker::new(true, Some(2), Some(THINK_END_ID));
         assert!(tracker.observe_token(100)); // count→1
-        assert!(tracker.observe_token(200)); // check 1<2, count→2
         assert!(!tracker.should_force_think_end());
-        assert!(tracker.observe_token(300)); // check 2>=2 → force! count→3
+        assert!(tracker.observe_token(200)); // count→2, 2>=2 → force!
         assert!(tracker.should_force_think_end());
         // When the forced think_end token is generated:
         assert!(tracker.observe_token(THINK_END_ID)); // transitions to content
         assert!(!tracker.should_force_think_end()); // force cleared
-        assert!(!tracker.observe_token(400)); // now content
+        assert!(!tracker.observe_token(300)); // now content
     }
 
     #[test]
@@ -501,16 +496,15 @@ mod tests {
         let mut tracker = ReasoningTracker::new(true, Some(3), Some(THINK_END_ID));
         tracker.observe_token(100); // count→1
         tracker.observe_token(200); // count→2
-        tracker.observe_token(300); // count→3
-        tracker.observe_token(400); // check 3>=3 → force=true, count→4
+        tracker.observe_token(300); // count→3, 3>=3 → force=true
 
         // Phase A of step N+1: consume the force flag
         assert!(tracker.should_force_think_end()); // returns true, sets end_scheduled
         assert!(!tracker.should_force_think_end()); // already consumed — must be false
 
         // Phase B of step N+1: the pipeline extracts the over-budget token (not </think>)
-        assert!(tracker.observe_token(500)); // still reasoning, count→5
-        // Must NOT re-trigger forcing despite count(5) >= budget(3)
+        assert!(tracker.observe_token(400)); // still reasoning, count→4
+        // Must NOT re-trigger forcing despite count(4) >= budget(3)
         assert!(!tracker.should_force_think_end());
 
         // Phase B of step N+2: the forced </think> token is finally extracted
@@ -518,7 +512,7 @@ mod tests {
         assert!(!tracker.should_force_think_end());
 
         // Phase B of step N+3: normal content token
-        assert!(!tracker.observe_token(600)); // content
+        assert!(!tracker.observe_token(500)); // content
     }
 
     #[test]

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -234,17 +234,31 @@ pub(crate) fn finalize_chat_result(
 
     let num_tokens = generated_tokens.len() as u32;
 
-    // Only attempt think splitting when generation started inside a reasoning
-    // block. In no-thinking mode the prompt already closed the think block,
-    // so any literal </think> in the output is normal content.
-    let think_tag = if starts_in_thinking
-        && tools::has_think_end_token(generated_tokens, think_end_id)
-    {
-        think_end_str
+    let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
+        // No-thinking mode: all text is content. Any literal <think> tags
+        // are normal model output, not reasoning boundaries.
+        let (clean, calls) = tools::parse_tool_calls(&text);
+        (clean, calls, None)
+    } else if tools::has_think_end_token(generated_tokens, think_end_id) {
+        // Thinking mode with confirmed </think>: split at token boundary.
+        tools::split_at_think_end(&text, think_end_str)
     } else {
-        None
+        // Thinking mode, truncated (no </think> before EOS/max_tokens):
+        // entire output is reasoning, no content.
+        let thinking_text = text.trim();
+        // Strip leading <think> from old-style templates that emit it
+        // in the generated text (newer templates inject it in the prompt).
+        let thinking_text = thinking_text
+            .strip_prefix("<think>")
+            .unwrap_or(thinking_text)
+            .trim();
+        let thinking = if thinking_text.is_empty() {
+            None
+        } else {
+            Some(thinking_text.to_string())
+        };
+        (String::new(), vec![], thinking)
     };
-    let (clean_text, tool_calls, thinking) = tools::split_at_think_end(&text, think_tag);
 
     // Suppress reasoning if not requested
     let thinking = if include_reasoning { thinking } else { None };

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -108,6 +108,9 @@ pub(crate) struct ReasoningTracker {
     budget: Option<i32>,
     think_end_id: Option<u32>,
     force_think_end: bool,
+    /// Set after `should_force_think_end` is consumed, prevents re-triggering
+    /// from subsequent `observe_token` calls before the forced token is extracted.
+    end_scheduled: bool,
 }
 
 impl ReasoningTracker {
@@ -123,6 +126,7 @@ impl ReasoningTracker {
             budget,
             think_end_id,
             force_think_end: false,
+            end_scheduled: false,
         }
     }
 
@@ -137,12 +141,13 @@ impl ReasoningTracker {
         if self.think_end_id == Some(token_id) {
             self.in_thinking = false;
             self.force_think_end = false;
+            self.end_scheduled = false;
             return true; // </think> itself is part of reasoning
         }
 
         self.thinking_token_count += 1;
         if let Some(budget) = self.budget {
-            if self.thinking_token_count >= budget {
+            if self.thinking_token_count >= budget && !self.end_scheduled {
                 self.force_think_end = true;
             }
         }
@@ -150,13 +155,20 @@ impl ReasoningTracker {
     }
 
     /// Whether the next token should be forced to think_end_id.
+    /// Consumes the flag — returns true at most once per budget trigger.
     ///
     /// Check this BEFORE building the next decode step's graph.
-    pub fn should_force_think_end(&self) -> bool {
-        self.force_think_end && self.think_end_id.is_some()
+    pub fn should_force_think_end(&mut self) -> bool {
+        if self.force_think_end && self.think_end_id.is_some() {
+            self.force_think_end = false;
+            self.end_scheduled = true;
+            true
+        } else {
+            false
+        }
     }
 
-    /// The think_end token ID to force. Only valid when `should_force_think_end()` is true.
+    /// The think_end token ID to force. Only valid when `should_force_think_end()` returned true.
     pub fn forced_token_id(&self) -> u32 {
         self.think_end_id
             .expect("should_force_think_end was true but think_end_id is None")
@@ -400,6 +412,33 @@ mod tests {
         assert!(tracker.observe_token(THINK_END_ID)); // transitions to content
         assert!(!tracker.should_force_think_end()); // force cleared
         assert!(!tracker.observe_token(300)); // now content
+    }
+
+    #[test]
+    fn test_tracker_no_double_force_with_pipeline_lag() {
+        // Simulates pipelined decode: after should_force_think_end() is consumed,
+        // the pipeline extracts an over-budget token before the forced </think>
+        // arrives. The tracker must NOT re-trigger forcing.
+        let mut tracker = ReasoningTracker::new(true, Some(3), Some(THINK_END_ID));
+        tracker.observe_token(100); // count=1
+        tracker.observe_token(200); // count=2
+        tracker.observe_token(300); // count=3 >= budget → force=true
+
+        // Phase A of step N+1: consume the force flag
+        assert!(tracker.should_force_think_end()); // returns true, sets end_scheduled
+        assert!(!tracker.should_force_think_end()); // already consumed — must be false
+
+        // Phase B of step N+1: the pipeline extracts the over-budget token (not </think>)
+        assert!(tracker.observe_token(400)); // still reasoning, count=4
+        // Must NOT re-trigger forcing despite count(4) >= budget(3)
+        assert!(!tracker.should_force_think_end());
+
+        // Phase B of step N+2: the forced </think> token is finally extracted
+        assert!(tracker.observe_token(THINK_END_ID)); // transitions to content
+        assert!(!tracker.should_force_think_end());
+
+        // Phase B of step N+3: normal content token
+        assert!(!tracker.observe_token(500)); // content
     }
 
     #[test]

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -37,6 +37,19 @@ pub(crate) struct ChatParams {
     pub include_reasoning: bool,
 }
 
+/// Resolve the effective `enable_thinking` value from `reasoning_effort`.
+///
+/// In vLLM, `enable_thinking` is a low-level template kwarg nested inside
+/// `chat_template_kwargs`. `reasoning_effort` is the user-facing control that
+/// drives it. This function maps the user-facing API to the template parameter.
+pub(crate) fn resolve_enable_thinking(config: &ChatConfig) -> Option<bool> {
+    match config.reasoning_effort.as_deref() {
+        Some("none") | Some("low") => Some(false),
+        Some("medium") | Some("high") => Some(true),
+        _ => None, // not set → default (template decides, typically true)
+    }
+}
+
 /// Extract ChatConfig fields into flat variables with defaults.
 pub(crate) fn extract_chat_params(config: &ChatConfig) -> ChatParams {
     ChatParams {

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -546,4 +546,18 @@ mod tests {
             assert!(!tracker.should_force_think_end());
         }
     }
+
+    #[test]
+    fn test_tracker_no_think_end_id_labels_as_reasoning() {
+        // When thinking is enabled but think_end_id is missing (tokenizer
+        // renders </think> as multiple tokens), observe_token should still
+        // return true (reasoning) for every token — consistent with the
+        // text-level finalization that will find reasoning via parsing.
+        let mut tracker = ReasoningTracker::new(true, None, None);
+        assert!(tracker.observe_token(100)); // reasoning
+        assert!(tracker.observe_token(200)); // reasoning
+        assert!(tracker.observe_token(300)); // reasoning
+        // Never transitions — no think_end_id to match
+        assert!(!tracker.should_force_think_end()); // budget disabled
+    }
 }

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -59,7 +59,11 @@ pub(crate) fn extract_chat_params(config: &ChatConfig) -> ChatParams {
         report_performance: config.report_performance.unwrap_or(false),
         reuse_cache: config.reuse_cache.unwrap_or(true),
         thinking_token_budget: config.thinking_token_budget,
-        include_reasoning: config.include_reasoning.unwrap_or(true),
+        include_reasoning: config.include_reasoning.unwrap_or_else(|| {
+            // reasoning_effort == "none" implies include_reasoning = false
+            // unless explicitly overridden by the include_reasoning field
+            !matches!(config.reasoning_effort.as_deref(), Some("none"))
+        }),
     }
 }
 

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -429,6 +429,180 @@ pub(crate) fn verify_cache_prefix(
     }
 }
 
+/// Closures for model-specific operations in the decode loop.
+///
+/// `F`: forward pass — takes (input_ids [1,1], embedding_weight) → Result<(logits, needs_squeeze)>.
+/// `E`: eval step — takes (next_token, logits, budget_forced) → schedules async eval.
+#[allow(dead_code)]
+pub(crate) struct DecodeOps<F, E>
+where
+    F: FnMut(&MxArray, &MxArray) -> Result<(MxArray, bool)>,
+    E: Fn(&MxArray, &MxArray, bool),
+{
+    pub forward: F,
+    pub eval_step: E,
+}
+
+/// Pipelined decode loop shared across all Qwen3.5 model variants.
+///
+/// Generates the token-by-token decode loop with:
+/// - Pipelining: builds step N+1's graph before blocking on step N
+/// - Budget enforcement via ReasoningTracker
+/// - Penalty application via apply_all_penalties
+/// - Stop conditions: EOS, repetition cutoff
+/// - Every-256-step synchronize_and_clear_cache
+/// - Profiler instrumentation
+///
+/// The optional `streaming:` block adds callback emission, cancellation,
+/// incremental detokenization, and is_reasoning tagging.
+#[allow(unused_macros)]
+macro_rules! decode_loop {
+    (
+        ops: $ops:expr,
+        y: $y:expr,
+        embedding_weight: $emb:expr,
+        params: $p:expr,
+        reasoning_tracker: $tracker:expr,
+        profiler: $profiler:expr,
+        max_new_tokens: $max:expr,
+        eos_id: $eos:expr,
+        generated_tokens: $gen:expr,
+        token_history: $hist:expr,
+        finish_reason: $reason:expr,
+        first_token_instant: $first_tok:expr,
+        report_perf: $report:expr,
+        generation_stream: $stream:expr
+        $(, streaming: {
+            callback: $cb:expr,
+            cancelled: $cancelled:expr,
+            decode_stream: $ds:expr,
+            tokenizer: $tok:expr,
+            streamed_text_len: $slen:expr,
+            last_is_reasoning: $last_r:expr
+        })?
+    ) => {{
+        for step in 0..$max {
+            let next_y = if step + 1 < $max {
+                let _stream_ctx = $crate::stream::StreamContext::new($stream);
+
+                $profiler.begin("forward");
+                let next_ids = $y.reshape(&[1, 1])?;
+                let (mut logits, needs_squeeze) = ($ops.forward)(&next_ids, &$emb)?;
+                if needs_squeeze {
+                    logits = logits.squeeze(Some(&[1]))?;
+                }
+                $profiler.end();
+
+                let (next_token, budget_forced) =
+                    if $tracker.should_force_think_end() {
+                        let forced_id = $tracker.forced_token_id() as i32;
+                        ($crate::array::MxArray::from_int32(&[forced_id], &[1])?, true)
+                    } else {
+                        $profiler.begin("rep_penalty");
+                        logits = $crate::models::qwen3_5::chat_common::apply_all_penalties(
+                            logits, &$hist, &$p,
+                        )?;
+                        $profiler.end();
+
+                        $profiler.begin("sample");
+                        let t = $crate::sampling::sample(&logits, $p.sampling_config)?;
+                        $profiler.end();
+                        (t, false)
+                    };
+
+                $profiler.begin("eval_caches");
+                ($ops.eval_step)(&next_token, &logits, budget_forced);
+                $profiler.end();
+
+                Some(next_token)
+            } else {
+                None
+            };
+
+            $profiler.begin("eval_token");
+            $y.eval();
+            $profiler.end();
+
+            $profiler.begin("extract");
+            let token_id = $y.item_at_int32(0)? as u32;
+            $profiler.end();
+            $profiler.mark_first_token();
+            if $report && $first_tok.is_none() {
+                $first_tok = Some(std::time::Instant::now());
+            }
+
+            $gen.push(token_id);
+            $hist.push(token_id);
+            let _is_reasoning = $tracker.observe_token(token_id);
+
+            // Streaming-only block (conditionally compiled via macro repetition)
+            $(
+                $last_r = _is_reasoning;
+
+                if $cancelled.load(std::sync::atomic::Ordering::Relaxed) {
+                    $reason = String::from("cancelled");
+                    break;
+                }
+
+                let token_text = $crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
+                    &mut $ds,
+                    $tok.inner(),
+                    token_id,
+                    &$gen,
+                    $slen,
+                );
+                $slen += token_text.len();
+                $cb.call(
+                    Ok($crate::models::qwen3_5::model::ChatStreamChunk {
+                        text: token_text,
+                        done: false,
+                        finish_reason: None,
+                        tool_calls: None,
+                        thinking: None,
+                        num_tokens: None,
+                        raw_text: None,
+                        performance: None,
+                        is_reasoning: Some(_is_reasoning),
+                    }),
+                    napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking,
+                );
+            )?
+
+            if token_id == $eos {
+                $reason = String::from("stop");
+                break;
+            }
+
+            if let Some(reason) = $crate::sampling::check_repetition_cutoff(
+                &$gen,
+                $p.max_consecutive_tokens,
+                $p.max_ngram_repeats,
+                $p.ngram_size,
+            ) {
+                $reason = reason.to_string();
+                break;
+            }
+
+            match next_y {
+                Some(next) => $y = next,
+                None => break,
+            }
+
+            $profiler.step();
+
+            if (step + 1) % 256 == 0 {
+                $crate::array::synchronize_and_clear_cache();
+            }
+        }
+
+        $profiler.snapshot_memory_after();
+        $profiler.report();
+    }};
+}
+
+#[allow(unused_imports)]
+pub(crate) use decode_loop;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -235,9 +235,10 @@ pub(crate) fn finalize_chat_result(
     let num_tokens = generated_tokens.len() as u32;
 
     let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
-        // No-thinking mode: all text is content. Any literal <think> tags
-        // are normal model output, not reasoning boundaries.
-        let (clean, calls) = tools::parse_tool_calls(&text);
+        // No-thinking mode: all text is content. Strip think markup for
+        // old-template compatibility, but treat content as normal text.
+        let stripped = tools::strip_think_markup(&text);
+        let (clean, calls) = tools::parse_tool_calls(&stripped);
         (clean, calls, None)
     } else if tools::has_think_end_token(generated_tokens, think_end_id) {
         // Thinking mode with confirmed </think>: split at token boundary.
@@ -246,10 +247,11 @@ pub(crate) fn finalize_chat_result(
         // Thinking mode, truncated (no </think> before EOS/max_tokens):
         // entire output is reasoning, no content.
         let thinking_text = text.trim();
-        // Strip leading <think> from old-style templates that emit it
-        // in the generated text (newer templates inject it in the prompt).
+        // Strip leading <think>/<longcat_think> from old-style templates
+        // that emit it in the generated text.
         let thinking_text = thinking_text
             .strip_prefix("<think>")
+            .or_else(|| thinking_text.strip_prefix("<longcat_think>"))
             .unwrap_or(thinking_text)
             .trim();
         let thinking = if thinking_text.is_empty() {

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2104,30 +2104,47 @@ impl Qwen3_5Model {
                             // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < p.max_new_tokens {
                                 let _stream_ctx = StreamContext::new(generation_stream);
+
+                                profiler.begin("forward");
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
+                                profiler.end();
 
                                 let (next_token, budget_forced) =
                                     if reasoning_tracker.should_force_think_end() {
                                         let forced_id = reasoning_tracker.forced_token_id() as i32;
                                         (MxArray::from_int32(&[forced_id], &[1])?, true)
                                     } else {
+                                        profiler.begin("rep_penalty");
                                         logits = apply_all_penalties(logits, &token_history, &p)?;
-                                        (sample(&logits, p.sampling_config)?, false)
+                                        profiler.end();
+
+                                        profiler.begin("sample");
+                                        let t = sample(&logits, p.sampling_config)?;
+                                        profiler.end();
+                                        (t, false)
                                     };
 
+                                profiler.begin("eval_caches");
                                 eval_token_and_compiled_caches(&next_token);
                                 if budget_forced {
                                     logits.eval();
                                 }
+                                profiler.end();
+
                                 Some(next_token)
                             } else {
                                 None
                             };
 
                             // Wait for step N (GPU already computing N+1)
+                            profiler.begin("eval_token");
                             y.eval();
+                            profiler.end();
+
+                            profiler.begin("extract");
                             let token_id = y.item_at_int32(0)? as u32;
+                            profiler.end();
                             profiler.mark_first_token();
                             if p.report_performance && first_token_instant.is_none() {
                                 first_token_instant = Some(std::time::Instant::now());
@@ -2243,6 +2260,8 @@ impl Qwen3_5Model {
                             // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < p.max_new_tokens {
                                 let _stream_ctx = StreamContext::new(generation_stream);
+
+                                profiler.begin("forward");
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let logits = forward_inner(
                                     &next_ids,
@@ -2254,26 +2273,41 @@ impl Qwen3_5Model {
                                     Some(&embedding_weight_t),
                                 )?;
                                 let mut logits = logits.squeeze(Some(&[1]))?;
+                                profiler.end();
 
                                 let next_token = if reasoning_tracker.should_force_think_end() {
                                     let forced_id = reasoning_tracker.forced_token_id() as i32;
                                     MxArray::from_int32(&[forced_id], &[1])?
                                 } else {
+                                    profiler.begin("rep_penalty");
                                     logits = apply_all_penalties(logits, &token_history, &p)?;
-                                    sample(&logits, p.sampling_config)?
+                                    profiler.end();
+
+                                    profiler.begin("sample");
+                                    let t = sample(&logits, p.sampling_config)?;
+                                    profiler.end();
+                                    t
                                 };
 
+                                profiler.begin("eval_caches");
                                 // Eval next_token and logits to ensure the forward
                                 // graph (including KV cache updates) is materialized.
                                 MxArray::async_eval_arrays(&[&next_token, &logits]);
+                                profiler.end();
+
                                 Some(next_token)
                             } else {
                                 None
                             };
 
                             // Wait for step N (GPU already computing N+1)
+                            profiler.begin("eval_token");
                             y.eval();
+                            profiler.end();
+
+                            profiler.begin("extract");
                             let token_id = y.item_at_int32(0)? as u32;
+                            profiler.end();
                             profiler.mark_first_token();
                             if p.report_performance && first_token_instant.is_none() {
                                 first_token_instant = Some(std::time::Instant::now());

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1369,23 +1369,30 @@ impl Qwen3_5Model {
                         let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
                         profiler.end();
 
-                        let next_token = if reasoning_tracker.should_force_think_end() {
-                            let forced_id = reasoning_tracker.forced_token_id() as i32;
-                            MxArray::from_int32(&[forced_id], &[1])?
-                        } else {
-                            profiler.begin("rep_penalty");
-                            logits = apply_all_penalties(logits, &token_history, &p)?;
-                            profiler.end();
+                        let (next_token, budget_forced) =
+                            if reasoning_tracker.should_force_think_end() {
+                                let forced_id = reasoning_tracker.forced_token_id() as i32;
+                                (MxArray::from_int32(&[forced_id], &[1])?, true)
+                            } else {
+                                profiler.begin("rep_penalty");
+                                logits = apply_all_penalties(logits, &token_history, &p)?;
+                                profiler.end();
 
-                            profiler.begin("sample");
-                            let t = sample(&logits, p.sampling_config)?;
-                            profiler.end();
-                            t
-                        };
+                                profiler.begin("sample");
+                                let t = sample(&logits, p.sampling_config)?;
+                                profiler.end();
+                                (t, false)
+                            };
 
                         profiler.begin("eval_caches");
                         eval_token_and_compiled_caches(&next_token);
                         profiler.end();
+                        if budget_forced {
+                            // next_token is a constant with no graph dependency on
+                            // forward_compiled. Eval logits to ensure the forward
+                            // graph and KV cache updates are materialized.
+                            logits.eval();
+                        }
 
                         Some(next_token)
                     } else {
@@ -2159,38 +2166,42 @@ impl Qwen3_5Model {
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
 
-                                let next_token = if reasoning_tracker.should_force_think_end() {
-                                    let forced_id = reasoning_tracker.forced_token_id() as i32;
-                                    MxArray::from_int32(&[forced_id], &[1])?
-                                } else {
-                                    if repetition_penalty != 1.0 {
-                                        logits = apply_repetition_penalty(
-                                            &logits,
-                                            &token_history,
-                                            repetition_penalty,
-                                            Some(repetition_context_size),
-                                        )?;
-                                    }
-                                    if presence_penalty != 0.0 {
-                                        logits = apply_presence_penalty(
-                                            &logits,
-                                            &token_history,
-                                            presence_penalty,
-                                            Some(presence_context_size),
-                                        )?;
-                                    }
-                                    if frequency_penalty != 0.0 {
-                                        logits = apply_frequency_penalty(
-                                            &logits,
-                                            &token_history,
-                                            frequency_penalty,
-                                            Some(frequency_context_size),
-                                        )?;
-                                    }
-                                    sample(&logits, sampling_config)?
-                                };
+                                let (next_token, budget_forced) =
+                                    if reasoning_tracker.should_force_think_end() {
+                                        let forced_id = reasoning_tracker.forced_token_id() as i32;
+                                        (MxArray::from_int32(&[forced_id], &[1])?, true)
+                                    } else {
+                                        if repetition_penalty != 1.0 {
+                                            logits = apply_repetition_penalty(
+                                                &logits,
+                                                &token_history,
+                                                repetition_penalty,
+                                                Some(repetition_context_size),
+                                            )?;
+                                        }
+                                        if presence_penalty != 0.0 {
+                                            logits = apply_presence_penalty(
+                                                &logits,
+                                                &token_history,
+                                                presence_penalty,
+                                                Some(presence_context_size),
+                                            )?;
+                                        }
+                                        if frequency_penalty != 0.0 {
+                                            logits = apply_frequency_penalty(
+                                                &logits,
+                                                &token_history,
+                                                frequency_penalty,
+                                                Some(frequency_context_size),
+                                            )?;
+                                        }
+                                        (sample(&logits, sampling_config)?, false)
+                                    };
 
                                 eval_token_and_compiled_caches(&next_token);
+                                if budget_forced {
+                                    logits.eval();
+                                }
                                 Some(next_token)
                             } else {
                                 None

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -13,7 +13,7 @@ use tracing::{info, warn};
 use crate::array::MxArray;
 use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
 use crate::nn::{Embedding, Linear, RMSNorm};
-use crate::sampling::{SamplingConfig, check_repetition_cutoff, sample};
+use crate::sampling::{SamplingConfig, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::tools::ToolCallResult;
@@ -1980,118 +1980,42 @@ impl Qwen3_5Model {
                             p.thinking_token_budget,
                             think_end_id,
                         );
-                        for step in 0..p.max_new_tokens {
-                            // Build and submit graph for step N+1.
-                            // forward() always runs to keep KV caches consistent.
-                            let next_y = if step + 1 < p.max_new_tokens {
-                                let _stream_ctx = StreamContext::new(generation_stream);
 
-                                profiler.begin("forward");
-                                let next_ids = y.reshape(&[1, 1])?;
-                                let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
-                                profiler.end();
-
-                                let (next_token, budget_forced) =
-                                    if reasoning_tracker.should_force_think_end() {
-                                        let forced_id = reasoning_tracker.forced_token_id() as i32;
-                                        (MxArray::from_int32(&[forced_id], &[1])?, true)
-                                    } else {
-                                        profiler.begin("rep_penalty");
-                                        logits = apply_all_penalties(logits, &token_history, &p)?;
-                                        profiler.end();
-
-                                        profiler.begin("sample");
-                                        let t = sample(&logits, p.sampling_config)?;
-                                        profiler.end();
-                                        (t, false)
-                                    };
-
-                                profiler.begin("eval_caches");
-                                eval_token_and_compiled_caches(&next_token);
+                        let mut ops = chat_common::DecodeOps {
+                            forward: |ids: &MxArray, emb: &MxArray| -> Result<(MxArray, bool)> {
+                                Ok((forward_compiled(ids, emb)?, false))
+                            },
+                            eval_step: |token: &MxArray, logits: &MxArray, budget_forced: bool| {
+                                eval_token_and_compiled_caches(token);
                                 if budget_forced {
                                     logits.eval();
                                 }
-                                profiler.end();
-
-                                Some(next_token)
-                            } else {
-                                None
-                            };
-
-                            // Wait for step N (GPU already computing N+1)
-                            profiler.begin("eval_token");
-                            y.eval();
-                            profiler.end();
-
-                            profiler.begin("extract");
-                            let token_id = y.item_at_int32(0)? as u32;
-                            profiler.end();
-                            profiler.mark_first_token();
-                            if p.report_performance && first_token_instant.is_none() {
-                                first_token_instant = Some(std::time::Instant::now());
+                            },
+                        };
+                        chat_common::decode_loop!(
+                            ops: ops,
+                            y: y,
+                            embedding_weight: embedding_weight,
+                            params: p,
+                            reasoning_tracker: reasoning_tracker,
+                            profiler: profiler,
+                            max_new_tokens: p.max_new_tokens,
+                            eos_id: eos_id,
+                            generated_tokens: generated_tokens,
+                            token_history: token_history,
+                            finish_reason: finish_reason,
+                            first_token_instant: first_token_instant,
+                            report_perf: p.report_performance,
+                            generation_stream: generation_stream,
+                            streaming: {
+                                callback: callback,
+                                cancelled: cancelled_inner,
+                                decode_stream: decode_stream,
+                                tokenizer: tokenizer_for_decode,
+                                streamed_text_len: streamed_text_len,
+                                last_is_reasoning: last_is_reasoning
                             }
-                            generated_tokens.push(token_id);
-                            token_history.push(token_id);
-
-                            let is_reasoning = reasoning_tracker.observe_token(token_id);
-                            last_is_reasoning = is_reasoning;
-
-                            if cancelled_inner.load(Ordering::Relaxed) {
-                                finish_reason = String::from("cancelled");
-                                break;
-                            }
-
-                            let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
-                                &mut decode_stream,
-                                tokenizer_for_decode.inner(),
-                                token_id,
-                                &generated_tokens,
-                                streamed_text_len,
-                            );
-                            streamed_text_len += token_text.len();
-                            callback.call(
-                                Ok(ChatStreamChunk {
-                                    text: token_text,
-                                    done: false,
-                                    finish_reason: None,
-                                    tool_calls: None,
-                                    thinking: None,
-                                    num_tokens: None,
-                                    raw_text: None,
-                                    performance: None,
-                                    is_reasoning: Some(is_reasoning),
-                                }),
-                                ThreadsafeFunctionCallMode::NonBlocking,
-                            );
-
-                            if token_id == eos_id {
-                                finish_reason = String::from("stop");
-                                break;
-                            }
-
-                            if let Some(reason) = check_repetition_cutoff(
-                                &generated_tokens,
-                                p.max_consecutive_tokens,
-                                p.max_ngram_repeats,
-                                p.ngram_size,
-                            ) {
-                                finish_reason = reason.to_string();
-                                break;
-                            }
-
-                            match next_y {
-                                Some(next) => y = next,
-                                None => break,
-                            }
-
-                            profiler.step();
-
-                            if (step + 1) % 256 == 0 {
-                                crate::array::synchronize_and_clear_cache();
-                            }
-                        }
-                        profiler.snapshot_memory_after();
-                        profiler.report();
+                        );
 
                         // === Export caches from C++ before CompiledResetGuard drops ===
                         if reuse_cache {
@@ -2136,125 +2060,48 @@ impl Qwen3_5Model {
                             p.thinking_token_budget,
                             think_end_id,
                         );
-                        for step in 0..p.max_new_tokens {
-                            // Build and submit graph for step N+1.
-                            // forward() always runs to keep KV caches consistent.
-                            let next_y = if step + 1 < p.max_new_tokens {
-                                let _stream_ctx = StreamContext::new(generation_stream);
 
-                                profiler.begin("forward");
-                                let next_ids = y.reshape(&[1, 1])?;
+                        let mut ops = chat_common::DecodeOps {
+                            forward: |ids: &MxArray, emb: &MxArray| -> Result<(MxArray, bool)> {
                                 let logits = forward_inner(
-                                    &next_ids,
-                                    &embedding_weight,
+                                    ids,
+                                    emb,
                                     &mut layers_guard,
                                     &mut caches_guard,
                                     &final_norm_guard,
                                     &lm_head_guard,
                                     Some(&embedding_weight_t),
                                 )?;
-                                let mut logits = logits.squeeze(Some(&[1]))?;
-                                profiler.end();
-
-                                let next_token = if reasoning_tracker.should_force_think_end() {
-                                    let forced_id = reasoning_tracker.forced_token_id() as i32;
-                                    MxArray::from_int32(&[forced_id], &[1])?
-                                } else {
-                                    profiler.begin("rep_penalty");
-                                    logits = apply_all_penalties(logits, &token_history, &p)?;
-                                    profiler.end();
-
-                                    profiler.begin("sample");
-                                    let t = sample(&logits, p.sampling_config)?;
-                                    profiler.end();
-                                    t
-                                };
-
-                                profiler.begin("eval_caches");
-                                // Eval next_token and logits to ensure the forward
-                                // graph (including KV cache updates) is materialized.
-                                MxArray::async_eval_arrays(&[&next_token, &logits]);
-                                profiler.end();
-
-                                Some(next_token)
-                            } else {
-                                None
-                            };
-
-                            // Wait for step N (GPU already computing N+1)
-                            profiler.begin("eval_token");
-                            y.eval();
-                            profiler.end();
-
-                            profiler.begin("extract");
-                            let token_id = y.item_at_int32(0)? as u32;
-                            profiler.end();
-                            profiler.mark_first_token();
-                            if p.report_performance && first_token_instant.is_none() {
-                                first_token_instant = Some(std::time::Instant::now());
+                                Ok((logits, true))
+                            },
+                            eval_step: |token: &MxArray, logits: &MxArray, _budget_forced: bool| {
+                                MxArray::async_eval_arrays(&[token, logits]);
+                            },
+                        };
+                        chat_common::decode_loop!(
+                            ops: ops,
+                            y: y,
+                            embedding_weight: embedding_weight,
+                            params: p,
+                            reasoning_tracker: reasoning_tracker,
+                            profiler: profiler,
+                            max_new_tokens: p.max_new_tokens,
+                            eos_id: eos_id,
+                            generated_tokens: generated_tokens,
+                            token_history: token_history,
+                            finish_reason: finish_reason,
+                            first_token_instant: first_token_instant,
+                            report_perf: p.report_performance,
+                            generation_stream: generation_stream,
+                            streaming: {
+                                callback: callback,
+                                cancelled: cancelled_inner,
+                                decode_stream: decode_stream,
+                                tokenizer: tokenizer_for_decode,
+                                streamed_text_len: streamed_text_len,
+                                last_is_reasoning: last_is_reasoning
                             }
-                            generated_tokens.push(token_id);
-                            token_history.push(token_id);
-
-                            let is_reasoning = reasoning_tracker.observe_token(token_id);
-                            last_is_reasoning = is_reasoning;
-
-                            if cancelled_inner.load(Ordering::Relaxed) {
-                                finish_reason = String::from("cancelled");
-                                break;
-                            }
-
-                            let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
-                                &mut decode_stream,
-                                tokenizer_for_decode.inner(),
-                                token_id,
-                                &generated_tokens,
-                                streamed_text_len,
-                            );
-                            streamed_text_len += token_text.len();
-                            callback.call(
-                                Ok(ChatStreamChunk {
-                                    text: token_text,
-                                    done: false,
-                                    finish_reason: None,
-                                    tool_calls: None,
-                                    thinking: None,
-                                    num_tokens: None,
-                                    raw_text: None,
-                                    performance: None,
-                                    is_reasoning: Some(is_reasoning),
-                                }),
-                                ThreadsafeFunctionCallMode::NonBlocking,
-                            );
-
-                            if token_id == eos_id {
-                                finish_reason = String::from("stop");
-                                break;
-                            }
-
-                            if let Some(reason) = check_repetition_cutoff(
-                                &generated_tokens,
-                                p.max_consecutive_tokens,
-                                p.max_ngram_repeats,
-                                p.ngram_size,
-                            ) {
-                                finish_reason = reason.to_string();
-                                break;
-                            }
-
-                            match next_y {
-                                Some(next) => y = next,
-                                None => break,
-                            }
-
-                            profiler.step();
-
-                            if (step + 1) % 256 == 0 {
-                                crate::array::synchronize_and_clear_cache();
-                            }
-                        }
-                        profiler.snapshot_memory_after();
-                        profiler.report();
+                        );
                     }
 
                     // _compiled_guard dropped here (if Some), calling mlx_qwen35_compiled_reset()

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1782,7 +1782,9 @@ impl Qwen3_5Model {
                         min_p: config.min_p,
                     });
                     let thinking_token_budget = config.thinking_token_budget;
-                    let include_reasoning = config.include_reasoning.unwrap_or(true);
+                    let include_reasoning = config.include_reasoning.unwrap_or_else(|| {
+                        !matches!(config.reasoning_effort.as_deref(), Some("none"))
+                    });
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -2214,13 +2216,13 @@ impl Qwen3_5Model {
                             generated_tokens.push(token_id);
                             token_history.push(token_id);
 
+                            let is_reasoning = reasoning_tracker.observe_token(token_id);
+                            last_is_reasoning = is_reasoning;
+
                             if cancelled_inner.load(Ordering::Relaxed) {
                                 finish_reason = String::from("cancelled");
                                 break;
                             }
-
-                            let is_reasoning = reasoning_tracker.observe_token(token_id);
-                            last_is_reasoning = is_reasoning;
 
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
@@ -2391,13 +2393,13 @@ impl Qwen3_5Model {
                             generated_tokens.push(token_id);
                             token_history.push(token_id);
 
+                            let is_reasoning = reasoning_tracker.observe_token(token_id);
+                            last_is_reasoning = is_reasoning;
+
                             if cancelled_inner.load(Ordering::Relaxed) {
                                 finish_reason = String::from("cancelled");
                                 break;
                             }
-
-                            let is_reasoning = reasoning_tracker.observe_token(token_id);
-                            last_is_reasoning = is_reasoning;
 
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -22,6 +22,7 @@ use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::tools;
 use crate::tools::ToolCallResult;
 
+use super::chat_common;
 use super::chat_common::{
     apply_all_penalties, compute_performance_metrics, extract_chat_params, finalize_chat_result,
     save_cache_state, verify_cache_prefix,
@@ -194,6 +195,20 @@ pub struct ChatConfig {
     /// Set to false to suppress thinking by injecting empty <think></think> tags.
     #[napi(ts_type = "boolean | undefined")]
     pub enable_thinking: Option<bool>,
+    /// Maximum number of thinking tokens before forcing </think>.
+    /// When the model has generated this many tokens while in thinking mode,
+    /// the next token is forced to be the think_end token. None = unlimited.
+    #[napi(ts_type = "number | undefined")]
+    pub thinking_token_budget: Option<i32>,
+    /// Whether to include reasoning/thinking content in the output.
+    /// When false, the `thinking` field of ChatResult/ChatStreamChunk will always be None.
+    /// Default: true (reasoning is included).
+    #[napi(ts_type = "boolean | undefined")]
+    pub include_reasoning: Option<bool>,
+    /// Reasoning effort level. Overrides `enableThinking` when set:
+    /// "low"/"none" → enableThinking=false, "medium"/"high" → enableThinking=true.
+    #[napi(ts_type = "string | undefined")]
+    pub reasoning_effort: Option<String>,
     /// When true, include performance metrics (TTFT, prefill tok/s, decode tok/s) in the result
     #[napi(ts_type = "boolean | undefined")]
     pub report_performance: Option<bool>,
@@ -233,6 +248,11 @@ pub struct ChatStreamChunk {
     pub raw_text: Option<String>,
     /// Performance metrics (only present in the final chunk when `reportPerformance: true`)
     pub performance: Option<crate::profiling::PerformanceMetrics>,
+    /// Whether this delta chunk contains reasoning/thinking content.
+    /// true = reasoning (inside <think>...</think>), false = content (after </think>).
+    /// Only present on intermediate (non-final) chunks.
+    #[napi(ts_type = "boolean | undefined")]
+    pub is_reasoning: Option<bool>,
 }
 
 /// Handle returned by `chat_stream()` to control an in-progress streaming generation.
@@ -923,6 +943,9 @@ impl Qwen3_5Model {
             ngram_size: None,
             tools: None,
             enable_thinking: None,
+            thinking_token_budget: None,
+            include_reasoning: None,
+            reasoning_effort: None,
             report_performance: None,
             reuse_cache: None,
         });
@@ -1010,7 +1033,11 @@ impl Qwen3_5Model {
             let mut first_token_instant: Option<std::time::Instant> = None;
 
             let tool_defs = config.tools.as_deref();
-            let enable_thinking = config.enable_thinking;
+            let enable_thinking = match config.reasoning_effort.as_deref() {
+                Some("low") | Some("none") => Some(false),
+                Some("medium") | Some("high") => Some(true),
+                _ => config.enable_thinking,
+            };
             let tokens = tokenizer.apply_chat_template_sync(
                 &messages,
                 Some(true),
@@ -1324,29 +1351,46 @@ impl Qwen3_5Model {
                 // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                 profiler.set_label("chat_compiled");
 
+                let starts_in_thinking =
+                    enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let mut reasoning_tracker = chat_common::ReasoningTracker::new(
+                    starts_in_thinking,
+                    p.thinking_token_budget,
+                    think_end_id,
+                );
+
                 for step in 0..max_new_tokens {
                     // Build and submit graph for step N+1 before waiting for N
                     let next_y = if step + 1 < max_new_tokens {
-                        let _stream_ctx = StreamContext::new(generation_stream);
+                        if reasoning_tracker.should_force_think_end() {
+                            // Budget exhausted — force </think> token
+                            let forced_id = reasoning_tracker.forced_token_id() as i32;
+                            let forced = MxArray::from_int32(&[forced_id], &[1])?;
+                            eval_token_and_compiled_caches(&forced);
+                            Some(forced)
+                        } else {
+                            let _stream_ctx = StreamContext::new(generation_stream);
 
-                        profiler.begin("forward");
-                        let next_ids = y.reshape(&[1, 1])?;
-                        let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
-                        profiler.end();
+                            profiler.begin("forward");
+                            let next_ids = y.reshape(&[1, 1])?;
+                            let mut logits =
+                                forward_compiled(&next_ids, &embedding_weight)?;
+                            profiler.end();
 
-                        profiler.begin("rep_penalty");
-                        logits = apply_all_penalties(logits, &token_history, &p)?;
-                        profiler.end();
+                            profiler.begin("rep_penalty");
+                            logits = apply_all_penalties(logits, &token_history, &p)?;
+                            profiler.end();
 
-                        profiler.begin("sample");
-                        let next_token = sample(&logits, p.sampling_config)?;
-                        profiler.end();
+                            profiler.begin("sample");
+                            let next_token = sample(&logits, p.sampling_config)?;
+                            profiler.end();
 
-                        profiler.begin("eval_caches");
-                        eval_token_and_compiled_caches(&next_token);
-                        profiler.end();
+                            profiler.begin("eval_caches");
+                            eval_token_and_compiled_caches(&next_token);
+                            profiler.end();
 
-                        Some(next_token)
+                            Some(next_token)
+                        }
                     } else {
                         None
                     };
@@ -1366,6 +1410,7 @@ impl Qwen3_5Model {
 
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
+                    reasoning_tracker.observe_token(token_id);
 
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
@@ -1433,6 +1478,14 @@ impl Qwen3_5Model {
                 // Build next step's graph before blocking on current token.
                 profiler.set_label("chat_rust");
 
+                let starts_in_thinking =
+                    enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let mut reasoning_tracker = chat_common::ReasoningTracker::new(
+                    starts_in_thinking,
+                    p.thinking_token_budget,
+                    think_end_id,
+                );
+
                 // Kick off first token's async eval
                 MxArray::async_eval_arrays(&[&y]);
 
@@ -1440,35 +1493,42 @@ impl Qwen3_5Model {
                     // Build NEXT step's graph BEFORE blocking on current token.
                     let mut next_y_opt: Option<MxArray> = None;
                     if step + 1 < max_new_tokens {
-                        let _stream_ctx = StreamContext::new(generation_stream);
+                        if reasoning_tracker.should_force_think_end() {
+                            let forced_id = reasoning_tracker.forced_token_id() as i32;
+                            let forced = MxArray::from_int32(&[forced_id], &[1])?;
+                            MxArray::async_eval_arrays(&[&forced]);
+                            next_y_opt = Some(forced);
+                        } else {
+                            let _stream_ctx = StreamContext::new(generation_stream);
 
-                        profiler.begin("forward");
-                        let next_ids = y.reshape(&[1, 1])?;
-                        let logits = forward_inner(
-                            &next_ids,
-                            &embedding_weight,
-                            &mut layers_guard,
-                            &mut caches_guard,
-                            &final_norm_guard,
-                            &lm_head_guard,
-                            Some(&embedding_weight_t),
-                        )?;
-                        let mut logits = logits.squeeze(Some(&[1]))?;
-                        profiler.end();
+                            profiler.begin("forward");
+                            let next_ids = y.reshape(&[1, 1])?;
+                            let logits = forward_inner(
+                                &next_ids,
+                                &embedding_weight,
+                                &mut layers_guard,
+                                &mut caches_guard,
+                                &final_norm_guard,
+                                &lm_head_guard,
+                                Some(&embedding_weight_t),
+                            )?;
+                            let mut logits = logits.squeeze(Some(&[1]))?;
+                            profiler.end();
 
-                        profiler.begin("rep_penalty");
-                        logits = apply_all_penalties(logits, &token_history, &p)?;
-                        profiler.end();
+                            profiler.begin("rep_penalty");
+                            logits = apply_all_penalties(logits, &token_history, &p)?;
+                            profiler.end();
 
-                        profiler.begin("sample");
-                        let next_token = sample(&logits, p.sampling_config)?;
-                        profiler.end();
+                            profiler.begin("sample");
+                            let next_token = sample(&logits, p.sampling_config)?;
+                            profiler.end();
 
-                        profiler.begin("async_eval");
-                        MxArray::async_eval_arrays(&[&next_token]);
-                        profiler.end();
+                            profiler.begin("async_eval");
+                            MxArray::async_eval_arrays(&[&next_token]);
+                            profiler.end();
 
-                        next_y_opt = Some(next_token);
+                            next_y_opt = Some(next_token);
+                        }
                     }
 
                     // Block on the CURRENT token
@@ -1486,6 +1546,7 @@ impl Qwen3_5Model {
 
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
+                    reasoning_tracker.observe_token(token_id);
 
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
@@ -1551,6 +1612,7 @@ impl Qwen3_5Model {
                 think_end_id,
                 think_end_str.as_deref(),
                 performance,
+                p.include_reasoning,
             )
         })
         .await
@@ -1588,6 +1650,9 @@ impl Qwen3_5Model {
             ngram_size: None,
             tools: None,
             enable_thinking: None,
+            thinking_token_budget: None,
+            include_reasoning: None,
+            reasoning_effort: None,
             report_performance: None,
             reuse_cache: None,
         });
@@ -1683,7 +1748,11 @@ impl Qwen3_5Model {
                     };
 
                     let tool_defs = config.tools.as_deref();
-                    let enable_thinking = config.enable_thinking;
+                    let enable_thinking = match config.reasoning_effort.as_deref() {
+                Some("low") | Some("none") => Some(false),
+                Some("medium") | Some("high") => Some(true),
+                _ => config.enable_thinking,
+            };
                     let tokens = tokenizer.apply_chat_template_sync(
                         &messages,
                         Some(true),
@@ -1709,6 +1778,8 @@ impl Qwen3_5Model {
                         top_p: config.top_p,
                         min_p: config.min_p,
                     });
+                    let thinking_token_budget = config.thinking_token_budget;
+                    let include_reasoning = config.include_reasoning.unwrap_or(true);
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -2067,39 +2138,59 @@ impl Qwen3_5Model {
 
                         // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("chat_stream_compiled");
+
+                        let starts_in_thinking =
+                            enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                        let mut reasoning_tracker = chat_common::ReasoningTracker::new(
+                            starts_in_thinking,
+                            thinking_token_budget,
+                            think_end_id,
+                        );
+
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
-                                let _stream_ctx = StreamContext::new(generation_stream);
-                                let next_ids = y.reshape(&[1, 1])?;
-                                let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
-                                if repetition_penalty != 1.0 {
-                                    logits = apply_repetition_penalty(
-                                        &logits,
-                                        &token_history,
-                                        repetition_penalty,
-                                        Some(repetition_context_size),
-                                    )?;
+                                if reasoning_tracker.should_force_think_end() {
+                                    let forced_id =
+                                        reasoning_tracker.forced_token_id() as i32;
+                                    let forced =
+                                        MxArray::from_int32(&[forced_id], &[1])?;
+                                    eval_token_and_compiled_caches(&forced);
+                                    Some(forced)
+                                } else {
+                                    let _stream_ctx =
+                                        StreamContext::new(generation_stream);
+                                    let next_ids = y.reshape(&[1, 1])?;
+                                    let mut logits =
+                                        forward_compiled(&next_ids, &embedding_weight)?;
+                                    if repetition_penalty != 1.0 {
+                                        logits = apply_repetition_penalty(
+                                            &logits,
+                                            &token_history,
+                                            repetition_penalty,
+                                            Some(repetition_context_size),
+                                        )?;
+                                    }
+                                    if presence_penalty != 0.0 {
+                                        logits = apply_presence_penalty(
+                                            &logits,
+                                            &token_history,
+                                            presence_penalty,
+                                            Some(presence_context_size),
+                                        )?;
+                                    }
+                                    if frequency_penalty != 0.0 {
+                                        logits = apply_frequency_penalty(
+                                            &logits,
+                                            &token_history,
+                                            frequency_penalty,
+                                            Some(frequency_context_size),
+                                        )?;
+                                    }
+                                    let next_token = sample(&logits, sampling_config)?;
+                                    eval_token_and_compiled_caches(&next_token);
+                                    Some(next_token)
                                 }
-                                if presence_penalty != 0.0 {
-                                    logits = apply_presence_penalty(
-                                        &logits,
-                                        &token_history,
-                                        presence_penalty,
-                                        Some(presence_context_size),
-                                    )?;
-                                }
-                                if frequency_penalty != 0.0 {
-                                    logits = apply_frequency_penalty(
-                                        &logits,
-                                        &token_history,
-                                        frequency_penalty,
-                                        Some(frequency_context_size),
-                                    )?;
-                                }
-                                let next_token = sample(&logits, sampling_config)?;
-                                eval_token_and_compiled_caches(&next_token);
-                                Some(next_token)
                             } else {
                                 None
                             };
@@ -2119,6 +2210,8 @@ impl Qwen3_5Model {
                                 break;
                             }
 
+                            let is_reasoning = reasoning_tracker.observe_token(token_id);
+
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
                                 tokenizer_for_decode.inner(),
@@ -2137,6 +2230,7 @@ impl Qwen3_5Model {
                                     num_tokens: None,
                                     raw_text: None,
                                     performance: None,
+                                    is_reasoning: Some(is_reasoning),
                                 }),
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
@@ -2207,48 +2301,67 @@ impl Qwen3_5Model {
                     } else {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("chat_stream_rust");
+
+                        let starts_in_thinking =
+                            enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                        let mut reasoning_tracker = chat_common::ReasoningTracker::new(
+                            starts_in_thinking,
+                            thinking_token_budget,
+                            think_end_id,
+                        );
+
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
-                                let _stream_ctx = StreamContext::new(generation_stream);
-                                let next_ids = y.reshape(&[1, 1])?;
-                                let logits = forward_inner(
-                                    &next_ids,
-                                    &embedding_weight,
-                                    &mut layers_guard,
-                                    &mut caches_guard,
-                                    &final_norm_guard,
-                                    &lm_head_guard,
-                                    Some(&embedding_weight_t),
-                                )?;
-                                let mut logits = logits.squeeze(Some(&[1]))?;
-                                if repetition_penalty != 1.0 {
-                                    logits = apply_repetition_penalty(
-                                        &logits,
-                                        &token_history,
-                                        repetition_penalty,
-                                        Some(repetition_context_size),
+                                if reasoning_tracker.should_force_think_end() {
+                                    let forced_id =
+                                        reasoning_tracker.forced_token_id() as i32;
+                                    let forced =
+                                        MxArray::from_int32(&[forced_id], &[1])?;
+                                    MxArray::async_eval_arrays(&[&forced]);
+                                    Some(forced)
+                                } else {
+                                    let _stream_ctx =
+                                        StreamContext::new(generation_stream);
+                                    let next_ids = y.reshape(&[1, 1])?;
+                                    let logits = forward_inner(
+                                        &next_ids,
+                                        &embedding_weight,
+                                        &mut layers_guard,
+                                        &mut caches_guard,
+                                        &final_norm_guard,
+                                        &lm_head_guard,
+                                        Some(&embedding_weight_t),
                                     )?;
+                                    let mut logits = logits.squeeze(Some(&[1]))?;
+                                    if repetition_penalty != 1.0 {
+                                        logits = apply_repetition_penalty(
+                                            &logits,
+                                            &token_history,
+                                            repetition_penalty,
+                                            Some(repetition_context_size),
+                                        )?;
+                                    }
+                                    if presence_penalty != 0.0 {
+                                        logits = apply_presence_penalty(
+                                            &logits,
+                                            &token_history,
+                                            presence_penalty,
+                                            Some(presence_context_size),
+                                        )?;
+                                    }
+                                    if frequency_penalty != 0.0 {
+                                        logits = apply_frequency_penalty(
+                                            &logits,
+                                            &token_history,
+                                            frequency_penalty,
+                                            Some(frequency_context_size),
+                                        )?;
+                                    }
+                                    let next_token = sample(&logits, sampling_config)?;
+                                    MxArray::async_eval_arrays(&[&next_token]);
+                                    Some(next_token)
                                 }
-                                if presence_penalty != 0.0 {
-                                    logits = apply_presence_penalty(
-                                        &logits,
-                                        &token_history,
-                                        presence_penalty,
-                                        Some(presence_context_size),
-                                    )?;
-                                }
-                                if frequency_penalty != 0.0 {
-                                    logits = apply_frequency_penalty(
-                                        &logits,
-                                        &token_history,
-                                        frequency_penalty,
-                                        Some(frequency_context_size),
-                                    )?;
-                                }
-                                let next_token = sample(&logits, sampling_config)?;
-                                MxArray::async_eval_arrays(&[&next_token]);
-                                Some(next_token)
                             } else {
                                 None
                             };
@@ -2268,6 +2381,8 @@ impl Qwen3_5Model {
                                 break;
                             }
 
+                            let is_reasoning = reasoning_tracker.observe_token(token_id);
+
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
                                 tokenizer_for_decode.inner(),
@@ -2286,6 +2401,7 @@ impl Qwen3_5Model {
                                     num_tokens: None,
                                     raw_text: None,
                                     performance: None,
+                                    is_reasoning: Some(is_reasoning),
                                 }),
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
@@ -2385,6 +2501,7 @@ impl Qwen3_5Model {
                                 num_tokens: None,
                                 raw_text: None,
                                 performance: None,
+                                is_reasoning: None,
                             }),
                             ThreadsafeFunctionCallMode::NonBlocking,
                         );
@@ -2399,6 +2516,7 @@ impl Qwen3_5Model {
                     };
                     let (clean_text, tool_calls, thinking) =
                         tools::split_at_think_end(&text, think_tag);
+                    let thinking = if include_reasoning { thinking } else { None };
 
                     // If we have valid tool calls, override finish reason
                     let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
@@ -2445,6 +2563,7 @@ impl Qwen3_5Model {
                             num_tokens: Some(num_tokens),
                             raw_text: Some(text),
                             performance: perf_metrics,
+                            is_reasoning: None,
                         }),
                         ThreadsafeFunctionCallMode::NonBlocking,
                     );

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2531,15 +2531,22 @@ impl Qwen3_5Model {
 
                     let num_tokens = generated_tokens.len() as u32;
 
-                    let think_tag = if starts_in_thinking
-                        && tools::has_think_end_token(&generated_tokens, think_end_id)
+                    let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
+                        let (clean, calls) = tools::parse_tool_calls(&text);
+                        (clean, calls, None)
+                    } else if tools::has_think_end_token(&generated_tokens, think_end_id)
                     {
-                        think_end_str.as_deref()
+                        tools::split_at_think_end(&text, think_end_str.as_deref())
                     } else {
-                        None
+                        let t = text.trim();
+                        let t = t.strip_prefix("<think>").unwrap_or(t).trim();
+                        let thinking = if t.is_empty() {
+                            None
+                        } else {
+                            Some(t.to_string())
+                        };
+                        (String::new(), vec![], thinking)
                     };
-                    let (clean_text, tool_calls, thinking) =
-                        tools::split_at_think_end(&text, think_tag);
                     let thinking = if include_reasoning { thinking } else { None };
 
                     // If we have valid tool calls, override finish reason

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1351,8 +1351,7 @@ impl Qwen3_5Model {
                 // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                 profiler.set_label("chat_compiled");
 
-                let starts_in_thinking =
-                    enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
                 let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                     starts_in_thinking,
                     p.thinking_token_budget,
@@ -1368,12 +1367,10 @@ impl Qwen3_5Model {
 
                         profiler.begin("forward");
                         let next_ids = y.reshape(&[1, 1])?;
-                        let mut logits =
-                            forward_compiled(&next_ids, &embedding_weight)?;
+                        let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
                         profiler.end();
 
-                        let next_token = if reasoning_tracker.should_force_think_end()
-                        {
+                        let next_token = if reasoning_tracker.should_force_think_end() {
                             let forced_id = reasoning_tracker.forced_token_id() as i32;
                             MxArray::from_int32(&[forced_id], &[1])?
                         } else {
@@ -1479,8 +1476,7 @@ impl Qwen3_5Model {
                 // Build next step's graph before blocking on current token.
                 profiler.set_label("chat_rust");
 
-                let starts_in_thinking =
-                    enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
                 let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                     starts_in_thinking,
                     p.thinking_token_budget,
@@ -1608,8 +1604,7 @@ impl Qwen3_5Model {
                 generated_tokens.len(),
             );
 
-            let starts_in_thinking =
-                enable_thinking.unwrap_or(true) && think_end_id.is_some();
+            let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
             finalize_chat_result(
                 &tokenizer_for_decode,
                 &generated_tokens,
@@ -1755,10 +1750,10 @@ impl Qwen3_5Model {
 
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = match config.reasoning_effort.as_deref() {
-                Some("low") | Some("none") => Some(false),
-                Some("medium") | Some("high") => Some(true),
-                _ => config.enable_thinking,
-            };
+                        Some("low") | Some("none") => Some(false),
+                        Some("medium") | Some("high") => Some(true),
+                        _ => config.enable_thinking,
+                    };
                     let tokens = tokenizer.apply_chat_template_sync(
                         &messages,
                         Some(true),
@@ -1785,9 +1780,9 @@ impl Qwen3_5Model {
                         min_p: config.min_p,
                     });
                     let thinking_token_budget = config.thinking_token_budget;
-                    let include_reasoning = config.include_reasoning.unwrap_or_else(|| {
-                        !matches!(config.reasoning_effort.as_deref(), Some("none"))
-                    });
+                    let include_reasoning = config
+                        .include_reasoning
+                        .unwrap_or(!matches!(config.reasoning_effort.as_deref(), Some("none")));
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -2158,51 +2153,44 @@ impl Qwen3_5Model {
                             thinking_token_budget,
                             think_end_id,
                         );
-                        // Use outer last_is_reasoning (shared with residual flush)
-                        last_is_reasoning = starts_in_thinking;
-
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < max_new_tokens {
-                                let _stream_ctx =
-                                    StreamContext::new(generation_stream);
+                                let _stream_ctx = StreamContext::new(generation_stream);
                                 let next_ids = y.reshape(&[1, 1])?;
-                                let mut logits =
-                                    forward_compiled(&next_ids, &embedding_weight)?;
+                                let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
 
-                                let next_token =
-                                    if reasoning_tracker.should_force_think_end() {
-                                        let forced_id =
-                                            reasoning_tracker.forced_token_id() as i32;
-                                        MxArray::from_int32(&[forced_id], &[1])?
-                                    } else {
-                                        if repetition_penalty != 1.0 {
-                                            logits = apply_repetition_penalty(
-                                                &logits,
-                                                &token_history,
-                                                repetition_penalty,
-                                                Some(repetition_context_size),
-                                            )?;
-                                        }
-                                        if presence_penalty != 0.0 {
-                                            logits = apply_presence_penalty(
-                                                &logits,
-                                                &token_history,
-                                                presence_penalty,
-                                                Some(presence_context_size),
-                                            )?;
-                                        }
-                                        if frequency_penalty != 0.0 {
-                                            logits = apply_frequency_penalty(
-                                                &logits,
-                                                &token_history,
-                                                frequency_penalty,
-                                                Some(frequency_context_size),
-                                            )?;
-                                        }
-                                        sample(&logits, sampling_config)?
-                                    };
+                                let next_token = if reasoning_tracker.should_force_think_end() {
+                                    let forced_id = reasoning_tracker.forced_token_id() as i32;
+                                    MxArray::from_int32(&[forced_id], &[1])?
+                                } else {
+                                    if repetition_penalty != 1.0 {
+                                        logits = apply_repetition_penalty(
+                                            &logits,
+                                            &token_history,
+                                            repetition_penalty,
+                                            Some(repetition_context_size),
+                                        )?;
+                                    }
+                                    if presence_penalty != 0.0 {
+                                        logits = apply_presence_penalty(
+                                            &logits,
+                                            &token_history,
+                                            presence_penalty,
+                                            Some(presence_context_size),
+                                        )?;
+                                    }
+                                    if frequency_penalty != 0.0 {
+                                        logits = apply_frequency_penalty(
+                                            &logits,
+                                            &token_history,
+                                            frequency_penalty,
+                                            Some(frequency_context_size),
+                                        )?;
+                                    }
+                                    sample(&logits, sampling_config)?
+                                };
 
                                 eval_token_and_compiled_caches(&next_token);
                                 Some(next_token)
@@ -2325,15 +2313,11 @@ impl Qwen3_5Model {
                             thinking_token_budget,
                             think_end_id,
                         );
-                        // Use outer last_is_reasoning (shared with residual flush)
-                        last_is_reasoning = starts_in_thinking;
-
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < max_new_tokens {
-                                let _stream_ctx =
-                                    StreamContext::new(generation_stream);
+                                let _stream_ctx = StreamContext::new(generation_stream);
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let logits = forward_inner(
                                     &next_ids,
@@ -2346,38 +2330,36 @@ impl Qwen3_5Model {
                                 )?;
                                 let mut logits = logits.squeeze(Some(&[1]))?;
 
-                                let next_token =
-                                    if reasoning_tracker.should_force_think_end() {
-                                        let forced_id =
-                                            reasoning_tracker.forced_token_id() as i32;
-                                        MxArray::from_int32(&[forced_id], &[1])?
-                                    } else {
-                                        if repetition_penalty != 1.0 {
-                                            logits = apply_repetition_penalty(
-                                                &logits,
-                                                &token_history,
-                                                repetition_penalty,
-                                                Some(repetition_context_size),
-                                            )?;
-                                        }
-                                        if presence_penalty != 0.0 {
-                                            logits = apply_presence_penalty(
-                                                &logits,
-                                                &token_history,
-                                                presence_penalty,
-                                                Some(presence_context_size),
-                                            )?;
-                                        }
-                                        if frequency_penalty != 0.0 {
-                                            logits = apply_frequency_penalty(
-                                                &logits,
-                                                &token_history,
-                                                frequency_penalty,
-                                                Some(frequency_context_size),
-                                            )?;
-                                        }
-                                        sample(&logits, sampling_config)?
-                                    };
+                                let next_token = if reasoning_tracker.should_force_think_end() {
+                                    let forced_id = reasoning_tracker.forced_token_id() as i32;
+                                    MxArray::from_int32(&[forced_id], &[1])?
+                                } else {
+                                    if repetition_penalty != 1.0 {
+                                        logits = apply_repetition_penalty(
+                                            &logits,
+                                            &token_history,
+                                            repetition_penalty,
+                                            Some(repetition_context_size),
+                                        )?;
+                                    }
+                                    if presence_penalty != 0.0 {
+                                        logits = apply_presence_penalty(
+                                            &logits,
+                                            &token_history,
+                                            presence_penalty,
+                                            Some(presence_context_size),
+                                        )?;
+                                    }
+                                    if frequency_penalty != 0.0 {
+                                        logits = apply_frequency_penalty(
+                                            &logits,
+                                            &token_history,
+                                            frequency_penalty,
+                                            Some(frequency_context_size),
+                                        )?;
+                                    }
+                                    sample(&logits, sampling_config)?
+                                };
 
                                 // Eval next_token and logits to ensure the forward
                                 // graph (including KV cache updates) is materialized.
@@ -2534,8 +2516,7 @@ impl Qwen3_5Model {
                     let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
                         let (clean, calls) = tools::parse_tool_calls(&text);
                         (clean, calls, None)
-                    } else if tools::has_think_end_token(&generated_tokens, think_end_id)
-                    {
+                    } else if tools::has_think_end_token(&generated_tokens, think_end_id) {
                         tools::split_at_think_end(&text, think_end_str.as_deref())
                     } else {
                         let t = text.trim();

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1344,7 +1344,7 @@ impl Qwen3_5Model {
                 // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                 profiler.set_label("chat_compiled");
 
-                let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let starts_in_thinking = enable_thinking.unwrap_or(true);
                 let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                     starts_in_thinking,
                     p.thinking_token_budget,
@@ -1476,7 +1476,7 @@ impl Qwen3_5Model {
                 // Build next step's graph before blocking on current token.
                 profiler.set_label("chat_rust");
 
-                let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let starts_in_thinking = enable_thinking.unwrap_or(true);
                 let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                     starts_in_thinking,
                     p.thinking_token_budget,
@@ -2057,8 +2057,7 @@ impl Qwen3_5Model {
                         None
                     };
 
-                    let starts_in_thinking =
-                        enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                    let starts_in_thinking = enable_thinking.unwrap_or(true);
                     let mut last_is_reasoning = starts_in_thinking;
 
                     if use_compiled {
@@ -2140,8 +2139,7 @@ impl Qwen3_5Model {
                         // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("chat_stream_compiled");
 
-                        let starts_in_thinking =
-                            enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                        let starts_in_thinking = enable_thinking.unwrap_or(true);
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
                             thinking_token_budget,
@@ -2304,8 +2302,7 @@ impl Qwen3_5Model {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("chat_stream_rust");
 
-                        let starts_in_thinking =
-                            enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                        let starts_in_thinking = enable_thinking.unwrap_or(true);
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
                             thinking_token_budget,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -13,10 +13,7 @@ use tracing::{info, warn};
 use crate::array::MxArray;
 use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
 use crate::nn::{Embedding, Linear, RMSNorm};
-use crate::sampling::{
-    SamplingConfig, apply_frequency_penalty, apply_presence_penalty, apply_repetition_penalty,
-    check_repetition_cutoff, sample,
-};
+use crate::sampling::{SamplingConfig, check_repetition_cutoff, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::tools::ToolCallResult;
@@ -1757,24 +1754,7 @@ impl Qwen3_5Model {
 
                     let mut first_token_instant: Option<std::time::Instant> = None;
 
-                    let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
-                    let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
-                    let repetition_context_size = config.repetition_context_size.unwrap_or(256);
-                    let presence_penalty = config.presence_penalty.unwrap_or(0.0);
-                    let presence_context_size = config.presence_context_size.unwrap_or(20);
-                    let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
-                    let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-                    let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-                    let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-                    let ngram_size = config.ngram_size.unwrap_or(64);
-                    let sampling_config = Some(SamplingConfig {
-                        temperature: config.temperature,
-                        top_k: config.top_k,
-                        top_p: config.top_p,
-                        min_p: config.min_p,
-                    });
-                    let thinking_token_budget = config.thinking_token_budget;
-                    let include_reasoning = chat_common::resolve_include_reasoning(&config);
+                    let p = chat_common::extract_chat_params(&config);
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -1968,7 +1948,7 @@ impl Qwen3_5Model {
                                     &final_norm_guard,
                                     &lm_head_guard,
                                     &model_config,
-                                    max_new_tokens,
+                                    p.max_new_tokens,
                                     generation_stream,
                                     &vision_cache_stream,
                                     model_id,
@@ -2020,33 +2000,10 @@ impl Qwen3_5Model {
                     // Track token history for repetition penalty
                     let mut token_history: Vec<u32> = tokens.clone();
 
-                    // Apply repetition penalty to prefill logits
-                    if repetition_penalty != 1.0 && !token_history.is_empty() {
-                        last_logits = apply_repetition_penalty(
-                            &last_logits,
-                            &token_history,
-                            repetition_penalty,
-                            Some(repetition_context_size),
-                        )?;
-                    }
-                    if presence_penalty != 0.0 {
-                        last_logits = apply_presence_penalty(
-                            &last_logits,
-                            &token_history,
-                            presence_penalty,
-                            Some(presence_context_size),
-                        )?;
-                    }
-                    if frequency_penalty != 0.0 {
-                        last_logits = apply_frequency_penalty(
-                            &last_logits,
-                            &token_history,
-                            frequency_penalty,
-                            Some(frequency_context_size),
-                        )?;
-                    }
+                    // Apply penalties to prefill logits
+                    last_logits = apply_all_penalties(last_logits, &token_history, &p)?;
 
-                    let mut y = sample(&last_logits, sampling_config)?;
+                    let mut y = sample(&last_logits, p.sampling_config)?;
                     MxArray::async_eval_arrays(&[&y]);
 
                     let _compiled_guard = if use_compiled {
@@ -2069,7 +2026,7 @@ impl Qwen3_5Model {
                         } else {
                             use mlx_sys as sys;
                             let prefill_len = seq_len as i32;
-                            let max_kv_len = ((prefill_len + max_new_tokens + 255) / 256) * 256;
+                            let max_kv_len = ((prefill_len + p.max_new_tokens + 255) / 256) * 256;
                             let num_layers = model_config.num_layers as usize;
                             let mut cache_ptrs: Vec<*mut sys::mlx_array> =
                                 vec![std::ptr::null_mut(); num_layers * 2];
@@ -2139,13 +2096,13 @@ impl Qwen3_5Model {
 
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
-                            thinking_token_budget,
+                            p.thinking_token_budget,
                             think_end_id,
                         );
-                        for step in 0..max_new_tokens {
+                        for step in 0..p.max_new_tokens {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
-                            let next_y = if step + 1 < max_new_tokens {
+                            let next_y = if step + 1 < p.max_new_tokens {
                                 let _stream_ctx = StreamContext::new(generation_stream);
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
@@ -2155,31 +2112,8 @@ impl Qwen3_5Model {
                                         let forced_id = reasoning_tracker.forced_token_id() as i32;
                                         (MxArray::from_int32(&[forced_id], &[1])?, true)
                                     } else {
-                                        if repetition_penalty != 1.0 {
-                                            logits = apply_repetition_penalty(
-                                                &logits,
-                                                &token_history,
-                                                repetition_penalty,
-                                                Some(repetition_context_size),
-                                            )?;
-                                        }
-                                        if presence_penalty != 0.0 {
-                                            logits = apply_presence_penalty(
-                                                &logits,
-                                                &token_history,
-                                                presence_penalty,
-                                                Some(presence_context_size),
-                                            )?;
-                                        }
-                                        if frequency_penalty != 0.0 {
-                                            logits = apply_frequency_penalty(
-                                                &logits,
-                                                &token_history,
-                                                frequency_penalty,
-                                                Some(frequency_context_size),
-                                            )?;
-                                        }
-                                        (sample(&logits, sampling_config)?, false)
+                                        logits = apply_all_penalties(logits, &token_history, &p)?;
+                                        (sample(&logits, p.sampling_config)?, false)
                                     };
 
                                 eval_token_and_compiled_caches(&next_token);
@@ -2195,7 +2129,7 @@ impl Qwen3_5Model {
                             y.eval();
                             let token_id = y.item_at_int32(0)? as u32;
                             profiler.mark_first_token();
-                            if report_perf && first_token_instant.is_none() {
+                            if p.report_performance && first_token_instant.is_none() {
                                 first_token_instant = Some(std::time::Instant::now());
                             }
                             generated_tokens.push(token_id);
@@ -2239,9 +2173,9 @@ impl Qwen3_5Model {
 
                             if let Some(reason) = check_repetition_cutoff(
                                 &generated_tokens,
-                                max_consecutive_tokens,
-                                max_ngram_repeats,
-                                ngram_size,
+                                p.max_consecutive_tokens,
+                                p.max_ngram_repeats,
+                                p.ngram_size,
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
@@ -2301,13 +2235,13 @@ impl Qwen3_5Model {
 
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
-                            thinking_token_budget,
+                            p.thinking_token_budget,
                             think_end_id,
                         );
-                        for step in 0..max_new_tokens {
+                        for step in 0..p.max_new_tokens {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
-                            let next_y = if step + 1 < max_new_tokens {
+                            let next_y = if step + 1 < p.max_new_tokens {
                                 let _stream_ctx = StreamContext::new(generation_stream);
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let logits = forward_inner(
@@ -2325,31 +2259,8 @@ impl Qwen3_5Model {
                                     let forced_id = reasoning_tracker.forced_token_id() as i32;
                                     MxArray::from_int32(&[forced_id], &[1])?
                                 } else {
-                                    if repetition_penalty != 1.0 {
-                                        logits = apply_repetition_penalty(
-                                            &logits,
-                                            &token_history,
-                                            repetition_penalty,
-                                            Some(repetition_context_size),
-                                        )?;
-                                    }
-                                    if presence_penalty != 0.0 {
-                                        logits = apply_presence_penalty(
-                                            &logits,
-                                            &token_history,
-                                            presence_penalty,
-                                            Some(presence_context_size),
-                                        )?;
-                                    }
-                                    if frequency_penalty != 0.0 {
-                                        logits = apply_frequency_penalty(
-                                            &logits,
-                                            &token_history,
-                                            frequency_penalty,
-                                            Some(frequency_context_size),
-                                        )?;
-                                    }
-                                    sample(&logits, sampling_config)?
+                                    logits = apply_all_penalties(logits, &token_history, &p)?;
+                                    sample(&logits, p.sampling_config)?
                                 };
 
                                 // Eval next_token and logits to ensure the forward
@@ -2364,7 +2275,7 @@ impl Qwen3_5Model {
                             y.eval();
                             let token_id = y.item_at_int32(0)? as u32;
                             profiler.mark_first_token();
-                            if report_perf && first_token_instant.is_none() {
+                            if p.report_performance && first_token_instant.is_none() {
                                 first_token_instant = Some(std::time::Instant::now());
                             }
                             generated_tokens.push(token_id);
@@ -2408,9 +2319,9 @@ impl Qwen3_5Model {
 
                             if let Some(reason) = check_repetition_cutoff(
                                 &generated_tokens,
-                                max_consecutive_tokens,
-                                max_ngram_repeats,
-                                ngram_size,
+                                p.max_consecutive_tokens,
+                                p.max_ngram_repeats,
+                                p.ngram_size,
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
@@ -2510,7 +2421,7 @@ impl Qwen3_5Model {
                         enable_thinking.unwrap_or(true),
                         think_end_id,
                         think_end_str.as_deref(),
-                        include_reasoning,
+                        p.include_reasoning,
                     );
 
                     // If we have valid tool calls, override finish reason

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1348,94 +1348,33 @@ impl Qwen3_5Model {
                     think_end_id,
                 );
 
-                for step in 0..max_new_tokens {
-                    // Build and submit graph for step N+1 before waiting for N.
-                    // forward() always runs to keep KV caches consistent;
-                    // budget enforcement only overrides the sampling step.
-                    let next_y = if step + 1 < max_new_tokens {
-                        let _stream_ctx = StreamContext::new(generation_stream);
-
-                        profiler.begin("forward");
-                        let next_ids = y.reshape(&[1, 1])?;
-                        let mut logits = forward_compiled(&next_ids, &embedding_weight)?;
-                        profiler.end();
-
-                        let (next_token, budget_forced) =
-                            if reasoning_tracker.should_force_think_end() {
-                                let forced_id = reasoning_tracker.forced_token_id() as i32;
-                                (MxArray::from_int32(&[forced_id], &[1])?, true)
-                            } else {
-                                profiler.begin("rep_penalty");
-                                logits = apply_all_penalties(logits, &token_history, &p)?;
-                                profiler.end();
-
-                                profiler.begin("sample");
-                                let t = sample(&logits, p.sampling_config)?;
-                                profiler.end();
-                                (t, false)
-                            };
-
-                        profiler.begin("eval_caches");
-                        eval_token_and_compiled_caches(&next_token);
-                        profiler.end();
+                let mut ops = chat_common::DecodeOps {
+                    forward: |ids: &MxArray, emb: &MxArray| -> Result<(MxArray, bool)> {
+                        Ok((forward_compiled(ids, emb)?, false))
+                    },
+                    eval_step: |token: &MxArray, logits: &MxArray, budget_forced: bool| {
+                        eval_token_and_compiled_caches(token);
                         if budget_forced {
-                            // next_token is a constant with no graph dependency on
-                            // forward_compiled. Eval logits to ensure the forward
-                            // graph and KV cache updates are materialized.
                             logits.eval();
                         }
-
-                        Some(next_token)
-                    } else {
-                        None
-                    };
-
-                    // Wait for step N (GPU already computing N+1)
-                    profiler.begin("eval_token");
-                    y.eval();
-                    profiler.end();
-
-                    profiler.begin("extract");
-                    let token_id = y.item_at_int32(0)? as u32;
-                    profiler.end();
-                    profiler.mark_first_token();
-                    if p.report_performance && first_token_instant.is_none() {
-                        first_token_instant = Some(std::time::Instant::now());
-                    }
-
-                    generated_tokens.push(token_id);
-                    token_history.push(token_id);
-                    reasoning_tracker.observe_token(token_id);
-
-                    if token_id == eos_id {
-                        finish_reason = String::from("stop");
-                        break;
-                    }
-
-                    if let Some(reason) = check_repetition_cutoff(
-                        &generated_tokens,
-                        p.max_consecutive_tokens,
-                        p.max_ngram_repeats,
-                        p.ngram_size,
-                    ) {
-                        finish_reason = reason.to_string();
-                        break;
-                    }
-
-                    match next_y {
-                        Some(next) => y = next,
-                        None => break,
-                    }
-
-                    profiler.step();
-
-                    if (step + 1) % 256 == 0 {
-                        crate::array::synchronize_and_clear_cache();
-                    }
-                }
-
-                profiler.snapshot_memory_after();
-                profiler.report();
+                    },
+                };
+                chat_common::decode_loop!(
+                    ops: ops,
+                    y: y,
+                    embedding_weight: embedding_weight,
+                    params: p,
+                    reasoning_tracker: reasoning_tracker,
+                    profiler: profiler,
+                    max_new_tokens: max_new_tokens,
+                    eos_id: eos_id,
+                    generated_tokens: generated_tokens,
+                    token_history: token_history,
+                    finish_reason: finish_reason,
+                    first_token_instant: first_token_instant,
+                    report_perf: p.report_performance,
+                    generation_stream: generation_stream
+                );
 
                 // === Export caches from C++ before CompiledResetGuard drops ===
                 if reuse_cache {
@@ -1483,97 +1422,39 @@ impl Qwen3_5Model {
                 // Kick off first token's async eval
                 MxArray::async_eval_arrays(&[&y]);
 
-                for step in 0..max_new_tokens {
-                    // Build NEXT step's graph BEFORE blocking on current token.
-                    // forward() always runs to keep KV caches consistent.
-                    let mut next_y_opt: Option<MxArray> = None;
-                    if step + 1 < max_new_tokens {
-                        let _stream_ctx = StreamContext::new(generation_stream);
-
-                        profiler.begin("forward");
-                        let next_ids = y.reshape(&[1, 1])?;
+                let mut ops = chat_common::DecodeOps {
+                    forward: |ids: &MxArray, emb: &MxArray| -> Result<(MxArray, bool)> {
                         let logits = forward_inner(
-                            &next_ids,
-                            &embedding_weight,
+                            ids,
+                            emb,
                             &mut layers_guard,
                             &mut caches_guard,
                             &final_norm_guard,
                             &lm_head_guard,
                             Some(&embedding_weight_t),
                         )?;
-                        let mut logits = logits.squeeze(Some(&[1]))?;
-                        profiler.end();
-
-                        let next_token = if reasoning_tracker.should_force_think_end() {
-                            let forced_id = reasoning_tracker.forced_token_id() as i32;
-                            MxArray::from_int32(&[forced_id], &[1])?
-                        } else {
-                            profiler.begin("rep_penalty");
-                            logits = apply_all_penalties(logits, &token_history, &p)?;
-                            profiler.end();
-
-                            profiler.begin("sample");
-                            let t = sample(&logits, p.sampling_config)?;
-                            profiler.end();
-                            t
-                        };
-
-                        profiler.begin("async_eval");
-                        // Eval both next_token and logits to ensure forward graph
-                        // (including KV cache updates) is materialized.
-                        MxArray::async_eval_arrays(&[&next_token, &logits]);
-                        profiler.end();
-
-                        next_y_opt = Some(next_token);
-                    }
-
-                    // Block on the CURRENT token
-                    profiler.begin("eval_token");
-                    y.eval();
-                    profiler.end();
-
-                    profiler.begin("extract");
-                    let token_id = y.item_at_int32(0)? as u32;
-                    profiler.end();
-                    profiler.mark_first_token();
-                    if p.report_performance && first_token_instant.is_none() {
-                        first_token_instant = Some(std::time::Instant::now());
-                    }
-
-                    generated_tokens.push(token_id);
-                    token_history.push(token_id);
-                    reasoning_tracker.observe_token(token_id);
-
-                    if token_id == eos_id {
-                        finish_reason = String::from("stop");
-                        break;
-                    }
-
-                    if let Some(reason) = check_repetition_cutoff(
-                        &generated_tokens,
-                        p.max_consecutive_tokens,
-                        p.max_ngram_repeats,
-                        p.ngram_size,
-                    ) {
-                        finish_reason = reason.to_string();
-                        break;
-                    }
-
-                    profiler.step();
-
-                    if let Some(next_y) = next_y_opt {
-                        y = next_y;
-                    } else {
-                        break;
-                    }
-
-                    if (step + 1) % 256 == 0 {
-                        crate::array::synchronize_and_clear_cache();
-                    }
-                }
-
-                profiler.snapshot_memory_after();
-                profiler.report();
+                        Ok((logits, true)) // needs squeeze
+                    },
+                    eval_step: |token: &MxArray, logits: &MxArray, _budget_forced: bool| {
+                        MxArray::async_eval_arrays(&[token, logits]);
+                    },
+                };
+                chat_common::decode_loop!(
+                    ops: ops,
+                    y: y,
+                    embedding_weight: embedding_weight,
+                    params: p,
+                    reasoning_tracker: reasoning_tracker,
+                    profiler: profiler,
+                    max_new_tokens: max_new_tokens,
+                    eos_id: eos_id,
+                    generated_tokens: generated_tokens,
+                    token_history: token_history,
+                    finish_reason: finish_reason,
+                    first_token_instant: first_token_instant,
+                    report_perf: p.report_performance,
+                    generation_stream: generation_stream
+                );
             }
 
             // _compiled_guard dropped here (if Some), calling mlx_qwen35_compiled_reset()

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -190,10 +190,13 @@ pub struct ChatConfig {
     pub ngram_size: Option<i32>,
     #[napi(ts_type = "Array<ToolDefinition>")]
     pub tools: Option<Vec<ToolDefinition>>,
-    /// Enable thinking mode (Qwen3's <think> tags). Default: true (model thinks naturally).
-    /// Set to false to suppress thinking by injecting empty <think></think> tags.
-    #[napi(ts_type = "boolean | undefined")]
-    pub enable_thinking: Option<bool>,
+    /// Reasoning effort level. Controls whether the model thinks before answering.
+    /// - "none" / "low": thinking disabled (template injects closed think block).
+    ///   "none" also sets includeReasoning to false by default.
+    /// - "medium" / "high": thinking enabled (default behavior).
+    /// - Not set: thinking enabled (model thinks naturally).
+    #[napi(ts_type = "string | undefined")]
+    pub reasoning_effort: Option<String>,
     /// Maximum number of thinking tokens before forcing </think>.
     /// When the model has generated this many tokens while in thinking mode,
     /// the next token is forced to be the think_end token. None = unlimited.
@@ -201,13 +204,9 @@ pub struct ChatConfig {
     pub thinking_token_budget: Option<i32>,
     /// Whether to include reasoning/thinking content in the output.
     /// When false, the `thinking` field of ChatResult/ChatStreamChunk will always be None.
-    /// Default: true (reasoning is included).
+    /// Default: true (false when reasoningEffort is "none").
     #[napi(ts_type = "boolean | undefined")]
     pub include_reasoning: Option<bool>,
-    /// Reasoning effort level. Overrides `enableThinking` when set:
-    /// "low"/"none" → enableThinking=false, "medium"/"high" → enableThinking=true.
-    #[napi(ts_type = "string | undefined")]
-    pub reasoning_effort: Option<String>,
     /// When true, include performance metrics (TTFT, prefill tok/s, decode tok/s) in the result
     #[napi(ts_type = "boolean | undefined")]
     pub report_performance: Option<bool>,
@@ -941,7 +940,6 @@ impl Qwen3_5Model {
             max_ngram_repeats: None,
             ngram_size: None,
             tools: None,
-            enable_thinking: None,
             thinking_token_budget: None,
             include_reasoning: None,
             reasoning_effort: None,
@@ -1032,11 +1030,7 @@ impl Qwen3_5Model {
             let mut first_token_instant: Option<std::time::Instant> = None;
 
             let tool_defs = config.tools.as_deref();
-            let enable_thinking = match config.reasoning_effort.as_deref() {
-                Some("low") | Some("none") => Some(false),
-                Some("medium") | Some("high") => Some(true),
-                _ => config.enable_thinking,
-            };
+            let enable_thinking = chat_common::resolve_enable_thinking(&config);
             let tokens = tokenizer.apply_chat_template_sync(
                 &messages,
                 Some(true),
@@ -1655,7 +1649,6 @@ impl Qwen3_5Model {
             max_ngram_repeats: None,
             ngram_size: None,
             tools: None,
-            enable_thinking: None,
             thinking_token_budget: None,
             include_reasoning: None,
             reasoning_effort: None,
@@ -1754,11 +1747,7 @@ impl Qwen3_5Model {
                     };
 
                     let tool_defs = config.tools.as_deref();
-                    let enable_thinking = match config.reasoning_effort.as_deref() {
-                        Some("low") | Some("none") => Some(false),
-                        Some("medium") | Some("high") => Some(true),
-                        _ => config.enable_thinking,
-                    };
+                    let enable_thinking = chat_common::resolve_enable_thinking(&config);
                     let tokens = tokenizer.apply_chat_template_sync(
                         &messages,
                         Some(true),

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2532,8 +2532,7 @@ impl Qwen3_5Model {
                     let num_tokens = generated_tokens.len() as u32;
 
                     let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
-                        let stripped = tools::strip_think_markup(&text);
-                        let (clean, calls) = tools::parse_tool_calls(&stripped);
+                        let (clean, calls) = tools::parse_tool_calls(&text);
                         (clean, calls, None)
                     } else if tools::has_think_end_token(&generated_tokens, think_end_id)
                     {

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1360,37 +1360,38 @@ impl Qwen3_5Model {
                 );
 
                 for step in 0..max_new_tokens {
-                    // Build and submit graph for step N+1 before waiting for N
+                    // Build and submit graph for step N+1 before waiting for N.
+                    // forward() always runs to keep KV caches consistent;
+                    // budget enforcement only overrides the sampling step.
                     let next_y = if step + 1 < max_new_tokens {
-                        if reasoning_tracker.should_force_think_end() {
-                            // Budget exhausted — force </think> token
+                        let _stream_ctx = StreamContext::new(generation_stream);
+
+                        profiler.begin("forward");
+                        let next_ids = y.reshape(&[1, 1])?;
+                        let mut logits =
+                            forward_compiled(&next_ids, &embedding_weight)?;
+                        profiler.end();
+
+                        let next_token = if reasoning_tracker.should_force_think_end()
+                        {
                             let forced_id = reasoning_tracker.forced_token_id() as i32;
-                            let forced = MxArray::from_int32(&[forced_id], &[1])?;
-                            eval_token_and_compiled_caches(&forced);
-                            Some(forced)
+                            MxArray::from_int32(&[forced_id], &[1])?
                         } else {
-                            let _stream_ctx = StreamContext::new(generation_stream);
-
-                            profiler.begin("forward");
-                            let next_ids = y.reshape(&[1, 1])?;
-                            let mut logits =
-                                forward_compiled(&next_ids, &embedding_weight)?;
-                            profiler.end();
-
                             profiler.begin("rep_penalty");
                             logits = apply_all_penalties(logits, &token_history, &p)?;
                             profiler.end();
 
                             profiler.begin("sample");
-                            let next_token = sample(&logits, p.sampling_config)?;
+                            let t = sample(&logits, p.sampling_config)?;
                             profiler.end();
+                            t
+                        };
 
-                            profiler.begin("eval_caches");
-                            eval_token_and_compiled_caches(&next_token);
-                            profiler.end();
+                        profiler.begin("eval_caches");
+                        eval_token_and_compiled_caches(&next_token);
+                        profiler.end();
 
-                            Some(next_token)
-                        }
+                        Some(next_token)
                     } else {
                         None
                     };
@@ -1491,44 +1492,46 @@ impl Qwen3_5Model {
 
                 for step in 0..max_new_tokens {
                     // Build NEXT step's graph BEFORE blocking on current token.
+                    // forward() always runs to keep KV caches consistent.
                     let mut next_y_opt: Option<MxArray> = None;
                     if step + 1 < max_new_tokens {
-                        if reasoning_tracker.should_force_think_end() {
+                        let _stream_ctx = StreamContext::new(generation_stream);
+
+                        profiler.begin("forward");
+                        let next_ids = y.reshape(&[1, 1])?;
+                        let logits = forward_inner(
+                            &next_ids,
+                            &embedding_weight,
+                            &mut layers_guard,
+                            &mut caches_guard,
+                            &final_norm_guard,
+                            &lm_head_guard,
+                            Some(&embedding_weight_t),
+                        )?;
+                        let mut logits = logits.squeeze(Some(&[1]))?;
+                        profiler.end();
+
+                        let next_token = if reasoning_tracker.should_force_think_end() {
                             let forced_id = reasoning_tracker.forced_token_id() as i32;
-                            let forced = MxArray::from_int32(&[forced_id], &[1])?;
-                            MxArray::async_eval_arrays(&[&forced]);
-                            next_y_opt = Some(forced);
+                            MxArray::from_int32(&[forced_id], &[1])?
                         } else {
-                            let _stream_ctx = StreamContext::new(generation_stream);
-
-                            profiler.begin("forward");
-                            let next_ids = y.reshape(&[1, 1])?;
-                            let logits = forward_inner(
-                                &next_ids,
-                                &embedding_weight,
-                                &mut layers_guard,
-                                &mut caches_guard,
-                                &final_norm_guard,
-                                &lm_head_guard,
-                                Some(&embedding_weight_t),
-                            )?;
-                            let mut logits = logits.squeeze(Some(&[1]))?;
-                            profiler.end();
-
                             profiler.begin("rep_penalty");
                             logits = apply_all_penalties(logits, &token_history, &p)?;
                             profiler.end();
 
                             profiler.begin("sample");
-                            let next_token = sample(&logits, p.sampling_config)?;
+                            let t = sample(&logits, p.sampling_config)?;
                             profiler.end();
+                            t
+                        };
 
-                            profiler.begin("async_eval");
-                            MxArray::async_eval_arrays(&[&next_token]);
-                            profiler.end();
+                        profiler.begin("async_eval");
+                        // Eval both next_token and logits to ensure forward graph
+                        // (including KV cache updates) is materialized.
+                        MxArray::async_eval_arrays(&[&next_token, &logits]);
+                        profiler.end();
 
-                            next_y_opt = Some(next_token);
-                        }
+                        next_y_opt = Some(next_token);
                     }
 
                     // Block on the CURRENT token
@@ -2060,6 +2063,9 @@ impl Qwen3_5Model {
                         None
                     };
 
+                    let mut last_is_reasoning =
+                        enable_thinking.unwrap_or(true) && think_end_id.is_some();
+
                     if use_compiled {
                         if vlm_compiled_init_done {
                             // VLM prefill already called compiled_init_from_prefill and
@@ -2146,51 +2152,54 @@ impl Qwen3_5Model {
                             thinking_token_budget,
                             think_end_id,
                         );
+                        // Use outer last_is_reasoning (shared with residual flush)
+                        last_is_reasoning = starts_in_thinking;
 
                         for step in 0..max_new_tokens {
-                            // Build and submit graph for step N+1
+                            // Build and submit graph for step N+1.
+                            // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < max_new_tokens {
-                                if reasoning_tracker.should_force_think_end() {
-                                    let forced_id =
-                                        reasoning_tracker.forced_token_id() as i32;
-                                    let forced =
-                                        MxArray::from_int32(&[forced_id], &[1])?;
-                                    eval_token_and_compiled_caches(&forced);
-                                    Some(forced)
-                                } else {
-                                    let _stream_ctx =
-                                        StreamContext::new(generation_stream);
-                                    let next_ids = y.reshape(&[1, 1])?;
-                                    let mut logits =
-                                        forward_compiled(&next_ids, &embedding_weight)?;
-                                    if repetition_penalty != 1.0 {
-                                        logits = apply_repetition_penalty(
-                                            &logits,
-                                            &token_history,
-                                            repetition_penalty,
-                                            Some(repetition_context_size),
-                                        )?;
-                                    }
-                                    if presence_penalty != 0.0 {
-                                        logits = apply_presence_penalty(
-                                            &logits,
-                                            &token_history,
-                                            presence_penalty,
-                                            Some(presence_context_size),
-                                        )?;
-                                    }
-                                    if frequency_penalty != 0.0 {
-                                        logits = apply_frequency_penalty(
-                                            &logits,
-                                            &token_history,
-                                            frequency_penalty,
-                                            Some(frequency_context_size),
-                                        )?;
-                                    }
-                                    let next_token = sample(&logits, sampling_config)?;
-                                    eval_token_and_compiled_caches(&next_token);
-                                    Some(next_token)
-                                }
+                                let _stream_ctx =
+                                    StreamContext::new(generation_stream);
+                                let next_ids = y.reshape(&[1, 1])?;
+                                let mut logits =
+                                    forward_compiled(&next_ids, &embedding_weight)?;
+
+                                let next_token =
+                                    if reasoning_tracker.should_force_think_end() {
+                                        let forced_id =
+                                            reasoning_tracker.forced_token_id() as i32;
+                                        MxArray::from_int32(&[forced_id], &[1])?
+                                    } else {
+                                        if repetition_penalty != 1.0 {
+                                            logits = apply_repetition_penalty(
+                                                &logits,
+                                                &token_history,
+                                                repetition_penalty,
+                                                Some(repetition_context_size),
+                                            )?;
+                                        }
+                                        if presence_penalty != 0.0 {
+                                            logits = apply_presence_penalty(
+                                                &logits,
+                                                &token_history,
+                                                presence_penalty,
+                                                Some(presence_context_size),
+                                            )?;
+                                        }
+                                        if frequency_penalty != 0.0 {
+                                            logits = apply_frequency_penalty(
+                                                &logits,
+                                                &token_history,
+                                                frequency_penalty,
+                                                Some(frequency_context_size),
+                                            )?;
+                                        }
+                                        sample(&logits, sampling_config)?
+                                    };
+
+                                eval_token_and_compiled_caches(&next_token);
+                                Some(next_token)
                             } else {
                                 None
                             };
@@ -2211,6 +2220,7 @@ impl Qwen3_5Model {
                             }
 
                             let is_reasoning = reasoning_tracker.observe_token(token_id);
+                            last_is_reasoning = is_reasoning;
 
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
@@ -2309,59 +2319,64 @@ impl Qwen3_5Model {
                             thinking_token_budget,
                             think_end_id,
                         );
+                        // Use outer last_is_reasoning (shared with residual flush)
+                        last_is_reasoning = starts_in_thinking;
 
                         for step in 0..max_new_tokens {
-                            // Build and submit graph for step N+1
+                            // Build and submit graph for step N+1.
+                            // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < max_new_tokens {
-                                if reasoning_tracker.should_force_think_end() {
-                                    let forced_id =
-                                        reasoning_tracker.forced_token_id() as i32;
-                                    let forced =
-                                        MxArray::from_int32(&[forced_id], &[1])?;
-                                    MxArray::async_eval_arrays(&[&forced]);
-                                    Some(forced)
-                                } else {
-                                    let _stream_ctx =
-                                        StreamContext::new(generation_stream);
-                                    let next_ids = y.reshape(&[1, 1])?;
-                                    let logits = forward_inner(
-                                        &next_ids,
-                                        &embedding_weight,
-                                        &mut layers_guard,
-                                        &mut caches_guard,
-                                        &final_norm_guard,
-                                        &lm_head_guard,
-                                        Some(&embedding_weight_t),
-                                    )?;
-                                    let mut logits = logits.squeeze(Some(&[1]))?;
-                                    if repetition_penalty != 1.0 {
-                                        logits = apply_repetition_penalty(
-                                            &logits,
-                                            &token_history,
-                                            repetition_penalty,
-                                            Some(repetition_context_size),
-                                        )?;
-                                    }
-                                    if presence_penalty != 0.0 {
-                                        logits = apply_presence_penalty(
-                                            &logits,
-                                            &token_history,
-                                            presence_penalty,
-                                            Some(presence_context_size),
-                                        )?;
-                                    }
-                                    if frequency_penalty != 0.0 {
-                                        logits = apply_frequency_penalty(
-                                            &logits,
-                                            &token_history,
-                                            frequency_penalty,
-                                            Some(frequency_context_size),
-                                        )?;
-                                    }
-                                    let next_token = sample(&logits, sampling_config)?;
-                                    MxArray::async_eval_arrays(&[&next_token]);
-                                    Some(next_token)
-                                }
+                                let _stream_ctx =
+                                    StreamContext::new(generation_stream);
+                                let next_ids = y.reshape(&[1, 1])?;
+                                let logits = forward_inner(
+                                    &next_ids,
+                                    &embedding_weight,
+                                    &mut layers_guard,
+                                    &mut caches_guard,
+                                    &final_norm_guard,
+                                    &lm_head_guard,
+                                    Some(&embedding_weight_t),
+                                )?;
+                                let mut logits = logits.squeeze(Some(&[1]))?;
+
+                                let next_token =
+                                    if reasoning_tracker.should_force_think_end() {
+                                        let forced_id =
+                                            reasoning_tracker.forced_token_id() as i32;
+                                        MxArray::from_int32(&[forced_id], &[1])?
+                                    } else {
+                                        if repetition_penalty != 1.0 {
+                                            logits = apply_repetition_penalty(
+                                                &logits,
+                                                &token_history,
+                                                repetition_penalty,
+                                                Some(repetition_context_size),
+                                            )?;
+                                        }
+                                        if presence_penalty != 0.0 {
+                                            logits = apply_presence_penalty(
+                                                &logits,
+                                                &token_history,
+                                                presence_penalty,
+                                                Some(presence_context_size),
+                                            )?;
+                                        }
+                                        if frequency_penalty != 0.0 {
+                                            logits = apply_frequency_penalty(
+                                                &logits,
+                                                &token_history,
+                                                frequency_penalty,
+                                                Some(frequency_context_size),
+                                            )?;
+                                        }
+                                        sample(&logits, sampling_config)?
+                                    };
+
+                                // Eval next_token and logits to ensure the forward
+                                // graph (including KV cache updates) is materialized.
+                                MxArray::async_eval_arrays(&[&next_token, &logits]);
+                                Some(next_token)
                             } else {
                                 None
                             };
@@ -2382,6 +2397,7 @@ impl Qwen3_5Model {
                             }
 
                             let is_reasoning = reasoning_tracker.observe_token(token_id);
+                            last_is_reasoning = is_reasoning;
 
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
@@ -2501,7 +2517,7 @@ impl Qwen3_5Model {
                                 num_tokens: None,
                                 raw_text: None,
                                 performance: None,
-                                is_reasoning: None,
+                                is_reasoning: Some(last_is_reasoning),
                             }),
                             ThreadsafeFunctionCallMode::NonBlocking,
                         );

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1774,9 +1774,7 @@ impl Qwen3_5Model {
                         min_p: config.min_p,
                     });
                     let thinking_token_budget = config.thinking_token_budget;
-                    let include_reasoning = config
-                        .include_reasoning
-                        .unwrap_or(!matches!(config.reasoning_effort.as_deref(), Some("none")));
+                    let include_reasoning = chat_common::resolve_include_reasoning(&config);
 
                     let mut layers_guard = layers_arc
                         .write()

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2137,7 +2137,6 @@ impl Qwen3_5Model {
                         // Compiled C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("chat_stream_compiled");
 
-                        let starts_in_thinking = enable_thinking.unwrap_or(true);
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
                             thinking_token_budget,
@@ -2300,7 +2299,6 @@ impl Qwen3_5Model {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("chat_stream_rust");
 
-                        let starts_in_thinking = enable_thinking.unwrap_or(true);
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
                             thinking_token_budget,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1608,6 +1608,8 @@ impl Qwen3_5Model {
                 generated_tokens.len(),
             );
 
+            let starts_in_thinking =
+                enable_thinking.unwrap_or(true) && think_end_id.is_some();
             finalize_chat_result(
                 &tokenizer_for_decode,
                 &generated_tokens,
@@ -1616,6 +1618,7 @@ impl Qwen3_5Model {
                 think_end_str.as_deref(),
                 performance,
                 p.include_reasoning,
+                starts_in_thinking,
             )
         })
         .await
@@ -2065,8 +2068,9 @@ impl Qwen3_5Model {
                         None
                     };
 
-                    let mut last_is_reasoning =
+                    let starts_in_thinking =
                         enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                    let mut last_is_reasoning = starts_in_thinking;
 
                     if use_compiled {
                         if vlm_compiled_init_done {
@@ -2527,7 +2531,9 @@ impl Qwen3_5Model {
 
                     let num_tokens = generated_tokens.len() as u32;
 
-                    let think_tag = if tools::has_think_end_token(&generated_tokens, think_end_id) {
+                    let think_tag = if starts_in_thinking
+                        && tools::has_think_end_token(&generated_tokens, think_end_id)
+                    {
                         think_end_str.as_deref()
                     } else {
                         None

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -19,7 +19,6 @@ use crate::sampling::{
 };
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
-use crate::tools;
 use crate::tools::ToolCallResult;
 
 use super::chat_common;
@@ -1604,7 +1603,6 @@ impl Qwen3_5Model {
                 generated_tokens.len(),
             );
 
-            let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
             finalize_chat_result(
                 &tokenizer_for_decode,
                 &generated_tokens,
@@ -1613,7 +1611,7 @@ impl Qwen3_5Model {
                 think_end_str.as_deref(),
                 performance,
                 p.include_reasoning,
-                starts_in_thinking,
+                enable_thinking.unwrap_or(true),
             )
         })
         .await
@@ -2513,26 +2511,14 @@ impl Qwen3_5Model {
 
                     let num_tokens = generated_tokens.len() as u32;
 
-                    let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
-                        let (clean, calls) = tools::parse_tool_calls(&text);
-                        (clean, calls, None)
-                    } else if tools::has_think_end_token(&generated_tokens, think_end_id) {
-                        tools::split_at_think_end(&text, think_end_str.as_deref())
-                    } else {
-                        let t = text.trim();
-                        let t = t
-                            .strip_prefix("<think>")
-                            .or_else(|| t.strip_prefix("<longcat_think>"))
-                            .unwrap_or(t)
-                            .trim();
-                        let thinking = if t.is_empty() {
-                            None
-                        } else {
-                            Some(t.to_string())
-                        };
-                        (String::new(), vec![], thinking)
-                    };
-                    let thinking = if include_reasoning { thinking } else { None };
+                    let (clean_text, tool_calls, thinking) = chat_common::parse_thinking_and_tools(
+                        &text,
+                        &generated_tokens,
+                        enable_thinking.unwrap_or(true),
+                        think_end_id,
+                        think_end_str.as_deref(),
+                        include_reasoning,
+                    );
 
                     // If we have valid tool calls, override finish reason
                     let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2532,14 +2532,19 @@ impl Qwen3_5Model {
                     let num_tokens = generated_tokens.len() as u32;
 
                     let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
-                        let (clean, calls) = tools::parse_tool_calls(&text);
+                        let stripped = tools::strip_think_markup(&text);
+                        let (clean, calls) = tools::parse_tool_calls(&stripped);
                         (clean, calls, None)
                     } else if tools::has_think_end_token(&generated_tokens, think_end_id)
                     {
                         tools::split_at_think_end(&text, think_end_str.as_deref())
                     } else {
                         let t = text.trim();
-                        let t = t.strip_prefix("<think>").unwrap_or(t).trim();
+                        let t = t
+                            .strip_prefix("<think>")
+                            .or_else(|| t.strip_prefix("<longcat_think>"))
+                            .unwrap_or(t)
+                            .trim();
                         let thinking = if t.is_empty() {
                             None
                         } else {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1959,6 +1959,7 @@ impl Qwen3_5MoeModel {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < max_new_tokens {
+                                let _stream_ctx = StreamContext::new(generation_stream);
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -18,6 +18,10 @@ use crate::models::qwen3_5::model::{
 use crate::models::qwen3_5::processing::Qwen35VLImageProcessor;
 use crate::models::qwen3_5::vision::Qwen3_5VisionEncoder;
 
+use super::config::Qwen3_5MoeConfig;
+use super::decoder_layer::DecoderLayer;
+use super::layer_cache::Qwen3_5LayerCache;
+use super::persistence;
 use super::quantized_linear::LinearProj;
 use crate::array::MxArray;
 use crate::array::mask::create_causal_mask;
@@ -34,12 +38,6 @@ use crate::sampling::{
 };
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
-use crate::tools;
-
-use super::config::Qwen3_5MoeConfig;
-use super::decoder_layer::DecoderLayer;
-use super::layer_cache::Qwen3_5LayerCache;
-use super::persistence;
 
 // Import the shared model ID counter from the dense module — dense and MoE
 // share the same C++ weight map, so IDs must be globally unique.
@@ -1164,23 +1162,29 @@ impl Qwen3_5MoeModel {
                         let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
                         profiler.end();
 
-                        let next_token = if reasoning_tracker.should_force_think_end() {
-                            // Budget exhausted — force </think> token
-                            let forced_id = reasoning_tracker.forced_token_id() as i32;
-                            MxArray::from_int32(&[forced_id], &[1])?
-                        } else {
-                            profiler.begin("rep_penalty");
-                            logits = apply_all_penalties(logits, &token_history, &p)?;
-                            profiler.end();
+                        let (next_token, budget_forced) =
+                            if reasoning_tracker.should_force_think_end() {
+                                // Budget exhausted — force </think> token
+                                let forced_id = reasoning_tracker.forced_token_id() as i32;
+                                (MxArray::from_int32(&[forced_id], &[1])?, true)
+                            } else {
+                                profiler.begin("rep_penalty");
+                                logits = apply_all_penalties(logits, &token_history, &p)?;
+                                profiler.end();
 
-                            profiler.begin("sample");
-                            let t = sample(&logits, p.sampling_config)?;
-                            profiler.end();
-                            t
-                        };
+                                profiler.begin("sample");
+                                let t = sample(&logits, p.sampling_config)?;
+                                profiler.end();
+                                (t, false)
+                            };
 
                         profiler.begin("eval_caches");
                         eval_token_and_moe_caches(&next_token);
+                        if budget_forced {
+                            // When budget-forced, next_token is a constant that doesn't
+                            // pull the forward graph. Eval logits to materialize cache updates.
+                            logits.eval();
+                        }
                         profiler.end();
 
                         Some(next_token)
@@ -1397,7 +1401,6 @@ impl Qwen3_5MoeModel {
                 generated_tokens.len(),
             );
 
-            let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
             finalize_chat_result(
                 &tokenizer_for_decode,
                 &generated_tokens,
@@ -1406,7 +1409,7 @@ impl Qwen3_5MoeModel {
                 think_end_str.as_deref(),
                 performance,
                 p.include_reasoning,
-                starts_in_thinking,
+                enable_thinking.unwrap_or(true),
             )
         })
         .await
@@ -1959,38 +1962,44 @@ impl Qwen3_5MoeModel {
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
 
-                                let next_token = if reasoning_tracker.should_force_think_end() {
-                                    let forced_id = reasoning_tracker.forced_token_id() as i32;
-                                    MxArray::from_int32(&[forced_id], &[1])?
-                                } else {
-                                    if repetition_penalty != 1.0 {
-                                        logits = apply_repetition_penalty(
-                                            &logits,
-                                            &token_history,
-                                            repetition_penalty,
-                                            Some(repetition_context_size),
-                                        )?;
-                                    }
-                                    if presence_penalty != 0.0 {
-                                        logits = apply_presence_penalty(
-                                            &logits,
-                                            &token_history,
-                                            presence_penalty,
-                                            Some(presence_context_size),
-                                        )?;
-                                    }
-                                    if frequency_penalty != 0.0 {
-                                        logits = apply_frequency_penalty(
-                                            &logits,
-                                            &token_history,
-                                            frequency_penalty,
-                                            Some(frequency_context_size),
-                                        )?;
-                                    }
-                                    sample(&logits, sampling_config)?
-                                };
+                                let (next_token, budget_forced) =
+                                    if reasoning_tracker.should_force_think_end() {
+                                        let forced_id = reasoning_tracker.forced_token_id() as i32;
+                                        (MxArray::from_int32(&[forced_id], &[1])?, true)
+                                    } else {
+                                        if repetition_penalty != 1.0 {
+                                            logits = apply_repetition_penalty(
+                                                &logits,
+                                                &token_history,
+                                                repetition_penalty,
+                                                Some(repetition_context_size),
+                                            )?;
+                                        }
+                                        if presence_penalty != 0.0 {
+                                            logits = apply_presence_penalty(
+                                                &logits,
+                                                &token_history,
+                                                presence_penalty,
+                                                Some(presence_context_size),
+                                            )?;
+                                        }
+                                        if frequency_penalty != 0.0 {
+                                            logits = apply_frequency_penalty(
+                                                &logits,
+                                                &token_history,
+                                                frequency_penalty,
+                                                Some(frequency_context_size),
+                                            )?;
+                                        }
+                                        (sample(&logits, sampling_config)?, false)
+                                    };
 
                                 eval_token_and_moe_caches(&next_token);
+                                if budget_forced {
+                                    // When budget-forced, next_token is a constant that doesn't
+                                    // pull the forward graph. Eval logits to materialize cache updates.
+                                    logits.eval();
+                                }
                                 Some(next_token)
                             } else {
                                 None
@@ -2344,26 +2353,14 @@ impl Qwen3_5MoeModel {
 
                     let num_tokens = generated_tokens.len() as u32;
 
-                    let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
-                        let (clean, calls) = tools::parse_tool_calls(&text);
-                        (clean, calls, None)
-                    } else if tools::has_think_end_token(&generated_tokens, think_end_id_stream) {
-                        tools::split_at_think_end(&text, think_end_str_stream.as_deref())
-                    } else {
-                        let t = text.trim();
-                        let t = t
-                            .strip_prefix("<think>")
-                            .or_else(|| t.strip_prefix("<longcat_think>"))
-                            .unwrap_or(t)
-                            .trim();
-                        let thinking = if t.is_empty() {
-                            None
-                        } else {
-                            Some(t.to_string())
-                        };
-                        (String::new(), vec![], thinking)
-                    };
-                    let thinking = if include_reasoning { thinking } else { None };
+                    let (clean_text, tool_calls, thinking) = chat_common::parse_thinking_and_tools(
+                        &text,
+                        &generated_tokens,
+                        enable_thinking.unwrap_or(true),
+                        think_end_id_stream,
+                        think_end_str_stream.as_deref(),
+                        include_reasoning,
+                    );
 
                     // If we have valid tool calls, override finish reason
                     let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1142,94 +1142,33 @@ impl Qwen3_5MoeModel {
                     think_end_id,
                 );
 
-                for step in 0..max_new_tokens {
-                    // Build and submit graph for step N+1 before waiting for N.
-                    // forward() always runs to keep KV caches consistent;
-                    // budget enforcement only overrides the sampling step.
-                    let next_y = if step + 1 < max_new_tokens {
-                        let _stream_ctx = StreamContext::new(generation_stream);
-
-                        profiler.begin("forward");
-                        let next_ids = y.reshape(&[1, 1])?;
-                        let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
-                        profiler.end();
-
-                        let (next_token, budget_forced) =
-                            if reasoning_tracker.should_force_think_end() {
-                                // Budget exhausted — force </think> token
-                                let forced_id = reasoning_tracker.forced_token_id() as i32;
-                                (MxArray::from_int32(&[forced_id], &[1])?, true)
-                            } else {
-                                profiler.begin("rep_penalty");
-                                logits = apply_all_penalties(logits, &token_history, &p)?;
-                                profiler.end();
-
-                                profiler.begin("sample");
-                                let t = sample(&logits, p.sampling_config)?;
-                                profiler.end();
-                                (t, false)
-                            };
-
-                        profiler.begin("eval_caches");
-                        eval_token_and_moe_caches(&next_token);
+                let mut ops = chat_common::DecodeOps {
+                    forward: |ids: &MxArray, emb: &MxArray| -> Result<(MxArray, bool)> {
+                        Ok((forward_moe_cpp(ids, emb)?, false))
+                    },
+                    eval_step: |token: &MxArray, logits: &MxArray, budget_forced: bool| {
+                        eval_token_and_moe_caches(token);
                         if budget_forced {
-                            // When budget-forced, next_token is a constant that doesn't
-                            // pull the forward graph. Eval logits to materialize cache updates.
                             logits.eval();
                         }
-                        profiler.end();
-
-                        Some(next_token)
-                    } else {
-                        None
-                    };
-
-                    // Wait for step N (GPU already computing N+1)
-                    profiler.begin("eval_token");
-                    y.eval();
-                    profiler.end();
-
-                    profiler.begin("extract");
-                    let token_id = y.item_at_int32(0)? as u32;
-                    profiler.end();
-                    profiler.mark_first_token();
-                    if p.report_performance && first_token_instant.is_none() {
-                        first_token_instant = Some(std::time::Instant::now());
-                    }
-
-                    generated_tokens.push(token_id);
-                    token_history.push(token_id);
-                    reasoning_tracker.observe_token(token_id);
-
-                    if token_id == eos_id {
-                        finish_reason = String::from("stop");
-                        break;
-                    }
-
-                    if let Some(reason) = check_repetition_cutoff(
-                        &generated_tokens,
-                        p.max_consecutive_tokens,
-                        p.max_ngram_repeats,
-                        p.ngram_size,
-                    ) {
-                        finish_reason = reason.to_string();
-                        break;
-                    }
-
-                    match next_y {
-                        Some(next) => y = next,
-                        None => break,
-                    }
-
-                    profiler.step();
-
-                    if (step + 1) % 256 == 0 {
-                        crate::array::synchronize_and_clear_cache();
-                    }
-                }
-
-                profiler.snapshot_memory_after();
-                profiler.report();
+                    },
+                };
+                chat_common::decode_loop!(
+                    ops: ops,
+                    y: y,
+                    embedding_weight: embedding_weight,
+                    params: p,
+                    reasoning_tracker: reasoning_tracker,
+                    profiler: profiler,
+                    max_new_tokens: max_new_tokens,
+                    eos_id: eos_id,
+                    generated_tokens: generated_tokens,
+                    token_history: token_history,
+                    finish_reason: finish_reason,
+                    first_token_instant: first_token_instant,
+                    report_perf: p.report_performance,
+                    generation_stream: generation_stream
+                );
 
                 // === Export caches from C++ before MoeResetGuard drops ===
                 if reuse_cache {
@@ -1274,16 +1213,11 @@ impl Qwen3_5MoeModel {
                     think_end_id,
                 );
 
-                for step in 0..max_new_tokens {
-                    // Build and submit graph for step N+1 before waiting for N.
-                    // forward() always runs to keep KV caches consistent;
-                    // budget enforcement only overrides the sampling step.
-                    let next_y = if step + 1 < max_new_tokens {
-                        profiler.begin("forward");
-                        let next_ids = y.reshape(&[1, 1])?;
+                let mut ops = chat_common::DecodeOps {
+                    forward: |ids: &MxArray, emb: &MxArray| -> Result<(MxArray, bool)> {
                         let logits = forward_inner(
-                            &next_ids,
-                            &embedding_weight,
+                            ids,
+                            emb,
                             &mut layers_guard,
                             &mut caches_guard,
                             &final_norm_guard,
@@ -1291,80 +1225,28 @@ impl Qwen3_5MoeModel {
                             fa_idx,
                             Some(&embedding_weight_t),
                         )?;
-                        let mut logits = logits.squeeze(Some(&[1]))?;
-                        profiler.end();
-
-                        let next_token = if reasoning_tracker.should_force_think_end() {
-                            let forced_id = reasoning_tracker.forced_token_id() as i32;
-                            MxArray::from_int32(&[forced_id], &[1])?
-                        } else {
-                            profiler.begin("rep_penalty");
-                            logits = apply_all_penalties(logits, &token_history, &p)?;
-                            profiler.end();
-
-                            profiler.begin("sample");
-                            let t = sample(&logits, p.sampling_config)?;
-                            profiler.end();
-                            t
-                        };
-
-                        profiler.begin("async_eval");
-                        // Eval both next_token and logits to ensure forward graph
-                        // (including KV cache updates) is materialized.
-                        MxArray::async_eval_arrays(&[&next_token, &logits]);
-                        profiler.end();
-
-                        Some(next_token)
-                    } else {
-                        None
-                    };
-
-                    // Wait for step N (GPU already computing N+1)
-                    profiler.begin("eval_token");
-                    y.eval();
-                    profiler.end();
-
-                    profiler.begin("extract");
-                    let token_id = y.item_at_int32(0)? as u32;
-                    profiler.end();
-                    profiler.mark_first_token();
-                    if p.report_performance && first_token_instant.is_none() {
-                        first_token_instant = Some(std::time::Instant::now());
-                    }
-
-                    generated_tokens.push(token_id);
-                    token_history.push(token_id);
-                    reasoning_tracker.observe_token(token_id);
-
-                    if token_id == eos_id {
-                        finish_reason = String::from("stop");
-                        break;
-                    }
-
-                    if let Some(reason) = check_repetition_cutoff(
-                        &generated_tokens,
-                        p.max_consecutive_tokens,
-                        p.max_ngram_repeats,
-                        p.ngram_size,
-                    ) {
-                        finish_reason = reason.to_string();
-                        break;
-                    }
-
-                    match next_y {
-                        Some(next) => y = next,
-                        None => break,
-                    }
-
-                    profiler.step();
-
-                    if (step + 1) % 256 == 0 {
-                        crate::array::synchronize_and_clear_cache();
-                    }
-                }
-
-                profiler.snapshot_memory_after();
-                profiler.report();
+                        Ok((logits, true)) // needs squeeze
+                    },
+                    eval_step: |token: &MxArray, logits: &MxArray, _budget_forced: bool| {
+                        MxArray::async_eval_arrays(&[token, logits]);
+                    },
+                };
+                chat_common::decode_loop!(
+                    ops: ops,
+                    y: y,
+                    embedding_weight: embedding_weight,
+                    params: p,
+                    reasoning_tracker: reasoning_tracker,
+                    profiler: profiler,
+                    max_new_tokens: max_new_tokens,
+                    eos_id: eos_id,
+                    generated_tokens: generated_tokens,
+                    token_history: token_history,
+                    finish_reason: finish_reason,
+                    first_token_instant: first_token_instant,
+                    report_perf: p.report_performance,
+                    generation_stream: generation_stream
+                );
 
                 drop(layers_guard);
                 drop(caches_guard);

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -2358,8 +2358,7 @@ impl Qwen3_5MoeModel {
                     let num_tokens = generated_tokens.len() as u32;
 
                     let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
-                        let stripped = tools::strip_think_markup(&text);
-                        let (clean, calls) = tools::parse_tool_calls(&stripped);
+                        let (clean, calls) = tools::parse_tool_calls(&text);
                         (clean, calls, None)
                     } else if tools::has_think_end_token(
                         &generated_tokens,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -32,10 +32,7 @@ use crate::models::qwen3_5::chat_common::{
     save_cache_state, verify_cache_prefix,
 };
 use crate::nn::{Embedding, Linear, RMSNorm};
-use crate::sampling::{
-    SamplingConfig, apply_frequency_penalty, apply_presence_penalty, apply_repetition_penalty,
-    check_repetition_cutoff, sample,
-};
+use crate::sampling::{SamplingConfig, check_repetition_cutoff, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 
@@ -1538,24 +1535,7 @@ impl Qwen3_5MoeModel {
                         enable_thinking,
                     )?;
 
-                    let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
-                    let repetition_penalty = config.repetition_penalty.unwrap_or(1.0);
-                    let repetition_context_size = config.repetition_context_size.unwrap_or(256);
-                    let presence_penalty = config.presence_penalty.unwrap_or(0.0);
-                    let presence_context_size = config.presence_context_size.unwrap_or(20);
-                    let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
-                    let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-                    let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-                    let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-                    let ngram_size = config.ngram_size.unwrap_or(64);
-                    let sampling_config = Some(SamplingConfig {
-                        temperature: config.temperature,
-                        top_k: config.top_k,
-                        top_p: config.top_p,
-                        min_p: config.min_p,
-                    });
-                    let thinking_token_budget = config.thinking_token_budget;
-                    let include_reasoning = chat_common::resolve_include_reasoning(&config);
+                    let p = chat_common::extract_chat_params(&config);
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -1817,33 +1797,10 @@ impl Qwen3_5MoeModel {
                     };
                     profiler.end_prefill();
 
-                    // Apply repetition penalty to prefill logits
-                    if repetition_penalty != 1.0 && !token_history.is_empty() {
-                        last_logits = apply_repetition_penalty(
-                            &last_logits,
-                            &token_history,
-                            repetition_penalty,
-                            Some(repetition_context_size),
-                        )?;
-                    }
-                    if presence_penalty != 0.0 {
-                        last_logits = apply_presence_penalty(
-                            &last_logits,
-                            &token_history,
-                            presence_penalty,
-                            Some(presence_context_size),
-                        )?;
-                    }
-                    if frequency_penalty != 0.0 {
-                        last_logits = apply_frequency_penalty(
-                            &last_logits,
-                            &token_history,
-                            frequency_penalty,
-                            Some(frequency_context_size),
-                        )?;
-                    }
+                    // Apply penalties to prefill logits
+                    last_logits = apply_all_penalties(last_logits, &token_history, &p)?;
 
-                    let mut y = sample(&last_logits, sampling_config)?;
+                    let mut y = sample(&last_logits, p.sampling_config)?;
                     MxArray::async_eval_arrays(&[&y]);
 
                     let starts_in_thinking = enable_thinking.unwrap_or(true);
@@ -1855,7 +1812,7 @@ impl Qwen3_5MoeModel {
                         // Initialize C++ MoE forward pass from prefill caches
                         use mlx_sys as sys;
                         let prefill_len = seq_len as i32;
-                        let max_kv_len = ((prefill_len + max_new_tokens + 255) / 256) * 256;
+                        let max_kv_len = ((prefill_len + p.max_new_tokens + 255) / 256) * 256;
                         let num_layers = model_config.num_layers as usize;
                         let mut cache_ptrs: Vec<*mut sys::mlx_array> =
                             vec![std::ptr::null_mut(); num_layers * 2];
@@ -1937,13 +1894,13 @@ impl Qwen3_5MoeModel {
 
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
-                            thinking_token_budget,
+                            p.thinking_token_budget,
                             think_end_id_stream,
                         );
-                        for step in 0..max_new_tokens {
+                        for step in 0..p.max_new_tokens {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
-                            let next_y = if step + 1 < max_new_tokens {
+                            let next_y = if step + 1 < p.max_new_tokens {
                                 let _stream_ctx = StreamContext::new(generation_stream);
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
@@ -1953,31 +1910,8 @@ impl Qwen3_5MoeModel {
                                         let forced_id = reasoning_tracker.forced_token_id() as i32;
                                         (MxArray::from_int32(&[forced_id], &[1])?, true)
                                     } else {
-                                        if repetition_penalty != 1.0 {
-                                            logits = apply_repetition_penalty(
-                                                &logits,
-                                                &token_history,
-                                                repetition_penalty,
-                                                Some(repetition_context_size),
-                                            )?;
-                                        }
-                                        if presence_penalty != 0.0 {
-                                            logits = apply_presence_penalty(
-                                                &logits,
-                                                &token_history,
-                                                presence_penalty,
-                                                Some(presence_context_size),
-                                            )?;
-                                        }
-                                        if frequency_penalty != 0.0 {
-                                            logits = apply_frequency_penalty(
-                                                &logits,
-                                                &token_history,
-                                                frequency_penalty,
-                                                Some(frequency_context_size),
-                                            )?;
-                                        }
-                                        (sample(&logits, sampling_config)?, false)
+                                        logits = apply_all_penalties(logits, &token_history, &p)?;
+                                        (sample(&logits, p.sampling_config)?, false)
                                     };
 
                                 eval_token_and_moe_caches(&next_token);
@@ -1995,7 +1929,7 @@ impl Qwen3_5MoeModel {
                             y.eval();
                             let token_id = y.item_at_int32(0)? as u32;
                             profiler.mark_first_token();
-                            if report_perf && first_token_instant.is_none() {
+                            if p.report_performance && first_token_instant.is_none() {
                                 first_token_instant = Some(std::time::Instant::now());
                             }
                             generated_tokens.push(token_id);
@@ -2039,9 +1973,9 @@ impl Qwen3_5MoeModel {
 
                             if let Some(reason) = check_repetition_cutoff(
                                 &generated_tokens,
-                                max_consecutive_tokens,
-                                max_ngram_repeats,
-                                ngram_size,
+                                p.max_consecutive_tokens,
+                                p.max_ngram_repeats,
+                                p.ngram_size,
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
@@ -2102,13 +2036,13 @@ impl Qwen3_5MoeModel {
 
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
-                            thinking_token_budget,
+                            p.thinking_token_budget,
                             think_end_id_stream,
                         );
-                        for step in 0..max_new_tokens {
+                        for step in 0..p.max_new_tokens {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
-                            let next_y = if step + 1 < max_new_tokens {
+                            let next_y = if step + 1 < p.max_new_tokens {
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let logits = forward_inner(
                                     &next_ids,
@@ -2126,31 +2060,8 @@ impl Qwen3_5MoeModel {
                                     let forced_id = reasoning_tracker.forced_token_id() as i32;
                                     MxArray::from_int32(&[forced_id], &[1])?
                                 } else {
-                                    if repetition_penalty != 1.0 {
-                                        logits = apply_repetition_penalty(
-                                            &logits,
-                                            &token_history,
-                                            repetition_penalty,
-                                            Some(repetition_context_size),
-                                        )?;
-                                    }
-                                    if presence_penalty != 0.0 {
-                                        logits = apply_presence_penalty(
-                                            &logits,
-                                            &token_history,
-                                            presence_penalty,
-                                            Some(presence_context_size),
-                                        )?;
-                                    }
-                                    if frequency_penalty != 0.0 {
-                                        logits = apply_frequency_penalty(
-                                            &logits,
-                                            &token_history,
-                                            frequency_penalty,
-                                            Some(frequency_context_size),
-                                        )?;
-                                    }
-                                    sample(&logits, sampling_config)?
+                                    logits = apply_all_penalties(logits, &token_history, &p)?;
+                                    sample(&logits, p.sampling_config)?
                                 };
 
                                 // Eval both next_token and logits to ensure forward graph
@@ -2165,7 +2076,7 @@ impl Qwen3_5MoeModel {
                             y.eval();
                             let token_id = y.item_at_int32(0)? as u32;
                             profiler.mark_first_token();
-                            if report_perf && first_token_instant.is_none() {
+                            if p.report_performance && first_token_instant.is_none() {
                                 first_token_instant = Some(std::time::Instant::now());
                             }
                             generated_tokens.push(token_id);
@@ -2209,9 +2120,9 @@ impl Qwen3_5MoeModel {
 
                             if let Some(reason) = check_repetition_cutoff(
                                 &generated_tokens,
-                                max_consecutive_tokens,
-                                max_ngram_repeats,
-                                ngram_size,
+                                p.max_consecutive_tokens,
+                                p.max_ngram_repeats,
+                                p.ngram_size,
                             ) {
                                 finish_reason = reason.to_string();
                                 break;
@@ -2343,7 +2254,7 @@ impl Qwen3_5MoeModel {
                         enable_thinking.unwrap_or(true),
                         think_end_id_stream,
                         think_end_str_stream.as_deref(),
-                        include_reasoning,
+                        p.include_reasoning,
                     );
 
                     // If we have valid tool calls, override finish reason

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1399,6 +1399,8 @@ impl Qwen3_5MoeModel {
                 generated_tokens.len(),
             );
 
+            let starts_in_thinking =
+                enable_thinking.unwrap_or(true) && think_end_id.is_some();
             finalize_chat_result(
                 &tokenizer_for_decode,
                 &generated_tokens,
@@ -1407,6 +1409,7 @@ impl Qwen3_5MoeModel {
                 think_end_str.as_deref(),
                 performance,
                 p.include_reasoning,
+                starts_in_thinking,
             )
         })
         .await
@@ -1855,8 +1858,9 @@ impl Qwen3_5MoeModel {
                     let mut y = sample(&last_logits, sampling_config)?;
                     MxArray::async_eval_arrays(&[&y]);
 
-                    let mut last_is_reasoning =
+                    let starts_in_thinking =
                         enable_thinking.unwrap_or(true) && think_end_id_stream.is_some();
+                    let mut last_is_reasoning = starts_in_thinking;
 
                     if use_cpp {
                         // Guard ensures mlx_qwen35_moe_reset() is called even if `?` returns early.
@@ -2353,12 +2357,13 @@ impl Qwen3_5MoeModel {
 
                     let num_tokens = generated_tokens.len() as u32;
 
-                    let think_tag =
-                        if tools::has_think_end_token(&generated_tokens, think_end_id_stream) {
-                            think_end_str_stream.as_deref()
-                        } else {
-                            None
-                        };
+                    let think_tag = if starts_in_thinking
+                        && tools::has_think_end_token(&generated_tokens, think_end_id_stream)
+                    {
+                        think_end_str_stream.as_deref()
+                    } else {
+                        None
+                    };
                     let (clean_text, tool_calls, thinking) =
                         tools::split_at_think_end(&text, think_tag);
                     let thinking = if include_reasoning { thinking } else { None };

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1154,34 +1154,37 @@ impl Qwen3_5MoeModel {
                 );
 
                 for step in 0..max_new_tokens {
-                    // Build and submit graph for step N+1 before waiting for N
+                    // Build and submit graph for step N+1 before waiting for N.
+                    // forward() always runs to keep KV caches consistent;
+                    // budget enforcement only overrides the sampling step.
                     let next_y = if step + 1 < max_new_tokens {
-                        if reasoning_tracker.should_force_think_end() {
+                        let _stream_ctx = StreamContext::new(generation_stream);
+
+                        profiler.begin("forward");
+                        let next_ids = y.reshape(&[1, 1])?;
+                        let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
+                        profiler.end();
+
+                        let next_token = if reasoning_tracker.should_force_think_end() {
                             // Budget exhausted — force </think> token
                             let forced_id = reasoning_tracker.forced_token_id() as i32;
-                            let forced = MxArray::from_int32(&[forced_id], &[1])?;
-                            eval_token_and_moe_caches(&forced);
-                            Some(forced)
+                            MxArray::from_int32(&[forced_id], &[1])?
                         } else {
-                            profiler.begin("forward");
-                            let next_ids = y.reshape(&[1, 1])?;
-                            let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
-                            profiler.end();
-
                             profiler.begin("rep_penalty");
                             logits = apply_all_penalties(logits, &token_history, &p)?;
                             profiler.end();
 
                             profiler.begin("sample");
-                            let next_token = sample(&logits, p.sampling_config)?;
+                            let t = sample(&logits, p.sampling_config)?;
                             profiler.end();
+                            t
+                        };
 
-                            profiler.begin("eval_caches");
-                            eval_token_and_moe_caches(&next_token);
-                            profiler.end();
+                        profiler.begin("eval_caches");
+                        eval_token_and_moe_caches(&next_token);
+                        profiler.end();
 
-                            Some(next_token)
-                        }
+                        Some(next_token)
                     } else {
                         None
                     };
@@ -1278,43 +1281,46 @@ impl Qwen3_5MoeModel {
                 );
 
                 for step in 0..max_new_tokens {
-                    // Build and submit graph for step N+1 before waiting for N
+                    // Build and submit graph for step N+1 before waiting for N.
+                    // forward() always runs to keep KV caches consistent;
+                    // budget enforcement only overrides the sampling step.
                     let next_y = if step + 1 < max_new_tokens {
-                        if reasoning_tracker.should_force_think_end() {
-                            let forced_id = reasoning_tracker.forced_token_id() as i32;
-                            let forced = MxArray::from_int32(&[forced_id], &[1])?;
-                            MxArray::async_eval_arrays(&[&forced]);
-                            Some(forced)
-                        } else {
-                            profiler.begin("forward");
-                            let next_ids = y.reshape(&[1, 1])?;
-                            let logits = forward_inner(
-                                &next_ids,
-                                &embedding_weight,
-                                &mut layers_guard,
-                                &mut caches_guard,
-                                &final_norm_guard,
-                                &lm_head_guard,
-                                fa_idx,
-                                Some(&embedding_weight_t),
-                            )?;
-                            let mut logits = logits.squeeze(Some(&[1]))?;
-                            profiler.end();
+                        profiler.begin("forward");
+                        let next_ids = y.reshape(&[1, 1])?;
+                        let logits = forward_inner(
+                            &next_ids,
+                            &embedding_weight,
+                            &mut layers_guard,
+                            &mut caches_guard,
+                            &final_norm_guard,
+                            &lm_head_guard,
+                            fa_idx,
+                            Some(&embedding_weight_t),
+                        )?;
+                        let mut logits = logits.squeeze(Some(&[1]))?;
+                        profiler.end();
 
+                        let next_token = if reasoning_tracker.should_force_think_end() {
+                            let forced_id = reasoning_tracker.forced_token_id() as i32;
+                            MxArray::from_int32(&[forced_id], &[1])?
+                        } else {
                             profiler.begin("rep_penalty");
                             logits = apply_all_penalties(logits, &token_history, &p)?;
                             profiler.end();
 
                             profiler.begin("sample");
-                            let next_token = sample(&logits, p.sampling_config)?;
+                            let t = sample(&logits, p.sampling_config)?;
                             profiler.end();
+                            t
+                        };
 
-                            profiler.begin("async_eval");
-                            MxArray::async_eval_arrays(&[&next_token]);
-                            profiler.end();
+                        profiler.begin("async_eval");
+                        // Eval both next_token and logits to ensure forward graph
+                        // (including KV cache updates) is materialized.
+                        MxArray::async_eval_arrays(&[&next_token, &logits]);
+                        profiler.end();
 
-                            Some(next_token)
-                        }
+                        Some(next_token)
                     } else {
                         None
                     };
@@ -1847,6 +1853,9 @@ impl Qwen3_5MoeModel {
                     let mut y = sample(&last_logits, sampling_config)?;
                     MxArray::async_eval_arrays(&[&y]);
 
+                    let mut last_is_reasoning =
+                        enable_thinking.unwrap_or(true) && think_end_id_stream.is_some();
+
                     if use_cpp {
                         // Guard ensures mlx_qwen35_moe_reset() is called even if `?` returns early.
                         let _moe_guard = MoeResetGuard;
@@ -1940,48 +1949,51 @@ impl Qwen3_5MoeModel {
                             thinking_token_budget,
                             think_end_id_stream,
                         );
+                        // Use outer last_is_reasoning (shared with residual flush)
+                        last_is_reasoning = starts_in_thinking;
 
                         for step in 0..max_new_tokens {
-                            // Build and submit graph for step N+1
+                            // Build and submit graph for step N+1.
+                            // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < max_new_tokens {
-                                if reasoning_tracker.should_force_think_end() {
-                                    let forced_id =
-                                        reasoning_tracker.forced_token_id() as i32;
-                                    let forced =
-                                        MxArray::from_int32(&[forced_id], &[1])?;
-                                    eval_token_and_moe_caches(&forced);
-                                    Some(forced)
-                                } else {
-                                    let next_ids = y.reshape(&[1, 1])?;
-                                    let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
-                                    if repetition_penalty != 1.0 {
-                                        logits = apply_repetition_penalty(
-                                            &logits,
-                                            &token_history,
-                                            repetition_penalty,
-                                            Some(repetition_context_size),
-                                        )?;
-                                    }
-                                    if presence_penalty != 0.0 {
-                                        logits = apply_presence_penalty(
-                                            &logits,
-                                            &token_history,
-                                            presence_penalty,
-                                            Some(presence_context_size),
-                                        )?;
-                                    }
-                                    if frequency_penalty != 0.0 {
-                                        logits = apply_frequency_penalty(
-                                            &logits,
-                                            &token_history,
-                                            frequency_penalty,
-                                            Some(frequency_context_size),
-                                        )?;
-                                    }
-                                    let next_token = sample(&logits, sampling_config)?;
-                                    eval_token_and_moe_caches(&next_token);
-                                    Some(next_token)
-                                }
+                                let next_ids = y.reshape(&[1, 1])?;
+                                let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
+
+                                let next_token =
+                                    if reasoning_tracker.should_force_think_end() {
+                                        let forced_id =
+                                            reasoning_tracker.forced_token_id() as i32;
+                                        MxArray::from_int32(&[forced_id], &[1])?
+                                    } else {
+                                        if repetition_penalty != 1.0 {
+                                            logits = apply_repetition_penalty(
+                                                &logits,
+                                                &token_history,
+                                                repetition_penalty,
+                                                Some(repetition_context_size),
+                                            )?;
+                                        }
+                                        if presence_penalty != 0.0 {
+                                            logits = apply_presence_penalty(
+                                                &logits,
+                                                &token_history,
+                                                presence_penalty,
+                                                Some(presence_context_size),
+                                            )?;
+                                        }
+                                        if frequency_penalty != 0.0 {
+                                            logits = apply_frequency_penalty(
+                                                &logits,
+                                                &token_history,
+                                                frequency_penalty,
+                                                Some(frequency_context_size),
+                                            )?;
+                                        }
+                                        sample(&logits, sampling_config)?
+                                    };
+
+                                eval_token_and_moe_caches(&next_token);
+                                Some(next_token)
                             } else {
                                 None
                             };
@@ -2002,6 +2014,7 @@ impl Qwen3_5MoeModel {
                             }
 
                             let is_reasoning = reasoning_tracker.observe_token(token_id);
+                            last_is_reasoning = is_reasoning;
 
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
@@ -2101,58 +2114,63 @@ impl Qwen3_5MoeModel {
                             thinking_token_budget,
                             think_end_id_stream,
                         );
+                        // Use outer last_is_reasoning (shared with residual flush)
+                        last_is_reasoning = starts_in_thinking;
 
                         for step in 0..max_new_tokens {
-                            // Build and submit graph for step N+1
+                            // Build and submit graph for step N+1.
+                            // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < max_new_tokens {
-                                if reasoning_tracker.should_force_think_end() {
-                                    let forced_id =
-                                        reasoning_tracker.forced_token_id() as i32;
-                                    let forced =
-                                        MxArray::from_int32(&[forced_id], &[1])?;
-                                    MxArray::async_eval_arrays(&[&forced]);
-                                    Some(forced)
-                                } else {
-                                    let next_ids = y.reshape(&[1, 1])?;
-                                    let logits = forward_inner(
-                                        &next_ids,
-                                        &embedding_weight,
-                                        &mut layers_guard,
-                                        &mut caches_guard,
-                                        &final_norm_guard,
-                                        &lm_head_guard,
-                                        fa_idx,
-                                        Some(&embedding_weight_t),
-                                    )?;
-                                    let mut logits = logits.squeeze(Some(&[1]))?;
-                                    if repetition_penalty != 1.0 {
-                                        logits = apply_repetition_penalty(
-                                            &logits,
-                                            &token_history,
-                                            repetition_penalty,
-                                            Some(repetition_context_size),
-                                        )?;
-                                    }
-                                    if presence_penalty != 0.0 {
-                                        logits = apply_presence_penalty(
-                                            &logits,
-                                            &token_history,
-                                            presence_penalty,
-                                            Some(presence_context_size),
-                                        )?;
-                                    }
-                                    if frequency_penalty != 0.0 {
-                                        logits = apply_frequency_penalty(
-                                            &logits,
-                                            &token_history,
-                                            frequency_penalty,
-                                            Some(frequency_context_size),
-                                        )?;
-                                    }
-                                    let next_token = sample(&logits, sampling_config)?;
-                                    MxArray::async_eval_arrays(&[&next_token]);
-                                    Some(next_token)
-                                }
+                                let next_ids = y.reshape(&[1, 1])?;
+                                let logits = forward_inner(
+                                    &next_ids,
+                                    &embedding_weight,
+                                    &mut layers_guard,
+                                    &mut caches_guard,
+                                    &final_norm_guard,
+                                    &lm_head_guard,
+                                    fa_idx,
+                                    Some(&embedding_weight_t),
+                                )?;
+                                let mut logits = logits.squeeze(Some(&[1]))?;
+
+                                let next_token =
+                                    if reasoning_tracker.should_force_think_end() {
+                                        let forced_id =
+                                            reasoning_tracker.forced_token_id() as i32;
+                                        MxArray::from_int32(&[forced_id], &[1])?
+                                    } else {
+                                        if repetition_penalty != 1.0 {
+                                            logits = apply_repetition_penalty(
+                                                &logits,
+                                                &token_history,
+                                                repetition_penalty,
+                                                Some(repetition_context_size),
+                                            )?;
+                                        }
+                                        if presence_penalty != 0.0 {
+                                            logits = apply_presence_penalty(
+                                                &logits,
+                                                &token_history,
+                                                presence_penalty,
+                                                Some(presence_context_size),
+                                            )?;
+                                        }
+                                        if frequency_penalty != 0.0 {
+                                            logits = apply_frequency_penalty(
+                                                &logits,
+                                                &token_history,
+                                                frequency_penalty,
+                                                Some(frequency_context_size),
+                                            )?;
+                                        }
+                                        sample(&logits, sampling_config)?
+                                    };
+
+                                // Eval both next_token and logits to ensure forward graph
+                                // (including KV cache updates) is materialized.
+                                MxArray::async_eval_arrays(&[&next_token, &logits]);
+                                Some(next_token)
                             } else {
                                 None
                             };
@@ -2173,6 +2191,7 @@ impl Qwen3_5MoeModel {
                             }
 
                             let is_reasoning = reasoning_tracker.observe_token(token_id);
+                            last_is_reasoning = is_reasoning;
 
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
@@ -2324,7 +2343,7 @@ impl Qwen3_5MoeModel {
                                 num_tokens: None,
                                 raw_text: None,
                                 performance: None,
-                                is_reasoning: None,
+                                is_reasoning: Some(last_is_reasoning),
                             }),
                             ThreadsafeFunctionCallMode::NonBlocking,
                         );

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -2357,15 +2357,27 @@ impl Qwen3_5MoeModel {
 
                     let num_tokens = generated_tokens.len() as u32;
 
-                    let think_tag = if starts_in_thinking
-                        && tools::has_think_end_token(&generated_tokens, think_end_id_stream)
-                    {
-                        think_end_str_stream.as_deref()
+                    let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
+                        let (clean, calls) = tools::parse_tool_calls(&text);
+                        (clean, calls, None)
+                    } else if tools::has_think_end_token(
+                        &generated_tokens,
+                        think_end_id_stream,
+                    ) {
+                        tools::split_at_think_end(
+                            &text,
+                            think_end_str_stream.as_deref(),
+                        )
                     } else {
-                        None
+                        let t = text.trim();
+                        let t = t.strip_prefix("<think>").unwrap_or(t).trim();
+                        let thinking = if t.is_empty() {
+                            None
+                        } else {
+                            Some(t.to_string())
+                        };
+                        (String::new(), vec![], thinking)
                     };
-                    let (clean_text, tool_calls, thinking) =
-                        tools::split_at_think_end(&text, think_tag);
                     let thinking = if include_reasoning { thinking } else { None };
 
                     // If we have valid tool calls, override finish reason

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -32,7 +32,7 @@ use crate::models::qwen3_5::chat_common::{
     save_cache_state, verify_cache_prefix,
 };
 use crate::nn::{Embedding, Linear, RMSNorm};
-use crate::sampling::{SamplingConfig, check_repetition_cutoff, sample};
+use crate::sampling::{SamplingConfig, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 
@@ -1779,120 +1779,41 @@ impl Qwen3_5MoeModel {
                             p.thinking_token_budget,
                             think_end_id_stream,
                         );
-                        for step in 0..p.max_new_tokens {
-                            // Build and submit graph for step N+1.
-                            // forward() always runs to keep KV caches consistent.
-                            let next_y = if step + 1 < p.max_new_tokens {
-                                let _stream_ctx = StreamContext::new(generation_stream);
-
-                                profiler.begin("forward");
-                                let next_ids = y.reshape(&[1, 1])?;
-                                let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
-                                profiler.end();
-
-                                let (next_token, budget_forced) =
-                                    if reasoning_tracker.should_force_think_end() {
-                                        let forced_id = reasoning_tracker.forced_token_id() as i32;
-                                        (MxArray::from_int32(&[forced_id], &[1])?, true)
-                                    } else {
-                                        profiler.begin("rep_penalty");
-                                        logits = apply_all_penalties(logits, &token_history, &p)?;
-                                        profiler.end();
-
-                                        profiler.begin("sample");
-                                        let t = sample(&logits, p.sampling_config)?;
-                                        profiler.end();
-                                        (t, false)
-                                    };
-
-                                profiler.begin("eval_caches");
-                                eval_token_and_moe_caches(&next_token);
+                        let mut ops = chat_common::DecodeOps {
+                            forward: |ids: &MxArray, emb: &MxArray| -> Result<(MxArray, bool)> {
+                                Ok((forward_moe_cpp(ids, emb)?, false))
+                            },
+                            eval_step: |token: &MxArray, logits: &MxArray, budget_forced: bool| {
+                                eval_token_and_moe_caches(token);
                                 if budget_forced {
-                                    // When budget-forced, next_token is a constant that doesn't
-                                    // pull the forward graph. Eval logits to materialize cache updates.
                                     logits.eval();
                                 }
-                                profiler.end();
-
-                                Some(next_token)
-                            } else {
-                                None
-                            };
-
-                            // Wait for step N (GPU already computing N+1)
-                            profiler.begin("eval_token");
-                            y.eval();
-                            profiler.end();
-
-                            profiler.begin("extract");
-                            let token_id = y.item_at_int32(0)? as u32;
-                            profiler.end();
-                            profiler.mark_first_token();
-                            if p.report_performance && first_token_instant.is_none() {
-                                first_token_instant = Some(std::time::Instant::now());
+                            },
+                        };
+                        chat_common::decode_loop!(
+                            ops: ops,
+                            y: y,
+                            embedding_weight: embedding_weight,
+                            params: p,
+                            reasoning_tracker: reasoning_tracker,
+                            profiler: profiler,
+                            max_new_tokens: p.max_new_tokens,
+                            eos_id: eos_id,
+                            generated_tokens: generated_tokens,
+                            token_history: token_history,
+                            finish_reason: finish_reason,
+                            first_token_instant: first_token_instant,
+                            report_perf: p.report_performance,
+                            generation_stream: generation_stream,
+                            streaming: {
+                                callback: callback,
+                                cancelled: cancelled_inner,
+                                decode_stream: decode_stream,
+                                tokenizer: tokenizer_for_decode,
+                                streamed_text_len: streamed_text_len,
+                                last_is_reasoning: last_is_reasoning
                             }
-                            generated_tokens.push(token_id);
-                            token_history.push(token_id);
-
-                            let is_reasoning = reasoning_tracker.observe_token(token_id);
-                            last_is_reasoning = is_reasoning;
-
-                            if cancelled_inner.load(Ordering::Relaxed) {
-                                finish_reason = String::from("cancelled");
-                                break;
-                            }
-
-                            let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
-                                &mut decode_stream,
-                                tokenizer_for_decode.inner(),
-                                token_id,
-                                &generated_tokens,
-                                streamed_text_len,
-                            );
-                            streamed_text_len += token_text.len();
-                            callback.call(
-                                Ok(ChatStreamChunk {
-                                    text: token_text,
-                                    done: false,
-                                    finish_reason: None,
-                                    tool_calls: None,
-                                    thinking: None,
-                                    num_tokens: None,
-                                    raw_text: None,
-                                    performance: None,
-                                    is_reasoning: Some(is_reasoning),
-                                }),
-                                ThreadsafeFunctionCallMode::NonBlocking,
-                            );
-
-                            if token_id == eos_id {
-                                finish_reason = String::from("stop");
-                                break;
-                            }
-
-                            if let Some(reason) = check_repetition_cutoff(
-                                &generated_tokens,
-                                p.max_consecutive_tokens,
-                                p.max_ngram_repeats,
-                                p.ngram_size,
-                            ) {
-                                finish_reason = reason.to_string();
-                                break;
-                            }
-
-                            match next_y {
-                                Some(next) => y = next,
-                                None => break,
-                            }
-
-                            profiler.step();
-
-                            if (step + 1) % 256 == 0 {
-                                crate::array::synchronize_and_clear_cache();
-                            }
-                        }
-                        profiler.snapshot_memory_after();
-                        profiler.report();
+                        );
 
                         // === Export caches from C++ before MoeResetGuard drops ===
                         if reuse_cache {
@@ -1938,17 +1859,11 @@ impl Qwen3_5MoeModel {
                             p.thinking_token_budget,
                             think_end_id_stream,
                         );
-                        for step in 0..p.max_new_tokens {
-                            // Build and submit graph for step N+1.
-                            // forward() always runs to keep KV caches consistent.
-                            let next_y = if step + 1 < p.max_new_tokens {
-                                let _stream_ctx = StreamContext::new(generation_stream);
-
-                                profiler.begin("forward");
-                                let next_ids = y.reshape(&[1, 1])?;
+                        let mut ops = chat_common::DecodeOps {
+                            forward: |ids: &MxArray, emb: &MxArray| -> Result<(MxArray, bool)> {
                                 let logits = forward_inner(
-                                    &next_ids,
-                                    &embedding_weight,
+                                    ids,
+                                    emb,
                                     &mut layers_guard,
                                     &mut caches_guard,
                                     &final_norm_guard,
@@ -1956,109 +1871,36 @@ impl Qwen3_5MoeModel {
                                     fa_idx,
                                     Some(&embedding_weight_t),
                                 )?;
-                                let mut logits = logits.squeeze(Some(&[1]))?;
-                                profiler.end();
-
-                                let next_token = if reasoning_tracker.should_force_think_end() {
-                                    let forced_id = reasoning_tracker.forced_token_id() as i32;
-                                    MxArray::from_int32(&[forced_id], &[1])?
-                                } else {
-                                    profiler.begin("rep_penalty");
-                                    logits = apply_all_penalties(logits, &token_history, &p)?;
-                                    profiler.end();
-
-                                    profiler.begin("sample");
-                                    let t = sample(&logits, p.sampling_config)?;
-                                    profiler.end();
-                                    t
-                                };
-
-                                profiler.begin("eval_caches");
-                                // Eval both next_token and logits to ensure forward graph
-                                // (including KV cache updates) is materialized.
-                                MxArray::async_eval_arrays(&[&next_token, &logits]);
-                                profiler.end();
-
-                                Some(next_token)
-                            } else {
-                                None
-                            };
-
-                            // Wait for step N (GPU already computing N+1)
-                            profiler.begin("eval_token");
-                            y.eval();
-                            profiler.end();
-
-                            profiler.begin("extract");
-                            let token_id = y.item_at_int32(0)? as u32;
-                            profiler.end();
-                            profiler.mark_first_token();
-                            if p.report_performance && first_token_instant.is_none() {
-                                first_token_instant = Some(std::time::Instant::now());
+                                Ok((logits, true))
+                            },
+                            eval_step: |token: &MxArray, logits: &MxArray, _budget_forced: bool| {
+                                MxArray::async_eval_arrays(&[token, logits]);
+                            },
+                        };
+                        chat_common::decode_loop!(
+                            ops: ops,
+                            y: y,
+                            embedding_weight: embedding_weight,
+                            params: p,
+                            reasoning_tracker: reasoning_tracker,
+                            profiler: profiler,
+                            max_new_tokens: p.max_new_tokens,
+                            eos_id: eos_id,
+                            generated_tokens: generated_tokens,
+                            token_history: token_history,
+                            finish_reason: finish_reason,
+                            first_token_instant: first_token_instant,
+                            report_perf: p.report_performance,
+                            generation_stream: generation_stream,
+                            streaming: {
+                                callback: callback,
+                                cancelled: cancelled_inner,
+                                decode_stream: decode_stream,
+                                tokenizer: tokenizer_for_decode,
+                                streamed_text_len: streamed_text_len,
+                                last_is_reasoning: last_is_reasoning
                             }
-                            generated_tokens.push(token_id);
-                            token_history.push(token_id);
-
-                            let is_reasoning = reasoning_tracker.observe_token(token_id);
-                            last_is_reasoning = is_reasoning;
-
-                            if cancelled_inner.load(Ordering::Relaxed) {
-                                finish_reason = String::from("cancelled");
-                                break;
-                            }
-
-                            let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
-                                &mut decode_stream,
-                                tokenizer_for_decode.inner(),
-                                token_id,
-                                &generated_tokens,
-                                streamed_text_len,
-                            );
-                            streamed_text_len += token_text.len();
-                            callback.call(
-                                Ok(ChatStreamChunk {
-                                    text: token_text,
-                                    done: false,
-                                    finish_reason: None,
-                                    tool_calls: None,
-                                    thinking: None,
-                                    num_tokens: None,
-                                    raw_text: None,
-                                    performance: None,
-                                    is_reasoning: Some(is_reasoning),
-                                }),
-                                ThreadsafeFunctionCallMode::NonBlocking,
-                            );
-
-                            if token_id == eos_id {
-                                finish_reason = String::from("stop");
-                                break;
-                            }
-
-                            if let Some(reason) = check_repetition_cutoff(
-                                &generated_tokens,
-                                p.max_consecutive_tokens,
-                                p.max_ngram_repeats,
-                                p.ngram_size,
-                            ) {
-                                finish_reason = reason.to_string();
-                                break;
-                            }
-
-                            match next_y {
-                                Some(next) => y = next,
-                                None => break,
-                            }
-
-                            profiler.step();
-
-                            if (step + 1) % 256 == 0 {
-                                crate::array::synchronize_and_clear_cache();
-                            }
-                        }
-
-                        profiler.snapshot_memory_after();
-                        profiler.report();
+                        );
 
                         drop(layers_guard);
                         drop(caches_guard);

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1848,8 +1848,7 @@ impl Qwen3_5MoeModel {
                     let mut y = sample(&last_logits, sampling_config)?;
                     MxArray::async_eval_arrays(&[&y]);
 
-                    let starts_in_thinking =
-                        enable_thinking.unwrap_or(true) && think_end_id_stream.is_some();
+                    let starts_in_thinking = enable_thinking.unwrap_or(true);
                     let mut last_is_reasoning = starts_in_thinking;
 
                     if use_cpp {
@@ -1938,8 +1937,7 @@ impl Qwen3_5MoeModel {
                         // C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("moe_chat_stream_compiled");
 
-                        let starts_in_thinking =
-                            enable_thinking.unwrap_or(true) && think_end_id_stream.is_some();
+                        let starts_in_thinking = enable_thinking.unwrap_or(true);
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
                             thinking_token_budget,
@@ -2105,8 +2103,7 @@ impl Qwen3_5MoeModel {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("moe_chat_stream_rust");
 
-                        let starts_in_thinking =
-                            enable_thinking.unwrap_or(true) && think_end_id_stream.is_some();
+                        let starts_in_thinking = enable_thinking.unwrap_or(true);
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
                             thinking_token_budget,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1138,7 +1138,7 @@ impl Qwen3_5MoeModel {
                 // token behind), matching Python mlx-lm's pipelining behavior.
                 profiler.set_label("moe_chat_compiled");
 
-                let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let starts_in_thinking = enable_thinking.unwrap_or(true);
                 let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                     starts_in_thinking,
                     p.thinking_token_budget,
@@ -1270,7 +1270,7 @@ impl Qwen3_5MoeModel {
                 // Rust fallback decode loop (pipelined)
                 profiler.set_label("moe_chat_rust");
 
-                let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let starts_in_thinking = enable_thinking.unwrap_or(true);
                 let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                     starts_in_thinking,
                     p.thinking_token_budget,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1902,32 +1902,49 @@ impl Qwen3_5MoeModel {
                             // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < p.max_new_tokens {
                                 let _stream_ctx = StreamContext::new(generation_stream);
+
+                                profiler.begin("forward");
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
+                                profiler.end();
 
                                 let (next_token, budget_forced) =
                                     if reasoning_tracker.should_force_think_end() {
                                         let forced_id = reasoning_tracker.forced_token_id() as i32;
                                         (MxArray::from_int32(&[forced_id], &[1])?, true)
                                     } else {
+                                        profiler.begin("rep_penalty");
                                         logits = apply_all_penalties(logits, &token_history, &p)?;
-                                        (sample(&logits, p.sampling_config)?, false)
+                                        profiler.end();
+
+                                        profiler.begin("sample");
+                                        let t = sample(&logits, p.sampling_config)?;
+                                        profiler.end();
+                                        (t, false)
                                     };
 
+                                profiler.begin("eval_caches");
                                 eval_token_and_moe_caches(&next_token);
                                 if budget_forced {
                                     // When budget-forced, next_token is a constant that doesn't
                                     // pull the forward graph. Eval logits to materialize cache updates.
                                     logits.eval();
                                 }
+                                profiler.end();
+
                                 Some(next_token)
                             } else {
                                 None
                             };
 
                             // Wait for step N (GPU already computing N+1)
+                            profiler.begin("eval_token");
                             y.eval();
+                            profiler.end();
+
+                            profiler.begin("extract");
                             let token_id = y.item_at_int32(0)? as u32;
+                            profiler.end();
                             profiler.mark_first_token();
                             if p.report_performance && first_token_instant.is_none() {
                                 first_token_instant = Some(std::time::Instant::now());
@@ -2043,6 +2060,9 @@ impl Qwen3_5MoeModel {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
                             let next_y = if step + 1 < p.max_new_tokens {
+                                let _stream_ctx = StreamContext::new(generation_stream);
+
+                                profiler.begin("forward");
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let logits = forward_inner(
                                     &next_ids,
@@ -2055,26 +2075,41 @@ impl Qwen3_5MoeModel {
                                     Some(&embedding_weight_t),
                                 )?;
                                 let mut logits = logits.squeeze(Some(&[1]))?;
+                                profiler.end();
 
                                 let next_token = if reasoning_tracker.should_force_think_end() {
                                     let forced_id = reasoning_tracker.forced_token_id() as i32;
                                     MxArray::from_int32(&[forced_id], &[1])?
                                 } else {
+                                    profiler.begin("rep_penalty");
                                     logits = apply_all_penalties(logits, &token_history, &p)?;
-                                    sample(&logits, p.sampling_config)?
+                                    profiler.end();
+
+                                    profiler.begin("sample");
+                                    let t = sample(&logits, p.sampling_config)?;
+                                    profiler.end();
+                                    t
                                 };
 
+                                profiler.begin("eval_caches");
                                 // Eval both next_token and logits to ensure forward graph
                                 // (including KV cache updates) is materialized.
                                 MxArray::async_eval_arrays(&[&next_token, &logits]);
+                                profiler.end();
+
                                 Some(next_token)
                             } else {
                                 None
                             };
 
                             // Wait for step N (GPU already computing N+1)
+                            profiler.begin("eval_token");
                             y.eval();
+                            profiler.end();
+
+                            profiler.begin("extract");
                             let token_id = y.item_at_int32(0)? as u32;
+                            profiler.end();
                             profiler.mark_first_token();
                             if p.report_performance && first_token_instant.is_none() {
                                 first_token_instant = Some(std::time::Instant::now());

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -2358,7 +2358,8 @@ impl Qwen3_5MoeModel {
                     let num_tokens = generated_tokens.len() as u32;
 
                     let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
-                        let (clean, calls) = tools::parse_tool_calls(&text);
+                        let stripped = tools::strip_think_markup(&text);
+                        let (clean, calls) = tools::parse_tool_calls(&stripped);
                         (clean, calls, None)
                     } else if tools::has_think_end_token(
                         &generated_tokens,
@@ -2370,7 +2371,11 @@ impl Qwen3_5MoeModel {
                         )
                     } else {
                         let t = text.trim();
-                        let t = t.strip_prefix("<think>").unwrap_or(t).trim();
+                        let t = t
+                            .strip_prefix("<think>")
+                            .or_else(|| t.strip_prefix("<longcat_think>"))
+                            .unwrap_or(t)
+                            .trim();
                         let thinking = if t.is_empty() {
                             None
                         } else {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -729,7 +729,6 @@ impl Qwen3_5MoeModel {
             max_ngram_repeats: None,
             ngram_size: None,
             tools: None,
-            enable_thinking: None,
             thinking_token_budget: None,
             include_reasoning: None,
             reasoning_effort: None,
@@ -808,11 +807,7 @@ impl Qwen3_5MoeModel {
             let use_cpp = _weight_guard.is_some();
 
             let tool_defs = config.tools.as_deref();
-            let enable_thinking = match config.reasoning_effort.as_deref() {
-                Some("low") | Some("none") => Some(false),
-                Some("medium") | Some("high") => Some(true),
-                _ => config.enable_thinking,
-            };
+            let enable_thinking = chat_common::resolve_enable_thinking(&config);
             let tokens = tokenizer.apply_chat_template_sync(
                 &messages,
                 Some(true),
@@ -1446,7 +1441,6 @@ impl Qwen3_5MoeModel {
             max_ngram_repeats: None,
             ngram_size: None,
             tools: None,
-            enable_thinking: None,
             thinking_token_budget: None,
             include_reasoning: None,
             reasoning_effort: None,
@@ -1536,11 +1530,7 @@ impl Qwen3_5MoeModel {
                     let use_cpp = _weight_guard.is_some();
 
                     let tool_defs = config.tools.as_deref();
-                    let enable_thinking = match config.reasoning_effort.as_deref() {
-                        Some("low") | Some("none") => Some(false),
-                        Some("medium") | Some("high") => Some(true),
-                        _ => config.enable_thinking,
-                    };
+                    let enable_thinking = chat_common::resolve_enable_thinking(&config);
                     let tokens = tokenizer.apply_chat_template_sync(
                         &messages,
                         Some(true),

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -22,6 +22,7 @@ use super::quantized_linear::LinearProj;
 use crate::array::MxArray;
 use crate::array::mask::create_causal_mask;
 use crate::models::qwen3::{BatchGenerationResult, GenerationConfig, GenerationResult};
+use crate::models::qwen3_5::chat_common;
 use crate::models::qwen3_5::chat_common::{
     apply_all_penalties, compute_performance_metrics, extract_chat_params, finalize_chat_result,
     save_cache_state, verify_cache_prefix,
@@ -731,6 +732,9 @@ impl Qwen3_5MoeModel {
             ngram_size: None,
             tools: None,
             enable_thinking: None,
+            thinking_token_budget: None,
+            include_reasoning: None,
+            reasoning_effort: None,
             report_performance: None,
             reuse_cache: None,
         });
@@ -806,7 +810,11 @@ impl Qwen3_5MoeModel {
             let use_cpp = _weight_guard.is_some();
 
             let tool_defs = config.tools.as_deref();
-            let enable_thinking = config.enable_thinking;
+            let enable_thinking = match config.reasoning_effort.as_deref() {
+                Some("low") | Some("none") => Some(false),
+                Some("medium") | Some("high") => Some(true),
+                _ => config.enable_thinking,
+            };
             let tokens = tokenizer.apply_chat_template_sync(
                 &messages,
                 Some(true),
@@ -1136,27 +1144,44 @@ impl Qwen3_5MoeModel {
                 // Rep penalty uses token_history as-of graph build time (one
                 // token behind), matching Python mlx-lm's pipelining behavior.
                 profiler.set_label("moe_chat_compiled");
+
+                let starts_in_thinking =
+                    enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let mut reasoning_tracker = chat_common::ReasoningTracker::new(
+                    starts_in_thinking,
+                    p.thinking_token_budget,
+                    think_end_id,
+                );
+
                 for step in 0..max_new_tokens {
                     // Build and submit graph for step N+1 before waiting for N
                     let next_y = if step + 1 < max_new_tokens {
-                        profiler.begin("forward");
-                        let next_ids = y.reshape(&[1, 1])?;
-                        let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
-                        profiler.end();
+                        if reasoning_tracker.should_force_think_end() {
+                            // Budget exhausted — force </think> token
+                            let forced_id = reasoning_tracker.forced_token_id() as i32;
+                            let forced = MxArray::from_int32(&[forced_id], &[1])?;
+                            eval_token_and_moe_caches(&forced);
+                            Some(forced)
+                        } else {
+                            profiler.begin("forward");
+                            let next_ids = y.reshape(&[1, 1])?;
+                            let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
+                            profiler.end();
 
-                        profiler.begin("rep_penalty");
-                        logits = apply_all_penalties(logits, &token_history, &p)?;
-                        profiler.end();
+                            profiler.begin("rep_penalty");
+                            logits = apply_all_penalties(logits, &token_history, &p)?;
+                            profiler.end();
 
-                        profiler.begin("sample");
-                        let next_token = sample(&logits, p.sampling_config)?;
-                        profiler.end();
+                            profiler.begin("sample");
+                            let next_token = sample(&logits, p.sampling_config)?;
+                            profiler.end();
 
-                        profiler.begin("eval_caches");
-                        eval_token_and_moe_caches(&next_token);
-                        profiler.end();
+                            profiler.begin("eval_caches");
+                            eval_token_and_moe_caches(&next_token);
+                            profiler.end();
 
-                        Some(next_token)
+                            Some(next_token)
+                        }
                     } else {
                         None
                     };
@@ -1176,6 +1201,7 @@ impl Qwen3_5MoeModel {
 
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
+                    reasoning_tracker.observe_token(token_id);
 
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
@@ -1242,37 +1268,53 @@ impl Qwen3_5MoeModel {
             } else {
                 // Rust fallback decode loop (pipelined)
                 profiler.set_label("moe_chat_rust");
+
+                let starts_in_thinking =
+                    enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let mut reasoning_tracker = chat_common::ReasoningTracker::new(
+                    starts_in_thinking,
+                    p.thinking_token_budget,
+                    think_end_id,
+                );
+
                 for step in 0..max_new_tokens {
                     // Build and submit graph for step N+1 before waiting for N
                     let next_y = if step + 1 < max_new_tokens {
-                        profiler.begin("forward");
-                        let next_ids = y.reshape(&[1, 1])?;
-                        let logits = forward_inner(
-                            &next_ids,
-                            &embedding_weight,
-                            &mut layers_guard,
-                            &mut caches_guard,
-                            &final_norm_guard,
-                            &lm_head_guard,
-                            fa_idx,
-                            Some(&embedding_weight_t),
-                        )?;
-                        let mut logits = logits.squeeze(Some(&[1]))?;
-                        profiler.end();
+                        if reasoning_tracker.should_force_think_end() {
+                            let forced_id = reasoning_tracker.forced_token_id() as i32;
+                            let forced = MxArray::from_int32(&[forced_id], &[1])?;
+                            MxArray::async_eval_arrays(&[&forced]);
+                            Some(forced)
+                        } else {
+                            profiler.begin("forward");
+                            let next_ids = y.reshape(&[1, 1])?;
+                            let logits = forward_inner(
+                                &next_ids,
+                                &embedding_weight,
+                                &mut layers_guard,
+                                &mut caches_guard,
+                                &final_norm_guard,
+                                &lm_head_guard,
+                                fa_idx,
+                                Some(&embedding_weight_t),
+                            )?;
+                            let mut logits = logits.squeeze(Some(&[1]))?;
+                            profiler.end();
 
-                        profiler.begin("rep_penalty");
-                        logits = apply_all_penalties(logits, &token_history, &p)?;
-                        profiler.end();
+                            profiler.begin("rep_penalty");
+                            logits = apply_all_penalties(logits, &token_history, &p)?;
+                            profiler.end();
 
-                        profiler.begin("sample");
-                        let next_token = sample(&logits, p.sampling_config)?;
-                        profiler.end();
+                            profiler.begin("sample");
+                            let next_token = sample(&logits, p.sampling_config)?;
+                            profiler.end();
 
-                        profiler.begin("async_eval");
-                        MxArray::async_eval_arrays(&[&next_token]);
-                        profiler.end();
+                            profiler.begin("async_eval");
+                            MxArray::async_eval_arrays(&[&next_token]);
+                            profiler.end();
 
-                        Some(next_token)
+                            Some(next_token)
+                        }
                     } else {
                         None
                     };
@@ -1292,6 +1334,7 @@ impl Qwen3_5MoeModel {
 
                     generated_tokens.push(token_id);
                     token_history.push(token_id);
+                    reasoning_tracker.observe_token(token_id);
 
                     if token_id == eos_id {
                         finish_reason = String::from("stop");
@@ -1357,6 +1400,7 @@ impl Qwen3_5MoeModel {
                 think_end_id,
                 think_end_str.as_deref(),
                 performance,
+                p.include_reasoning,
             )
         })
         .await
@@ -1394,6 +1438,9 @@ impl Qwen3_5MoeModel {
             ngram_size: None,
             tools: None,
             enable_thinking: None,
+            thinking_token_budget: None,
+            include_reasoning: None,
+            reasoning_effort: None,
             report_performance: None,
             reuse_cache: None,
         });
@@ -1480,7 +1527,11 @@ impl Qwen3_5MoeModel {
                     let use_cpp = _weight_guard.is_some();
 
                     let tool_defs = config.tools.as_deref();
-                    let enable_thinking = config.enable_thinking;
+                    let enable_thinking = match config.reasoning_effort.as_deref() {
+                Some("low") | Some("none") => Some(false),
+                Some("medium") | Some("high") => Some(true),
+                _ => config.enable_thinking,
+            };
                     let tokens = tokenizer.apply_chat_template_sync(
                         &messages,
                         Some(true),
@@ -1504,6 +1555,8 @@ impl Qwen3_5MoeModel {
                         top_p: config.top_p,
                         min_p: config.min_p,
                     });
+                    let thinking_token_budget = config.thinking_token_budget;
+                    let include_reasoning = config.include_reasoning.unwrap_or(true);
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -1879,38 +1932,56 @@ impl Qwen3_5MoeModel {
 
                         // C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("moe_chat_stream_compiled");
+
+                        let starts_in_thinking =
+                            enable_thinking.unwrap_or(true) && think_end_id_stream.is_some();
+                        let mut reasoning_tracker = chat_common::ReasoningTracker::new(
+                            starts_in_thinking,
+                            thinking_token_budget,
+                            think_end_id_stream,
+                        );
+
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
-                                let next_ids = y.reshape(&[1, 1])?;
-                                let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
-                                if repetition_penalty != 1.0 {
-                                    logits = apply_repetition_penalty(
-                                        &logits,
-                                        &token_history,
-                                        repetition_penalty,
-                                        Some(repetition_context_size),
-                                    )?;
+                                if reasoning_tracker.should_force_think_end() {
+                                    let forced_id =
+                                        reasoning_tracker.forced_token_id() as i32;
+                                    let forced =
+                                        MxArray::from_int32(&[forced_id], &[1])?;
+                                    eval_token_and_moe_caches(&forced);
+                                    Some(forced)
+                                } else {
+                                    let next_ids = y.reshape(&[1, 1])?;
+                                    let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
+                                    if repetition_penalty != 1.0 {
+                                        logits = apply_repetition_penalty(
+                                            &logits,
+                                            &token_history,
+                                            repetition_penalty,
+                                            Some(repetition_context_size),
+                                        )?;
+                                    }
+                                    if presence_penalty != 0.0 {
+                                        logits = apply_presence_penalty(
+                                            &logits,
+                                            &token_history,
+                                            presence_penalty,
+                                            Some(presence_context_size),
+                                        )?;
+                                    }
+                                    if frequency_penalty != 0.0 {
+                                        logits = apply_frequency_penalty(
+                                            &logits,
+                                            &token_history,
+                                            frequency_penalty,
+                                            Some(frequency_context_size),
+                                        )?;
+                                    }
+                                    let next_token = sample(&logits, sampling_config)?;
+                                    eval_token_and_moe_caches(&next_token);
+                                    Some(next_token)
                                 }
-                                if presence_penalty != 0.0 {
-                                    logits = apply_presence_penalty(
-                                        &logits,
-                                        &token_history,
-                                        presence_penalty,
-                                        Some(presence_context_size),
-                                    )?;
-                                }
-                                if frequency_penalty != 0.0 {
-                                    logits = apply_frequency_penalty(
-                                        &logits,
-                                        &token_history,
-                                        frequency_penalty,
-                                        Some(frequency_context_size),
-                                    )?;
-                                }
-                                let next_token = sample(&logits, sampling_config)?;
-                                eval_token_and_moe_caches(&next_token);
-                                Some(next_token)
                             } else {
                                 None
                             };
@@ -1930,6 +2001,8 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
+                            let is_reasoning = reasoning_tracker.observe_token(token_id);
+
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
                                 tokenizer_for_decode.inner(),
@@ -1948,6 +2021,7 @@ impl Qwen3_5MoeModel {
                                     num_tokens: None,
                                     raw_text: None,
                                     performance: None,
+                                    is_reasoning: Some(is_reasoning),
                                 }),
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
@@ -2019,48 +2093,66 @@ impl Qwen3_5MoeModel {
                     } else {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("moe_chat_stream_rust");
+
+                        let starts_in_thinking =
+                            enable_thinking.unwrap_or(true) && think_end_id_stream.is_some();
+                        let mut reasoning_tracker = chat_common::ReasoningTracker::new(
+                            starts_in_thinking,
+                            thinking_token_budget,
+                            think_end_id_stream,
+                        );
+
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1
                             let next_y = if step + 1 < max_new_tokens {
-                                let next_ids = y.reshape(&[1, 1])?;
-                                let logits = forward_inner(
-                                    &next_ids,
-                                    &embedding_weight,
-                                    &mut layers_guard,
-                                    &mut caches_guard,
-                                    &final_norm_guard,
-                                    &lm_head_guard,
-                                    fa_idx,
-                                    Some(&embedding_weight_t),
-                                )?;
-                                let mut logits = logits.squeeze(Some(&[1]))?;
-                                if repetition_penalty != 1.0 {
-                                    logits = apply_repetition_penalty(
-                                        &logits,
-                                        &token_history,
-                                        repetition_penalty,
-                                        Some(repetition_context_size),
+                                if reasoning_tracker.should_force_think_end() {
+                                    let forced_id =
+                                        reasoning_tracker.forced_token_id() as i32;
+                                    let forced =
+                                        MxArray::from_int32(&[forced_id], &[1])?;
+                                    MxArray::async_eval_arrays(&[&forced]);
+                                    Some(forced)
+                                } else {
+                                    let next_ids = y.reshape(&[1, 1])?;
+                                    let logits = forward_inner(
+                                        &next_ids,
+                                        &embedding_weight,
+                                        &mut layers_guard,
+                                        &mut caches_guard,
+                                        &final_norm_guard,
+                                        &lm_head_guard,
+                                        fa_idx,
+                                        Some(&embedding_weight_t),
                                     )?;
+                                    let mut logits = logits.squeeze(Some(&[1]))?;
+                                    if repetition_penalty != 1.0 {
+                                        logits = apply_repetition_penalty(
+                                            &logits,
+                                            &token_history,
+                                            repetition_penalty,
+                                            Some(repetition_context_size),
+                                        )?;
+                                    }
+                                    if presence_penalty != 0.0 {
+                                        logits = apply_presence_penalty(
+                                            &logits,
+                                            &token_history,
+                                            presence_penalty,
+                                            Some(presence_context_size),
+                                        )?;
+                                    }
+                                    if frequency_penalty != 0.0 {
+                                        logits = apply_frequency_penalty(
+                                            &logits,
+                                            &token_history,
+                                            frequency_penalty,
+                                            Some(frequency_context_size),
+                                        )?;
+                                    }
+                                    let next_token = sample(&logits, sampling_config)?;
+                                    MxArray::async_eval_arrays(&[&next_token]);
+                                    Some(next_token)
                                 }
-                                if presence_penalty != 0.0 {
-                                    logits = apply_presence_penalty(
-                                        &logits,
-                                        &token_history,
-                                        presence_penalty,
-                                        Some(presence_context_size),
-                                    )?;
-                                }
-                                if frequency_penalty != 0.0 {
-                                    logits = apply_frequency_penalty(
-                                        &logits,
-                                        &token_history,
-                                        frequency_penalty,
-                                        Some(frequency_context_size),
-                                    )?;
-                                }
-                                let next_token = sample(&logits, sampling_config)?;
-                                MxArray::async_eval_arrays(&[&next_token]);
-                                Some(next_token)
                             } else {
                                 None
                             };
@@ -2080,6 +2172,8 @@ impl Qwen3_5MoeModel {
                                 break;
                             }
 
+                            let is_reasoning = reasoning_tracker.observe_token(token_id);
+
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
                                 tokenizer_for_decode.inner(),
@@ -2098,6 +2192,7 @@ impl Qwen3_5MoeModel {
                                     num_tokens: None,
                                     raw_text: None,
                                     performance: None,
+                                    is_reasoning: Some(is_reasoning),
                                 }),
                                 ThreadsafeFunctionCallMode::NonBlocking,
                             );
@@ -2229,6 +2324,7 @@ impl Qwen3_5MoeModel {
                                 num_tokens: None,
                                 raw_text: None,
                                 performance: None,
+                                is_reasoning: None,
                             }),
                             ThreadsafeFunctionCallMode::NonBlocking,
                         );
@@ -2244,6 +2340,7 @@ impl Qwen3_5MoeModel {
                         };
                     let (clean_text, tool_calls, thinking) =
                         tools::split_at_think_end(&text, think_tag);
+                    let thinking = if include_reasoning { thinking } else { None };
 
                     // If we have valid tool calls, override finish reason
                     let finish_reason = if tool_calls.iter().any(|tc| tc.status == "ok") {
@@ -2263,6 +2360,7 @@ impl Qwen3_5MoeModel {
                             num_tokens: Some(num_tokens),
                             raw_text: Some(text),
                             performance,
+                            is_reasoning: None,
                         }),
                         ThreadsafeFunctionCallMode::NonBlocking,
                     );

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1935,7 +1935,6 @@ impl Qwen3_5MoeModel {
                         // C++ decode loop (pipelined — submit N+1 before eval N)
                         profiler.set_label("moe_chat_stream_compiled");
 
-                        let starts_in_thinking = enable_thinking.unwrap_or(true);
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
                             thinking_token_budget,
@@ -2101,7 +2100,6 @@ impl Qwen3_5MoeModel {
                         // Rust fallback decode loop (pipelined)
                         profiler.set_label("moe_chat_stream_rust");
 
-                        let starts_in_thinking = enable_thinking.unwrap_or(true);
                         let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                             starts_in_thinking,
                             thinking_token_budget,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1145,8 +1145,7 @@ impl Qwen3_5MoeModel {
                 // token behind), matching Python mlx-lm's pipelining behavior.
                 profiler.set_label("moe_chat_compiled");
 
-                let starts_in_thinking =
-                    enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
                 let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                     starts_in_thinking,
                     p.thinking_token_budget,
@@ -1272,8 +1271,7 @@ impl Qwen3_5MoeModel {
                 // Rust fallback decode loop (pipelined)
                 profiler.set_label("moe_chat_rust");
 
-                let starts_in_thinking =
-                    enable_thinking.unwrap_or(true) && think_end_id.is_some();
+                let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
                 let mut reasoning_tracker = chat_common::ReasoningTracker::new(
                     starts_in_thinking,
                     p.thinking_token_budget,
@@ -1399,8 +1397,7 @@ impl Qwen3_5MoeModel {
                 generated_tokens.len(),
             );
 
-            let starts_in_thinking =
-                enable_thinking.unwrap_or(true) && think_end_id.is_some();
+            let starts_in_thinking = enable_thinking.unwrap_or(true) && think_end_id.is_some();
             finalize_chat_result(
                 &tokenizer_for_decode,
                 &generated_tokens,
@@ -1537,10 +1534,10 @@ impl Qwen3_5MoeModel {
 
                     let tool_defs = config.tools.as_deref();
                     let enable_thinking = match config.reasoning_effort.as_deref() {
-                Some("low") | Some("none") => Some(false),
-                Some("medium") | Some("high") => Some(true),
-                _ => config.enable_thinking,
-            };
+                        Some("low") | Some("none") => Some(false),
+                        Some("medium") | Some("high") => Some(true),
+                        _ => config.enable_thinking,
+                    };
                     let tokens = tokenizer.apply_chat_template_sync(
                         &messages,
                         Some(true),
@@ -1565,9 +1562,9 @@ impl Qwen3_5MoeModel {
                         min_p: config.min_p,
                     });
                     let thinking_token_budget = config.thinking_token_budget;
-                    let include_reasoning = config.include_reasoning.unwrap_or_else(|| {
-                        !matches!(config.reasoning_effort.as_deref(), Some("none"))
-                    });
+                    let include_reasoning = config
+                        .include_reasoning
+                        .unwrap_or(!matches!(config.reasoning_effort.as_deref(), Some("none")));
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -1955,9 +1952,6 @@ impl Qwen3_5MoeModel {
                             thinking_token_budget,
                             think_end_id_stream,
                         );
-                        // Use outer last_is_reasoning (shared with residual flush)
-                        last_is_reasoning = starts_in_thinking;
-
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
@@ -1965,38 +1959,36 @@ impl Qwen3_5MoeModel {
                                 let next_ids = y.reshape(&[1, 1])?;
                                 let mut logits = forward_moe_cpp(&next_ids, &embedding_weight)?;
 
-                                let next_token =
-                                    if reasoning_tracker.should_force_think_end() {
-                                        let forced_id =
-                                            reasoning_tracker.forced_token_id() as i32;
-                                        MxArray::from_int32(&[forced_id], &[1])?
-                                    } else {
-                                        if repetition_penalty != 1.0 {
-                                            logits = apply_repetition_penalty(
-                                                &logits,
-                                                &token_history,
-                                                repetition_penalty,
-                                                Some(repetition_context_size),
-                                            )?;
-                                        }
-                                        if presence_penalty != 0.0 {
-                                            logits = apply_presence_penalty(
-                                                &logits,
-                                                &token_history,
-                                                presence_penalty,
-                                                Some(presence_context_size),
-                                            )?;
-                                        }
-                                        if frequency_penalty != 0.0 {
-                                            logits = apply_frequency_penalty(
-                                                &logits,
-                                                &token_history,
-                                                frequency_penalty,
-                                                Some(frequency_context_size),
-                                            )?;
-                                        }
-                                        sample(&logits, sampling_config)?
-                                    };
+                                let next_token = if reasoning_tracker.should_force_think_end() {
+                                    let forced_id = reasoning_tracker.forced_token_id() as i32;
+                                    MxArray::from_int32(&[forced_id], &[1])?
+                                } else {
+                                    if repetition_penalty != 1.0 {
+                                        logits = apply_repetition_penalty(
+                                            &logits,
+                                            &token_history,
+                                            repetition_penalty,
+                                            Some(repetition_context_size),
+                                        )?;
+                                    }
+                                    if presence_penalty != 0.0 {
+                                        logits = apply_presence_penalty(
+                                            &logits,
+                                            &token_history,
+                                            presence_penalty,
+                                            Some(presence_context_size),
+                                        )?;
+                                    }
+                                    if frequency_penalty != 0.0 {
+                                        logits = apply_frequency_penalty(
+                                            &logits,
+                                            &token_history,
+                                            frequency_penalty,
+                                            Some(frequency_context_size),
+                                        )?;
+                                    }
+                                    sample(&logits, sampling_config)?
+                                };
 
                                 eval_token_and_moe_caches(&next_token);
                                 Some(next_token)
@@ -2120,9 +2112,6 @@ impl Qwen3_5MoeModel {
                             thinking_token_budget,
                             think_end_id_stream,
                         );
-                        // Use outer last_is_reasoning (shared with residual flush)
-                        last_is_reasoning = starts_in_thinking;
-
                         for step in 0..max_new_tokens {
                             // Build and submit graph for step N+1.
                             // forward() always runs to keep KV caches consistent.
@@ -2140,38 +2129,36 @@ impl Qwen3_5MoeModel {
                                 )?;
                                 let mut logits = logits.squeeze(Some(&[1]))?;
 
-                                let next_token =
-                                    if reasoning_tracker.should_force_think_end() {
-                                        let forced_id =
-                                            reasoning_tracker.forced_token_id() as i32;
-                                        MxArray::from_int32(&[forced_id], &[1])?
-                                    } else {
-                                        if repetition_penalty != 1.0 {
-                                            logits = apply_repetition_penalty(
-                                                &logits,
-                                                &token_history,
-                                                repetition_penalty,
-                                                Some(repetition_context_size),
-                                            )?;
-                                        }
-                                        if presence_penalty != 0.0 {
-                                            logits = apply_presence_penalty(
-                                                &logits,
-                                                &token_history,
-                                                presence_penalty,
-                                                Some(presence_context_size),
-                                            )?;
-                                        }
-                                        if frequency_penalty != 0.0 {
-                                            logits = apply_frequency_penalty(
-                                                &logits,
-                                                &token_history,
-                                                frequency_penalty,
-                                                Some(frequency_context_size),
-                                            )?;
-                                        }
-                                        sample(&logits, sampling_config)?
-                                    };
+                                let next_token = if reasoning_tracker.should_force_think_end() {
+                                    let forced_id = reasoning_tracker.forced_token_id() as i32;
+                                    MxArray::from_int32(&[forced_id], &[1])?
+                                } else {
+                                    if repetition_penalty != 1.0 {
+                                        logits = apply_repetition_penalty(
+                                            &logits,
+                                            &token_history,
+                                            repetition_penalty,
+                                            Some(repetition_context_size),
+                                        )?;
+                                    }
+                                    if presence_penalty != 0.0 {
+                                        logits = apply_presence_penalty(
+                                            &logits,
+                                            &token_history,
+                                            presence_penalty,
+                                            Some(presence_context_size),
+                                        )?;
+                                    }
+                                    if frequency_penalty != 0.0 {
+                                        logits = apply_frequency_penalty(
+                                            &logits,
+                                            &token_history,
+                                            frequency_penalty,
+                                            Some(frequency_context_size),
+                                        )?;
+                                    }
+                                    sample(&logits, sampling_config)?
+                                };
 
                                 // Eval both next_token and logits to ensure forward graph
                                 // (including KV cache updates) is materialized.
@@ -2360,14 +2347,8 @@ impl Qwen3_5MoeModel {
                     let (clean_text, tool_calls, thinking) = if !starts_in_thinking {
                         let (clean, calls) = tools::parse_tool_calls(&text);
                         (clean, calls, None)
-                    } else if tools::has_think_end_token(
-                        &generated_tokens,
-                        think_end_id_stream,
-                    ) {
-                        tools::split_at_think_end(
-                            &text,
-                            think_end_str_stream.as_deref(),
-                        )
+                    } else if tools::has_think_end_token(&generated_tokens, think_end_id_stream) {
+                        tools::split_at_think_end(&text, think_end_str_stream.as_deref())
                     } else {
                         let t = text.trim();
                         let t = t

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1562,7 +1562,9 @@ impl Qwen3_5MoeModel {
                         min_p: config.min_p,
                     });
                     let thinking_token_budget = config.thinking_token_budget;
-                    let include_reasoning = config.include_reasoning.unwrap_or(true);
+                    let include_reasoning = config.include_reasoning.unwrap_or_else(|| {
+                        !matches!(config.reasoning_effort.as_deref(), Some("none"))
+                    });
 
                     let mut layers_guard = layers_arc
                         .write()
@@ -2008,13 +2010,13 @@ impl Qwen3_5MoeModel {
                             generated_tokens.push(token_id);
                             token_history.push(token_id);
 
+                            let is_reasoning = reasoning_tracker.observe_token(token_id);
+                            last_is_reasoning = is_reasoning;
+
                             if cancelled_inner.load(Ordering::Relaxed) {
                                 finish_reason = String::from("cancelled");
                                 break;
                             }
-
-                            let is_reasoning = reasoning_tracker.observe_token(token_id);
-                            last_is_reasoning = is_reasoning;
 
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,
@@ -2185,13 +2187,13 @@ impl Qwen3_5MoeModel {
                             generated_tokens.push(token_id);
                             token_history.push(token_id);
 
+                            let is_reasoning = reasoning_tracker.observe_token(token_id);
+                            last_is_reasoning = is_reasoning;
+
                             if cancelled_inner.load(Ordering::Relaxed) {
                                 finish_reason = String::from("cancelled");
                                 break;
                             }
-
-                            let is_reasoning = reasoning_tracker.observe_token(token_id);
-                            last_is_reasoning = is_reasoning;
 
                             let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                                 &mut decode_stream,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1555,9 +1555,7 @@ impl Qwen3_5MoeModel {
                         min_p: config.min_p,
                     });
                     let thinking_token_budget = config.thinking_token_budget;
-                    let include_reasoning = config
-                        .include_reasoning
-                        .unwrap_or(!matches!(config.reasoning_effort.as_deref(), Some("none")));
+                    let include_reasoning = chat_common::resolve_include_reasoning(&config);
 
                     let mut layers_guard = layers_arc
                         .write()

--- a/crates/mlx-core/src/tools/mod.rs
+++ b/crates/mlx-core/src/tools/mod.rs
@@ -565,28 +565,32 @@ pub fn has_think_end_token(generated_tokens: &[u32], think_end_id: Option<u32>) 
 /// Split generated output using token-level thinking detection.
 ///
 /// When the think-end token was found in generated tokens (`think_end_tag` is Some),
-/// splits at the corresponding text boundary. Supports both `</think>` and
-/// `</longcat_think>` variants. Falls back to `parse_generation_output` when
-/// no think-end token was detected.
+/// splits at the corresponding text boundary. This is the authoritative path that
+/// ensures tool parsing isolation: tool calls are only extracted from the content
+/// portion after `</think>`, never from reasoning text.
+///
+/// Supports both `</think>` and `</longcat_think>` variants, and handles old-style
+/// templates that emit `<think>` in generated text (stripped as a prefix).
+///
+/// Falls back to `parse_generation_output` only when `think_end_tag` is None.
 pub fn split_at_think_end(
     raw_text: &str,
     think_end_tag: Option<&str>,
 ) -> (String, Vec<ToolCallResult>, Option<String>) {
-    // If the text contains paired <think>...</think> blocks, use the standard
-    // tag-pair parser (handles models that emit the full opening tag).
-    if raw_text.contains("<think>") || raw_text.contains("<longcat_think>") {
-        return parse_generation_output(raw_text);
-    }
-    // Token-level split: the template injected <think>\n as a prefix, so the
-    // generated text starts with thinking content followed by </think>.
-    // When think_end_tag is Some, we have token-level confirmation that the
-    // think-end token was generated, so we always split at its position
-    // regardless of what follows (the newline heuristic is only needed for
-    // the text-level guess path in parse_thinking).
+    // Token-level split: authoritative when think_end_tag is confirmed.
+    // Always takes priority — even when <think> appears in the text (old templates).
+    // Tool calls are parsed only from content after the boundary.
     if let Some(tag) = think_end_tag
         && let Some(close_pos) = raw_text.find(tag)
     {
         let thinking_text = raw_text[..close_pos].trim();
+        // Strip opening think tag from old-style templates that emit it
+        // in generated text (newer templates inject it in the prompt).
+        let thinking_text = thinking_text
+            .strip_prefix("<think>")
+            .or_else(|| thinking_text.strip_prefix("<longcat_think>"))
+            .unwrap_or(thinking_text)
+            .trim();
         let after_tag = &raw_text[close_pos + tag.len()..];
         let response_text = after_tag.trim_start_matches('\n').trim_start();
         let thinking = if thinking_text.is_empty() {
@@ -597,6 +601,8 @@ pub fn split_at_think_end(
         let (clean_text, tool_calls) = parse_tool_calls(response_text);
         return (clean_text.trim().to_string(), tool_calls, thinking);
     }
+    // No token-level confirmation: fall back to generic text-level parsing.
+    // This path is used by callers without token-level info (e.g. build_reward_outputs).
     parse_generation_output(raw_text)
 }
 
@@ -1252,5 +1258,63 @@ The weather in Tokyo is sunny."#;
         // Empty content doesn't start with '{', contain '<function=', or '<name>',
         // so classify_and_parse_tool_call returns None — no tool call produced.
         assert_eq!(calls.len(), 0);
+    }
+
+    // ---- split_at_think_end: tool isolation with token-confirmed boundary ----
+
+    #[test]
+    fn test_split_at_think_end_old_template_tool_in_reasoning() {
+        // Old-style template: explicit <think> + tool_call inside reasoning.
+        // Tool call must NOT be extracted — it's inside the reasoning block.
+        let text = "<think>Let me call <tool_call>{\"name\":\"search\",\"arguments\":{\"q\":\"test\"}}</tool_call> to help</think>\nThe answer is 42";
+        let (clean, tools, thinking) = split_at_think_end(text, Some("</think>"));
+        assert_eq!(clean, "The answer is 42");
+        assert!(tools.is_empty(), "tool_call inside reasoning must not be extracted");
+        let t = thinking.unwrap();
+        assert!(t.contains("tool_call"), "tool_call text should remain in thinking");
+        assert!(t.starts_with("Let me call"), "<think> prefix should be stripped");
+    }
+
+    #[test]
+    fn test_split_at_think_end_tool_only_in_content() {
+        // Tool call in content portion after </think> — should be extracted.
+        let text = "<think>reasoning</think>\n<tool_call>{\"name\":\"search\",\"arguments\":{\"q\":\"test\"}}</tool_call>";
+        let (clean, tools, thinking) = split_at_think_end(text, Some("</think>"));
+        assert_eq!(thinking.unwrap(), "reasoning");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "search");
+        assert!(clean.trim().is_empty());
+    }
+
+    #[test]
+    fn test_split_at_think_end_literal_think_in_reasoning() {
+        // Literal <think> inside reasoning text (e.g., model explaining tags).
+        // Must not cause mis-split — token boundary is authoritative.
+        let text = "The model uses <think> tags for reasoning</think>\ncontent here";
+        let (clean, tools, thinking) = split_at_think_end(text, Some("</think>"));
+        assert_eq!(clean, "content here");
+        assert!(tools.is_empty());
+        let t = thinking.unwrap();
+        assert!(t.contains("<think>"), "literal <think> preserved in thinking");
+    }
+
+    #[test]
+    fn test_split_at_think_end_longcat_variant() {
+        // longcat_think variant with tool_call inside reasoning.
+        let text = "<longcat_think>reasoning <tool_call>{\"name\":\"f\",\"arguments\":{}}</tool_call></longcat_think>\nanswer";
+        let (clean, tools, thinking) = split_at_think_end(text, Some("</longcat_think>"));
+        assert_eq!(clean, "answer");
+        assert!(tools.is_empty(), "tool_call inside longcat reasoning must not be extracted");
+        assert!(thinking.unwrap().contains("tool_call"));
+    }
+
+    #[test]
+    fn test_split_at_think_end_budget_forced_no_newline() {
+        // Budget-forced </think> with no newline separator (model continues directly).
+        let text = "thinking content</think>immediate content";
+        let (clean, tools, thinking) = split_at_think_end(text, Some("</think>"));
+        assert_eq!(thinking.unwrap(), "thinking content");
+        assert_eq!(clean, "immediate content");
+        assert!(tools.is_empty());
     }
 }

--- a/crates/mlx-core/src/tools/mod.rs
+++ b/crates/mlx-core/src/tools/mod.rs
@@ -579,8 +579,10 @@ pub fn split_at_think_end(
     // Token-level split: authoritative when think_end_tag is confirmed.
     // Always takes priority — even when <think> appears in the text (old templates).
     // Tool calls are parsed only from content after the boundary.
+    // Uses rfind (last occurrence) so that a literal </think> mentioned earlier
+    // in reasoning text (e.g., explaining XML) doesn't cause a premature split.
     if let Some(tag) = think_end_tag
-        && let Some(close_pos) = raw_text.find(tag)
+        && let Some(close_pos) = raw_text.rfind(tag)
     {
         let thinking_text = raw_text[..close_pos].trim();
         // Strip opening think tag from old-style templates that emit it
@@ -1330,5 +1332,21 @@ The weather in Tokyo is sunny."#;
         assert_eq!(thinking.unwrap(), "thinking content");
         assert_eq!(clean, "immediate content");
         assert!(tools.is_empty());
+    }
+
+    #[test]
+    fn test_split_at_think_end_literal_close_tag_in_reasoning() {
+        // Reasoning text mentions </think> literally before the actual boundary.
+        // rfind ensures we split at the LAST occurrence (the real boundary).
+        let text =
+            "The model emits </think> to end reasoning. Let me continue.</think>\nactual content";
+        let (clean, tools, thinking) = split_at_think_end(text, Some("</think>"));
+        assert_eq!(clean, "actual content");
+        assert!(tools.is_empty());
+        let t = thinking.unwrap();
+        assert!(
+            t.contains("</think> to end reasoning"),
+            "literal </think> should be preserved in thinking, got: {t}"
+        );
     }
 }

--- a/crates/mlx-core/src/tools/mod.rs
+++ b/crates/mlx-core/src/tools/mod.rs
@@ -496,7 +496,6 @@ pub fn has_thinking(text: &str) -> bool {
     text.contains("<think>") || text.contains("<longcat_think>")
 }
 
-
 /// Result of parsing tool calls from text
 #[napi(object)]
 pub struct ParseToolCallsResult {
@@ -1269,10 +1268,19 @@ The weather in Tokyo is sunny."#;
         let text = "<think>Let me call <tool_call>{\"name\":\"search\",\"arguments\":{\"q\":\"test\"}}</tool_call> to help</think>\nThe answer is 42";
         let (clean, tools, thinking) = split_at_think_end(text, Some("</think>"));
         assert_eq!(clean, "The answer is 42");
-        assert!(tools.is_empty(), "tool_call inside reasoning must not be extracted");
+        assert!(
+            tools.is_empty(),
+            "tool_call inside reasoning must not be extracted"
+        );
         let t = thinking.unwrap();
-        assert!(t.contains("tool_call"), "tool_call text should remain in thinking");
-        assert!(t.starts_with("Let me call"), "<think> prefix should be stripped");
+        assert!(
+            t.contains("tool_call"),
+            "tool_call text should remain in thinking"
+        );
+        assert!(
+            t.starts_with("Let me call"),
+            "<think> prefix should be stripped"
+        );
     }
 
     #[test]
@@ -1295,7 +1303,10 @@ The weather in Tokyo is sunny."#;
         assert_eq!(clean, "content here");
         assert!(tools.is_empty());
         let t = thinking.unwrap();
-        assert!(t.contains("<think>"), "literal <think> preserved in thinking");
+        assert!(
+            t.contains("<think>"),
+            "literal <think> preserved in thinking"
+        );
     }
 
     #[test]
@@ -1304,7 +1315,10 @@ The weather in Tokyo is sunny."#;
         let text = "<longcat_think>reasoning <tool_call>{\"name\":\"f\",\"arguments\":{}}</tool_call></longcat_think>\nanswer";
         let (clean, tools, thinking) = split_at_think_end(text, Some("</longcat_think>"));
         assert_eq!(clean, "answer");
-        assert!(tools.is_empty(), "tool_call inside longcat reasoning must not be extracted");
+        assert!(
+            tools.is_empty(),
+            "tool_call inside longcat reasoning must not be extracted"
+        );
         assert!(thinking.unwrap().contains("tool_call"));
     }
 

--- a/crates/mlx-core/src/tools/mod.rs
+++ b/crates/mlx-core/src/tools/mod.rs
@@ -572,15 +572,16 @@ pub fn split_at_think_end(
     }
     // Token-level split: the template injected <think>\n as a prefix, so the
     // generated text starts with thinking content followed by </think>.
+    // When think_end_tag is Some, we have token-level confirmation that the
+    // think-end token was generated, so we always split at its position
+    // regardless of what follows (the newline heuristic is only needed for
+    // the text-level guess path in parse_thinking).
     if let Some(tag) = think_end_tag
         && let Some(close_pos) = raw_text.find(tag)
     {
-        let after_tag = &raw_text[close_pos + tag.len()..];
-        if !after_tag.is_empty() && !after_tag.starts_with('\n') {
-            return parse_generation_output(raw_text);
-        }
         let thinking_text = raw_text[..close_pos].trim();
-        let response_text = after_tag.trim();
+        let after_tag = &raw_text[close_pos + tag.len()..];
+        let response_text = after_tag.trim_start_matches('\n').trim_start();
         let thinking = if thinking_text.is_empty() {
             None
         } else {

--- a/crates/mlx-core/src/tools/mod.rs
+++ b/crates/mlx-core/src/tools/mod.rs
@@ -579,10 +579,11 @@ pub fn split_at_think_end(
     // Token-level split: authoritative when think_end_tag is confirmed.
     // Always takes priority — even when <think> appears in the text (old templates).
     // Tool calls are parsed only from content after the boundary.
-    // Uses rfind (last occurrence) so that a literal </think> mentioned earlier
-    // in reasoning text (e.g., explaining XML) doesn't cause a premature split.
+    // Uses find (first occurrence): </think> is a special token, so the first
+    // text match is the real boundary. Content after the boundary may mention
+    // </think> literally; rfind would incorrectly split at that later occurrence.
     if let Some(tag) = think_end_tag
-        && let Some(close_pos) = raw_text.rfind(tag)
+        && let Some(close_pos) = raw_text.find(tag)
     {
         let thinking_text = raw_text[..close_pos].trim();
         // Strip opening think tag from old-style templates that emit it
@@ -1335,18 +1336,16 @@ The weather in Tokyo is sunny."#;
     }
 
     #[test]
-    fn test_split_at_think_end_literal_close_tag_in_reasoning() {
-        // Reasoning text mentions </think> literally before the actual boundary.
-        // rfind ensures we split at the LAST occurrence (the real boundary).
-        let text =
-            "The model emits </think> to end reasoning. Let me continue.</think>\nactual content";
+    fn test_split_at_think_end_close_tag_in_content() {
+        // Content after the real boundary mentions </think> literally.
+        // find (first occurrence) splits at the real boundary, not the literal.
+        let text = "reasoning here</think>\nThe </think> tag ends reasoning.";
         let (clean, tools, thinking) = split_at_think_end(text, Some("</think>"));
-        assert_eq!(clean, "actual content");
+        assert_eq!(thinking.unwrap(), "reasoning here");
         assert!(tools.is_empty());
-        let t = thinking.unwrap();
         assert!(
-            t.contains("</think> to end reasoning"),
-            "literal </think> should be preserved in thinking, got: {t}"
+            clean.contains("</think> tag ends reasoning"),
+            "literal </think> in content should be preserved, got: {clean}"
         );
     }
 }

--- a/crates/mlx-core/src/tools/mod.rs
+++ b/crates/mlx-core/src/tools/mod.rs
@@ -496,15 +496,6 @@ pub fn has_thinking(text: &str) -> bool {
     text.contains("<think>") || text.contains("<longcat_think>")
 }
 
-/// Strip think/longcat_think markup tags from text, keeping inner content.
-/// Used in no-thinking mode for old-template compatibility: tags are removed
-/// but their content is treated as normal text, not reasoning.
-pub fn strip_think_markup(text: &str) -> String {
-    text.replace("<think>", "")
-        .replace("</think>", "")
-        .replace("<longcat_think>", "")
-        .replace("</longcat_think>", "")
-}
 
 /// Result of parsing tool calls from text
 #[napi(object)]

--- a/crates/mlx-core/src/tools/mod.rs
+++ b/crates/mlx-core/src/tools/mod.rs
@@ -442,43 +442,49 @@ pub fn has_tool_calls(text: &str) -> bool {
 /// explaining XML tags), the fallback only applies when `</think>` is followed by
 /// a newline or end-of-text — not when it's embedded mid-sentence.
 pub fn parse_thinking(text: &str) -> (String, Option<String>) {
-    let blocks = extract_tag_blocks(text, "<think>", "</think>");
+    // Check both <think> and <longcat_think> paired blocks.
+    for (open, close) in [
+        ("<think>", "</think>"),
+        ("<longcat_think>", "</longcat_think>"),
+    ] {
+        let blocks = extract_tag_blocks(text, open, close);
+        if !blocks.is_empty() {
+            let thinking_parts: Vec<&str> = blocks
+                .iter()
+                .map(|(_, _, inner)| inner.trim())
+                .filter(|s| !s.is_empty())
+                .collect();
 
-    if !blocks.is_empty() {
-        let thinking_parts: Vec<&str> = blocks
-            .iter()
-            .map(|(_, _, inner)| inner.trim())
-            .filter(|s| !s.is_empty())
-            .collect();
-
-        let thinking = if thinking_parts.is_empty() {
-            None
-        } else {
-            Some(thinking_parts.join("\n\n"))
-        };
-
-        let cleaned_text = strip_tag_blocks(text, "<think>", "</think>");
-        return (cleaned_text, thinking);
-    }
-
-    // Handle missing opening <think> tag (template already added it as prefix).
-    // The template adds `<think>\n` as the assistant generation prompt, so the
-    // model's output starts with thinking content + `</think>`.
-    //
-    // To distinguish from literal `</think>` in content (e.g., "Use </think> to
-    // close the tag"), only apply when `</think>` is followed by a newline or
-    // end-of-text — the model always generates `</think>\n\n` before the response.
-    if let Some(close_pos) = text.find("</think>") {
-        let after_tag = &text[close_pos + "</think>".len()..];
-        if after_tag.is_empty() || after_tag.starts_with('\n') {
-            let thinking_content = text[..close_pos].trim();
-            let after = after_tag.trim();
-            let thinking = if thinking_content.is_empty() {
+            let thinking = if thinking_parts.is_empty() {
                 None
             } else {
-                Some(thinking_content.to_string())
+                Some(thinking_parts.join("\n\n"))
             };
-            return (after.to_string(), thinking);
+
+            let cleaned_text = strip_tag_blocks(text, open, close);
+            return (cleaned_text, thinking);
+        }
+    }
+
+    // Handle missing opening tag (template already added it as prefix).
+    // The template adds `<think>\n` (or `<longcat_think>\n`) as the assistant
+    // generation prompt, so the model's output starts with thinking + close tag.
+    //
+    // To distinguish from literal close tags in content, only apply when the
+    // close tag is followed by a newline or end-of-text.
+    for close_tag in ["</think>", "</longcat_think>"] {
+        if let Some(close_pos) = text.find(close_tag) {
+            let after_tag = &text[close_pos + close_tag.len()..];
+            if after_tag.is_empty() || after_tag.starts_with('\n') {
+                let thinking_content = text[..close_pos].trim();
+                let after = after_tag.trim();
+                let thinking = if thinking_content.is_empty() {
+                    None
+                } else {
+                    Some(thinking_content.to_string())
+                };
+                return (after.to_string(), thinking);
+            }
         }
     }
 
@@ -487,7 +493,17 @@ pub fn parse_thinking(text: &str) -> (String, Option<String>) {
 
 /// Check if text contains any thinking tags
 pub fn has_thinking(text: &str) -> bool {
-    text.contains("<think>")
+    text.contains("<think>") || text.contains("<longcat_think>")
+}
+
+/// Strip think/longcat_think markup tags from text, keeping inner content.
+/// Used in no-thinking mode for old-template compatibility: tags are removed
+/// but their content is treated as normal text, not reasoning.
+pub fn strip_think_markup(text: &str) -> String {
+    text.replace("<think>", "")
+        .replace("</think>", "")
+        .replace("<longcat_think>", "")
+        .replace("</longcat_think>", "")
 }
 
 /// Result of parsing tool calls from text

--- a/docs/vllm_reasoning_control_flow_spec_for_mlx_node.md
+++ b/docs/vllm_reasoning_control_flow_spec_for_mlx_node.md
@@ -1,0 +1,748 @@
+# vLLM Reasoning / Thinking Control Flow Spec for `mlx-node`
+
+This document is a **feature-parity spec** for implementing vLLM-style reasoning / thinking control flow in `mlx-node`, with special attention to the **Qwen3 / Qwen3.5** family because that is where the serving-time behavior is the most nuanced. It covers the request path from **OpenAI-compatible ingress** through **chat template rendering**, **reasoning parser selection**, **streaming and non-streaming response assembly**, **tool-calling interaction**, and **thinking-token budget enforcement**. It does **not** attempt to spec unrelated internals such as scheduler fairness, KV-cache allocation, or kernel-level execution. The current vLLM docs also note a naming transition: the structured field is now called **`reasoning`**, while older integrations may still refer to **`reasoning_content`**. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/features/reasoning_outputs/))
+
+---
+
+## 1. Scope and target behavior
+
+`mlx-node` should aim to replicate the behavior of vLLM’s **reasoning-aware online serving path**, especially the semantics exposed through the **chat completions** API. In vLLM’s public docs, reasoning outputs are documented primarily on the **online chat completion endpoint**: the non-streaming response carries `message.reasoning`, and streaming responses carry `delta.reasoning`. Tool parsing is explicitly documented to operate on the **final content channel**, not on the reasoning channel. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/features/reasoning_outputs/))
+
+For Qwen3/Qwen3.5, reasoning control is primarily implemented through three cooperating layers:
+
+1. **Chat template kwargs**, especially `enable_thinking`.
+2. **A model-specific reasoning parser**, selected with `--reasoning-parser qwen3`.
+3. **An optional thinking budget**, enforced by `thinking_token_budget` plus `--reasoning-config`. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/protocol/))
+
+The core design principle is:
+
+> **Prompt rendering decides what mode the model enters; parsing decides how generated text is split into `reasoning` vs `content`; budget enforcement decides when a reasoning block must be terminated.**
+
+---
+
+## 2. Public API surface that matters
+
+A vLLM-compatible `mlx-node` implementation should expose the following request-level controls on the chat-completions path:
+
+- `chat_template_kwargs`
+- `include_reasoning`
+- `thinking_token_budget`
+- `reasoning_effort`  
+  plus normal generation parameters such as max tokens, temperature, top-p, stop sequences, and tool-calling options. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/protocol/))
+
+### 2.1 `chat_template_kwargs`
+
+This is the main hook for model-family-specific behavior. For Qwen3/Qwen3.5, the important key is:
+
+```json
+{
+  "enable_thinking": false
+}
+```
+
+In vLLM serving, this can be provided per request via `extra_body.chat_template_kwargs`, or globally at server startup with `--default-chat-template-kwargs '{"enable_thinking": false}'`. Request-level kwargs override server defaults. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/protocol/))
+
+### 2.2 `include_reasoning`
+
+This controls whether structured reasoning is emitted back to the client. In vLLM’s serving flow, when `include_reasoning` is false, the serving path initializes `reasoning_ended = True` and later suppresses reasoning in the assembled response. Separately, the request validator maps `reasoning_effort == "none"` to `include_reasoning = False`. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+### 2.3 `thinking_token_budget`
+
+This is a **hard serving-time control** for reasoning length. vLLM passes it through `SamplingParams`, and the request path rejects it unless `reasoning_config` is configured. The public docs state that once the parser sees the model has entered the thinking section, reaching the configured budget causes vLLM to force the model to emit the configured `think_end_str`. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/sampling_params/))
+
+### 2.4 `reasoning_effort`
+
+In current vLLM protocol code, `reasoning_effort` is fed into chat rendering parameters, and `reasoning_effort == "none"` disables structured reasoning output. It is therefore best treated as a **template/rendering concern** plus a **response policy flag**, not as a substitute for `thinking_token_budget`. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/protocol/))
+
+---
+
+## 3. Server bootstrap control flow
+
+At startup, the vLLM server wires together four distinct configuration surfaces:
+
+1. **Reasoning parser selection** via `--reasoning-parser`.
+2. **Server-wide template defaults** via `--default-chat-template-kwargs`.
+3. **Reasoning boundary strings** via `--reasoning-config`.
+4. **Optional tool parser / tool-calling configuration**. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/cli_args/))
+
+### 3.1 Reasoning parser registry
+
+vLLM keeps a central `ReasoningParserManager` registry that can register parsers eagerly or lazily and resolve them by name at runtime. If the configured parser name is unknown, the manager throws a `KeyError`. This means `mlx-node` should also separate **parser registration** from **parser instantiation**, rather than hard-coding Qwen behavior directly into the serving loop. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/basic_parsers/))
+
+### 3.2 Parser selection for Qwen
+
+For Qwen3/Qwen3.5, vLLM uses the `qwen3` reasoning parser. Qwen’s own deployment docs note that compatibility between `enable_thinking=False` and proper reasoning parsing was fixed in **vLLM 0.9.0**; earlier **0.8.5-era** guidance warned that disabling thinking and parsing reasoning content were not compatible. For parity, `mlx-node` should target the newer behavior, not the old limitation. ([qwen.readthedocs.io](https://qwen.readthedocs.io/en/latest/deployment/vllm.html))
+
+### 3.3 Reasoning config bootstrap
+
+`ReasoningConfig` carries at least:
+
+- `think_start_str`
+- `think_end_str`
+
+At initialization time, vLLM tokenizes these strings with the model tokenizer and stores their token-ID sequences. If tokenization fails, initialization raises an error. This is important: the budget mechanism is **not** based on plain string matching at serving time; it is based on **token-sequence-aware state tracking**. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/config/reasoning/))
+
+---
+
+## 4. End-to-end request lifecycle
+
+The full reasoning-aware request path in vLLM is:
+
+1. Request arrives at the **OpenAI-compatible chat completion endpoint**.
+2. The server validates model and basic request shape.
+3. Chat messages are rendered into a prompt using the selected chat template plus merged template kwargs.
+4. If a reasoning parser is configured, the server instantiates it with the **same template kwargs** used for rendering.
+5. The server computes sampling params, including `thinking_token_budget`.
+6. The server determines whether the **prompt already ends the reasoning section**.
+7. The request is handed to the engine.
+8. Generated text is split into `reasoning` and `content` in streaming or non-streaming mode.
+9. Tool parsing, if enabled, only sees **content**, never reasoning.
+10. The final response is assembled with `message.reasoning` and `message.content`, or with streaming deltas. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+---
+
+## 5. Prompt rendering control flow
+
+### 5.1 Entry point
+
+The chat completion path calls `render_chat_request`, which validates the target model and delegates to the rendering layer. vLLM’s serving renderer then:
+
+- preprocesses the request,
+- merges default chat-template kwargs,
+- adds tool information if needed,
+- builds tokenization params,
+- builds chat params,
+- and asynchronously renders the final prompt. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+### 5.2 Merge semantics
+
+The server merges template kwargs with this precedence:
+
+```text
+effective_chat_template_kwargs = server_defaults overridden by request_kwargs
+```
+
+In code terms, vLLM’s helper uses `default | request`, meaning **request-level keys win**. `mlx-node` should match this exactly, since most users expect `extra_body.chat_template_kwargs` to override server defaults on a per-request basis. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/engine/serving/))
+
+### 5.3 Why parser instantiation must use the same kwargs
+
+vLLM instantiates the reasoning parser with the same merged `chat_template_kwargs` used for rendering. This is not incidental. For Qwen3/Qwen3.5, the parser needs to know whether the prompt was rendered with `enable_thinking=False`, because that changes how the prompt is seeded and therefore how the first generated tokens must be interpreted. `mlx-node` should treat this as a **hard invariant**:
+
+> **The parser configuration must be derived from the exact same effective template kwargs that were used to render the prompt.** ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+---
+
+## 6. Qwen3 / Qwen3.5 template semantics
+
+This is the most important model-family-specific behavior for parity.
+
+### 6.1 When thinking is enabled
+
+Qwen3.5’s official chat template emits a generation prefix that begins with:
+
+```text
+<think>\n
+```
+
+That means the model is being prompted to start generating inside the reasoning section. ([huggingface.co](https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/chat_template.jinja))
+
+### 6.2 When thinking is disabled
+
+When `enable_thinking` is false, Qwen3.5’s template emits:
+
+```text
+<think>\n\n</think>\n\n
+```
+
+before the assistant response content. This means the prompt already contains a **closed reasoning block**. The consequence is subtle but crucial: in generation, the model may not emit `<think>` at all, and the first generated tokens should generally be interpreted as **final content**, not reasoning. vLLM’s Qwen parser has explicit logic for this case. ([huggingface.co](https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/chat_template.jinja))
+
+### 6.3 Why Qwen3.5 differs from older Qwen3 behavior
+
+vLLM’s Qwen parser docs state that **starting with Qwen3.5**, the chat template puts `<think>` into the prompt, so generation commonly only encounters `</think>`. The parser still strips an emitted `<think>` if it appears, for backward compatibility with older pre-2507 templates. `mlx-node` should therefore support both patterns:
+
+- **new style**: prompt already contains `<think>`, generation may only produce `</think>`;
+- **old style**: generation may still emit `<think>` explicitly. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/qwen3_reasoning_parser/))
+
+### 6.4 History serialization rule
+
+Qwen’s model card recommends **not feeding prior thinking content back into conversation history**. The provided chat template implements this best practice by omitting older reasoning blocks from prior assistant turns, while still allowing reasoning serialization in the most recent turn context where needed. `mlx-node` should replicate that selective history behavior rather than blindly replaying all prior reasoning text. ([huggingface.co](https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/README.md?utm_source=chatgpt.com))
+
+---
+
+## 7. Reasoning parser architecture
+
+### 7.1 Base parser contract
+
+vLLM’s `ReasoningParser` is an abstract class initialized with a tokenizer and required to implement, among other things, `is_reasoning_end(input_ids)`. `BaseThinkingReasoningParser` extends this with token validation for the configured think-start and think-end tokens and stores their token IDs. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/basic_parsers/))
+
+### 7.2 `is_reasoning_end(input_ids)`
+
+In the base implementation, `is_reasoning_end` scans backward through input token IDs. If it sees an end token before a start token, it returns true; if it sees a start token first, it returns false. In practice, this asks:
+
+> “At the end of the current prompt or prefix, are we logically **outside** the reasoning section?” ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/))
+
+This function is used in two places:
+
+1. Before generation begins, to determine whether the **prompt already ended reasoning**.
+2. During tool-calling / streaming logic, to decide when it is safe to interpret new tokens as content or tool calls. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+### 7.3 `extract_content_ids`
+
+The base parser also exposes `extract_content_ids`, which returns token IDs after the first detected reasoning-end token. This is especially important in the **streaming + tool-calling** path, where tool parsing must not see reasoning tokens. `mlx-node` should expose an equivalent token-level utility. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/))
+
+---
+
+## 8. Qwen-specific parser behavior
+
+### 8.1 Constructor behavior
+
+The Qwen parser reads `chat_template_kwargs` from the request object at construction time and stores:
+
+```python
+self.thinking_enabled = chat_kwargs.get("enable_thinking", True)
+```
+
+This is the parser’s switch for all later special-casing. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/qwen3_reasoning_parser/))
+
+### 8.2 Non-streaming extraction logic
+
+In non-streaming mode, the Qwen parser behaves as follows:
+
+1. If output starts with `<think>`, strip it.
+2. If no `</think>` is found:
+   - if `thinking_enabled == False`, treat the entire output as **content**;
+   - if `thinking_enabled == True`, treat the entire output as **reasoning** because the answer is truncated before reasoning ended.
+3. If `</think>` is found, split into:
+   - reasoning = text before the end token,
+   - content = text after the end token. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/qwen3_reasoning_parser/))
+
+This distinction is essential. In `mlx-node`, the absence of `</think>` must not always mean “all reasoning”; it depends on whether the template told the model to think in the first place. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/qwen3_reasoning_parser/))
+
+### 8.3 Streaming extraction logic
+
+In streaming mode, the Qwen parser:
+
+1. strips `<think>` if present in the current delta;
+2. checks whether `</think>` occurs in the current delta;
+3. if yes, emits a delta split between reasoning and content;
+4. if the end token already occurred in previous token IDs, treats subsequent deltas as content;
+5. otherwise treats the delta as reasoning. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/qwen3_reasoning_parser/))
+
+This means `mlx-node` streaming must preserve **cross-chunk parser state**, not just inspect one delta at a time. The parser decision depends on:
+
+- previous token IDs,
+- the current delta text,
+- and whether the prompt was already outside reasoning. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/qwen3_reasoning_parser/))
+
+---
+
+## 9. Request preparation before generation
+
+After rendering, vLLM computes generation parameters. On the chat completion path, `create_chat_completion` does the following:
+
+1. get tokenizer,
+2. merge `chat_template_kwargs`,
+3. instantiate the reasoning parser if configured,
+4. compute sampling params or beam params,
+5. determine initial `reasoning_ended`,
+6. call the engine. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+### 9.1 Initial `reasoning_ended`
+
+The initialization logic is:
+
+- if `include_reasoning == False`, set `reasoning_ended = True`;
+- else if a reasoning parser exists, compute `reasoning_ended = parser.is_reasoning_end(prompt_token_ids)`;
+- else leave it unset / none. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+This is a key design choice: the engine and stream assembler are told **up front** whether generation starts inside or outside a reasoning block.
+
+### 9.2 Beam-search caveat
+
+In the current serving code path, ordinary sampling goes through `SamplingParams` and passes reasoning-aware state into `engine_client.generate`. Beam search uses a separate path with `BeamSearchParams`. Since `thinking_token_budget` is part of `SamplingParams`, parity work in `mlx-node` should treat the budget controller as part of the **sampling/generation path**, not as a beam-search primitive. That is an implementation inference from the public code paths and API surfaces. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+---
+
+## 10. Streaming response control flow
+
+This is where most of the subtle logic lives.
+
+### 10.1 State initialized per streamed choice
+
+The streaming generator maintains arrays such as:
+
+- `previous_texts`
+- `all_previous_token_ids`
+- `added_content_delta_arr`
+- `reasoning_end_arr`
+- `prompt_is_reasoning_end_arr` ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+`mlx-node` should maintain equivalent per-choice state objects rather than one global parser state.
+
+### 10.2 One-time prompt inspection
+
+On the first chunk for each choice, if prompt token IDs are available and a parser exists, vLLM computes:
+
+```text
+prompt_is_reasoning_end = parser.is_reasoning_end(prompt_token_ids)
+```
+
+This is especially important for Qwen with `enable_thinking=False`, because the prompt may already contain a closed think block. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+### 10.3 Fast path when prompt already ended reasoning
+
+If `prompt_is_reasoning_end` is true, vLLM may bypass the reasoning parser and route `delta_text` directly to `DeltaMessage(content=...)`. The Qwen parser docs explicitly mention this path for the case where the prompt includes `<think>\n\n</think>\n\n`. This is the mechanism that makes Qwen3.5 “no-thinking mode” work correctly under streaming. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/qwen3_reasoning_parser/))
+
+### 10.4 Normal reasoning-to-content transition
+
+If the prompt starts inside reasoning, the stream path repeatedly calls `extract_reasoning_streaming(...)`. Once the parser detects the reasoning end token:
+
+- the current delta may be split into reasoning and content,
+- `reasoning_end_arr[i]` flips true,
+- future deltas are content-only. ([docs.vllm.ai](https://docs.vllm.ai/en/stable/api/vllm/reasoning/qwen3_reasoning_parser/))
+
+### 10.5 Streaming response schema
+
+vLLM’s public docs state that reasoning deltas are emitted as `delta.reasoning`, while answer text is emitted as normal `delta.content`. `mlx-node` should match that schema if it is targeting vLLM/OpenAI-compatible clients expecting the current field naming. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/features/reasoning_outputs/))
+
+---
+
+## 11. Non-streaming response control flow
+
+The non-streaming path is simpler.
+
+After generation completes, vLLM:
+
+1. runs `parser.extract_reasoning(output.text, request=request)`,
+2. optionally nulls reasoning if `include_reasoning == False`,
+3. runs tool parsing on **content only**,
+4. builds the final `ChatMessage(role, reasoning, content, tool_calls)`. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+This means `mlx-node` non-streaming should always do post-generation splitting in this order:
+
+```text
+raw model text
+→ reasoning/content split
+→ reasoning suppression if requested
+→ tool parsing from content only
+→ final response assembly
+```
+
+That ordering matters. Tool parsing must not inspect text that was classified as reasoning. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+---
+
+## 12. Tool-calling interaction
+
+This is a common source of bugs in parity implementations.
+
+### 12.1 Core rule
+
+vLLM’s docs explicitly state:
+
+> tool calling only parses functions from the **content** field, not the reasoning field. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/features/reasoning_outputs/))
+
+That rule holds in both streaming and non-streaming paths.
+
+### 12.2 Auto-tool mode
+
+In the streaming path with auto tool choice and reasoning enabled, vLLM waits until reasoning has ended before feeding token IDs into the tool parser. When the transition happens, it uses `extract_content_ids(...)` so the tool parser only sees the content portion. `mlx-node` should implement the same delayed handoff. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+### 12.3 Named tool choice / required tool choice
+
+vLLM also special-cases named-tool and required-tool flows to avoid spuriously classifying the first streamed chunk as reasoning when the prompt already ended the reasoning block. This is another reason `prompt_is_reasoning_end` must be tracked per choice. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/serving/))
+
+### 12.4 Validation boundary
+
+The rendering/preprocessing layer validates tool-related constraints before generation, and later stages only run tool extraction if tool parsing is configured and `tool_choice != "none"`. `mlx-node` should keep this separation: **validate early, parse late**. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/serve/render/serving/?utm_source=chatgpt.com))
+
+---
+
+## 13. Thinking-token budget control flow
+
+This is the serving-time mechanism that stops overthinking.
+
+### 13.1 Public behavior
+
+The vLLM docs describe the budget like this: if `thinking_token_budget` is set, once generation enters the thinking section and the budget is reached, vLLM forces the model to produce `think_end_str`. The feature requires:
+
+- `--reasoning-parser`
+- `--reasoning-config`
+- per-request `thinking_token_budget` ([docs.vllm.ai](https://docs.vllm.ai/en/latest/features/reasoning_outputs/))
+
+### 13.2 Validation
+
+The input processor rejects a request that sets `thinking_token_budget` when `reasoning_config` is missing. `mlx-node` should enforce the same validation and fail early. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/v1/engine/input_processor/))
+
+### 13.3 Internal state machine
+
+vLLM’s built-in `ThinkingTokenBudgetLogitsProcessor` keeps per-request state including:
+
+- whether generation is currently inside thinking (`in_think`),
+- whether it is currently forcing the end token sequence (`in_end`),
+- current think token count (`think_count`),
+- current progress within the end-token sequence (`end_count`),
+- prompt token IDs,
+- output token IDs,
+- previous output length,
+- countdown fields for cheaper re-checks. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/v1/sample/logits_processor/))
+
+### 13.4 Initialization from prompt
+
+When a request is added, the processor scans the prompt for the **last** think-start and think-end token sequences. If the last start comes after the last end, the request begins in thinking mode. For Qwen3.5 this matters because the prompt may already contain `<think>` or even a closed `<think>...</think>` block depending on `enable_thinking`. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/v1/sample/logits_processor/))
+
+### 13.5 Budget counting
+
+As generation progresses, the processor scans newly appended output tokens for start/end marker sequences. While `in_think` is true, it increments `think_count`. If `think_count >= thinking_token_budget`, the state flips into `in_end = True`, which means the processor will start forcing the end-token sequence. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/v1/sample/logits_processor/))
+
+### 13.6 Forced end-token emission
+
+When `in_end` is true, the logits processor overrides the next token choice by assigning a huge logit to the appropriate next token in `think_end_token_ids`. It continues until the full end-token sequence has been emitted, then clears `in_end`. This is not advisory prompting; it is an explicit decoding-time intervention. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/v1/sample/logits_processor/))
+
+### 13.7 Implication for `mlx-node`
+
+For parity, `mlx-node` should implement the thinking budget as a **token-level decoding controller**, not as a post-hoc truncation step. Post-hoc truncation would not match vLLM’s behavior in streaming, because clients would already have seen the extra reasoning tokens. The budget controller must act **during generation**. That conclusion follows directly from the logits-processor design in vLLM. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/v1/sample/logits_processor/))
+
+---
+
+## 14. `mlx-node` implementation architecture
+
+### 14.1 Existing infrastructure (already implemented)
+
+The following components are already in place and will be reused:
+
+**Template controller** — `Qwen3Tokenizer::apply_chat_template_sync()` (`crates/mlx-core/src/tokenizer.rs`, line 1078) renders the Jinja2 chat template with `enable_thinking` in the template context. When `enable_thinking=true` (default), the template emits `<think>\n` as the generation prefix. When `false`, it emits `<think>\n\n</think>\n\n`. The `reasoning_content` field on `ChatMessage` is serialized into the template context for multi-turn history.
+
+**Think-end token detection** — `Qwen3Tokenizer::detect_think_end()` (`tokenizer.rs`, line 1128) scans the tokenizer vocabulary at load time for `</think>` or `</longcat_think>` and stores the token ID as `think_end_id` and the string as `think_end_str`. These are available via accessor methods.
+
+**Post-generation parsing** — `tools::split_at_think_end()` (`crates/mlx-core/src/tools/mod.rs`, line 564) splits generated text at the `</think>` boundary using both token-level and text-level detection. It already enforces tool parsing isolation: tools are parsed only from the content portion after `</think>`, never from the thinking portion. The helper `tools::has_think_end_token()` (line 554) checks whether the `think_end_id` token was generated.
+
+**Chat finalization** — `chat_common::finalize_chat_result()` (`crates/mlx-core/src/models/qwen3_5/chat_common.rs`, line 127) decodes tokens, calls `split_at_think_end`, and builds the `ChatResult` with `thinking: Option<String>`.
+
+### 14.2 New component: `ReasoningTracker`
+
+**Location:** `crates/mlx-core/src/models/qwen3_5/chat_common.rs`
+
+Unlike vLLM's `ReasoningParserManager` registry + `BaseThinkingReasoningParser` class hierarchy, `mlx-node` uses a lightweight `ReasoningTracker` struct. This is justified because:
+
+1. `mlx-node` currently only targets Qwen3/Qwen3.5 models, not a multi-model serving fleet.
+2. The Qwen `</think>` token is a single token (not a multi-token sequence), making token-level tracking trivial.
+3. The existing `split_at_think_end()` already handles all the text-level parsing for non-streaming finalization.
+
+The `ReasoningTracker` operates at the **token level** during the decode loop:
+
+```rust
+pub(crate) struct ReasoningTracker {
+    /// Whether the model is currently generating reasoning tokens.
+    in_thinking: bool,
+    /// Count of tokens generated while in thinking mode.
+    thinking_token_count: i32,
+    /// Maximum thinking tokens before forcing </think>. None = unlimited.
+    budget: Option<i32>,
+    /// Token ID for </think> (from tokenizer vocabulary).
+    think_end_id: Option<u32>,
+    /// Whether the budget has been exhausted and we must force </think> next.
+    force_think_end: bool,
+}
+```
+
+**Initialization:** `starts_in_thinking` is `true` when `enable_thinking != Some(false)` AND `think_end_id.is_some()`. This matches the Qwen3.5 template behavior: when thinking is enabled, the template injects `<think>\n` in the prompt and the model starts generating inside a reasoning block. When thinking is disabled, the template injects `<think>\n\n</think>\n\n` and the model starts in content mode.
+
+**Per-token operation:** `observe_token(token_id) -> bool` returns whether the token is reasoning content. When it sees `think_end_id`, it transitions `in_thinking` to `false`. While `in_thinking`, it increments the token counter and sets `force_think_end` when the budget is reached.
+
+**Budget enforcement:** `should_force_think_end() -> bool` is checked before building the next decode step's graph. When true, the decode loop short-circuits the normal forward+sample path and directly produces the `think_end_id` token.
+
+### 14.3 Streaming reasoning tags
+
+vLLM uses a `stream_choice()` function that calls `parser.extract_reasoning_streaming()` with accumulated text and token IDs. `mlx-node` takes a simpler approach: since `think_end_id` is a single token, each streaming delta chunk is tagged with `is_reasoning: bool` based on the `ReasoningTracker` state at the time of emission. No text-level parsing is needed during streaming.
+
+This maps to vLLM's `delta.reasoning` / `delta.content` distinction: consumers check `isReasoning` on each delta chunk to route text to the appropriate display channel.
+
+### 14.4 Tool parsing isolation (already implemented)
+
+`tools::split_at_think_end()` first separates thinking content from response content at the `</think>` boundary, then calls `parse_tool_calls()` only on the response portion. This satisfies the vLLM requirement that tool extraction never sees reasoning text. No additional changes are needed.
+
+### 14.5 Thinking budget controller
+
+vLLM implements budget enforcement as a `ThinkingTokenBudgetLogitsProcessor` that overrides logits. `mlx-node` has no logits processor infrastructure and does not need one. Instead, budget enforcement is a **token-level override in the decode loop**: when the `ReasoningTracker` signals budget exhaustion, the next decode step skips the forward+sample pipeline and directly produces the `think_end_id` token as an `MxArray`.
+
+**Pipelining consideration:** The Qwen3.5 decode loop is pipelined — step N+1's graph is submitted before step N's result is extracted. When the budget is reached at step N (detected via `observe_token`), step N+1's graph has already been submitted. The forced `think_end_id` takes effect at step N+2: the `should_force_think_end()` check in the "build next step" block produces the forced token instead of running forward+sample. This means the actual thinking token count may be `budget + 1`. This 1-token lag matches vLLM's behavior, where the logits processor also operates with a scan-and-apply delay.
+
+For the **compiled C++ path**, the forced token must still go through `eval_token_and_compiled_caches()` so the compiled KV caches update correctly. For the **Rust fallback path**, it goes through `MxArray::async_eval_arrays()`.
+
+---
+
+## 15. Normative behavior for `mlx-node`
+
+### 15.1 Prompt / tracker consistency
+
+`mlx-node` **MUST** initialize the `ReasoningTracker` using the same effective `enable_thinking` value used to render the prompt. The tracker’s `starts_in_thinking` flag must match the template’s behavior: `true` when the template injected `<think>\n`, `false` when it injected the closed `<think>\n\n</think>\n\n` block.
+
+### 15.2 Qwen no-thinking mode
+
+For Qwen3.5 with `enable_thinking=false`, `mlx-node` **MUST** render the closed think block in the prompt and **MUST** classify all generated text as content (tracker starts with `in_thinking=false`). This is the equivalent of vLLM’s `prompt_is_reasoning_end=true` fast path.
+
+### 15.3 Streaming schema
+
+In streaming mode, `mlx-node` **MUST** tag each delta chunk with `is_reasoning: bool` to distinguish reasoning from content. The existing `thinking: Option<String>` field on the final chunk continues to carry the accumulated reasoning text. Consumers check `isReasoning` to route delta text.
+
+### 15.4 Tool parsing isolation (already satisfied)
+
+`mlx-node` **MUST NOT** parse tool calls from reasoning text. This is already enforced by `split_at_think_end()` which separates at the `</think>` boundary before parsing tools. No changes needed.
+
+### 15.5 Budget enforcement
+
+`mlx-node` **MUST** enforce `thinking_token_budget` during generation by forcing the `think_end_id` token in the decode loop, not by post-generation truncation. The budget controller is the `ReasoningTracker` struct integrated into the decode loop.
+
+### 15.6 History handling for Qwen (already supported)
+
+`mlx-node` **SHOULD** follow Qwen’s official best practice and avoid replaying old reasoning content in history. The `ChatMessage.reasoning_content` field and the Jinja2 template already handle this — the template selectively includes or omits reasoning from prior turns.
+
+### 15.7 Old-template compatibility (already handled)
+
+`mlx-node` **SHOULD** tolerate older Qwen templates that emit `<think>` in generated output. The existing `parse_thinking()` and `split_at_think_end()` functions already handle both patterns: explicit `<think>...</think>` pairs and the implicit-prefix case where only `</think>` appears in the generated text.
+
+---
+
+## 16. `mlx-node` implementation pseudocode
+
+### 16.1 Request entry point (`chat()` / `chat_stream()`)
+
+```rust
+fn chat(messages, config) {
+    // 1. Resolve reasoning_effort → enable_thinking
+    let enable_thinking = match config.reasoning_effort.as_deref() {
+        Some("low") | Some("none") => Some(false),
+        Some("medium") | Some("high") => Some(true),
+        _ => config.enable_thinking,
+    };
+
+    // 2. Render prompt via Jinja2 template
+    let tokens = tokenizer.apply_chat_template_sync(
+        &messages, Some(true), tool_defs, enable_thinking,
+    );
+
+    // 3. Initialize reasoning tracker
+    let starts_in_thinking = enable_thinking.unwrap_or(true)
+        && think_end_id.is_some();
+    let mut tracker = ReasoningTracker::new(
+        starts_in_thinking,
+        config.thinking_token_budget,
+        think_end_id,
+    );
+
+    // 4. Prefill + decode loop (see 16.2)
+    // 5. Finalize with include_reasoning suppression
+}
+```
+
+### 16.2 Decode loop with reasoning tracking and budget enforcement
+
+```rust
+// Pipelined decode loop (compiled or Rust variant)
+for step in 0..max_new_tokens {
+    // Build step N+1’s graph — with budget check
+    let next_y = if step + 1 < max_new_tokens {
+        if tracker.should_force_think_end() {
+            // Budget exhausted: force </think> token
+            let forced = MxArray::from_int32(&[think_end_id as i32], &[1]);
+            eval_token_and_compiled_caches(&forced); // or async_eval for Rust path
+            Some(forced)
+        } else {
+            // Normal path: forward → penalties → sample → eval
+            let logits = forward_compiled(&y.reshape(&[1, 1]), &embedding_weight);
+            let logits = apply_all_penalties(logits, &token_history, &params);
+            let next_token = sample(&logits, sampling_config);
+            eval_token_and_compiled_caches(&next_token);
+            Some(next_token)
+        }
+    } else {
+        None
+    };
+
+    // Wait for step N
+    y.eval();
+    let token_id = y.item_at_int32(0) as u32;
+    generated_tokens.push(token_id);
+    token_history.push(token_id);
+
+    // Track reasoning state
+    let is_reasoning = tracker.observe_token(token_id);
+
+    // [streaming only] Emit tagged delta chunk
+    callback(ChatStreamChunk {
+        text: step_decode_stream(token_id),
+        done: false,
+        is_reasoning: Some(is_reasoning),
+        ..
+    });
+
+    // Stop conditions
+    if token_id == eos_id { break; }
+    if check_repetition_cutoff(..) { break; }
+
+    y = next_y.unwrap_or_else(|| break);
+}
+```
+
+### 16.3 `ReasoningTracker` state machine
+
+```rust
+impl ReasoningTracker {
+    fn observe_token(&mut self, token_id: u32) -> bool {
+        if !self.in_thinking { return false; }
+
+        if self.think_end_id == Some(token_id) {
+            self.in_thinking = false;
+            self.force_think_end = false;
+            return true; // </think> itself is part of reasoning
+        }
+
+        self.thinking_token_count += 1;
+        if let Some(budget) = self.budget {
+            if self.thinking_token_count >= budget {
+                self.force_think_end = true;
+            }
+        }
+        true
+    }
+
+    fn should_force_think_end(&self) -> bool {
+        self.force_think_end && self.think_end_id.is_some()
+    }
+}
+```
+
+### 16.4 Finalization with `include_reasoning` suppression
+
+```rust
+fn finalize_chat_result(.., include_reasoning: bool) -> ChatResult {
+    let text = tokenizer.decode_sync(&generated_tokens, true);
+    let (clean_text, tool_calls, thinking) = split_at_think_end(&text, think_tag);
+    let thinking = if include_reasoning { thinking } else { None };
+    ChatResult { text: clean_text, tool_calls, thinking, .. }
+}
+```
+
+---
+
+## 17. Edge cases `mlx-node` must test
+
+### 17.1 Qwen3.5 with thinking disabled
+
+`ReasoningTracker` starts with `in_thinking=false`. First streamed chunk must have `is_reasoning: false`. All deltas are content.
+
+### 17.2 Qwen3.5 with thinking enabled, truncated generation
+
+No `</think>` appears before EOS / max_tokens. `ReasoningTracker` stays in `in_thinking=true` throughout. Non-streaming `finalize_chat_result` treats all text as thinking (existing `split_at_think_end` behavior when `think_end_tag` is not found and thinking was enabled).
+
+### 17.3 Qwen3.5 with thinking disabled, no end token in output
+
+`ReasoningTracker` started in content mode. All output is content. `thinking` field is `None`.
+
+### 17.4 Old Qwen templates that emit `<think>` in generated text
+
+The `ReasoningTracker` operates at the token level and only looks for `think_end_id`. An emitted `<think>` token in the generated text does not affect tracker state. The post-generation `parse_thinking()` already handles stripping `<think>` from the text.
+
+### 17.5 `</think>` token in streaming
+
+When `think_end_id` is generated, `observe_token()` transitions `in_thinking` to `false`. The `</think>` token’s delta text itself is tagged `is_reasoning: true` (it is part of the reasoning block). The very next delta is `is_reasoning: false`.
+
+### 17.6 Auto tool choice after reasoning
+
+`split_at_think_end()` already ensures tool parsing only sees content after `</think>`. No changes needed.
+
+### 17.7 `include_reasoning=false`
+
+`finalize_chat_result()` sets `thinking = None` when `include_reasoning` is false. During streaming, delta chunks still carry `is_reasoning` tags (consumers can filter), but the final chunk’s `thinking` field is `None`.
+
+### 17.8 `thinking_token_budget=0`
+
+`ReasoningTracker` starts with `thinking_token_count=0` and `budget=Some(0)`. On the very first thinking token, `observe_token()` increments to 1 which exceeds budget 0, setting `force_think_end=true`. The next decode step forces `think_end_id`. The model emits at most 1 thinking token before `</think>`.
+
+### 17.9 `thinking_token_budget` without `think_end_id`
+
+If the tokenizer does not have a `</think>` token, `ReasoningTracker::new()` sets `think_end_id=None` and `should_force_think_end()` returns `false` regardless of budget. The budget is silently ignored. This is safe because models without `</think>` in their vocabulary cannot enter thinking mode.
+
+---
+
+## 18. Compatibility notes
+
+### 18.1 `enable_thinking` is the canonical control
+
+The main vLLM docs and Qwen docs consistently use `chat_template_kwargs.enable_thinking=false` to disable thinking, and the official Qwen3.5 chat template keys off `enable_thinking`. A vLLM recipe page uses `{"reasoning": false}` instead, but `mlx-node` follows the official template and uses `enable_thinking`.
+
+### 18.2 Field naming: `thinking` (not `reasoning`)
+
+vLLM uses `message.reasoning` / `delta.reasoning` as the canonical field name. `mlx-node` uses `thinking` on `ChatResult` and `ChatStreamChunk` to match the existing API. The streaming delta uses `is_reasoning: bool` as a tagging flag (not a separate text field). For input messages, `ChatMessage.reasoning_content` is used for multi-turn history, matching the Jinja2 template variable name.
+
+### 18.3 No server-level defaults
+
+vLLM supports server-level `--default-chat-template-kwargs` and request-level overrides. `mlx-node` is a library, not a server — all kwargs are per-call via `ChatConfig`. The merge semantics are not needed.
+
+---
+
+## 19. Implementation order
+
+### Phase 1: Data structures (no behavioral change)
+
+1. Add `thinking_token_budget`, `include_reasoning`, `reasoning_effort` to `ChatConfig`
+2. Add `is_reasoning` to `ChatStreamChunk`
+3. Add fields to `ChatParams`, update `extract_chat_params()`
+4. Create `ReasoningTracker` struct in `chat_common.rs`
+5. Build and verify compilation
+
+### Phase 2: `reasoning_effort` resolution
+
+6. Add `reasoning_effort → enable_thinking` resolution before `apply_chat_template_sync()` in `chat()` and `chat_stream()` (×4 locations: dense + MoE)
+
+### Phase 3: Streaming reasoning tags
+
+7. Create `ReasoningTracker` before each decode loop (×8 loops)
+8. Call `observe_token()` after token extraction in all loops
+9. Set `is_reasoning` on streaming delta chunks (×4 streaming loops)
+10. Update TypeScript `ChatStreamDelta` type and `_createChatStream()`
+
+### Phase 4: Budget enforcement
+
+11. Add `should_force_think_end()` check in "build next_y" block (×8 loops)
+12. Force `think_end_id` token when budget exhausted
+
+### Phase 5: `include_reasoning` suppression
+
+13. Update `finalize_chat_result()` to accept and apply `include_reasoning`
+14. Apply suppression in streaming finalization blocks
+
+### Phase 6: Tests
+
+15. Unit tests for `ReasoningTracker` state machine
+16. Streaming test for `isReasoning` delta tagging
+17. Integration test: thinking budget enforcement
+
+---
+
+## 20. Files to modify
+
+| File | Changes |
+|------|---------|
+| `crates/mlx-core/src/models/qwen3_5/model.rs` | `ChatConfig` +3 fields, `ChatStreamChunk` +1 field, `reasoning_effort` resolution (×2), `ReasoningTracker` in 4 decode loops, budget enforcement in 4 loops, `is_reasoning` in 2 streaming loops |
+| `crates/mlx-core/src/models/qwen3_5/chat_common.rs` | `ReasoningTracker` struct + unit tests, `ChatParams` +2 fields, `extract_chat_params()`, `finalize_chat_result()` + `include_reasoning` |
+| `crates/mlx-core/src/models/qwen3_5_moe/model.rs` | Same decode loop changes as dense: `reasoning_effort` (×2), tracker in 4 loops, budget in 4 loops, `is_reasoning` in 2 streaming loops, `finalize_chat_result` call |
+| `packages/lm/src/stream.ts` | `ChatStreamDelta` + `isReasoning`, `_createChatStream()` propagation |
+
+Files NOT modified (already correct):
+- `crates/mlx-core/src/tools/mod.rs` — tool parsing isolation already works
+- `crates/mlx-core/src/tokenizer.rs` — `think_end_id` detection, `enable_thinking` already wired
+- `crates/mlx-core/src/sampling.rs` — no logits processor needed
+
+---
+
+## 21. Summary
+
+The `mlx-node` reasoning control flow relies on three cooperating mechanisms:
+
+- **Template controls mode.** `enable_thinking` (resolved from `reasoning_effort` if set) changes the prompt shape via the Jinja2 chat template.
+- **`ReasoningTracker` controls structure.** Token-level tracking of `think_end_id` determines reasoning vs content during decoding. Each streaming delta is tagged `is_reasoning`.
+- **Budget controller acts during decoding.** `thinking_token_budget` forces `think_end_id` inline in the decode loop when the budget is exhausted. This is not post-hoc truncation.
+- **Tool parser sees content only.** `split_at_think_end()` separates at the `</think>` boundary before calling `parse_tool_calls()`. Already implemented.
+- **`include_reasoning` suppresses output.** The `thinking` field is set to `None` in `finalize_chat_result()` when suppression is requested.

--- a/docs/vllm_reasoning_control_flow_spec_for_mlx_node.md
+++ b/docs/vllm_reasoning_control_flow_spec_for_mlx_node.md
@@ -27,7 +27,7 @@ A vLLM-compatible `mlx-node` implementation should expose the following request-
 - `chat_template_kwargs`
 - `include_reasoning`
 - `thinking_token_budget`
-- `reasoning_effort`  
+- `reasoning_effort`
   plus normal generation parameters such as max tokens, temperature, top-p, stop sequences, and tool-calling options. ([docs.vllm.ai](https://docs.vllm.ai/en/latest/api/vllm/entrypoints/openai/chat_completion/protocol/))
 
 ### 2.1 `chat_template_kwargs`

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -2121,6 +2121,23 @@ export interface ChatConfig {
    * Set to false to suppress thinking by injecting empty <think></think> tags.
    */
   enableThinking?: boolean | undefined;
+  /**
+   * Maximum number of thinking tokens before forcing </think>.
+   * When the model has generated this many tokens while in thinking mode,
+   * the next token is forced to be the think_end token. None = unlimited.
+   */
+  thinkingTokenBudget?: number | undefined;
+  /**
+   * Whether to include reasoning/thinking content in the output.
+   * When false, the `thinking` field of ChatResult/ChatStreamChunk will always be null.
+   * Default: true (reasoning is included).
+   */
+  includeReasoning?: boolean | undefined;
+  /**
+   * Reasoning effort level. Overrides `enableThinking` when set:
+   * "low"/"none" → enableThinking=false, "medium"/"high" → enableThinking=true.
+   */
+  reasoningEffort?: string | undefined;
   /** When true, include performance metrics (TTFT, prefill tok/s, decode tok/s) in the result */
   reportPerformance?: boolean | undefined;
   /**
@@ -2184,6 +2201,12 @@ export interface ChatStreamChunk {
   rawText?: string;
   /** Performance metrics (only present in the final chunk when `reportPerformance: true`) */
   performance?: PerformanceMetrics;
+  /**
+   * Whether this delta chunk contains reasoning/thinking content.
+   * true = reasoning (inside <think>...</think>), false = content (after </think>).
+   * Only present on intermediate (non-final) chunks.
+   */
+  isReasoning?: boolean;
 }
 
 /** Result from classify_and_rotate: orientation info + corrected image bytes. */

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -2117,11 +2117,6 @@ export interface ChatConfig {
   ngramSize?: number | undefined;
   tools?: Array<ToolDefinition>;
   /**
-   * Enable thinking mode (Qwen3's <think> tags). Default: true (model thinks naturally).
-   * Set to false to suppress thinking by injecting empty <think></think> tags.
-   */
-  enableThinking?: boolean | undefined;
-  /**
    * Maximum number of thinking tokens before forcing </think>.
    * When the model has generated this many tokens while in thinking mode,
    * the next token is forced to be the think_end token. None = unlimited.
@@ -2134,8 +2129,9 @@ export interface ChatConfig {
    */
   includeReasoning?: boolean | undefined;
   /**
-   * Reasoning effort level. Overrides `enableThinking` when set:
-   * "low"/"none" → enableThinking=false, "medium"/"high" → enableThinking=true.
+   * Reasoning effort level. Controls whether the model thinks before answering:
+   * "low"/"none" → thinking disabled, "medium"/"high" → thinking enabled.
+   * Not set → thinking enabled (model thinks naturally).
    */
   reasoningEffort?: string | undefined;
   /** When true, include performance metrics (TTFT, prefill tok/s, decode tok/s) in the result */

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -11,6 +11,7 @@ import type {
 export interface ChatStreamDelta {
   text: string;
   done: false;
+  isReasoning?: boolean;
 }
 
 export interface ChatStreamFinal {
@@ -95,7 +96,7 @@ export async function* _createChatStream(
           } as ChatStreamFinal;
           return;
         }
-        yield { text: chunk.text, done: false } as ChatStreamDelta;
+        yield { text: chunk.text, done: false, isReasoning: chunk.isReasoning ?? undefined } as ChatStreamDelta;
       }
     }
   } finally {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors core Qwen3.5/Qwen3.5-MoE decode loops and changes how thinking/tool parsing are derived from config, which can affect generation correctness, streaming semantics, and cache/compiled-path behavior.
> 
> **Overview**
> Adds vLLM-style reasoning controls for Qwen models by replacing `enable_thinking` with `reasoning_effort`, `thinking_token_budget`, and `include_reasoning`, and wires these into chat template rendering for Qwen3/Qwen3.5 (including Qianfan OCR). 
> 
> Refactors Qwen3.5 dense + MoE generation to use a shared `decode_loop!` with a new token-level `ReasoningTracker` that can **force `</think>`** when the thinking budget is hit, and tags streaming deltas with `is_reasoning` while optionally suppressing final `thinking` output.
> 
> Hardens thinking/tool parsing by centralizing finalization in `parse_thinking_and_tools`, updating `tools::parse_thinking`/`split_at_think_end` to support `<longcat_think>` and to ensure tool calls are only extracted from post-`</think>` content; adds extensive unit tests and updates TS typings/stream wrapper to expose `isReasoning`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dde8a5327f6846bbeb74464b3c8ab9a377a1b3e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->