### PR TITLE
feat: mlx launch claude, server-side tools, tier-2 prefix cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           path: packages/core/
       - name: Run tests
         run: |
-          yarn mlx download model
+          yarn mlx download model --output .cache/models/qwen3-0.6b
           yarn mlx convert --input .cache/models/qwen3-0.6b -d bf16 --output .cache/models/qwen3-0.6b-mlx-bf16
           yarn mlx download dataset
           ${{ matrix.test }}

--- a/__test__/cli/config.test.ts
+++ b/__test__/cli/config.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { resolveModelsDir } from '../../packages/cli/src/config.js';
+
+describe('resolveModelsDir', () => {
+  let workRoot: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    workRoot = mkdtempSync(join(tmpdir(), 'mlx-config-test-'));
+    fakeHome = join(workRoot, 'home');
+    mkdirSync(fakeHome, { recursive: true });
+    vi.stubEnv('HOME', fakeHome);
+    delete process.env.MLX_MODELS_DIR;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(workRoot, { recursive: true, force: true });
+  });
+
+  it('uses the explicit argument when provided', () => {
+    const explicit = join(workRoot, 'explicit');
+    const got = resolveModelsDir(explicit);
+    expect(got).toBe(resolve(explicit));
+  });
+
+  it('falls through to env when explicit is absent', () => {
+    const envDir = join(workRoot, 'env-models');
+    vi.stubEnv('MLX_MODELS_DIR', envDir);
+    const got = resolveModelsDir();
+    expect(got).toBe(resolve(envDir));
+  });
+
+  it('reads modelsDir from ~/.mlx-node/config.json when env is unset', () => {
+    const configDir = join(fakeHome, '.mlx-node');
+    mkdirSync(configDir, { recursive: true });
+    const configuredDir = join(workRoot, 'configured');
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({ modelsDir: configuredDir }));
+    const got = resolveModelsDir();
+    expect(got).toBe(resolve(configuredDir));
+  });
+
+  it('falls back to ~/.mlx-node/models when nothing else is set', () => {
+    const got = resolveModelsDir();
+    expect(got).toBe(join(fakeHome, '.mlx-node', 'models'));
+  });
+
+  it('tolerates malformed config.json with a warning and falls back to default', () => {
+    const configDir = join(fakeHome, '.mlx-node');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), '{ not valid json');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const got = resolveModelsDir();
+      expect(got).toBe(join(fakeHome, '.mlx-node', 'models'));
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('prefers explicit arg over env and config.json', () => {
+    vi.stubEnv('MLX_MODELS_DIR', join(workRoot, 'should-lose-env'));
+    const configDir = join(fakeHome, '.mlx-node');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({ modelsDir: join(workRoot, 'should-lose-config') }));
+    const explicit = join(workRoot, 'winner');
+    const got = resolveModelsDir(explicit);
+    expect(got).toBe(resolve(explicit));
+  });
+});

--- a/__test__/cli/download-model.test.ts
+++ b/__test__/cli/download-model.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 
-import { isGlobVariantPresent, isModelAlreadyDownloaded } from '../../packages/cli/src/commands/download-model.js';
+import {
+  isGgufRepoComplete,
+  isGlobVariantPresent,
+  isModelAlreadyDownloaded,
+} from '../../packages/cli/src/commands/download-model.js';
 
 describe('isModelAlreadyDownloaded', () => {
   let dir: string;
@@ -141,5 +145,59 @@ describe('isGlobVariantPresent', () => {
   it('matches case-insensitively (gguf repos vary in capitalization)', () => {
     expect(isGlobVariantPresent(['model.q4_k_m.gguf'], ['*Q4_K_M*'])).toBe(true);
     expect(isGlobVariantPresent(['model.Q4_K_M.gguf'], ['*q4_k_m*'])).toBe(true);
+  });
+});
+
+describe('isGgufRepoComplete', () => {
+  it('returns false when only some of the remote GGUF variants are present locally', () => {
+    // Regression: previously a no-glob re-run after an interrupted
+    // download (e.g. only Q2_K landed) silently exited as "already
+    // downloaded" because the early-return only checked
+    // `files.some(.gguf)`. The fix compares against the remote
+    // manifest and refuses to short-circuit until every advertised
+    // GGUF variant is on disk.
+    const local = ['model.Q2_K.gguf', 'config.json'];
+    const remote = ['model.Q2_K.gguf', 'model.Q4_K_M.gguf', 'model.Q8_0.gguf'];
+    expect(isGgufRepoComplete(local, remote)).toBe(false);
+  });
+
+  it('returns true when every remote GGUF variant is present locally', () => {
+    const local = ['model.Q4_K_M.gguf', 'config.json'];
+    const remote = ['model.Q4_K_M.gguf'];
+    expect(isGgufRepoComplete(local, remote)).toBe(true);
+  });
+
+  it('returns false when the remote repo is not a GGUF repo (no .gguf files in manifest)', () => {
+    // Caller should route through `isModelAlreadyDownloaded` for
+    // safetensors / Paddle repos. A `false` return here tells the
+    // caller "do not take the GGUF early-return branch".
+    const local = ['model.safetensors', 'config.json'];
+    const remote = ['model.safetensors', 'config.json', 'tokenizer.json'];
+    expect(isGgufRepoComplete(local, remote)).toBe(false);
+  });
+
+  it('returns false on an empty remote manifest (likely upstream error)', () => {
+    // An empty manifest is almost certainly a network / auth failure
+    // rather than a legitimate empty repo. Returning false routes the
+    // caller through the download loop where the real error will
+    // surface (404 / auth) instead of being masked as "already
+    // downloaded".
+    expect(isGgufRepoComplete(['model.Q4_K_M.gguf'], [])).toBe(false);
+    expect(isGgufRepoComplete([], [])).toBe(false);
+  });
+
+  it('compares basenames so a sub-directory remote layout still resolves cleanly', () => {
+    // Some repos publish under a prefix (e.g. `models/foo.gguf`); the
+    // local `readdir(outputDir)` is always flat, so the helper compares
+    // basenames on both sides.
+    const local = ['model.Q4_K_M.gguf'];
+    const remote = ['models/model.Q4_K_M.gguf'];
+    expect(isGgufRepoComplete(local, remote)).toBe(true);
+  });
+
+  it('returns false when the local file list is empty', () => {
+    // Defensive: a fresh outputDir against a non-empty manifest is
+    // never complete.
+    expect(isGgufRepoComplete([], ['model.Q4_K_M.gguf'])).toBe(false);
   });
 });

--- a/__test__/cli/download-model.test.ts
+++ b/__test__/cli/download-model.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 
-import { isModelAlreadyDownloaded } from '../../packages/cli/src/commands/download-model.js';
+import { isGlobVariantPresent, isModelAlreadyDownloaded } from '../../packages/cli/src/commands/download-model.js';
 
 describe('isModelAlreadyDownloaded', () => {
   let dir: string;
@@ -104,5 +104,42 @@ describe('isModelAlreadyDownloaded', () => {
     write('model.safetensors', 'x');
     write('model.safetensors.index.json', JSON.stringify({ weight_map: { x: 'never-existed.safetensors' } }));
     expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(true);
+  });
+});
+
+describe('isGlobVariantPresent', () => {
+  it('returns false when no patterns are provided', () => {
+    expect(isGlobVariantPresent(['config.json', 'tokenizer.json', 'model.Q8_0.gguf'], [])).toBe(false);
+  });
+
+  it('returns false when a prior Q8 download leaves only CORE_FILES + a non-matching gguf', () => {
+    // Regression: previously the early-return counted CORE_FILES toward
+    // the "matched" set, so any prior gguf download (which lays down
+    // config.json + tokenizer.json) auto-satisfied the >1 threshold and
+    // a fresh `--glob "*Q4*"` exited as "already downloaded" without
+    // ever fetching the Q4 weights. The helper must look ONLY at user-
+    // glob matches.
+    const files = ['config.json', 'tokenizer.json', 'tokenizer_config.json', 'model.Q8_0.gguf'];
+    expect(isGlobVariantPresent(files, ['*Q4*'])).toBe(false);
+  });
+
+  it('returns true when an existing file matches one of the glob patterns', () => {
+    const files = ['config.json', 'tokenizer.json', 'model.Q4_K_M.gguf'];
+    expect(isGlobVariantPresent(files, ['*Q4*'])).toBe(true);
+  });
+
+  it('returns true when ANY pattern matches (multi-glob OR semantics)', () => {
+    const files = ['config.json', 'model.Q8_0.gguf'];
+    expect(isGlobVariantPresent(files, ['*Q4*', '*Q8*'])).toBe(true);
+  });
+
+  it('returns false when no file matches any pattern (CORE_FILES alone do not count)', () => {
+    const files = ['config.json', 'tokenizer.json', 'tokenizer_config.json'];
+    expect(isGlobVariantPresent(files, ['*BF16*'])).toBe(false);
+  });
+
+  it('matches case-insensitively (gguf repos vary in capitalization)', () => {
+    expect(isGlobVariantPresent(['model.q4_k_m.gguf'], ['*Q4_K_M*'])).toBe(true);
+    expect(isGlobVariantPresent(['model.Q4_K_M.gguf'], ['*q4_k_m*'])).toBe(true);
   });
 });

--- a/__test__/cli/download-model.test.ts
+++ b/__test__/cli/download-model.test.ts
@@ -8,6 +8,7 @@ import {
   isGgufRepoComplete,
   isGlobMatchedSetComplete,
   isGlobVariantPresent,
+  isLocalCopyComplete,
   isModelAlreadyDownloaded,
 } from '../../packages/cli/src/commands/download-model.js';
 
@@ -246,5 +247,57 @@ describe('isGlobMatchedSetComplete', () => {
   it('returns false when no glob patterns are provided', () => {
     // Defensive: the helper requires at least one pattern to compare against.
     expect(isGlobMatchedSetComplete(['model.Q4_K_M.gguf'], ['model.Q4_K_M.gguf'], [])).toBe(false);
+  });
+});
+
+describe('isLocalCopyComplete', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'mlx-download-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns false when the destination file does not exist', () => {
+    expect(isLocalCopyComplete(join(dir, 'missing.bin'), 100)).toBe(false);
+  });
+
+  it('returns true when the destination exists and size matches', () => {
+    // Regression: previously the download loop unconditionally called
+    // copyFile for every file in `filesToDownload`, re-copying gigabytes
+    // of already-complete shards from the HF cache to outputDir on every
+    // resume. The skip is gated on size-equality so a single Edit catches
+    // truncated/interrupted prior copies.
+    const path = join(dir, 'shard.bin');
+    writeFileSync(path, 'x'.repeat(100));
+    expect(isLocalCopyComplete(path, 100)).toBe(true);
+  });
+
+  it('returns false when the destination is truncated (interrupted prior copy)', () => {
+    // A previous `copyFile` killed mid-write would leave a smaller-than-
+    // expected file. The size mismatch must trigger a re-copy so the resume
+    // doesn't ship a corrupt shard to disk.
+    const path = join(dir, 'shard.bin');
+    writeFileSync(path, 'x'.repeat(50));
+    expect(isLocalCopyComplete(path, 100)).toBe(false);
+  });
+
+  it('returns false when the destination is larger than expected (corrupt write)', () => {
+    const path = join(dir, 'shard.bin');
+    writeFileSync(path, 'x'.repeat(150));
+    expect(isLocalCopyComplete(path, 100)).toBe(false);
+  });
+
+  it('falls back to existence-only when expectedSize is non-positive', () => {
+    // The HF manifest occasionally returns size=0 for tiny metadata files
+    // or when the expand=true field isn't populated. Existence is the
+    // best signal we can use without re-fetching the LFS pointer.
+    const path = join(dir, 'meta.json');
+    writeFileSync(path, '{}');
+    expect(isLocalCopyComplete(path, 0)).toBe(true);
+    expect(isLocalCopyComplete(path, -1)).toBe(true);
   });
 });

--- a/__test__/cli/download-model.test.ts
+++ b/__test__/cli/download-model.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 
 import {
   isGgufRepoComplete,
+  isGlobMatchedSetComplete,
   isGlobVariantPresent,
   isModelAlreadyDownloaded,
 } from '../../packages/cli/src/commands/download-model.js';
@@ -199,5 +200,51 @@ describe('isGgufRepoComplete', () => {
     // Defensive: a fresh outputDir against a non-empty manifest is
     // never complete.
     expect(isGgufRepoComplete([], ['model.Q4_K_M.gguf'])).toBe(false);
+  });
+});
+
+describe('isGlobMatchedSetComplete', () => {
+  it('returns false when only some of the remote glob-matched files are present locally', () => {
+    // Regression: previously the early-return used `isGlobVariantPresent`,
+    // which only required AT LEAST ONE local hit. An interrupted prior
+    // `--glob "*Q4*"` run that fetched one Q4 shard but not the others
+    // would silently exit as "Matched files already downloaded" while
+    // leaving the local copy incomplete.
+    const remote = ['model.Q4_0.gguf', 'model.Q4_K_M.gguf', 'model.Q8_0.gguf', 'config.json'];
+    const local = ['model.Q4_0.gguf', 'config.json'];
+    expect(isGlobMatchedSetComplete(local, remote, ['*Q4*'])).toBe(false);
+  });
+
+  it('returns true when every remote glob-matched file is present locally', () => {
+    const remote = ['model.Q4_0.gguf', 'model.Q4_K_M.gguf', 'model.Q8_0.gguf', 'config.json'];
+    const local = ['model.Q4_0.gguf', 'model.Q4_K_M.gguf', 'config.json'];
+    expect(isGlobMatchedSetComplete(local, remote, ['*Q4*'])).toBe(true);
+  });
+
+  it('returns false when the remote manifest has no files matching the glob', () => {
+    // Empty intersection: nothing was supposed to be downloaded.
+    // Declaring "complete" here would be wrong — the downstream
+    // "no files matched the given criteria" path handles this case
+    // after listing available variants.
+    const remote = ['model.safetensors', 'config.json'];
+    const local: string[] = [];
+    expect(isGlobMatchedSetComplete(local, remote, ['*Q4*'])).toBe(false);
+  });
+
+  it('returns false on an empty remote manifest (likely upstream error)', () => {
+    expect(isGlobMatchedSetComplete(['model.Q4_K_M.gguf'], [], ['*Q4*'])).toBe(false);
+  });
+
+  it('compares basenames so a sub-directory remote layout still resolves cleanly', () => {
+    // Some repos publish under a prefix (e.g. `models/Q4_K_M.gguf`); the
+    // local `readdir(outputDir)` is always flat. Mirrors `isGgufRepoComplete`.
+    const remote = ['models/model.Q4_K_M.gguf'];
+    const local = ['model.Q4_K_M.gguf'];
+    expect(isGlobMatchedSetComplete(local, remote, ['*Q4*'])).toBe(true);
+  });
+
+  it('returns false when no glob patterns are provided', () => {
+    // Defensive: the helper requires at least one pattern to compare against.
+    expect(isGlobMatchedSetComplete(['model.Q4_K_M.gguf'], ['model.Q4_K_M.gguf'], [])).toBe(false);
   });
 });

--- a/__test__/cli/download-model.test.ts
+++ b/__test__/cli/download-model.test.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+
+import { isModelAlreadyDownloaded } from '../../packages/cli/src/commands/download-model.js';
+
+describe('isModelAlreadyDownloaded', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'mlx-download-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name: string, contents: string): void {
+    writeFileSync(join(dir, name), contents);
+  }
+
+  it('returns false when config.json is missing', () => {
+    write('model.safetensors', 'x');
+    expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(false);
+  });
+
+  it('returns true for a single-file safetensors model with config', () => {
+    write('config.json', '{}');
+    write('model.safetensors', 'x');
+    expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(true);
+  });
+
+  it('returns true for a Paddle model (inference.pdiparams) with config', () => {
+    write('config.json', '{}');
+    write('inference.pdiparams', 'x');
+    expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(true);
+  });
+
+  it('returns false when a sharded index references shards that are missing on disk', () => {
+    // Regression: previously the early-return only checked that
+    // model.safetensors.index.json was present. An interrupted prior
+    // download that landed the index but not all shards would silently
+    // be declared "already downloaded".
+    write('config.json', '{}');
+    write(
+      'model.safetensors.index.json',
+      JSON.stringify({
+        metadata: { total_size: 12345 },
+        weight_map: {
+          'layer.0.weight': 'model-00001-of-00002.safetensors',
+          'layer.1.weight': 'model-00002-of-00002.safetensors',
+        },
+      }),
+    );
+    // Only the first shard exists; the second is missing.
+    write('model-00001-of-00002.safetensors', 'shard-1');
+
+    expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(false);
+  });
+
+  it('returns true for a sharded model when ALL referenced shards exist', () => {
+    write('config.json', '{}');
+    write(
+      'model.safetensors.index.json',
+      JSON.stringify({
+        metadata: { total_size: 12345 },
+        weight_map: {
+          'layer.0.weight': 'model-00001-of-00002.safetensors',
+          'layer.1.weight': 'model-00002-of-00002.safetensors',
+          'layer.2.weight': 'model-00002-of-00002.safetensors', // duplicate target dedups
+        },
+      }),
+    );
+    write('model-00001-of-00002.safetensors', 'shard-1');
+    write('model-00002-of-00002.safetensors', 'shard-2');
+
+    expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(true);
+  });
+
+  it('returns false when the index file is malformed JSON', () => {
+    write('config.json', '{}');
+    write('model.safetensors.index.json', '{not json');
+    expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(false);
+  });
+
+  it('returns false when the index file lacks weight_map', () => {
+    write('config.json', '{}');
+    write('model.safetensors.index.json', JSON.stringify({ metadata: { total_size: 0 } }));
+    expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(false);
+  });
+
+  it('returns false when weight_map is empty', () => {
+    write('config.json', '{}');
+    write('model.safetensors.index.json', JSON.stringify({ weight_map: {} }));
+    expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(false);
+  });
+
+  it('still considers single-file safetensors complete even alongside an unverified index', () => {
+    // If both `model.safetensors` and `model.safetensors.index.json` are
+    // present, the single file wins — no need to parse the index.
+    write('config.json', '{}');
+    write('model.safetensors', 'x');
+    write('model.safetensors.index.json', JSON.stringify({ weight_map: { x: 'never-existed.safetensors' } }));
+    expect(isModelAlreadyDownloaded(dir, readdirSync(dir))).toBe(true);
+  });
+});

