### PR TITLE
fix: accept output_text, reasoning, and input_image in /v1/responses mapper

### DIFF
--- a/__test__/server/anthropic-request-mapper.test.ts
+++ b/__test__/server/anthropic-request-mapper.test.ts
@@ -263,6 +263,10 @@ describe('mapAnthropicRequest', () => {
   });
 
   it('rejects trailing image followed by text after a tool_result prefix', () => {
+    // The text-after-image guard fires during the main loop (before the
+    // trailing-mixed check) because the serializer cannot preserve text
+    // that follows an image in any turn, not just after a tool_result
+    // prefix. Either rejection is equivalent for the caller.
     expect(() =>
       mapAnthropicRequest({
         model: 'claude-3-5-sonnet-20241022',
@@ -278,7 +282,7 @@ describe('mapAnthropicRequest', () => {
           },
         ],
       }),
-    ).toThrow(/mixing trailing text and image blocks after a tool_result prefix/i);
+    ).toThrow(/text block after an image block in the same user turn/i);
   });
 
   it('rejects multiple trailing image blocks after a tool_result prefix', () => {
@@ -856,5 +860,113 @@ describe('mapAnthropicRequest', () => {
     });
 
     expect(messages).toEqual([{ role: 'tool', content: 'Result: success', toolCallId: 'call_789' }]);
+  });
+
+  describe('text/image ordering in pure user turns', () => {
+    // Existing tool_result-prefix rejection at line ~160 catches mixed
+    // trailing content after tool_result, but a PURE user turn (no
+    // tool_result blocks) was previously silently concatenating all text
+    // and stacking all images, reordering the caller's content. These
+    // tests pin the uniform rejection for both call patterns.
+    const png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    it('rejects [image, text] in a pure user turn', () => {
+      // Image-first-then-text gets reordered to text-first-then-image by
+      // the flat ChatMessage + Jinja serializer pipeline. Reject rather
+      // than silently rewrite the caller's intent.
+      expect(() =>
+        mapAnthropicRequest({
+          model: 'claude-3-5-sonnet-20241022',
+          max_tokens: 1024,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'image', source: { type: 'base64', media_type: 'image/png', data: png } },
+                { type: 'text', text: 'describe this' },
+              ],
+            },
+          ],
+        }),
+      ).toThrow(/text block after an image block in the same user turn/i);
+    });
+
+    it('rejects [text, image, text] in a pure user turn', () => {
+      expect(() =>
+        mapAnthropicRequest({
+          model: 'claude-3-5-sonnet-20241022',
+          max_tokens: 1024,
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'before' },
+                { type: 'image', source: { type: 'base64', media_type: 'image/png', data: png } },
+                { type: 'text', text: 'after' },
+              ],
+            },
+          ],
+        }),
+      ).toThrow(/text block after an image block/i);
+    });
+
+    it('accepts [text, image] in a pure user turn (representable by the flat ChatMessage)', () => {
+      const { messages } = mapAnthropicRequest({
+        model: 'claude-3-5-sonnet-20241022',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'what colour is this?' },
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: png } },
+            ],
+          },
+        ],
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('user');
+      expect(messages[0].content).toBe('what colour is this?');
+      expect(messages[0].images).toHaveLength(1);
+    });
+
+    it('accepts [text, text, image] (all text parts before the image)', () => {
+      const { messages } = mapAnthropicRequest({
+        model: 'claude-3-5-sonnet-20241022',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'part one. ' },
+              { type: 'text', text: 'part two.' },
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: png } },
+            ],
+          },
+        ],
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('part one. part two.');
+      expect(messages[0].images).toHaveLength(1);
+    });
+
+    it('accepts multiple images with no text (no ordering ambiguity)', () => {
+      const { messages } = mapAnthropicRequest({
+        model: 'claude-3-5-sonnet-20241022',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: png } },
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: png } },
+            ],
+          },
+        ],
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('');
+      expect(messages[0].images).toHaveLength(2);
+    });
   });
 });

--- a/__test__/server/request-mapper.test.ts
+++ b/__test__/server/request-mapper.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vite-plus/test';
 
-import { mapRequest, reconstructMessagesFromChain } from '../../packages/server/src/mappers/request.js';
+import {
+  mapRequest,
+  reconstructMessagesFromChain,
+  stringifyStoredInputMessages,
+} from '../../packages/server/src/mappers/request.js';
 
 describe('mapRequest', () => {
   it('maps a string input to a single user message', () => {
@@ -1080,5 +1084,85 @@ describe('reconstructMessagesFromChain', () => {
     // Pin that `reasoningContent` is absent, not present-but-empty — some downstream
     // paths distinguish `undefined` from `''` when deciding whether to emit <think>.
     expect(messages[1]).not.toHaveProperty('reasoningContent');
+  });
+});
+
+describe('stored-input codec (images round-trip)', () => {
+  // `StoredResponseRecord.inputJson` is serialised with
+  // `stringifyStoredInputMessages` and re-parsed by
+  // `reconstructMessagesFromChain`. Plain `JSON.stringify` would turn
+  // `Uint8Array([1,2,3])` into `{"0":1,"1":2,"2":3}`, which fails the
+  // NAPI `Uint8Array` coercion on cold replay through
+  // `previous_response_id` chains that carry images. Guard that
+  // round-trip here.
+  it('encodes Uint8Array images as base64 in the stored JSON', () => {
+    const msgs = [
+      {
+        role: 'user' as const,
+        content: 'look',
+        images: [new Uint8Array([0xff, 0x00, 0x01, 0x02])],
+      },
+    ];
+    const json = stringifyStoredInputMessages(msgs);
+    const parsedRaw = JSON.parse(json);
+    expect(parsedRaw[0].images).toHaveLength(1);
+    expect(parsedRaw[0].images[0]).toEqual({ __u8__: Buffer.from([0xff, 0x00, 0x01, 0x02]).toString('base64') });
+    // Regression guard: the legacy numeric-keyed shape MUST NOT appear.
+    expect(parsedRaw[0].images[0]).not.toHaveProperty('0');
+  });
+
+  it('reconstructs images back to Uint8Array instances with identical bytes', () => {
+    const bytes = new Uint8Array([10, 20, 30, 40, 50]);
+    const inputJson = stringifyStoredInputMessages([
+      {
+        role: 'user',
+        content: 'round-trip me',
+        images: [bytes],
+      },
+    ]);
+    const [msg] = reconstructMessagesFromChain([{ inputJson, outputJson: '[]' }]);
+    expect(msg.role).toBe('user');
+    expect(msg.images).toBeDefined();
+    expect(msg.images).toHaveLength(1);
+    // `Buffer.from(_, 'base64')` returns a Uint8Array subclass — satisfies
+    // the NAPI `Array<Uint8Array>` type check downstream.
+    expect(msg.images![0]).toBeInstanceOf(Uint8Array);
+    expect(Array.from(msg.images![0])).toEqual(Array.from(bytes));
+  });
+
+  it('preserves multiple images across round-trip in order', () => {
+    const inputJson = stringifyStoredInputMessages([
+      {
+        role: 'user',
+        content: 'compare',
+        images: [new Uint8Array([1]), new Uint8Array([2, 2]), new Uint8Array([3, 3, 3])],
+      },
+    ]);
+    const [msg] = reconstructMessagesFromChain([{ inputJson, outputJson: '[]' }]);
+    expect(msg.images).toHaveLength(3);
+    expect(Array.from(msg.images![0])).toEqual([1]);
+    expect(Array.from(msg.images![1])).toEqual([2, 2]);
+    expect(Array.from(msg.images![2])).toEqual([3, 3, 3]);
+  });
+
+  it('leaves image-less messages unchanged (byte-for-byte parity with plain JSON.stringify)', () => {
+    const msgs = [
+      { role: 'user' as const, content: 'no images here' },
+      { role: 'assistant' as const, content: 'reply' },
+    ];
+    expect(stringifyStoredInputMessages(msgs)).toBe(JSON.stringify(msgs));
+  });
+
+  it('does not rehydrate unrelated objects that happen to carry a __u8__ key', () => {
+    // Defensive: the reviver keys on the exact sentinel shape
+    // `{__u8__: "<base64>"}`. A user-supplied message whose `content`
+    // is a literal JSON string containing that substring must not be
+    // transformed — the sentinel only appears inside the `images` array,
+    // and only via `stringifyStoredInputMessages`.
+    const inputJson = JSON.stringify([{ role: 'user', content: 'here is a fake sentinel: {"__u8__":"deadbeef"}' }]);
+    const [msg] = reconstructMessagesFromChain([{ inputJson, outputJson: '[]' }]);
+    expect(typeof msg.content).toBe('string');
+    expect(msg.content).toContain('__u8__');
+    expect(msg.images).toBeUndefined();
   });
 });

--- a/__test__/server/request-mapper.test.ts
+++ b/__test__/server/request-mapper.test.ts
@@ -1165,4 +1165,33 @@ describe('stored-input codec (images round-trip)', () => {
     expect(msg.content).toContain('__u8__');
     expect(msg.images).toBeUndefined();
   });
+
+  it('round-trips images when they arrive as Node Buffer (matches mapRequest output)', () => {
+    // Regression guard: `resolveMessageContent` used to push raw `Buffer`
+    // instances into `msg.images`. `Buffer.prototype.toJSON` is invoked
+    // by `JSON.stringify` BEFORE the replacer, so a naive
+    // `value instanceof Uint8Array` check would skip the sentinel even
+    // though `Buffer extends Uint8Array` at the class level. The
+    // replacer must handle the `{type:"Buffer",data:[...]}` shape too
+    // so stored history stays rehydratable regardless of which producer
+    // built the ChatMessage.
+    const bytes = [0xde, 0xad, 0xbe, 0xef];
+    const inputJson = stringifyStoredInputMessages([
+      {
+        role: 'user',
+        content: 'buffer input',
+        images: [Buffer.from(bytes) as unknown as Uint8Array],
+      },
+    ]);
+    // Wire shape must be the sentinel, NOT `{type:"Buffer",data:[...]}`.
+    const wire = JSON.parse(inputJson);
+    expect(wire[0].images[0]).toEqual({ __u8__: Buffer.from(bytes).toString('base64') });
+    expect(wire[0].images[0]).not.toHaveProperty('type');
+    expect(wire[0].images[0]).not.toHaveProperty('data');
+
+    const [msg] = reconstructMessagesFromChain([{ inputJson, outputJson: '[]' }]);
+    expect(msg.images).toHaveLength(1);
+    expect(msg.images![0]).toBeInstanceOf(Uint8Array);
+    expect(Array.from(msg.images![0])).toEqual(bytes);
+  });
 });

--- a/__test__/server/request-mapper.test.ts
+++ b/__test__/server/request-mapper.test.ts
@@ -691,6 +691,135 @@ describe('mapRequest', () => {
       ).toThrow(/only allowed on user messages/);
     });
   });
+
+  describe('text/image part ordering', () => {
+    // The flat internal `ChatMessage` shape cannot express a text part
+    // that appears AFTER an image part in the same message: the
+    // downstream Jinja serializer always renders text first, then all
+    // images. Reject ambiguous orderings rather than silently reorder
+    // them and change the caller's intent. Mirrors the rejection in
+    // `anthropic-request.ts` for its own user-turn shape.
+    const png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    it('rejects [input_text, input_image, input_text] (text after image)', () => {
+      expect(() =>
+        mapRequest({
+          model: 'test-model',
+          input: [
+            {
+              type: 'message',
+              role: 'user',
+              content: [
+                { type: 'input_text', text: 'before' },
+                { type: 'input_image', image_url: `data:image/png;base64,${png}` },
+                { type: 'input_text', text: 'after' },
+              ],
+            },
+          ],
+        }),
+      ).toThrow(/text content part after an image part in the same message/i);
+    });
+
+    it('rejects [input_image, input_text] (image first, text after)', () => {
+      // Silently reordering `[image, text]` to `[text, image]` would flip
+      // caption-vs-question framing for VLM prompts.
+      expect(() =>
+        mapRequest({
+          model: 'test-model',
+          input: [
+            {
+              type: 'message',
+              role: 'user',
+              content: [
+                { type: 'input_image', image_url: `data:image/png;base64,${png}` },
+                { type: 'input_text', text: 'what is this?' },
+              ],
+            },
+          ],
+        }),
+      ).toThrow(/text content part after an image part/i);
+    });
+
+    it('rejects [output_text, input_image, output_text] on replayed assistant messages', () => {
+      // `output_text` is a text-like part too. Reject text-after-image
+      // uniformly regardless of the text variant.
+      expect(() =>
+        mapRequest({
+          model: 'test-model',
+          input: [
+            {
+              type: 'message',
+              role: 'user',
+              content: [
+                { type: 'output_text', text: 'before', annotations: [] },
+                { type: 'input_image', image_url: `data:image/png;base64,${png}` },
+                { type: 'output_text', text: 'after', annotations: [] },
+              ],
+            } as any,
+          ],
+        }),
+      ).toThrow(/text content part after an image part/i);
+    });
+
+    it('accepts [input_text, input_image] (text before image — representable)', () => {
+      const { messages } = mapRequest({
+        model: 'test-model',
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'what colour?' },
+              { type: 'input_image', image_url: `data:image/png;base64,${png}` },
+            ],
+          },
+        ],
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('what colour?');
+      expect(messages[0].images).toHaveLength(1);
+    });
+
+    it('accepts [input_text, input_text, input_image, input_image] (all text before all images)', () => {
+      const { messages } = mapRequest({
+        model: 'test-model',
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'compare ' },
+              { type: 'input_text', text: 'these:' },
+              { type: 'input_image', image_url: `data:image/png;base64,${png}` },
+              { type: 'input_image', image_url: `data:image/png;base64,${png}` },
+            ],
+          },
+        ],
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('compare these:');
+      expect(messages[0].images).toHaveLength(2);
+    });
+
+    it('accepts images-only content (no ordering ambiguity)', () => {
+      const { messages } = mapRequest({
+        model: 'test-model',
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_image', image_url: `data:image/png;base64,${png}` },
+              { type: 'input_image', image_url: `data:image/png;base64,${png}` },
+            ],
+          },
+        ],
+      });
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('');
+      expect(messages[0].images).toHaveLength(2);
+    });
+  });
 });
 
 describe('reconstructMessagesFromChain', () => {

--- a/__test__/server/request-mapper.test.ts
+++ b/__test__/server/request-mapper.test.ts
@@ -512,6 +512,185 @@ describe('mapRequest', () => {
       ]);
     });
   });