--- a/__test__/cli/launch-claude/discover.test.ts
+++ b/__test__/cli/launch-claude/discover.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+
+import { discoverModels } from '../../../packages/cli/src/commands/launch-claude/discover.js';
+
+describe('discoverModels', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'mlx-discover-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeModel(name: string, config: Record<string, unknown>): void {
+    const dir = join(root, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), JSON.stringify(config));
+  }
+
+  it('returns [] when the directory does not exist', async () => {
+    const got = await discoverModels(join(root, 'missing'));
+    expect(got).toEqual([]);
+  });
+
+  it('returns [] when the directory is empty', async () => {
+    const got = await discoverModels(root);
+    expect(got).toEqual([]);
+  });
+
+  it('discovers a Qwen3.5 directory with modelType and preset', async () => {
+    makeModel('qwen3.5-demo', { model_type: 'qwen3_5' });
+    const got = await discoverModels(root);
+    expect(got).toHaveLength(1);
+    expect(got[0].name).toBe('qwen3.5-demo');
+    expect(got[0].modelType).toBe('qwen3_5');
+    expect(got[0].preset.maxOutputTokens).toBeGreaterThan(0);
+    expect(got[0].path.endsWith('qwen3.5-demo')).toBe(true);
+  });
+
+  it('filters out Harrier (non-generative) model entries', async () => {
+    makeModel('harrier-emb', { model_type: 'qwen3', architectures: ['Qwen3Model'] });
+    const got = await discoverModels(root);
+    expect(got).toEqual([]);
+  });
+
+  it('skips regular files in the directory', async () => {
+    writeFileSync(join(root, 'stray.txt'), 'not a model');
+    makeModel('qwen3-demo', { model_type: 'qwen3' });
+    const got = await discoverModels(root);
+    expect(got).toHaveLength(1);
+    expect(got[0].name).toBe('qwen3-demo');
+  });
+
+  it('sorts discovered entries by name ascending', async () => {
+    makeModel('zzz-model', { model_type: 'qwen3_5' });
+    makeModel('aaa-model', { model_type: 'qwen3_5' });
+    makeModel('mmm-model', { model_type: 'qwen3_5' });
+    const got = await discoverModels(root);
+    expect(got.map((e) => e.name)).toEqual(['aaa-model', 'mmm-model', 'zzz-model']);
+  });
+
+  it('skips subdirectories without config.json', async () => {
+    mkdirSync(join(root, 'empty-dir'), { recursive: true });
+    makeModel('qwen3-demo', { model_type: 'qwen3' });
+    const got = await discoverModels(root);
+    expect(got).toHaveLength(1);
+  });
+});

--- a/__test__/cli/launch-claude/forward-signal.test.ts
+++ b/__test__/cli/launch-claude/forward-signal.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { makeChildKillEscalation } from '../../../packages/cli/src/commands/launch-claude/index.js';
+
+describe('makeChildKillEscalation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does NOT escalate to SIGKILL if the child exits before the timeout', () => {
+    const kill = vi.fn();
+    let exited = false;
+    const forward = makeChildKillEscalation({
+      child: { kill },
+      isShuttingDown: () => false,
+      hasChildExited: () => exited,
+      escalateAfterMs: 5000,
+    });
+
+    forward('SIGINT');
+    // First call: forwarded signal.
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill).toHaveBeenLastCalledWith('SIGINT');
+
+    // Child terminates before the 5s window elapses.
+    exited = true;
+    vi.advanceTimersByTime(10_000);
+
+    // No SIGKILL escalation because hasChildExited() returned true at the deadline.
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill).not.toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('escalates to SIGKILL if the child has not exited by the timeout', () => {
+    const kill = vi.fn();
+    const forward = makeChildKillEscalation({
+      child: { kill },
+      isShuttingDown: () => false,
+      hasChildExited: () => false, // never exits
+      escalateAfterMs: 5000,
+    });
+
+    forward('SIGTERM');
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill).toHaveBeenLastCalledWith('SIGTERM');
+
+    vi.advanceTimersByTime(5000);
+
+    // Now the timer has fired and the child still hasn't exited → SIGKILL.
+    expect(kill).toHaveBeenCalledTimes(2);
+    expect(kill).toHaveBeenLastCalledWith('SIGKILL');
+  });
+
+  it('skips signal forwarding entirely while shutting down', () => {
+    const kill = vi.fn();
+    const forward = makeChildKillEscalation({
+      child: { kill },
+      isShuttingDown: () => true,
+      hasChildExited: () => false,
+      escalateAfterMs: 5000,
+    });
+
+    forward('SIGINT');
+    vi.advanceTimersByTime(10_000);
+
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('does not escalate even if the timer fires after the child exited', () => {
+    // Regression: previously the escalation check used `child.killed`, which
+    // flips to true the moment kill() *sends* the signal, so the !child.killed
+    // guard was always false and SIGKILL never fired. Here we model a child
+    // that exits "between" forward('SIGINT') and the timer firing.
+    const kill = vi.fn();
+    let exited = false;
+    const forward = makeChildKillEscalation({
+      child: { kill },
+      isShuttingDown: () => false,
+      hasChildExited: () => exited,
+      escalateAfterMs: 5000,
+    });
+
+    forward('SIGINT');
+    // Halfway through the window, the child finally exits.
+    vi.advanceTimersByTime(2500);
+    exited = true;
+    vi.advanceTimersByTime(2500);
+
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill).not.toHaveBeenCalledWith('SIGKILL');
+  });
+});

--- a/__test__/cli/launch-claude/forward-signal.test.ts
+++ b/__test__/cli/launch-claude/forward-signal.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
-import { makeChildKillEscalation } from '../../../packages/cli/src/commands/launch-claude/index.js';
+import { computeExitCode, makeChildKillEscalation } from '../../../packages/cli/src/commands/launch-claude/index.js';
 
 describe('makeChildKillEscalation', () => {
   beforeEach(() => {
@@ -92,5 +92,50 @@ describe('makeChildKillEscalation', () => {
 
     expect(kill).toHaveBeenCalledTimes(1);
     expect(kill).not.toHaveBeenCalledWith('SIGKILL');
+  });
+});
+
+describe('computeExitCode', () => {
+  // Regression: previously `child.on('exit', (code) => shutdown(code ?? 0))`
+  // ignored the `signal` arg, so a SIGINT/SIGTERM/SIGKILL'd `claude` reported
+  // success (exit 0). CI jobs reading exit code as "did the run pass" got a
+  // false green. POSIX convention: signal-killed processes exit with
+  // `128 + signal_number`; Node exposes the numbers via `os.constants.signals`.
+
+  it('passes through a normal numeric exit code', () => {
+    expect(computeExitCode(0, null)).toBe(0);
+    expect(computeExitCode(1, null)).toBe(1);
+    expect(computeExitCode(2, null)).toBe(2);
+    expect(computeExitCode(127, null)).toBe(127);
+  });
+
+  it('maps SIGTERM (signal 15) to 143', () => {
+    expect(computeExitCode(null, 'SIGTERM')).toBe(143);
+  });
+
+  it('maps SIGINT (signal 2) to 130', () => {
+    expect(computeExitCode(null, 'SIGINT')).toBe(130);
+  });
+
+  it('maps SIGKILL (signal 9) to 137', () => {
+    expect(computeExitCode(null, 'SIGKILL')).toBe(137);
+  });
+
+  it('returns 1 for the (null, null) defensive case', () => {
+    expect(computeExitCode(null, null)).toBe(1);
+  });
+
+  it('returns 1 for a signal name not present in os.constants.signals', () => {
+    // Cast to NodeJS.Signals to satisfy TS; in practice the runtime would only
+    // ever see standard signal names, but the helper must not blow up if a
+    // platform-specific or unknown name slips through.
+    expect(computeExitCode(null, 'SIGUNKNOWN' as NodeJS.Signals)).toBe(1);
+  });
+
+  it('prefers the numeric exit code over the signal when both are present', () => {
+    // Node's docs guarantee that exactly one of (code, signal) is non-null,
+    // but defensively the helper picks `code` if both happen to arrive.
+    expect(computeExitCode(0, 'SIGTERM' as NodeJS.Signals)).toBe(0);
+    expect(computeExitCode(7, 'SIGINT' as NodeJS.Signals)).toBe(7);
   });
 });

--- a/__test__/cli/launch-claude/logger.test.ts
+++ b/__test__/cli/launch-claude/logger.test.ts
@@ -1,0 +1,144 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { createServer, request as httpRequest } from 'node:http';
+import type { Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+import { attachLogger, resolveLogDir } from '../../../packages/cli/src/commands/launch-claude/logger.js';
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'mlx-log-test-'));
+}
+
+function pickFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address();
+      if (addr && typeof addr === 'object') {
+        const port = addr.port;
+        probe.close(() => resolve(port));
+      } else {
+        probe.close(() => reject(new Error('no port')));
+      }
+    });
+  });
+}
+
+function closeServer(srv: Server): Promise<void> {
+  return new Promise((resolve) => srv.close(() => resolve()));
+}
+
+function postJson(port: number, body: unknown): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        method: 'POST',
+        path: '/echo',
+        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) },
+      },
+      (res) => {
+        let out = '';
+        res.on('data', (c: Buffer) => {
+          out += c.toString('utf8');
+        });
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: out }));
+      },
+    );
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+describe('resolveLogDir', () => {
+  const prevEnv = process.env.MLX_LOG_DIR;
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.MLX_LOG_DIR;
+    else process.env.MLX_LOG_DIR = prevEnv;
+  });
+
+  it('prefers explicit over env over default', () => {
+    process.env.MLX_LOG_DIR = '/from/env';
+    expect(resolveLogDir('/from/flag', '/home')).toBe('/from/flag');
+    expect(resolveLogDir(undefined, '/home')).toBe('/from/env');
+  });
+
+  it('falls back to a timestamped dir under mlxNodeHome/logs', () => {
+    delete process.env.MLX_LOG_DIR;
+    const got = resolveLogDir(undefined, '/home/me/.mlx-node');
+    expect(got.startsWith('/home/me/.mlx-node/logs/')).toBe(true);
+    expect(got.length).toBeGreaterThan('/home/me/.mlx-node/logs/'.length);
+  });
+});
+
+describe('attachLogger', () => {
+  it('captures one NDJSON line per request with req+res bodies', async () => {
+    const logDir = makeTmpDir();
+    const port = await pickFreePort();
+
+    const srv = createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.writeHead(200);
+      res.write('{"hello":');
+      res.end('"world"}');
+    });
+    const logger = attachLogger(srv, logDir);
+    await new Promise<void>((resolve) => srv.listen(port, '127.0.0.1', resolve));
+
+    const reply = await postJson(port, { ping: 1 });
+    expect(reply.status).toBe(200);
+    expect(reply.body).toBe('{"hello":"world"}');
+
+    await logger.close();
+    await closeServer(srv);
+
+    const lines = readFileSync(join(logDir, 'requests.ndjson'), 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const row = JSON.parse(lines[0]) as {
+      method: string;
+      path: string;
+      status: number;
+      reqBody: string;
+      resBody: string;
+      elapsedMs: number;
+    };
+    expect(row.method).toBe('POST');
+    expect(row.path).toBe('/echo');
+    expect(row.status).toBe(200);
+    expect(row.reqBody).toBe('{"ping":1}');
+    expect(row.resBody).toBe('{"hello":"world"}');
+    expect(row.elapsedMs).toBeGreaterThanOrEqual(0);
+
+    const pretty = readFileSync(join(logDir, 'session.log'), 'utf-8');
+    expect(pretty).toContain('POST /echo');
+    expect(pretty).toContain('200 POST /echo');
+  });
+
+  it('captures streamed chunks in order (SSE-style)', async () => {
+    const logDir = makeTmpDir();
+    const port = await pickFreePort();
+
+    const srv = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.write('data: a\n\n');
+      res.write('data: b\n\n');
+      res.end('data: [DONE]\n\n');
+    });
+    const logger = attachLogger(srv, logDir);
+    await new Promise<void>((resolve) => srv.listen(port, '127.0.0.1', resolve));
+
+    await postJson(port, { stream: true });
+    await logger.close();
+    await closeServer(srv);
+
+    const row = JSON.parse(readFileSync(join(logDir, 'requests.ndjson'), 'utf-8').trim()) as { resBody: string };
+    expect(row.resBody).toBe('data: a\n\ndata: b\n\ndata: [DONE]\n\n');
+  });
+});

--- a/__test__/cli/launch-claude/swap.test.ts
+++ b/__test__/cli/launch-claude/swap.test.ts
@@ -184,6 +184,74 @@ describe('makeSwapController', () => {
     expect(loader).not.toHaveBeenCalledWith('/fake/a');
   });
 