+
+  describe('assistant history replay (client-echoed input[])', () => {
+    it('accepts output_text content parts when a client replays an assistant message', () => {
+      // Clients that do not use `previous_response_id` (pi-ai, Codex) replay
+      // the prior assistant turn as `{type:"message",role:"assistant",content:[{type:"output_text",...}]}`.
+      // Rejecting output_text breaks cold-start multi-turn outright.
+      const { messages } = mapRequest({
+        model: 'test-model',
+        input: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Remember 42.' }] },
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: "Got it. I'll remember 42.", annotations: [] }],
+          } as any,
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'What number?' }] },
+        ],
+      });
+
+      expect(messages).toEqual([
+        { role: 'user', content: 'Remember 42.' },
+        { role: 'assistant', content: "Got it. I'll remember 42." },
+        { role: 'user', content: 'What number?' },
+      ]);
+    });
+
+    it('coalesces a replayed reasoning item onto the trailing assistant message', () => {
+      // Real pi-ai payload shape: user → reasoning → message(assistant) → user.
+      // The reasoning summary must land as `reasoningContent` on the assistant turn.
+      const { messages } = mapRequest({
+        model: 'test-model',
+        input: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Hi' }] },
+          {
+            type: 'reasoning',
+            id: 'rs_1',
+            summary: [{ type: 'summary_text', text: 'Let me think briefly.' }],
+          } as any,
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Hello!', annotations: [] }],
+          } as any,
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Bye' }] },
+        ],
+      });
+
+      expect(messages).toEqual([
+        { role: 'user', content: 'Hi' },
+        { role: 'assistant', content: 'Hello!', reasoningContent: 'Let me think briefly.' },
+        { role: 'user', content: 'Bye' },
+      ]);
+    });
+
+    it('coalesces reasoning + function_call into one assistant turn', () => {
+      const { messages } = mapRequest({
+        model: 'test-model',
+        input: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Weather in SF?' }] },
+          {
+            type: 'reasoning',
+            summary: [{ type: 'summary_text', text: 'Tool required.' }],
+          } as any,
+          {
+            type: 'function_call',
+            id: 'fc-1',
+            call_id: 'call_a',
+            name: 'get_weather',
+            arguments: '{"city":"SF"}',
+          },
+        ],
+      });
+
+      expect(messages).toEqual([
+        { role: 'user', content: 'Weather in SF?' },
+        {
+          role: 'assistant',
+          content: '',
+          reasoningContent: 'Tool required.',
+          toolCalls: [{ name: 'get_weather', arguments: '{"city":"SF"}', id: 'call_a' }],
+        },
+      ]);
+    });
+
+    it('emits reasoning-only turn as a standalone assistant message when no trailing content', () => {
+      // Turn 1 ran out of budget inside thinking → client replays a lone reasoning item.
+      const { messages } = mapRequest({
+        model: 'test-model',
+        input: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Think briefly.' }] },
+          {
+            type: 'reasoning',
+            summary: [{ type: 'summary_text', text: 'thinking only.' }],
+          } as any,
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Continue.' }] },
+        ],
+      });
+
+      expect(messages).toEqual([
+        { role: 'user', content: 'Think briefly.' },
+        { role: 'assistant', content: '', reasoningContent: 'thinking only.' },
+        { role: 'user', content: 'Continue.' },
+      ]);
+    });
+
+    it('treats a replayed refusal part as text for model re-ingestion', () => {
+      const { messages } = mapRequest({
+        model: 'test-model',
+        input: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'refusal', refusal: 'I cannot help with that.' }],
+          } as any,
+        ],
+      });
+
+      expect(messages).toEqual([{ role: 'assistant', content: 'I cannot help with that.' }]);
+    });
+  });
+
+  describe('input_image content parts', () => {
+    it('decodes a base64 data URL into raw image bytes attached to the user turn', () => {
+      // 2x2 red PNG.
+      const b64 =
+        'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFUlEQVR4nGP8z8DwnwEDMGEKDQYxAEiRAP9t2B9IAAAAAElFTkSuQmCC';
+      const { messages } = mapRequest({
+        model: 'test-model',
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'What is in this image?' },
+              { type: 'input_image', image_url: `data:image/png;base64,${b64}` },
+            ],
+          },
+        ],
+      });
+
+      expect(messages).toHaveLength(1);
+      const u = messages[0];
+      expect(u.role).toBe('user');
+      expect(u.content).toBe('What is in this image?');
+      expect(u.images).toBeDefined();
+      expect(u.images).toHaveLength(1);
+      expect(Buffer.from(u.images![0]).subarray(0, 4)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    });
+
+    it('rejects input_image with a remote http(s) URL', () => {
+      expect(() =>
+        mapRequest({
+          model: 'test-model',
+          input: [
+            {
+              type: 'message',
+              role: 'user',
+              content: [{ type: 'input_image', image_url: 'https://example.com/cat.png' }],
+            },
+          ],
+        }),
+      ).toThrow(/base64 data URL/);
+    });
+
+    it('rejects input_image attached to a non-user message', () => {
+      expect(() =>
+        mapRequest({
+          model: 'test-model',
+          input: [
+            {
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'input_image', image_url: 'data:image/png;base64,AA==' }],
+            } as any,
+          ],
+        }),
+      ).toThrow(/only allowed on user messages/);
+    });
+  });
 });
 
 describe('reconstructMessagesFromChain', () => {

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -550,6 +550,52 @@ pub(crate) fn save_cache_state_direct(
     }
 }
 
+/// Commit session state after a text-only delta continuation.
+///
+/// The delta path (`chat_tokens_delta_sync` / `chat_stream_tokens_delta_sync`)
+/// appends a text delta on top of the live KV caches without touching the
+/// image attention state baked in by the preceding prefill. The "current
+/// turn is text-only" signal (`has_images == false`) MUST NOT be conflated
+/// with "the session has no image context" — the KV caches still encode
+/// every image patch from the earlier `chat_session_start` / VLM prefill,
+/// and clearing `cached_image_key` here would make the next cache-prefix
+/// verify think the session is pure text and accept a future image-carrying
+/// turn via the delta path (which produces garbage because the mrope
+/// offset `cached_rope_deltas` is stale for the new image grid).
+///
+/// This helper is identical to [`save_cache_state_direct`] except that it
+/// leaves `cached_image_key` untouched on the `reuse_cache=true` branch.
+/// The full-reset `reuse_cache=false` branch still clears everything —
+/// same invariant as the prefill helper.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn save_cache_state_after_delta(
+    reuse_cache: bool,
+    generated_tokens: &[u32],
+    finish_reason: &str,
+    save_tokens: &[u32],
+    cached_token_history: &mut Vec<u32>,
+    cached_image_key: &mut Option<u64>,
+    cached_rope_deltas: &mut Option<i32>,
+    caches: &mut Option<Vec<Qwen3_5LayerCache>>,
+) {
+    if reuse_cache {
+        let mut full_history = save_tokens.to_vec();
+        let history_tokens = if finish_reason == "length" && !generated_tokens.is_empty() {
+            &generated_tokens[..generated_tokens.len() - 1]
+        } else {
+            generated_tokens
+        };
+        full_history.extend_from_slice(history_tokens);
+        *cached_token_history = full_history;
+        // `cached_image_key` intentionally preserved — see doc comment.
+    } else {
+        *caches = None;
+        cached_token_history.clear();
+        *cached_image_key = None;
+        *cached_rope_deltas = None;
+    }
+}
+
 /// Direct-ownership version of `verify_cache_prefix` for dedicated-thread models.
 ///
 /// Takes direct refs instead of `Arc<RwLock<>>`. Used by Qwen3.5 Dense on
@@ -898,5 +944,125 @@ mod tests {
         assert!(tracker.observe_token(300)); // reasoning
         // Never transitions — no think_end_id to match
         assert!(!tracker.should_force_think_end()); // budget disabled
+    }
+}
+
+#[cfg(test)]
+mod save_cache_state_after_delta_tests {
+    //! Guards the sticky-`cached_image_key` invariant on the text-only
+    //! delta path. Before the fix, `save_cache_state_direct(has_images:
+    //! false, ...)` was called after every delta continuation, which
+    //! cleared `cached_image_key` even though the live KV cache still
+    //! encoded the prior prefill's image attention state. That
+    //! contradicted the TS `ChatSession` routing contract (warm cache
+    //! across text-only follow-ups) and caused the delta path to fail
+    //! with a cryptic "chat_tokens_delta_sync is text-only; session
+    //! currently holds image state" on the very next turn.
+    use super::save_cache_state_after_delta;
+
+    #[test]
+    fn delta_preserves_cached_image_key_on_reuse_cache_true() {
+        let mut cached_history: Vec<u32> = vec![1, 2, 3];
+        let mut cached_image_key: Option<u64> = Some(0xdeadbeef);
+        let mut cached_rope_deltas: Option<i32> = Some(5);
+        let mut caches: Option<Vec<super::Qwen3_5LayerCache>> =
+            Some(vec![super::Qwen3_5LayerCache::new_full_attention()]);
+
+        save_cache_state_after_delta(
+            /* reuse_cache */ true,
+            /* generated_tokens */ &[10, 11],
+            /* finish_reason */ "stop",
+            /* save_tokens */ &[1, 2, 3, 4],
+            &mut cached_history,
+            &mut cached_image_key,
+            &mut cached_rope_deltas,
+            &mut caches,
+        );
+
+        // Token history extended: pre-decode snapshot + generated tokens
+        assert_eq!(cached_history, vec![1, 2, 3, 4, 10, 11]);
+        // Image key preserved — THE invariant under test
+        assert_eq!(cached_image_key, Some(0xdeadbeef));
+        // Other cache state untouched
+        assert_eq!(cached_rope_deltas, Some(5));
+        assert!(caches.is_some());
+    }
+
+    #[test]
+    fn delta_drops_trailing_generated_token_on_length_stop() {
+        // Matches `save_cache_state_direct` truncation semantics: if the
+        // decode terminated at max_new_tokens, the last generated token
+        // was cut off mid-stream and must not be persisted.
+        let mut cached_history: Vec<u32> = vec![];
+        let mut cached_image_key: Option<u64> = Some(42);
+        let mut cached_rope_deltas: Option<i32> = None;
+        let mut caches: Option<Vec<super::Qwen3_5LayerCache>> = None;
+
+        save_cache_state_after_delta(
+            true,
+            &[10, 11, 12],
+            "length",
+            &[1, 2],
+            &mut cached_history,
+            &mut cached_image_key,
+            &mut cached_rope_deltas,
+            &mut caches,
+        );
+
+        assert_eq!(cached_history, vec![1, 2, 10, 11]);
+        assert_eq!(cached_image_key, Some(42));
+    }
+
+    #[test]
+    fn delta_full_reset_clears_everything_when_reuse_cache_false() {
+        // `reuse_cache=false` is the cold-path invariant from the prefill
+        // helper — when the caller opts out of cache reuse, every piece
+        // of session state must be cleared regardless of whether the
+        // image key was previously populated.
+        let mut cached_history: Vec<u32> = vec![1, 2, 3];
+        let mut cached_image_key: Option<u64> = Some(0xabc);
+        let mut cached_rope_deltas: Option<i32> = Some(7);
+        let mut caches: Option<Vec<super::Qwen3_5LayerCache>> =
+            Some(vec![super::Qwen3_5LayerCache::new_linear()]);
+
+        save_cache_state_after_delta(
+            false,
+            &[10],
+            "stop",
+            &[1],
+            &mut cached_history,
+            &mut cached_image_key,
+            &mut cached_rope_deltas,
+            &mut caches,
+        );
+
+        assert!(cached_history.is_empty());
+        assert!(cached_image_key.is_none());
+        assert!(cached_rope_deltas.is_none());
+        assert!(caches.is_none());
+    }
+
+    #[test]
+    fn delta_with_text_only_session_keeps_key_none() {
+        // Sanity: if the session never had images, the delta must not
+        // fabricate a key either.
+        let mut cached_history: Vec<u32> = vec![];
+        let mut cached_image_key: Option<u64> = None;
+        let mut cached_rope_deltas: Option<i32> = None;
+        let mut caches: Option<Vec<super::Qwen3_5LayerCache>> = None;
+
+        save_cache_state_after_delta(
+            true,
+            &[42],
+            "stop",
+            &[1, 2],
+            &mut cached_history,
+            &mut cached_image_key,
+            &mut cached_rope_deltas,
+            &mut caches,
+        );
+
+        assert_eq!(cached_image_key, None);
+        assert_eq!(cached_history, vec![1, 2, 42]);
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -507,6 +507,48 @@ pub(crate) fn finalize_chat_result(
     })
 }
 
+/// Whether the compiled init should re-apply the saved M-RoPE offset
+/// (`cached_rope_deltas`) after building the decode graph.
+///
+/// The offset is saved only when a VLM prefill ran, so `has_saved_delta`
+/// is effectively "the live KV cache encodes image attention". Two
+/// callers need to re-apply it:
+///   - **Fresh VLM prefill reusing a cached prefix** (`has_images &&
+///     cached_prefix_len > 0`): the new turn shares its image grid with
+///     the cached one, and the saved offset carries the image-adjusted
+///     M-RoPE position forward into the rebuilt compiled graph.
+///   - **Session delta continuation** (`is_delta`): the delta prefill
+///     just ran on top of the live KV caches, which still encode the
+///     prior VLM prefill's image attention. Without re-applying the
+///     offset, the newly-built compiled graph would decode at a
+///     sequential M-RoPE position and misposition all generated tokens
+///     relative to the cached image patches.
+///
+/// Pure function — extracted so the decision can be unit-tested
+/// without instantiating the compiled decoder.
+pub(crate) fn should_reapply_rope_delta(
+    has_saved_delta: bool,
+    is_delta: bool,
+    has_images: bool,
+    cached_prefix_len: usize,
+) -> bool {
+    has_saved_delta && (is_delta || (has_images && cached_prefix_len > 0))
+}
+
+/// Whether the compiled init should clear `cached_rope_deltas` after
+/// building the decode graph.
+///
+/// Only fresh text-only prefills clear the offset: they signal that the
+/// non-delta cache-prefix verify dropped any prior image-bearing cache,
+/// so the stored offset is stale. Delta continuations preserve the
+/// offset so chained text-only turns on an image session keep the
+/// image-adjusted M-RoPE position.
+///
+/// Pure function — extracted so the decision can be unit-tested.
+pub(crate) fn should_clear_rope_delta(is_delta: bool, has_images: bool) -> bool {
+    !has_images && !is_delta
+}
+
 /// Direct-ownership version of `save_cache_state` for dedicated-thread models.
 ///
 /// Takes `&mut` refs instead of `Arc<RwLock<>>`. Used by Qwen3.5 Dense on
@@ -1064,5 +1106,118 @@ mod save_cache_state_after_delta_tests {
 
         assert_eq!(cached_image_key, None);
         assert_eq!(cached_history, vec![1, 2, 42]);
+    }
+}
+
+#[cfg(test)]
+mod rope_delta_gate_tests {
+    //! Guards the M-RoPE offset lifecycle across the compiled decode
+    //! init branch. The prior bug hard-coded `has_images: false` on the
+    //! delta path and unconditionally cleared `cached_rope_deltas`,
+    //! which caused the compiled graph to decode text-only deltas at a
+    //! sequential position instead of the image-adjusted position —
+    //! mispositioning every generated token relative to the cached
+    //! image patches baked in by the earlier VLM prefill.
+    use super::{should_clear_rope_delta, should_reapply_rope_delta};
+
+    // ---- should_reapply_rope_delta ----
+
+    #[test]
+    fn reapply_skipped_when_no_saved_delta() {
+        // Text-only session, nothing to re-apply.
+        assert!(!should_reapply_rope_delta(false, false, false, 0));
+        // Image session with delta, but saved offset missing (fresh VLM
+        // prefill clears it before setting — we never enter the gated
+        // branch without a saved offset).
+        assert!(!should_reapply_rope_delta(false, true, false, 0));
+        assert!(!should_reapply_rope_delta(false, false, true, 100));
+    }
+
+    #[test]
+    fn reapply_fires_on_fresh_vlm_cache_prefix_reuse() {
+        // Fresh VLM prefill reusing a cached prefix: both `has_images`
+        // AND a non-zero `cached_prefix_len` must be present. The saved
+        // offset was written on the prior turn's VLM prefill, so a
+        // matching key + prefix means we rebuild the compiled graph at
+        // the same image-adjusted position.
+        assert!(should_reapply_rope_delta(true, false, true, 100));
+    }
+
+    #[test]
+    fn reapply_skipped_on_fresh_vlm_without_prefix_match() {
+        // VLM prefill without prefix reuse (cached_prefix_len == 0):
+        // the compiled init already ran the fresh prefill path, which
+        // computed the offset from scratch via M-RoPE. No re-apply.
+        assert!(!should_reapply_rope_delta(true, false, true, 0));
+    }
+
+    #[test]
+    fn reapply_skipped_on_fresh_text_prefill() {
+        // Fresh text prefill with no image state: the cache-prefix
+        // verify already dropped any prior image-bearing cache, so the
+        // saved offset is stale. `should_clear_rope_delta` handles that
+        // case by nulling it; re-apply stays off.
+        assert!(!should_reapply_rope_delta(true, false, false, 50));
+        assert!(!should_reapply_rope_delta(true, false, false, 0));
+    }
+
+    #[test]
+    fn reapply_fires_on_delta_continuation_with_saved_offset() {
+        // THE invariant this fix introduces: delta continuations on an
+        // image-bearing session re-apply the saved offset regardless of
+        // `has_images` (which is always false on the delta path by
+        // construction — delta prefills are text-only) and regardless
+        // of `cached_prefix_len` (which is always 0 on the delta path
+        // because the live KV cache already contains the full prior
+        // history and the delta bypasses the prefix-match flow).
+        assert!(should_reapply_rope_delta(true, true, false, 0));
+    }
+
+    #[test]
+    fn reapply_fires_on_chained_delta_turns() {
+        // Chained text-only deltas on the same image session: each
+        // turn's compiled init must re-apply the offset so the session
+        // stays positioned correctly. The save helper preserves
+        // `cached_rope_deltas` on the reuse_cache branch, so the next
+        // turn sees `has_saved_delta=true`.
+        assert!(should_reapply_rope_delta(true, true, false, 0));
+    }
+
+    // ---- should_clear_rope_delta ----
+
+    #[test]
+    fn clear_fires_only_on_fresh_text_prefill() {
+        // The ONE case where the saved offset is stale: a non-delta
+        // text prefill. The cache-prefix verify already dropped any
+        // prior image cache, so the offset has nothing valid to apply
+        // to on the next turn.
+        assert!(should_clear_rope_delta(false, false));
+    }
+
+    #[test]
+    fn clear_skipped_on_delta_path() {
+        // Delta continuations (text-only by construction) preserve the
+        // offset — regression gate for the bug this fix addresses. The
+        // live KV cache still encodes the prior VLM prefill's image
+        // attention, so the next delta turn (and the one after that)
+        // must re-apply the same saved offset.
+        assert!(!should_clear_rope_delta(true, false));
+    }
+
+    #[test]
+    fn clear_skipped_on_vlm_prefill() {
+        // VLM prefill sets a fresh offset and must not nuke it after
+        // init. The `is_delta` axis is false on the non-delta prefill
+        // path; the `has_images` axis guards the clear.
+        assert!(!should_clear_rope_delta(false, true));
+    }
+
+    #[test]
+    fn clear_skipped_on_vlm_delta_combination() {
+        // Belt-and-suspenders: even if a future caller ever set
+        // `is_delta=true, has_images=true`, the clear stays off. No
+        // current caller does this — the delta path rejects images at
+        // entry — but the gate is written defensively.
+        assert!(!should_clear_rope_delta(true, true));
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -461,6 +461,13 @@ pub(crate) struct ChatDecodeInputs {
     /// `true` when the VLM prefill has already run the compiled init.
     /// `false` for text-only paths and the session delta path.
     pub vlm_compiled_init_done: bool,
+    /// `true` when this invocation is a session DELTA continuation
+    /// (text-only append on top of the live KV cache). Drives the
+    /// post-decode save pathway: deltas keep `cached_image_key` sticky
+    /// so image attention state baked into the KV caches by a prior
+    /// prefill stays addressable; prefills (re)set the key based on
+    /// the fresh turn's `has_images`.
+    pub is_delta: bool,
 
     // --- Compiled-path state --------------------------------------------
     /// `true` when this model owns the compiled weights and the compiled
@@ -1179,6 +1186,7 @@ impl Qwen35Inner {
             last_logits,
             seq_len,
             vlm_compiled_init_done,
+            is_delta: false,
             use_compiled,
             has_images,
             cached_prefix_len,
@@ -1245,11 +1253,14 @@ impl Qwen35Inner {
                 "chat_tokens_delta_sync requires a non-empty delta",
             ));
         }
-        if self.cached_image_key.is_some() {
-            return Err(Error::from_reason(
-                "chat_tokens_delta_sync is text-only; session currently holds image state",
-            ));
-        }
+        // A populated `cached_image_key` means the live KV cache carries
+        // attention state for images seen on the preceding prefill. The
+        // delta path appends a text delta on top of that — the image
+        // context stays intact and the model can keep reasoning about
+        // it. We do NOT reject here; the outer `chat_session_continue_*`
+        // gate already rejects IMAGE-SET CHANGES (non-empty new images
+        // that don't match the cached key) with a prefixed error the TS
+        // `ChatSession` can catch and route through `chatSessionStart`.
 
         let report_perf = config.report_performance.unwrap_or(false);
 
@@ -1360,6 +1371,7 @@ impl Qwen35Inner {
             last_logits,
             seq_len: total_seq_len,
             vlm_compiled_init_done: false,
+            is_delta: true,
             use_compiled,
             has_images: false,
             cached_prefix_len,
@@ -1501,6 +1513,7 @@ impl Qwen35Inner {
             last_logits,
             seq_len,
             vlm_compiled_init_done,
+            is_delta,
             use_compiled,
             has_images,
             cached_prefix_len,
@@ -1716,20 +1729,37 @@ impl Qwen35Inner {
             );
         }
 
-        // Save cache state
-        save_cache_state_direct(
-            p.reuse_cache,
-            has_images,
-            &generated_tokens,
-            &finish_reason,
-            &save_tokens,
-            save_expanded_tokens.as_deref(),
-            save_image_cache_key,
-            &mut self.cached_token_history,
-            &mut self.cached_image_key,
-            &mut self.cached_rope_deltas,
-            &mut self.caches,
-        );
+        // Save cache state. Delta continuations preserve
+        // `cached_image_key` — the KV cache still holds the prior
+        // prefill's image attention state even though this turn was
+        // text-only. Prefill paths (re)set the key based on the fresh
+        // turn's `has_images`.
+        if is_delta {
+            chat_common::save_cache_state_after_delta(
+                p.reuse_cache,
+                &generated_tokens,
+                &finish_reason,
+                &save_tokens,
+                &mut self.cached_token_history,
+                &mut self.cached_image_key,
+                &mut self.cached_rope_deltas,
+                &mut self.caches,
+            );
+        } else {
+            save_cache_state_direct(
+                p.reuse_cache,
+                has_images,
+                &generated_tokens,
+                &finish_reason,
+                &save_tokens,
+                save_expanded_tokens.as_deref(),
+                save_image_cache_key,
+                &mut self.cached_token_history,
+                &mut self.cached_image_key,
+                &mut self.cached_rope_deltas,
+                &mut self.caches,
+            );
+        }
 
         let performance = compute_performance_metrics(
             generation_start,
@@ -1987,13 +2017,11 @@ impl Qwen35Inner {
             );
             return;
         }
-        if self.cached_image_key.is_some() {
-            send_stream_error(
-                &stream_tx,
-                "chat_stream_tokens_delta is text-only; session currently holds image state",
-            );
-            return;
-        }
+        // Text-only deltas are allowed on sessions whose KV cache carries
+        // prior image attention state — see `chat_tokens_delta_sync` for
+        // the full rationale. The outer `chat_stream_session_continue`
+        // gate already filters IMAGE-SET CHANGES via the
+        // `IMAGE_CHANGE_REQUIRES_SESSION_RESTART:` prefix path.
 
         // All guards passed — enter the prefill+decode helper. Any error
         // returned from here propagates as an mpsc error, same as
@@ -2303,17 +2331,14 @@ impl Qwen35Inner {
 
         // Save cache state unconditionally — even on cancellation, the
         // partial generated_tokens must be appended so the session stays
-        // consistent for the next turn. `has_images` is always false on
-        // the delta path and we pass the full pre-decode snapshot as the
-        // text-only `save_tokens`.
-        save_cache_state_direct(
+        // consistent for the next turn. Delta continuations preserve
+        // `cached_image_key` so the next turn's cache-prefix verify
+        // still sees the prior prefill's image state.
+        chat_common::save_cache_state_after_delta(
             p.reuse_cache,
-            false,
             &generated_tokens,
             &finish_reason,
             &save_tokens,
-            None,
-            0,
             &mut self.cached_token_history,
             &mut self.cached_image_key,
             &mut self.cached_rope_deltas,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -998,8 +998,9 @@ impl Qwen35Inner {
                 let all_images = extract_images_from_messages(&messages);
                 let image_refs: Vec<&[u8]> = all_images.iter().map(|v| v.as_slice()).collect();
                 let processed_pre = img_proc.process_many(&image_refs)?;
-                let num_image_tokens = compute_num_image_tokens(&processed_pre.grid_thw(), sms)?;
-                let expanded = inject_image_placeholders(&tokens, num_image_tokens);
+                let per_image_token_counts =
+                    compute_image_token_counts_per_image(&processed_pre.grid_thw(), sms)?;
+                let expanded = inject_image_placeholders(&tokens, &per_image_token_counts);
                 let cache_key = compute_image_cache_key(&all_images);
                 (expanded, cache_key, Some(processed_pre))
             } else {
@@ -2472,8 +2473,9 @@ impl Qwen35Inner {
                 let all_images = extract_images_from_messages(&messages);
                 let image_refs: Vec<&[u8]> = all_images.iter().map(|v| v.as_slice()).collect();
                 let processed_pre = img_proc.process_many(&image_refs)?;
-                let num_image_tokens = compute_num_image_tokens(&processed_pre.grid_thw(), sms)?;
-                let expanded = inject_image_placeholders(&tokens, num_image_tokens);
+                let per_image_token_counts =
+                    compute_image_token_counts_per_image(&processed_pre.grid_thw(), sms)?;
+                let expanded = inject_image_placeholders(&tokens, &per_image_token_counts);
                 let cache_key = compute_image_cache_key(&all_images);
                 (expanded, cache_key, Some(processed_pre))
             } else {
@@ -5251,39 +5253,99 @@ pub(crate) fn extract_images_from_messages(messages: &[ChatMessage]) -> Vec<Vec<
     all_images
 }
 
-/// Compute the number of merged image tokens from a processed grid_thw array.
-pub(crate) fn compute_num_image_tokens(grid: &MxArray, spatial_merge_size: i32) -> Result<usize> {
+/// Compute the per-image merged-token count from a processed grid_thw
+/// array. Each entry is the number of `IMAGE_TOKEN_ID` slots that image
+/// must occupy in the prompt so the vision embeddings align 1:1 with the
+/// corresponding token positions.
+pub(crate) fn compute_image_token_counts_per_image(
+    grid: &MxArray,
+    spatial_merge_size: i32,
+) -> Result<Vec<usize>> {
     grid.eval();
     let grid_data = grid.to_int32()?;
     let merge_factor = spatial_merge_size * spatial_merge_size;
-    let mut num_tokens = 0usize;
+    let mut counts = Vec::with_capacity(grid_data.len() / 3);
     for i in 0..(grid_data.len() / 3) {
         let t = grid_data[i * 3];
         let h = grid_data[i * 3 + 1];
         let w = grid_data[i * 3 + 2];
-        num_tokens += ((t * h * w) / merge_factor) as usize;
+        counts.push(((t * h * w) / merge_factor) as usize);
     }
-    Ok(num_tokens)
+    Ok(counts)
 }
 
-/// Ensure image token placeholders are present in the tokenized output.
+/// Ensure the tokenized prompt contains the right number of
+/// `IMAGE_TOKEN_ID` placeholders — one per vision patch, in the order
+/// produced by the chat template.
 ///
-/// If the chat template didn't inject `IMAGE_TOKEN_ID` placeholders,
-/// splice `num_image_tokens` of them after position 0 (after BOS).
-/// Always returns an owned Vec.
-pub(crate) fn inject_image_placeholders(tokens: &[u32], num_image_tokens: usize) -> Vec<u32> {
+/// Three input shapes are accepted:
+///
+/// 1. **Template emitted one `<|image_pad|>` per image** (the proper
+///    Qwen VLM shape, produced by
+///    `tokenizer::serialize_message_for_jinja` when the user turn
+///    carries images). Each placeholder is expanded in-place to its
+///    image's grid count. This keeps the vision tokens inside the user
+///    turn — `get_rope_index` builds correct M-RoPE positions and the
+///    model attends to the image in-context.
+///
+/// 2. **Template already emitted the fully expanded count** (non-Qwen
+///    templates that inline the full patch run). Pass through unchanged.
+///
+/// 3. **Template emitted zero placeholders** (non-VLM template, or a
+///    VLM template that silently drops vision markers). Splice the
+///    total count right after BOS as a last-resort fallback. Vision
+///    tokens land outside the user turn; this usually still produces
+///    sensible output for simple prompts but M-RoPE position IDs are
+///    suboptimal.
+pub(crate) fn inject_image_placeholders(
+    tokens: &[u32],
+    per_image_token_counts: &[usize],
+) -> Vec<u32> {
+    let total: usize = per_image_token_counts.iter().sum();
+    if total == 0 {
+        return tokens.to_vec();
+    }
     let existing = tokens
         .iter()
         .filter(|&&t| t == IMAGE_TOKEN_ID as u32)
         .count();
-    if num_image_tokens > 0 && existing == 0 {
+
+    if existing == 0 {
+        // Case 3 — fallback splice after BOS.
         let mut new_tokens = tokens.to_vec();
-        let placeholders: Vec<u32> = vec![IMAGE_TOKEN_ID as u32; num_image_tokens];
+        let placeholders: Vec<u32> = vec![IMAGE_TOKEN_ID as u32; total];
         new_tokens.splice(1..1, placeholders);
-        new_tokens
-    } else {
-        tokens.to_vec()
+        return new_tokens;
     }
+
+    if existing == per_image_token_counts.len() {
+        // Case 1 — one placeholder per image; expand each in place to
+        // its grid count. Capacity pre-sized to the final length so no
+        // reallocations.
+        let mut new_tokens: Vec<u32> = Vec::with_capacity(tokens.len() + total - existing);
+        let mut img_iter = per_image_token_counts.iter().copied();
+        for &t in tokens {
+            if t == IMAGE_TOKEN_ID as u32 {
+                match img_iter.next() {
+                    Some(count) => {
+                        new_tokens.extend(std::iter::repeat_n(IMAGE_TOKEN_ID as u32, count));
+                    }
+                    None => {
+                        // More placeholders than images — preserve as-is
+                        // and let `get_rope_index` surface the mismatch.
+                        new_tokens.push(t);
+                    }
+                }
+            } else {
+                new_tokens.push(t);
+            }
+        }
+        return new_tokens;
+    }
+
+    // Case 2 (existing == total) or unknown shape — return as-is.
+    // `get_rope_index` will surface any mismatch.
+    tokens.to_vec()
 }
 
 /// Compute M-RoPE position IDs for VLM
@@ -5801,4 +5863,69 @@ pub(crate) fn vlm_prepare_vision_features(
     );
 
     Ok((inputs_embeds, position_ids, rope_deltas))
+}
+
+#[cfg(test)]
+mod image_placeholder_tests {
+    use super::*;
+
+    const BOS: u32 = 1;
+    const USER: u32 = 100;
+    const TEXT: u32 = 200;
+    const IMG: u32 = IMAGE_TOKEN_ID as u32;
+
+    #[test]
+    fn expands_single_placeholder_per_image_inline() {
+        // Template emitted: BOS, USER, <|image_pad|>, TEXT
+        // Expected: BOS, USER, <|image_pad|>×5, TEXT  (vision wrapper stays
+        // INSIDE the user turn instead of getting spliced after BOS).
+        let tokens = vec![BOS, USER, IMG, TEXT];
+        let out = inject_image_placeholders(&tokens, &[5]);
+        assert_eq!(out, vec![BOS, USER, IMG, IMG, IMG, IMG, IMG, TEXT]);
+    }
+
+    #[test]
+    fn expands_distinct_grid_counts_for_multiple_images_in_order() {
+        // Two images with different grid sizes — each placeholder must be
+        // replaced by its own image's count, not the other way around.
+        let tokens = vec![BOS, IMG, TEXT, IMG];
+        let out = inject_image_placeholders(&tokens, &[2, 3]);
+        assert_eq!(out, vec![BOS, IMG, IMG, TEXT, IMG, IMG, IMG]);
+    }
+
+    #[test]
+    fn empty_counts_is_passthrough() {
+        let tokens = vec![BOS, USER, TEXT];
+        let out = inject_image_placeholders(&tokens, &[]);
+        assert_eq!(out, tokens);
+    }
+
+    #[test]
+    fn fallback_splices_total_after_bos_when_template_emitted_none() {
+        // Case 3: template didn't emit any placeholder. Fallback splice
+        // preserved for non-VLM templates / silent vision-dropping
+        // templates.
+        let tokens = vec![BOS, USER, TEXT];
+        let out = inject_image_placeholders(&tokens, &[3]);
+        assert_eq!(out, vec![BOS, IMG, IMG, IMG, USER, TEXT]);
+    }
+
+    #[test]
+    fn fully_expanded_input_passes_through_unchanged() {
+        // Case 2: template already emitted the full 5-token run. `existing`
+        // (5) != `per_image.len()` (1) so the "one-per-image" branch
+        // doesn't fire; total (5) matches so no fallback splice either.
+        let tokens = vec![BOS, USER, IMG, IMG, IMG, IMG, IMG, TEXT];
+        let out = inject_image_placeholders(&tokens, &[5]);
+        assert_eq!(out, tokens);
+    }
+
+    #[test]
+    fn preserves_relative_position_of_surrounding_tokens() {
+        // Regression guard: every non-IMG token must survive in its
+        // original relative order.
+        let tokens = vec![BOS, USER, 10, 11, IMG, 12, 13];
+        let out = inject_image_placeholders(&tokens, &[4]);
+        assert_eq!(out, vec![BOS, USER, 10, 11, IMG, IMG, IMG, IMG, 12, 13]);
+    }
 }

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -5384,14 +5384,33 @@ pub(crate) fn get_rope_index(
         let end = start + seq_len as usize;
         let batch_tokens: Vec<i32> = input_ids_data[start..end].to_vec();
 
-        let mut image_positions: Vec<usize> = Vec::new();
-        for (i, &token) in batch_tokens.iter().enumerate() {
-            if token == image_token_id {
-                image_positions.push(i);
+        // Scan `batch_tokens` for maximal contiguous runs of
+        // `image_token_id`. After the tokenizer fix that serialises
+        // one `<|image_pad|>` per image inline in the user turn and
+        // `inject_image_placeholders` expands each marker in place,
+        // the prompt can carry MULTIPLE separated image runs when
+        // history is replayed (e.g. two image-bearing user turns
+        // joined by an assistant reply). Flattening the span from
+        // `positions[0]` to `positions[last]` the way the old
+        // single-span code did would skip every interior text token
+        // between runs and blow up the downstream shape check.
+        let mut image_runs: Vec<(usize, usize)> = Vec::new();
+        {
+            let mut i = 0;
+            while i < batch_tokens.len() {
+                if batch_tokens[i] == image_token_id {
+                    let start = i;
+                    while i < batch_tokens.len() && batch_tokens[i] == image_token_id {
+                        i += 1;
+                    }
+                    image_runs.push((start, i));
+                } else {
+                    i += 1;
+                }
             }
         }
 
-        if image_positions.is_empty() {
+        if image_runs.is_empty() {
             for i in 0..seq_len {
                 all_position_ids[0].push(i);
                 all_position_ids[1].push(i);
@@ -5426,58 +5445,95 @@ pub(crate) fn get_rope_index(
             total_expected_tokens += num_tokens;
         }
 
-        if total_expected_tokens != image_positions.len() {
+        let total_image_tokens: usize = image_runs.iter().map(|(s, e)| e - s).sum();
+        if total_expected_tokens != total_image_tokens {
             return Err(Error::new(
                 Status::GenericFailure,
                 format!(
                     "Image token count mismatch: expected {} from grid, found {} in prompt",
-                    total_expected_tokens,
-                    image_positions.len()
+                    total_expected_tokens, total_image_tokens,
                 ),
             ));
         }
 
-        // Build position IDs
-        let image_start = image_positions[0];
-        let image_end = image_positions[image_positions.len() - 1] + 1;
-
-        // Text before images: sequential
-        for i in 0..image_start {
-            all_position_ids[0].push(i as i64);
-            all_position_ids[1].push(i as i64);
-            all_position_ids[2].push(i as i64);
+        // One image → one contiguous run. If this doesn't hold, the
+        // prompt shape is ambiguous (either `inject_image_placeholders`
+        // merged two adjacent runs into one or the grid count split a
+        // single image across multiple runs). Bail rather than guess a
+        // pairing.
+        if image_runs.len() != num_images {
+            return Err(Error::new(
+                Status::GenericFailure,
+                format!(
+                    "Image run layout mismatch: prompt carries {} contiguous image-token runs but {} images \
+                     were processed; expected one run per image. If you meant to send multiple images in the \
+                     same turn, place them adjacent to each other in the content array.",
+                    image_runs.len(),
+                    num_images,
+                ),
+            ));
         }
 
-        // Image tokens: 2D spatial positions
-        let mut current_pos = image_start as i64;
-        let mut max_pos = image_start as i64;
+        // Per-run length must match the grid count for the image at
+        // the same ordinal position. Ordering is enforced by the
+        // tokenizer serialiser (images emitted in input array order)
+        // and by the image processor (grids returned in the same order).
+        for (run_idx, (run_start, run_end)) in image_runs.iter().enumerate() {
+            let expected = image_token_info[run_idx].3;
+            let actual = run_end - run_start;
+            if expected != actual {
+                return Err(Error::new(
+                    Status::GenericFailure,
+                    format!(
+                        "Image run {run_idx} has {actual} placeholder tokens but its grid expects {expected}",
+                    ),
+                ));
+            }
+        }
 
-        for (llm_grid_t, llm_grid_h, llm_grid_w, _) in &image_token_info {
-            for t_idx in 0..*llm_grid_t {
-                for h_idx in 0..*llm_grid_h {
-                    for w_idx in 0..*llm_grid_w {
-                        all_position_ids[0].push(current_pos + t_idx);
-                        all_position_ids[1].push(current_pos + h_idx);
-                        all_position_ids[2].push(current_pos + w_idx);
+        // Emit positions by walking the sequence: text gap, image run,
+        // text gap, image run, … final text gap. `current_pos` carries
+        // the M-RoPE counter forward across both text and image
+        // segments so every token gets a monotonically non-decreasing
+        // position id in each axis.
+        let mut cursor: usize = 0;
+        let mut current_pos: i64 = 0;
+
+        for (run_idx, (run_start, run_end)) in image_runs.iter().enumerate() {
+            // Text gap before this image run
+            for _ in cursor..*run_start {
+                all_position_ids[0].push(current_pos);
+                all_position_ids[1].push(current_pos);
+                all_position_ids[2].push(current_pos);
+                current_pos += 1;
+            }
+
+            // Spatial positions for the image at this run
+            let (llm_grid_t, llm_grid_h, llm_grid_w, _) = image_token_info[run_idx];
+            let image_base = current_pos;
+            for t_idx in 0..llm_grid_t {
+                for h_idx in 0..llm_grid_h {
+                    for w_idx in 0..llm_grid_w {
+                        all_position_ids[0].push(image_base + t_idx);
+                        all_position_ids[1].push(image_base + h_idx);
+                        all_position_ids[2].push(image_base + w_idx);
                     }
                 }
             }
-            let img_max = current_pos
-                + std::cmp::max(
-                    *llm_grid_t - 1,
-                    std::cmp::max(*llm_grid_h - 1, *llm_grid_w - 1),
-                );
-            max_pos = std::cmp::max(max_pos, img_max);
-            current_pos = img_max + 1;
+            let max_axis = std::cmp::max(
+                llm_grid_t - 1,
+                std::cmp::max(llm_grid_h - 1, llm_grid_w - 1),
+            );
+            current_pos = image_base + max_axis + 1;
+            cursor = *run_end;
         }
 
-        // Text after images: continue from max
-        let next_pos = max_pos + 1;
-        for i in image_end..seq_len as usize {
-            let pos = next_pos + (i - image_end) as i64;
-            all_position_ids[0].push(pos);
-            all_position_ids[1].push(pos);
-            all_position_ids[2].push(pos);
+        // Trailing text after the last image run
+        for _ in cursor..seq_len as usize {
+            all_position_ids[0].push(current_pos);
+            all_position_ids[1].push(current_pos);
+            all_position_ids[2].push(current_pos);
+            current_pos += 1;
         }
     }
 
@@ -5927,5 +5983,204 @@ mod image_placeholder_tests {
         let tokens = vec![BOS, USER, 10, 11, IMG, 12, 13];
         let out = inject_image_placeholders(&tokens, &[4]);
         assert_eq!(out, vec![BOS, USER, 10, 11, IMG, IMG, IMG, IMG, 12, 13]);
+    }
+}
+
+#[cfg(test)]
+mod rope_index_tests {
+    //! `get_rope_index` builds M-RoPE position IDs for VLM prefill. The
+    //! pre-fix implementation collapsed every `IMAGE_TOKEN_ID` in the
+    //! prompt to a single contiguous span from `positions[0]` to
+    //! `positions[last]`; a multi-turn history with two image-bearing
+    //! user turns joined by an assistant reply silently skipped every
+    //! interior text token, leaving `all_position_ids` shorter than
+    //! `seq_len` and crashing the downstream reshape with a cryptic
+    //! "length mismatch". These tests pin per-run indexing against that
+    //! regression.
+    use super::*;
+    use crate::array::MxArray;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+    const IMG: i32 = IMAGE_TOKEN_ID;
+    const TEXT_A: i32 = 100;
+    const TEXT_B: i32 = 200;
+
+    /// MLX's MPS backend is not re-entrant — every test that touches an
+    /// `MxArray` must hold this mutex so only one such test runs at a
+    /// time across the test binary.
+    fn mlx_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// Encode a flat `Vec<i32>` token stream as a `[1, seq_len]`
+    /// `MxArray` and a `[num_images, 3]` grid array (or `None`) to
+    /// feed `get_rope_index`.
+    fn mk_inputs(tokens: &[i32], grids: &[(i64, i64, i64)]) -> (MxArray, Option<MxArray>) {
+        let seq_len = tokens.len() as i64;
+        let input_ids = MxArray::from_int32(tokens, &[1, seq_len]).unwrap();
+        let grid = if grids.is_empty() {
+            None
+        } else {
+            let flat: Vec<i32> = grids
+                .iter()
+                .flat_map(|(t, h, w)| [*t as i32, *h as i32, *w as i32])
+                .collect();
+            Some(MxArray::from_int32(&flat, &[grids.len() as i64, 3]).unwrap())
+        };
+        (input_ids, grid)
+    }
+
+    fn extract_positions(pos: &MxArray) -> (Vec<i32>, Vec<i32>, Vec<i32>) {
+        // pos shape [3, 1, seq_len] — flatten to Vec<i32> and split.
+        pos.eval();
+        let flat = pos.to_int32().unwrap();
+        let n = flat.len() / 3;
+        (
+            flat[0..n].to_vec(),
+            flat[n..2 * n].to_vec(),
+            flat[2 * n..3 * n].to_vec(),
+        )
+    }
+
+    #[test]
+    fn pure_text_prompt_gets_sequential_positions() {
+        let _g = mlx_lock().lock().unwrap();
+        let tokens = vec![TEXT_A, TEXT_B, TEXT_A, TEXT_B];
+        let (ids, grid) = mk_inputs(&tokens, &[]);
+        let (pos, rope_deltas) = get_rope_index(&ids, grid.as_ref(), 2, IMG).unwrap();
+        let (t, h, w) = extract_positions(&pos);
+        assert_eq!(t, vec![0, 1, 2, 3]);
+        assert_eq!(h, vec![0, 1, 2, 3]);
+        assert_eq!(w, vec![0, 1, 2, 3]);
+        assert_eq!(rope_deltas, 0);
+    }
+
+    #[test]
+    fn single_image_run_preserves_baseline_shape() {
+        let _g = mlx_lock().lock().unwrap();
+        // 2 text + (grid 2x2x2=8 tokens after spatial_merge=2, so t=2,h=4,w=4, split=2
+        //   → llm grid 2×2×2 = 8 image tokens) + 2 text
+        let tokens: Vec<i32> = [TEXT_A, TEXT_B]
+            .iter()
+            .chain(std::iter::repeat_n(&IMG, 8))
+            .chain([TEXT_A, TEXT_B].iter())
+            .copied()
+            .collect();
+        let (ids, grid) = mk_inputs(&tokens, &[(2, 4, 4)]);
+        let (pos, _) = get_rope_index(&ids, grid.as_ref(), 2, IMG).unwrap();
+        let (t, h, w) = extract_positions(&pos);
+        // Leading text
+        assert_eq!(&t[..2], &[0, 1]);
+        assert_eq!(&h[..2], &[0, 1]);
+        // Image span starts at 2; with llm_grid_t=2 h=2 w=2 → max_axis=1
+        // so current_pos advances to 2 + 1 + 1 = 4 after the image.
+        // Trailing text: 4, 5
+        assert_eq!(&t[10..], &[4, 5]);
+        assert_eq!(&h[10..], &[4, 5]);
+        assert_eq!(&w[10..], &[4, 5]);
+    }
+
+    #[test]
+    fn two_image_runs_separated_by_text_emits_every_position() {
+        // THE regression test for the P2 bug — pre-fix this crashed the
+        // downstream reshape with a length mismatch.
+        let _g = mlx_lock().lock().unwrap();
+        let mut tokens: Vec<i32> = Vec::new();
+        tokens.push(TEXT_A); // position 0
+        tokens.extend(std::iter::repeat_n(IMG, 8)); // 1 image → llm 2×2×2=8
+        tokens.push(TEXT_A); // interior text between images
+        tokens.push(TEXT_B);
+        tokens.extend(std::iter::repeat_n(IMG, 8)); // 2nd image → same grid
+        tokens.push(TEXT_A); // trailing text
+
+        let (ids, grid) = mk_inputs(&tokens, &[(2, 4, 4), (2, 4, 4)]);
+        let (pos, _) = get_rope_index(&ids, grid.as_ref(), 2, IMG).unwrap();
+        let (t, _h, _w) = extract_positions(&pos);
+
+        // seq_len == tokens.len() — every token must have a position
+        // (the old single-span path dropped the interior text entries,
+        // which then failed the reshape at the end of get_rope_index).
+        assert_eq!(
+            t.len(),
+            tokens.len(),
+            "position count must equal token count"
+        );
+
+        // Leading text at pos 0
+        assert_eq!(t[0], 0);
+        // Image 1 at base=1, max_axis=1 → current_pos after = 3
+        // Interior text: 3, 4
+        assert_eq!(t[9], 3);
+        assert_eq!(t[10], 4);
+        // Image 2 at base=5, max_axis=1 → current_pos after = 7
+        // Trailing text: 7
+        assert_eq!(*t.last().unwrap(), 7);
+    }
+
+    #[test]
+    fn leading_image_run_no_text_prefix() {
+        let _g = mlx_lock().lock().unwrap();
+        let tokens: Vec<i32> = std::iter::repeat_n(IMG, 8)
+            .chain([TEXT_A, TEXT_B].iter().copied())
+            .collect();
+        let (ids, grid) = mk_inputs(&tokens, &[(2, 4, 4)]);
+        let (pos, _) = get_rope_index(&ids, grid.as_ref(), 2, IMG).unwrap();
+        let (t, _, _) = extract_positions(&pos);
+        assert_eq!(t.len(), tokens.len());
+        // Image at base=0, max_axis=1 → current_pos=2 after, trailing text 2, 3
+        assert_eq!(&t[8..], &[2, 3]);
+    }
+
+    #[test]
+    fn trailing_image_run_no_text_suffix() {
+        let _g = mlx_lock().lock().unwrap();
+        let tokens: Vec<i32> = [TEXT_A, TEXT_B]
+            .iter()
+            .copied()
+            .chain(std::iter::repeat_n(IMG, 8))
+            .collect();
+        let (ids, grid) = mk_inputs(&tokens, &[(2, 4, 4)]);
+        let (pos, _) = get_rope_index(&ids, grid.as_ref(), 2, IMG).unwrap();
+        let (t, _, _) = extract_positions(&pos);
+        assert_eq!(t.len(), tokens.len());
+        assert_eq!(&t[..2], &[0, 1]);
+    }
+
+    #[test]
+    fn run_count_must_match_image_count() {
+        // 2 image runs in the prompt but only 1 grid supplied — ambiguous
+        // pairing; reject.
+        let _g = mlx_lock().lock().unwrap();
+        let mut tokens = vec![TEXT_A];
+        tokens.extend(std::iter::repeat_n(IMG, 4));
+        tokens.push(TEXT_A);
+        tokens.extend(std::iter::repeat_n(IMG, 4));
+        let (ids, grid) = mk_inputs(&tokens, &[(2, 4, 4)]);
+        let err = match get_rope_index(&ids, grid.as_ref(), 2, IMG) {
+            Ok(_) => panic!("expected get_rope_index to error"),
+            Err(e) => e,
+        };
+        assert!(
+            err.reason.contains("Image run layout mismatch"),
+            "got: {}",
+            err.reason
+        );
+    }
+
+    #[test]
+    fn per_run_length_must_match_its_grid_count() {
+        // 2 runs, 2 grids — but run 0 has too few tokens for grid 0.
+        let _g = mlx_lock().lock().unwrap();
+        let mut tokens = vec![TEXT_A];
+        tokens.extend(std::iter::repeat_n(IMG, 4)); // should be 8 for (2,4,4)
+        tokens.push(TEXT_A);
+        tokens.extend(std::iter::repeat_n(IMG, 12)); // compensates the total, but per-run wrong
+        let (ids, grid) = mk_inputs(&tokens, &[(2, 4, 4), (2, 4, 4)]);
+        let err = match get_rope_index(&ids, grid.as_ref(), 2, IMG) {
+            Ok(_) => panic!("expected get_rope_index to error"),
+            Err(e) => e,
+        };
+        assert!(err.reason.contains("Image run 0"), "got: {}", err.reason);
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -5481,52 +5481,94 @@ pub(crate) fn get_rope_index(
             ));
         }
 
-        // One image → one contiguous run. If this doesn't hold, the
-        // prompt shape is ambiguous (either `inject_image_placeholders`
-        // merged two adjacent runs into one or the grid count split a
-        // single image across multiple runs). Bail rather than guess a
-        // pairing.
-        if image_runs.len() != num_images {
+        // Two token layouts are valid here:
+        //
+        //  (a) N runs, one per image — the proper Qwen VLM shape after
+        //      the tokenizer serialiser emits a `{type:"image"}` part
+        //      per image and `inject_image_placeholders` expands each
+        //      marker in place. Per-run length must match its grid.
+        //
+        //  (b) 1 big run whose length equals the grids' total —
+        //      the fallback layout for chat templates that emit no
+        //      `<|image_pad|>` markers, where
+        //      `inject_image_placeholders` crams every image's tokens
+        //      into a single splice after BOS. No text gap sits between
+        //      images in this layout, so the position walk collapses
+        //      consecutive sub-runs into one contiguous span without
+        //      emitting any interior text.
+        //
+        // We canonicalise both into a `per_image_offsets: Vec<(start,
+        // grid_info)>` list of length `num_images` and feed it to the
+        // position walk below. Any other shape is ambiguous (we'd have
+        // to guess which grid goes with which run) — reject it.
+        let per_image_offsets: Vec<(usize, (i64, i64, i64, usize))> = if image_runs.len()
+            == num_images
+        {
+            // Case (a): validate per-run length, then pair by ordinal.
+            for (run_idx, (run_start, run_end)) in image_runs.iter().enumerate() {
+                let expected = image_token_info[run_idx].3;
+                let actual = run_end - run_start;
+                if expected != actual {
+                    return Err(Error::new(
+                        Status::GenericFailure,
+                        format!(
+                            "Image run {run_idx} has {actual} placeholder tokens but its grid expects {expected}",
+                        ),
+                    ));
+                }
+            }
+            image_runs
+                .iter()
+                .zip(image_token_info.iter().copied())
+                .map(|((start, _), info)| (*start, info))
+                .collect()
+        } else if image_runs.len() == 1 {
+            // Case (b): fallback splice — synthesise per-image start
+            // offsets by walking `image_token_info` lengths from the
+            // single run's start. Total was already validated against
+            // `total_expected_tokens` above, so this just distributes
+            // the shared span across the grids.
+            let big_start = image_runs[0].0;
+            let mut offsets = Vec::with_capacity(num_images);
+            let mut cursor = big_start;
+            for info in image_token_info.iter().copied() {
+                offsets.push((cursor, info));
+                cursor += info.3;
+            }
+            offsets
+        } else {
             return Err(Error::new(
                 Status::GenericFailure,
                 format!(
                     "Image run layout mismatch: prompt carries {} contiguous image-token runs but {} images \
-                     were processed; expected one run per image. If you meant to send multiple images in the \
-                     same turn, place them adjacent to each other in the content array.",
+                     were processed; expected either one run per image or a single contiguous fallback run \
+                     containing every image's tokens.",
                     image_runs.len(),
                     num_images,
                 ),
             ));
-        }
+        };
 
-        // Per-run length must match the grid count for the image at
-        // the same ordinal position. Ordering is enforced by the
-        // tokenizer serialiser (images emitted in input array order)
-        // and by the image processor (grids returned in the same order).
-        for (run_idx, (run_start, run_end)) in image_runs.iter().enumerate() {
-            let expected = image_token_info[run_idx].3;
-            let actual = run_end - run_start;
-            if expected != actual {
-                return Err(Error::new(
-                    Status::GenericFailure,
-                    format!(
-                        "Image run {run_idx} has {actual} placeholder tokens but its grid expects {expected}",
-                    ),
-                ));
-            }
-        }
+        // End of the last image token in the token stream — everything
+        // beyond is trailing text. For case (a) this is the last run's
+        // end; for case (b) it's the shared run's end. In both cases
+        // it equals `image_runs.last().unwrap().1`.
+        let last_image_end = image_runs.last().expect("at least one run").1;
 
-        // Emit positions by walking the sequence: text gap, image run,
-        // text gap, image run, … final text gap. `current_pos` carries
-        // the M-RoPE counter forward across both text and image
-        // segments so every token gets a monotonically non-decreasing
-        // position id in each axis.
+        // Emit positions by walking the sequence: text gap, image,
+        // text gap, image, … final text gap. `current_pos` carries the
+        // M-RoPE counter forward across both text and image segments so
+        // every token gets a monotonically non-decreasing position id
+        // in each axis. Synthesised case-(b) sub-runs sit back-to-back
+        // so their text-gap loops iterate zero times between them —
+        // the walk collapses naturally.
         let mut cursor: usize = 0;
         let mut current_pos: i64 = 0;
 
-        for (run_idx, (run_start, run_end)) in image_runs.iter().enumerate() {
-            // Text gap before this image run
-            for _ in cursor..*run_start {
+        for (run_start, info) in per_image_offsets.iter().copied() {
+            // Text gap before this image run (zero-length for adjacent
+            // case-(b) sub-runs after the first).
+            for _ in cursor..run_start {
                 all_position_ids[0].push(current_pos);
                 all_position_ids[1].push(current_pos);
                 all_position_ids[2].push(current_pos);
@@ -5534,7 +5576,7 @@ pub(crate) fn get_rope_index(
             }
 
             // Spatial positions for the image at this run
-            let (llm_grid_t, llm_grid_h, llm_grid_w, _) = image_token_info[run_idx];
+            let (llm_grid_t, llm_grid_h, llm_grid_w, count) = info;
             let image_base = current_pos;
             for t_idx in 0..llm_grid_t {
                 for h_idx in 0..llm_grid_h {
@@ -5550,10 +5592,13 @@ pub(crate) fn get_rope_index(
                 std::cmp::max(llm_grid_h - 1, llm_grid_w - 1),
             );
             current_pos = image_base + max_axis + 1;
-            cursor = *run_end;
+            cursor = run_start + count;
         }
 
-        // Trailing text after the last image run
+        // Trailing text after the last image (run in case (a), sub-run
+        // end in case (b) — both resolve to `last_image_end`).
+        debug_assert_eq!(cursor, last_image_end);
+        let _ = last_image_end;
         for _ in cursor..seq_len as usize {
             all_position_ids[0].push(current_pos);
             all_position_ids[1].push(current_pos);
@@ -6207,5 +6252,58 @@ mod rope_index_tests {
             Err(e) => e,
         };
         assert!(err.reason.contains("Image run 0"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn multi_image_fallback_single_contiguous_run_is_accepted() {
+        // Fallback case (b): chat template emits zero `<|image_pad|>`
+        // markers and `inject_image_placeholders` crams every image's
+        // tokens into a single splice after BOS. For N images with
+        // distinct grids, the prompt carries ONE big contiguous run of
+        // `sum(per_image_counts)` image tokens. The old strict guard
+        // rejected this as "run layout mismatch" even though it was
+        // the legitimate fallback layout that previously worked via
+        // the old single-span position walk. The new path synthesises
+        // per-image sub-run offsets from the shared span and emits
+        // correct M-RoPE positions for each image.
+        let _g = mlx_lock().lock().unwrap();
+        // Two 1×2×2 grids → 4 image tokens each, 8 total.
+        let mut tokens = vec![TEXT_A];
+        tokens.extend(std::iter::repeat_n(IMG, 8));
+        tokens.push(TEXT_B);
+        let (ids, grid) = mk_inputs(&tokens, &[(1, 4, 4), (1, 4, 4)]);
+        let (pos, _) = get_rope_index(&ids, grid.as_ref(), 2, IMG)
+            .expect("fallback single-run layout for two images must be accepted");
+        let (t, _, _) = extract_positions(&pos);
+        assert_eq!(t.len(), tokens.len(), "every token must have a position");
+        // Leading text at 0.
+        assert_eq!(t[0], 0);
+        // First image base = 1, llm grid 1×2×2, max_axis=1 → current_pos
+        // after = 3. Next image base = 3, max_axis=1 → current_pos
+        // after = 5. Trailing TEXT_B at 5.
+        assert_eq!(*t.last().unwrap(), 5);
+    }
+
+    #[test]
+    fn multi_image_fallback_with_distinct_grids_preserves_per_image_offsets() {
+        // Same fallback shape but with DIFFERENT grid sizes per image —
+        // the synthesised sub-run offsets must distribute the shared
+        // span correctly (image[0] consumes its own count tokens,
+        // image[1] starts right after).
+        let _g = mlx_lock().lock().unwrap();
+        // image 0: 1×2×2 → 4 tokens. image 1: 1×4×4 → 16 tokens. Total 20.
+        let mut tokens = vec![TEXT_A];
+        tokens.extend(std::iter::repeat_n(IMG, 20));
+        tokens.push(TEXT_B);
+        let (ids, grid) = mk_inputs(&tokens, &[(1, 4, 4), (1, 8, 8)]);
+        let (pos, _) = get_rope_index(&ids, grid.as_ref(), 2, IMG)
+            .expect("fallback layout with distinct per-image grids must succeed");
+        let (t, _, _) = extract_positions(&pos);
+        assert_eq!(t.len(), tokens.len());
+        assert_eq!(t[0], 0);
+        // image 0 base=1, max_axis = max(0,1,1) = 1 → current_pos = 3
+        // image 1 base=3, max_axis = max(0,3,3) = 3 → current_pos = 7
+        // Trailing TEXT_B at 7.
+        assert_eq!(*t.last().unwrap(), 7);
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1604,10 +1604,17 @@ impl Qwen35Inner {
                     );
                 }
 
-                // VLM cache reuse: apply saved rope_deltas
-                if has_images
-                    && cached_prefix_len > 0
-                    && let Some(delta) = self.cached_rope_deltas
+                // Re-apply the saved M-RoPE offset when the compiled
+                // state is being (re)initialized from a KV cache that
+                // encodes image attention — see
+                // `chat_common::should_reapply_rope_delta`.
+                if let Some(delta) = self.cached_rope_deltas
+                    && chat_common::should_reapply_rope_delta(
+                        true,
+                        is_delta,
+                        has_images,
+                        cached_prefix_len,
+                    )
                 {
                     unsafe {
                         mlx_sys::mlx_qwen35_compiled_adjust_offset(delta);
@@ -1615,8 +1622,9 @@ impl Qwen35Inner {
                 }
             }
 
-            // For text-only, clear stale rope deltas
-            if !has_images {
+            // Clear stale rope deltas only on fresh text-only prefills —
+            // see `chat_common::should_clear_rope_delta`.
+            if chat_common::should_clear_rope_delta(is_delta, has_images) {
                 self.cached_rope_deltas = None;
             }
 
@@ -2209,8 +2217,20 @@ impl Qwen35Inner {
                     prefill_len,
                 );
             }
-            // Text-only path: clear stale rope deltas.
-            self.cached_rope_deltas = None;
+            // Re-apply the saved M-RoPE offset if the session carries
+            // image state. The delta prefill just ran against the live
+            // KV caches, which still encode the prior VLM prefill's
+            // image attention; without re-applying the offset here, the
+            // newly-built compiled graph would use a sequential M-RoPE
+            // position and misposition all decoded tokens relative to
+            // the cached image patches. `cached_rope_deltas` stays
+            // alive across deltas so chained text-only turns on the
+            // same image session keep the offset.
+            if let Some(delta) = self.cached_rope_deltas {
+                unsafe {
+                    mlx_sys::mlx_qwen35_compiled_adjust_offset(delta);
+                }
+            }
 
             profiler.set_label("chat_stream_delta_compiled");
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1959,8 +1959,20 @@ impl Qwen35MoeInner {
                 );
             }
 
-            // Text-only delta path: clear stale rope deltas.
-            self.cached_rope_deltas = None;
+            // Re-apply the saved M-RoPE offset if the session carries
+            // image state. The delta prefill just ran against the live
+            // KV caches, which still encode the prior VLM prefill's
+            // image attention; without re-applying the offset here, the
+            // newly-built compiled graph would use a sequential M-RoPE
+            // position and misposition all decoded tokens relative to
+            // the cached image patches. `cached_rope_deltas` stays
+            // alive across deltas so chained text-only turns on the
+            // same image session keep the offset.
+            if let Some(delta) = self.cached_rope_deltas {
+                unsafe {
+                    mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
+                }
+            }
 
             profiler.set_label("moe_chat_delta_compiled");
 
@@ -2578,8 +2590,18 @@ impl Qwen35MoeInner {
                 );
             }
 
-            // Text-only delta path: clear stale rope deltas.
-            self.cached_rope_deltas = None;
+            // Re-apply the saved M-RoPE offset if the session carries
+            // image state. See the sync sibling for the full rationale:
+            // the live KV caches still encode the prior VLM prefill's
+            // image attention, so the offset must re-apply here for
+            // tokens to position correctly. `cached_rope_deltas` stays
+            // alive across deltas so chained streaming text-only turns
+            // on the same image session keep the offset.
+            if let Some(delta) = self.cached_rope_deltas {
+                unsafe {
+                    mlx_sys::mlx_qwen35_moe_adjust_offset(delta);
+                }
+            }
 
             profiler.set_label("moe_chat_stream_delta_compiled");
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1778,11 +1778,13 @@ impl Qwen35MoeInner {
                 "chat_tokens_delta_sync requires a non-empty delta",
             ));
         }
-        if self.cached_image_key.is_some() {
-            return Err(Error::from_reason(
-                "chat_tokens_delta_sync is text-only; session currently holds image state",
-            ));
-        }
+        // Text-only delta on image-bearing cache is intentional — the KV
+        // cache retains the image attention state from the prior prefill.
+        // See the sibling guard's doc in `qwen3_5/model.rs`. The outer
+        // `chat_session_continue_sync` gate filters real image-set
+        // changes with the `IMAGE_CHANGE_REQUIRES_SESSION_RESTART:`
+        // prefix so the TS `ChatSession` can route those through
+        // `chatSessionStart`.
 
         let report_perf = config.report_performance.unwrap_or(false);
 
@@ -2062,16 +2064,18 @@ impl Qwen35MoeInner {
             );
         }
 
-        // Save cache state. `has_images` is always false on the delta path
-        // and we pass the full pre-decode snapshot as the text-only save.
-        save_cache_state_direct(
+        // Save cache state. Delta continuations preserve
+        // `cached_image_key` — the live KV cache still encodes the prior
+        // prefill's image attention state even though this turn is
+        // text-only, and a subsequent cache-prefix verify needs that
+        // key to stay in place so a later image-bearing turn correctly
+        // flags an image-set change instead of being accepted on the
+        // delta path.
+        chat_common::save_cache_state_after_delta(
             p.reuse_cache,
-            false,
             &generated_tokens,
             &finish_reason,
             &save_tokens,
-            None,
-            0,
             &mut self.cached_token_history,
             &mut self.cached_image_key,
             &mut self.cached_rope_deltas,
@@ -2379,13 +2383,10 @@ impl Qwen35MoeInner {
             );
             return;
         }
-        if self.cached_image_key.is_some() {
-            send_stream_error(
-                &stream_tx,
-                "chat_stream_tokens_delta is text-only; session currently holds image state",
-            );
-            return;
-        }
+        // Text-only streaming deltas are allowed over image-bearing
+        // cache — see the sync sibling for the rationale. Real image-set
+        // changes are caught by the outer `chat_stream_session_continue`
+        // gate.
 
         let cb = StreamSender(stream_tx.clone());
         let result =
@@ -2700,15 +2701,13 @@ impl Qwen35MoeInner {
 
         // Save cache state unconditionally — even on cancellation, the
         // partial generated_tokens must be appended so the session stays
-        // consistent for the next turn.
-        save_cache_state_direct(
+        // consistent for the next turn. Delta stream preserves
+        // `cached_image_key` (see the sync sibling's rationale).
+        chat_common::save_cache_state_after_delta(
             p.reuse_cache,
-            false,
             &generated_tokens,
             &finish_reason,
             &save_tokens,
-            None,
-            0,
             &mut self.cached_token_history,
             &mut self.cached_image_key,
             &mut self.cached_rope_deltas,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -11,7 +11,7 @@ use crate::model_thread::{ResponseTx, StreamTx};
 use crate::models::paddleocr_vl::processing::ProcessedImages;
 use crate::models::qwen3_5::model::{
     ChatConfig, ChatResult, ChatStreamChunk, ChatStreamHandle, VisionCache, VisionCacheInner,
-    compute_num_image_tokens, eval_layer_caches, extract_images_from_messages,
+    compute_image_token_counts_per_image, eval_layer_caches, extract_images_from_messages,
     inject_image_placeholders, vlm_prepare_vision_features,
 };
 use crate::models::qwen3_5::processing::Qwen35VLImageProcessor;
@@ -724,8 +724,9 @@ impl Qwen35MoeInner {
                 let all_images = extract_images_from_messages(&messages);
                 let image_refs: Vec<&[u8]> = all_images.iter().map(|v| v.as_slice()).collect();
                 let processed_pre = img_proc.process_many(&image_refs)?;
-                let num_image_tokens = compute_num_image_tokens(&processed_pre.grid_thw(), sms)?;
-                let expanded = inject_image_placeholders(&tokens, num_image_tokens);
+                let per_image_token_counts =
+                    compute_image_token_counts_per_image(&processed_pre.grid_thw(), sms)?;
+                let expanded = inject_image_placeholders(&tokens, &per_image_token_counts);
                 let cache_key = compute_image_cache_key(&all_images);
                 (expanded, cache_key, Some(processed_pre))
             } else {
@@ -1223,8 +1224,9 @@ impl Qwen35MoeInner {
                 let all_images = extract_images_from_messages(&messages);
                 let image_refs: Vec<&[u8]> = all_images.iter().map(|v| v.as_slice()).collect();
                 let processed_pre = img_proc.process_many(&image_refs)?;
-                let num_image_tokens = compute_num_image_tokens(&processed_pre.grid_thw(), sms)?;
-                let expanded = inject_image_placeholders(&tokens, num_image_tokens);
+                let per_image_token_counts =
+                    compute_image_token_counts_per_image(&processed_pre.grid_thw(), sms)?;
+                let expanded = inject_image_placeholders(&tokens, &per_image_token_counts);
                 let cache_key = compute_image_cache_key(&all_images);
                 (expanded, cache_key, Some(processed_pre))
             } else {

--- a/crates/mlx-core/src/tokenizer.rs
+++ b/crates/mlx-core/src/tokenizer.rs
@@ -662,7 +662,14 @@ impl Qwen3Tokenizer {
 
     /// Sanitize all messages (role validation + content injection prevention).
     /// Called once before any formatting path to ensure consistent security.
-    /// Note: images are not cloned as they are not used in template formatting.
+    ///
+    /// Images are preserved (cloned byte-for-byte) — VLM Jinja templates
+    /// need them to emit the `<|vision_start|><|image_pad|><|vision_end|>`
+    /// wrapper inline in the user turn via
+    /// [`serialize_message_for_jinja`]. `Uint8Array` has no `Clone` impl
+    /// (it holds a raw JS buffer reference), so we rebuild each array
+    /// with `with_data_copied` from its underlying slice. Byte content
+    /// is not subject to ChatML text sanitisation.
     fn sanitize_messages(messages: &[ChatMessage]) -> Vec<ChatMessage> {
         messages
             .iter()
@@ -672,7 +679,11 @@ impl Qwen3Tokenizer {
                 tool_calls: msg.tool_calls.clone(),
                 tool_call_id: msg.tool_call_id.clone(),
                 reasoning_content: msg.reasoning_content.clone(),
-                images: None,
+                images: msg.images.as_ref().map(|imgs| {
+                    imgs.iter()
+                        .map(|img| Uint8Array::with_data_copied(img.as_ref()))
+                        .collect()
+                }),
             })
             .collect()
     }
@@ -1463,6 +1474,110 @@ mod tests {
         assert!(
             user_turn.contains("What is this?"),
             "user text missing from user turn: {user_turn}",
+        );
+    }
+
+    /// `sanitize_messages` sits between `apply_chat_template(_sync)` and
+    /// `render_chat_template_jinja2` on every production path. If it
+    /// zeroes `images`, `serialize_message_for_jinja` sees
+    /// `msg.images: None` and the VLM content-array branch never fires,
+    /// so the template falls back to the post-BOS `inject_image_placeholders`
+    /// splice (vision tokens outside the user turn). Guard against that
+    /// regression directly.
+    #[test]
+    fn sanitize_messages_preserves_user_images_byte_for_byte() {
+        let original = vec![
+            ChatMessage {
+                role: "user".to_string(),
+                content: "describe these".to_string(),
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                images: Some(vec![
+                    Uint8Array::new(vec![0x01, 0x02, 0x03, 0x04]),
+                    Uint8Array::new(vec![0xaa, 0xbb, 0xcc]),
+                ]),
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "ok".to_string(),
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                images: None,
+            },
+        ];
+
+        let sanitized = Qwen3Tokenizer::sanitize_messages_public(&original);
+
+        assert_eq!(sanitized.len(), 2);
+        let user = &sanitized[0];
+        assert_eq!(user.role, "user");
+        let imgs = user
+            .images
+            .as_ref()
+            .expect("user images must survive sanitise");
+        assert_eq!(imgs.len(), 2);
+        assert_eq!(imgs[0].as_ref(), &[0x01, 0x02, 0x03, 0x04]);
+        assert_eq!(imgs[1].as_ref(), &[0xaa, 0xbb, 0xcc]);
+
+        // assistant path unchanged: still None.
+        assert!(sanitized[1].images.is_none());
+    }
+
+    /// End-to-end: sanitize → serialize → Jinja render. Covers the exact
+    /// composition production runs every turn. The direct-serialize test
+    /// above only proves the helper itself is correct — this one proves
+    /// the production chain is correct.
+    #[test]
+    fn sanitize_then_render_emits_vision_wrapper_in_user_turn() {
+        let template = r#"{%- for message in messages -%}
+<|im_start|>{{ message.role }}
+{%- if message.content is string -%}
+{{ message.content }}
+{%- else -%}
+{%- for item in message.content -%}
+{%- if 'image' in item or item.type == 'image' -%}
+<|vision_start|><|image_pad|><|vision_end|>
+{%- elif 'text' in item -%}
+{{ item.text }}
+{%- endif -%}
+{%- endfor -%}
+{%- endif -%}
+<|im_end|>
+{% endfor -%}"#;
+
+        let mut env = Environment::new();
+        env.add_template("chat", template).unwrap();
+        let tmpl = env.get_template("chat").unwrap();
+
+        let msgs = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "What is this?".to_string(),
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            images: Some(vec![Uint8Array::new(vec![0; 4])]),
+        }];
+
+        let sanitized = Qwen3Tokenizer::sanitize_messages_public(&msgs);
+        let messages_value: Vec<serde_json::Value> =
+            sanitized.iter().map(serialize_message_for_jinja).collect();
+
+        let rendered = tmpl
+            .render(context! { messages => messages_value })
+            .unwrap();
+
+        let start_idx = rendered.find("<|im_start|>user").unwrap();
+        let end_idx = rendered[start_idx..].find("<|im_end|>").unwrap() + start_idx;
+        let user_turn = &rendered[start_idx..end_idx];
+        assert!(
+            user_turn.contains("<|vision_start|><|image_pad|><|vision_end|>"),
+            "vision wrapper not inside user turn after sanitize: {user_turn}",
+        );
+        assert!(
+            user_turn.contains("What is this?"),
+            "user text missing from user turn after sanitize: {user_turn}",
         );
     }
 }

--- a/crates/mlx-core/src/tokenizer.rs
+++ b/crates/mlx-core/src/tokenizer.rs
@@ -948,56 +948,8 @@ impl Qwen3Tokenizer {
         });
 
         // Convert messages to JSON-serializable format (already sanitized by caller)
-        let messages_value: Vec<serde_json::Value> = messages
-            .iter()
-            .map(|msg| {
-                let mut obj = serde_json::Map::new();
-                obj.insert("role".to_string(), serde_json::json!(msg.role));
-                obj.insert("content".to_string(), serde_json::json!(msg.content));
-
-                if let Some(tool_calls) = &msg.tool_calls {
-                    let calls: Vec<serde_json::Value> = tool_calls
-                        .iter()
-                        .map(|tc| {
-                            let mut call_obj = serde_json::Map::new();
-                            if let Some(id) = &tc.id {
-                                call_obj.insert("id".to_string(), serde_json::json!(id));
-                            }
-                            // Flat format (backward compat with some templates)
-                            call_obj.insert("name".to_string(), serde_json::json!(tc.name));
-                            // Parse arguments
-                            let args_value =
-                                serde_json::from_str::<serde_json::Value>(&tc.arguments)
-                                    .unwrap_or_else(|_| serde_json::json!(tc.arguments));
-                            call_obj.insert("arguments".to_string(), args_value.clone());
-                            // Wrapped format (Gemma4/OpenAI standard: tool_call.function.name)
-                            call_obj.insert(
-                                "function".to_string(),
-                                serde_json::json!({
-                                    "name": tc.name,
-                                    "arguments": args_value,
-                                }),
-                            );
-                            serde_json::Value::Object(call_obj)
-                        })
-                        .collect();
-                    obj.insert("tool_calls".to_string(), serde_json::json!(calls));
-                }
-
-                if let Some(tool_call_id) = &msg.tool_call_id {
-                    obj.insert("tool_call_id".to_string(), serde_json::json!(tool_call_id));
-                }
-
-                if let Some(reasoning) = &msg.reasoning_content {
-                    obj.insert(
-                        "reasoning_content".to_string(),
-                        serde_json::json!(reasoning),
-                    );
-                }
-
-                serde_json::Value::Object(obj)
-            })
-            .collect();
+        let messages_value: Vec<serde_json::Value> =
+            messages.iter().map(serialize_message_for_jinja).collect();
 
         // Build context for Jinja2 template
         // Note: enable_thinking defaults to true to allow model to think naturally.
@@ -1263,6 +1215,82 @@ impl Qwen3Tokenizer {
     }
 }
 
+/// Serialize a single `ChatMessage` into the shape Jinja chat templates
+/// expect.
+///
+/// Mirrors the Python reference `mlx-vlm/mlx_vlm/prompt_utils.py`'s
+/// `_format_list_with_image`: when a `user` message carries one or more
+/// images, `content` is rendered as a content-parts array
+/// `[{type:"text", text:...}, {type:"image"}, ...]` so VLM Jinja templates
+/// (Qwen3/3.5/3.6 VL, Gemma4, etc.) emit the `<|vision_start|>
+/// <|image_pad|><|vision_end|>` wrapper inline in the user turn.
+/// Otherwise `content` stays a plain string — preserving byte-for-byte
+/// parity with every text-only template path.
+///
+/// `msg.images` is `#[serde(skip)]` so a direct `serde_json::to_value(msg)`
+/// would drop images entirely, which is why this helper exists.
+pub(crate) fn serialize_message_for_jinja(msg: &ChatMessage) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("role".to_string(), serde_json::json!(msg.role));
+
+    let has_images = msg.images.as_ref().is_some_and(|imgs| !imgs.is_empty());
+
+    if has_images && msg.role == "user" {
+        let mut parts: Vec<serde_json::Value> = Vec::new();
+        if !msg.content.is_empty() {
+            parts.push(serde_json::json!({ "type": "text", "text": msg.content }));
+        }
+        // SAFETY: `is_some_and` above ensured this is Some and non-empty.
+        for _ in msg.images.as_ref().unwrap() {
+            parts.push(serde_json::json!({ "type": "image" }));
+        }
+        obj.insert("content".to_string(), serde_json::Value::Array(parts));
+    } else {
+        obj.insert("content".to_string(), serde_json::json!(msg.content));
+    }
+
+    if let Some(tool_calls) = &msg.tool_calls {
+        let calls: Vec<serde_json::Value> = tool_calls
+            .iter()
+            .map(|tc| {
+                let mut call_obj = serde_json::Map::new();
+                if let Some(id) = &tc.id {
+                    call_obj.insert("id".to_string(), serde_json::json!(id));
+                }
+                // Flat format (backward compat with some templates)
+                call_obj.insert("name".to_string(), serde_json::json!(tc.name));
+                // Parse arguments
+                let args_value = serde_json::from_str::<serde_json::Value>(&tc.arguments)
+                    .unwrap_or_else(|_| serde_json::json!(tc.arguments));
+                call_obj.insert("arguments".to_string(), args_value.clone());
+                // Wrapped format (Gemma4/OpenAI standard: tool_call.function.name)
+                call_obj.insert(
+                    "function".to_string(),
+                    serde_json::json!({
+                        "name": tc.name,
+                        "arguments": args_value,
+                    }),
+                );
+                serde_json::Value::Object(call_obj)
+            })
+            .collect();
+        obj.insert("tool_calls".to_string(), serde_json::json!(calls));
+    }
+
+    if let Some(tool_call_id) = &msg.tool_call_id {
+        obj.insert("tool_call_id".to_string(), serde_json::json!(tool_call_id));
+    }
+
+    if let Some(reasoning) = &msg.reasoning_content {
+        obj.insert(
+            "reasoning_content".to_string(),
+            serde_json::json!(reasoning),
+        );
+    }
+
+    serde_json::Value::Object(obj)
+}
+
 fn encoding_to_uint32_array<'env>(
     env: &'env Env,
     encoding: Encoding,
@@ -1278,5 +1306,163 @@ fn encoding_to_uint32_array<'env>(
                 drop(encoding);
             },
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minijinja::{Environment, context};
+
+    fn user_msg(content: &str, num_images: usize) -> ChatMessage {
+        let images = if num_images > 0 {
+            Some(
+                (0..num_images)
+                    .map(|i| Uint8Array::new(vec![i as u8; 4]))
+                    .collect(),
+            )
+        } else {
+            None
+        };
+        ChatMessage {
+            role: "user".to_string(),
+            content: content.to_string(),
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            images,
+        }
+    }
+
+    #[test]
+    fn text_only_user_renders_content_as_string() {
+        // Preserves the existing shape for every text-only template path —
+        // any change here would fork the byte-for-byte parity the
+        // text-only suite (Qwen3, Qwen3.5, LFM2, Gemma4) relies on.
+        let msg = user_msg("Hello", 0);
+        let v = serialize_message_for_jinja(&msg);
+        assert_eq!(v["role"], "user");
+        assert!(v["content"].is_string());
+        assert_eq!(v["content"], "Hello");
+    }
+
+    #[test]
+    fn user_with_one_image_emits_content_array_with_text_and_image() {
+        let msg = user_msg("Describe this.", 1);
+        let v = serialize_message_for_jinja(&msg);
+        assert_eq!(v["role"], "user");
+        let parts = v["content"].as_array().expect("content is an array");
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "Describe this.");
+        assert_eq!(parts[1]["type"], "image");
+    }
+
+    #[test]
+    fn user_with_multiple_images_emits_one_image_part_per_image() {
+        let msg = user_msg("Compare.", 3);
+        let v = serialize_message_for_jinja(&msg);
+        let parts = v["content"].as_array().unwrap();
+        assert_eq!(parts.len(), 4);
+        assert_eq!(parts[0]["type"], "text");
+        for (i, part) in parts.iter().enumerate().skip(1) {
+            assert_eq!(part["type"], "image", "part {i} should be image");
+        }
+    }
+
+    #[test]
+    fn user_image_without_text_omits_text_part() {
+        // Empty content + one image → just the image part, no empty text
+        // block. Matches mlx-vlm's `_format_list_with_image` output.
+        let msg = user_msg("", 1);
+        let v = serialize_message_for_jinja(&msg);
+        let parts = v["content"].as_array().unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["type"], "image");
+    }
+
+    #[test]
+    fn non_user_role_with_images_keeps_content_as_string() {
+        // Only the user turn should ever ship images in practice; system /
+        // assistant / tool keep their flat `content: string` shape so
+        // templates that don't expect arrays on those roles keep working.
+        let mut msg = user_msg("A reply", 2);
+        msg.role = "assistant".to_string();
+        let v = serialize_message_for_jinja(&msg);
+        assert!(v["content"].is_string());
+        assert_eq!(v["content"], "A reply");
+    }
+
+    #[test]
+    fn user_images_none_is_equivalent_to_text_only() {
+        let mut msg = user_msg("Hi", 0);
+        msg.images = None;
+        let v = serialize_message_for_jinja(&msg);
+        assert_eq!(v["content"], "Hi");
+    }
+
+    #[test]
+    fn user_images_empty_vec_is_equivalent_to_text_only() {
+        // `is_some_and(|imgs| !imgs.is_empty())` must reject Some([]) too,
+        // or the array branch would emit a content-array with just the
+        // text part and trip downstream Jinja templates that only branch
+        // on string-vs-array.
+        let mut msg = user_msg("Hi", 0);
+        msg.images = Some(Vec::new());
+        let v = serialize_message_for_jinja(&msg);
+        assert_eq!(v["content"], "Hi");
+    }
+
+    /// Render a minimal Jinja template that mimics the relevant slice of
+    /// the Qwen3.6 VL chat template (see
+    /// `.cache/models/Qwen3.6-35b-a3b-UD-Q4_K_XL-mlx/chat_template.jinja`)
+    /// to verify the content-array path actually produces the vision
+    /// wrapper inline inside the user turn — not spliced after BOS by the
+    /// `inject_image_placeholders` fallback.
+    #[test]
+    fn rendered_prompt_includes_vision_wrapper_for_user_image() {
+        let template = r#"{%- for message in messages -%}
+<|im_start|>{{ message.role }}
+{%- if message.content is string -%}
+{{ message.content }}
+{%- else -%}
+{%- for item in message.content -%}
+{%- if 'image' in item or item.type == 'image' -%}
+<|vision_start|><|image_pad|><|vision_end|>
+{%- elif 'text' in item -%}
+{{ item.text }}
+{%- endif -%}
+{%- endfor -%}
+{%- endif -%}
+<|im_end|>
+{% endfor -%}"#;
+
+        let mut env = Environment::new();
+        env.add_template("chat", template).unwrap();
+        let tmpl = env.get_template("chat").unwrap();
+
+        let msg = user_msg("What is this?", 1);
+        let messages_value: Vec<serde_json::Value> = vec![serialize_message_for_jinja(&msg)];
+
+        let rendered = tmpl
+            .render(context! { messages => messages_value })
+            .unwrap();
+
+        assert!(
+            rendered.contains("<|vision_start|><|image_pad|><|vision_end|>"),
+            "rendered prompt missing vision wrapper:\n{rendered}",
+        );
+        // The wrapper must land INSIDE the user turn, after the text.
+        let start_idx = rendered.find("<|im_start|>user").unwrap();
+        let end_idx = rendered[start_idx..].find("<|im_end|>").unwrap() + start_idx;
+        let user_turn = &rendered[start_idx..end_idx];
+        assert!(
+            user_turn.contains("<|vision_start|>"),
+            "vision wrapper not inside user turn: {user_turn}",
+        );
+        assert!(
+            user_turn.contains("What is this?"),
+            "user text missing from user turn: {user_turn}",
+        );
     }
 }

--- a/packages/server/src/endpoints/responses.ts
+++ b/packages/server/src/endpoints/responses.ts
@@ -15,7 +15,7 @@ import type { ChatConfig, ChatMessage, ChatResult, ResponseStore, StoredResponse
 import type { ChatSession, ChatStreamEvent, SessionCapableModel } from '@mlx-node/lm';
 
 import { sendBadRequest, sendInternalError, sendNotFound, sendRateLimit, sendStorageTimeout } from '../errors.js';
-import { mapRequest, reconstructMessagesFromChain } from '../mappers/request.js';
+import { mapRequest, reconstructMessagesFromChain, stringifyStoredInputMessages } from '../mappers/request.js';
 import {
   buildPartialResponse,
   buildResponseObject,
@@ -1313,7 +1313,7 @@ function buildResponseRecord(
     model: response.model,
     status: response.status,
     instructions: response.instructions ?? undefined,
-    inputJson: JSON.stringify(newInputMessages),
+    inputJson: stringifyStoredInputMessages(newInputMessages),
     outputJson: JSON.stringify(response.output),
     outputText: response.output_text,
     usageJson: JSON.stringify(response.usage),

--- a/packages/server/src/mappers/anthropic-request.ts
+++ b/packages/server/src/mappers/anthropic-request.ts
@@ -105,6 +105,14 @@ export function mapAnthropicRequest(req: AnthropicMessagesRequest): MappedAnthro
         const trailingImages: Uint8Array[] = [];
         let seenNonToolResult = false;
         let seenToolResult = false;
+        // The flat `ChatMessage` shape cannot represent a text block that
+        // appears AFTER an image block in the same turn — the downstream
+        // Jinja serializer always places text before images. Reject that
+        // interleaving up front rather than silently reordering it and
+        // changing the caller's intent. This parallels the identical
+        // guard in `request.ts:resolveMessageContent` for the
+        // `/v1/responses` mapper.
+        let seenImage = false;
 
         for (const block of content as AnthropicContentBlock[]) {
           if (block.type === 'tool_result') {
@@ -124,10 +132,19 @@ export function mapAnthropicRequest(req: AnthropicMessagesRequest): MappedAnthro
               isError: block.is_error === true,
             });
           } else if (block.type === 'text') {
+            if (seenImage) {
+              throw new Error(
+                'Unsupported: text block after an image block in the same user turn is not representable ' +
+                  'in the internal message model. The flat ChatMessage shape and the Jinja serializer both ' +
+                  'place all text before all images, so any mapping would silently reorder your content. ' +
+                  'Place all text blocks before any image blocks, or split across separate user turns.',
+              );
+            }
             seenNonToolResult = true;
             trailingText.push(block.text);
           } else if (block.type === 'image' && block.source.type === 'base64') {
             seenNonToolResult = true;
+            seenImage = true;
             trailingImages.push(Buffer.from(block.source.data, 'base64'));
           } else {
             throw new Error(`Unsupported content block type: "${block.type}"`);

--- a/packages/server/src/mappers/request.ts
+++ b/packages/server/src/mappers/request.ts
@@ -4,17 +4,56 @@ import type { ChatConfig, ChatMessage, ToolDefinition } from '@mlx-node/core';
 
 import type { ContentPart, ResponsesAPIRequest, ResponsesToolDefinition } from '../types.js';
 
-function resolveContent(content: string | ContentPart[]): string {
-  if (typeof content === 'string') return content;
+/**
+ * Resolve a message's `content` array into text + optional image bytes.
+ *
+ * Accepts both input-side (`input_text`, `input_image`) and replay-side
+ * (`output_text`, `refusal`, `summary_text`) content parts. Clients that echo
+ * prior assistant turns in `input[]` instead of using `previous_response_id`
+ * (pi-ai, Codex) send `output_text` on assistant messages — rejecting those
+ * would break cold-start replay. `input_image` with a base64 `data:` URL is
+ * decoded to bytes; `http(s)://` URLs are not fetched (the mapper stays sync).
+ */
+function resolveMessageContent(
+  content: string | ContentPart[],
+  role: 'user' | 'assistant' | 'system',
+): { text: string; images?: Uint8Array[] } {
+  if (typeof content === 'string') return { text: content };
+
   const parts: string[] = [];
+  const images: Uint8Array[] = [];
+
   for (const p of content) {
-    if (p.type === 'input_text') {
+    if (p.type === 'input_text' || p.type === 'output_text' || p.type === 'summary_text') {
       parts.push(p.text);
+    } else if (p.type === 'refusal') {
+      parts.push(p.refusal);
+    } else if (p.type === 'input_image') {
+      if (role !== 'user') {
+        throw new Error(`input_image content parts are only allowed on user messages (got role="${role}")`);
+      }
+      if (p.file_id) {
+        throw new Error('input_image.file_id is not supported — inline the image as a data URL');
+      }
+      if (!p.image_url) {
+        throw new Error('input_image is missing image_url');
+      }
+      const match = /^data:[^;,]+;base64,(.+)$/s.exec(p.image_url);
+      if (!match) {
+        throw new Error(
+          'input_image.image_url must be a base64 data URL (data:<mime>;base64,<payload>); ' +
+            'remote http(s) URLs are not fetched by this server',
+        );
+      }
+      images.push(Buffer.from(match[1], 'base64'));
     } else {
-      throw new Error(`Unsupported content part type: "${p.type as string}"`);
+      throw new Error(`Unsupported content part type: "${(p as { type: string }).type}"`);
     }
   }
-  return parts.join('');
+
+  const out: { text: string; images?: Uint8Array[] } = { text: parts.join('') };
+  if (images.length > 0) out.images = images;
+  return out;
 }
 
 /** NAPI `ToolDefinition` requires `parameters.properties` to be a JSON string. */
@@ -55,22 +94,39 @@ export function mapRequest(req: ResponsesAPIRequest, priorMessages?: ChatMessage
     messages.push(...priorMessages);
   }
 
-  // Coalesce a `message + function_call+` run (or a pure `function_call+` run)
-  // into ONE assistant `ChatMessage` carrying both `content` and `toolCalls`.
-  // `ChatSession.sendStream()` appends exactly one assistant message per turn,
-  // and `validateAndCanonicalizeHistoryToolOrder` requires each fan-out's
-  // `toolCalls` to pair 1:1 with the trailing tool block — splitting would
-  // reshape the conversation and make the walker reject the turn as orphaned.
-  // A `message` item immediately after a `function_call` starts a new turn.
+  // An assistant turn may serialise into any interleaving of `reasoning`,
+  // `message` (assistant), and `function_call` items. We coalesce that run
+  // into ONE assistant `ChatMessage` carrying `content` + `reasoningContent`
+  // + `toolCalls`, matching the hot-path `ChatSession` shape exactly. Any
+  // non-assistant item (user / system / function_call_output) flushes the
+  // current turn. An assistant `message` item that appears AFTER a
+  // `function_call` opens a fresh turn — preserving the pre-existing
+  // convention documented in the fan-out tests.
   if (typeof req.input === 'string') {
     messages.push({ role: 'user', content: req.input });
   } else {
-    let prevItemType: string | null = null;
+    let currentAssistant: ChatMessage | null = null;
+    let assistantHasToolCalls = false;
+
+    const flushAssistant = () => {
+      if (currentAssistant) {
+        messages.push(currentAssistant);
+        currentAssistant = null;
+        assistantHasToolCalls = false;
+      }
+    };
+    const ensureAssistant = (): ChatMessage => {
+      if (!currentAssistant) {
+        currentAssistant = { role: 'assistant', content: '' };
+      }
+      return currentAssistant;
+    };
+
     for (const item of req.input) {
       if (item == null || typeof item !== 'object') {
         throw new Error('Each input item must be a non-null object');
       }
-      const itemType = item.type ?? 'message';
+      const itemType = (item as { type?: string }).type ?? 'message';
 
       if (itemType === 'message') {
         const msg = item as { role: string; content: string | ContentPart[] };
@@ -79,32 +135,36 @@ export function mapRequest(req: ResponsesAPIRequest, priorMessages?: ChatMessage
         if (role !== 'user' && role !== 'assistant' && role !== 'system') {
           throw new Error(`Unsupported message role: "${msg.role}"`);
         }
-        messages.push({
-          role,
-          content: resolveContent(msg.content),
-        });
-      } else if (itemType === 'function_call') {
-        // Coalesce onto the preceding assistant turn — see the loop header.
-        const fc = item as { name: string; arguments: string; call_id: string };
-        const last = messages[messages.length - 1];
-        const canCoalesce =
-          (prevItemType === 'function_call' || prevItemType === 'message') &&
-          last !== undefined &&
-          last.role === 'assistant';
-        if (canCoalesce) {
-          if (last!.toolCalls === undefined) {
-            last!.toolCalls = [];
+
+        if (role === 'assistant') {
+          // `message` after a `function_call` opens a new turn.
+          if (assistantHasToolCalls) {
+            flushAssistant();
           }
-          last!.toolCalls!.push({ name: fc.name, arguments: fc.arguments, id: fc.call_id });
+          const a = ensureAssistant();
+          const { text } = resolveMessageContent(msg.content, 'assistant');
+          a.content = (a.content ?? '') + text;
         } else {
-          messages.push({
-            role: 'assistant',
-            content: '',
-            toolCalls: [{ name: fc.name, arguments: fc.arguments, id: fc.call_id }],
-          });
+          flushAssistant();
+          const { text, images } = resolveMessageContent(msg.content, role);
+          const m: ChatMessage = { role, content: text };
+          if (images) m.images = images;
+          messages.push(m);
         }
+      } else if (itemType === 'reasoning') {
+        const r = item as { summary?: { text?: string }[] };
+        const summary = (r.summary ?? []).map((s) => s.text ?? '').join('');
+        const a = ensureAssistant();
+        a.reasoningContent = (a.reasoningContent ?? '') + summary;
+      } else if (itemType === 'function_call') {
+        const fc = item as { name: string; arguments: string; call_id: string };
+        const a = ensureAssistant();
+        a.toolCalls ??= [];
+        a.toolCalls.push({ name: fc.name, arguments: fc.arguments, id: fc.call_id });
+        assistantHasToolCalls = true;
       } else if (itemType === 'function_call_output') {
         const fco = item as { call_id: string; output: string };
+        flushAssistant();
         messages.push({
           role: 'tool',
           content: fco.output,
@@ -113,9 +173,9 @@ export function mapRequest(req: ResponsesAPIRequest, priorMessages?: ChatMessage
       } else {
         throw new Error(`Unsupported input item type: "${itemType as string}"`);
       }
-
-      prevItemType = itemType;
     }
+
+    flushAssistant();
   }
 
   const config: ChatConfig = {

--- a/packages/server/src/mappers/request.ts
+++ b/packages/server/src/mappers/request.ts
@@ -67,7 +67,15 @@ function resolveMessageContent(
             'remote http(s) URLs are not fetched by this server',
         );
       }
-      images.push(Buffer.from(match[1], 'base64'));
+      // Wrap as a plain `Uint8Array` rather than storing the raw
+      // `Buffer`. `Buffer` is a `Uint8Array` subclass, but it defines
+      // its own `toJSON()` that `JSON.stringify` calls BEFORE any
+      // replacer runs — so a Buffer-backed value would serialise as
+      // `{type:"Buffer",data:[...]}` and skip the `__u8__` sentinel in
+      // `stringifyStoredInputMessages`, corrupting image round-trip
+      // through `previous_response_id` chains. A plain `Uint8Array`
+      // has no `toJSON`, so the replacer fires as intended.
+      images.push(new Uint8Array(Buffer.from(match[1], 'base64')));
       seenImage = true;
     } else {
       throw new Error(`Unsupported content part type: "${(p as { type: string }).type}"`);
@@ -264,11 +272,28 @@ function isEncodedUint8Array(value: unknown): value is EncodedUint8Array {
  * preserving any `Uint8Array` image payloads as base64-encoded sentinels
  * so a later `reconstructMessagesFromChain` can revive them into real
  * `Uint8Array`s for the NAPI chat-session boundary.
+ *
+ * The replacer runs AFTER `toJSON`, so a `Buffer` (which defines
+ * `Buffer.prototype.toJSON` returning `{type:"Buffer",data:[...]}`)
+ * would otherwise slip past the `instanceof Uint8Array` check. We
+ * match both shapes defensively — the production `resolveMessageContent`
+ * path now wraps with `new Uint8Array(...)` at decode time, but any
+ * future caller that sneaks a `Buffer` through still round-trips
+ * instead of silently corrupting image state.
  */
 export function stringifyStoredInputMessages(messages: ChatMessage[]): string {
   return JSON.stringify(messages, (_key, value: unknown) => {
     if (value instanceof Uint8Array) {
       return { [UINT8_SENTINEL]: Buffer.from(value).toString('base64') };
+    }
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      (value as { type?: unknown }).type === 'Buffer' &&
+      Array.isArray((value as { data?: unknown }).data)
+    ) {
+      const data = (value as { data: number[] }).data;
+      return { [UINT8_SENTINEL]: Buffer.from(data).toString('base64') };
     }
     return value;
   });

--- a/packages/server/src/mappers/request.ts
+++ b/packages/server/src/mappers/request.ts
@@ -22,11 +22,33 @@ function resolveMessageContent(
 
   const parts: string[] = [];
   const images: Uint8Array[] = [];
+  // The internal `ChatMessage` shape is `{ content: string, images: Uint8Array[] }`
+  // and the downstream Jinja serializer always emits `[{type:"text",...},
+  // {type:"image"}*N]` — it cannot represent a text part that appears AFTER
+  // an image part in the caller's content array. Detect and reject that
+  // shape rather than silently reordering it and changing user intent.
+  // Mirrors the existing rejection in `anthropic-request.ts` for the
+  // tool_result + trailing-mixed case.
+  let seenImage = false;
 
   for (const p of content) {
     if (p.type === 'input_text' || p.type === 'output_text' || p.type === 'summary_text') {
+      if (seenImage) {
+        throw new Error(
+          'Unsupported: text content part after an image part in the same message is not representable ' +
+            'in the internal message model. The flat ChatMessage shape and the Jinja serializer both place ' +
+            'all text before all images in a user turn, so any mapping would silently reorder your content. ' +
+            'Place all text parts before any image parts, or split across separate user turns.',
+        );
+      }
       parts.push(p.text);
     } else if (p.type === 'refusal') {
+      if (seenImage) {
+        throw new Error(
+          'Unsupported: refusal content part after an image part in the same message is not representable ' +
+            'in the internal message model; the flat ChatMessage shape would silently reorder it.',
+        );
+      }
       parts.push(p.refusal);
     } else if (p.type === 'input_image') {
       if (role !== 'user') {
@@ -46,6 +68,7 @@ function resolveMessageContent(
         );
       }
       images.push(Buffer.from(match[1], 'base64'));
+      seenImage = true;
     } else {
       throw new Error(`Unsupported content part type: "${(p as { type: string }).type}"`);
     }

--- a/packages/server/src/mappers/request.ts
+++ b/packages/server/src/mappers/request.ts
@@ -238,15 +238,62 @@ export function mapRequest(req: ResponsesAPIRequest, priorMessages?: ChatMessage
 }
 
 /**
+ * Sentinel key used to tag base64-encoded `Uint8Array` payloads in
+ * persisted `inputJson`. Plain `JSON.stringify` turns a `Uint8Array`
+ * into a numeric-keyed object (e.g. `{"0":1,"1":2,...}`), which
+ * (a) bloats the row ~8× vs base64 and (b) does not round-trip — the
+ * parsed object fails the NAPI `Uint8Array` type check on cold replay,
+ * breaking `previous_response_id` continuations that carry images.
+ */
+const UINT8_SENTINEL = '__u8__';
+
+interface EncodedUint8Array {
+  [UINT8_SENTINEL]: string;
+}
+
+function isEncodedUint8Array(value: unknown): value is EncodedUint8Array {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as Record<string, unknown>)[UINT8_SENTINEL] === 'string'
+  );
+}
+
+/**
+ * Serialise a `ChatMessage[]` snapshot for `StoredResponseRecord.inputJson`,
+ * preserving any `Uint8Array` image payloads as base64-encoded sentinels
+ * so a later `reconstructMessagesFromChain` can revive them into real
+ * `Uint8Array`s for the NAPI chat-session boundary.
+ */
+export function stringifyStoredInputMessages(messages: ChatMessage[]): string {
+  return JSON.stringify(messages, (_key, value: unknown) => {
+    if (value instanceof Uint8Array) {
+      return { [UINT8_SENTINEL]: Buffer.from(value).toString('base64') };
+    }
+    return value;
+  });
+}
+
+/**
  * Reconstruct `ChatMessage[]` from a stored response chain. Each record
  * stores `inputJson` (messages sent) and `outputJson` (output items); we
  * interleave them.
+ *
+ * Image payloads encoded as `{__u8__: "<base64>"}` by
+ * `stringifyStoredInputMessages` are rehydrated back into `Buffer`
+ * (a `Uint8Array` subclass) so replayed user turns carry the same
+ * runtime shape the native chat-session APIs expect.
  */
 export function reconstructMessagesFromChain(chain: { inputJson: string; outputJson: string }[]): ChatMessage[] {
   const messages: ChatMessage[] = [];
 
   for (const record of chain) {
-    const inputMessages = JSON.parse(record.inputJson) as ChatMessage[];
+    const inputMessages = JSON.parse(record.inputJson, (_key, value: unknown) => {
+      if (isEncodedUint8Array(value)) {
+        return Buffer.from(value[UINT8_SENTINEL], 'base64');
+      }
+      return value;
+    }) as ChatMessage[];
     messages.push(...inputMessages);
 
     const outputItems = JSON.parse(record.outputJson) as Array<{

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -5,7 +5,50 @@ export interface InputTextPart {
   text: string;
 }
 
-export type ContentPart = InputTextPart;
+/**
+ * An image attached to a user message. `image_url` may be an `http(s)://` URL
+ * (not fetched by the mapper) or a `data:<mime>;base64,<payload>` URL
+ * (decoded and forwarded to the model as raw bytes).
+ */
+export interface InputImagePart {
+  type: 'input_image';
+  image_url?: string;
+  file_id?: string;
+  detail?: 'auto' | 'low' | 'high';
+}
+
+/**
+ * Echoed back by clients (Codex, pi-ai, etc.) when they replay prior
+ * assistant turns in `input[]` instead of using `previous_response_id`.
+ * Equivalent to `InputTextPart` for mapping purposes — we only need the text.
+ */
+export interface InputAssistantTextPart {
+  type: 'output_text';
+  text: string;
+  annotations?: never[];
+}
+
+/** Echoed back by clients when replaying a refusal block from a prior turn. */
+export interface InputRefusalPart {
+  type: 'refusal';
+  refusal: string;
+}
+
+/**
+ * Some clients inline a reasoning summary as a content part on an assistant
+ * message instead of as a top-level `reasoning` input item.
+ */
+export interface InputSummaryTextPart {
+  type: 'summary_text';
+  text: string;
+}
+
+export type ContentPart =
+  | InputTextPart
+  | InputImagePart
+  | InputAssistantTextPart
+  | InputRefusalPart
+  | InputSummaryTextPart;
 
 // ---------------------------------------------------------------------------
 // Input items
@@ -31,7 +74,19 @@ export interface InputFunctionCallOutput {
   output: string;
 }
 
-export type InputItem = InputMessage | InputFunctionCall | InputFunctionCallOutput;
+/**
+ * Top-level reasoning item replayed by clients that echo prior assistant
+ * reasoning summaries instead of using `previous_response_id`. The summary
+ * is coalesced onto the next assistant `ChatMessage` as `reasoningContent`.
+ */
+export interface InputReasoningItem {
+  type: 'reasoning';
+  id?: string;
+  summary?: { type?: 'summary_text'; text: string }[];
+  encrypted_content?: string;
+}
+
+export type InputItem = InputMessage | InputFunctionCall | InputFunctionCallOutput | InputReasoningItem;
 
 // ---------------------------------------------------------------------------
 // Tool definitions (Responses API shape)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes request/history mapping and VLM session/cache handling (image placeholders, M-RoPE offsets, and delta continuations), which can affect multi-turn correctness and replayed history integrity.
> 
> **Overview**
> **Expands the `/v1/responses` request mapper and stored-history codec to properly handle client replay and images.** `mapRequest` now accepts replayed assistant `output_text`, top-level `reasoning` items, and `refusal/summary_text` parts; it also decodes `input_image` base64 data URLs into `ChatMessage.images` and coalesces interleaved assistant `reasoning`/`message`/`function_call` items into a single assistant turn.
> 
> **Adds strict text/image ordering guards** in both the OpenAI and Anthropic mappers to reject any text-after-image interleaving within a single user turn (previously the pipeline could silently reorder content).
> 
> **Makes images survive persistence and VLM templating, and fixes Qwen3.5 VLM session correctness.** Stored `inputJson` is now written via `stringifyStoredInputMessages` (base64 sentinel) and revived during `reconstructMessagesFromChain` so `Uint8Array` images round-trip; tokenizer sanitization/serialization now preserves user images so Jinja templates can emit inline vision markers; Qwen3.5/Qwen3.5-MoE update image placeholder expansion (per-image counts), robust M-RoPE position indexing for multiple image runs, and session-delta handling so text-only deltas can continue on image-bearing sessions without clearing `cached_image_key`/rope deltas. Extensive new unit tests cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c338174b8cd2a926ee9e4f1d66f7ad8c732eb1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->