+  it('does not reload the previous resident when an alias request races a /model swap', { timeout: 5000 }, async () => {
+    // Regression: previously `targetEntry` and `isAlias` were captured at
+    // QUEUE time (i.e. the moment `resolveModel` was called), reading
+    // `resident` before chaining onto `currentOp`. A concurrent unknown-name
+    // (haiku alias) request that arrived DURING a `/model a → b` switch
+    // would capture `targetEntry = a` (the at-queue-time resident), then,
+    // when its turn ran AFTER b had become resident, would swap back to a
+    // and undo the user's switch.
+    //
+    // Fix: read `resident` inside the serialized .then() body so the
+    // target is computed against the live state at run time.
+    const reg = fakeRegistry();
+
+    // Controllable loader: each call returns a promise we can resolve on demand.
+    const pending: { path: string; resolve: (v: LoadableModel) => void }[] = [];
+    const loader = vi.fn(
+      (path: string) =>
+        new Promise<LoadableModel>((resolve) => {
+          pending.push({ path, resolve });
+        }),
+    );
+    const ctrl = makeSwapController(discovered(['a', 'b']), reg as unknown as ModelRegistry, loader);
+
+    // 1) Establish resident=a.
+    const pA = ctrl.resolveModel('a');
+    // Drain microtasks so the loader call lands.
+    await Promise.resolve();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].path).toBe('/fake/a');
+    pending[0].resolve({ marker: '/fake/a' } as unknown as LoadableModel);
+    await pA;
+
+    // 2) Start a swap to b — DO NOT await; b is mid-load.
+    const pB = ctrl.resolveModel('b');
+    // Let the .then() body run up to the loader await.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(pending).toHaveLength(2);
+    expect(pending[1].path).toBe('/fake/b');
+
+    // 3) Concurrently fire an alias request while b is still loading.
+    // At THIS moment the live `resident` is still a, but by the time the
+    // alias's queued body runs, b will be resident. Old code captured
+    // targetEntry = a here and would have re-loaded a after b finished.
+    const pAlias = ctrl.resolveModel('claude-haiku-4-5-20251001');
+    await Promise.resolve();
+
+    // 4) Unblock the b load. The alias body runs next.
+    pending[1].resolve({ marker: '/fake/b' } as unknown as LoadableModel);
+    await pB;
+    await pAlias;
+
+    // 5) Final state: only two real loads (a then b). No third load of a.
+    const loadedPaths = loader.mock.calls.map((c) => c[0]);
+    expect(loadedPaths).toEqual(['/fake/a', '/fake/b']);
+    expect(loadedPaths.filter((p) => p === '/fake/a')).toHaveLength(1);
+
+    // The alias must be registered onto b's instance — not re-registered onto a.
+    const aliasRegister = reg.register.mock.calls.find((c) => c[0] === 'claude-haiku-4-5-20251001');
+    expect(aliasRegister).toBeDefined();
+    expect(aliasRegister?.[1]).toEqual({ marker: '/fake/b' });
+
+    // And `a` must have been unregistered exactly once (during the a → b swap),
+    // never re-registered as a fresh resident.
+    expect(reg.unregister.mock.calls.map((c) => c[0])).toContain('a');
+    expect(reg.register.mock.calls.filter((c) => c[0] === 'a')).toHaveLength(1);
+  });
+
   it('lists discovered entries in name order', () => {
     const reg = fakeRegistry();
     const loader = vi.fn(async () => ({}) as unknown as LoadableModel);

--- a/__test__/cli/launch-claude/swap.test.ts
+++ b/__test__/cli/launch-claude/swap.test.ts
@@ -252,6 +252,58 @@ describe('makeSwapController', () => {
     expect(reg.register.mock.calls.filter((c) => c[0] === 'a')).toHaveLength(1);
   });
 
+  it('restores alias state when a swap load fails so a later swap can re-point them', async () => {
+    // Regression: previously, when `loadModelFn` threw mid-swap, we had
+    // already done `aliases.clear()` + `registry.unregister(oldResident)`.
+    // The controller forgot the alias names while the registry's alias
+    // bindings still held the old model object (alias bindings have their
+    // own refcount on the binding). A subsequent successful swap would NOT
+    // re-point those aliases (the controller no longer remembered them),
+    // leaving alias-routed traffic permanently pinned to the stale model
+    // and the old model's memory permanently leaked.
+    //
+    // Black-box assertion: do the failed swap, then do a successful swap
+    // to a *new* model, and verify the haiku alias is repointed onto the
+    // new model. If the controller's alias set hadn't been restored, the
+    // haiku alias would still point at the original model after the
+    // successful swap.
+    const reg = fakeRegistry();
+    let shouldFail = false;
+    const loader = vi.fn(async (p: string) => {
+      if (shouldFail) throw new Error(`refusing to load ${p}`);
+      return { marker: p } as unknown as LoadableModel;
+    });
+    const ctrl = makeSwapController(discovered(['a', 'b', 'c']), reg as unknown as ModelRegistry, loader);
+
+    // 1) Load `a` and install a haiku alias on it.
+    await ctrl.resolveModel('a');
+    await ctrl.resolveModel('claude-haiku-x');
+    // Sanity: alias resolves to a's instance.
+    const aInstance = reg.register.mock.calls.find((c) => c[0] === 'a')?.[1];
+    const probe = (name: string): unknown => (reg.get as unknown as (n: string) => unknown)(name);
+    expect(probe('claude-haiku-x')).toBe(aInstance);
+
+    // 2) Attempt a swap to `b` and have it FAIL during load.
+    shouldFail = true;
+    await expect(ctrl.resolveModel('b')).rejects.toThrow(/refusing to load/);
+
+    // After the failure: the alias name MUST still resolve in the registry
+    // (the alias binding kept the old model alive across the failed swap).
+    expect(probe('claude-haiku-x')).toBeDefined();
+
+    // 3) Now perform a successful swap to `c`. If alias state was correctly
+    // restored, the haiku alias gets repointed onto c. If it wasn't, the
+    // haiku alias would still be pinned to a's instance (or worse, to a
+    // ghost binding) because the controller forgot it existed.
+    shouldFail = false;
+    await ctrl.resolveModel('c');
+
+    const cInstance = reg.register.mock.calls.filter((c) => c[0] === 'c').slice(-1)[0]?.[1];
+    expect(cInstance).toEqual({ marker: '/fake/c' });
+    expect(probe('claude-haiku-x')).toBe(cInstance);
+    expect(probe('claude-haiku-x')).not.toBe(aInstance);
+  });
+
   it('lists discovered entries in name order', () => {
     const reg = fakeRegistry();
     const loader = vi.fn(async () => ({}) as unknown as LoadableModel);

--- a/__test__/cli/launch-claude/swap.test.ts
+++ b/__test__/cli/launch-claude/swap.test.ts
@@ -1,0 +1,200 @@
+import type { LoadableModel } from '@mlx-node/lm';
+import type { ModelRegistry } from '@mlx-node/server';
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+import type { DiscoveredModel } from '../../../packages/cli/src/commands/launch-claude/discover.js';
+import { makeSwapController } from '../../../packages/cli/src/commands/launch-claude/swap.js';
+
+interface FakeRegistry {
+  get: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  unregister: ReturnType<typeof vi.fn>;
+}
+
+function fakeRegistry(): FakeRegistry {
+  const resident = new Map<string, unknown>();
+  const get = vi.fn((name: string) => resident.get(name));
+  const register = vi.fn((name: string, model: unknown) => {
+    resident.set(name, model);
+  });
+  const unregister = vi.fn((name: string) => {
+    resident.delete(name);
+    return true;
+  });
+  return { get, register, unregister };
+}
+
+function discovered(names: string[]): DiscoveredModel[] {
+  return names.map((n) => ({
+    name: n,
+    path: `/fake/${n}`,
+    modelType: 'qwen3_5' as const,
+    preset: {
+      sampling: { temperature: 0.6, topP: 0.95, topK: 20, minP: 0, presencePenalty: 0, repetitionPenalty: 1 },
+      maxOutputTokens: 1024,
+    },
+  }));
+}
+
+describe('makeSwapController', () => {
+  it('loads a model on first resolve and registers it under the requested name', async () => {
+    const reg = fakeRegistry();
+    const loader = vi.fn(async (p: string) => ({ marker: p }) as unknown as LoadableModel);
+    const ctrl = makeSwapController(discovered(['a']), reg as unknown as ModelRegistry, loader);
+
+    await ctrl.resolveModel('a');
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(loader).toHaveBeenCalledWith('/fake/a');
+    expect(reg.register).toHaveBeenCalledTimes(1);
+    const [name, model, opts] = reg.register.mock.calls[0];
+    expect(name).toBe('a');
+    expect(model).toEqual({ marker: '/fake/a' });
+    expect(opts?.samplingDefaults).toBeDefined();
+    expect(opts?.samplingDefaults?.temperature).toBe(0.6);
+  });
+
+  it('unregisters the previous resident when switching models', async () => {
+    const reg = fakeRegistry();
+    const loader = vi.fn(async (p: string) => ({ marker: p }) as unknown as LoadableModel);
+    const ctrl = makeSwapController(discovered(['a', 'b']), reg as unknown as ModelRegistry, loader);
+
+    await ctrl.resolveModel('a');
+    await ctrl.resolveModel('b');
+
+    expect(loader.mock.calls.map((c) => c[0])).toEqual(['/fake/a', '/fake/b']);
+    expect(reg.unregister).toHaveBeenCalledWith('a');
+    expect(reg.register.mock.calls.map((c) => c[0])).toEqual(['a', 'b']);
+  });
+
+  it('deduplicates concurrent calls targeting the same name', async () => {
+    const reg = fakeRegistry();
+    let resolveLoad: ((v: LoadableModel) => void) | null = null;
+    const loader = vi.fn(
+      () =>
+        new Promise<LoadableModel>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+    const ctrl = makeSwapController(discovered(['a']), reg as unknown as ModelRegistry, loader);
+
+    const p1 = ctrl.resolveModel('a');
+    const p2 = ctrl.resolveModel('a');
+    // Give both calls a chance to chain onto currentOp.
+    await Promise.resolve();
+    resolveLoad!({ marker: '/fake/a' } as unknown as LoadableModel);
+    await Promise.all([p1, p2]);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(reg.register).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes concurrent calls for different names in arrival order', async () => {
+    const reg = fakeRegistry();
+    const order: string[] = [];
+    const loader = vi.fn(async (p: string) => {
+      order.push(`start:${p}`);
+      await new Promise((r) => setTimeout(r, 10));
+      order.push(`end:${p}`);
+      return { marker: p } as unknown as LoadableModel;
+    });
+    const ctrl = makeSwapController(discovered(['a', 'b']), reg as unknown as ModelRegistry, loader);
+
+    const pA = ctrl.resolveModel('a');
+    const pB = ctrl.resolveModel('b');
+    await Promise.all([pA, pB]);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(order).toEqual(['start:/fake/a', 'end:/fake/a', 'start:/fake/b', 'end:/fake/b']);
+  });
+
+  it('aliases an unknown name to discovered[0] on first call', async () => {
+    const reg = fakeRegistry();
+    const loader = vi.fn(async (p: string) => ({ marker: p }) as unknown as LoadableModel);
+    const ctrl = makeSwapController(discovered(['a', 'b']), reg as unknown as ModelRegistry, loader);
+
+    // Claude Code hardcodes `claude-haiku-*` for subagent dispatches;
+    // those should not 404 — we alias them to the resident model.
+    await ctrl.resolveModel('claude-haiku-4-5-20251001');
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(loader).toHaveBeenCalledWith('/fake/a');
+    // Two register calls: one for the real resident, one for the alias.
+    expect(reg.register).toHaveBeenCalledTimes(2);
+    expect(reg.register.mock.calls.map((c) => c[0])).toEqual(['a', 'claude-haiku-4-5-20251001']);
+    // Both point at the same model instance.
+    expect(reg.register.mock.calls[0][1]).toBe(reg.register.mock.calls[1][1]);
+  });
+
+  it('aliases an unknown name to the current resident, not discovered[0]', async () => {
+    const reg = fakeRegistry();
+    const loader = vi.fn(async (p: string) => ({ marker: p }) as unknown as LoadableModel);
+    const ctrl = makeSwapController(discovered(['a', 'b']), reg as unknown as ModelRegistry, loader);
+
+    // User /model-picks 'b' first, THEN a subagent dispatch fires.
+    await ctrl.resolveModel('b');
+    await ctrl.resolveModel('claude-haiku-4-5-20251001');
+
+    // Alias should point at 'b' (resident), not 'a' (discovered[0]).
+    const aliasRegister = reg.register.mock.calls.find((c) => c[0] === 'claude-haiku-4-5-20251001');
+    expect(aliasRegister).toBeDefined();
+    expect(aliasRegister?.[1]).toEqual({ marker: '/fake/b' });
+  });
+
+  it('carries aliases across a resident swap instead of unregistering them', async () => {
+    // Regression: previously we unregistered all aliases before loading
+    // the new resident, which raced with any in-flight messages.ts
+    // request whose `resolveModel` had just returned but hadn't yet
+    // called `registry.get(alias)`. That request saw a null lookup and
+    // returned 404. The fix is to re-point the alias onto the new
+    // resident (same-name register with a different model object drops
+    // the old binding's refcount atomically) so `registry.get(alias)`
+    // always resolves to *some* live instance.
+    const reg = fakeRegistry();
+    const loader = vi.fn(async (p: string) => ({ marker: p }) as unknown as LoadableModel);
+    const ctrl = makeSwapController(discovered(['a', 'b']), reg as unknown as ModelRegistry, loader);
+
+    await ctrl.resolveModel('a');
+    await ctrl.resolveModel('claude-haiku-4-5-20251001');
+    await ctrl.resolveModel('b');
+
+    // Only the old resident's NAME is unregistered; the alias is re-pointed.
+    const unregOrder = reg.unregister.mock.calls.map((c) => c[0]);
+    expect(unregOrder).toContain('a');
+    expect(unregOrder).not.toContain('claude-haiku-4-5-20251001');
+
+    // The alias got a second `register` call, now bound to b's instance.
+    const aliasRegs = reg.register.mock.calls.filter((c) => c[0] === 'claude-haiku-4-5-20251001');
+    expect(aliasRegs.length).toBe(2);
+    expect(aliasRegs[0]?.[1]).toEqual({ marker: '/fake/a' });
+    expect(aliasRegs[1]?.[1]).toEqual({ marker: '/fake/b' });
+  });
+
+  it('respects defaultName fallback for unknown aliases on the very first call', async () => {
+    // With --model flag the user picks a specific discovered entry; we
+    // shouldn't load alphabetically-first discovered[0] just because a
+    // haiku title-gen arrived before the main chat turn.
+    const reg = fakeRegistry();
+    const loader = vi.fn(async (p: string) => ({ marker: p }) as unknown as LoadableModel);
+    const ctrl = makeSwapController(discovered(['a', 'b']), reg as unknown as ModelRegistry, loader, 'b');
+
+    await ctrl.resolveModel('claude-haiku-4-5-20251001');
+
+    // Loader called with b's path (the chosen default), not a's.
+    expect(loader).toHaveBeenCalledWith('/fake/b');
+    expect(loader).not.toHaveBeenCalledWith('/fake/a');
+  });
+
+  it('lists discovered entries in name order', () => {
+    const reg = fakeRegistry();
+    const loader = vi.fn(async () => ({}) as unknown as LoadableModel);
+    const ctrl = makeSwapController(discovered(['zebra', 'alpha', 'mike']), reg as unknown as ModelRegistry, loader);
+
+    const listed = ctrl.listModels();
+    expect(listed.map((e) => e.id)).toEqual(['alpha', 'mike', 'zebra']);
+    for (const entry of listed) {
+      expect(entry.object).toBe('model');
+      expect(entry.owned_by).toBe('mlx-node');
+      expect(typeof entry.created).toBe('number');
+    }
+  });
+});

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -296,6 +296,50 @@ describe('handleCreateMessage', () => {
       expect(parsed.error.type).toBe('not_found_error');
       expect(parsed.error.message).toContain('nonexistent');
     });
+
+    it('does NOT call resolveModel when mapAnthropicRequest will reject the body as 400', async () => {
+      // Regression: previously `resolveModel` ran AFTER shallow validation but
+      // BEFORE `mapAnthropicRequest`, so a malformed-but-shallow-valid request
+      // (e.g. an unsupported content block type) triggered a multi-second
+      // model load — and possibly evicted the currently-resident model — just
+      // to return 400 a moment later.
+      //
+      // Fix: hoist the (pure-transform) `mapAnthropicRequest` above the
+      // resolveModel hook so mapping errors short-circuit before any load.
+      const registry = new ModelRegistry();
+      const resolveModel = vi.fn().mockResolvedValue(undefined);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [
+            {
+              role: 'user',
+              content: [
+                // Unsupported block type — mapAnthropicRequest throws.
+                { type: 'mystery_block_type', text: 'oops' } as any,
+              ],
+            },
+          ],
+          max_tokens: 100,
+        },
+        registry,
+        undefined,
+        null,
+        resolveModel,
+      );
+
+      // The critical assertion: the lazy-load hook MUST NOT have fired for a
+      // request that was destined to 400 on mapping. Asserted first because
+      // it's the load-bearing claim of this regression test.
+      expect(resolveModel).not.toHaveBeenCalled();
+      expect(getStatus()).toBe(400);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.type).toBe('error');
+      expect(parsed.error.type).toBe('invalid_request_error');
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -343,6 +343,121 @@ describe('handleCreateMessage', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Idle sweeper bracketing of resolveModel
+  // -----------------------------------------------------------------------
+
+  describe('resolveModel idle-sweeper bracketing', () => {
+    it('wraps resolveModel in withSuspendedDrains BEFORE beginRequest fires', async () => {
+      // Regression: in `mlx launch claude` mode `resolveModel` may run a
+      // 30s `loadModel()` on first sight of an unknown name. The previous
+      // request's `endRequest()` arms a 30s drain timer that fires
+      // `clearCache()` on expiry. If we did NOT bracket the lazy-load
+      // call, the timer could fire MID-LOAD while weight materialization
+      // was still allocating through the Metal free pool — exactly the
+      // hot-load race that `withSuspendedDrains` exists to prevent.
+      //
+      // The fix wraps the `resolveModel(...)` invocation in
+      // `idleSweeper.withSuspendedDrains(...)` so the drain is suspended
+      // for the full duration of the load. The bracket MUST land BEFORE
+      // `beginRequest()` (which itself only cancels an already-armed
+      // timer; it does not protect against a timer that fires *during*
+      // the await on resolveModel before beginRequest runs).
+      const registry = new ModelRegistry();
+      const { res } = createMockRes();
+
+      // Side-effect: register the model so the post-resolveModel
+      // `registry.get(...)` lookup succeeds and the handler proceeds
+      // through dispatch. The mock model simply returns a canned
+      // `ChatResult`.
+      const mockModel = createMockModel();
+      const resolveOrder: string[] = [];
+      const resolveModel = vi.fn(async (_name: string) => {
+        resolveOrder.push('resolveModel:enter');
+        // Force at least one event-loop turn so the await is real.
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+        registry.register('test-model', mockModel);
+        resolveOrder.push('resolveModel:exit');
+      });
+
+      // Fake idle sweeper. `withSuspendedDrains` simply runs the supplied
+      // function; the assertion is purely on call ordering.
+      const withSuspendedDrains = vi.fn(async <T>(fn: () => T | Promise<T>): Promise<T> => {
+        return await fn();
+      });
+      const beginRequest = vi.fn();
+      const endRequest = vi.fn();
+      const fakeSweeper = {
+        withSuspendedDrains,
+        beginRequest,
+        endRequest,
+        suspendDrains: vi.fn(() => () => {}),
+        close: vi.fn(),
+        isPending: false,
+        inFlight: 0,
+      };
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 100,
+        },
+        registry,
+        undefined,
+        fakeSweeper as any,
+        resolveModel,
+      );
+
+      // Load-bearing assertion #1: resolveModel was actually invoked.
+      expect(resolveModel).toHaveBeenCalledTimes(1);
+      expect(resolveModel).toHaveBeenCalledWith('test-model');
+
+      // Load-bearing assertion #2: the bracket wraps resolveModel.
+      expect(withSuspendedDrains).toHaveBeenCalledTimes(1);
+      expect(resolveOrder).toEqual(['resolveModel:enter', 'resolveModel:exit']);
+
+      // Load-bearing assertion #3: withSuspendedDrains runs BEFORE
+      // beginRequest. Without this ordering the previous request's
+      // armed timer could fire mid-load.
+      expect(beginRequest).toHaveBeenCalledTimes(1);
+      expect(withSuspendedDrains.mock.invocationCallOrder[0]).toBeLessThan(beginRequest.mock.invocationCallOrder[0]);
+
+      // Sanity: the matching endRequest fires.
+      expect(endRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to a direct resolveModel call when no idle sweeper is provided', async () => {
+      // The bracket is conditional on `idleSweeper != null` so a host
+      // that opted out (or hasn't wired one) still gets the lazy-load
+      // hook fired. Asserts the fallback branch.
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel();
+      const resolveModel = vi.fn(async (_name: string) => {
+        registry.register('test-model', mockModel);
+      });
+      const { res, getStatus } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 100,
+        },
+        registry,
+        undefined,
+        // No sweeper → direct call.
+        null,
+        resolveModel,
+      );
+
+      expect(resolveModel).toHaveBeenCalledTimes(1);
+      expect(getStatus()).toBe(200);
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Non-streaming
   // -----------------------------------------------------------------------
 

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -427,6 +427,46 @@ describe('handleCreateMessage', () => {
       expect(endRequest).toHaveBeenCalledTimes(1);
     });
 
+    it('returns 500 with an Anthropic-shape error envelope when resolveModel rejects', async () => {
+      // Regression: previously `resolveModel` ran outside any try/catch in
+      // this handler, so a rejection (bad model path, corrupt weights,
+      // native loader error in `mlx launch claude` mode) bubbled up to the
+      // outer `createHandler` catch which emits the OpenAI-shape
+      // `{ "error": { type, message } }` body via `sendInternalError`.
+      // This endpoint is `/v1/messages` (Anthropic) — clients parse the
+      // `{ "type": "error", "error": { "type": "api_error", "message": ... } }`
+      // envelope, so the OpenAI-shape body could not be parsed.
+      //
+      // Fix: wrap the `resolveModel(...)` call in a try/catch and route
+      // failures through `sendAnthropicInternalError`. Mirrors the
+      // `mapAnthropicRequest` try/catch a few lines above in the same handler.
+      const registry = new ModelRegistry();
+      const resolveModel = vi.fn().mockRejectedValue(new Error('bad model path'));
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 100,
+        },
+        registry,
+        undefined,
+        null,
+        resolveModel,
+      );
+
+      expect(resolveModel).toHaveBeenCalledTimes(1);
+      expect(getStatus()).toBe(500);
+      const parsed = JSON.parse(getBody());
+      // Anthropic-shape envelope: `{ type: 'error', error: { type, message } }`
+      // (see `sendAnthropicInternalError` in `packages/server/src/errors.ts`).
+      expect(parsed.type).toBe('error');
+      expect(parsed.error.type).toBe('api_error');
+      expect(parsed.error.message).toContain('bad model path');
+    });
+
     it('falls back to a direct resolveModel call when no idle sweeper is provided', async () => {
       // The bracket is conditional on `idleSweeper != null` so a host
       // that opted out (or hasn't wired one) still gets the lazy-load

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,8 @@
     "@huggingface/hub": "^2.11.0",
     "@inquirer/prompts": "^8.4.1",
     "@mlx-node/core": "workspace:*",
+    "@mlx-node/lm": "workspace:*",
+    "@mlx-node/server": "workspace:*",
     "@napi-rs/keyring": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@huggingface/hub": "^2.11.0",
+    "@inquirer/prompts": "^8.4.1",
     "@mlx-node/core": "workspace:*",
     "@mlx-node/lm": "workspace:*",
     "@mlx-node/server": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@huggingface/hub": "^2.11.0",
-    "@inquirer/prompts": "^8.4.1",
     "@mlx-node/core": "workspace:*",
     "@mlx-node/lm": "workspace:*",
     "@mlx-node/server": "workspace:*",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,7 @@ Commands:
   download model     Download a model from HuggingFace
   download dataset   Download a dataset from HuggingFace
   convert            Convert model weights to MLX format
+  launch claude      Start a local server and spawn Claude Code pointed at it
 
 Options:
   -h, --help         Show this help message
@@ -25,7 +26,8 @@ Options:
 Examples:
   mlx download model -m Qwen/Qwen3-0.6B
   mlx download dataset -d openai/gsm8k
-  mlx convert -i .cache/models/qwen3-0.6b -o .cache/models/qwen3-0.6b-mlx -d bf16
+  mlx convert -i ~/.mlx-node/models/qwen3-0.6b -o ~/.mlx-node/models/qwen3-0.6b-mlx -d bf16
+  mlx launch claude
 `);
 }
 
@@ -73,6 +75,28 @@ Run mlx download <subcommand> --help for more information.
       const rest = args.slice(1);
       const { run } = await import('./commands/convert.js');
       await run(rest);
+      break;
+    }
+
+    case 'launch': {
+      const rest = args.slice(2);
+      if (!subcommand || subcommand === '--help' || subcommand === '-h') {
+        console.log(`
+Usage:
+  mlx launch claude     Start a local server and spawn Claude Code pointed at it
+
+Run mlx launch <subcommand> --help for more information.
+`);
+        return;
+      }
+      if (subcommand === 'claude') {
+        const { run } = await import('./commands/launch-claude/index.js');
+        await run(rest);
+      } else {
+        console.error(`Unknown launch subcommand: ${subcommand}`);
+        console.error('Available: claude');
+        process.exit(1);
+      }
       break;
     }
 

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { readdir, copyFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -315,6 +315,34 @@ export function isGgufRepoComplete(localFiles: string[], remoteFiles: string[]):
   return true;
 }
 
+/**
+ * Per-file check inside the download loop: is `destPath` already a complete
+ * copy of the remote `file`?
+ *
+ * Returns true when the local file exists AND its byte size matches the
+ * remote manifest's `file.size`. Truncated/interrupted prior copies fail
+ * the size check and re-copy. When the manifest has no size (`<= 0`), we
+ * fall back to existence-only — losing partial-recovery for that one
+ * file but matching the pre-d139679 reconciler's `existsSync` check.
+ *
+ * Why this exists: `downloadFileToCacheDir` is content-addressed (no
+ * network re-fetch when the cache already holds the blob), but the
+ * subsequent `copyFile` always copies bytes regardless. For a sharded
+ * model with the early-return short-circuited (e.g. an interrupted run
+ * left the safetensors index but not all shards), the per-file copy
+ * would otherwise re-write every already-complete shard to disk on
+ * resume — gigabytes of pointless I/O.
+ */
+export function isLocalCopyComplete(destPath: string, expectedSize: number): boolean {
+  if (!existsSync(destPath)) return false;
+  if (expectedSize <= 0) return true;
+  try {
+    return statSync(destPath).size === expectedSize;
+  } catch {
+    return false;
+  }
+}
+
 async function verifyDownload(outputDir: string, weightFiles: string[]): Promise<boolean> {
   console.log('\nVerifying download...');
 
@@ -442,9 +470,9 @@ export async function run(argv: string[]) {
       // Manifest-aware completeness: only short-circuit when every
       // remote `.gguf` is present locally. Falling through to the
       // download loop is safe — `downloadFileToCacheDir` is content-
-      // addressed and the per-file `copyFile` to `outputDir` is
-      // idempotent, so files already on disk re-copy from cache
-      // without re-downloading bytes.
+      // addressed and the per-file loop's `isLocalCopyComplete` check
+      // skips the `copyFile` for files already on disk at the right
+      // size, so resume only does I/O for the genuinely missing shards.
       console.log('Fetching file list from HuggingFace...\n');
       cachedManifest = await getModelFiles(modelName, HUGGINGFACE_TOKEN, globPatterns);
       const remoteBasenames = cachedManifest.allFiles.map((f) => f.path.split('/').pop() ?? f.path);
@@ -495,9 +523,8 @@ export async function run(argv: string[]) {
         return;
       }
       // Incomplete: fall through to the download loop. The per-file
-      // copy is idempotent (`downloadFileToCacheDir` is content-addressed
-      // and `copyFile` overwrites), so already-present files re-copy
-      // from cache without re-downloading bytes.
+      // loop's `isLocalCopyComplete` check skips already-present files,
+      // so resume only fetches/copies the genuinely missing shards.
       const missing = cachedManifest.filesToDownload.filter((f) => {
         const basename = f.path.split('/').pop() ?? f.path;
         return !files.includes(basename);
@@ -557,16 +584,26 @@ export async function run(argv: string[]) {
   for (let i = 0; i < total; i++) {
     const file = filesToDownload[i];
     const fileSizeStr = file.size ? formatBytes(file.size) : '';
-    console.log(`  [${i + 1}/${total}] ${file.path}${fileSizeStr ? ` (${fileSizeStr})` : ''}...`);
-    const snapshotPath = await downloadFileToCacheDir({
-      repo: { type: 'model', name: modelName },
-      path: file.path,
-      cacheDir,
-      accessToken: HUGGINGFACE_TOKEN,
-    });
     const destPath = join(outputDir, file.path);
-    await ensureDir(dirname(destPath));
-    await copyFile(snapshotPath, destPath);
+    // Skip files already on disk with matching size — `downloadFileToCacheDir`
+    // is content-addressed (no network re-fetch) but `copyFile` always copies
+    // bytes, so without this check a resumed sharded download re-writes every
+    // already-complete shard from cache to outputDir on every invocation.
+    if (isLocalCopyComplete(destPath, file.size)) {
+      console.log(
+        `  [${i + 1}/${total}] ${file.path}${fileSizeStr ? ` (${fileSizeStr})` : ''} — already present, skipping copy`,
+      );
+    } else {
+      console.log(`  [${i + 1}/${total}] ${file.path}${fileSizeStr ? ` (${fileSizeStr})` : ''}...`);
+      const snapshotPath = await downloadFileToCacheDir({
+        repo: { type: 'model', name: modelName },
+        path: file.path,
+        cacheDir,
+        accessToken: HUGGINGFACE_TOKEN,
+      });
+      await ensureDir(dirname(destPath));
+      await copyFile(snapshotPath, destPath);
+    }
     if (file.path.endsWith('.safetensors') || file.path.endsWith('.pdiparams') || file.path.endsWith('.gguf')) {
       weightFiles.push(file.path);
     }

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { readdir, copyFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
@@ -151,6 +151,57 @@ async function getModelFiles(modelName: string, accessToken?: string, globPatter
   return { totalSize, filesToDownload, allFiles };
 }
 
+/**
+ * Pre-flight check: does `outputDir` already hold a complete model download?
+ *
+ * Returns true ONLY when we can declare "already downloaded" with confidence.
+ * For sharded models we additionally parse `model.safetensors.index.json`
+ * and verify every shard listed under `weight_map` is present on disk —
+ * otherwise an interrupted prior run that landed the index but not all
+ * shards would silently exit as "already downloaded" and leave the user
+ * with a broken local copy.
+ *
+ * Pure function: takes the directory + its file list and only reads the
+ * index file when sharded-model checks need it. No network, no other I/O.
+ */
+export function isModelAlreadyDownloaded(outputDir: string, files: string[]): boolean {
+  const fileSet = new Set(files);
+  const hasConfig = fileSet.has('config.json');
+  if (!hasConfig) return false;
+
+  const hasSingleModel = fileSet.has('model.safetensors');
+  const hasPaddleModel = fileSet.has('inference.pdiparams');
+  if (hasSingleModel || hasPaddleModel) return true;
+
+  const hasShardedModel = fileSet.has('model.safetensors.index.json');
+  if (!hasShardedModel) return false;
+
+  // Sharded: verify every shard the index references actually exists on disk.
+  let parsed: unknown;
+  try {
+    const raw = readFileSync(join(outputDir, 'model.safetensors.index.json'), 'utf8');
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  const weightMap =
+    parsed && typeof parsed === 'object' && 'weight_map' in parsed
+      ? (parsed as { weight_map?: unknown }).weight_map
+      : undefined;
+  if (!weightMap || typeof weightMap !== 'object') return false;
+
+  const shardFilenames = new Set<string>();
+  for (const value of Object.values(weightMap as Record<string, unknown>)) {
+    if (typeof value === 'string') shardFilenames.add(value);
+  }
+  if (shardFilenames.size === 0) return false;
+
+  for (const shard of shardFilenames) {
+    if (!existsSync(join(outputDir, shard))) return false;
+  }
+  return true;
+}
+
 async function verifyDownload(outputDir: string, weightFiles: string[]): Promise<boolean> {
   console.log('\nVerifying download...');
 
@@ -253,12 +304,8 @@ export async function run(argv: string[]) {
   // Check if already downloaded
   if (existsSync(outputDir)) {
     const files = await readdir(outputDir);
-    const hasConfig = files.includes('config.json');
-    const hasSingleModel = files.includes('model.safetensors');
-    const hasShardedModel = files.includes('model.safetensors.index.json');
-    const hasPaddleModel = files.includes('inference.pdiparams');
     const hasGguf = files.some((f) => f.endsWith('.gguf'));
-    if (hasConfig && (hasSingleModel || hasShardedModel || hasPaddleModel)) {
+    if (isModelAlreadyDownloaded(outputDir, files)) {
       console.log('Model already downloaded!\n');
       console.log('To re-download, delete the output directory first:');
       console.log(`   rm -rf ${outputDir}\n`);

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -224,6 +224,51 @@ export function isGlobVariantPresent(files: string[], globPatterns: string[]): b
 }
 
 /**
+ * Pre-flight check: is the user's glob-filtered download complete?
+ *
+ * Returns true ONLY when EVERY remote file whose basename matches any of
+ * the supplied glob patterns is also present locally. Returns false on
+ * empty intersection (no remote file matches any glob — the downstream
+ * "no files matched" path handles that case) and false on empty manifest
+ * (likely upstream error).
+ *
+ * Why this exists: `isGlobVariantPresent` only checks for AT LEAST ONE
+ * local hit. If a prior `--glob "*Q4*"` run was interrupted after fetching
+ * one Q4 shard but before the others, rerunning the same command would
+ * exit as "Matched files already downloaded" while silently leaving the
+ * local copy incomplete. This helper closes that gap by verifying the
+ * full glob-matched set against the remote manifest — symmetric to
+ * `isGgufRepoComplete` for the no-glob branch.
+ *
+ * Per-file basenames are compared on both sides (the remote manifest may
+ * publish under a sub-directory like `models/foo.gguf` while the local
+ * `readdir(outputDir)` is flat) so nested-prefix repos don't false-negative.
+ *
+ * Pure function: no I/O, no network. Caller fetches the manifest via
+ * `getModelFiles` (or equivalent) and hands the basenames in.
+ */
+export function isGlobMatchedSetComplete(localFiles: string[], remoteFiles: string[], globPatterns: string[]): boolean {
+  if (globPatterns.length === 0) return false;
+  if (remoteFiles.length === 0) return false;
+  const globs = globPatterns.map(globToRegex);
+  const localSet = new Set(localFiles);
+  let matched = 0;
+  for (const remote of remoteFiles) {
+    const basename = remote.split('/').pop() ?? remote;
+    if (!matchesAnyGlob(basename, globs) && !matchesAnyGlob(remote, globs)) continue;
+    matched++;
+    if (!localSet.has(basename)) return false;
+  }
+  // Empty intersection: no remote file matches any glob. The caller's
+  // downstream "no files matched the given criteria" path handles this
+  // case after listing available variants; declaring "complete" here
+  // would be wrong (nothing was supposed to be downloaded but nothing
+  // was — that's not the same as "we already have what was requested").
+  if (matched === 0) return false;
+  return true;
+}
+
+/**
  * Pre-flight check: is a no-glob GGUF download complete?
  *
  * Returns true ONLY when EVERY `.gguf` file in the remote repo manifest
@@ -422,17 +467,48 @@ export async function run(argv: string[]) {
         console.log('');
       }
     }
-    // For glob downloads, only declare "already downloaded" when at least one
-    // file actually matches the user's glob. CORE_FILES (config.json,
-    // tokenizer.json, …) are present after ANY prior download, so they cannot
-    // serve as proof of a specific quantization variant — relying on them was
-    // why first running `--glob "*Q8*"` then `--glob "*Q4*"` used to short-
-    // circuit and never fetch the Q4 weights.
+    // For glob downloads, only declare "already downloaded" when EVERY
+    // remote file matching the user's glob is also present locally. The
+    // previous "at least one local hit" check (`isGlobVariantPresent`)
+    // would short-circuit on a partial download — e.g. an interrupted
+    // prior `--glob "*Q4*"` run that fetched one Q4 shard but not the
+    // others would silently exit as "Matched files already downloaded"
+    // and leave the local copy incomplete. CORE_FILES (config.json,
+    // tokenizer.json, …) are still implicitly excluded because they
+    // never match a quantization-variant glob.
+    //
+    // This is manifest-aware, so we pay one extra HuggingFace round-trip
+    // on the hot "already downloaded" path. Correctness wins over the
+    // ~200ms saved — symmetric to the non-glob GGUF completeness check
+    // a few lines above. We cache the manifest into `cachedManifest` so
+    // the post-`ensureDir` block reuses it instead of fetching twice.
     if (hasGguf && globPatterns?.length && isGlobVariantPresent(files, globPatterns)) {
-      console.log('Matched files already downloaded!\n');
-      console.log('To re-download, delete the output directory first:');
-      console.log(`   rm -rf ${outputDir}\n`);
-      return;
+      if (cachedManifest === null) {
+        console.log('Fetching file list from HuggingFace...\n');
+        cachedManifest = await getModelFiles(modelName, HUGGINGFACE_TOKEN, globPatterns);
+      }
+      const remoteBasenames = cachedManifest.allFiles.map((f) => f.path.split('/').pop() ?? f.path);
+      if (isGlobMatchedSetComplete(files, remoteBasenames, globPatterns)) {
+        console.log('Matched files already downloaded!\n');
+        console.log('To re-download, delete the output directory first:');
+        console.log(`   rm -rf ${outputDir}\n`);
+        return;
+      }
+      // Incomplete: fall through to the download loop. The per-file
+      // copy is idempotent (`downloadFileToCacheDir` is content-addressed
+      // and `copyFile` overwrites), so already-present files re-copy
+      // from cache without re-downloading bytes.
+      const missing = cachedManifest.filesToDownload.filter((f) => {
+        const basename = f.path.split('/').pop() ?? f.path;
+        return !files.includes(basename);
+      });
+      if (missing.length > 0) {
+        console.log(`Detected ${missing.length} missing file(s); resuming download...`);
+        for (const f of missing) {
+          console.log(`  ${f.path}${f.size ? ` (${formatBytes(f.size)})` : ''}`);
+        }
+        console.log('');
+      }
     }
   }
 

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -223,6 +223,53 @@ export function isGlobVariantPresent(files: string[], globPatterns: string[]): b
   return files.some((f) => matchesAnyGlob(f, globs));
 }
 
+/**
+ * Pre-flight check: is a no-glob GGUF download complete?
+ *
+ * Returns true ONLY when EVERY `.gguf` file in the remote repo manifest
+ * is also present locally. Returns false otherwise — including the
+ * "this is not a GGUF repo" case (the remote has no `.gguf` files), so
+ * the caller knows to fall through to the normal sharded/single-file
+ * checks rather than mis-routing through the GGUF early-return.
+ *
+ * Why this exists: the previous early-return was `files.some((f) =>
+ * f.endsWith('.gguf'))`, so as soon as ANY `.gguf` was on disk the
+ * command silently exited. For multi-variant GGUF repos that publish
+ * Q2_K, Q3_K_M, Q4_K_M, Q5_K_M, Q6_K, Q8_0 as separate files, an
+ * interrupted prior download that left only Q2_K on disk would short-
+ * circuit a re-run without `--glob` and never fetch the rest. The user
+ * received zero warning that their local copy was incomplete.
+ *
+ * The fix is manifest-aware: compare the local file list against the
+ * remote `.gguf` filenames and only declare "already downloaded" when
+ * every advertised variant is present. Per-file basenames are compared
+ * (the remote manifest uses paths like `models/Q4_K_M.gguf` while local
+ * `readdir` is flat) so nested-prefix repos don't false-negative.
+ *
+ * Pure function: no I/O, no network. Caller fetches the manifest via
+ * `getModelFiles` (or equivalent) and hands the basenames in.
+ */
+export function isGgufRepoComplete(localFiles: string[], remoteFiles: string[]): boolean {
+  // Empty manifest is never complete — and is almost certainly an upstream
+  // error rather than a legitimate empty repo. Falling through to the
+  // download loop will surface the real failure (404 / auth rejection /
+  // network) instead of masking it as "already downloaded".
+  if (remoteFiles.length === 0) return false;
+  const remoteGguf = remoteFiles.filter((f) => f.endsWith('.gguf'));
+  // Not a GGUF repo — caller should route through the normal
+  // `isModelAlreadyDownloaded` (sharded / single-file) path instead.
+  if (remoteGguf.length === 0) return false;
+  const localSet = new Set(localFiles);
+  for (const remote of remoteGguf) {
+    // Remote manifest paths can include prefixes (`models/foo.gguf`);
+    // local `readdir(outputDir)` is flat. Compare basenames so a repo
+    // that publishes under a sub-directory still resolves cleanly.
+    const basename = remote.split('/').pop() ?? remote;
+    if (!localSet.has(basename)) return false;
+  }
+  return true;
+}
+
 async function verifyDownload(outputDir: string, weightFiles: string[]): Promise<boolean> {
   console.log('\nVerifying download...');
 
@@ -322,7 +369,21 @@ export async function run(argv: string[]) {
   }
   console.log(`Output: ${outputDir}\n`);
 
-  // Check if already downloaded
+  // Check if already downloaded.
+  //
+  // For non-GGUF repos the local-only `isModelAlreadyDownloaded` check
+  // is sufficient (single-file safetensors → 1 weight file; sharded →
+  // we parse the index and verify every shard is present). For GGUF
+  // repos the local-only path is wrong: a multi-variant repo (Q2_K,
+  // Q3_K_M, Q4_K_M, Q5_K_M, Q6_K, Q8_0 as separate files) where a
+  // prior interrupted run left only Q2_K on disk would silently exit
+  // as "already downloaded" without ever fetching the rest. So for the
+  // GGUF early-return we hoist the manifest fetch above the check and
+  // require EVERY remote `.gguf` to be present locally before
+  // declaring complete. The trade-off — one extra network round-trip
+  // on the hot "already downloaded" path — is intentional; correctness
+  // wins over the ~200ms saved.
+  let cachedManifest: { totalSize: number; filesToDownload: ListFileEntry[]; allFiles: ListFileEntry[] } | null = null;
   if (existsSync(outputDir)) {
     const files = await readdir(outputDir);
     const hasGguf = files.some((f) => f.endsWith('.gguf'));
@@ -333,10 +394,33 @@ export async function run(argv: string[]) {
       return;
     }
     if (hasGguf && !globPatterns?.length) {
-      console.log('GGUF file(s) already downloaded!\n');
-      console.log('To re-download, delete the output directory first:');
-      console.log(`   rm -rf ${outputDir}\n`);
-      return;
+      // Manifest-aware completeness: only short-circuit when every
+      // remote `.gguf` is present locally. Falling through to the
+      // download loop is safe — `downloadFileToCacheDir` is content-
+      // addressed and the per-file `copyFile` to `outputDir` is
+      // idempotent, so files already on disk re-copy from cache
+      // without re-downloading bytes.
+      console.log('Fetching file list from HuggingFace...\n');
+      cachedManifest = await getModelFiles(modelName, HUGGINGFACE_TOKEN, globPatterns);
+      const remoteBasenames = cachedManifest.allFiles.map((f) => f.path.split('/').pop() ?? f.path);
+      if (isGgufRepoComplete(files, remoteBasenames)) {
+        console.log('GGUF file(s) already downloaded!\n');
+        console.log('To re-download, delete the output directory first:');
+        console.log(`   rm -rf ${outputDir}\n`);
+        return;
+      }
+      // Incomplete: fall through to the download loop. Report which
+      // variants are missing so the user knows what's about to fetch.
+      const missing = cachedManifest.allFiles.filter(
+        (f) => f.path.endsWith('.gguf') && !files.includes(f.path.split('/').pop() ?? f.path),
+      );
+      if (missing.length > 0) {
+        console.log(`Detected ${missing.length} missing GGUF file(s); resuming download...`);
+        for (const f of missing) {
+          console.log(`  ${f.path}${f.size ? ` (${formatBytes(f.size)})` : ''}`);
+        }
+        console.log('');
+      }
     }
     // For glob downloads, only declare "already downloaded" when at least one
     // file actually matches the user's glob. CORE_FILES (config.json,
@@ -354,9 +438,14 @@ export async function run(argv: string[]) {
 
   await ensureDir(outputDir);
 
-  console.log('Fetching file list from HuggingFace...\n');
-
-  const { totalSize, filesToDownload, allFiles } = await getModelFiles(modelName, HUGGINGFACE_TOKEN, globPatterns);
+  // Reuse the manifest fetched during the GGUF completeness check if we
+  // already have it, otherwise fetch fresh. Either way the same shape
+  // is destructured below.
+  if (cachedManifest === null) {
+    console.log('Fetching file list from HuggingFace...\n');
+  }
+  const { totalSize, filesToDownload, allFiles } =
+    cachedManifest ?? (await getModelFiles(modelName, HUGGINGFACE_TOKEN, globPatterns));
 
   if (filesToDownload.length === 0) {
     console.error('No files matched the given criteria.\n');

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -202,6 +202,27 @@ export function isModelAlreadyDownloaded(outputDir: string, files: string[]): bo
   return true;
 }
 
+/**
+ * Pre-flight check: do any files in `outputDir` actually match the user's
+ * glob patterns?
+ *
+ * Returns true ONLY when at least one existing file matches a glob —
+ * proving the requested variant is already on disk. CORE_FILES (config,
+ * tokenizer, etc.) are deliberately excluded: they're auxiliary metadata
+ * laid down by ANY prior download, so counting them would falsely report
+ * a Q4 variant as "already downloaded" the moment a Q8 variant had been
+ * fetched (which already drops config.json + tokenizer.json into the
+ * same directory).
+ *
+ * Pure function: no I/O, no network. Caller passes the file list and
+ * patterns; helper returns boolean.
+ */
+export function isGlobVariantPresent(files: string[], globPatterns: string[]): boolean {
+  if (globPatterns.length === 0) return false;
+  const globs = globPatterns.map(globToRegex);
+  return files.some((f) => matchesAnyGlob(f, globs));
+}
+
 async function verifyDownload(outputDir: string, weightFiles: string[]): Promise<boolean> {
   console.log('\nVerifying download...');
 
@@ -317,16 +338,17 @@ export async function run(argv: string[]) {
       console.log(`   rm -rf ${outputDir}\n`);
       return;
     }
-    // For glob downloads, check if all glob-matched files are present
-    if (hasGguf && globPatterns?.length) {
-      const globs = globPatterns.map(globToRegex);
-      const matchedExisting = files.filter((f) => matchesAnyGlob(f, globs) || CORE_FILES.includes(f));
-      if (matchedExisting.length > 1) {
-        console.log('Matched files already downloaded!\n');
-        console.log('To re-download, delete the output directory first:');
-        console.log(`   rm -rf ${outputDir}\n`);
-        return;
-      }
+    // For glob downloads, only declare "already downloaded" when at least one
+    // file actually matches the user's glob. CORE_FILES (config.json,
+    // tokenizer.json, …) are present after ANY prior download, so they cannot
+    // serve as proof of a specific quantization variant — relying on them was
+    // why first running `--glob "*Q8*"` then `--glob "*Q4*"` used to short-
+    // circuit and never fetch the Q4 weights.
+    if (hasGguf && globPatterns?.length && isGlobVariantPresent(files, globPatterns)) {
+      console.log('Matched files already downloaded!\n');
+      console.log('To re-download, delete the output directory first:');
+      console.log(`   rm -rf ${outputDir}\n`);
+      return;
     }
   }
 

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { copyFile } from 'node:fs/promises';
+import { readdir, copyFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { parseArgs } from 'node:util';
@@ -8,6 +8,7 @@ import { listFiles, whoAmI, downloadFileToCacheDir, type ListFileEntry } from '@
 import { input } from '@inquirer/prompts';
 import { AsyncEntry } from '@napi-rs/keyring';
 
+import { resolveModelsDir } from '../config.js';
 import { ensureDir, formatBytes } from '../utils.js';
 
 const DEFAULT_CACHE_DIR = join(homedir(), '.cache', 'huggingface');
@@ -25,7 +26,8 @@ Usage:
 
 Options:
   -m, --model <name>      HuggingFace model name (default: ${DEFAULT_MODEL})
-  -o, --output <dir>      Output directory (default: .cache/models/<model-slug>)
+  -o, --output <dir>      Output directory (default: ~/.mlx-node/models/<model-slug>;
+                          honors MLX_MODELS_DIR env and ~/.mlx-node/config.json modelsDir)
   -g, --glob <pattern>    Filter files by glob pattern (can be repeated)
   --cache-dir <dir>       HuggingFace cache directory (default: ~/.cache/huggingface)
   -h, --help              Show this help message
@@ -41,7 +43,7 @@ Glob Filtering:
 
 Examples:
   mlx download model
-  mlx download model --model Qwen/Qwen3-1.7B --output .cache/models/qwen3-1.7b
+  mlx download model --model Qwen/Qwen3-1.7B --output ~/.mlx-node/models/qwen3-1.7b
 
   # Download only the BF16 GGUF variant
   mlx download model -m unsloth/Qwen3.5-9B-GGUF -g "*BF16*"
@@ -226,7 +228,7 @@ export async function run(argv: string[]) {
   const modelName = args.model!;
   const globPatterns = args.glob;
   const modelSlug = modelName.split('/').pop()!.toLowerCase();
-  const outputDir = resolve(args.output ?? join('.cache', 'models', modelSlug));
+  const outputDir = resolve(args.output ?? join(resolveModelsDir(), modelSlug));
 
   const HUGGINGFACE_TOKEN = (await keyringEntry.getPassword()) ?? undefined;
 
@@ -248,15 +250,43 @@ export async function run(argv: string[]) {
   }
   console.log(`Output: ${outputDir}\n`);
 
-  // Always fetch the remote file list and diff against what's on disk.
-  // The prior "Model already downloaded!" short-circuit skipped the
-  // network call entirely, so any file added to the HF repo after the
-  // initial download (e.g. Google pushing `chat_template.jinja` to
-  // `google/gemma-4-26B-A4B-it` eleven days ago) stayed missing
-  // locally until the user manually wiped the directory. The
-  // reconciler model — fetch remote, diff, download only absent
-  // entries — makes the command idempotent and cheap to re-run.
+  // Check if already downloaded
+  if (existsSync(outputDir)) {
+    const files = await readdir(outputDir);
+    const hasConfig = files.includes('config.json');
+    const hasSingleModel = files.includes('model.safetensors');
+    const hasShardedModel = files.includes('model.safetensors.index.json');
+    const hasPaddleModel = files.includes('inference.pdiparams');
+    const hasGguf = files.some((f) => f.endsWith('.gguf'));
+    if (hasConfig && (hasSingleModel || hasShardedModel || hasPaddleModel)) {
+      console.log('Model already downloaded!\n');
+      console.log('To re-download, delete the output directory first:');
+      console.log(`   rm -rf ${outputDir}\n`);
+      return;
+    }
+    if (hasGguf && !globPatterns?.length) {
+      console.log('GGUF file(s) already downloaded!\n');
+      console.log('To re-download, delete the output directory first:');
+      console.log(`   rm -rf ${outputDir}\n`);
+      return;
+    }
+    // For glob downloads, check if all glob-matched files are present
+    if (hasGguf && globPatterns?.length) {
+      const globs = globPatterns.map(globToRegex);
+      const matchedExisting = files.filter((f) => matchesAnyGlob(f, globs) || CORE_FILES.includes(f));
+      if (matchedExisting.length > 1) {
+        console.log('Matched files already downloaded!\n');
+        console.log('To re-download, delete the output directory first:');
+        console.log(`   rm -rf ${outputDir}\n`);
+        return;
+      }
+    }
+  }
+
+  await ensureDir(outputDir);
+
   console.log('Fetching file list from HuggingFace...\n');
+
   const { totalSize, filesToDownload, allFiles } = await getModelFiles(modelName, HUGGINGFACE_TOKEN, globPatterns);
 
   if (filesToDownload.length === 0) {
@@ -274,46 +304,7 @@ export async function run(argv: string[]) {
     process.exit(1);
   }
 
-  // Partition the remote file set into "missing locally" vs "already
-  // present". Size-based completeness isn't checked — a half-downloaded
-  // file remains opaque (same behavior as the old code). Users who
-  // suspect corruption should still wipe and re-download.
-  const outputExists = existsSync(outputDir);
-  const missingFiles: ListFileEntry[] = [];
-  let missingSize = 0;
-  if (outputExists) {
-    for (const f of filesToDownload) {
-      const localPath = join(outputDir, f.path);
-      if (!existsSync(localPath)) {
-        missingFiles.push(f);
-        if (f.size) missingSize += f.size;
-      }
-    }
-  } else {
-    missingFiles.push(...filesToDownload);
-    missingSize = totalSize;
-  }
-
-  // Every weight/GGUF file the reconciler considered "expected" —
-  // both the already-present set and anything we'll now fetch — goes
-  // into `weightFiles` so `verifyDownload` confirms the complete
-  // manifest at the end, not just the delta we downloaded this run.
-  const weightFiles: string[] = filesToDownload
-    .filter((f) => f.path.endsWith('.safetensors') || f.path.endsWith('.pdiparams') || f.path.endsWith('.gguf'))
-    .map((f) => f.path);
-
-  if (outputExists && missingFiles.length === 0) {
-    console.log(`Model already up-to-date (${filesToDownload.length} file(s), ${formatBytes(totalSize)}).\n`);
-    console.log('To force a re-download, delete the output directory first:');
-    console.log(`   rm -rf ${outputDir}\n`);
-    return;
-  }
-
-  await ensureDir(outputDir);
-
-  // Show what will actually be fetched, distinguishing a cold
-  // download from a reconcile-run where most of the repo is already
-  // on disk (common after an upstream README / template push).
+  // Show what will be downloaded
   if (globPatterns?.length) {
     console.log(`Matched ${filesToDownload.length} file(s):`);
     for (const f of filesToDownload) {
@@ -322,24 +313,15 @@ export async function run(argv: string[]) {
     console.log('');
   }
 
-  if (outputExists) {
-    const existingCount = filesToDownload.length - missingFiles.length;
-    console.log(
-      `Found ${existingCount}/${filesToDownload.length} file(s) locally; reconciling ${missingFiles.length} missing file(s) (~${formatBytes(missingSize)}).\n`,
-    );
-    for (const f of missingFiles) {
-      console.log(`  + ${f.path}${f.size ? ` (${formatBytes(f.size)})` : ''}`);
-    }
-    console.log('');
-  } else {
-    console.log(`Downloading ${missingFiles.length} file(s) (~${formatBytes(missingSize)})...\n`);
-  }
+  const sizeStr = formatBytes(totalSize);
+  console.log(`Downloading ${filesToDownload.length} file(s) (~${sizeStr})...\n`);
 
   const cacheDir = args['cache-dir'] ? resolve(args['cache-dir']) : DEFAULT_CACHE_DIR;
+  const weightFiles: string[] = [];
 
-  const total = missingFiles.length;
+  const total = filesToDownload.length;
   for (let i = 0; i < total; i++) {
-    const file = missingFiles[i];
+    const file = filesToDownload[i];
     const fileSizeStr = file.size ? formatBytes(file.size) : '';
     console.log(`  [${i + 1}/${total}] ${file.path}${fileSizeStr ? ` (${fileSizeStr})` : ''}...`);
     const snapshotPath = await downloadFileToCacheDir({
@@ -351,14 +333,15 @@ export async function run(argv: string[]) {
     const destPath = join(outputDir, file.path);
     await ensureDir(dirname(destPath));
     await copyFile(snapshotPath, destPath);
+    if (file.path.endsWith('.safetensors') || file.path.endsWith('.pdiparams') || file.path.endsWith('.gguf')) {
+      weightFiles.push(file.path);
+    }
   }
-
-  const actionVerb = outputExists ? 'Reconciled' : 'Download complete';
 
   // For GGUF downloads, skip strict verification (no config.json required in GGUF repos)
   const hasGgufFiles = weightFiles.some((f) => f.endsWith('.gguf'));
   if (hasGgufFiles) {
-    console.log(`\n${actionVerb}: ${weightFiles.length} weight file(s) expected in ${outputDir}\n`);
+    console.log(`\nDownload complete! ${weightFiles.length} file(s) saved to ${outputDir}\n`);
     console.log('To convert GGUF to MLX SafeTensors format:');
     for (const wf of weightFiles) {
       const ggufPath = join(outputDir, wf);
@@ -373,7 +356,7 @@ export async function run(argv: string[]) {
     }
     // Glob filter matched non-weight files (e.g. imatrix, calibration data).
     // Skip model verification — user is downloading auxiliary files.
-    console.log(`\n${actionVerb}: ${filesToDownload.length} non-weight file(s) in ${outputDir}\n`);
+    console.log(`\nDownload complete! ${filesToDownload.length} non-weight file(s) saved to ${outputDir}\n`);
   } else {
     console.log(`Format: Base model (needs MLX conversion)`);
     console.log('Note: After download, convert to MLX format:');
@@ -381,7 +364,7 @@ export async function run(argv: string[]) {
 
     const success = await verifyDownload(outputDir, weightFiles);
     if (success) {
-      console.log(`\nModel ${actionVerb.toLowerCase()} successfully!\n`);
+      console.log('\nModel downloaded successfully!\n');
     } else {
       console.error('\nDownload incomplete. Please try again.\n');
       process.exit(1);

--- a/packages/cli/src/commands/launch-claude/discover.ts
+++ b/packages/cli/src/commands/launch-claude/discover.ts
@@ -1,0 +1,64 @@
+/** Discover locally-downloaded generative models under a given directory. */
+
+import type { Dirent } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+
+import { detectModelType, type ModelType } from '@mlx-node/lm';
+import { LAUNCH_PRESETS, type LaunchPreset } from '@mlx-node/server';
+
+/** A locally-downloaded model paired with its sampling preset. */
+export interface DiscoveredModel {
+  name: string;
+  path: string;
+  modelType: ModelType;
+  preset: LaunchPreset;
+}
+
+// Non-generative detection results that cannot back a chat endpoint.
+const NON_GENERATIVE: ReadonlySet<ModelType> = new Set<ModelType>(['harrier', 'qianfan-ocr', 'internvl_chat']);
+
+/**
+ * Scan `dir` for model subdirectories. Each subdirectory with a recognized
+ * `config.json` is returned with its inferred `ModelType` and `LaunchPreset`.
+ * Non-generative types are silently skipped. Entries with no preset or an
+ * undetectable config are skipped (warnings only emitted when `MLX_DEBUG`
+ * is set). Must stay cheap — do not load weights here.
+ */
+export async function discoverModels(dir: string): Promise<DiscoveredModel[]> {
+  const debug = Boolean(process.env.MLX_DEBUG);
+
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const out: DiscoveredModel[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const full = join(dir, entry.name);
+
+    let modelType: ModelType;
+    try {
+      modelType = await detectModelType(full);
+    } catch (err) {
+      if (debug) console.warn(`[mlx] skip ${full}: ${(err as Error).message}`);
+      continue;
+    }
+
+    if (NON_GENERATIVE.has(modelType)) continue;
+
+    const preset = LAUNCH_PRESETS[modelType];
+    if (!preset) {
+      if (debug) console.warn(`[mlx] skip ${full}: no LAUNCH_PRESETS entry for ${modelType}`);
+      continue;
+    }
+
+    out.push({ name: basename(full), path: full, modelType, preset });
+  }
+
+  out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return out;
+}

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -1,6 +1,7 @@
 /** `mlx launch claude` — start a local Anthropic-compatible server and spawn Claude Code pointed at it. */
 
 import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import { accessSync, constants as fsConstants } from 'node:fs';
 import { createServer as netCreateServer } from 'node:net';
 import { delimiter, join } from 'node:path';
@@ -190,6 +191,7 @@ export async function run(argv: string[]): Promise<void> {
   });
 
   let shuttingDown = false;
+  let childExited = false;
   const shutdown = async (exitCode: number): Promise<void> => {
     if (shuttingDown) return;
     shuttingDown = true;
@@ -209,6 +211,7 @@ export async function run(argv: string[]): Promise<void> {
   };
 
   child.on('exit', (code) => {
+    childExited = true;
     void shutdown(code ?? 0);
   });
   child.on('error', (err) => {
@@ -216,14 +219,38 @@ export async function run(argv: string[]): Promise<void> {
     void shutdown(1);
   });
 
-  const forwardSignal = (sig: NodeJS.Signals): void => {
-    if (shuttingDown) return;
-    child.kill(sig);
-    const timer = setTimeout(() => {
-      if (!child.killed) child.kill('SIGKILL');
-    }, 5000);
-    timer.unref();
-  };
+  const forwardSignal = makeChildKillEscalation({
+    child,
+    isShuttingDown: () => shuttingDown,
+    hasChildExited: () => childExited,
+  });
   process.on('SIGINT', () => forwardSignal('SIGINT'));
   process.on('SIGTERM', () => forwardSignal('SIGTERM'));
+}
+
+/**
+ * Build a signal forwarder that escalates to SIGKILL if the child hasn't
+ * exited within `escalateAfterMs`. Factored out (and exported) so the
+ * escalation logic is unit-testable without spawning a real process.
+ *
+ * Tracks termination via a caller-supplied `hasChildExited` predicate
+ * because `subprocess.killed` flips to true the moment the *signal* is
+ * sent, not when the child terminates — making it useless as an
+ * "is the child gone yet?" check.
+ */
+export function makeChildKillEscalation(opts: {
+  child: Pick<ChildProcess, 'kill'>;
+  isShuttingDown: () => boolean;
+  hasChildExited: () => boolean;
+  escalateAfterMs?: number;
+}): (sig: NodeJS.Signals) => void {
+  const escalateAfterMs = opts.escalateAfterMs ?? 5000;
+  return (sig: NodeJS.Signals): void => {
+    if (opts.isShuttingDown()) return;
+    opts.child.kill(sig);
+    const timer = setTimeout(() => {
+      if (!opts.hasChildExited()) opts.child.kill('SIGKILL');
+    }, escalateAfterMs);
+    timer.unref();
+  };
 }

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -1,0 +1,229 @@
+/** `mlx launch claude` — start a local Anthropic-compatible server and spawn Claude Code pointed at it. */
+
+import { spawn } from 'node:child_process';
+import { accessSync, constants as fsConstants } from 'node:fs';
+import { createServer as netCreateServer } from 'node:net';
+import { delimiter, join } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { loadModel } from '@mlx-node/lm';
+import { createServer } from '@mlx-node/server';
+
+import { resolveMlxNodeHome, resolveModelsDir } from '../../config.js';
+import { discoverModels } from './discover.js';
+import { attachLogger, resolveLogDir, type Logger } from './logger.js';
+import { makeSwapController } from './swap.js';
+
+function printHelp(): void {
+  console.log(`
+Launch Claude Code pointed at a local mlx-node server
+
+Usage:
+  mlx launch claude [options]
+
+Options:
+  --port <n>         Port for the local server (default: auto-pick a free port)
+  --host <h>         Host to bind (default: 127.0.0.1)
+  --models-dir <dir> Directory to discover models from
+                     (default: ~/.mlx-node/models; overridable via
+                     MLX_MODELS_DIR env or ~/.mlx-node/config.json)
+  --model <name>     Which discovered model is bound to Claude Code's
+                     "Custom model" slot (/model menu entry 5). Must
+                     match a directory name under --models-dir.
+                     Defaults to ANTHROPIC_MODEL env, else the first
+                     discovered model (alphabetical).
+  -v, --verbose      Write every HTTP request/response to a log dir for
+                     post-hoc analysis (cache hits, tool calls, SSE chunks)
+  --log-dir <dir>    Override the verbose log directory (implies --verbose).
+                     Default: ~/.mlx-node/logs/<ISO-timestamp>/.
+                     Also honors MLX_LOG_DIR env.
+  -h, --help         Show this help message
+
+  --                 Everything after this separator is forwarded to the
+                     spawned \`claude\` binary verbatim.
+
+Examples:
+  mlx launch claude
+  mlx launch claude --verbose
+  mlx launch claude --log-dir /tmp/mlx-debug
+  mlx launch claude --verbose -- --resume
+  mlx launch claude -- "write a haiku about kv caches"
+`);
+}
+
+async function pickFreePort(): Promise<number> {
+  // Bind to port 0, read the assigned port, close immediately. Racy in theory
+  // (another process could grab the port before we listen), but acceptable
+  // for a developer-local CLI.
+  return await new Promise<number>((resolve, reject) => {
+    const probe = netCreateServer();
+    probe.unref();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address();
+      if (addr && typeof addr === 'object') {
+        const port = addr.port;
+        probe.close(() => resolve(port));
+      } else {
+        probe.close(() => reject(new Error('could not determine free port')));
+      }
+    });
+  });
+}
+
+function findClaudeOnPath(): string | null {
+  const pathEnv = process.env.PATH ?? '';
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, 'claude');
+    try {
+      accessSync(candidate, fsConstants.X_OK);
+      return candidate;
+    } catch {
+      /* not here */
+    }
+  }
+  return null;
+}
+
+export async function run(argv: string[]): Promise<void> {
+  const parsed = parseArgs({
+    args: argv,
+    options: {
+      port: { type: 'string' },
+      host: { type: 'string' },
+      'models-dir': { type: 'string' },
+      model: { type: 'string' },
+      verbose: { type: 'boolean', short: 'v', default: false },
+      'log-dir': { type: 'string' },
+      help: { type: 'boolean', short: 'h', default: false },
+    },
+    allowPositionals: true,
+  });
+  const args = parsed.values;
+  const claudeArgs = parsed.positionals;
+
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const modelsDir = resolveModelsDir(args['models-dir']);
+  const discovered = await discoverModels(modelsDir);
+  if (discovered.length === 0) {
+    console.error(`No models discovered under ${modelsDir}.`);
+    console.error('Run: mlx download model --model Qwen/Qwen3.5-9B');
+    process.exit(1);
+  }
+
+  // Which discovered model becomes Claude Code's "Custom model" slot.
+  // Precedence: --model flag > ANTHROPIC_MODEL env > discovered[0] (alphabetical).
+  const requestedModel = args.model ?? process.env.ANTHROPIC_MODEL;
+  const defaultModel = requestedModel != null ? discovered.find((m) => m.name === requestedModel) : undefined;
+  if (requestedModel != null && !defaultModel) {
+    console.error(`Model "${requestedModel}" not found under ${modelsDir}.`);
+    console.error('Discovered models:');
+    for (const m of discovered) console.error(`  - ${m.name}`);
+    process.exit(1);
+  }
+  const boundModel = defaultModel ?? discovered[0];
+
+  const portArg = args.port != null ? Number(args.port) : undefined;
+  if (portArg !== undefined && (!Number.isInteger(portArg) || portArg <= 0)) {
+    console.error(`Invalid --port: ${String(args.port)}`);
+    process.exit(1);
+  }
+  const port = portArg ?? (await pickFreePort());
+  const host = args.host ?? '127.0.0.1';
+
+  const claudeBin = findClaudeOnPath();
+  if (!claudeBin) {
+    console.error('Could not find `claude` on PATH.');
+    console.error('Install Claude Code: https://docs.claude.com/en/docs/claude-code/quickstart');
+    process.exit(1);
+  }
+
+  // The swap controller needs the registry from the server instance, but the
+  // server needs the controller's callbacks at construction. Bridge via a
+  // late-bound holder: the callbacks capture `ctrlRef.current` by closure.
+  const ctrlRef: { current: ReturnType<typeof makeSwapController> | null } = { current: null };
+  const server = await createServer({
+    port,
+    host,
+    resolveModel: (name) => ctrlRef.current!.resolveModel(name),
+    listModels: () => ctrlRef.current!.listModels(),
+  });
+  ctrlRef.current = makeSwapController(discovered, server.registry, loadModel, boundModel.name);
+
+  // Verbose logging: attach AFTER `createServer` so we wrap every
+  // incoming request (including `GET /v1/models` which claude fires
+  // on startup). `--log-dir` implies `--verbose`.
+  const verbose = args.verbose || args['log-dir'] != null || process.env.MLX_LOG_DIR != null;
+  let logger: Logger | null = null;
+  if (verbose) {
+    const logDir = resolveLogDir(args['log-dir'], resolveMlxNodeHome());
+    logger = attachLogger(server.server, logDir);
+  }
+
+  console.log(
+    `[mlx] models dir: ${modelsDir} | listening on http://${host}:${port} | discovered ${discovered.length} model(s) | default: ${boundModel.name}`,
+  );
+  if (logger) {
+    console.log(`[mlx] verbose logging → ${logger.logDir}`);
+    console.log(`[mlx] tail -f "${join(logger.logDir, 'session.log')}"`);
+  }
+
+  const child = spawn(claudeBin, claudeArgs, {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ANTHROPIC_BASE_URL: `http://${host}:${port}`,
+      ANTHROPIC_AUTH_TOKEN: 'mlx-node-local',
+      ANTHROPIC_MODEL: boundModel.name,
+      // NOTE: intentionally NOT setting ANTHROPIC_SMALL_FAST_MODEL /
+      // ANTHROPIC_DEFAULT_HAIKU_MODEL. Claude Code falls back to
+      // `claude-haiku-*` for subagents + title generation; the swap
+      // controller aliases any unknown name to the current resident
+      // so those calls always follow whatever model the user picked
+      // via `/model`.
+    },
+  });
+
+  let shuttingDown = false;
+  const shutdown = async (exitCode: number): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    if (logger) {
+      try {
+        await logger.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      await server.close();
+    } catch {
+      /* ignore */
+    }
+    process.exit(exitCode);
+  };
+
+  child.on('exit', (code) => {
+    void shutdown(code ?? 0);
+  });
+  child.on('error', (err) => {
+    console.error(`[mlx] failed to spawn claude: ${err.message}`);
+    void shutdown(1);
+  });
+
+  const forwardSignal = (sig: NodeJS.Signals): void => {
+    if (shuttingDown) return;
+    child.kill(sig);
+    const timer = setTimeout(() => {
+      if (!child.killed) child.kill('SIGKILL');
+    }, 5000);
+    timer.unref();
+  };
+  process.on('SIGINT', () => forwardSignal('SIGINT'));
+  process.on('SIGTERM', () => forwardSignal('SIGTERM'));
+}

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -4,6 +4,7 @@ import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { accessSync, constants as fsConstants } from 'node:fs';
 import { createServer as netCreateServer } from 'node:net';
+import { constants as osConstants } from 'node:os';
 import { delimiter, join } from 'node:path';
 import { parseArgs } from 'node:util';
 
@@ -210,9 +211,9 @@ export async function run(argv: string[]): Promise<void> {
     process.exit(exitCode);
   };
 
-  child.on('exit', (code) => {
+  child.on('exit', (code, signal) => {
     childExited = true;
-    void shutdown(code ?? 0);
+    void shutdown(computeExitCode(code, signal));
   });
   child.on('error', (err) => {
     console.error(`[mlx] failed to spawn claude: ${err.message}`);
@@ -226,6 +227,37 @@ export async function run(argv: string[]): Promise<void> {
   });
   process.on('SIGINT', () => forwardSignal('SIGINT'));
   process.on('SIGTERM', () => forwardSignal('SIGTERM'));
+}
+
+/**
+ * Map Node's `child.on('exit', (code, signal))` callback args onto a single
+ * shell-style exit code.
+ *
+ * Background: Node delivers `code === null && signal !== null` whenever the
+ * child terminated due to a signal. The previous handler ignored `signal`
+ * and coerced `null → 0`, so a SIGINT/SIGTERM/SIGKILL'd `claude` would
+ * report success — CI jobs treating exit code as "did the run pass" got a
+ * false green even when the process was killed. POSIX convention is
+ * `128 + signal_number` for signal-killed processes; we look the number up
+ * in `os.constants.signals` (Node exposes the standard signals there).
+ *
+ * Falls back to `1` for the genuinely-unknown cases:
+ *   - `(null, null)` — should never happen per Node's docs.
+ *   - `(null, <signal not in os.constants.signals>)` — defensive, in case a
+ *     non-standard or platform-specific signal name reaches us.
+ *
+ * Exported purely for unit testing — the real `child.on('exit', ...)` callback
+ * delegates straight to this helper.
+ */
+export function computeExitCode(code: number | null, signal: NodeJS.Signals | null): number {
+  if (code != null) return code;
+  if (signal != null) {
+    const signals = osConstants.signals as Record<string, number | undefined>;
+    const num = signals[signal];
+    if (typeof num === 'number') return 128 + num;
+    return 1;
+  }
+  return 1;
 }
 
 /**

--- a/packages/cli/src/commands/launch-claude/logger.ts
+++ b/packages/cli/src/commands/launch-claude/logger.ts
@@ -1,0 +1,187 @@
+/**
+ * Request/response logger for `mlx launch claude --verbose`.
+ *
+ * Each HTTP turn is written as one line of newline-delimited JSON to
+ * `requests.ndjson`. Streaming responses capture every chunk written
+ * to the socket so SSE events land verbatim — enough to audit cache
+ * hits (`x-session-cache` header), tool-call round-trips, and the
+ * model's token-level output post-hoc.
+ *
+ * `session.log` is the human-readable companion: one line per request
+ * arrival and completion, for `tail -f` during a live session.
+ */
+
+import { Buffer } from 'node:buffer';
+import { createWriteStream, mkdirSync } from 'node:fs';
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { join } from 'node:path';
+
+export interface Logger {
+  /** Absolute log directory in use. */
+  readonly logDir: string;
+  /** Flush and close the underlying streams. Safe to call multiple times. */
+  close(): Promise<void>;
+}
+
+/**
+ * Attach request/response capture to `server`. The caller is responsible
+ * for calling `close()` before `server.close()` completes so the tail of
+ * the streams is flushed to disk.
+ */
+export function attachLogger(server: Server, logDir: string): Logger {
+  mkdirSync(logDir, { recursive: true });
+
+  const reqLog = createWriteStream(join(logDir, 'requests.ndjson'), { flags: 'a' });
+  const pretty = createWriteStream(join(logDir, 'session.log'), { flags: 'a' });
+
+  const writePretty = (line: string): void => {
+    try {
+      pretty.write(`${new Date().toISOString()} ${line}\n`);
+    } catch {
+      /* never let logging failure break serving */
+    }
+  };
+
+  writePretty(`[logging] writing to ${logDir}`);
+  writePretty(`[logging]   requests.ndjson  — one JSON line per HTTP turn (full body in/out, SSE chunks)`);
+  writePretty(`[logging]   session.log      — human-readable chronological trace`);
+
+  // Node's http.Server multicasts request events — our listener fires
+  // alongside the createServer handler. Dedupe in case the same
+  // request ever re-enters (paranoia; it shouldn't).
+  const seen = new WeakSet<IncomingMessage>();
+
+  // Prepend so our listener runs BEFORE the main handler. This is
+  // what lets the write/end wrappers land before any synchronous
+  // response path writes — a sync handler (easy to hit in tests)
+  // would otherwise miss the wrap entirely.
+  server.prependListener('request', (req: IncomingMessage, res: ServerResponse) => {
+    if (seen.has(req)) return;
+    seen.add(req);
+
+    const start = Date.now();
+    const rid = `${start.toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+    writePretty(`[req ${rid}] ${req.method ?? '?'} ${req.url ?? '?'}`);
+
+    let reqBody = '';
+    req.on('data', (chunk: Buffer) => {
+      reqBody += chunk.toString('utf8');
+    });
+
+    // Wrap res.write / res.end to capture streamed chunks (SSE + regular).
+    // Preserve original method semantics — we only observe, never transform.
+    const chunks: string[] = [];
+    const origWrite = res.write.bind(res);
+    const origEnd = res.end.bind(res);
+
+    // biome-ignore lint/suspicious/noExplicitAny: capture wrapper
+    (res as any).write = (chunk: unknown, ...rest: unknown[]): boolean => {
+      if (chunk != null) {
+        try {
+          chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Uint8Array).toString('utf8'));
+        } catch {
+          /* ignore */
+        }
+      }
+      return (origWrite as (...a: unknown[]) => boolean)(chunk, ...rest);
+    };
+
+    // biome-ignore lint/suspicious/noExplicitAny: capture wrapper
+    (res as any).end = (chunk: unknown, ...rest: unknown[]): ServerResponse => {
+      if (chunk != null) {
+        try {
+          chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Uint8Array).toString('utf8'));
+        } catch {
+          /* ignore */
+        }
+      }
+      return (origEnd as (...a: unknown[]) => ServerResponse)(chunk, ...rest);
+    };
+
+    // Write the NDJSON entry when BOTH the request body has been fully
+    // consumed (`req.on('end')`) AND the response has fully flushed
+    // (`res.on('finish')`). Necessary because a synchronous handler can
+    // call `res.end()` before our `req.on('data')` listener has seen
+    // any chunks — the stream was set flowing on `.on('data', ...)`
+    // but the chunks deliver in a later tick.
+    let reqDone = false;
+    let resDone = false;
+    let emitted = false;
+    const tryEmit = (): void => {
+      if (emitted || !reqDone || !resDone) return;
+      emitted = true;
+      const resBody = chunks.join('');
+      const entry = {
+        rid,
+        t: new Date(start).toISOString(),
+        method: req.method,
+        path: req.url,
+        reqHeaders: req.headers,
+        reqBody: reqBody || null,
+        status: res.statusCode,
+        resHeaders: res.getHeaders(),
+        resBody,
+        elapsedMs: Date.now() - start,
+      };
+      try {
+        reqLog.write(`${JSON.stringify(entry)}\n`);
+      } catch {
+        /* never block the response */
+      }
+      writePretty(
+        `[req ${rid}] ${res.statusCode} ${req.method ?? '?'} ${req.url ?? '?'} ${entry.elapsedMs}ms ${resBody.length}B`,
+      );
+    };
+    req.on('end', () => {
+      reqDone = true;
+      tryEmit();
+    });
+    req.on('close', () => {
+      // Client may drop the body mid-flight; emit whatever we have.
+      reqDone = true;
+      tryEmit();
+    });
+    res.on('finish', () => {
+      resDone = true;
+      tryEmit();
+    });
+    res.on('close', () => {
+      if (!res.writableEnded) {
+        writePretty(`[req ${rid}] aborted (client close) after ${Date.now() - start}ms`);
+      }
+      // Abort path: treat as done so we still emit what we captured.
+      resDone = true;
+      tryEmit();
+    });
+  });
+
+  let closed = false;
+  return {
+    logDir,
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      await Promise.all([
+        new Promise<void>((resolve) => reqLog.end(resolve)),
+        new Promise<void>((resolve) => pretty.end(resolve)),
+      ]);
+    },
+  };
+}
+
+/**
+ * Resolve the log directory for a verbose launch.
+ *
+ * Order: explicit `--log-dir` > `MLX_LOG_DIR` env > a fresh timestamped
+ * directory under `<mlxNodeHome>/logs/`. The timestamped default gives
+ * each launch its own dir so concurrent / sequential runs don't
+ * interleave into one file.
+ */
+export function resolveLogDir(explicit: string | undefined, mlxNodeHome: string): string {
+  if (explicit) return explicit;
+  const envDir = process.env.MLX_LOG_DIR;
+  if (envDir) return envDir;
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return join(mlxNodeHome, 'logs', stamp);
+}

--- a/packages/cli/src/commands/launch-claude/swap.ts
+++ b/packages/cli/src/commands/launch-claude/swap.ts
@@ -86,17 +86,65 @@ export function makeSwapController(
       // window yields a spurious 404. Instead we carry the alias set
       // across the swap and re-point them to the new resident below,
       // so the name always resolves to *some* live instance.
+      const oldResident = resident;
       const carriedAliases = new Set(aliases);
-      if (resident && resident.name !== targetEntry.name) {
+      if (oldResident && oldResident.name !== targetEntry.name) {
+        // Drop our local alias bookkeeping AND the old resident's primary
+        // name binding, but leave the alias *names* in the registry pointed
+        // at the old model — they hold the only refcount preventing GC,
+        // and an in-flight `registry.get(alias)` must keep resolving to
+        // *some* live instance until the new model is in hand.
         aliases.clear();
-        registry.unregister(resident.name);
+        registry.unregister(oldResident.name);
         resident = null;
       }
 
-      // Ensure the target is resident.
+      // Ensure the target is resident. If the load throws, restore the
+      // pre-swap controller state so future swap attempts know about the
+      // aliases we just cleared — otherwise the alias *names* stay bound
+      // in the registry to the old model object forever (alias bindings
+      // hold their own refcount), but the controller forgets they exist
+      // and never repoints them, leaving alias-routed traffic permanently
+      // pinned to a stale model.
       let instance = registry.get(targetEntry.name);
       if (!instance) {
-        const loaded = await loadModelFn(targetEntry.path);
+        let loaded: LoadableModel;
+        try {
+          loaded = await loadModelFn(targetEntry.path);
+        } catch (err) {
+          // Recovery: re-populate the controller's alias set so the next
+          // resolveModel call still owns them. The alias→old-model bindings
+          // are still live in the registry (we never unregistered them), so
+          // we can recover the old model object via any surviving alias and
+          // re-bind the old resident's primary name.
+          //
+          // If `carriedAliases` is empty (no aliases ever existed) AND we
+          // unregistered `oldResident.name`, the binding's refcount may have
+          // hit zero and the model is gone. There's nothing the controller
+          // can do to recover in that case — the user will need to /model-
+          // pick again. This is acceptable: alias-less load failures are
+          // rare, and the user-facing symptom is "prior model gone, please
+          // re-pick", not silently-wrong responses.
+          for (const aliasName of carriedAliases) aliases.add(aliasName);
+          if (oldResident) {
+            let oldInstance: SessionCapableModel | undefined;
+            for (const aliasName of carriedAliases) {
+              const probe = registry.get(aliasName);
+              if (probe) {
+                oldInstance = probe;
+                break;
+              }
+            }
+            if (oldInstance) {
+              const oldEntry = byName.get(oldResident.name);
+              registry.register(oldResident.name, oldInstance, {
+                samplingDefaults: oldEntry?.preset.sampling,
+              });
+              resident = oldResident;
+            }
+          }
+          throw err;
+        }
         instance = loaded as unknown as SessionCapableModel;
         registry.register(targetEntry.name, instance, {
           samplingDefaults: targetEntry.preset.sampling,

--- a/packages/cli/src/commands/launch-claude/swap.ts
+++ b/packages/cli/src/commands/launch-claude/swap.ts
@@ -1,0 +1,139 @@
+/**
+ * Single-resident lazy-load policy for `mlx launch claude`.
+ *
+ * The launch command discovers every local model up-front but loads at most
+ * one into the `ModelRegistry` at a time. Switching models (e.g. via Claude
+ * Code's `/model` picker) unregisters the previous instance, letting GC +
+ * native destructors reclaim memory, before loading the new one.
+ */
+
+import type { LoadableModel, SessionCapableModel } from '@mlx-node/lm';
+import type { ModelRegistry, PublicModelEntry } from '@mlx-node/server';
+
+import type { DiscoveredModel } from './discover.js';
+
+export interface SwapController {
+  resolveModel: (name: string) => Promise<void>;
+  listModels: () => PublicModelEntry[];
+}
+
+/**
+ * Build the `resolveModel` + `listModels` callbacks for the handler.
+ *
+ * `loadModelFn` is injected so tests can stub it without touching native code.
+ * The controller serializes every `resolveModel` invocation on a single
+ * promise chain so two concurrent requests for different-but-currently-
+ * unloaded models cannot race on the native compiled-path globals.
+ */
+export function makeSwapController(
+  discovered: DiscoveredModel[],
+  registry: ModelRegistry,
+  loadModelFn: (path: string) => Promise<LoadableModel>,
+  defaultName?: string,
+): SwapController {
+  const byName = new Map<string, DiscoveredModel>();
+  for (const entry of discovered) byName.set(entry.name, entry);
+
+  const ordered = [...discovered].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  // Which entry unknown names (haiku subagent dispatches, etc.) fall back
+  // to before anything is resident. Defaults to discovered[0], but the
+  // caller can pin it to the user's `--model` pick so the first haiku
+  // title-gen doesn't trigger a load of the alphabetically-first model
+  // followed by an immediate swap to the user's real choice.
+  const fallbackEntry = (defaultName != null ? byName.get(defaultName) : undefined) ?? discovered[0];
+
+  let resident: { name: string } | null = null;
+  // Names we registered as aliases to the current resident (e.g.
+  // Claude Code's hardcoded `claude-haiku-*` for subagent dispatches /
+  // title generation). Tracked so we can unregister them on `/model`
+  // swap — otherwise an alias's refcount would keep the old binding
+  // alive past the user's swap.
+  const aliases = new Set<string>();
+  let currentOp: Promise<unknown> = Promise.resolve();
+
+  async function resolveModel(name: string): Promise<void> {
+    // Fast path: already registered under this name (either as a real
+    // resident or as an alias we previously installed). Avoid chaining.
+    if (registry.get(name)) return;
+
+    // Pick the discovered entry to resolve against. If the requested
+    // name matches a discovered model, use it. Otherwise (unknown
+    // name — Claude Code's hardcoded small-fast-model, etc.) fall
+    // through to the current resident so subagent dispatches don't
+    // 404, loading discovered[0] on first boot if nothing is resident
+    // yet.
+    const knownEntry = byName.get(name);
+    const targetEntry = knownEntry ?? (resident ? (byName.get(resident.name) ?? fallbackEntry) : fallbackEntry);
+    const isAlias = targetEntry.name !== name;
+
+    const next = currentOp.then(async () => {
+      // Re-check under the serialized section — a prior waiter may have loaded it.
+      if (registry.get(name)) return;
+
+      // Swap out any stale resident that isn't the target.
+      //
+      // We do NOT unregister the aliases here: in-flight messages.ts
+      // requests may be microtask-racing between "resolveModel returned"
+      // and "registry.get(body.model)" and dropping the alias in that
+      // window yields a spurious 404. Instead we carry the alias set
+      // across the swap and re-point them to the new resident below,
+      // so the name always resolves to *some* live instance.
+      const carriedAliases = new Set(aliases);
+      if (resident && resident.name !== targetEntry.name) {
+        aliases.clear();
+        registry.unregister(resident.name);
+        resident = null;
+      }
+
+      // Ensure the target is resident.
+      let instance = registry.get(targetEntry.name);
+      if (!instance) {
+        const loaded = await loadModelFn(targetEntry.path);
+        instance = loaded as unknown as SessionCapableModel;
+        registry.register(targetEntry.name, instance, {
+          samplingDefaults: targetEntry.preset.sampling,
+        });
+        resident = { name: targetEntry.name };
+      } else if (!resident) {
+        resident = { name: targetEntry.name };
+      }
+
+      // Re-point any aliases carried across the swap onto the new
+      // resident. `registry.register(sameName, differentModel)` drops
+      // the old binding's refcount and installs the new one atomically,
+      // so any concurrent `registry.get(alias)` either sees the old or
+      // new instance — never null.
+      for (const aliasName of carriedAliases) {
+        if (aliasName === targetEntry.name) continue;
+        registry.register(aliasName, instance, {
+          samplingDefaults: targetEntry.preset.sampling,
+        });
+        aliases.add(aliasName);
+      }
+
+      // For unknown names, register an alias on the resident instance so
+      // the endpoint's `registry.get(name)` lookup succeeds.
+      if (isAlias) {
+        registry.register(name, instance, {
+          samplingDefaults: targetEntry.preset.sampling,
+        });
+        aliases.add(name);
+      }
+    });
+    currentOp = next.catch(() => undefined);
+    await next;
+  }
+
+  function listModels(): PublicModelEntry[] {
+    const created = Math.floor(Date.now() / 1000);
+    return ordered.map((entry) => ({
+      id: entry.name,
+      object: 'model',
+      created,
+      owned_by: 'mlx-node',
+    }));
+  }
+
+  return { resolveModel, listModels };
+}

--- a/packages/cli/src/commands/launch-claude/swap.ts
+++ b/packages/cli/src/commands/launch-claude/swap.ts
@@ -57,19 +57,26 @@ export function makeSwapController(
     // resident or as an alias we previously installed). Avoid chaining.
     if (registry.get(name)) return;
 
-    // Pick the discovered entry to resolve against. If the requested
-    // name matches a discovered model, use it. Otherwise (unknown
-    // name — Claude Code's hardcoded small-fast-model, etc.) fall
-    // through to the current resident so subagent dispatches don't
-    // 404, loading discovered[0] on first boot if nothing is resident
-    // yet.
-    const knownEntry = byName.get(name);
-    const targetEntry = knownEntry ?? (resident ? (byName.get(resident.name) ?? fallbackEntry) : fallbackEntry);
-    const isAlias = targetEntry.name !== name;
-
     const next = currentOp.then(async () => {
       // Re-check under the serialized section — a prior waiter may have loaded it.
       if (registry.get(name)) return;
+
+      // Pick the discovered entry to resolve against. If the requested
+      // name matches a discovered model, use it. Otherwise (unknown
+      // name — Claude Code's hardcoded small-fast-model, etc.) fall
+      // through to the current resident so subagent dispatches don't
+      // 404, loading discovered[0] on first boot if nothing is resident
+      // yet.
+      //
+      // CRITICAL: this must read `resident` at RUN time, not QUEUE time.
+      // If we capture it before chaining onto `currentOp`, a swap that
+      // ran ahead of us will leave us with a stale target — e.g. a haiku
+      // alias request that arrived during a `/model a → b` switch would
+      // capture `targetEntry = a`, then re-bind itself to `a` and undo
+      // the user's switch when its turn finally comes around.
+      const knownEntry = byName.get(name);
+      const targetEntry = knownEntry ?? (resident ? (byName.get(resident.name) ?? fallbackEntry) : fallbackEntry);
+      const isAlias = targetEntry.name !== name;
 
       // Swap out any stale resident that isn't the target.
       //

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared `$HOME/.mlx-node` layout helpers. Drives both `mlx download model`
+ * (output destination) and `mlx launch claude` (model discovery root).
+ */
+
+import { mkdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/** Absolute path to `$HOME/.mlx-node`. Used for `config.json` lookup and as the default parent of `models/`. */
+export function resolveMlxNodeHome(): string {
+  return join(homedir(), '.mlx-node');
+}
+
+/**
+ * Resolve the directory where downloaded models live.
+ *
+ * Resolution order:
+ *   1. `explicit` arg (non-empty)
+ *   2. `MLX_MODELS_DIR` env var
+ *   3. `modelsDir` field in `$HOME/.mlx-node/config.json`
+ *   4. `$HOME/.mlx-node/models`
+ *
+ * Creates the chosen directory (recursive) before returning.
+ */
+export function resolveModelsDir(explicit?: string): string {
+  if (explicit && explicit.length > 0) {
+    return ensureDir(resolve(explicit));
+  }
+
+  const envDir = process.env.MLX_MODELS_DIR;
+  if (envDir && envDir.length > 0) {
+    return ensureDir(resolve(envDir));
+  }
+
+  const configPath = join(resolveMlxNodeHome(), 'config.json');
+  const fromConfig = readModelsDirFromConfig(configPath);
+  if (fromConfig) {
+    return ensureDir(resolve(fromConfig));
+  }
+
+  return ensureDir(join(resolveMlxNodeHome(), 'models'));
+}
+
+function readModelsDirFromConfig(configPath: string): string | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, 'utf-8');
+  } catch {
+    // Missing / unreadable file: fall through to default.
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { modelsDir?: unknown };
+    if (typeof parsed.modelsDir === 'string' && parsed.modelsDir.length > 0) {
+      return parsed.modelsDir;
+    }
+    return undefined;
+  } catch {
+    console.warn(`[mlx] warning: malformed JSON in ${configPath}; falling back to default models dir`);
+    return undefined;
+  }
+}
+
+function ensureDir(path: string): string {
+  mkdirSync(path, { recursive: true });
+  return path;
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,5 +9,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../lm" }, { "path": "../server" }]
 }

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -520,10 +520,22 @@ export async function handleCreateMessage(
   // the disabled sweeper, so the bracket is unconditional whenever
   // a sweeper is supplied.
   if (resolveModel) {
-    if (idleSweeper) {
-      await idleSweeper.withSuspendedDrains(() => resolveModel(body.model));
-    } else {
-      await resolveModel(body.model);
+    // A throw here (bad model path, corrupt weights, native loader failure)
+    // would otherwise bubble up to the outer `createHandler` catch which
+    // emits the OpenAI-shape `{ error: ... }` envelope via `sendInternalError`.
+    // This endpoint is Anthropic; clients parse the
+    // `{ type: 'error', error: { type, message } }` shape, so we must
+    // serialize the failure through `sendAnthropicInternalError` here. Mirrors
+    // the `mapAnthropicRequest` try/catch above.
+    try {
+      if (idleSweeper) {
+        await idleSweeper.withSuspendedDrains(() => resolveModel(body.model));
+      } else {
+        await resolveModel(body.model);
+      }
+    } catch (err) {
+      sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to resolve model');
+      return;
     }
   }
 

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -485,6 +485,24 @@ export async function handleCreateMessage(
     }
   }
 
+  // Run the Anthropic→internal mapping BEFORE the lazy-load hook.
+  //
+  // Background: in `mlx launch claude` mode `resolveModel` may load a
+  // 27GB model from disk (~30s) on first sight of an unknown name. If
+  // we then fail mapping (unsupported role, malformed tool block, etc.)
+  // we've burned a load — and possibly evicted the currently-resident
+  // model — just to return 400 a moment later. Mapping is a pure
+  // transform with no side effects, so it's safe to hoist above
+  // resolveModel and use as a cheap pre-flight gate.
+  let mappedMessages: ChatMessage[];
+  let mappedConfig: ChatConfig;
+  try {
+    ({ messages: mappedMessages, config: mappedConfig } = mapAnthropicRequest(body));
+  } catch (err) {
+    sendAnthropicBadRequest(res, err instanceof Error ? err.message : 'Invalid request');
+    return;
+  }
+
   // Lazy-load hook: give the host a chance to register the requested
   // model before we look it up. Errors bubble up to the handler's
   // top-level catch which returns 500.
@@ -557,14 +575,11 @@ export async function handleCreateMessage(
     // downstream to catch the race later.
     const preLockInstanceId: number = lease.instanceId;
 
-    let messages: ChatMessage[];
-    let config: ChatConfig;
-    try {
-      ({ messages, config } = mapAnthropicRequest(body));
-    } catch (err) {
-      sendAnthropicBadRequest(res, err instanceof Error ? err.message : 'Invalid request');
-      return;
-    }
+    // `mapAnthropicRequest` already ran (and succeeded) above as a cheap
+    // pre-flight gate before `resolveModel` so a malformed request can't
+    // trigger a multi-second model load just to 400 a moment later.
+    const messages: ChatMessage[] = mappedMessages;
+    const config: ChatConfig = mappedConfig;
 
     // Canonicalize every assistant fan-out's trailing tool block against its
     // declared sibling order. Several native session backends pair tool results

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -459,6 +459,7 @@ export async function handleCreateMessage(
   registry: ModelRegistry,
   httpReq?: IncomingMessage,
   idleSweeper?: IdleSweeper | null,
+  resolveModel?: (name: string) => Promise<void>,
 ): Promise<void> {
   if (body == null || typeof body !== 'object') {
     sendAnthropicBadRequest(res, 'Request body must be a JSON object');
@@ -482,6 +483,13 @@ export async function handleCreateMessage(
       sendAnthropicBadRequest(res, 'Each message must be a non-null object');
       return;
     }
+  }
+
+  // Lazy-load hook: give the host a chance to register the requested
+  // model before we look it up. Errors bubble up to the handler's
+  // top-level catch which returns 500.
+  if (resolveModel) {
+    await resolveModel(body.model);
   }
 
   const model = registry.get(body.model);

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -506,8 +506,25 @@ export async function handleCreateMessage(
   // Lazy-load hook: give the host a chance to register the requested
   // model before we look it up. Errors bubble up to the handler's
   // top-level catch which returns 500.
+  //
+  // The load is bracketed by `idleSweeper.withSuspendedDrains` so the
+  // post-request drain timer armed by the PREVIOUS request's
+  // `endRequest()` cannot fire mid-load. In `mlx launch claude` mode
+  // `resolveModel` may invoke a 30s `loadModel()` on first sight of an
+  // unknown name; if the prior request's matching `endRequest()`
+  // armed the default 30s drain immediately before this load began,
+  // the timer would otherwise call `clearCache()` while weight
+  // materialization was still allocating through the Metal free pool —
+  // exactly the hot-load race `withSuspendedDrains` exists to prevent.
+  // The wrapper handles try/finally itself and is a pass-through on
+  // the disabled sweeper, so the bracket is unconditional whenever
+  // a sweeper is supplied.
   if (resolveModel) {
-    await resolveModel(body.model);
+    if (idleSweeper) {
+      await idleSweeper.withSuspendedDrains(() => resolveModel(body.model));
+    } else {
+      await resolveModel(body.model);
+    }
   }
 
   const model = registry.get(body.model);

--- a/packages/server/src/endpoints/models.ts
+++ b/packages/server/src/endpoints/models.ts
@@ -2,10 +2,15 @@
 
 import type { ServerResponse } from 'node:http';
 
+import type { PublicModelEntry } from '../handler.js';
 import type { ModelRegistry } from '../registry.js';
 
-export function handleListModels(res: ServerResponse, registry: ModelRegistry): void {
-  const models = registry.list();
+export function handleListModels(
+  res: ServerResponse,
+  registry: ModelRegistry,
+  listModels?: () => PublicModelEntry[],
+): void {
+  const models = listModels ? listModels() : registry.list();
   const body = {
     object: 'list',
     data: models,

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -9,6 +9,19 @@ import type { IdleSweeper } from './idle-sweeper.js';
 import type { ModelRegistry } from './registry.js';
 import { routeRequest } from './router.js';
 
+/**
+ * Entry in the list returned by `GET /v1/models`. Matches the shape
+ * `ModelRegistry.list()` produces — exported so callers that supply a
+ * custom `listModels` callback (e.g. `mlx launch claude` discovering
+ * every model on disk) can build entries without importing internals.
+ */
+export interface PublicModelEntry {
+  id: string;
+  object: 'model';
+  created: number;
+  owned_by: string;
+}
+
 export interface HandlerOptions {
   /** Enable CORS headers (default: true). */
   cors?: boolean;
@@ -31,6 +44,18 @@ export interface HandlerOptions {
    * traffic keep the allocator pinned forever.
    */
   idleSweeper?: IdleSweeper | null;
+  /**
+   * Optional async callback invoked by `/v1/messages` before it looks
+   * the model up in the registry. The callback should register the
+   * model on demand; on return, the endpoint does `registry.get(name)`
+   * and 404s if still unresolved.
+   */
+  resolveModel?: (name: string) => Promise<void>;
+  /**
+   * Optional override for `GET /v1/models`. When provided, that endpoint
+   * returns this list instead of `registry.list()`.
+   */
+  listModels?: () => PublicModelEntry[];
 }
 
 export function createHandler(
@@ -41,6 +66,8 @@ export function createHandler(
   const store = options?.store ?? null;
   const responseRetentionSec = options?.responseRetentionSec;
   const idleSweeper = options?.idleSweeper ?? null;
+  const resolveModel = options?.resolveModel;
+  const listModels = options?.listModels;
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     if (cors) {
@@ -59,7 +86,7 @@ export function createHandler(
     // post-`res.end()` bookkeeping (e.g. `SessionRegistry.adopt`). `http.createServer`
     // ignores the return value, so this is transparent to production callers.
     try {
-      await routeRequest(req, res, registry, store, responseRetentionSec, idleSweeper);
+      await routeRequest(req, res, registry, store, responseRetentionSec, idleSweeper, resolveModel, listModels);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Internal server error';
       if (!res.headersSent) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,7 +36,9 @@ export type { SessionLookupResult, SessionRegistryOptions } from './session-regi
 // import it from the deep path
 // `packages/server/src/session-registry.js` instead.
 
-export { QWEN_SAMPLING_DEFAULTS } from './presets.js';
+export { QWEN_SAMPLING_DEFAULTS, GEMMA4_SAMPLING_DEFAULTS, LFM2_SAMPLING_DEFAULTS, LAUNCH_PRESETS } from './presets.js';
+export type { LaunchPreset } from './presets.js';
+export type { PublicModelEntry } from './handler.js';
 
 export type {
   ResponsesAPIRequest,

--- a/packages/server/src/presets.ts
+++ b/packages/server/src/presets.ts
@@ -60,3 +60,57 @@ export const QWEN_SAMPLING_DEFAULTS = {
     repetitionPenalty: 1.0,
   } satisfies ChatConfig,
 } as const;
+
+/** Sampling defaults for Gemma4 Instruct. */
+export const GEMMA4_SAMPLING_DEFAULTS: ChatConfig = {
+  temperature: 0.7,
+  topP: 0.95,
+  topK: 64,
+  minP: 0.0,
+  presencePenalty: 0.0,
+  repetitionPenalty: 1.0,
+};
+
+/** Sampling defaults for LFM2.5 Thinking. */
+export const LFM2_SAMPLING_DEFAULTS: ChatConfig = {
+  temperature: 0.05,
+  topP: 1.0,
+  topK: 50,
+  minP: 0.0,
+  presencePenalty: 0.0,
+  repetitionPenalty: 1.05,
+};
+
+/** Sampling + per-model output token cap exposed by {@link LAUNCH_PRESETS}. */
+export interface LaunchPreset {
+  sampling: ChatConfig;
+  maxOutputTokens: number;
+}
+
+/**
+ * Per-`ModelType` presets used by `mlx launch claude` to pre-wire a
+ * discovered model with sensible sampling defaults + a max output
+ * token budget. Keyed on the string returned by `detectModelType()`.
+ */
+export const LAUNCH_PRESETS: Record<string, LaunchPreset> = {
+  qwen3: {
+    sampling: QWEN_SAMPLING_DEFAULTS.thinkingCoding,
+    maxOutputTokens: 38912,
+  },
+  qwen3_5: {
+    sampling: QWEN_SAMPLING_DEFAULTS.thinkingCoding,
+    maxOutputTokens: 81920,
+  },
+  qwen3_5_moe: {
+    sampling: QWEN_SAMPLING_DEFAULTS.thinkingCoding,
+    maxOutputTokens: 81920,
+  },
+  gemma4: {
+    sampling: GEMMA4_SAMPLING_DEFAULTS,
+    maxOutputTokens: 16384,
+  },
+  lfm2: {
+    sampling: LFM2_SAMPLING_DEFAULTS,
+    maxOutputTokens: 8192,
+  },
+};

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -14,6 +14,7 @@ import {
   sendMethodNotAllowed,
   sendNotFound,
 } from './errors.js';
+import type { PublicModelEntry } from './handler.js';
 import type { IdleSweeper } from './idle-sweeper.js';
 import type { ModelRegistry } from './registry.js';
 import type { AnthropicMessagesRequest } from './types-anthropic.js';
@@ -47,6 +48,8 @@ export async function routeRequest(
   store: ResponseStore | null,
   responseRetentionSec?: number,
   idleSweeper?: IdleSweeper | null,
+  resolveModel?: (name: string) => Promise<void>,
+  listModels?: () => PublicModelEntry[],
 ): Promise<void> {
   const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
   const path = url.pathname;
@@ -56,7 +59,7 @@ export async function routeRequest(
       sendMethodNotAllowed(res, 'GET');
       return;
     }
-    handleListModels(res, registry);
+    handleListModels(res, registry, listModels);
     return;
   }
 
@@ -98,7 +101,7 @@ export async function routeRequest(
       return;
     }
 
-    await handleCreateMessage(res, body, registry, req, idleSweeper);
+    await handleCreateMessage(res, body, registry, req, idleSweeper, resolveModel);
     return;
   }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path';
 
 import { ResponseStore } from '@mlx-node/core';
 
+import type { PublicModelEntry } from './handler.js';
 import { createHandler } from './handler.js';
 import { createIdleSweeper, DEFAULT_IDLE_CLEAR_CACHE_MS, parseIdleClearCacheEnv } from './idle-sweeper.js';
 import { ModelRegistry } from './registry.js';
@@ -132,6 +133,21 @@ export interface ServerConfig {
    * model is untouched and covers in-flight memory churn.
    */
   idleClearCacheMs?: number;
+  /**
+   * Optional async callback invoked before the endpoint layer looks
+   * the model up in the registry. Intended for lazy-load schemes:
+   * the callback should register the model into `registry` if it can;
+   * on return, the endpoint does `registry.get(body.model)` and 404s
+   * if still unresolved. Callback errors bubble up as 500s.
+   */
+  resolveModel?: (name: string) => Promise<void>;
+  /**
+   * Optional override for `GET /v1/models` enumeration. When provided,
+   * the endpoint returns this list instead of `registry.list()`.
+   * Intended for dynamic discovery schemes (e.g. enumerate every model
+   * on disk while only the currently-resident one is registered).
+   */
+  listModels?: () => PublicModelEntry[];
 }
 
 export interface ServerInstance {
@@ -248,7 +264,14 @@ export async function createServer(config?: ServerConfig): Promise<ServerInstanc
   }, CLEANUP_INTERVAL_MS);
   cleanupTimer.unref();
 
-  const handler = createHandler(registry, { cors, store, responseRetentionSec, idleSweeper });
+  const handler = createHandler(registry, {
+    cors,
+    store,
+    responseRetentionSec,
+    idleSweeper,
+    resolveModel: config?.resolveModel,
+    listModels: config?.listModels,
+  });
   const server = httpCreateServer(handler);
 
   await new Promise<void>((resolve, reject) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,6 +257,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/checkbox@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "@inquirer/checkbox@npm:5.1.4"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.5"
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/figures": "npm:^2.0.5"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/38d6c8b49c392307c29fbb252d5dd09a819aecc34c83f01a7652efa09d7b8b901c448216496eda3962e319209243297ec575eff4e081a758bb08adb805f7e3d4
+  languageName: node
+  linkType: hard
+
 "@inquirer/confirm@npm:^6.0.11":
   version: 6.0.11
   resolution: "@inquirer/confirm@npm:6.0.11"
@@ -269,6 +286,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/acb6f3d8bcd81c9eb8cec3fe9f9884ba3372a0bef16e31091db8e01e3814eaa150b67c6a657d4f7c721416d47f9a02ca99562c98ce7a33fc4e4f432c4d48d504
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^6.0.12":
+  version: 6.0.12
+  resolution: "@inquirer/confirm@npm:6.0.12"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/36e9b1ef60e08562f07bcbcd78ba0a681b2fa3e5f54fa5e12303fc5982e8ba875ed782c24161e2295028b2b404ba690e841837303d16eeeb28df7aa9eb8aa835
   languageName: node
   linkType: hard
 
@@ -292,6 +324,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/core@npm:^11.1.9":
+  version: 11.1.9
+  resolution: "@inquirer/core@npm:11.1.9"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.5"
+    "@inquirer/figures": "npm:^2.0.5"
+    "@inquirer/type": "npm:^4.0.5"
+    cli-width: "npm:^4.1.0"
+    fast-wrap-ansi: "npm:^0.2.0"
+    mute-stream: "npm:^3.0.0"
+    signal-exit: "npm:^4.1.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/f7b162ce5f67fb75aab00a3668fdd8c8629aec790087840ea66ee8ead6009ab2066bec9cbf5bcc394ccdf130e6139051d6bace334b3a66c4f05349585213172c
+  languageName: node
+  linkType: hard
+
 "@inquirer/editor@npm:^5.1.0":
   version: 5.1.0
   resolution: "@inquirer/editor@npm:5.1.0"
@@ -308,6 +360,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/editor@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@inquirer/editor@npm:5.1.1"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/external-editor": "npm:^3.0.0"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/d9506fc4d16362ee060df0c8aa722ee85eae79e0be373253ecc49d0f51569f886bf0d09da9ae9910e3d5f79dca10767a5c1711c799af41c668b2a97866470221
+  languageName: node
+  linkType: hard
+
 "@inquirer/expand@npm:^5.0.12":
   version: 5.0.12
   resolution: "@inquirer/expand@npm:5.0.12"
@@ -320,6 +388,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/c3b6699957ff6eb3ef1dcf5a306fe7a92498a3dc1ecbb7e73888c6208a9fba959d2ba70b58aaa27760294f4b92f3cb809346d80f8471be263951ad19a325a0b6
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^5.0.13":
+  version: 5.0.13
+  resolution: "@inquirer/expand@npm:5.0.13"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/108055f24dc4348a4981003003ca41fe793c7b3292ff80f583a1e1f1097bee64a0c2e5795cae969bcf77d4f34f03a3feeaa6315363eb01554f1c1eae6769c9f5
   languageName: node
   linkType: hard
 
@@ -360,6 +443,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/input@npm:^5.0.12":
+  version: 5.0.12
+  resolution: "@inquirer/input@npm:5.0.12"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/bb8273925c774bc5dffd93d6edc9e24391ab03c3ddd0c604987abbb74a7efcf03ca10b3bd0607ccf6613369e004417b14cf3c031327601118cff2cc98c5098e6
+  languageName: node
+  linkType: hard
+
 "@inquirer/number@npm:^4.0.11":
   version: 4.0.11
   resolution: "@inquirer/number@npm:4.0.11"
@@ -372,6 +470,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/d4d4166bf3723bf14262d412e39cdcdcab0dafc46928d11e1b874a81ddd4191587e484135e6aa7b68933a3defaee91db7350bfdf0f965743e8128c05908e2c46
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^4.0.12":
+  version: 4.0.12
+  resolution: "@inquirer/number@npm:4.0.12"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/e933967d9879792775d4ac8f4abcc9c2f263107a1e3c1cdd5ce85dd446a03bed2f6cb01c41ed1a3b45b80f385eb3a991d1442703d9816416c79c0ca6f20e57f3
   languageName: node
   linkType: hard
 
@@ -388,6 +501,22 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/e19ff9fc21a54e812cb565b1fd93114d25793f1f353a1606e6b79c89f939f23ce096914643a9ca5c3b4883ccfc0c06de9032608a366afd652d68e6da76b7ae64
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^5.0.12":
+  version: 5.0.12
+  resolution: "@inquirer/password@npm:5.0.12"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.5"
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/e1399196f01ff5fadc1d3e1bc6946a4f53a5753ccf8e39b2f11f1dae5c51fdb85e33ef44760d83c5b58dacc442de603f32e9c991b2e5f2f8a2a451ff62e1fe48
   languageName: node
   linkType: hard
 
@@ -414,6 +543,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/prompts@npm:^8.4.1":
+  version: 8.4.2
+  resolution: "@inquirer/prompts@npm:8.4.2"
+  dependencies:
+    "@inquirer/checkbox": "npm:^5.1.4"
+    "@inquirer/confirm": "npm:^6.0.12"
+    "@inquirer/editor": "npm:^5.1.1"
+    "@inquirer/expand": "npm:^5.0.13"
+    "@inquirer/input": "npm:^5.0.12"
+    "@inquirer/number": "npm:^4.0.12"
+    "@inquirer/password": "npm:^5.0.12"
+    "@inquirer/rawlist": "npm:^5.2.8"
+    "@inquirer/search": "npm:^4.1.8"
+    "@inquirer/select": "npm:^5.1.4"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/0519d6a52e195e24b03949afda1ad7fc2ae752c72a7ba554d4bdbbac844fd47dc83d79e67f732c6bf3c56a407e3171b92bd3b0dc334fd35eea446a889d1100f7
+  languageName: node
+  linkType: hard
+
 "@inquirer/rawlist@npm:^5.2.7":
   version: 5.2.7
   resolution: "@inquirer/rawlist@npm:5.2.7"
@@ -426,6 +578,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/78c63e779dacc84f453de8c6acd7ca226584af156bca8e9f34d6f96de22b554bba8bd542d424bc33ab0ebfa4e06598505e49ebaaaf3f9d694f6c4959baa2e022
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^5.2.8":
+  version: 5.2.8
+  resolution: "@inquirer/rawlist@npm:5.2.8"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/35b0a9e29972342669365af70ea8feebc4e13ce688ce53c1fae723cbd02a7082294553eeb49ee443f5e993c1a97be31fcbe366f7cb573c075557316717792527
   languageName: node
   linkType: hard
 
@@ -445,6 +612,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/search@npm:^4.1.8":
+  version: 4.1.8
+  resolution: "@inquirer/search@npm:4.1.8"
+  dependencies:
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/figures": "npm:^2.0.5"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/7281c59e8953aa4663c5afe3d6a3b558ec3e97867569f29dcc0a67e89ff05b37f374ac34ebc7356a7137f76a5172d52c60469cadcc323cc733b4d635b5cf3334
+  languageName: node
+  linkType: hard
+
 "@inquirer/select@npm:^5.1.3":
   version: 5.1.3
   resolution: "@inquirer/select@npm:5.1.3"
@@ -459,6 +642,23 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/536dc10aa4d1ddd2f97aa21e161f5dce77fedfb8d2c5869ccc3a4001d782e03c2aee4ec9776448b7ec99112dbb5ebceec9b6ddbc225c6de13935624a237e099e
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "@inquirer/select@npm:5.1.4"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.5"
+    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/figures": "npm:^2.0.5"
+    "@inquirer/type": "npm:^4.0.5"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/30b6b061acd08f3f4cfde08a626446d308271e32569acec03f8c87a17e04c21aeccbecf354c8b254a2decfbe7d2189d8ae4443bf10d0be4a2aedeb4e850574c2
   languageName: node
   linkType: hard
 
@@ -495,6 +695,7 @@ __metadata:
   resolution: "@mlx-node/cli@workspace:packages/cli"
   dependencies:
     "@huggingface/hub": "npm:^2.11.0"
+    "@inquirer/prompts": "npm:^8.4.1"
     "@mlx-node/core": "workspace:*"
     "@mlx-node/lm": "workspace:*"
     "@mlx-node/server": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,7 +391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/prompts@npm:^8.0.0, @inquirer/prompts@npm:^8.4.1":
+"@inquirer/prompts@npm:^8.0.0":
   version: 8.4.1
   resolution: "@inquirer/prompts@npm:8.4.1"
   dependencies:
@@ -495,8 +495,9 @@ __metadata:
   resolution: "@mlx-node/cli@workspace:packages/cli"
   dependencies:
     "@huggingface/hub": "npm:^2.11.0"
-    "@inquirer/prompts": "npm:^8.4.1"
     "@mlx-node/core": "workspace:*"
+    "@mlx-node/lm": "workspace:*"
+    "@mlx-node/server": "workspace:*"
     "@napi-rs/keyring": "npm:^1.2.0"
     "@types/node": "npm:^25.6.0"
   bin:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new CLI workflow that spawns processes and adds server hooks for lazy model resolution and custom model listing, changing request handling and error paths for `/v1/messages` and `/v1/models`. Also updates download logic to parse manifests/indexes and skip copies, which could affect existing resume behavior across model formats.
> 
> **Overview**
> Adds a new `mlx launch claude` CLI command that starts a local Anthropic-compatible server, discovers locally downloaded models, lazy-loads/swallows model swaps via a serialized swap controller (including aliasing unknown Claude model names), and can optionally capture full request/response logs for debugging.
> 
> Improves `mlx download model` defaults and robustness by introducing a shared `~/.mlx-node` config (`MLX_MODELS_DIR`/`config.json`) for model storage, adding stricter “already downloaded” checks (sharded safetensors shard verification, GGUF manifest completeness, glob-matched set completeness), and skipping redundant local `copyFile` operations when the destination file size already matches.
> 
> Extends the server API to support `resolveModel` (lazy registration) and `listModels` overrides, reorders `/v1/messages` to map/validate before loading, brackets loads with the idle-sweeper drain suspension, and ensures resolve failures return Anthropic-shaped 500 errors. Updates presets/export surface to include `LAUNCH_PRESETS` and adds sampling defaults for `gemma4` and `lfm2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3dfaeb446bb07146004626f187be6e86d8d31cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->