### PR TITLE
perf: optimize inference control flow tracing and cache reuse

### DIFF
--- a/__test__/cli/launch-claude/logger.test.ts
+++ b/__test__/cli/launch-claude/logger.test.ts
@@ -141,4 +141,41 @@ describe('attachLogger', () => {
     const row = JSON.parse(readFileSync(join(logDir, 'requests.ndjson'), 'utf-8').trim()) as { resBody: string };
     expect(row.resBody).toBe('data: a\n\ndata: b\n\ndata: [DONE]\n\n');
   });
+
+  it('logs total first-token latency separately from native ttft', async () => {
+    const logDir = makeTmpDir();
+    const port = await pickFreePort();
+
+    const srv = createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          model: 'gemma-test',
+          stop_reason: 'end_turn',
+          usage: {
+            input_tokens: 20,
+            output_tokens: 5,
+            time_to_first_token_ms: 250,
+            prefill_tokens_per_second: 20,
+            decode_tokens_per_second: 40,
+            server_inference_elapsed_ms: 350,
+            server_total_time_to_first_token_ms: 312,
+            server_model_resolve_ms: 57,
+            server_queue_ms: 5,
+            server_pre_inference_ms: 62,
+          },
+        }),
+      );
+    });
+    const logger = attachLogger(srv, logDir);
+    await new Promise<void>((resolve) => srv.listen(port, '127.0.0.1', resolve));
+
+    await postJson(port, { model: 'gemma-test' });
+    await logger.close();
+    await closeServer(srv);
+
+    const pretty = readFileSync(join(logDir, 'session.log'), 'utf-8');
+    expect(pretty).toContain('perf(ttfb=312ms ttft=250ms prefill=20.00/s decode=40.00/s infer=350ms)');
+    expect(pretty).toContain('server(resolve=57ms queue=5ms pre=62ms)');
+  });
 });

--- a/__test__/models/qwen35-stream.test.ts
+++ b/__test__/models/qwen35-stream.test.ts
@@ -60,6 +60,54 @@ describe.sequential('_runChatStream bridge', () => {
     expect(events[3].done).toBe(true);
   });
 
+  it('should preserve native reasoning flags on delta chunks', async () => {
+    const native = (
+      _messages: unknown[],
+      _config: unknown,
+      callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+    ): Promise<ChatStreamHandle> => {
+      const handle = { cancel: () => {} } as ChatStreamHandle;
+      setTimeout(() => {
+        callback(null, {
+          text: 'camel',
+          done: false,
+          isReasoning: true,
+        } as ChatStreamChunk);
+        callback(null, {
+          text: 'snake',
+          done: false,
+          is_reasoning: true,
+        } as unknown as ChatStreamChunk);
+        callback(null, {
+          text: 'done',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          numTokens: 2,
+          rawText: 'done',
+        } as ChatStreamChunk);
+      }, 0);
+      return Promise.resolve(handle);
+    };
+
+    const events: ChatStreamEvent[] = [];
+    const messages: ChatMessage[] = [{ role: 'user', content: 'Hi' }];
+    for await (const event of _runChatStream((callback) => native(messages, null, callback))) {
+      events.push(event);
+    }
+
+    expect(events[0]).toEqual({
+      text: 'camel',
+      done: false,
+      isReasoning: true,
+    });
+    expect(events[1]).toEqual({
+      text: 'snake',
+      done: false,
+      isReasoning: true,
+    });
+  });
+
   it('should populate final chunk fields correctly', async () => {
     let finalEvent: ChatStreamEvent | null = null;
     const messages: ChatMessage[] = [{ role: 'user', content: 'Hi' }];

--- a/__test__/server/anthropic-response-mapper.test.ts
+++ b/__test__/server/anthropic-response-mapper.test.ts
@@ -83,14 +83,25 @@ describe('buildAnthropicResponse', () => {
     const response = buildAnthropicResponse(result, baseReq, 'msg_thinking');
 
     expect(response.content).toHaveLength(2);
-    expect(response.content[0]).toEqual({ type: 'thinking', thinking: 'Let me reason through this.' });
+    expect(response.content[0]).toEqual({
+      type: 'thinking',
+      thinking: 'Let me reason through this.',
+    });
     expect(response.content[1]).toEqual({ type: 'text', text: 'Hello!' });
   });
 
   it('tool use response produces tool_use blocks with parsed input', () => {
     const result = makeChatResult({
       text: '',
-      toolCalls: [{ id: 'toolu_01', name: 'get_weather', arguments: '{"city":"SF"}', status: 'ok', rawContent: '' }],
+      toolCalls: [
+        {
+          id: 'toolu_01',
+          name: 'get_weather',
+          arguments: '{"city":"SF"}',
+          status: 'ok',
+          rawContent: '',
+        },
+      ],
     });
     const response = buildAnthropicResponse(result, baseReq, 'msg_tool');
 
@@ -104,10 +115,48 @@ describe('buildAnthropicResponse', () => {
     expect(response.stop_reason).toBe('tool_use');
   });
 
+  it('recovers Gemma4 raw tool-call text without duplicating reasoning when tools are not allowed', () => {
+    const result = makeChatResult({
+      text: '',
+      thinking: 'I should inspect files.',
+      toolCalls: [
+        {
+          id: 'toolu_01',
+          name: 'read_file',
+          arguments: '{"path":"Cargo.toml"}',
+          status: 'ok',
+          rawContent: '',
+        },
+      ],
+      rawText:
+        '<|channel>thought\nI should inspect files.\n<channel|><|tool_call>call:read_file{path:<|"|>Cargo.toml<|"|>}<tool_call|><turn|>',
+    });
+    const response = buildAnthropicResponse(result, baseReq, 'msg_no_tools', undefined, false);
+
+    expect(response.stop_reason).toBe('end_turn');
+    expect(response.content).toHaveLength(2);
+    expect(response.content[0]).toEqual({
+      type: 'thinking',
+      thinking: 'I should inspect files.',
+    });
+    expect(response.content[1]).toEqual({
+      type: 'text',
+      text: '<|tool_call>call:read_file{path:<|"|>Cargo.toml<|"|>}<tool_call|>',
+    });
+  });
+
   it('tool use with object arguments uses them directly', () => {
     const result = makeChatResult({
       text: '',
-      toolCalls: [{ id: 'toolu_02', name: 'search', arguments: { query: 'MLX' }, status: 'ok', rawContent: '' }],
+      toolCalls: [
+        {
+          id: 'toolu_02',
+          name: 'search',
+          arguments: { query: 'MLX' },
+          status: 'ok',
+          rawContent: '',
+        },
+      ],
     });
     const response = buildAnthropicResponse(result, baseReq, 'msg_obj_args');
 
@@ -123,7 +172,15 @@ describe('buildAnthropicResponse', () => {
     const result = makeChatResult({
       thinking: 'I should call a tool.',
       text: 'Let me look that up.',
-      toolCalls: [{ id: 'toolu_03', name: 'lookup', arguments: '{"term":"foo"}', status: 'ok', rawContent: '' }],
+      toolCalls: [
+        {
+          id: 'toolu_03',
+          name: 'lookup',
+          arguments: '{"term":"foo"}',
+          status: 'ok',
+          rawContent: '',
+        },
+      ],
     });
     const response = buildAnthropicResponse(result, baseReq, 'msg_mixed');
 
@@ -152,7 +209,11 @@ describe('buildAnthropicResponse', () => {
     // Anthropic spec leaves the cache fields OPTIONAL and other
     // Anthropic-compatible servers omit them on misses — so a wire
     // emitting `cache_read_input_tokens: 0` would diverge.
-    const result = makeChatResult({ promptTokens: 11, numTokens: 4, cachedTokens: 0 });
+    const result = makeChatResult({
+      promptTokens: 11,
+      numTokens: 4,
+      cachedTokens: 0,
+    });
     const response = buildAnthropicResponse(result, baseReq, 'msg_no_cache');
 
     expect(response.usage.input_tokens).toBe(11);
@@ -166,7 +227,11 @@ describe('buildAnthropicResponse', () => {
     // cost on the turn, so on a cache HIT it MUST be the unsuffixed
     // remainder (`promptTokens - cachedTokens`) — billing UIs read
     // these fields directly.
-    const result = makeChatResult({ promptTokens: 20, numTokens: 5, cachedTokens: 7 });
+    const result = makeChatResult({
+      promptTokens: 20,
+      numTokens: 5,
+      cachedTokens: 7,
+    });
     const response = buildAnthropicResponse(result, baseReq, 'msg_cache_hit');
 
     expect(response.usage.cache_read_input_tokens).toBe(7);
@@ -268,7 +333,15 @@ describe('buildAnthropicResponse', () => {
   it('empty text with tool calls produces no text block, only tool_use blocks', () => {
     const result = makeChatResult({
       text: '',
-      toolCalls: [{ id: 'toolu_04', name: 'fn', arguments: '{}', status: 'ok', rawContent: '' }],
+      toolCalls: [
+        {
+          id: 'toolu_04',
+          name: 'fn',
+          arguments: '{}',
+          status: 'ok',
+          rawContent: '',
+        },
+      ],
     });
     const response = buildAnthropicResponse(result, baseReq, 'msg_no_text');
 
@@ -280,7 +353,15 @@ describe('buildAnthropicResponse', () => {
   it('skips tool calls with status !== "ok"', () => {
     const result = makeChatResult({
       text: 'Done.',
-      toolCalls: [{ id: 'toolu_err', name: 'broken', arguments: '{}', status: 'error', rawContent: '' }],
+      toolCalls: [
+        {
+          id: 'toolu_err',
+          name: 'broken',
+          arguments: '{}',
+          status: 'error',
+          rawContent: '',
+        },
+      ],
     });
     const response = buildAnthropicResponse(result, baseReq, 'msg_err_tool');
 
@@ -291,7 +372,15 @@ describe('buildAnthropicResponse', () => {
   it('generates a toolu_ prefixed id when tool call id is missing', () => {
     const result = makeChatResult({
       text: '',
-      toolCalls: [{ id: undefined as unknown as string, name: 'fn', arguments: '{}', status: 'ok', rawContent: '' }],
+      toolCalls: [
+        {
+          id: undefined as unknown as string,
+          name: 'fn',
+          arguments: '{}',
+          status: 'ok',
+          rawContent: '',
+        },
+      ],
     });
     const response = buildAnthropicResponse(result, baseReq, 'msg_gen_id');
 

--- a/__test__/server/anthropic-response-mapper.test.ts
+++ b/__test__/server/anthropic-response-mapper.test.ts
@@ -192,6 +192,44 @@ describe('buildAnthropicResponse', () => {
     expect(response.usage.time_to_first_token_ms).toBe(1234);
     expect(response.usage.prefill_tokens_per_second).toBe(800);
     expect(response.usage.decode_tokens_per_second).toBe(73.5);
+    expect(response.usage.server_time_to_first_token_ms).toBe(1234);
+    expect(response.usage.server_prefill_tokens_per_second).toBe(800);
+    expect(response.usage.server_decode_tokens_per_second).toBe(73.5);
+    expect(response.usage.prefill_input_tokens).toBe(5);
+    expect(response.usage).not.toHaveProperty('cached_prefix_tokens');
+  });
+
+  it('adds cached-prefix context for perf fields on cache hits', () => {
+    const result = makeChatResult({
+      promptTokens: 20,
+      numTokens: 5,
+      cachedTokens: 15,
+    });
+    const response = buildAnthropicResponse(
+      result,
+      baseReq,
+      'msg_cache_perf',
+      {
+        ttftMs: 250,
+        prefillTokensPerSecond: 20,
+        decodeTokensPerSecond: 40,
+      },
+      true,
+      {
+        server_model_resolve_ms: 57,
+        server_queue_ms: 5,
+        server_pre_inference_ms: 62,
+      },
+    );
+
+    expect(response.usage.input_tokens).toBe(5);
+    expect(response.usage.cache_read_input_tokens).toBe(15);
+    expect(response.usage.prefill_input_tokens).toBe(5);
+    expect(response.usage.cached_prefix_tokens).toBe(15);
+    expect(response.usage.server_inference_elapsed_ms).toBe(350);
+    expect(response.usage.server_model_resolve_ms).toBe(57);
+    expect(response.usage.server_queue_ms).toBe(5);
+    expect(response.usage.server_pre_inference_ms).toBe(62);
   });
 
   it('elides perf fields when performance is undefined', () => {
@@ -385,6 +423,37 @@ describe('buildMessageDelta', () => {
     expect(event.usage.time_to_first_token_ms).toBe(1234);
     expect(event.usage.prefill_tokens_per_second).toBe(800);
     expect(event.usage.decode_tokens_per_second).toBe(73.5);
+    expect(event.usage.server_time_to_first_token_ms).toBe(1234);
+    expect(event.usage.server_prefill_tokens_per_second).toBe(800);
+    expect(event.usage.server_decode_tokens_per_second).toBe(73.5);
+  });
+
+  it('adds cached-prefix context to streaming perf usage', () => {
+    const event = buildMessageDelta(
+      'end_turn',
+      5,
+      20,
+      15,
+      {
+        ttftMs: 250,
+        prefillTokensPerSecond: 20,
+        decodeTokensPerSecond: 40,
+      },
+      {
+        server_model_resolve_ms: 57,
+        server_queue_ms: 5,
+        server_pre_inference_ms: 62,
+      },
+    );
+
+    expect(event.usage.input_tokens).toBe(5);
+    expect(event.usage.cache_read_input_tokens).toBe(15);
+    expect(event.usage.prefill_input_tokens).toBe(5);
+    expect(event.usage.cached_prefix_tokens).toBe(15);
+    expect(event.usage.server_inference_elapsed_ms).toBe(350);
+    expect(event.usage.server_model_resolve_ms).toBe(57);
+    expect(event.usage.server_queue_ms).toBe(5);
+    expect(event.usage.server_pre_inference_ms).toBe(62);
   });
 
   it('elides perf fields when performance is undefined', () => {

--- a/__test__/server/anthropic-response-mapper.test.ts
+++ b/__test__/server/anthropic-response-mapper.test.ts
@@ -115,7 +115,7 @@ describe('buildAnthropicResponse', () => {
     expect(response.stop_reason).toBe('tool_use');
   });
 
-  it('recovers Gemma4 raw tool-call text without duplicating reasoning when tools are not allowed', () => {
+  it('suppresses Gemma4 parsed tool-call text without duplicating reasoning when tools are not allowed', () => {
     const result = makeChatResult({
       text: '',
       thinking: 'I should inspect files.',
@@ -141,7 +141,7 @@ describe('buildAnthropicResponse', () => {
     });
     expect(response.content[1]).toEqual({
       type: 'text',
-      text: '<|tool_call>call:read_file{path:<|"|>Cargo.toml<|"|>}<tool_call|>',
+      text: '',
     });
   });
 

--- a/__test__/server/anthropic-response-mapper.test.ts
+++ b/__test__/server/anthropic-response-mapper.test.ts
@@ -230,6 +230,7 @@ describe('buildAnthropicResponse', () => {
     expect(response.usage.prefill_input_tokens).toBe(5);
     expect(response.usage.cached_prefix_tokens).toBe(15);
     expect(response.usage.server_inference_elapsed_ms).toBe(350);
+    expect(response.usage.server_total_time_to_first_token_ms).toBe(312);
     expect(response.usage.server_model_resolve_ms).toBe(57);
     expect(response.usage.server_queue_ms).toBe(5);
     expect(response.usage.server_pre_inference_ms).toBe(62);
@@ -460,6 +461,7 @@ describe('buildMessageDelta', () => {
     expect(event.usage.prefill_input_tokens).toBe(5);
     expect(event.usage.cached_prefix_tokens).toBe(15);
     expect(event.usage.server_inference_elapsed_ms).toBe(350);
+    expect(event.usage.server_total_time_to_first_token_ms).toBe(312);
     expect(event.usage.server_model_resolve_ms).toBe(57);
     expect(event.usage.server_queue_ms).toBe(5);
     expect(event.usage.server_pre_inference_ms).toBe(62);

--- a/__test__/server/anthropic-response-mapper.test.ts
+++ b/__test__/server/anthropic-response-mapper.test.ts
@@ -219,6 +219,9 @@ describe('buildAnthropicResponse', () => {
         server_model_resolve_ms: 57,
         server_queue_ms: 5,
         server_pre_inference_ms: 62,
+        server_paged_prefill_chunk_size: 4096,
+        server_paged_prefill_eval_interval: 8,
+        server_paged_decode_cache_clear_interval: 64,
       },
     );
 
@@ -230,6 +233,9 @@ describe('buildAnthropicResponse', () => {
     expect(response.usage.server_model_resolve_ms).toBe(57);
     expect(response.usage.server_queue_ms).toBe(5);
     expect(response.usage.server_pre_inference_ms).toBe(62);
+    expect(response.usage.server_paged_prefill_chunk_size).toBe(4096);
+    expect(response.usage.server_paged_prefill_eval_interval).toBe(8);
+    expect(response.usage.server_paged_decode_cache_clear_interval).toBe(64);
   });
 
   it('elides perf fields when performance is undefined', () => {
@@ -443,6 +449,9 @@ describe('buildMessageDelta', () => {
         server_model_resolve_ms: 57,
         server_queue_ms: 5,
         server_pre_inference_ms: 62,
+        server_paged_prefill_chunk_size: 4096,
+        server_paged_prefill_eval_interval: 8,
+        server_paged_decode_cache_clear_interval: 64,
       },
     );
 
@@ -454,6 +463,9 @@ describe('buildMessageDelta', () => {
     expect(event.usage.server_model_resolve_ms).toBe(57);
     expect(event.usage.server_queue_ms).toBe(5);
     expect(event.usage.server_pre_inference_ms).toBe(62);
+    expect(event.usage.server_paged_prefill_chunk_size).toBe(4096);
+    expect(event.usage.server_paged_prefill_eval_interval).toBe(8);
+    expect(event.usage.server_paged_decode_cache_clear_interval).toBe(64);
   });
 
   it('elides perf fields when performance is undefined', () => {

--- a/__test__/server/messages-count-tokens-handler.test.ts
+++ b/__test__/server/messages-count-tokens-handler.test.ts
@@ -1,0 +1,227 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { Readable, Writable } from 'node:stream';
+
+import type { ChatResult } from '@mlx-node/core';
+import type { SessionCapableModel } from '@mlx-node/lm';
+import { createHandler, ModelRegistry } from '@mlx-node/server';
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+function createMockReq(method: string, url: string, body?: object): IncomingMessage {
+  const req = new Readable({
+    read() {
+      if (body) {
+        this.push(JSON.stringify(body));
+      }
+      this.push(null);
+    },
+  }) as IncomingMessage;
+  req.method = method;
+  req.url = url;
+  req.headers = { 'content-type': 'application/json', host: 'localhost:3000' };
+  return req;
+}
+
+function createMockRes(): {
+  res: ServerResponse;
+  getStatus: () => number;
+  getBody: () => string;
+  waitForEnd: () => Promise<void>;
+} {
+  let status = 200;
+  let body = '';
+  let endResolve: () => void;
+  const endPromise = new Promise<void>((resolve) => {
+    endResolve = resolve;
+  });
+
+  const writable = new Writable({
+    write(chunk: Uint8Array | string, _encoding: string, callback: () => void) {
+      body += chunk.toString();
+      callback();
+    },
+  }) as Writable & {
+    headersSent: boolean;
+    writeHead: (status: number) => Writable;
+    setHeader: () => Writable;
+  };
+
+  writable.writeHead = (s: number) => {
+    status = s;
+    writable.headersSent = true;
+    return writable;
+  };
+  writable.setHeader = () => writable;
+  writable.headersSent = false;
+
+  const origEnd = writable.end.bind(writable);
+  writable.end = (chunkArg?: unknown, encodingArg?: unknown, cbArg?: unknown) => {
+    let chunk: string | Uint8Array | undefined;
+    let cb: ((err?: Error | null) => void) | undefined;
+    if (typeof chunkArg === 'function') {
+      cb = chunkArg as (err?: Error | null) => void;
+    } else {
+      chunk = chunkArg as string | Uint8Array | undefined;
+      if (typeof encodingArg === 'function') {
+        cb = encodingArg as (err?: Error | null) => void;
+      } else if (typeof cbArg === 'function') {
+        cb = cbArg as (err?: Error | null) => void;
+      }
+    }
+    if (chunk != null) body += chunk.toString();
+    writable.headersSent = true;
+    origEnd(undefined, (err?: Error | null) => {
+      if (cb) cb(err ?? null);
+      endResolve();
+    });
+    return writable;
+  };
+
+  return {
+    res: writable as unknown as ServerResponse,
+    getStatus: () => status,
+    getBody: () => body,
+    waitForEnd: () => endPromise,
+  };
+}
+
+function createCountingModel(tokenCount: number): SessionCapableModel & {
+  applyChatTemplate: ReturnType<typeof vi.fn>;
+  spies: {
+    chatSessionStart: ReturnType<typeof vi.fn>;
+    chatStreamSessionStart: ReturnType<typeof vi.fn>;
+  };
+} {
+  const result: ChatResult = {
+    text: 'unexpected',
+    toolCalls: [],
+    numTokens: 0,
+    promptTokens: 0,
+    reasoningTokens: 0,
+    finishReason: 'stop',
+    rawText: 'unexpected',
+    cachedTokens: 0,
+  };
+  async function* stream() {
+    yield { done: true, text: '', finishReason: 'stop', toolCalls: [], numTokens: 0, promptTokens: 0, rawText: '' };
+  }
+  const chatSessionStart = vi.fn().mockResolvedValue(result);
+  const chatStreamSessionStart = vi.fn(() => stream());
+  return {
+    applyChatTemplate: vi.fn(async () => new Uint32Array(tokenCount)),
+    chatSessionStart,
+    chatSessionContinue: vi.fn().mockResolvedValue(result),
+    chatSessionContinueTool: vi.fn().mockResolvedValue(result),
+    chatStreamSessionStart,
+    chatStreamSessionContinue: vi.fn(() => stream()),
+    chatStreamSessionContinueTool: vi.fn(() => stream()),
+    resetCaches: vi.fn(),
+    spies: { chatSessionStart, chatStreamSessionStart },
+  } as unknown as SessionCapableModel & {
+    applyChatTemplate: ReturnType<typeof vi.fn>;
+    spies: {
+      chatSessionStart: ReturnType<typeof vi.fn>;
+      chatStreamSessionStart: ReturnType<typeof vi.fn>;
+    };
+  };
+}
+
+function createSessionOnlyModel(): SessionCapableModel {
+  const model = createCountingModel(0);
+  delete (model as Partial<{ applyChatTemplate: unknown }>).applyChatTemplate;
+  return model;
+}
+
+describe('POST /v1/messages/count_tokens', () => {
+  it('counts chat-template tokens without requiring max_tokens or running inference', async () => {
+    const registry = new ModelRegistry();
+    const model = createCountingModel(17);
+    registry.register('test-model', model);
+    const handler = createHandler(registry);
+    const req = createMockReq('POST', '/v1/messages/count_tokens', {
+      model: 'test-model',
+      system: 'You are concise.',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+    const { res, getStatus, getBody, waitForEnd } = createMockRes();
+
+    await handler(req, res);
+    await waitForEnd();
+
+    expect(getStatus()).toBe(200);
+    expect(JSON.parse(getBody())).toEqual({ input_tokens: 17 });
+    expect(model.applyChatTemplate).toHaveBeenCalledWith(
+      [
+        { role: 'system', content: 'You are concise.' },
+        { role: 'user', content: 'Hello' },
+      ],
+      true,
+      null,
+    );
+    expect(model.spies.chatSessionStart).not.toHaveBeenCalled();
+    expect(model.spies.chatStreamSessionStart).not.toHaveBeenCalled();
+  });
+
+  it('uses the Anthropic mapper for tools before counting', async () => {
+    const registry = new ModelRegistry();
+    const model = createCountingModel(23);
+    registry.register('tool-model', model);
+    const handler = createHandler(registry);
+    const req = createMockReq('POST', '/v1/messages/count_tokens', {
+      model: 'tool-model',
+      tools: [
+        {
+          name: 'lookup',
+          description: 'Lookup a value',
+          input_schema: {
+            type: 'object',
+            properties: { id: { type: 'string' } },
+            required: ['id'],
+          },
+        },
+      ],
+      messages: [{ role: 'user', content: 'Find abc' }],
+    });
+    const { res, getStatus, getBody, waitForEnd } = createMockRes();
+
+    await handler(req, res);
+    await waitForEnd();
+
+    expect(getStatus()).toBe(200);
+    expect(JSON.parse(getBody())).toEqual({ input_tokens: 23 });
+    const [, , tools] = model.applyChatTemplate.mock.calls[0];
+    expect(tools).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'lookup',
+          description: 'Lookup a value',
+          parameters: {
+            type: 'object',
+            properties: JSON.stringify({ id: { type: 'string' } }),
+            required: ['id'],
+          },
+        },
+      },
+    ]);
+  });
+
+  it('returns 501 when the registered model lacks a non-generating chat-template tokenizer API', async () => {
+    const registry = new ModelRegistry();
+    registry.register('session-only', createSessionOnlyModel());
+    const handler = createHandler(registry);
+    const req = createMockReq('POST', '/v1/messages/count_tokens', {
+      model: 'session-only',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+    const { res, getStatus, getBody, waitForEnd } = createMockRes();
+
+    await handler(req, res);
+    await waitForEnd();
+
+    expect(getStatus()).toBe(501);
+    const parsed = JSON.parse(getBody());
+    expect(parsed.type).toBe('error');
+    expect(parsed.error.type).toBe('not_supported_error');
+    expect(parsed.error.message).toContain('applyChatTemplate');
+  });
+});

--- a/__test__/server/messages-count-tokens-handler.test.ts
+++ b/__test__/server/messages-count-tokens-handler.test.ts
@@ -224,4 +224,104 @@ describe('POST /v1/messages/count_tokens', () => {
     expect(parsed.error.type).toBe('not_supported_error');
     expect(parsed.error.message).toContain('applyChatTemplate');
   });
+
+  it('rejects a queued token-count request when the model binding is re-registered before counting starts', async () => {
+    const registry = new ModelRegistry();
+    const originalModel = createCountingModel(17);
+    const swappedModel = createCountingModel(29);
+    registry.register('race-model', originalModel);
+
+    const sessionReg = registry.getSessionRegistry('race-model');
+    expect(sessionReg).toBeDefined();
+
+    let releaseBlocker!: () => void;
+    const blockerGate = new Promise<void>((resolve) => {
+      releaseBlocker = resolve;
+    });
+    let blockerEntered!: () => void;
+    const blockerEnteredPromise = new Promise<void>((resolve) => {
+      blockerEntered = resolve;
+    });
+    const blockerDone = sessionReg!.withExclusive(async () => {
+      blockerEntered();
+      await blockerGate;
+    });
+    await blockerEnteredPromise;
+
+    const handler = createHandler(registry);
+    const req = createMockReq('POST', '/v1/messages/count_tokens', {
+      model: 'race-model',
+      messages: [{ role: 'user', content: 'queued count' }],
+    });
+    const { res, getStatus, getBody, waitForEnd } = createMockRes();
+    const queuedDone = (async () => {
+      await handler(req, res);
+      await waitForEnd();
+    })();
+
+    for (let i = 0; i < 10 && sessionReg!.queueDepth !== 1; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(sessionReg!.queueDepth).toBe(1);
+
+    registry.register('race-model', swappedModel);
+    releaseBlocker();
+    await blockerDone;
+    await queuedDone;
+
+    expect(getStatus()).toBe(400);
+    const parsed = JSON.parse(getBody());
+    expect(parsed.type).toBe('error');
+    expect(parsed.error.type).toBe('invalid_request_error');
+    expect(parsed.error.message).toContain('race-model');
+    expect(parsed.error.message).toMatch(/binding changed/i);
+    expect(parsed.error.message).toMatch(/token-count request was queued/i);
+    expect(originalModel.applyChatTemplate).not.toHaveBeenCalled();
+    expect(swappedModel.applyChatTemplate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token-count result when the model binding changes while counting is running', async () => {
+    const registry = new ModelRegistry();
+    const originalModel = createCountingModel(17);
+    const swappedModel = createCountingModel(29);
+    let resolveApply!: (tokens: Uint32Array) => void;
+    const applyGate = new Promise<Uint32Array>((resolve) => {
+      resolveApply = resolve;
+    });
+    let markApplyStarted!: () => void;
+    const applyStarted = new Promise<void>((resolve) => {
+      markApplyStarted = resolve;
+    });
+    originalModel.applyChatTemplate = vi.fn(async () => {
+      markApplyStarted();
+      return applyGate;
+    });
+    registry.register('race-model', originalModel);
+
+    const handler = createHandler(registry);
+    const req = createMockReq('POST', '/v1/messages/count_tokens', {
+      model: 'race-model',
+      messages: [{ role: 'user', content: 'running count' }],
+    });
+    const { res, getStatus, getBody, waitForEnd } = createMockRes();
+    const countDone = (async () => {
+      await handler(req, res);
+      await waitForEnd();
+    })();
+
+    await applyStarted;
+    registry.register('race-model', swappedModel);
+    resolveApply(new Uint32Array(17));
+    await countDone;
+
+    expect(getStatus()).toBe(400);
+    const parsed = JSON.parse(getBody());
+    expect(parsed.type).toBe('error');
+    expect(parsed.error.type).toBe('invalid_request_error');
+    expect(parsed.error.message).toContain('race-model');
+    expect(parsed.error.message).toMatch(/binding changed/i);
+    expect(parsed.error.message).toMatch(/running/i);
+    expect(originalModel.applyChatTemplate).toHaveBeenCalledTimes(1);
+    expect(swappedModel.applyChatTemplate).not.toHaveBeenCalled();
+  });
 });

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -596,6 +596,50 @@ describe('handleCreateMessage', () => {
       expect(parsed.usage.output_tokens).toBe(10);
     });
 
+    it('clamps max_tokens to the registered output cap before dispatch', async () => {
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel();
+      registry.register('test-model', mockModel, { maxOutputTokens: 16 });
+      const { res, getStatus } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'Hello' }],
+          max_tokens: 128000,
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const startSpy = mockModel.chatSessionStart as unknown as ReturnType<typeof vi.fn>;
+      const config = startSpy.mock.calls[0]?.[1] as { maxNewTokens?: number };
+      expect(config.maxNewTokens).toBe(16);
+    });
+
+    it('leaves max_tokens unchanged when no registered output cap exists', async () => {
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel();
+      registry.register('test-model', mockModel);
+      const { res, getStatus } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'Hello' }],
+          max_tokens: 128000,
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const startSpy = mockModel.chatSessionStart as unknown as ReturnType<typeof vi.fn>;
+      const config = startSpy.mock.calls[0]?.[1] as { maxNewTokens?: number };
+      expect(config.maxNewTokens).toBe(128000);
+    });
+
     it('returns thinking + text content blocks', async () => {
       const registry = new ModelRegistry();
       const mockModel = createMockModel(
@@ -846,6 +890,43 @@ describe('handleCreateMessage', () => {
       // message_stop
       const msgStop = events.find((e) => e.event === 'message_stop');
       expect(msgStop).toBeDefined();
+    });
+
+    it('clamps max_tokens to the registered output cap before streaming dispatch', async () => {
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'Hello', done: false, isReasoning: false },
+        {
+          text: 'Hello',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 1,
+          promptTokens: 1,
+          reasoningTokens: 0,
+          rawText: 'Hello',
+        },
+      ];
+      const mockModel = createMockStreamModel(streamEvents);
+      registry.register('test-model', mockModel, { maxOutputTokens: 16 });
+      const { res, getStatus } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'Hi' }],
+          max_tokens: 128000,
+          stream: true,
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const streamSpy = mockModel.chatStreamSessionStart as unknown as ReturnType<typeof vi.fn>;
+      const config = streamSpy.mock.calls[0]?.[1] as { maxNewTokens?: number };
+      expect(config.maxNewTokens).toBe(16);
     });
 
     it('emits thinking + text with correct content block indices', async () => {

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -259,7 +259,11 @@ describe('handleCreateMessage', () => {
 
       await handleCreateMessage(
         res,
-        { model: 'test', messages: [{ role: 'user', content: 'hi' }], max_tokens: 0 } as any,
+        {
+          model: 'test',
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 0,
+        } as any,
         registry,
       );
 
@@ -286,7 +290,11 @@ describe('handleCreateMessage', () => {
 
       await handleCreateMessage(
         res,
-        { model: 'nonexistent', messages: [{ role: 'user', content: 'hi' }], max_tokens: 100 },
+        {
+          model: 'nonexistent',
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 100,
+        },
         registry,
       );
 
@@ -676,6 +684,63 @@ describe('handleCreateMessage', () => {
       expect(parsed.content[1].text).toBe('The answer is 42.');
     });
 
+    it('streaming recovers Gemma4 raw tool-call text without leaking channel markers when tools are absent', async () => {
+      const rawText =
+        '<|channel>thought\nI should inspect files.\n<channel|><|tool_call>call:read_file{path:<|"|>Cargo.toml<|"|>}<tool_call|><turn|>';
+      const registry = new ModelRegistry();
+      registry.register(
+        'test-model',
+        createMockStreamModel([
+          { text: 'I should inspect files.', done: false, isReasoning: true },
+          {
+            text: '',
+            done: true,
+            finishReason: 'tool_calls',
+            toolCalls: [
+              {
+                status: 'ok',
+                id: 'toolu_abc123',
+                name: 'read_file',
+                arguments: '{"path":"Cargo.toml"}',
+              } as ToolCallResult,
+            ],
+            thinking: 'I should inspect files.',
+            numTokens: 20,
+            promptTokens: 10,
+            reasoningTokens: 0,
+            rawText,
+          },
+        ]),
+      );
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'summarize Cargo.toml' }],
+          max_tokens: 100,
+          stream: true,
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const text = events
+        .filter((e) => e.event === 'content_block_delta')
+        .map((e) => e.data['delta'] as { type?: string; text?: string })
+        .filter((delta) => delta.type === 'text_delta')
+        .map((delta) => delta.text ?? '')
+        .join('');
+
+      expect(text).toBe('<|tool_call>call:read_file{path:<|"|>Cargo.toml<|"|>}<tool_call|>');
+      expect(text).not.toContain('<|channel>');
+      expect(text).not.toContain('<channel|>');
+
+      const stop = events.find((e) => e.event === 'message_delta')?.data['delta'] as { stop_reason?: string };
+      expect(stop.stop_reason).toBe('end_turn');
+    });
+
     it('returns tool_use content blocks', async () => {
       const registry = new ModelRegistry();
       const mockModel = createMockModel(
@@ -705,7 +770,12 @@ describe('handleCreateMessage', () => {
           model: 'test-model',
           messages: [{ role: 'user', content: 'What is the weather?' }],
           max_tokens: 100,
-          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+          tools: [
+            {
+              name: 'get_weather',
+              input_schema: { type: 'object', properties: {} },
+            },
+          ],
         },
         registry,
       );
@@ -1036,7 +1106,12 @@ describe('handleCreateMessage', () => {
           messages: [{ role: 'user', content: 'Weather?' }],
           max_tokens: 100,
           stream: true,
-          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+          tools: [
+            {
+              name: 'get_weather',
+              input_schema: { type: 'object', properties: {} },
+            },
+          ],
         },
         registry,
       );
@@ -1102,7 +1177,12 @@ describe('handleCreateMessage', () => {
           messages: [{ role: 'user', content: 'Search' }],
           max_tokens: 100,
           stream: true,
-          tools: [{ name: 'search', input_schema: { type: 'object', properties: {} } }],
+          tools: [
+            {
+              name: 'search',
+              input_schema: { type: 'object', properties: {} },
+            },
+          ],
         },
         registry,
       );
@@ -1261,7 +1341,11 @@ describe('handleCreateMessage', () => {
         // this advances emittedTextLength to 2 BEFORE suppression triggers.
         { text: '\n\n', done: false, isReasoning: false },
         // Unclosed tool_call — tagBuffer suppresses everything from here on.
-        { text: '<tool_call>\n<function=Agent>{"q":"x"}', done: false, isReasoning: false },
+        {
+          text: '<tool_call>\n<function=Agent>{"q":"x"}',
+          done: false,
+          isReasoning: false,
+        },
         {
           // Native side trims the leading "\n\n" (split_at_think_end), so
           // finalText starts with "<tool_call>" — NOT "\n\n<tool_call>".
@@ -1346,7 +1430,14 @@ describe('handleCreateMessage', () => {
           done: true,
           finishReason: 'stop',
           // Non-ok tool call — okToolCalls filter returns [].
-          toolCalls: [{ id: 'tool_1', name: 'lookup', arguments: '', status: 'invalid_json' }],
+          toolCalls: [
+            {
+              id: 'tool_1',
+              name: 'lookup',
+              arguments: '',
+              status: 'invalid_json',
+            },
+          ],
           thinking: null,
           numTokens: 25,
           promptTokens: 5,
@@ -1365,7 +1456,12 @@ describe('handleCreateMessage', () => {
           messages: [{ role: 'user', content: 'use a tool' }],
           max_tokens: 30,
           stream: true,
-          tools: [{ name: 'lookup', input_schema: { type: 'object', properties: {} } }],
+          tools: [
+            {
+              name: 'lookup',
+              input_schema: { type: 'object', properties: {} },
+            },
+          ],
         },
         registry,
       );
@@ -1395,7 +1491,11 @@ describe('handleCreateMessage', () => {
       const registry = new ModelRegistry();
       const streamEvents = [
         { text: longWhitespace, done: false, isReasoning: false },
-        { text: '<tool_call>\n<function=Agent>{"q":"x"}', done: false, isReasoning: false },
+        {
+          text: '<tool_call>\n<function=Agent>{"q":"x"}',
+          done: false,
+          isReasoning: false,
+        },
         {
           // Native split_at_think_end trims the leading whitespace → finalText
           // starts with "<tool_call>" (length ~38, less than emittedText's 80
@@ -1462,7 +1562,14 @@ describe('handleCreateMessage', () => {
           text: 'Let me check.',
           done: true,
           finishReason: 'tool_calls',
-          toolCalls: [{ id: 'tool_1', name: 'lookup', arguments: { q: 'x' }, status: 'ok' }],
+          toolCalls: [
+            {
+              id: 'tool_1',
+              name: 'lookup',
+              arguments: { q: 'x' },
+              status: 'ok',
+            },
+          ],
           thinking: null,
           numTokens: 20,
           promptTokens: 5,
@@ -1481,7 +1588,12 @@ describe('handleCreateMessage', () => {
           messages: [{ role: 'user', content: 'use a tool' }],
           max_tokens: 30,
           stream: true,
-          tools: [{ name: 'lookup', input_schema: { type: 'object', properties: {} } }],
+          tools: [
+            {
+              name: 'lookup',
+              input_schema: { type: 'object', properties: {} },
+            },
+          ],
         },
         registry,
       );
@@ -1665,7 +1777,10 @@ describe('handleCreateMessage', () => {
       // message on the envelope.
       const errorEvents = events.filter((e) => e.event === 'error');
       expect(errorEvents).toHaveLength(1);
-      const errorBody = errorEvents[0].data['error'] as { type: string; message: string };
+      const errorBody = errorEvents[0].data['error'] as {
+        type: string;
+        message: string;
+      };
       expect(errorBody.type).toBe('api_error');
       expect(errorBody.message).toContain('native decode crashed mid-flight');
 
@@ -1762,7 +1877,10 @@ describe('handleCreateMessage', () => {
       // Exactly one `error` event, citing the client disconnect.
       const errorEvents = events.filter((e) => e.event === 'error');
       expect(errorEvents).toHaveLength(1);
-      const errorBody = errorEvents[0].data['error'] as { type: string; message: string };
+      const errorBody = errorEvents[0].data['error'] as {
+        type: string;
+        message: string;
+      };
       expect(errorBody.type).toBe('api_error');
       expect(errorBody.message).toMatch(/client disconnected/i);
 
@@ -1987,7 +2105,10 @@ describe('handleCreateMessage', () => {
       const errorEvent = events.find((e) => e.event === 'error');
       expect(errorEvent).toBeDefined();
       expect(errorEvent!.data['type']).toBe('error');
-      const errorBody = errorEvent!.data['error'] as { type: string; message: string };
+      const errorBody = errorEvent!.data['error'] as {
+        type: string;
+        message: string;
+      };
       expect(errorBody.type).toBe('api_error');
       expect(errorBody.message).toMatch(/finishReason=error|did not commit/i);
 
@@ -2026,7 +2147,10 @@ describe('handleCreateMessage', () => {
       const errorEvents = events.filter((e) => e.event === 'error');
       expect(errorEvents).toHaveLength(1);
       expect(errorEvents[0].data['type']).toBe('error');
-      const errorBody = errorEvents[0].data['error'] as { type: string; message: string };
+      const errorBody = errorEvents[0].data['error'] as {
+        type: string;
+        message: string;
+      };
       expect(errorBody.type).toBe('api_error');
       expect(errorBody.message).toMatch(/without a done event|stream ended/i);
 
@@ -2110,8 +2234,18 @@ describe('handleCreateMessage', () => {
             {
               role: 'assistant',
               content: [
-                { type: 'tool_use', id: 'call_a', name: 'get_weather', input: { city: 'SF' } },
-                { type: 'tool_use', id: 'call_b', name: 'get_news', input: { q: 'tech' } },
+                {
+                  type: 'tool_use',
+                  id: 'call_a',
+                  name: 'get_weather',
+                  input: { city: 'SF' },
+                },
+                {
+                  type: 'tool_use',
+                  id: 'call_b',
+                  name: 'get_news',
+                  input: { q: 'tech' },
+                },
               ],
             },
             {
@@ -2119,8 +2253,16 @@ describe('handleCreateMessage', () => {
               content: [
                 // Intentionally reversed order — the handler must
                 // canonicalize to [call_a, call_b] before dispatch.
-                { type: 'tool_result', tool_use_id: 'call_b', content: '{"headlines":[]}' },
-                { type: 'tool_result', tool_use_id: 'call_a', content: '{"temp":68}' },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_b',
+                  content: '{"headlines":[]}',
+                },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_a',
+                  content: '{"temp":68}',
+                },
               ],
             },
           ],
@@ -2171,31 +2313,67 @@ describe('handleCreateMessage', () => {
             {
               role: 'assistant',
               content: [
-                { type: 'tool_use', id: 'call_1', name: 'get_a', input: { k: 'a' } },
-                { type: 'tool_use', id: 'call_2', name: 'get_b', input: { k: 'b' } },
+                {
+                  type: 'tool_use',
+                  id: 'call_1',
+                  name: 'get_a',
+                  input: { k: 'a' },
+                },
+                {
+                  type: 'tool_use',
+                  id: 'call_2',
+                  name: 'get_b',
+                  input: { k: 'b' },
+                },
               ],
             },
             {
               role: 'user',
               content: [
                 // First fan-out's tool_result blocks reversed.
-                { type: 'tool_result', tool_use_id: 'call_2', content: '{"v":"b-result"}' },
-                { type: 'tool_result', tool_use_id: 'call_1', content: '{"v":"a-result"}' },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_2',
+                  content: '{"v":"b-result"}',
+                },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_1',
+                  content: '{"v":"a-result"}',
+                },
               ],
             },
             {
               role: 'assistant',
               content: [
-                { type: 'tool_use', id: 'call_3', name: 'get_c', input: { k: 'c' } },
-                { type: 'tool_use', id: 'call_4', name: 'get_d', input: { k: 'd' } },
+                {
+                  type: 'tool_use',
+                  id: 'call_3',
+                  name: 'get_c',
+                  input: { k: 'c' },
+                },
+                {
+                  type: 'tool_use',
+                  id: 'call_4',
+                  name: 'get_d',
+                  input: { k: 'd' },
+                },
               ],
             },
             {
               role: 'user',
               content: [
                 // Second fan-out already canonical.
-                { type: 'tool_result', tool_use_id: 'call_3', content: '{"v":"c-result"}' },
-                { type: 'tool_result', tool_use_id: 'call_4', content: '{"v":"d-result"}' },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_3',
+                  content: '{"v":"c-result"}',
+                },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_4',
+                  content: '{"v":"d-result"}',
+                },
               ],
             },
           ],
@@ -2247,15 +2425,33 @@ describe('handleCreateMessage', () => {
             {
               role: 'assistant',
               content: [
-                { type: 'tool_use', id: 'call_a', name: 'get_weather', input: { city: 'SF' } },
-                { type: 'tool_use', id: 'call_b', name: 'get_news', input: { q: 'tech' } },
+                {
+                  type: 'tool_use',
+                  id: 'call_a',
+                  name: 'get_weather',
+                  input: { city: 'SF' },
+                },
+                {
+                  type: 'tool_use',
+                  id: 'call_b',
+                  name: 'get_news',
+                  input: { q: 'tech' },
+                },
               ],
             },
             {
               role: 'user',
               content: [
-                { type: 'tool_result', tool_use_id: 'call_a', content: '{"temp":68}' },
-                { type: 'tool_result', tool_use_id: 'call_b', content: '{"headlines":[]}' },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_a',
+                  content: '{"temp":68}',
+                },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_b',
+                  content: '{"headlines":[]}',
+                },
               ],
             },
           ],
@@ -2299,15 +2495,29 @@ describe('handleCreateMessage', () => {
             {
               role: 'assistant',
               content: [
-                { type: 'tool_use', id: 'call_a', name: 'get_weather', input: { city: 'SF' } },
-                { type: 'tool_use', id: 'call_b', name: 'get_news', input: { q: 'tech' } },
+                {
+                  type: 'tool_use',
+                  id: 'call_a',
+                  name: 'get_weather',
+                  input: { city: 'SF' },
+                },
+                {
+                  type: 'tool_use',
+                  id: 'call_b',
+                  name: 'get_news',
+                  input: { q: 'tech' },
+                },
               ],
             },
             {
               role: 'user',
               content: [
                 // Only call_a is resolved — call_b is missing.
-                { type: 'tool_result', tool_use_id: 'call_a', content: '{"temp":68}' },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_a',
+                  content: '{"temp":68}',
+                },
               ],
             },
             {
@@ -2350,11 +2560,24 @@ describe('handleCreateMessage', () => {
             { role: 'user', content: 'get weather' },
             {
               role: 'assistant',
-              content: [{ type: 'tool_use', id: 'call_a', name: 'get_weather', input: { city: 'SF' } }],
+              content: [
+                {
+                  type: 'tool_use',
+                  id: 'call_a',
+                  name: 'get_weather',
+                  input: { city: 'SF' },
+                },
+              ],
             },
             {
               role: 'user',
-              content: [{ type: 'tool_result', tool_use_id: 'call_ghost', content: '{"temp":68}' }],
+              content: [
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_ghost',
+                  content: '{"temp":68}',
+                },
+              ],
             },
           ],
           max_tokens: 100,
@@ -2388,16 +2611,34 @@ describe('handleCreateMessage', () => {
             {
               role: 'assistant',
               content: [
-                { type: 'tool_use', id: 'call_a', name: 'get_weather', input: { city: 'SF' } },
-                { type: 'tool_use', id: 'call_b', name: 'get_news', input: { q: 'tech' } },
+                {
+                  type: 'tool_use',
+                  id: 'call_a',
+                  name: 'get_weather',
+                  input: { city: 'SF' },
+                },
+                {
+                  type: 'tool_use',
+                  id: 'call_b',
+                  name: 'get_news',
+                  input: { q: 'tech' },
+                },
               ],
             },
             {
               role: 'user',
               content: [
                 { type: 'text', text: 'here are outputs' },
-                { type: 'tool_result', tool_use_id: 'call_b', content: '{"v":"b"}' },
-                { type: 'tool_result', tool_use_id: 'call_a', content: '{"v":"a"}' },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_b',
+                  content: '{"v":"b"}',
+                },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_a',
+                  content: '{"v":"a"}',
+                },
               ],
             },
           ],
@@ -2438,16 +2679,34 @@ describe('handleCreateMessage', () => {
             {
               role: 'assistant',
               content: [
-                { type: 'tool_use', id: 'call_a', name: 'get_weather', input: { city: 'SF' } },
-                { type: 'tool_use', id: 'call_b', name: 'get_news', input: { q: 'tech' } },
+                {
+                  type: 'tool_use',
+                  id: 'call_a',
+                  name: 'get_weather',
+                  input: { city: 'SF' },
+                },
+                {
+                  type: 'tool_use',
+                  id: 'call_b',
+                  name: 'get_news',
+                  input: { q: 'tech' },
+                },
               ],
             },
             {
               role: 'user',
               content: [
                 // Reversed — canonicalization will reorder to [call_a, call_b].
-                { type: 'tool_result', tool_use_id: 'call_b', content: '{"v":"b"}' },
-                { type: 'tool_result', tool_use_id: 'call_a', content: '{"v":"a"}' },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_b',
+                  content: '{"v":"b"}',
+                },
+                {
+                  type: 'tool_result',
+                  tool_use_id: 'call_a',
+                  content: '{"v":"a"}',
+                },
               ],
             },
             { role: 'user', content: 'here are outputs' },
@@ -2465,7 +2724,12 @@ describe('handleCreateMessage', () => {
       const startSpy = mockModel.chatSessionStart as unknown as ReturnType<typeof vi.fn>;
       expect(startSpy).toHaveBeenCalledTimes(1);
       const [primedMessages] = startSpy.mock.calls[0] as [
-        Array<{ role: string; content: string; toolCallId?: string; toolCalls?: Array<{ id: string }> }>,
+        Array<{
+          role: string;
+          content: string;
+          toolCallId?: string;
+          toolCalls?: Array<{ id: string }>;
+        }>,
       ];
 
       const assistantIdx = primedMessages.findIndex((m) => m.role === 'assistant');
@@ -2503,7 +2767,14 @@ describe('handleCreateMessage', () => {
             { role: 'user', content: 'call the tool' },
             {
               role: 'assistant',
-              content: [{ type: 'tool_use', id: 'call_fail', name: 'get_weather', input: { city: 'SF' } }],
+              content: [
+                {
+                  type: 'tool_use',
+                  id: 'call_fail',
+                  name: 'get_weather',
+                  input: { city: 'SF' },
+                },
+              ],
             },
             {
               role: 'user',
@@ -2534,7 +2805,10 @@ describe('handleCreateMessage', () => {
       expect(toolMsg).toBeDefined();
       expect(toolMsg!.content).toBe(JSON.stringify({ is_error: true, content: 'boom: connection refused' }));
       // Envelope content is valid JSON and round-trips cleanly.
-      const parsed = JSON.parse(toolMsg!.content) as { is_error: boolean; content: string };
+      const parsed = JSON.parse(toolMsg!.content) as {
+        is_error: boolean;
+        content: string;
+      };
       expect(parsed.is_error).toBe(true);
       expect(parsed.content).toBe('boom: connection refused');
     });
@@ -3273,8 +3547,18 @@ describe('handleCreateMessage', () => {
       // like the simpler three-turn test above — but with a rotating
       // billing block prepended.
       const startResults = [
-        makeChatResult({ text: 'A1', cachedTokens: 0, promptTokens: 5, numTokens: 3 }),
-        makeChatResult({ text: 'A2', cachedTokens: 12, promptTokens: 20, numTokens: 5 }),
+        makeChatResult({
+          text: 'A1',
+          cachedTokens: 0,
+          promptTokens: 5,
+          numTokens: 3,
+        }),
+        makeChatResult({
+          text: 'A2',
+          cachedTokens: 12,
+          promptTokens: 20,
+          numTokens: 5,
+        }),
       ];
       const chatSessionStart = vi.fn().mockResolvedValueOnce(startResults[0]).mockResolvedValueOnce(startResults[1]);
       const resetCaches = vi.fn();
@@ -3298,7 +3582,10 @@ describe('handleCreateMessage', () => {
         {
           model: 'test-model',
           system: [
-            { type: 'text', text: 'x-anthropic-billing-header: cc_version=2.1.119.806; cch=AAAA;' },
+            {
+              type: 'text',
+              text: 'x-anthropic-billing-header: cc_version=2.1.119.806; cch=AAAA;',
+            },
             { type: 'text', text: 'You are Claude.' },
           ],
           messages: [{ role: 'user', content: 'A' }],
@@ -3321,7 +3608,10 @@ describe('handleCreateMessage', () => {
           system: [
             // cch= rotated. Without the strip this whole request would
             // miss the warm slot at the gate level.
-            { type: 'text', text: 'x-anthropic-billing-header: cc_version=2.1.119.806; cch=BBBB;' },
+            {
+              type: 'text',
+              text: 'x-anthropic-billing-header: cc_version=2.1.119.806; cch=BBBB;',
+            },
             { type: 'text', text: 'You are Claude.' },
           ],
           messages: [
@@ -3339,7 +3629,9 @@ describe('handleCreateMessage', () => {
       expect(r2.getStatus()).toBe(200);
       expect(r2.getHeaders()['x-session-cache']).toBe('prefix_hit');
       expect(r2.getHeaders()['x-cached-tokens']).toBe('12');
-      const t2Body = JSON.parse(r2.getBody()) as { usage: Record<string, number> };
+      const t2Body = JSON.parse(r2.getBody()) as {
+        usage: Record<string, number>;
+      };
       expect(t2Body.usage.cache_read_input_tokens).toBe(12);
       expect(t2Body.usage.input_tokens).toBe(8); // 20 - 12
       expect(sessionReg.size).toBe(1);
@@ -3353,8 +3645,14 @@ describe('handleCreateMessage', () => {
       expect(chatSessionStart).toHaveBeenCalledTimes(2);
       const turn1Messages = chatSessionStart.mock.calls[0]![0] as ChatMessage[];
       const turn2Messages = chatSessionStart.mock.calls[1]![0] as ChatMessage[];
-      expect(turn1Messages[0]).toEqual({ role: 'system', content: 'You are Claude.' });
-      expect(turn2Messages[0]).toEqual({ role: 'system', content: 'You are Claude.' });
+      expect(turn1Messages[0]).toEqual({
+        role: 'system',
+        content: 'You are Claude.',
+      });
+      expect(turn2Messages[0]).toEqual({
+        role: 'system',
+        content: 'You are Claude.',
+      });
     });
 
     it('three-turn streaming replay reuses the warm slot (header reports streaming)', async () => {
@@ -3809,7 +4107,12 @@ describe('handleCreateMessage', () => {
             messages: [{ role: 'user', content: 'hi' }],
             max_tokens: 100,
             stream: true,
-            tools: [{ name: 'do_thing', input_schema: { type: 'object', properties: {} } }],
+            tools: [
+              {
+                name: 'do_thing',
+                input_schema: { type: 'object', properties: {} },
+              },
+            ],
           },
           registry,
         );
@@ -4049,8 +4352,22 @@ describe('handleCreateMessage', () => {
       //     existing classification.
       const chatSessionStart = vi
         .fn()
-        .mockResolvedValueOnce(makeChatResult({ text: 'A1', numTokens: 3, promptTokens: 5, cachedTokens: 0 }))
-        .mockResolvedValueOnce(makeChatResult({ text: 'A2', numTokens: 5, promptTokens: 20, cachedTokens: 7 }));
+        .mockResolvedValueOnce(
+          makeChatResult({
+            text: 'A1',
+            numTokens: 3,
+            promptTokens: 5,
+            cachedTokens: 0,
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeChatResult({
+            text: 'A2',
+            numTokens: 5,
+            promptTokens: 20,
+            cachedTokens: 7,
+          }),
+        );
       const mockModel = {
         chatSessionStart,
         chatSessionContinue: vi.fn().mockRejectedValue(new Error('hot path: not expected')),
@@ -4076,7 +4393,9 @@ describe('handleCreateMessage', () => {
         registry,
       );
       expect(r1.getStatus()).toBe(200);
-      const t1Body = JSON.parse(r1.getBody()) as { usage: Record<string, number> };
+      const t1Body = JSON.parse(r1.getBody()) as {
+        usage: Record<string, number>;
+      };
       expect(t1Body.usage.input_tokens).toBe(5);
       expect(t1Body.usage.output_tokens).toBe(3);
       expect(t1Body.usage).not.toHaveProperty('cache_read_input_tokens');
@@ -4104,7 +4423,9 @@ describe('handleCreateMessage', () => {
         registry,
       );
       expect(r2.getStatus()).toBe(200);
-      const t2Body = JSON.parse(r2.getBody()) as { usage: Record<string, number> };
+      const t2Body = JSON.parse(r2.getBody()) as {
+        usage: Record<string, number>;
+      };
       expect(t2Body.usage.cache_read_input_tokens).toBe(7);
       expect(t2Body.usage.input_tokens).toBe(13);
       expect(t2Body.usage.output_tokens).toBe(5);
@@ -4241,13 +4562,27 @@ describe('handleCreateMessage', () => {
       // `'prefix_hit'`.
       const chatSessionStart = vi
         .fn()
-        .mockResolvedValueOnce(makeChatResult({ text: 'first', numTokens: 4, promptTokens: 6, cachedTokens: 0 }))
+        .mockResolvedValueOnce(
+          makeChatResult({
+            text: 'first',
+            numTokens: 4,
+            promptTokens: 6,
+            cachedTokens: 0,
+          }),
+        )
         // Second turn: instructions match (same `system: 'S'`) so
         // `getOrCreateWarmAny` returns a hit, BUT the mocked native
         // result reports `cachedTokens === 0` — exactly what
         // `verify_cache_prefix_direct` returns when the prefix
         // mismatched after a hidden change (images, tools, template).
-        .mockResolvedValueOnce(makeChatResult({ text: 'second', numTokens: 6, promptTokens: 11, cachedTokens: 0 }));
+        .mockResolvedValueOnce(
+          makeChatResult({
+            text: 'second',
+            numTokens: 6,
+            promptTokens: 11,
+            cachedTokens: 0,
+          }),
+        );
       const resetCaches = vi.fn();
       const mockModel = {
         chatSessionStart,
@@ -4320,7 +4655,9 @@ describe('handleCreateMessage', () => {
 
         // Body cache fields stay OFF the wire — no
         // `cache_read_input_tokens`, no `cache_creation_input_tokens`.
-        const t2Body = JSON.parse(r2.getBody()) as { usage: Record<string, number> };
+        const t2Body = JSON.parse(r2.getBody()) as {
+          usage: Record<string, number>;
+        };
         expect(t2Body.usage).not.toHaveProperty('cache_read_input_tokens');
         expect(t2Body.usage).not.toHaveProperty('cache_creation_input_tokens');
         expect(t2Body.usage.input_tokens).toBe(11);

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -684,7 +684,7 @@ describe('handleCreateMessage', () => {
       expect(parsed.content[1].text).toBe('The answer is 42.');
     });
 
-    it('streaming recovers Gemma4 raw tool-call text without leaking channel markers when tools are absent', async () => {
+    it('streaming suppresses Gemma4 parsed tool-call markup when tools are absent', async () => {
       const rawText =
         '<|channel>thought\nI should inspect files.\n<channel|><|tool_call>call:read_file{path:<|"|>Cargo.toml<|"|>}<tool_call|><turn|>';
       const registry = new ModelRegistry();
@@ -733,9 +733,11 @@ describe('handleCreateMessage', () => {
         .map((delta) => delta.text ?? '')
         .join('');
 
-      expect(text).toBe('<|tool_call>call:read_file{path:<|"|>Cargo.toml<|"|>}<tool_call|>');
+      expect(text).toBe('');
       expect(text).not.toContain('<|channel>');
       expect(text).not.toContain('<channel|>');
+      expect(text).not.toContain('<|tool_call>');
+      expect(text).not.toContain('<tool_call|>');
 
       const stop = events.find((e) => e.event === 'message_delta')?.data['delta'] as { stop_reason?: string };
       expect(stop.stop_reason).toBe('end_turn');
@@ -790,7 +792,7 @@ describe('handleCreateMessage', () => {
       expect(toolBlock.input).toEqual({ location: 'San Francisco' });
     });
 
-    it('does not emit tool_use blocks when request has no tools', async () => {
+    it('does not emit tool_use blocks or parsed tool markup when request has no tools', async () => {
       const registry = new ModelRegistry();
       const mockModel = createMockModel(
         makeChatResult({
@@ -832,7 +834,7 @@ describe('handleCreateMessage', () => {
       expect(parsed.content).toEqual([
         {
           type: 'text',
-          text: '<tool_call>{"name":"get_weather","arguments":{"location":"San Francisco"}}</tool_call>',
+          text: '',
         },
       ]);
       expect(noToolsSessionReg.size).toBe(0);
@@ -1202,7 +1204,7 @@ describe('handleCreateMessage', () => {
       expect(toolStarts).toHaveLength(1);
     });
 
-    it('streams literal tool_call markup as text when request has no tools', async () => {
+    it('suppresses parsed tool_call markup when request has no tools', async () => {
       const registry = new ModelRegistry();
       const streamEvents = [
         { text: '<tool_call>', done: false, isReasoning: false },
@@ -1242,11 +1244,16 @@ describe('handleCreateMessage', () => {
       );
 
       const events = parseSSE(getBody());
+      const textStarts = events.filter(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'text',
+      );
+      expect(textStarts).toHaveLength(0);
+
       const textDeltas = events.filter(
         (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
       );
       const combined = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
-      expect(combined).toBe('<tool_call>{"name":"search"}</tool_call>');
+      expect(combined).toBe('');
 
       const toolStarts = events.filter(
         (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'tool_use',

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -676,6 +676,54 @@ describe('handleCreateMessage', () => {
       expect(toolBlock.input).toEqual({ location: 'San Francisco' });
     });
 
+    it('does not emit tool_use blocks when request has no tools', async () => {
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel(
+        makeChatResult({
+          text: '',
+          toolCalls: [
+            {
+              status: 'ok',
+              id: 'toolu_no_tools',
+              name: 'get_weather',
+              arguments: '{"location":"San Francisco"}',
+              rawContent: '{"name":"get_weather","arguments":{"location":"San Francisco"}}',
+            } as ToolCallResult,
+          ],
+          numTokens: 20,
+          promptTokens: 10,
+          reasoningTokens: 0,
+          finishReason: 'stop',
+          rawText: '<tool_call>{"name":"get_weather","arguments":{"location":"San Francisco"}}</tool_call>',
+        }),
+      );
+      registry.register('test-model', mockModel);
+      const noToolsSessionReg = registry.getSessionRegistry('test-model')!;
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'What is the weather?' }],
+          max_tokens: 100,
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.stop_reason).toBe('end_turn');
+      expect(parsed.content.some((b: any) => b.type === 'tool_use')).toBe(false);
+      expect(parsed.content).toEqual([
+        {
+          type: 'text',
+          text: '<tool_call>{"name":"get_weather","arguments":{"location":"San Francisco"}}</tool_call>',
+        },
+      ]);
+      expect(noToolsSessionReg.size).toBe(0);
+    });
+
     it('drops the warm slot when chatSessionStart resolves with finishReason="error"', async () => {
       // Defensive-hardening gate: today every native failure throws,
       // but `runSessionNonStreaming` enforces the invariant locally so
@@ -907,6 +955,7 @@ describe('handleCreateMessage', () => {
           messages: [{ role: 'user', content: 'Weather?' }],
           max_tokens: 100,
           stream: true,
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
         },
         registry,
       );
@@ -972,6 +1021,7 @@ describe('handleCreateMessage', () => {
           messages: [{ role: 'user', content: 'Search' }],
           max_tokens: 100,
           stream: true,
+          tools: [{ name: 'search', input_schema: { type: 'object', properties: {} } }],
         },
         registry,
       );
@@ -989,6 +1039,67 @@ describe('handleCreateMessage', () => {
         (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'tool_use',
       );
       expect(toolStarts).toHaveLength(1);
+    });
+
+    it('streams literal tool_call markup as text when request has no tools', async () => {
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: '<tool_call>', done: false, isReasoning: false },
+        { text: '{"name":"search"}', done: false, isReasoning: false },
+        {
+          text: '',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [
+            {
+              status: 'ok',
+              id: 'toolu_no_tools',
+              name: 'search',
+              arguments: '{"query":"test"}',
+            },
+          ],
+          thinking: null,
+          numTokens: 8,
+          promptTokens: 4,
+          reasoningTokens: 0,
+          rawText: '<tool_call>{"name":"search"}</tool_call>',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const noToolsStreamSessionReg = registry.getSessionRegistry('test-model')!;
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'Search' }],
+          max_tokens: 100,
+          stream: true,
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const combined = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(combined).toBe('<tool_call>{"name":"search"}</tool_call>');
+
+      const toolStarts = events.filter(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'tool_use',
+      );
+      expect(toolStarts).toHaveLength(0);
+
+      const jsonDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'input_json_delta',
+      );
+      expect(jsonDeltas).toHaveLength(0);
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('end_turn');
+      expect(noToolsStreamSessionReg.size).toBe(0);
     });
 
     it('recovers suppressed text after false-alarm tool_call tag when text was already emitted', async () => {
@@ -1173,6 +1284,7 @@ describe('handleCreateMessage', () => {
           messages: [{ role: 'user', content: 'use a tool' }],
           max_tokens: 30,
           stream: true,
+          tools: [{ name: 'lookup', input_schema: { type: 'object', properties: {} } }],
         },
         registry,
       );
@@ -1288,6 +1400,7 @@ describe('handleCreateMessage', () => {
           messages: [{ role: 'user', content: 'use a tool' }],
           max_tokens: 30,
           stream: true,
+          tools: [{ name: 'lookup', input_schema: { type: 'object', properties: {} } }],
         },
         registry,
       );
@@ -3615,6 +3728,7 @@ describe('handleCreateMessage', () => {
             messages: [{ role: 'user', content: 'hi' }],
             max_tokens: 100,
             stream: true,
+            tools: [{ name: 'do_thing', input_schema: { type: 'object', properties: {} } }],
           },
           registry,
         );

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -1001,6 +1001,82 @@ describe('handleCreateMessage', () => {
       expect(config.maxNewTokens).toBe(16);
     });
 
+    it('uses a short non-thinking config for Claude Code title generation requests', async () => {
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: '{', done: false, isReasoning: true },
+        { text: '{"title": "Analyze codebase architecture"}', done: false, isReasoning: false },
+        {
+          text: '{"title": "Analyze codebase architecture"}',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 8,
+          promptTokens: 32,
+          reasoningTokens: 0,
+          rawText: '{"title": "Analyze codebase architecture"}',
+        },
+      ];
+      const mockModel = createMockStreamModel(streamEvents);
+      registry.register('test-model', mockModel, { maxOutputTokens: 81920 });
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'Deepresearch the whole codebase, describe the architecture' }],
+          system: [
+            { type: 'text', text: 'x-anthropic-billing-header: cc_version=2.1.138; cch=d2ad0;' },
+            { type: 'text', text: "You are Claude Code, Anthropic's official CLI for Claude." },
+            {
+              type: 'text',
+              text:
+                'Generate a concise, sentence-case title (3-7 words) that captures the main topic. ' +
+                'Return JSON with a single "title" field.',
+            },
+          ],
+          tools: [],
+          max_tokens: 64000,
+          output_config: {
+            format: {
+              type: 'json_schema',
+              schema: {
+                type: 'object',
+                properties: { title: { type: 'string' } },
+                required: ['title'],
+                additionalProperties: false,
+              },
+            },
+          },
+          stream: true,
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const streamSpy = mockModel.chatStreamSessionStart as unknown as ReturnType<typeof vi.fn>;
+      const config = streamSpy.mock.calls[0]?.[1] as {
+        maxNewTokens?: number;
+        reasoningEffort?: string;
+        thinkingTokenBudget?: number;
+        includeReasoning?: boolean;
+      };
+      expect(config.maxNewTokens).toBe(128);
+      expect(config.reasoningEffort).toBe('none');
+      expect(config.thinkingTokenBudget).toBe(0);
+      expect(config.includeReasoning).toBe(false);
+
+      const events = parseSSE(getBody());
+      const thinkingStart = events.find(
+        (event) =>
+          event.event === 'content_block_start' &&
+          (event.data['content_block'] as Record<string, unknown> | undefined)?.['type'] === 'thinking',
+      );
+      expect(thinkingStart).toBeUndefined();
+    });
+
     it('emits thinking + text with correct content block indices', async () => {
       const registry = new ModelRegistry();
       const streamEvents = [

--- a/__test__/server/messages-paged-no-warm-reuse.test.ts
+++ b/__test__/server/messages-paged-no-warm-reuse.test.ts
@@ -162,7 +162,8 @@ describe('handleCreateMessage — paged-active warm-slot bypass', () => {
     // adopts a warm entry. The size invariant is the load-bearing
     // proof: 0 before AND 0 after a successful dispatch.
     const registry = new ModelRegistry();
-    registry.register('paged-model', createMockModel(/* paged */ true));
+    const mockModel = createMockModel(/* paged */ true);
+    registry.register('paged-model', mockModel);
     const sessionReg = registry.getSessionRegistry('paged-model')!;
     expect(sessionReg.size).toBe(0);
 
@@ -181,6 +182,11 @@ describe('handleCreateMessage — paged-active warm-slot bypass', () => {
     expect(getStatus()).toBe(200);
     // The load-bearing assertion: paged path NEVER adopts the warm slot.
     expect(sessionReg.size).toBe(0);
+    // Paged reuse is native/content-addressed. A fresh JS ChatSession is
+    // still allocated, but the endpoint must not call the public full
+    // native reset because that clears MoE GDN prefix checkpoints between
+    // otherwise cacheable stateless turns.
+    expect(mockModel.resetCaches).not.toHaveBeenCalled();
     // Pre-dispatch header is `fresh` because `lookup.hit` is always
     // false on the paged path; no `cachedTokens > 0` promotion fired
     // because the mock returned `cachedTokens: 0`.
@@ -274,7 +280,8 @@ describe('handleCreateMessage — paged-active warm-slot bypass', () => {
     // the sentinel id, otherwise non-paged models lose their only
     // cross-conversation reuse mechanism.
     const registry = new ModelRegistry();
-    registry.register('flat-model', createMockModel(/* paged */ false));
+    const mockModel = createMockModel(/* paged */ false);
+    registry.register('flat-model', mockModel);
     const sessionReg = registry.getSessionRegistry('flat-model')!;
 
     const { res, getStatus } = createMockRes();
@@ -292,6 +299,9 @@ describe('handleCreateMessage — paged-active warm-slot bypass', () => {
     expect(getStatus()).toBe(200);
     // Load-bearing: non-paged path DID adopt the warm slot.
     expect(sessionReg.size).toBe(1);
+    // Non-paged MISS still takes the public full reset branch. Its only
+    // authorized native-cache-preserving path is a warm-slot HIT.
+    expect(mockModel.resetCaches).toHaveBeenCalledTimes(1);
   });
 
   it('two parallel paged-active requests with the same system both get fresh sessions and BOTH commit (no warm-slot serialization)', async () => {

--- a/__test__/server/model-work-coordinator-queue-cap.test.ts
+++ b/__test__/server/model-work-coordinator-queue-cap.test.ts
@@ -1,0 +1,282 @@
+import type { ServerResponse } from 'node:http';
+import { Writable } from 'node:stream';
+
+import type { ChatResult } from '@mlx-node/core';
+import type { SessionCapableModel } from '@mlx-node/lm';
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+import { handleCreateMessage } from '../../packages/server/src/endpoints/messages.js';
+import { handleCreateResponse } from '../../packages/server/src/endpoints/responses.js';
+import { ModelWorkCoordinator } from '../../packages/server/src/model-work-coordinator.js';
+import { ModelRegistry } from '../../packages/server/src/registry.js';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve));
+const timeout = (ms: number) => new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), ms));
+
+function makeChatResult(overrides: Partial<ChatResult> = {}): ChatResult {
+  return {
+    text: 'ok',
+    toolCalls: [],
+    numTokens: 1,
+    promptTokens: 1,
+    reasoningTokens: 0,
+    finishReason: 'stop',
+    rawText: 'ok',
+    cachedTokens: 0,
+    ...overrides,
+  };
+}
+
+function createModel(): SessionCapableModel {
+  return {
+    chatSessionStart: vi.fn(async () => makeChatResult()),
+    chatSessionContinue: vi.fn(async () => makeChatResult()),
+    chatSessionContinueTool: vi.fn(async () => makeChatResult()),
+    chatStreamSessionStart: vi.fn(),
+    chatStreamSessionContinue: vi.fn(),
+    chatStreamSessionContinueTool: vi.fn(),
+    resetCaches: vi.fn(),
+  } as unknown as SessionCapableModel;
+}
+
+function createMockRes(): {
+  res: ServerResponse;
+  getStatus: () => number;
+  getBody: () => string;
+  getHeaders: () => Record<string, string | string[]>;
+  waitForEnd: () => Promise<void>;
+} {
+  let status = 200;
+  let body = '';
+  const headers: Record<string, string | string[]> = {};
+  let endResolve!: () => void;
+  const endPromise = new Promise<void>((resolve) => {
+    endResolve = resolve;
+  });
+
+  const writable = new Writable({
+    write(chunk: Uint8Array | string, _encoding: string, callback: () => void) {
+      body += chunk.toString();
+      callback();
+    },
+  }) as Writable & {
+    headersSent: boolean;
+    writeHead: (statusCode: number, headers?: Record<string, string>) => Writable;
+    setHeader: (name: string, value: string) => void;
+  };
+
+  writable.headersSent = false;
+  writable.writeHead = (statusCode: number, responseHeaders?: Record<string, string>) => {
+    status = statusCode;
+    if (responseHeaders) {
+      for (const [key, value] of Object.entries(responseHeaders)) {
+        headers[key.toLowerCase()] = value;
+      }
+    }
+    writable.headersSent = true;
+    return writable;
+  };
+  writable.setHeader = (name: string, value: string) => {
+    headers[name.toLowerCase()] = value;
+  };
+
+  const originalEnd = writable.end.bind(writable);
+  writable.end = (chunkArg?: unknown, encodingArg?: unknown, cbArg?: unknown) => {
+    let chunk: string | Uint8Array | undefined;
+    let cb: ((err?: Error | null) => void) | undefined;
+    if (typeof chunkArg === 'function') {
+      cb = chunkArg as (err?: Error | null) => void;
+    } else {
+      chunk = chunkArg as string | Uint8Array | undefined;
+      if (typeof encodingArg === 'function') {
+        cb = encodingArg as (err?: Error | null) => void;
+      } else if (typeof cbArg === 'function') {
+        cb = cbArg as (err?: Error | null) => void;
+      }
+    }
+    if (chunk != null) body += chunk.toString();
+    writable.headersSent = true;
+    originalEnd(undefined, (err?: Error | null) => {
+      if (cb) cb(err ?? null);
+      endResolve();
+    });
+    return writable;
+  };
+
+  return {
+    res: writable as unknown as ServerResponse,
+    getStatus: () => status,
+    getBody: () => body,
+    getHeaders: () => headers,
+    waitForEnd: () => endPromise,
+  };
+}
+
+async function waitForQueueDepth(registry: ModelRegistry, modelName: string, expected: number): Promise<void> {
+  for (let i = 0; i < 10; i += 1) {
+    if (registry.getSessionRegistry(modelName)?.queueDepth === expected) return;
+    await tick();
+  }
+  expect(registry.getSessionRegistry(modelName)?.queueDepth).toBe(expected);
+}
+
+describe('ModelWorkCoordinator + SessionRegistry queue cap', () => {
+  it('POST /v1/messages enforces the per-model queue cap before waiting behind a model-load writer', async () => {
+    const registry = new ModelRegistry({ maxQueueDepth: 1 });
+    registry.register('cap-model', createModel());
+    const coordinator = new ModelWorkCoordinator();
+    const writerStarted = deferred();
+    const releaseWriter = deferred();
+    let requestA: Promise<void> | undefined;
+    let requestB: Promise<void> | undefined;
+    const writer = coordinator.withModelLoad(async () => {
+      writerStarted.resolve(undefined);
+      await releaseWriter.promise;
+    });
+
+    await writerStarted.promise;
+
+    try {
+      const mockA = createMockRes();
+      requestA = handleCreateMessage(
+        mockA.res,
+        {
+          model: 'cap-model',
+          messages: [{ role: 'user', content: 'A' }],
+          max_tokens: 16,
+        },
+        registry,
+        undefined,
+        null,
+        undefined,
+        coordinator,
+      );
+      await tick();
+
+      const mockB = createMockRes();
+      requestB = handleCreateMessage(
+        mockB.res,
+        {
+          model: 'cap-model',
+          messages: [{ role: 'user', content: 'B' }],
+          max_tokens: 16,
+        },
+        registry,
+        undefined,
+        null,
+        undefined,
+        coordinator,
+      );
+      await waitForQueueDepth(registry, 'cap-model', 1);
+
+      const mockC = createMockRes();
+      const requestC = handleCreateMessage(
+        mockC.res,
+        {
+          model: 'cap-model',
+          messages: [{ role: 'user', content: 'C' }],
+          max_tokens: 16,
+        },
+        registry,
+        undefined,
+        null,
+        undefined,
+        coordinator,
+      );
+      const cOutcome = await Promise.race([requestC.then(() => 'done' as const), timeout(50)]);
+
+      expect(cOutcome).toBe('done');
+      await mockC.waitForEnd();
+      expect(mockC.getStatus()).toBe(429);
+      expect(mockC.getHeaders()['retry-after']).toBe('1');
+      const parsed = JSON.parse(mockC.getBody());
+      expect(parsed.type).toBe('error');
+      expect(parsed.error.type).toBe('rate_limit_error');
+      expect(parsed.error.message).toContain('Model queue full');
+    } finally {
+      releaseWriter.resolve(undefined);
+      await writer;
+      if (requestA) await requestA;
+      if (requestB) await requestB;
+    }
+  });
+
+  it('POST /v1/responses enforces the per-model queue cap before waiting behind a model-load writer', async () => {
+    const registry = new ModelRegistry({ maxQueueDepth: 1 });
+    registry.register('cap-model', createModel());
+    const coordinator = new ModelWorkCoordinator();
+    const writerStarted = deferred();
+    const releaseWriter = deferred();
+    let requestA: Promise<void> | undefined;
+    let requestB: Promise<void> | undefined;
+    const writer = coordinator.withModelLoad(async () => {
+      writerStarted.resolve(undefined);
+      await releaseWriter.promise;
+    });
+
+    await writerStarted.promise;
+
+    try {
+      const mockA = createMockRes();
+      requestA = handleCreateResponse(
+        mockA.res,
+        { model: 'cap-model', input: 'A' },
+        registry,
+        null,
+        undefined,
+        undefined,
+        null,
+        coordinator,
+      );
+      await tick();
+
+      const mockB = createMockRes();
+      requestB = handleCreateResponse(
+        mockB.res,
+        { model: 'cap-model', input: 'B' },
+        registry,
+        null,
+        undefined,
+        undefined,
+        null,
+        coordinator,
+      );
+      await waitForQueueDepth(registry, 'cap-model', 1);
+
+      const mockC = createMockRes();
+      const requestC = handleCreateResponse(
+        mockC.res,
+        { model: 'cap-model', input: 'C' },
+        registry,
+        null,
+        undefined,
+        undefined,
+        null,
+        coordinator,
+      );
+      const cOutcome = await Promise.race([requestC.then(() => 'done' as const), timeout(50)]);
+
+      expect(cOutcome).toBe('done');
+      await mockC.waitForEnd();
+      expect(mockC.getStatus()).toBe(429);
+      expect(mockC.getHeaders()['retry-after']).toBe('1');
+      const parsed = JSON.parse(mockC.getBody());
+      expect(parsed.error.type).toBe('rate_limit_error');
+      expect(parsed.error.code).toBe('queue_full');
+      expect(parsed.error.message).toContain('Model queue full');
+    } finally {
+      releaseWriter.resolve(undefined);
+      await writer;
+      if (requestA) await requestA;
+      if (requestB) await requestB;
+    }
+  });
+});

--- a/__test__/server/model-work-coordinator.test.ts
+++ b/__test__/server/model-work-coordinator.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { ModelWorkCoordinator } from '../../packages/server/src/model-work-coordinator.js';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe('ModelWorkCoordinator', () => {
+  it('lets inference readers overlap', async () => {
+    const coordinator = new ModelWorkCoordinator();
+    const release = deferred();
+    const events: string[] = [];
+
+    const a = coordinator.withInference(async () => {
+      events.push('a:start');
+      await release.promise;
+      events.push('a:end');
+    });
+    const b = coordinator.withInference(async () => {
+      events.push('b:start');
+      await release.promise;
+      events.push('b:end');
+    });
+
+    await tick();
+    expect(events).toEqual(['a:start', 'b:start']);
+
+    release.resolve();
+    await Promise.all([a, b]);
+    expect(events).toEqual(['a:start', 'b:start', 'a:end', 'b:end']);
+  });
+
+  it('gives pending model loads priority over new inference readers', async () => {
+    const coordinator = new ModelWorkCoordinator();
+    const releaseRead = deferred();
+    const releaseWrite = deferred();
+    const events: string[] = [];
+
+    const read1 = coordinator.withInference(async () => {
+      events.push('read1:start');
+      await releaseRead.promise;
+      events.push('read1:end');
+    });
+    await tick();
+
+    const write = coordinator.withModelLoad(async () => {
+      events.push('write:start');
+      await releaseWrite.promise;
+      events.push('write:end');
+    });
+    const read2 = coordinator.withInference(async () => {
+      events.push('read2:start');
+    });
+
+    await tick();
+    expect(events).toEqual(['read1:start']);
+
+    releaseRead.resolve();
+    await tick();
+    expect(events).toEqual(['read1:start', 'read1:end', 'write:start']);
+
+    releaseWrite.resolve();
+    await Promise.all([read1, write, read2]);
+    expect(events).toEqual(['read1:start', 'read1:end', 'write:start', 'write:end', 'read2:start']);
+  });
+});

--- a/__test__/server/response-mapper.test.ts
+++ b/__test__/server/response-mapper.test.ts
@@ -173,6 +173,56 @@ describe('buildUsage', () => {
     expect(usage.output_tokens).toBe(0);
     expect(usage.total_tokens).toBe(0);
   });
+
+  it('emits server/native timing fields with cached-prefix context', () => {
+    const result = makeChatResult({
+      promptTokens: 20,
+      numTokens: 5,
+      cachedTokens: 15,
+      performance: {
+        ttftMs: 250,
+        prefillTokensPerSecond: 20,
+        decodeTokensPerSecond: 40,
+      },
+    });
+    const usage = buildUsage(result);
+
+    expect(usage.input_tokens).toBe(20);
+    expect(usage.input_tokens_details).toEqual({ cached_tokens: 15 });
+    expect(usage.time_to_first_token_ms).toBe(250);
+    expect(usage.server_time_to_first_token_ms).toBe(250);
+    expect(usage.prefill_tokens_per_second).toBe(20);
+    expect(usage.server_prefill_tokens_per_second).toBe(20);
+    expect(usage.decode_tokens_per_second).toBe(40);
+    expect(usage.server_decode_tokens_per_second).toBe(40);
+    expect(usage.prefill_input_tokens).toBe(5);
+    expect(usage.cached_prefix_tokens).toBe(15);
+    expect(usage.server_inference_elapsed_ms).toBe(350);
+  });
+
+  it('elides invalid timing metrics but keeps cache context when performance was requested', () => {
+    const result = makeChatResult({
+      promptTokens: 8,
+      numTokens: 1,
+      cachedTokens: 3,
+      performance: {
+        ttftMs: Number.NaN,
+        prefillTokensPerSecond: 0,
+        decodeTokensPerSecond: -1,
+      },
+    });
+    const usage = buildUsage(result);
+
+    expect(usage).not.toHaveProperty('time_to_first_token_ms');
+    expect(usage).not.toHaveProperty('server_time_to_first_token_ms');
+    expect(usage).not.toHaveProperty('prefill_tokens_per_second');
+    expect(usage).not.toHaveProperty('server_prefill_tokens_per_second');
+    expect(usage).not.toHaveProperty('decode_tokens_per_second');
+    expect(usage).not.toHaveProperty('server_decode_tokens_per_second');
+    expect(usage).not.toHaveProperty('server_inference_elapsed_ms');
+    expect(usage.prefill_input_tokens).toBe(5);
+    expect(usage.cached_prefix_tokens).toBe(3);
+  });
 });
 
 describe('computeOutputText', () => {

--- a/__test__/server/timing.test.ts
+++ b/__test__/server/timing.test.ts
@@ -1,0 +1,40 @@
+import { resolveServerTuningForUsage } from '@mlx-node/server';
+import { describe, expect, it } from 'vite-plus/test';
+
+describe('server timing tuning metadata', () => {
+  it('mirrors native env parser defaults', () => {
+    expect(resolveServerTuningForUsage({})).toEqual({
+      server_paged_prefill_chunk_size: 0,
+      server_paged_prefill_eval_interval: 8,
+      server_paged_decode_cache_clear_interval: 64,
+    });
+  });
+
+  it('accepts valid process-level tuning values', () => {
+    expect(
+      resolveServerTuningForUsage({
+        MLX_PAGED_PREFILL_CHUNK_SIZE: '8192',
+        MLX_PAGED_PREFILL_EVAL_INTERVAL: '16',
+        MLX_PAGED_DECODE_CACHE_CLEAR_INTERVAL: '128',
+      }),
+    ).toEqual({
+      server_paged_prefill_chunk_size: 8192,
+      server_paged_prefill_eval_interval: 16,
+      server_paged_decode_cache_clear_interval: 128,
+    });
+  });
+
+  it('falls back for invalid values using native-compatible bounds', () => {
+    expect(
+      resolveServerTuningForUsage({
+        MLX_PAGED_PREFILL_CHUNK_SIZE: '-1',
+        MLX_PAGED_PREFILL_EVAL_INTERVAL: '0',
+        MLX_PAGED_DECODE_CACHE_CLEAR_INTERVAL: 'abc',
+      }),
+    ).toEqual({
+      server_paged_prefill_chunk_size: 0,
+      server_paged_prefill_eval_interval: 8,
+      server_paged_decode_cache_clear_interval: 64,
+    });
+  });
+});

--- a/__test__/server/tool-call-buffer.test.ts
+++ b/__test__/server/tool-call-buffer.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { recoverSuppressedToolCallText } from '../../packages/server/src/mappers/anthropic-response.js';
+import { ToolCallTagBuffer } from '../../packages/server/src/tool-call-buffer.js';
+
+describe('ToolCallTagBuffer', () => {
+  it('suppresses Gemma4 structural tool-call tags split across chunks', () => {
+    const buffer = new ToolCallTagBuffer();
+
+    expect(buffer.push('title <|too')).toEqual({
+      safeText: 'title ',
+      tagFound: false,
+      cleanPrefix: '',
+    });
+    expect(buffer.push('l_call>call:list_files{path:<|"|>.<|"|>}')).toEqual({
+      safeText: '',
+      tagFound: true,
+      cleanPrefix: '',
+    });
+    expect(buffer.push('<|tool_response>')).toEqual({
+      safeText: '',
+      tagFound: false,
+      cleanPrefix: '',
+    });
+    expect(buffer.flush()).toBe('');
+  });
+
+  it('strips parsed tool-call and tool-response blocks when tool use is disallowed', () => {
+    const raw =
+      '<|channel>thought\nneed a file list<channel|><|tool_call>call:list_files{path:<|"|>.<|"|>}<tool_call|><|tool_response>';
+
+    expect(recoverSuppressedToolCallText(raw)).toBe('');
+    expect(recoverSuppressedToolCallText(`visible ${raw}`)).toBe('visible ');
+  });
+});

--- a/crates/mlx-core/src/array/attention.rs
+++ b/crates/mlx-core/src/array/attention.rs
@@ -94,3 +94,59 @@ pub fn scaled_dot_product_attention_causal(
     };
     MxArray::from_handle(handle, "scaled_dot_product_attention_causal")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::mask::create_causal_mask;
+
+    fn deterministic_data(len: usize, phase: f32) -> Vec<f32> {
+        (0..len)
+            .map(|i| {
+                let x = i as f32 + phase;
+                (x.sin() * 0.5) + (x.cos() * 0.25)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn causal_attention_matches_explicit_offset_mask_when_kv_is_longer() {
+        let batch = 1;
+        let heads = 2;
+        let q_len = 4;
+        let kv_len = 9;
+        let head_dim = 8;
+        let scale = 1.0 / (head_dim as f64).sqrt();
+
+        let q = MxArray::from_float32(
+            &deterministic_data(batch * heads * q_len * head_dim, 0.0),
+            &[batch as i64, heads as i64, q_len as i64, head_dim as i64],
+        )
+        .unwrap();
+        let k = MxArray::from_float32(
+            &deterministic_data(batch * heads * kv_len * head_dim, 1.0),
+            &[batch as i64, heads as i64, kv_len as i64, head_dim as i64],
+        )
+        .unwrap();
+        let v = MxArray::from_float32(
+            &deterministic_data(batch * heads * kv_len * head_dim, 2.0),
+            &[batch as i64, heads as i64, kv_len as i64, head_dim as i64],
+        )
+        .unwrap();
+
+        let mask = create_causal_mask(q_len as i32, Some((kv_len - q_len) as i32), None).unwrap();
+        let explicit = scaled_dot_product_attention(&q, &k, &v, scale, Some(&mask)).unwrap();
+        let causal = scaled_dot_product_attention_causal(&q, &k, &v, scale).unwrap();
+
+        let explicit = explicit.to_float32().unwrap();
+        let causal = causal.to_float32().unwrap();
+        assert_eq!(explicit.len(), causal.len());
+        for (idx, (a, b)) in explicit.iter().zip(causal.iter()).enumerate() {
+            let diff = (a - b).abs();
+            assert!(
+                diff <= 1e-4,
+                "causal SDPA diverged from explicit offset mask at {idx}: {a} vs {b} (diff {diff})"
+            );
+        }
+    }
+}

--- a/crates/mlx-core/src/array/data.rs
+++ b/crates/mlx-core/src/array/data.rs
@@ -1,5 +1,6 @@
 use super::handle::MxHandle;
 use super::{DType, MxArray};
+use crate::inference_trace::write as write_inference_trace;
 use mlx_sys as sys;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -40,13 +41,23 @@ impl MxArray {
 
     /// Synchronously evaluate multiple arrays (blocking).
     /// Used between prefill chunks to materialize KV caches and break lazy dependency chains.
-    pub(crate) fn eval_arrays(arrays: &[&MxArray]) {
+    pub(crate) fn eval_arrays(arrays: &[&MxArray]) -> Result<()> {
         if arrays.is_empty() {
-            return;
+            return Ok(());
         }
         let mut handles: Vec<*mut sys::mlx_array> = arrays.iter().map(|arr| arr.handle.0).collect();
-        unsafe {
-            sys::mlx_eval(handles.as_mut_ptr(), handles.len());
+        let ok = unsafe { sys::mlx_eval(handles.as_mut_ptr(), handles.len()) };
+        if ok {
+            Ok(())
+        } else {
+            write_inference_trace(format_args!(
+                "native_error context=eval_arrays count={}",
+                handles.len()
+            ));
+            Err(Error::from_reason(format!(
+                "MLX eval failed while materializing {} arrays; see MLX_INFERENCE_TRACE_FILE",
+                handles.len()
+            )))
         }
     }
 

--- a/crates/mlx-core/src/array/memory.rs
+++ b/crates/mlx-core/src/array/memory.rs
@@ -193,15 +193,19 @@ fn parse_chunk_size(env_value: Option<String>) -> i32 {
 /// tensor (e.g. an attention K/V) lets MLX skip the rest of the graph
 /// and the memory peak persists.
 #[inline]
-pub fn maybe_eval_clear_for_paged_prefill_layer(layer_idx: usize, hidden_states: &super::MxArray) {
+pub fn maybe_eval_clear_for_paged_prefill_layer(
+    layer_idx: usize,
+    hidden_states: &super::MxArray,
+) -> napi::Result<()> {
     let interval = paged_prefill_eval_interval();
     if interval <= 0 {
-        return;
+        return Ok(());
     }
     if (layer_idx + 1).is_multiple_of(interval as usize) {
-        hidden_states.eval();
+        super::MxArray::eval_arrays(&[hidden_states])?;
         clear_cache();
     }
+    Ok(())
 }
 
 /// Get actively used memory in bytes (excludes cached memory).

--- a/crates/mlx-core/src/array/memory.rs
+++ b/crates/mlx-core/src/array/memory.rs
@@ -1,4 +1,6 @@
+use crate::inference_trace::{elapsed_ms, write as write_inference_trace};
 use mlx_sys as sys;
+use napi::Error;
 
 /// Error returned by [`set_cache_limit`] when the underlying FFI shim caught
 /// a C++ exception (e.g. degraded Metal allocator on a misconfigured host).
@@ -316,40 +318,106 @@ pub fn heavy_cleanup() {
     }
 }
 
+const WEIGHT_MATERIALIZE_DEFAULT_CHUNK_MB: usize = 512;
+const WEIGHT_MATERIALIZE_MIN_CHUNK_MB: usize = 64;
+const WEIGHT_MATERIALIZE_MAX_CHUNK_MB: usize = 1024;
+
+fn weight_materialize_chunk_budget(max_working_set: usize) -> (usize, &'static str) {
+    if let Ok(raw) = std::env::var("MLX_WEIGHT_MATERIALIZE_CHUNK_MB")
+        && let Ok(mb) = raw.trim().parse::<usize>()
+        && mb > 0
+    {
+        return (mb.saturating_mul(1 << 20), "env");
+    }
+
+    if max_working_set > 0 {
+        let dynamic = max_working_set / 128;
+        let clamped = dynamic.clamp(
+            WEIGHT_MATERIALIZE_MIN_CHUNK_MB << 20,
+            WEIGHT_MATERIALIZE_MAX_CHUNK_MB << 20,
+        );
+        return (clamped, "auto_working_set");
+    }
+
+    (WEIGHT_MATERIALIZE_DEFAULT_CHUNK_MB << 20, "fallback")
+}
+
+fn eval_weight_materialize_chunk(
+    chunk_index: u32,
+    total_chunks_hint: u32,
+    chunk: &[&super::MxArray],
+    chunk_bytes: usize,
+) -> napi::Result<()> {
+    let chunk_start = std::time::Instant::now();
+    write_inference_trace(format_args!(
+        "[MLX_TRACE] weight_materialize_chunk_start index={} total_hint={} arrays={} bytes_mb={:.1}",
+        chunk_index,
+        total_chunks_hint,
+        chunk.len(),
+        chunk_bytes as f64 / (1u64 << 20) as f64,
+    ));
+
+    let mut handles: Vec<*mut sys::mlx_array> = chunk.iter().map(|arr| arr.handle.0).collect();
+    let ok = unsafe { sys::mlx_eval(handles.as_mut_ptr(), handles.len()) };
+    if !ok {
+        write_inference_trace(format_args!(
+            "[MLX_TRACE] weight_materialize_chunk_error index={} arrays={} bytes_mb={:.1}",
+            chunk_index,
+            chunk.len(),
+            chunk_bytes as f64 / (1u64 << 20) as f64,
+        ));
+        return Err(Error::from_reason(format!(
+            "MLX eval failed while materializing weight chunk {chunk_index} ({:.1} MB, {} arrays); see MLX_INFERENCE_TRACE_FILE",
+            chunk_bytes as f64 / (1u64 << 20) as f64,
+            chunk.len(),
+        )));
+    }
+
+    write_inference_trace(format_args!(
+        "[MLX_TRACE] weight_materialize_chunk_done index={} arrays={} bytes_mb={:.1} elapsed_ms={:.1}",
+        chunk_index,
+        chunk.len(),
+        chunk_bytes as f64 / (1u64 << 20) as f64,
+        elapsed_ms(chunk_start),
+    ));
+    Ok(())
+}
+
 /// Materialize mmap-backed weight arrays in byte-budgeted chunks.
 ///
 /// A single eval on all weights can cause Metal command buffer timeouts
 /// on large models (e.g. 65GB bf16). This function queries GPU memory
 /// via `max_recommended_working_set_size` and chunks eval calls so each
 /// batch stays within a fraction of available GPU memory.
-pub fn materialize_weights(arrays: &[&super::MxArray]) {
+pub fn materialize_weights(arrays: &[&super::MxArray]) -> napi::Result<()> {
     use tracing::info;
 
     if arrays.is_empty() {
-        return;
+        return Ok(());
     }
 
     let start = std::time::Instant::now();
     let total = arrays.len();
 
     let max_working_set = crate::stream::WiredLimitContext::get_max_working_set_size();
-
-    // Budget per chunk: 1/4 of max working set, clamped to [512MB, 4GB]
-    let budget = if max_working_set > 0 {
-        (max_working_set / 4).clamp(512 << 20, 4 << 30)
-    } else {
-        1 << 30 // 1GB fallback
-    };
+    let (budget, budget_source) = weight_materialize_chunk_budget(max_working_set);
 
     // Sum total bytes to decide: single eval or chunked
     let total_bytes: usize = arrays.iter().map(|a| a.nbytes()).sum();
+    let total_chunks_hint = u32::try_from(total_bytes.div_ceil(budget.max(1))).unwrap_or(u32::MAX);
+
+    write_inference_trace(format_args!(
+        "[MLX_TRACE] weight_materialize_start arrays={} total_gb={:.2} budget_mb={:.0} budget_source={} max_working_set_gb={:.1}",
+        total,
+        total_bytes as f64 / (1u64 << 30) as f64,
+        budget as f64 / (1u64 << 20) as f64,
+        budget_source,
+        max_working_set as f64 / (1u64 << 30) as f64,
+    ));
 
     if total_bytes <= budget {
         // Small enough for a single eval call
-        let mut handles: Vec<*mut sys::mlx_array> = arrays.iter().map(|arr| arr.handle.0).collect();
-        unsafe {
-            sys::mlx_eval(handles.as_mut_ptr(), handles.len());
-        }
+        eval_weight_materialize_chunk(1, 1, arrays, total_bytes)?;
         info!(
             "Materialized {} weight arrays ({:.1} GB) in {:.2}s",
             total,
@@ -367,12 +435,8 @@ pub fn materialize_weights(arrays: &[&super::MxArray]) {
 
             if chunk_bytes >= budget || i == total - 1 {
                 let chunk = &arrays[chunk_start..=i];
-                let mut handles: Vec<*mut sys::mlx_array> =
-                    chunk.iter().map(|arr| arr.handle.0).collect();
-                unsafe {
-                    sys::mlx_eval(handles.as_mut_ptr(), handles.len());
-                }
                 num_chunks += 1;
+                eval_weight_materialize_chunk(num_chunks, total_chunks_hint, chunk, chunk_bytes)?;
                 chunk_start = i + 1;
                 chunk_bytes = 0;
             }
@@ -387,6 +451,13 @@ pub fn materialize_weights(arrays: &[&super::MxArray]) {
             budget as f64 / (1u64 << 20) as f64,
         );
     }
+    write_inference_trace(format_args!(
+        "[MLX_TRACE] weight_materialize_done arrays={} total_gb={:.2} elapsed_ms={:.1}",
+        total,
+        total_bytes as f64 / (1u64 << 30) as f64,
+        elapsed_ms(start),
+    ));
+    Ok(())
 }
 
 /// Check if memory is safe for autograd graph construction

--- a/crates/mlx-core/src/inference_trace.rs
+++ b/crates/mlx-core/src/inference_trace.rs
@@ -1,0 +1,42 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::sync::OnceLock;
+
+pub(crate) fn enabled() -> bool {
+    trace_file().is_some()
+}
+
+fn trace_file() -> Option<&'static str> {
+    static TRACE_FILE: OnceLock<Option<String>> = OnceLock::new();
+    TRACE_FILE
+        .get_or_init(|| {
+            let enabled = match std::env::var("MLX_INFERENCE_TRACE") {
+                Ok(value) => matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                ),
+                Err(_) => false,
+            };
+            if !enabled {
+                return None;
+            }
+            std::env::var("MLX_INFERENCE_TRACE_FILE")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .as_deref()
+}
+
+pub(crate) fn write(args: std::fmt::Arguments<'_>) {
+    let Some(path) = trace_file() else {
+        return;
+    };
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(file, "{args}");
+    }
+}
+
+pub(crate) fn elapsed_ms(start: std::time::Instant) -> f64 {
+    start.elapsed().as_secs_f64() * 1000.0
+}

--- a/crates/mlx-core/src/inference_trace.rs
+++ b/crates/mlx-core/src/inference_trace.rs
@@ -6,18 +6,34 @@ pub(crate) fn enabled() -> bool {
     trace_file().is_some()
 }
 
+pub(crate) fn env_flag_value_enabled(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+pub(crate) fn env_flag_enabled(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| env_flag_value_enabled(&value))
+}
+
+pub(crate) fn env_flag_value_or_default(value: Option<&str>, default_when_unset: bool) -> bool {
+    value
+        .map(env_flag_value_enabled)
+        .unwrap_or(default_when_unset)
+}
+
+pub(crate) fn env_flag_enabled_or_default(name: &str, default_when_unset: bool) -> bool {
+    std::env::var(name)
+        .map(|value| env_flag_value_or_default(Some(&value), default_when_unset))
+        .unwrap_or(default_when_unset)
+}
+
 fn trace_file() -> Option<&'static str> {
     static TRACE_FILE: OnceLock<Option<String>> = OnceLock::new();
     TRACE_FILE
         .get_or_init(|| {
-            let enabled = match std::env::var("MLX_INFERENCE_TRACE") {
-                Ok(value) => matches!(
-                    value.trim().to_ascii_lowercase().as_str(),
-                    "1" | "true" | "yes" | "on"
-                ),
-                Err(_) => false,
-            };
-            if !enabled {
+            if !env_flag_enabled("MLX_INFERENCE_TRACE") {
                 return None;
             }
             std::env::var("MLX_INFERENCE_TRACE_FILE")
@@ -39,4 +55,31 @@ pub(crate) fn write(args: std::fmt::Arguments<'_>) {
 
 pub(crate) fn elapsed_ms(start: std::time::Instant) -> f64 {
     start.elapsed().as_secs_f64() * 1000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{env_flag_value_enabled, env_flag_value_or_default};
+
+    #[test]
+    fn env_flag_value_enabled_accepts_only_explicit_truthy_values() {
+        for value in ["1", "true", "TRUE", " yes ", "On"] {
+            assert!(env_flag_value_enabled(value), "{value:?} should enable");
+        }
+
+        for value in ["", "0", "false", "no", "off", "abc", "enabled", "2"] {
+            assert!(
+                !env_flag_value_enabled(value),
+                "{value:?} should not enable"
+            );
+        }
+    }
+
+    #[test]
+    fn env_flag_value_or_default_uses_default_only_when_unset() {
+        assert!(env_flag_value_or_default(None, true));
+        assert!(!env_flag_value_or_default(None, false));
+        assert!(env_flag_value_or_default(Some("on"), false));
+        assert!(!env_flag_value_or_default(Some("abc"), true));
+    }
 }

--- a/crates/mlx-core/src/lib.rs
+++ b/crates/mlx-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod dataset;
 pub mod decode_profiler;
 pub mod gradients;
 pub mod grpo;
+pub(crate) mod inference_trace;
 pub mod model_thread;
 pub mod models;
 pub mod nn;

--- a/crates/mlx-core/src/models/gemma4/attention.rs
+++ b/crates/mlx-core/src/models/gemma4/attention.rs
@@ -1,6 +1,11 @@
+use std::sync::OnceLock;
+
 use crate::array::MxArray;
 use crate::array::attention::{scaled_dot_product_attention, scaled_dot_product_attention_causal};
 use crate::array::mask::create_causal_mask;
+use crate::inference_trace::{
+    elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
+};
 use crate::nn::{Linear, RMSNorm, RoPE};
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
 use mlx_sys as sys;
@@ -9,6 +14,21 @@ use napi::bindgen_prelude::*;
 use super::config::Gemma4Config;
 use super::layer_cache::Gemma4LayerCache;
 use super::quantized_linear::{LinearProj, QuantizedLinear};
+
+fn paged_prefill_paged_attention_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        // Gemma4's long-context traces showed this bridge can regress
+        // stability/memory independently from Qwen. Keep it behind a
+        // Gemma4-specific opt-in instead of the global experiment flag.
+        std::env::var("MLX_GEMMA4_PAGED_PREFILL_PAGED_ATTENTION")
+            .map(|value| {
+                let normalized = value.trim().to_ascii_lowercase();
+                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+            })
+            .unwrap_or(false)
+    })
+}
 
 /// Trim mask to match K/V sequence length (e.g. after RotatingKVCache eviction).
 fn trim_mask(mask: Option<&MxArray>, kv_len: i64) -> Result<Option<MxArray>> {
@@ -250,6 +270,7 @@ impl Gemma4Attention {
     ) -> Result<MxArray> {
         let batch = x.shape_at(0)?;
         let seq_len = x.shape_at(1)?;
+        let trace_enabled = inference_trace_enabled();
 
         // Q/K/V projections
         let queries = self.q_proj.forward(x)?;
@@ -309,6 +330,28 @@ impl Gemma4Attention {
         };
 
         let mask = trim_mask(mask, keys.shape_at(2)?)?;
+        if trace_enabled && offset > 0 && seq_len > 1 {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 attention_flat_kv_ready offset_before={} seq_len={} kv_len={} mask_len={} needs_stash={}",
+                offset,
+                seq_len,
+                keys.shape_at(2).unwrap_or(-1),
+                mask.as_ref().and_then(|m| m.shape_at(3).ok()).unwrap_or(0),
+                needs_stash
+            ));
+        }
+
+        if trace_enabled && offset > 0 && seq_len > 1 {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 attention_flat_sdpa_start offset_before={} seq_len={} q_heads={} kv_heads={} kv_len={} mask={}",
+                offset,
+                seq_len,
+                queries.shape_at(1).unwrap_or(-1),
+                keys.shape_at(1).unwrap_or(-1),
+                keys.shape_at(2).unwrap_or(-1),
+                if mask.is_some() { "explicit" } else { "causal" }
+            ));
+        }
 
         // Scaled dot-product attention with scale=1.0
         let output = if let Some(ref m) = mask {
@@ -318,6 +361,14 @@ impl Gemma4Attention {
         } else {
             scaled_dot_product_attention(&queries, &keys, &values, 1.0, None)?
         };
+        if trace_enabled && offset > 0 && seq_len > 1 {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 attention_flat_sdpa_done offset_before={} seq_len={} kv_len={}",
+                offset,
+                seq_len,
+                keys.shape_at(2).unwrap_or(-1)
+            ));
+        }
 
         // Transpose back [B, H, T, D] → [B, T, H*D]
         let output = output.transpose(Some(&[0, 2, 1, 3]))?;
@@ -422,6 +473,7 @@ impl Gemma4Attention {
     ) -> Result<MxArray> {
         let batch = x.shape_at(0)?;
         let seq_len = x.shape_at(1)?;
+        let trace_enabled = inference_trace_enabled();
 
         // 1. Q/K/V projections (matches `forward`).
         let queries = self.q_proj.forward(x)?;
@@ -484,6 +536,23 @@ impl Gemma4Attention {
             self.head_dim as i64,
         ])?;
 
+        let write_trace_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 attention_paged_kv_write_start paged_idx={} first_position={} cached_prefix={} seq_len={} batch={} q_heads={} kv_heads={} head_dim={} input_dtype={:?} current_tokens={} blocks={}",
+                paged_idx,
+                first_logical_position,
+                cached_prefix_len,
+                seq_len,
+                batch,
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                x.dtype().ok(),
+                adapter.current_token_count(),
+                adapter.num_allocated_blocks()
+            ));
+        }
         adapter
             .update_keys_values(
                 paged_idx,
@@ -492,6 +561,15 @@ impl Gemma4Attention {
                 first_logical_position,
             )
             .map_err(napi::Error::from_reason)?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 attention_paged_kv_write_done paged_idx={} first_position={} seq_len={} elapsed_ms={:.1}",
+                paged_idx,
+                first_logical_position,
+                seq_len,
+                write_trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
 
         // 7. Compute attention output. Gemma4's attention scale is 1.0
         //    (the QK norm handles scaling).
@@ -516,19 +594,139 @@ impl Gemma4Attention {
             if cached_prefix_len == 0 {
                 // Fresh multi-token prefill: SDPA over in-flight Q/K/V
                 // with internal causal mask.
-                scaled_dot_product_attention_causal(&queries_bhtd, &keys_bhtd, &values_bhtd, 1.0)?
+                let sdpa_trace_start = trace_enabled.then(std::time::Instant::now);
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 attention_paged_sdpa_causal_start paged_idx={} seq_len={} cached_prefix=0",
+                        paged_idx, seq_len
+                    ));
+                }
+                let out = scaled_dot_product_attention_causal(
+                    &queries_bhtd,
+                    &keys_bhtd,
+                    &values_bhtd,
+                    1.0,
+                )?;
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 attention_paged_sdpa_causal_done paged_idx={} seq_len={} elapsed_ms={:.1}",
+                        paged_idx,
+                        seq_len,
+                        sdpa_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                    ));
+                }
+                out
             } else {
-                // Cache-hit multi-token prefill: read full
-                // [0, total_ctx) K/V back from the pool with an
-                // explicit causal+offset mask. The suffix was just
-                // written above.
+                // Cache-hit multi-token prefill: by default use materialized
+                // K/V because the current paged-prefill bridge is slower for
+                // Gemma4 26B. Keep the bridge opt-in for memory experiments.
                 let total_ctx = cached_prefix_len + (seq_len as u32);
-                let (k_full, v_full) = adapter
-                    .read_kv_range(paged_idx, 0, total_ctx)
-                    .map_err(napi::Error::from_reason)?;
-                let mask =
-                    create_causal_mask(seq_len as i32, Some(cached_prefix_len as i32), None)?;
-                scaled_dot_product_attention(&queries_bhtd, &k_full, &v_full, 1.0, Some(&mask))?
+                let maybe_paged_attn = if batch == 1 && paged_prefill_paged_attention_enabled() {
+                    let gather_trace_start = trace_enabled.then(std::time::Instant::now);
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_prefill_gather_start paged_idx={} cached_prefix={} seq_len={}",
+                            paged_idx, cached_prefix_len, seq_len
+                        ));
+                    }
+
+                    // [1, H, T, D] -> [T, H, D], matching
+                    // PagedKVCacheAdapter::gather_kv_for_prefill_chunk.
+                    let queries_3d = queries_bhtd
+                        .squeeze(Some(&[0]))?
+                        .transpose(Some(&[1, 0, 2]))?;
+                    match adapter.gather_kv_for_prefill_chunk(
+                        paged_idx,
+                        &queries_3d,
+                        cached_prefix_len,
+                        1.0,
+                    ) {
+                        Ok(attn_3d) => {
+                            let target_dtype = x.dtype()?;
+                            let attn_3d = attn_3d.astype(target_dtype)?;
+                            let out = attn_3d.transpose(Some(&[1, 0, 2]))?.reshape(&[
+                                1,
+                                self.num_heads as i64,
+                                seq_len,
+                                self.head_dim as i64,
+                            ])?;
+                            if trace_enabled {
+                                write_inference_trace(format_args!(
+                                    "[MLX_TRACE] gemma4 attention_paged_prefill_gather_done paged_idx={} cached_prefix={} seq_len={} elapsed_ms={:.1}",
+                                    paged_idx,
+                                    cached_prefix_len,
+                                    seq_len,
+                                    gather_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                                ));
+                            }
+                            Some(out)
+                        }
+                        Err(err) => {
+                            if trace_enabled {
+                                write_inference_trace(format_args!(
+                                    "[MLX_TRACE] gemma4 attention_paged_prefill_gather_fallback paged_idx={} cached_prefix={} seq_len={} error={}",
+                                    paged_idx, cached_prefix_len, seq_len, err
+                                ));
+                            }
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                match maybe_paged_attn {
+                    Some(out) => out,
+                    None => {
+                        let read_trace_start = trace_enabled.then(std::time::Instant::now);
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] gemma4 attention_paged_read_kv_start paged_idx={} total_ctx={} cached_prefix={} seq_len={}",
+                                paged_idx, total_ctx, cached_prefix_len, seq_len
+                            ));
+                        }
+                        let (k_full, v_full) = adapter
+                            .read_kv_range(paged_idx, 0, total_ctx)
+                            .map_err(napi::Error::from_reason)?;
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] gemma4 attention_paged_read_kv_done paged_idx={} total_ctx={} elapsed_ms={:.1}",
+                                paged_idx,
+                                total_ctx,
+                                read_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                            ));
+                        }
+                        let mask = create_causal_mask(
+                            seq_len as i32,
+                            Some(cached_prefix_len as i32),
+                            None,
+                        )?;
+                        let sdpa_trace_start = trace_enabled.then(std::time::Instant::now);
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] gemma4 attention_paged_sdpa_masked_start paged_idx={} q_len={} kv_len={} cached_prefix={}",
+                                paged_idx, seq_len, total_ctx, cached_prefix_len
+                            ));
+                        }
+                        let out = scaled_dot_product_attention(
+                            &queries_bhtd,
+                            &k_full,
+                            &v_full,
+                            1.0,
+                            Some(&mask),
+                        )?;
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] gemma4 attention_paged_sdpa_masked_done paged_idx={} q_len={} kv_len={} elapsed_ms={:.1}",
+                                paged_idx,
+                                seq_len,
+                                total_ctx,
+                                sdpa_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                            ));
+                        }
+                        out
+                    }
+                }
             }
         } else {
             // Single-token path (decode OR split-prefill pass 2):
@@ -552,8 +750,7 @@ impl Gemma4Attention {
             let attn_3d = adapter
                 .gather_kv_for_decode(paged_idx, &queries_3d, 1.0, /* softcap */ 1.0)
                 .map_err(napi::Error::from_reason)?;
-            // Cast back to x's dtype so the residual stays homogeneous
-            // (gather currently returns Float32).
+            // Cast back to x's dtype so the residual stays homogeneous.
             let target_dtype = x.dtype()?;
             let attn_3d = attn_3d.astype(target_dtype)?;
             attn_3d.reshape(&[1, self.num_heads as i64, 1, self.head_dim as i64])?
@@ -570,10 +767,9 @@ impl Gemma4Attention {
     /// Forward pass for KV-shared layers whose anchor is a global layer
     /// routed through the paged adapter.
     ///
-    /// Only Q is computed; K and V are read directly from the anchor's
-    /// paged slot via `adapter.read_kv_range(anchor_paged_idx, 0,
-    /// total_ctx)` (already RoPE-applied since the anchor wrote them
-    /// post-RoPE during its own forward_paged call).
+    /// Only Q is computed; K and V are consumed directly from the anchor's
+    /// paged slot (already RoPE-applied since the anchor wrote them
+    /// post-RoPE during its own `forward_paged` call).
     ///
     /// Caller responsibilities:
     /// 1. `cache_offset` is the RoPE offset for the queries — equal to
@@ -608,27 +804,57 @@ impl Gemma4Attention {
         let queries_bhtd = self.rope.forward(&queries, cache_offset)?;
 
         // SDPA. Same scale=1.0 as `forward_paged`. For prefill on a
-        // suffix we build an explicit causal mask offset by the cached
-        // prefix length (cache_offset). For decode (seq_len == 1) we
-        // dispatch the on-GPU `gather_kv_for_decode` Metal kernel
-        // directly — every cached key is at a strictly earlier position
-        // so mask=None is implicit, and we skip the `read_kv_range`
-        // host roundtrip that drove the long-context memory regression.
+        // suffix, keep the on-GPU paged prefill helper opt-in; the default
+        // materialized path is currently faster for Gemma4. For decode
+        // (seq_len == 1), dispatch the on-GPU decode helper — every cached
+        // key is at a strictly earlier position, so mask=None is implicit.
         let attn_bhtd = if is_prefill && seq_len > 1 {
-            // Cache-hit prefill: still need the full K/V as MxArrays for
-            // SDPA with an explicit causal+offset mask.
-            let (shared_keys, shared_values) = adapter
-                .read_kv_range(anchor_paged_idx, 0, total_ctx)
-                .map_err(napi::Error::from_reason)?;
-            let cached_prefix_len = (total_ctx as i64) - seq_len;
-            let mask = create_causal_mask(seq_len as i32, Some(cached_prefix_len as i32), None)?;
-            scaled_dot_product_attention(
-                &queries_bhtd,
-                &shared_keys,
-                &shared_values,
-                1.0,
-                Some(&mask),
-            )?
+            let cached_prefix_len = total_ctx
+                .checked_sub(seq_len as u32)
+                .ok_or_else(|| Error::from_reason("forward_paged_shared: total_ctx < seq_len"))?;
+            let maybe_paged_attn = if batch == 1 && paged_prefill_paged_attention_enabled() {
+                let queries_3d = queries_bhtd
+                    .squeeze(Some(&[0]))?
+                    .transpose(Some(&[1, 0, 2]))?;
+                match adapter.gather_kv_for_prefill_chunk(
+                    anchor_paged_idx,
+                    &queries_3d,
+                    cached_prefix_len,
+                    1.0,
+                ) {
+                    Ok(attn_3d) => {
+                        let target_dtype = x.dtype()?;
+                        let attn_3d = attn_3d.astype(target_dtype)?;
+                        Some(attn_3d.transpose(Some(&[1, 0, 2]))?.reshape(&[
+                            1,
+                            self.num_heads as i64,
+                            seq_len,
+                            self.head_dim as i64,
+                        ])?)
+                    }
+                    Err(_) => None,
+                }
+            } else {
+                None
+            };
+
+            match maybe_paged_attn {
+                Some(out) => out,
+                None => {
+                    let (shared_keys, shared_values) = adapter
+                        .read_kv_range(anchor_paged_idx, 0, total_ctx)
+                        .map_err(napi::Error::from_reason)?;
+                    let mask =
+                        create_causal_mask(seq_len as i32, Some(cached_prefix_len as i32), None)?;
+                    scaled_dot_product_attention(
+                        &queries_bhtd,
+                        &shared_keys,
+                        &shared_values,
+                        1.0,
+                        Some(&mask),
+                    )?
+                }
+            }
         } else {
             // Single-token path (decode OR split-prefill pass 2):
             // dispatch `gather_kv_for_decode` against the anchor's paged

--- a/crates/mlx-core/src/models/gemma4/attention.rs
+++ b/crates/mlx-core/src/models/gemma4/attention.rs
@@ -18,27 +18,17 @@ use super::quantized_linear::{LinearProj, QuantizedLinear};
 fn paged_prefill_paged_attention_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        // Keep cache-hit suffix attention on the paged K/V pool by default.
-        // The fallback path materializes the full cached prefix through
-        // read_kv_range and dominates long-context prefill traces.
-        std::env::var("MLX_GEMMA4_PAGED_PREFILL_PAGED_ATTENTION")
-            .map(|value| {
-                let normalized = value.trim().to_ascii_lowercase();
-                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
-            })
-            .unwrap_or(true)
+        crate::inference_trace::env_flag_enabled_or_default(
+            "MLX_GEMMA4_PAGED_PREFILL_PAGED_ATTENTION",
+            true,
+        )
     })
 }
 
 fn native_kv_write_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("MLX_GEMMA4_NATIVE_KV_WRITE")
-            .map(|value| {
-                let normalized = value.trim().to_ascii_lowercase();
-                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
-            })
-            .unwrap_or(true)
+        crate::inference_trace::env_flag_enabled_or_default("MLX_GEMMA4_NATIVE_KV_WRITE", true)
     })
 }
 

--- a/crates/mlx-core/src/models/gemma4/attention.rs
+++ b/crates/mlx-core/src/models/gemma4/attention.rs
@@ -18,15 +18,27 @@ use super::quantized_linear::{LinearProj, QuantizedLinear};
 fn paged_prefill_paged_attention_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        // Gemma4's long-context traces showed this bridge can regress
-        // stability/memory independently from Qwen. Keep it behind a
-        // Gemma4-specific opt-in instead of the global experiment flag.
+        // Keep cache-hit suffix attention on the paged K/V pool by default.
+        // The fallback path materializes the full cached prefix through
+        // read_kv_range and dominates long-context prefill traces.
         std::env::var("MLX_GEMMA4_PAGED_PREFILL_PAGED_ATTENTION")
             .map(|value| {
                 let normalized = value.trim().to_ascii_lowercase();
                 !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
             })
-            .unwrap_or(false)
+            .unwrap_or(true)
+    })
+}
+
+fn native_kv_write_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("MLX_GEMMA4_NATIVE_KV_WRITE")
+            .map(|value| {
+                let normalized = value.trim().to_ascii_lowercase();
+                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+            })
+            .unwrap_or(true)
     })
 }
 
@@ -35,10 +47,14 @@ fn trim_mask(mask: Option<&MxArray>, kv_len: i64) -> Result<Option<MxArray>> {
     match mask {
         Some(m) => {
             let mask_len = m.shape_at(3)?;
-            if mask_len != kv_len {
+            if mask_len == kv_len {
+                Ok(Some(m.clone()))
+            } else if mask_len > kv_len {
                 Ok(Some(m.slice_axis(3, mask_len - kv_len, mask_len)?))
             } else {
-                Ok(Some(m.clone()))
+                Err(Error::from_reason(format!(
+                    "Gemma4 attention mask is shorter than K/V: mask_len={mask_len}, kv_len={kv_len}"
+                )))
             }
         }
         None => Ok(None),
@@ -553,20 +569,50 @@ impl Gemma4Attention {
                 adapter.num_allocated_blocks()
             ));
         }
-        adapter
-            .update_keys_values(
+        let write_path = if native_kv_write_enabled() {
+            match adapter.update_keys_values_native(
                 paged_idx,
                 &keys_paged,
                 &values_paged,
                 first_logical_position,
-            )
-            .map_err(napi::Error::from_reason)?;
+            ) {
+                Ok(()) => "native",
+                Err(err) => {
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_kv_write_fallback paged_idx={} first_position={} seq_len={} error={}",
+                            paged_idx, first_logical_position, seq_len, err
+                        ));
+                    }
+                    adapter
+                        .update_keys_values(
+                            paged_idx,
+                            &keys_paged,
+                            &values_paged,
+                            first_logical_position,
+                        )
+                        .map_err(napi::Error::from_reason)?;
+                    "legacy"
+                }
+            }
+        } else {
+            adapter
+                .update_keys_values(
+                    paged_idx,
+                    &keys_paged,
+                    &values_paged,
+                    first_logical_position,
+                )
+                .map_err(napi::Error::from_reason)?;
+            "legacy"
+        };
         if trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 attention_paged_kv_write_done paged_idx={} first_position={} seq_len={} elapsed_ms={:.1}",
+                "[MLX_TRACE] gemma4 attention_paged_kv_write_done paged_idx={} first_position={} seq_len={} path={} elapsed_ms={:.1}",
                 paged_idx,
                 first_logical_position,
                 seq_len,
+                write_path,
                 write_trace_start.map(elapsed_ms).unwrap_or(0.0)
             ));
         }
@@ -617,16 +663,19 @@ impl Gemma4Attention {
                 }
                 out
             } else {
-                // Cache-hit multi-token prefill: by default use materialized
-                // K/V because the current paged-prefill bridge is slower for
-                // Gemma4 26B. Keep the bridge opt-in for memory experiments.
+                // Cache-hit multi-token prefill: prefer the MLX paged-attention
+                // bridge so each suffix token attends directly against the
+                // on-GPU paged pool. The helper represents token i with
+                // seq_len = cached_prefix_len + i + 1, matching the explicit
+                // offset causal mask used by the materialized fallback without
+                // copying full prefix K/V back through host memory.
                 let total_ctx = cached_prefix_len + (seq_len as u32);
                 let maybe_paged_attn = if batch == 1 && paged_prefill_paged_attention_enabled() {
                     let gather_trace_start = trace_enabled.then(std::time::Instant::now);
                     if trace_enabled {
                         write_inference_trace(format_args!(
-                            "[MLX_TRACE] gemma4 attention_paged_prefill_gather_start paged_idx={} cached_prefix={} seq_len={}",
-                            paged_idx, cached_prefix_len, seq_len
+                            "[MLX_TRACE] gemma4 attention_paged_prefill_gather_start paged_idx={} cached_prefix={} seq_len={} total_ctx={}",
+                            paged_idx, cached_prefix_len, seq_len, total_ctx
                         ));
                     }
 
@@ -652,10 +701,11 @@ impl Gemma4Attention {
                             ])?;
                             if trace_enabled {
                                 write_inference_trace(format_args!(
-                                    "[MLX_TRACE] gemma4 attention_paged_prefill_gather_done paged_idx={} cached_prefix={} seq_len={} elapsed_ms={:.1}",
+                                    "[MLX_TRACE] gemma4 attention_paged_prefill_gather_done paged_idx={} cached_prefix={} seq_len={} total_ctx={} path=paged_attention elapsed_ms={:.1}",
                                     paged_idx,
                                     cached_prefix_len,
                                     seq_len,
+                                    total_ctx,
                                     gather_trace_start.map(elapsed_ms).unwrap_or(0.0)
                                 ));
                             }
@@ -664,8 +714,8 @@ impl Gemma4Attention {
                         Err(err) => {
                             if trace_enabled {
                                 write_inference_trace(format_args!(
-                                    "[MLX_TRACE] gemma4 attention_paged_prefill_gather_fallback paged_idx={} cached_prefix={} seq_len={} error={}",
-                                    paged_idx, cached_prefix_len, seq_len, err
+                                    "[MLX_TRACE] gemma4 attention_paged_prefill_gather_fallback paged_idx={} cached_prefix={} seq_len={} total_ctx={} error={}",
+                                    paged_idx, cached_prefix_len, seq_len, total_ctx, err
                                 ));
                             }
                             None
@@ -730,13 +780,13 @@ impl Gemma4Attention {
             }
         } else {
             // Single-token path (decode OR split-prefill pass 2):
-            // dispatch the `gather_kv_for_decode` Metal kernel directly
-            // against the on-GPU paged buffers. Avoids the per-step host
-            // roundtrip (~57 MB per layer per K/V on long contexts) that
-            // `read_kv_range` performs and that was driving a ~40 GB
-            // memory regression in long-context decode (see Fix #2 spec).
+            // dispatch graph-native paged attention directly against the
+            // on-GPU paged buffers. That keeps the native paged-kv-write
+            // outputs and the attention read in one MLX dependency graph,
+            // avoiding the per-layer sync that the raw gather fallback must
+            // do before it reads the pool outside MLX's scheduler.
             //
-            // `gather_kv_for_decode` expects queries shape
+            // `gather_kv_for_decode_graph` expects queries shape
             // `[1, num_query_heads, head_size]` (3-D). For seq_len=1
             // `queries_bhtd` is `[1, n_heads, 1, head_dim]`, so squeeze
             // axis 2 to land on the expected layout. Returns
@@ -747,9 +797,34 @@ impl Gemma4Attention {
                 self.num_heads as i64,
                 self.head_dim as i64,
             ])?;
-            let attn_3d = adapter
-                .gather_kv_for_decode(paged_idx, &queries_3d, 1.0, /* softcap */ 1.0)
-                .map_err(napi::Error::from_reason)?;
+            let gather_trace_start = trace_enabled.then(std::time::Instant::now);
+            let attn_3d = match adapter.gather_kv_for_decode_graph(paged_idx, &queries_3d, 1.0, 1.0)
+            {
+                Ok(attn_3d) => {
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_decode_gather_done paged_idx={} path=graph total_ctx={} elapsed_ms={:.1}",
+                            paged_idx,
+                            adapter.current_token_count(),
+                            gather_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                        ));
+                    }
+                    attn_3d
+                }
+                Err(err) => {
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_decode_gather_fallback paged_idx={} path=raw total_ctx={} error={}",
+                            paged_idx,
+                            adapter.current_token_count(),
+                            err
+                        ));
+                    }
+                    adapter
+                        .gather_kv_for_decode(paged_idx, &queries_3d, 1.0, /* softcap */ 1.0)
+                        .map_err(napi::Error::from_reason)?
+                }
+            };
             // Cast back to x's dtype so the residual stays homogeneous.
             let target_dtype = x.dtype()?;
             let attn_3d = attn_3d.astype(target_dtype)?;
@@ -794,6 +869,7 @@ impl Gemma4Attention {
     ) -> Result<MxArray> {
         let batch = x.shape_at(0)?;
         let seq_len = x.shape_at(1)?;
+        let trace_enabled = inference_trace_enabled();
 
         // Q-only path (mirrors flat `forward_shared`).
         let queries = self.q_proj.forward(x)?;
@@ -803,16 +879,24 @@ impl Gemma4Attention {
         let queries = queries.transpose(Some(&[0, 2, 1, 3]))?;
         let queries_bhtd = self.rope.forward(&queries, cache_offset)?;
 
-        // SDPA. Same scale=1.0 as `forward_paged`. For prefill on a
-        // suffix, keep the on-GPU paged prefill helper opt-in; the default
-        // materialized path is currently faster for Gemma4. For decode
-        // (seq_len == 1), dispatch the on-GPU decode helper — every cached
-        // key is at a strictly earlier position, so mask=None is implicit.
+        // SDPA. Same scale=1.0 as `forward_paged`. For cache-hit suffix
+        // prefill, prefer the on-GPU paged prefill helper and fall back to
+        // materialized K/V only if the bridge rejects this shape/request. For
+        // decode (seq_len == 1), dispatch the on-GPU decode helper — every
+        // cached key is at a strictly earlier position, so mask=None is
+        // implicit.
         let attn_bhtd = if is_prefill && seq_len > 1 {
             let cached_prefix_len = total_ctx
                 .checked_sub(seq_len as u32)
                 .ok_or_else(|| Error::from_reason("forward_paged_shared: total_ctx < seq_len"))?;
             let maybe_paged_attn = if batch == 1 && paged_prefill_paged_attention_enabled() {
+                let gather_trace_start = trace_enabled.then(std::time::Instant::now);
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 attention_paged_shared_prefill_gather_start anchor_paged_idx={} cached_prefix={} seq_len={} total_ctx={}",
+                        anchor_paged_idx, cached_prefix_len, seq_len, total_ctx
+                    ));
+                }
                 let queries_3d = queries_bhtd
                     .squeeze(Some(&[0]))?
                     .transpose(Some(&[1, 0, 2]))?;
@@ -825,14 +909,33 @@ impl Gemma4Attention {
                     Ok(attn_3d) => {
                         let target_dtype = x.dtype()?;
                         let attn_3d = attn_3d.astype(target_dtype)?;
-                        Some(attn_3d.transpose(Some(&[1, 0, 2]))?.reshape(&[
+                        let out = attn_3d.transpose(Some(&[1, 0, 2]))?.reshape(&[
                             1,
                             self.num_heads as i64,
                             seq_len,
                             self.head_dim as i64,
-                        ])?)
+                        ])?;
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] gemma4 attention_paged_shared_prefill_gather_done anchor_paged_idx={} cached_prefix={} seq_len={} total_ctx={} path=paged_attention elapsed_ms={:.1}",
+                                anchor_paged_idx,
+                                cached_prefix_len,
+                                seq_len,
+                                total_ctx,
+                                gather_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                            ));
+                        }
+                        Some(out)
                     }
-                    Err(_) => None,
+                    Err(err) => {
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] gemma4 attention_paged_shared_prefill_gather_fallback anchor_paged_idx={} cached_prefix={} seq_len={} total_ctx={} error={}",
+                                anchor_paged_idx, cached_prefix_len, seq_len, total_ctx, err
+                            ));
+                        }
+                        None
+                    }
                 }
             } else {
                 None
@@ -841,32 +944,97 @@ impl Gemma4Attention {
             match maybe_paged_attn {
                 Some(out) => out,
                 None => {
+                    let read_trace_start = trace_enabled.then(std::time::Instant::now);
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_shared_read_kv_start anchor_paged_idx={} total_ctx={} cached_prefix={} seq_len={}",
+                            anchor_paged_idx, total_ctx, cached_prefix_len, seq_len
+                        ));
+                    }
                     let (shared_keys, shared_values) = adapter
                         .read_kv_range(anchor_paged_idx, 0, total_ctx)
                         .map_err(napi::Error::from_reason)?;
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_shared_read_kv_done anchor_paged_idx={} total_ctx={} elapsed_ms={:.1}",
+                            anchor_paged_idx,
+                            total_ctx,
+                            read_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                        ));
+                    }
                     let mask =
                         create_causal_mask(seq_len as i32, Some(cached_prefix_len as i32), None)?;
-                    scaled_dot_product_attention(
+                    let sdpa_trace_start = trace_enabled.then(std::time::Instant::now);
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_shared_sdpa_masked_start anchor_paged_idx={} q_len={} kv_len={} cached_prefix={}",
+                            anchor_paged_idx, seq_len, total_ctx, cached_prefix_len
+                        ));
+                    }
+                    let out = scaled_dot_product_attention(
                         &queries_bhtd,
                         &shared_keys,
                         &shared_values,
                         1.0,
                         Some(&mask),
-                    )?
+                    )?;
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_shared_sdpa_masked_done anchor_paged_idx={} q_len={} kv_len={} elapsed_ms={:.1}",
+                            anchor_paged_idx,
+                            seq_len,
+                            total_ctx,
+                            sdpa_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                        ));
+                    }
+                    out
                 }
             }
         } else {
             // Single-token path (decode OR split-prefill pass 2):
-            // dispatch `gather_kv_for_decode` against the anchor's paged
-            // slot. Queries shape: `[1, num_heads, head_dim]` (squeeze T=1).
+            // dispatch graph-native paged attention against the anchor's
+            // paged slot. Queries shape: `[1, num_heads, head_dim]`
+            // (squeeze T=1).
             let queries_3d = queries_bhtd.squeeze(Some(&[2]))?.reshape(&[
                 1,
                 self.num_heads as i64,
                 self.head_dim as i64,
             ])?;
-            let attn_3d = adapter
-                .gather_kv_for_decode(anchor_paged_idx, &queries_3d, 1.0, /* softcap */ 1.0)
-                .map_err(napi::Error::from_reason)?;
+            let gather_trace_start = trace_enabled.then(std::time::Instant::now);
+            let attn_3d = match adapter.gather_kv_for_decode_graph(
+                anchor_paged_idx,
+                &queries_3d,
+                1.0,
+                1.0,
+            ) {
+                Ok(attn_3d) => {
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_shared_decode_gather_done anchor_paged_idx={} path=graph total_ctx={} elapsed_ms={:.1}",
+                            anchor_paged_idx,
+                            total_ctx,
+                            gather_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                        ));
+                    }
+                    attn_3d
+                }
+                Err(err) => {
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 attention_paged_shared_decode_gather_fallback anchor_paged_idx={} path=raw total_ctx={} error={}",
+                            anchor_paged_idx, total_ctx, err
+                        ));
+                    }
+                    adapter
+                        .gather_kv_for_decode(
+                            anchor_paged_idx,
+                            &queries_3d,
+                            1.0,
+                            /* softcap */ 1.0,
+                        )
+                        .map_err(napi::Error::from_reason)?
+                }
+            };
             let target_dtype = x.dtype()?;
             let attn_3d = attn_3d.astype(target_dtype)?;
             attn_3d.reshape(&[1, self.num_heads as i64, 1, self.head_dim as i64])?
@@ -959,5 +1127,34 @@ impl Gemma4Attention {
     }
     pub fn set_quantized_o_proj(&mut self, ql: QuantizedLinear) {
         self.o_proj.set_quantized(ql);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trim_mask_rejects_mask_shorter_than_kv() {
+        let mask = MxArray::zeros(&[1, 1, 2, 3], None).unwrap();
+        let err = match trim_mask(Some(&mask), 4) {
+            Ok(_) => panic!("expected trim_mask to reject a short mask"),
+            Err(err) => err,
+        };
+        assert!(
+            err.reason.contains("mask is shorter than K/V"),
+            "unexpected error: {}",
+            err.reason
+        );
+    }
+
+    #[test]
+    fn trim_mask_trims_longer_mask_to_kv_len() {
+        let mask = MxArray::zeros(&[1, 1, 2, 5], None).unwrap();
+        let trimmed = trim_mask(Some(&mask), 3).unwrap().unwrap();
+        assert_eq!(trimmed.shape_at(0).unwrap(), 1);
+        assert_eq!(trimmed.shape_at(1).unwrap(), 1);
+        assert_eq!(trimmed.shape_at(2).unwrap(), 2);
+        assert_eq!(trimmed.shape_at(3).unwrap(), 3);
     }
 }

--- a/crates/mlx-core/src/models/gemma4/config.rs
+++ b/crates/mlx-core/src/models/gemma4/config.rs
@@ -107,7 +107,8 @@ pub struct Gemma4Config {
     // Paged attention options (opt-in)
     /// GPU memory budget for paged KV cache in megabytes.
     /// Only used when `use_block_paged_cache` is true.
-    /// Default: 2048 (2GB).
+    /// Default: auto-sized to cover `max_position_embeddings` for the
+    /// physical full-attention layers.
     #[serde(default)]
     #[napi(ts_type = "number | undefined")]
     pub paged_cache_memory_mb: Option<u32>,

--- a/crates/mlx-core/src/models/gemma4/config.rs
+++ b/crates/mlx-core/src/models/gemma4/config.rs
@@ -121,14 +121,13 @@ pub struct Gemma4Config {
 
     /// Use the new block-paged KV cache adapter (`PagedKVCacheAdapter`).
     ///
-    /// When `Some(true)` or unset (the default), `Gemma4Inner` allocates
-    /// a `BlockAllocator` + `LayerKVPool` pair and constructs a
-    /// `PagedKVCacheAdapter`. Sliding-window layers stay on the existing
-    /// flat `RotatingKVCache` path (window-trimmed semantics don't map
-    /// onto the paged pool), while full_attention (global) layers route
-    /// through the adapter — including `KV-shared` layers whose anchor
-    /// is global (read via `read_kv_range`) and KV-shared layers whose
-    /// anchor is sliding (pull from the flat anchor's stash).
+    /// When `Some(true)` or unset (the default), `Gemma4Inner` builds
+    /// model-independent KV-cache specs, groups them, and allocates a
+    /// `BlockAllocator` + `LayerKVPool` pair for physical full-attention
+    /// layers. Sliding-window layers still use `RotatingKVCache` until
+    /// true paged sliding-window groups are wired. KV-shared layers are
+    /// aliases: they reuse their anchor's cache slot and do not allocate
+    /// separate physical storage.
     ///
     /// Default: `true` (paged adapter on; opt-out via
     /// `use_block_paged_cache: false` in `config.json` to fall back to

--- a/crates/mlx-core/src/models/gemma4/decoder_layer.rs
+++ b/crates/mlx-core/src/models/gemma4/decoder_layer.rs
@@ -22,8 +22,9 @@ use super::quantized_linear::{Gemma4MLPVariant, QuantizedLinear, QuantizedSwitch
 /// Indexing rules:
 /// * `paged_idx` is the GLOBAL-LAYER ORDINAL into the paged adapter's
 ///   `LayerKVPool` (NOT the absolute decoder index). The pool is sized
-///   for the count of `full_attention` layers in `config.layer_types`,
-///   so global layers are numbered 0..N_global in their original order.
+///   for physical non-shared `full_attention` layers in `config.layer_types`,
+///   so global owner layers are numbered 0..N_global in their original order.
+///   KV-shared global layers reuse their anchor's ordinal.
 /// * `anchor_layer_idx` (in `SharedOnSliding`) is the ABSOLUTE decoder
 ///   index of the anchor whose flat `Gemma4LayerCache::Sliding` slot
 ///   feeds the shared layer's K/V via `take_stashed_kv`.

--- a/crates/mlx-core/src/models/gemma4/layer_cache.rs
+++ b/crates/mlx-core/src/models/gemma4/layer_cache.rs
@@ -1,4 +1,5 @@
 use crate::array::MxArray;
+use crate::transformer::rotating_kv_cache::{RotatingKVCacheSnapshot, RotatingKVCacheState};
 use crate::transformer::{KVCache, RotatingKVCache};
 use napi::bindgen_prelude::*;
 
@@ -47,6 +48,61 @@ impl Gemma4LayerCache {
         match &self.inner {
             CacheType::Global(c) => c.get_offset(),
             CacheType::Sliding(c) => c.get_offset(),
+        }
+    }
+
+    /// Returns true when this Gemma layer owns a sliding rotating cache.
+    pub fn is_sliding(&self) -> bool {
+        matches!(self.inner, CacheType::Sliding(_))
+    }
+
+    /// Return logical state for a sliding cache.
+    ///
+    /// Global layers return `None` so callers can iterate over all Gemma4
+    /// layers without separately checking the layer kind.
+    pub fn sliding_state(&self) -> Result<Option<RotatingKVCacheState>> {
+        match &self.inner {
+            CacheType::Global(_) => Ok(None),
+            CacheType::Sliding(c) => Ok(Some(c.state()?)),
+        }
+    }
+
+    /// Check that a sliding cache is initialized and aligned to `offset`.
+    pub fn sliding_offset_matches(&self, offset: i32) -> Result<bool> {
+        match &self.inner {
+            CacheType::Global(_) => Ok(false),
+            CacheType::Sliding(c) => {
+                let state = c.state()?;
+                Ok(state.initialized && state.offset == offset)
+            }
+        }
+    }
+
+    /// Snapshot a sliding cache's ordered K/V tail.
+    ///
+    /// Global layers and empty sliding caches return `None`.
+    pub fn snapshot_sliding(&self) -> Result<Option<RotatingKVCacheSnapshot>> {
+        match &self.inner {
+            CacheType::Global(_) => Ok(None),
+            CacheType::Sliding(c) => c.snapshot(),
+        }
+    }
+
+    /// Restore a sliding cache from an ordered K/V tail snapshot.
+    ///
+    /// This intentionally errors on global layers to prevent accidentally
+    /// loading sliding-window state into a full-attention cache.
+    pub fn restore_sliding_snapshot(&mut self, snapshot: &RotatingKVCacheSnapshot) -> Result<()> {
+        match &mut self.inner {
+            CacheType::Global(_) => Err(Error::new(
+                Status::InvalidArg,
+                "cannot restore a sliding snapshot into a Gemma4 global cache",
+            )),
+            CacheType::Sliding(c) => {
+                c.restore_snapshot(snapshot)?;
+                self.stashed_kv = None;
+                Ok(())
+            }
         }
     }
 
@@ -161,6 +217,12 @@ impl Gemma4LayerCache {
 mod tests {
     use super::*;
 
+    fn assert_float_data(arr: &MxArray, expected: &[f32]) {
+        arr.eval();
+        let data = arr.to_float32().unwrap().to_vec();
+        assert_eq!(data, expected);
+    }
+
     #[test]
     fn test_sliding_cache_stash_preserves_full_prefill() {
         // Create a sliding cache with small window (4 tokens)
@@ -231,5 +293,62 @@ mod tests {
             8,
             "global cache stores everything"
         );
+    }
+
+    #[test]
+    fn test_sliding_snapshot_restore_after_wrap() {
+        let mut source = Gemma4LayerCache::new_sliding(4);
+
+        let keys1 = MxArray::from_float32(&[1.0, 2.0, 3.0, 4.0], &[1, 1, 4, 1]).unwrap();
+        let values1 = MxArray::from_float32(&[10.0, 20.0, 30.0, 40.0], &[1, 1, 4, 1]).unwrap();
+        source.update_and_fetch(&keys1, &values1).unwrap();
+
+        let keys2 = MxArray::from_float32(&[5.0], &[1, 1, 1, 1]).unwrap();
+        let values2 = MxArray::from_float32(&[50.0], &[1, 1, 1, 1]).unwrap();
+        source.update_and_fetch(&keys2, &values2).unwrap();
+
+        let keys3 = MxArray::from_float32(&[6.0], &[1, 1, 1, 1]).unwrap();
+        let values3 = MxArray::from_float32(&[60.0], &[1, 1, 1, 1]).unwrap();
+        source.update_and_fetch(&keys3, &values3).unwrap();
+
+        assert!(source.is_sliding());
+        assert!(source.sliding_offset_matches(6).unwrap());
+        let source_state = source.sliding_state().unwrap().unwrap();
+        assert_eq!(source_state.offset, 6);
+        assert_eq!(source_state.cached_tokens, 4);
+
+        let snapshot = source.snapshot_sliding().unwrap().unwrap();
+        let mut restored = Gemma4LayerCache::new_sliding(4);
+        restored.restore_sliding_snapshot(&snapshot).unwrap();
+        assert!(restored.sliding_offset_matches(6).unwrap());
+
+        let (restored_keys, restored_values) = restored.get_cached_kv().unwrap();
+        assert_float_data(&restored_keys, &[3.0, 4.0, 5.0, 6.0]);
+        assert_float_data(&restored_values, &[30.0, 40.0, 50.0, 60.0]);
+
+        let append_keys = MxArray::from_float32(&[7.0, 8.0], &[1, 1, 2, 1]).unwrap();
+        let append_values = MxArray::from_float32(&[70.0, 80.0], &[1, 1, 2, 1]).unwrap();
+        let (attention_keys, attention_values) = restored
+            .update_and_fetch(&append_keys, &append_values)
+            .unwrap();
+        assert_float_data(&attention_keys, &[3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+        assert_float_data(&attention_values, &[30.0, 40.0, 50.0, 60.0, 70.0, 80.0]);
+
+        let (restored_tail, _) = restored.get_cached_kv().unwrap();
+        assert_float_data(&restored_tail, &[5.0, 6.0, 7.0, 8.0]);
+    }
+
+    #[test]
+    fn test_sliding_snapshot_not_restored_into_global_cache() {
+        let mut sliding = Gemma4LayerCache::new_sliding(4);
+        let keys = MxArray::ones(&[1, 1, 4, 1], None).unwrap();
+        let values = MxArray::ones(&[1, 1, 4, 1], None).unwrap();
+        sliding.update_and_fetch(&keys, &values).unwrap();
+        let snapshot = sliding.snapshot_sliding().unwrap().unwrap();
+
+        let mut global = Gemma4LayerCache::new_global();
+        assert!(!global.is_sliding());
+        assert!(global.snapshot_sliding().unwrap().is_none());
+        assert!(global.restore_sliding_snapshot(&snapshot).is_err());
     }
 }

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -7146,12 +7146,10 @@ fn gemma4_paged_prefill_body_chunk_size(configured_chunk_size: i32, body_tokens:
 fn gemma4_paged_prefill_paged_attention_enabled_for_chunking() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("MLX_GEMMA4_PAGED_PREFILL_PAGED_ATTENTION")
-            .map(|value| {
-                let normalized = value.trim().to_ascii_lowercase();
-                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
-            })
-            .unwrap_or(true)
+        crate::inference_trace::env_flag_enabled_or_default(
+            "MLX_GEMMA4_PAGED_PREFILL_PAGED_ATTENTION",
+            true,
+        )
     })
 }
 

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -3657,7 +3657,17 @@ impl Gemma4Inner {
                 })?;
             let paged_attention_enabled =
                 gemma4_paged_prefill_paged_attention_enabled_for_chunking();
-            let body_chunk_plan = gemma4_paged_prefill_body_chunk_plan(
+            let block_size = self
+                .paged_adapter
+                .as_ref()
+                .map(|adapter| adapter.block_size())
+                .unwrap_or(0);
+            let prompt_checkpoint_boundary_len = if block_size > 0 {
+                (full_tokens.len() as u32 / block_size) * block_size
+            } else {
+                0
+            };
+            let mut body_chunk_plan = gemma4_paged_prefill_body_chunk_plan(
                 configured_chunk_size,
                 pass1_tokens.len(),
                 pass2_first_position,
@@ -3665,6 +3675,10 @@ impl Gemma4Inner {
                 global_head_size,
                 paged_attention_enabled,
             )?;
+            gemma4_split_body_chunk_plan_at_position(
+                &mut body_chunk_plan,
+                prompt_checkpoint_boundary_len,
+            );
             let total_body_chunks = body_chunk_plan.len();
             let first_body_chunk_size = body_chunk_plan.first().map(|chunk| chunk.len).unwrap_or(0);
             let min_body_chunk_size = body_chunk_plan
@@ -3788,6 +3802,14 @@ impl Gemma4Inner {
                     .ok_or_else(|| {
                         Error::from_reason("Gemma4 paged prefill token position overflow")
                     })?;
+                if pass2_first_position == prompt_checkpoint_boundary_len {
+                    self.maybe_remember_gemma4_sliding_prompt_boundary_checkpoint(
+                        "paged_prefill",
+                        full_tokens,
+                        prompt_checkpoint_boundary_len,
+                        trace_enabled,
+                    )?;
+                }
                 if trace_enabled {
                     write_inference_trace(format_args!(
                         "[MLX_TRACE] gemma4 paged_prefill_body_chunk_done chunk={}/{} next_position={} elapsed_ms={:.1}",
@@ -3859,7 +3881,7 @@ impl Gemma4Inner {
         self.maybe_remember_gemma4_sliding_prompt_boundary_checkpoint(
             "paged_prefill",
             full_tokens,
-            full_tokens.len() as u32,
+            pass2_first_position + pass2_tokens.len() as u32,
             trace_enabled,
         )?;
 
@@ -6738,6 +6760,35 @@ fn gemma4_coalesce_single_token_restore_chunks(chunks: &mut Vec<Gemma4PagedPrefi
     *chunks = merged;
 }
 
+fn gemma4_split_body_chunk_plan_at_position(
+    chunks: &mut Vec<Gemma4PagedPrefillBodyChunk>,
+    boundary_position: u32,
+) {
+    if boundary_position == 0 {
+        return;
+    }
+
+    let Some(idx) = chunks.iter().position(|chunk| {
+        let first = chunk.first_position as u64;
+        let end = first + chunk.len as u64;
+        boundary_position as u64 > first && (boundary_position as u64) < end
+    }) else {
+        return;
+    };
+
+    let chunk = &mut chunks[idx];
+    let before_len = (boundary_position - chunk.first_position) as usize;
+    let after_len = chunk.len - before_len;
+    let after_chunk = Gemma4PagedPrefillBodyChunk {
+        start: chunk.start + before_len,
+        len: after_len,
+        first_position: boundary_position,
+        capped_by_v2_aux_limit: chunk.capped_by_v2_aux_limit,
+    };
+    chunk.len = before_len;
+    chunks.insert(idx + 1, after_chunk);
+}
+
 fn gemma4_paged_attention_v2_aux_fits(
     num_new_tokens: usize,
     first_position: u32,
@@ -7283,6 +7334,32 @@ mod tests {
             vec![2, 3]
         );
         assert_eq!(one_token_chunks[1].first_position, 2);
+    }
+
+    #[test]
+    fn test_gemma4_paged_prefill_chunk_plan_splits_prompt_cache_boundary() {
+        let mut plan =
+            super::gemma4_paged_prefill_body_chunk_plan(1024, 1432, 44_320, 16, 512, false)
+                .unwrap();
+        super::gemma4_split_body_chunk_plan_at_position(&mut plan, 45_744);
+        assert_eq!(
+            plan.iter().map(|chunk| chunk.len).collect::<Vec<_>>(),
+            vec![1024, 400, 8]
+        );
+        assert_eq!(
+            plan.iter()
+                .map(|chunk| chunk.first_position)
+                .collect::<Vec<_>>(),
+            vec![44_320, 45_344, 45_744]
+        );
+        assert_eq!(
+            plan.iter().map(|chunk| chunk.start).collect::<Vec<_>>(),
+            vec![0, 1024, 1424]
+        );
+
+        let mut unchanged = plan.clone();
+        super::gemma4_split_body_chunk_plan_at_position(&mut unchanged, 45_344);
+        assert_eq!(unchanged, plan);
     }
 
     #[test]

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -240,6 +240,7 @@ pub(crate) struct Gemma4Inner {
     /// back to the flat `Gemma4LayerCache` path.
     pub(crate) paged_adapter: Option<PagedKVCacheAdapter>,
     sliding_prefix_checkpoints: VecDeque<Gemma4SlidingPrefixCheckpoint>,
+    sliding_prompt_boundary_checkpoint: Option<Gemma4SlidingPrefixCheckpoint>,
     sliding_last_history_checkpoint: Option<Gemma4SlidingHistoryCheckpoint>,
     pub(crate) model_id: u64,
 }
@@ -806,6 +807,7 @@ impl Gemma4Inner {
             cached_image_key: None,
             paged_adapter,
             sliding_prefix_checkpoints: VecDeque::new(),
+            sliding_prompt_boundary_checkpoint: None,
             sliding_last_history_checkpoint: None,
             model_id,
         })
@@ -874,6 +876,7 @@ impl Gemma4Inner {
         self.cached_token_history.clear();
         self.cached_image_key = None;
         self.sliding_prefix_checkpoints.clear();
+        self.sliding_prompt_boundary_checkpoint = None;
         self.sliding_last_history_checkpoint = None;
     }
 
@@ -962,6 +965,20 @@ impl Gemma4Inner {
         let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
             return Ok(None);
         };
+
+        if let Some(checkpoint) = self.sliding_prompt_boundary_checkpoint.as_ref() {
+            if checkpoint.prefix_len == prefix_len
+                && checkpoint.block_size == block_size
+                && checkpoint.final_block_hash == final_block_hash
+                && checkpoint.tokens.as_slice() == prefix_tokens
+            {
+                if let Some(caches) =
+                    restore_gemma4_sliding_caches(&self.config, &checkpoint.snapshots, prefix_len)?
+                {
+                    return Ok(Some(caches));
+                }
+            }
+        }
 
         for checkpoint in self.sliding_prefix_checkpoints.iter().rev() {
             if checkpoint.prefix_len != prefix_len
@@ -1120,6 +1137,67 @@ impl Gemma4Inner {
         Ok(trace.finish(total_start))
     }
 
+    fn remember_gemma4_sliding_materialized_prompt_boundary_checkpoint(
+        &mut self,
+        tokens: &[u32],
+        prefix_len: u32,
+        block_size: u32,
+        cache_salt: u64,
+    ) -> Result<Gemma4SlidingCheckpointStoreTrace> {
+        let trace_enabled = inference_trace_enabled();
+        let total_start = trace_enabled.then(std::time::Instant::now);
+        let mut trace = Gemma4SlidingCheckpointStoreTrace::default();
+        let Some(final_block_hash) =
+            compute_gemma4_paged_prefix_block_hash(tokens, prefix_len, block_size, cache_salt)
+        else {
+            self.sliding_prompt_boundary_checkpoint = None;
+            return Ok(trace.finish(total_start));
+        };
+        let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
+            self.sliding_prompt_boundary_checkpoint = None;
+            return Ok(trace.finish(total_start));
+        };
+        if !gemma4_sliding_caches_ready_at(&self.config, self.caches.as_deref(), prefix_len)? {
+            self.sliding_prompt_boundary_checkpoint = None;
+            return Ok(trace.finish(total_start));
+        }
+
+        let snapshot_start = trace_enabled.then(std::time::Instant::now);
+        let Some(mut snapshots) = snapshot_gemma4_sliding_caches(
+            &self.config,
+            self.caches
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Gemma4 sliding prefix caches missing"))?,
+            prefix_len,
+        )?
+        else {
+            self.sliding_prompt_boundary_checkpoint = None;
+            trace.snapshot_ms = snapshot_start.map(elapsed_ms).unwrap_or(0.0);
+            return Ok(trace.finish(total_start));
+        };
+        trace.snapshot_ms = snapshot_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let eval_start = trace_enabled.then(std::time::Instant::now);
+        materialize_gemma4_sliding_snapshots(&mut snapshots)?;
+        trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let token_clone_start = trace_enabled.then(std::time::Instant::now);
+        let prefix_tokens = prefix_tokens.to_vec();
+        trace.token_clone_ms = token_clone_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let update_start = trace_enabled.then(std::time::Instant::now);
+        self.sliding_prompt_boundary_checkpoint = Some(Gemma4SlidingPrefixCheckpoint {
+            prefix_len,
+            block_size,
+            final_block_hash,
+            tokens: prefix_tokens,
+            snapshots,
+        });
+        trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
+        trace.stored = true;
+        Ok(trace.finish(total_start))
+    }
+
     fn maybe_remember_gemma4_sliding_decode_boundary_checkpoint(
         &mut self,
         trace_label: &str,
@@ -1145,6 +1223,43 @@ impl Gemma4Inner {
             write_inference_trace(format_args!(
                 "[MLX_TRACE] gemma4 {trace_label}_sliding_block_checkpoint boundary_tokens={} block_size={} stored={} materialize_ms={:.1} snapshot_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
                 prefix_len,
+                block_size,
+                store_trace.stored,
+                store_trace.eval_ms,
+                store_trace.snapshot_ms,
+                store_trace.token_clone_ms,
+                store_trace.update_ms,
+                store_trace.total_ms
+            ));
+        }
+        Ok(())
+    }
+
+    fn maybe_remember_gemma4_sliding_prompt_boundary_checkpoint(
+        &mut self,
+        trace_label: &str,
+        tokens: &[u32],
+        boundary_len: u32,
+        trace_enabled: bool,
+    ) -> Result<()> {
+        let Some(adapter) = self.paged_adapter.as_ref() else {
+            return Ok(());
+        };
+        let block_size = adapter.block_size();
+        if boundary_len == 0 || block_size == 0 || !boundary_len.is_multiple_of(block_size) {
+            return Ok(());
+        }
+
+        let store_trace = self.remember_gemma4_sliding_materialized_prompt_boundary_checkpoint(
+            tokens,
+            boundary_len,
+            block_size,
+            0,
+        )?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 {trace_label}_sliding_prompt_checkpoint boundary_tokens={} block_size={} stored={} materialize_ms={:.1} snapshot_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
+                boundary_len,
                 block_size,
                 store_trace.stored,
                 store_trace.eval_ms,
@@ -3740,6 +3855,13 @@ impl Gemma4Inner {
                 pass2_layer_loop_start.map(elapsed_ms).unwrap_or(0.0)
             ));
         }
+
+        self.maybe_remember_gemma4_sliding_prompt_boundary_checkpoint(
+            "paged_prefill",
+            full_tokens,
+            full_tokens.len() as u32,
+            trace_enabled,
+        )?;
 
         // Final norm + lm_head + softcap (only for the final token).
         hidden_states = self.final_norm.forward(&hidden_states)?;
@@ -7735,6 +7857,67 @@ mod tests {
         if let Some(adapter) = inner.paged_adapter.as_mut() {
             let _ = adapter.release_request();
         }
+    }
+
+    #[test]
+    fn test_gemma4_prompt_boundary_checkpoint_survives_decode_checkpoint_eviction() {
+        let cfg = paged_tiny_config(Some(true));
+        let mut inner = match super::Gemma4Inner::new(cfg) {
+            Ok(i) => i,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("No Metal device found") {
+                    eprintln!("skipping (no Metal device): {msg}");
+                    return;
+                }
+                panic!("unexpected Gemma4Inner::new failure: {msg}");
+            }
+        };
+
+        let block_size = 16;
+        let prompt: Vec<u32> = (10..26).collect();
+        let prompt_hash = super::compute_gemma4_paged_prefix_block_hash(
+            &prompt,
+            prompt.len() as u32,
+            block_size,
+            0,
+        )
+        .expect("prompt hash");
+        inner.sliding_prompt_boundary_checkpoint = Some(super::Gemma4SlidingPrefixCheckpoint {
+            prefix_len: prompt.len() as u32,
+            block_size,
+            final_block_hash: prompt_hash,
+            tokens: prompt.clone(),
+            snapshots: vec![None; inner.config.num_hidden_layers as usize],
+        });
+
+        for i in 0..(GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT + 3) {
+            let tokens: Vec<u32> = (0..16).map(|token| 100 + i as u32 + token).collect();
+            inner
+                .sliding_prefix_checkpoints
+                .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                    prefix_len: tokens.len() as u32,
+                    block_size,
+                    final_block_hash: i as u64 + 1,
+                    tokens,
+                    snapshots: vec![None; inner.config.num_hidden_layers as usize],
+                });
+            while inner.sliding_prefix_checkpoints.len() > GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT {
+                inner.sliding_prefix_checkpoints.pop_front();
+            }
+        }
+        assert_eq!(
+            inner.sliding_prefix_checkpoints.len(),
+            GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT
+        );
+
+        let restored = inner
+            .find_gemma4_sliding_prefix_checkpoint(&prompt, prompt.len() as u32, block_size, 0)
+            .expect("prefix lookup");
+        assert!(
+            restored.is_some(),
+            "prompt-boundary checkpoint must not be evicted by decode-boundary checkpoints"
+        );
     }
 
     /// KV-shared layers must resolve their anchor's pool slot

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -2730,20 +2730,20 @@ impl Gemma4Inner {
         cached_prefix_len: u32,
         trace_enabled: bool,
     ) -> Result<u32> {
-        let max_sliding_restore_tokens =
-            gemma4_max_sliding_restore_tokens(self.config.sliding_window);
-        if cached_prefix_len <= max_sliding_restore_tokens {
+        let Some(max_sliding_restore_tokens) =
+            gemma4_large_sliding_restore_suppression_limit(cached_prefix_len)
+        else {
             return Ok(cached_prefix_len);
-        }
+        };
 
-        // Global K/V can be reused from the paged pool, but Gemma4 sliding
-        // layers still need flat sliding caches reconstructed before prefill.
-        // Keep an upper bound because the restore pass still has to replay the
-        // residual stream through the prefix, even though global attention now
-        // reads paged K/V instead of rebuilding throwaway flat K/V.
+        // Emergency operator override. By default, large prefix hits stay enabled:
+        // the sliding restore pass is chunked, and global attention reads paged K/V
+        // instead of rebuilding throwaway global K/V. If a deployment hits a
+        // restore-specific issue, MLX_GEMMA4_MAX_SLIDING_RESTORE_TOKENS can force
+        // full prefill above the configured limit.
         if trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 {}_prefix_reuse_suppressed reason=large_sliding_restore cached_prefix_tokens={} limit={}",
+                "[MLX_TRACE] gemma4 {}_prefix_reuse_suppressed reason=large_sliding_restore_env_limit cached_prefix_tokens={} limit={}",
                 trace_label, cached_prefix_len, max_sliding_restore_tokens
             ));
         }
@@ -2765,7 +2765,7 @@ impl Gemma4Inner {
             .map_err(Error::from_reason)?;
         if trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 {}_adapter_reset_done reason=large_sliding_restore_suppressed cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={}",
+                "[MLX_TRACE] gemma4 {}_adapter_reset_done reason=large_sliding_restore_env_limit_suppressed cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={}",
                 trace_label,
                 prefix.cached_token_count,
                 prefix.blocks.len(),
@@ -6674,23 +6674,37 @@ fn physical_full_attention_layer_count(specs: &[LayerKVCacheSpec]) -> usize {
 const GEMMA4_PREFILL_STEP_SIZE: i64 = 512;
 const GEMMA4_PAGED_ATTENTION_V2_PARTITION_SIZE: u64 = 512;
 const GEMMA4_PAGED_ATTENTION_V2_AUX_ELEM_LIMIT: u128 = i32::MAX as u128;
-const GEMMA4_SLIDING_RESTORE_DEFAULT_MAX_TOKENS: u32 = 32_768;
-const GEMMA4_SLIDING_RESTORE_DEFAULT_WINDOW_MULTIPLIER: u32 = 32;
 
-fn gemma4_max_sliding_restore_tokens(sliding_window: i32) -> u32 {
+fn parse_gemma4_sliding_restore_limit(value: &str) -> Option<u32> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    value.parse::<u32>().ok()
+}
+
+fn gemma4_sliding_restore_limit_override() -> Option<u32> {
     static OVERRIDE: OnceLock<Option<u32>> = OnceLock::new();
-    let sliding_window = sliding_window.max(0) as u32;
-    let default = sliding_window
-        .saturating_mul(GEMMA4_SLIDING_RESTORE_DEFAULT_WINDOW_MULTIPLIER)
-        .min(GEMMA4_SLIDING_RESTORE_DEFAULT_MAX_TOKENS)
-        .max(sliding_window);
-    OVERRIDE
-        .get_or_init(|| {
-            std::env::var("MLX_GEMMA4_MAX_SLIDING_RESTORE_TOKENS")
-                .ok()
-                .and_then(|value| value.trim().parse::<u32>().ok())
-        })
-        .unwrap_or(default)
+    *OVERRIDE.get_or_init(|| {
+        std::env::var("MLX_GEMMA4_MAX_SLIDING_RESTORE_TOKENS")
+            .ok()
+            .and_then(|value| parse_gemma4_sliding_restore_limit(&value))
+    })
+}
+
+fn gemma4_large_sliding_restore_suppression_limit_for_override(
+    override_limit: Option<u32>,
+    cached_prefix_len: u32,
+) -> Option<u32> {
+    let limit = override_limit?;
+    (cached_prefix_len > limit).then_some(limit)
+}
+
+fn gemma4_large_sliding_restore_suppression_limit(cached_prefix_len: u32) -> Option<u32> {
+    gemma4_large_sliding_restore_suppression_limit_for_override(
+        gemma4_sliding_restore_limit_override(),
+        cached_prefix_len,
+    )
 }
 
 fn gemma4_paged_prefill_group_max_chunk() -> u32 {
@@ -7363,9 +7377,44 @@ mod tests {
     }
 
     #[test]
-    fn test_gemma4_sliding_restore_default_limit_is_bounded() {
-        assert_eq!(super::gemma4_max_sliding_restore_tokens(1024), 32_768);
-        assert_eq!(super::gemma4_max_sliding_restore_tokens(4096), 32_768);
+    fn test_gemma4_sliding_restore_default_is_uncapped() {
+        assert_eq!(
+            super::gemma4_large_sliding_restore_suppression_limit_for_override(None, 44_512),
+            None
+        );
+        assert_eq!(
+            super::gemma4_large_sliding_restore_suppression_limit_for_override(None, 1_000_000),
+            None
+        );
+    }
+
+    #[test]
+    fn test_gemma4_sliding_restore_env_limit_is_opt_in() {
+        assert_eq!(
+            super::parse_gemma4_sliding_restore_limit("32768"),
+            Some(32_768)
+        );
+        assert_eq!(
+            super::parse_gemma4_sliding_restore_limit(" 44512 "),
+            Some(44_512)
+        );
+        assert_eq!(super::parse_gemma4_sliding_restore_limit(""), None);
+        assert_eq!(super::parse_gemma4_sliding_restore_limit("off"), None);
+
+        assert_eq!(
+            super::gemma4_large_sliding_restore_suppression_limit_for_override(
+                Some(32_768),
+                32_768
+            ),
+            None
+        );
+        assert_eq!(
+            super::gemma4_large_sliding_restore_suppression_limit_for_override(
+                Some(32_768),
+                44_512
+            ),
+            Some(32_768)
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -407,7 +407,7 @@ pub(crate) enum PrefixCacheDecision {
     Miss,
 }
 
-const GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT: usize = 4;
+const GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT: usize = 16;
 
 struct Gemma4SlidingPrefixCheckpoint {
     prefix_len: u32,
@@ -7994,6 +7994,81 @@ mod tests {
         assert!(
             restored.is_some(),
             "prompt-boundary checkpoint must not be evicted by decode-boundary checkpoints"
+        );
+    }
+
+    #[test]
+    fn test_gemma4_decode_checkpoint_retains_recent_retokenization_drift() {
+        let cfg = paged_tiny_config(Some(true));
+        let mut inner = match super::Gemma4Inner::new(cfg) {
+            Ok(i) => i,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("No Metal device found") {
+                    eprintln!("skipping (no Metal device): {msg}");
+                    return;
+                }
+                panic!("unexpected Gemma4Inner::new failure: {msg}");
+            }
+        };
+
+        let block_size = 16;
+        let target_tokens: Vec<u32> = (1000..1016).collect();
+        let target_hash = super::compute_gemma4_paged_prefix_block_hash(
+            &target_tokens,
+            target_tokens.len() as u32,
+            block_size,
+            0,
+        )
+        .expect("target hash");
+        inner
+            .sliding_prefix_checkpoints
+            .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                prefix_len: target_tokens.len() as u32,
+                block_size,
+                final_block_hash: target_hash,
+                tokens: target_tokens.clone(),
+                snapshots: vec![None; inner.config.num_hidden_layers as usize],
+            });
+
+        // The observed Gemma4 tool-call retokenization drift needed the
+        // checkpoint five block boundaries behind the final decode state:
+        // 46272 was requested after 46288, 46304, 46320, and 46336 had
+        // also been checkpointed.
+        for i in 0..4 {
+            let tokens: Vec<u32> = (0..16).map(|token| 2000 + i as u32 + token).collect();
+            let hash = super::compute_gemma4_paged_prefix_block_hash(
+                &tokens,
+                tokens.len() as u32,
+                block_size,
+                0,
+            )
+            .expect("newer hash");
+            inner
+                .sliding_prefix_checkpoints
+                .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                    prefix_len: tokens.len() as u32,
+                    block_size,
+                    final_block_hash: hash,
+                    tokens,
+                    snapshots: vec![None; inner.config.num_hidden_layers as usize],
+                });
+            while inner.sliding_prefix_checkpoints.len() > GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT {
+                inner.sliding_prefix_checkpoints.pop_front();
+            }
+        }
+
+        let restored = inner
+            .find_gemma4_sliding_prefix_checkpoint(
+                &target_tokens,
+                target_tokens.len() as u32,
+                block_size,
+                0,
+            )
+            .expect("prefix lookup");
+        assert!(
+            restored.is_some(),
+            "decode checkpoints must retain the block needed after modest retokenization drift"
         );
     }
 

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -2,12 +2,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use napi::Either;
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 
 use crate::array::{DType, MxArray};
+use crate::inference_trace::{
+    elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
+};
 use crate::model_thread::{ResponseTx, StreamTx};
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::sampling::{SamplingConfig, sample};
@@ -745,16 +747,16 @@ impl Gemma4Inner {
     /// ## Field support
     ///
     /// **Supported**: `max_new_tokens`, `temperature`, `top_k`, `top_p`,
-    /// `min_p`, `tools`, `reasoning_effort` (mapped to the template's
-    /// `enable_thinking` kwarg via `chat_common::resolve_enable_thinking`),
-    /// `report_performance`, `reuse_cache`.
+    /// `min_p`, `tools`, `max_consecutive_tokens`,
+    /// `max_ngram_repeats`, `ngram_size`, `reasoning_effort` (mapped to
+    /// the template's `enable_thinking` kwarg via
+    /// `chat_common::resolve_enable_thinking`), `report_performance`,
+    /// `reuse_cache`.
     ///
     /// **Silent no-ops** (Gemma4 decode loop has no code path that reads
     /// them): `repetition_penalty`, `repetition_context_size`,
     /// `presence_penalty`, `presence_context_size`, `frequency_penalty`,
-    /// `frequency_context_size`, `max_consecutive_tokens`,
-    /// `max_ngram_repeats`, `ngram_size`, `thinking_token_budget`,
-    /// `include_reasoning`.
+    /// `frequency_context_size`, `thinking_token_budget`, `include_reasoning`.
     ///
     /// `eos_token_id` is the caller-supplied stop-on token id. The decode
     /// loop stops on this id OR any of `config.eos_token_ids`, so the
@@ -807,6 +809,7 @@ impl Gemma4Inner {
             Some(chat_common::compute_image_cache_key(&raw_images))
         };
         let sampling_config = make_sampling_config(&config, &self.config);
+        let repetition_cutoff = repetition_cutoff_from_config(&config);
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
         let eos_ids = self.config.eos_token_ids.clone();
 
@@ -1067,7 +1070,7 @@ impl Gemma4Inner {
             self.caches
                 .as_ref()
                 .expect("caches populated by init_caches_sync above"),
-        );
+        )?;
 
         // Last token → logits. `prompt` is the delta slice, so its final
         // position is `prefill_len - 1`. `prefill_body_gemma4` processed
@@ -1099,7 +1102,7 @@ impl Gemma4Inner {
             self.caches
                 .as_ref()
                 .expect("caches populated by init_caches_sync above"),
-        );
+        )?;
 
         // Mark first token time (TTFT = time to first token)
         let first_token_instant = std::time::Instant::now();
@@ -1201,6 +1204,12 @@ impl Gemma4Inner {
                     finish_reason = "stop".to_string();
                     break;
                 }
+                if let Some(reason) =
+                    check_gemma4_repetition_cutoff(&generated_tokens, repetition_cutoff)
+                {
+                    finish_reason = reason.to_string();
+                    break;
+                }
                 if let Some(next_token) = next_y {
                     current_y = next_token;
                 } else {
@@ -1272,6 +1281,12 @@ impl Gemma4Inner {
 
                 if is_eos_token(token_id, &eos_ids, eos_token_id) {
                     finish_reason = "stop".to_string();
+                    break;
+                }
+                if let Some(reason) =
+                    check_gemma4_repetition_cutoff(&generated_tokens, repetition_cutoff)
+                {
+                    finish_reason = reason.to_string();
                     break;
                 }
                 if let Some(next_token) = next_y {
@@ -1368,16 +1383,16 @@ impl Gemma4Inner {
     /// ## Field support
     ///
     /// **Supported**: `max_new_tokens`, `temperature`, `top_k`, `top_p`,
-    /// `min_p`, `tools`, `reasoning_effort` (mapped to the template's
-    /// `enable_thinking` kwarg via `chat_common::resolve_enable_thinking`),
-    /// `report_performance`, `reuse_cache`.
+    /// `min_p`, `tools`, `max_consecutive_tokens`,
+    /// `max_ngram_repeats`, `ngram_size`, `reasoning_effort` (mapped to
+    /// the template's `enable_thinking` kwarg via
+    /// `chat_common::resolve_enable_thinking`), `report_performance`,
+    /// `reuse_cache`.
     ///
     /// **Silent no-ops** (Gemma4 decode loop has no code path that reads
     /// them): `repetition_penalty`, `repetition_context_size`,
     /// `presence_penalty`, `presence_context_size`, `frequency_penalty`,
-    /// `frequency_context_size`, `max_consecutive_tokens`,
-    /// `max_ngram_repeats`, `ngram_size`, `thinking_token_budget`,
-    /// `include_reasoning`.
+    /// `frequency_context_size`, `thinking_token_budget`, `include_reasoning`.
     ///
     /// `eos_token_id` is the caller-supplied stop-on token id. The decode
     /// loop stops on this id OR any of `config.eos_token_ids` (used by
@@ -1425,6 +1440,7 @@ impl Gemma4Inner {
             Some(chat_common::compute_image_cache_key(&raw_images))
         };
         let sampling_config = make_sampling_config(&config, &self.config);
+        let repetition_cutoff = repetition_cutoff_from_config(&config);
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
         let eos_ids = self.config.eos_token_ids.clone();
 
@@ -1615,7 +1631,7 @@ impl Gemma4Inner {
             self.caches
                 .as_ref()
                 .expect("caches populated by init_caches_sync above"),
-        );
+        )?;
 
         let last_token = prompt.slice_axis(1, prefill_len as i64 - 1, prefill_len as i64)?;
         let logits = {
@@ -1643,7 +1659,7 @@ impl Gemma4Inner {
             self.caches
                 .as_ref()
                 .expect("caches populated by init_caches_sync above"),
-        );
+        )?;
 
         let first_token_instant = std::time::Instant::now();
         let mut generated_tokens: Vec<u32> = Vec::new();
@@ -1763,6 +1779,12 @@ impl Gemma4Inner {
                     finish_reason = "stop".to_string();
                     break;
                 }
+                if let Some(reason) =
+                    check_gemma4_repetition_cutoff(&generated_tokens, repetition_cutoff)
+                {
+                    finish_reason = reason.to_string();
+                    break;
+                }
                 if let Some(next_token) = next_y {
                     current_y = next_token;
                 } else {
@@ -1828,6 +1850,12 @@ impl Gemma4Inner {
 
                 if is_eos_token(token_id, &eos_ids, eos_token_id) {
                     finish_reason = "stop".to_string();
+                    break;
+                }
+                if let Some(reason) =
+                    check_gemma4_repetition_cutoff(&generated_tokens, repetition_cutoff)
+                {
+                    finish_reason = reason.to_string();
                     break;
                 }
                 if let Some(next_token) = next_y {
@@ -1960,6 +1988,61 @@ impl Gemma4Inner {
     // * Zero-delta prompts (every prompt token cached) are rejected.
     // =================================================================
 
+    fn suppress_large_sliding_prefix_reuse_if_needed(
+        &mut self,
+        trace_label: &str,
+        tokens: &[u32],
+        total_budget: u32,
+        seq_id: u32,
+        cached_prefix_len: u32,
+        trace_enabled: bool,
+    ) -> Result<u32> {
+        let max_sliding_restore_tokens = self.config.sliding_window.max(0) as u32;
+        if cached_prefix_len <= max_sliding_restore_tokens {
+            return Ok(cached_prefix_len);
+        }
+
+        // Global K/V can be reused from the paged pool, but Gemma4 sliding
+        // layers still need flat sliding caches reconstructed before prefill.
+        // The current reconstruction path replays the cached prefix through
+        // every sliding layer. For large hits, recomputing the whole prompt is
+        // cheaper and has a much lower transient graph/memory peak.
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 {}_prefix_reuse_suppressed reason=large_sliding_restore cached_prefix_tokens={} limit={}",
+                trace_label, cached_prefix_len, max_sliding_restore_tokens
+            ));
+        }
+        let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
+            Error::from_reason(format!(
+                "{}: paged_adapter is None while suppressing large sliding restore",
+                trace_label
+            ))
+        })?;
+        let _ = adapter.release_request();
+        adapter
+            .reset_for_new_request(seq_id)
+            .map_err(Error::from_reason)?;
+        let prefix = adapter
+            .find_cached_prefix(tokens, &[], 0, true)
+            .map_err(Error::from_reason)?;
+        let allocated = adapter
+            .allocate_suffix_blocks(total_budget)
+            .map_err(Error::from_reason)?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 {}_adapter_reset_done reason=large_sliding_restore_suppressed cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={}",
+                trace_label,
+                prefix.cached_token_count,
+                prefix.blocks.len(),
+                allocated,
+                adapter.current_token_count(),
+                adapter.num_allocated_blocks()
+            ));
+        }
+        Ok(0)
+    }
+
     /// Block-paged variant of [`Self::chat_sync_core`].
     ///
     /// Reached when `paged_adapter.is_some()` AND the prompt has no
@@ -1981,9 +2064,11 @@ impl Gemma4Inner {
         }
 
         let reuse_cache = config.reuse_cache.unwrap_or(true);
+        let repetition_cutoff = repetition_cutoff_from_config(&config);
         let prompt_token_count = tokens.len();
         let eos_ids = self.config.eos_token_ids.clone();
         let generation_start = std::time::Instant::now();
+        let trace_enabled = inference_trace_enabled();
 
         // === Adapter lifecycle: warm continuation OR cold start. ===
         // See PagedKVCacheAdapter::finalize_turn_keep_live for why warm-
@@ -1992,7 +2077,7 @@ impl Gemma4Inner {
         let seq_id: u32 = 0;
         // Lazy decode allocation: pass the prompt length only.
         let total_budget = tokens.len() as u32;
-        let cached_prefix_len = {
+        let mut cached_prefix_len = {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason(
                     "chat_sync_core_paged: paged_adapter is None — caller must check \
@@ -2039,6 +2124,14 @@ impl Gemma4Inner {
                 cached
             }
         };
+        cached_prefix_len = self.suppress_large_sliding_prefix_reuse_if_needed(
+            "sync_paged",
+            &tokens,
+            total_budget,
+            seq_id,
+            cached_prefix_len,
+            trace_enabled,
+        )?;
 
         // Reset sliding-layer flat caches for this turn — paged path
         // does not carry sliding prefix state across turns.
@@ -2071,6 +2164,7 @@ impl Gemma4Inner {
             max_new_tokens,
             eos_token_id,
             &eos_ids,
+            repetition_cutoff,
         );
 
         let (generated_tokens, finish_reason, first_token_instant) = match forward_result {
@@ -2169,6 +2263,7 @@ impl Gemma4Inner {
         max_new_tokens: i32,
         eos_token_id: u32,
         eos_ids: &[i32],
+        repetition_cutoff: Gemma4RepetitionCutoff,
     ) -> Result<(Vec<u32>, String, Option<std::time::Instant>)> {
         let suffix = &tokens[(cached_prefix_len as usize)..];
 
@@ -2215,6 +2310,12 @@ impl Gemma4Inner {
                 finish_reason = String::from("stop");
                 break;
             }
+            if let Some(reason) =
+                check_gemma4_repetition_cutoff(&generated_tokens, repetition_cutoff)
+            {
+                finish_reason = reason.to_string();
+                break;
+            }
             if step + 1 >= max_new_tokens {
                 break;
             }
@@ -2254,24 +2355,57 @@ impl Gemma4Inner {
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let prompt_token_count = tokens.len();
         let eos_ids = self.config.eos_token_ids.clone();
+        let repetition_cutoff = repetition_cutoff_from_config(&config);
         let generation_start = std::time::Instant::now();
+        let trace_enabled = inference_trace_enabled();
+        let trace_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 stream_paged_start prompt_tokens={} reuse_cache={} max_new_tokens={}",
+                prompt_token_count, reuse_cache, max_new_tokens
+            ));
+        }
 
         // Adapter lifecycle: warm continuation OR cold start (mirrors
         // chat_sync_core_paged).
         let seq_id: u32 = 0;
         // Lazy decode allocation: pass the prompt length only.
         let total_budget = tokens.len() as u32;
-        let cached_prefix_len = {
+        let mut cached_prefix_len = {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason("chat_stream_sync_core_paged: paged_adapter is None")
             })?;
+            let adapter_live = adapter.is_live_for_continue();
+            let adapter_request_tokens = adapter.request_tokens().len();
+            let adapter_common_prefix = tokens
+                .iter()
+                .zip(adapter.request_tokens().iter())
+                .take_while(|(a, b)| a == b)
+                .count();
             let can_continue = reuse_cache
-                && adapter.is_live_for_continue()
-                && tokens.starts_with(adapter.request_tokens());
+                && adapter_live
+                && adapter_common_prefix == adapter_request_tokens
+                && adapter_request_tokens <= tokens.len();
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 stream_paged_adapter live={} request_tokens={} common_prefix={} can_continue={} total_budget={}",
+                    adapter_live,
+                    adapter_request_tokens,
+                    adapter_common_prefix,
+                    can_continue,
+                    total_budget
+                ));
+            }
             if can_continue {
                 match adapter.continue_turn(&tokens, total_budget) {
                     Ok((prior, _)) => prior,
                     Err(_) => {
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] gemma4 stream_paged_adapter_continue_failed release_reset_start prior_tokens={}",
+                                adapter_request_tokens
+                            ));
+                        }
                         let _ = adapter.release_request();
                         adapter
                             .reset_for_new_request(seq_id)
@@ -2280,13 +2414,29 @@ impl Gemma4Inner {
                             .find_cached_prefix(&tokens, &[], 0, false)
                             .map_err(Error::from_reason)?;
                         let cached = prefix.cached_token_count;
-                        adapter
+                        let allocated = adapter
                             .allocate_suffix_blocks(total_budget)
                             .map_err(Error::from_reason)?;
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] gemma4 stream_paged_adapter_reset_done reason=continue_failed cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={}",
+                                cached,
+                                prefix.blocks.len(),
+                                allocated,
+                                adapter.current_token_count(),
+                                adapter.num_allocated_blocks()
+                            ));
+                        }
                         cached
                     }
                 }
             } else {
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 stream_paged_adapter_reset_start reason=not_continuation live={} prior_tokens={} common_prefix={}",
+                        adapter_live, adapter_request_tokens, adapter_common_prefix
+                    ));
+                }
                 if adapter.block_table().is_some() {
                     let _ = adapter.release_request();
                 }
@@ -2297,12 +2447,30 @@ impl Gemma4Inner {
                     .find_cached_prefix(&tokens, &[], 0, false)
                     .map_err(Error::from_reason)?;
                 let cached = prefix.cached_token_count;
-                adapter
+                let allocated = adapter
                     .allocate_suffix_blocks(total_budget)
                     .map_err(Error::from_reason)?;
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 stream_paged_adapter_reset_done reason=not_continuation cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={}",
+                        cached,
+                        prefix.blocks.len(),
+                        allocated,
+                        adapter.current_token_count(),
+                        adapter.num_allocated_blocks()
+                    ));
+                }
                 cached
             }
         };
+        cached_prefix_len = self.suppress_large_sliding_prefix_reuse_if_needed(
+            "stream_paged",
+            &tokens,
+            total_budget,
+            seq_id,
+            cached_prefix_len,
+            trace_enabled,
+        )?;
 
         // Reset sliding flat caches.
         self.reset_caches_sync()?;
@@ -2324,6 +2492,12 @@ impl Gemma4Inner {
                 "Gemma4 paged streaming: zero-delta prompt (every token cached) is not yet supported",
             ));
         }
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 stream_paged_prefill_dispatch cached_prefix_tokens={} suffix_tokens={} total_prompt_tokens={}",
+                cached_prefix_len, suffix_len, total_prompt_tokens
+            ));
+        }
 
         let stream_result = self.chat_stream_sync_core_paged_inner(
             &tokens,
@@ -2335,10 +2509,19 @@ impl Gemma4Inner {
             tokenizer.clone(),
             cb,
             cancelled,
+            repetition_cutoff,
         );
 
         let (generated_tokens, finish_reason, first_token_instant) = match stream_result {
             Ok(t) => {
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 stream_paged_native_done finish_reason={} generated_tokens={} elapsed_ms={:.1}",
+                        t.1,
+                        t.0.len(),
+                        trace_start.map(elapsed_ms).unwrap_or(0.0)
+                    ));
+                }
                 if let Some(adapter) = self.paged_adapter.as_mut() {
                     if reuse_cache {
                         let _ = adapter.finalize_turn_keep_live(&[], 0);
@@ -2350,6 +2533,13 @@ impl Gemma4Inner {
                 t
             }
             Err(e) => {
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 stream_paged_error elapsed_ms={:.1} error={}",
+                        trace_start.map(elapsed_ms).unwrap_or(0.0),
+                        e
+                    ));
+                }
                 if let Some(adapter) = self.paged_adapter.as_mut() {
                     let _ = adapter.release_request();
                 }
@@ -2446,8 +2636,11 @@ impl Gemma4Inner {
         tokenizer: Arc<Qwen3Tokenizer>,
         cb: &StreamSender,
         cancelled: &Arc<AtomicBool>,
+        repetition_cutoff: Gemma4RepetitionCutoff,
     ) -> Result<(Vec<u32>, String, Option<std::time::Instant>)> {
         let suffix = &tokens[(cached_prefix_len as usize)..];
+        let trace_enabled = inference_trace_enabled();
+        let prefill_trace_start = trace_enabled.then(std::time::Instant::now);
 
         let generation_stream = Stream::new(DeviceType::Gpu);
         let _wired_ctx = crate::stream::WiredLimitContext::new(usize::MAX, vec![generation_stream]);
@@ -2465,6 +2658,14 @@ impl Gemma4Inner {
         crate::array::synchronize_and_clear_cache();
 
         let first_token_instant = Some(std::time::Instant::now());
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 stream_paged_first_token_ready cached_prefix_tokens={} suffix_tokens={} elapsed_ms={:.1}",
+                cached_prefix_len,
+                suffix.len(),
+                prefill_trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
 
         // Streaming detokenizer + parser.
         let mut decode_stream = tokenizer.inner().decode_stream(false);
@@ -2472,10 +2673,19 @@ impl Gemma4Inner {
 
         let mut generated_tokens: Vec<u32> = Vec::with_capacity(max_new_tokens.max(0) as usize);
         let mut finish_reason = String::from("length");
+        let decode_trace_start = trace_enabled.then(std::time::Instant::now);
 
         for step in 0..max_new_tokens {
             if cancelled.load(Ordering::Relaxed) {
                 finish_reason = String::from("cancelled");
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 stream_paged_decode_cancelled step={} generated_tokens={} elapsed_ms={:.1}",
+                        step,
+                        generated_tokens.len(),
+                        decode_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                    ));
+                }
                 break;
             }
             // Force `y` to evaluate before reading via `item_at_int32`
@@ -2484,6 +2694,16 @@ impl Gemma4Inner {
             y.eval();
             let token_id = y.item_at_int32(0)? as u32;
             generated_tokens.push(token_id);
+            let should_trace_step = should_trace_decode_step(step);
+            if trace_enabled && should_trace_step {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 stream_paged_decode_token step={} token_id={} generated_tokens={} elapsed_ms={:.1}",
+                    step,
+                    token_id,
+                    generated_tokens.len(),
+                    decode_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
 
             // Emit any text segments produced by this token.
             if let Some(piece) = decode_stream
@@ -2496,16 +2716,56 @@ impl Gemma4Inner {
 
             if is_eos_token(token_id, eos_ids, eos_token_id) {
                 finish_reason = String::from("stop");
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 stream_paged_decode_stop step={} token_id={} generated_tokens={} elapsed_ms={:.1}",
+                        step,
+                        token_id,
+                        generated_tokens.len(),
+                        decode_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                    ));
+                }
+                break;
+            }
+            if let Some(reason) =
+                check_gemma4_repetition_cutoff(&generated_tokens, repetition_cutoff)
+            {
+                finish_reason = reason.to_string();
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 stream_paged_decode_repetition step={} token_id={} generated_tokens={} elapsed_ms={:.1}",
+                        step,
+                        token_id,
+                        generated_tokens.len(),
+                        decode_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                    ));
+                }
                 break;
             }
             if step + 1 >= max_new_tokens {
                 break;
             }
 
+            let step_trace_start =
+                (trace_enabled && should_trace_step).then(std::time::Instant::now);
             let next_logits = {
                 let _stream_ctx = StreamContext::new(generation_stream);
                 self.run_paged_decode_step(token_id)?
             };
+            if trace_enabled && should_trace_step {
+                let context_tokens = self
+                    .paged_adapter
+                    .as_ref()
+                    .map(|adapter| adapter.current_token_count())
+                    .unwrap_or(0);
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 stream_paged_decode_step_done step={} context_tokens={} elapsed_ms={:.1} step_ms={:.1}",
+                    step,
+                    context_tokens,
+                    decode_trace_start.map(elapsed_ms).unwrap_or(0.0),
+                    step_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
             let next_logits = next_logits.squeeze(Some(&[1]))?;
             y = sample_next_token(&next_logits, sampling_config)?;
             MxArray::async_eval_arrays(&[&y]);
@@ -2517,6 +2777,14 @@ impl Gemma4Inner {
         // yet emitted.
         let residual_segments = stream_parser.flush();
         dispatch_stream_segments(residual_segments, cb);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 stream_paged_decode_done finish_reason={} generated_tokens={} elapsed_ms={:.1}",
+                finish_reason,
+                generated_tokens.len(),
+                decode_trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
 
         Ok((generated_tokens, finish_reason, first_token_instant))
     }
@@ -2567,6 +2835,16 @@ impl Gemma4Inner {
 
         let suffix_len = suffix_tokens.len() as u32;
         let layer_kinds = self.compute_layer_kinds();
+        let trace_enabled = inference_trace_enabled();
+        let trace_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 paged_prefill_start full_tokens={} cached_prefix_tokens={} suffix_tokens={}",
+                full_tokens.len(),
+                cached_prefix_len,
+                suffix_tokens.len()
+            ));
+        }
 
         // For sliding layers we need state at position cached_prefix_len.
         // Sliding layers are restored each turn via reset_caches_sync, so
@@ -2575,7 +2853,15 @@ impl Gemma4Inner {
         // tokens, then the suffix passes below.
         if cached_prefix_len > 0 {
             let prefix = &full_tokens[..(cached_prefix_len as usize)];
+            let sliding_trace_start = trace_enabled.then(std::time::Instant::now);
             self.run_sliding_only_prefill(prefix, &layer_kinds)?;
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 paged_prefill_sliding_prefix_done prefix_tokens={} elapsed_ms={:.1}",
+                    prefix.len(),
+                    sliding_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
         }
 
         crate::models::gemma4::diagnostic::set_path("paged");
@@ -2584,9 +2870,9 @@ impl Gemma4Inner {
         // Two-pass split (mirrors flat `prefill_body_gemma4 →
         // forward_inner`):
         //   Pass 1: tokens `[..suffix_len-1]` (no-op if suffix_len == 1).
-        //           Layer-loop only — its hidden_states are discarded;
-        //           we keep the per-layer K/V writes the loop made into
-        //           the paged pool / sliding caches.
+        //           Run this body in bounded chunks so long-context paged
+        //           prefill does not build a single enormous lazy graph before
+        //           the first cache materialization.
         //   Pass 2: the FINAL token (length 1). Now
         //           `cached_prefix_len_for_chunk = cached_prefix_len +
         //           suffix_len - 1`, which is > 0, so global layers
@@ -2594,36 +2880,114 @@ impl Gemma4Inner {
         //           `forward_paged` — the same path decode uses. This
         //           aligns the SDPA reduction order with the flat
         //           path's `forward_inner` dispatch.
+        let configured_chunk_size = crate::array::paged_prefill_chunk_size();
+        let mut pass2_first_position = cached_prefix_len;
         if suffix_len > 1 {
-            // --- Pass 1: all-but-last suffix tokens. ---
+            // --- Pass 1: all-but-last suffix tokens, chunked. ---
             let pass1_tokens = &suffix_tokens[..(suffix_len as usize - 1)];
-            {
-                let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
-                    Error::from_reason("run_paged_prefill_chunk: paged_adapter is None")
-                })?;
-                adapter
-                    .record_tokens(pass1_tokens)
-                    .map_err(Error::from_reason)?;
+            let body_chunk_size = if configured_chunk_size > 0 {
+                (configured_chunk_size as i64).min(GEMMA4_PREFILL_STEP_SIZE) as usize
+            } else {
+                pass1_tokens.len()
+            };
+            let total_body_chunks = pass1_tokens.len().div_ceil(body_chunk_size);
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 paged_prefill_body_chunking body_tokens={} chunk_size={} configured_chunk_size={}",
+                    pass1_tokens.len(),
+                    body_chunk_size,
+                    configured_chunk_size
+                ));
             }
-            let _hidden_pass1 = self.run_paged_prefill_layer_loop(
-                pass1_tokens,
-                /* first_logical_position */ cached_prefix_len,
-                /* cached_prefix_len_for_chunk */ cached_prefix_len,
-                &layer_kinds,
-            )?;
+            for (chunk_idx, chunk) in pass1_tokens.chunks(body_chunk_size).enumerate() {
+                let chunk_first_position = pass2_first_position;
+                let chunk_trace_start = trace_enabled.then(std::time::Instant::now);
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 paged_prefill_body_chunk_start chunk={}/{} first_position={} tokens={}",
+                        chunk_idx + 1,
+                        total_body_chunks,
+                        chunk_first_position,
+                        chunk.len()
+                    ));
+                }
+                {
+                    let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
+                        Error::from_reason("run_paged_prefill_chunk: paged_adapter is None")
+                    })?;
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 paged_prefill_record_tokens_start chunk={}/{} first_position={} tokens={} current_tokens_before={} blocks_before={}",
+                            chunk_idx + 1,
+                            total_body_chunks,
+                            chunk_first_position,
+                            chunk.len(),
+                            adapter.current_token_count(),
+                            adapter.num_allocated_blocks()
+                        ));
+                    }
+                    adapter.record_tokens(chunk).map_err(Error::from_reason)?;
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] gemma4 paged_prefill_record_tokens_done chunk={}/{} current_tokens_after={} blocks_after={}",
+                            chunk_idx + 1,
+                            total_body_chunks,
+                            adapter.current_token_count(),
+                            adapter.num_allocated_blocks()
+                        ));
+                    }
+                }
+                let layer_loop_start = trace_enabled.then(std::time::Instant::now);
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 paged_prefill_layer_loop_start chunk={}/{} first_position={} cached_prefix_for_chunk={} tokens={}",
+                        chunk_idx + 1,
+                        total_body_chunks,
+                        chunk_first_position,
+                        chunk_first_position,
+                        chunk.len()
+                    ));
+                }
+                let _hidden_pass1 = self.run_paged_prefill_layer_loop(
+                    chunk,
+                    chunk_first_position,
+                    chunk_first_position,
+                    &layer_kinds,
+                )?;
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 paged_prefill_layer_loop_done chunk={}/{} first_position={} tokens={} elapsed_ms={:.1}",
+                        chunk_idx + 1,
+                        total_body_chunks,
+                        chunk_first_position,
+                        chunk.len(),
+                        layer_loop_start.map(elapsed_ms).unwrap_or(0.0)
+                    ));
+                }
 
-            // Materialize sliding-cache writes from pass 1 before pass 2
-            // reads through them. The paged pool's `update_keys_values`
-            // calls `synchronize_mlx()` internally so global-layer K/V
-            // is already on-pool, but the sliding flat caches are still
-            // lazy graphs at this point. Mirrors the
-            // `eval_gemma4_caches(caches)` call between chunks in
-            // `prefill_body_gemma4`. We deliberately do NOT eval the
-            // pass-1 hidden_states — it is discarded.
-            if let Some(caches) = self.caches.as_ref() {
-                eval_gemma4_caches(caches);
+                // Materialize sliding-cache writes from this body chunk before
+                // the next chunk reads through them. The paged pool's
+                // `update_keys_values` calls synchronize internally for
+                // global-layer K/V; the sliding flat caches are still lazy.
+                if let Some(caches) = self.caches.as_ref() {
+                    eval_gemma4_caches(caches)?;
+                }
+                crate::array::clear_cache();
+                pass2_first_position = pass2_first_position
+                    .checked_add(chunk.len() as u32)
+                    .ok_or_else(|| {
+                        Error::from_reason("Gemma4 paged prefill token position overflow")
+                    })?;
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 paged_prefill_body_chunk_done chunk={}/{} next_position={} elapsed_ms={:.1}",
+                        chunk_idx + 1,
+                        total_body_chunks,
+                        pass2_first_position,
+                        chunk_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                    ));
+                }
             }
-            crate::array::clear_cache();
         }
 
         // --- Pass 2: the FINAL suffix token (length 1). ---
@@ -2632,18 +2996,50 @@ impl Gemma4Inner {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason("run_paged_prefill_chunk: paged_adapter is None")
             })?;
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 paged_prefill_final_record_tokens_start first_position={} tokens={} current_tokens_before={} blocks_before={}",
+                    pass2_first_position,
+                    pass2_tokens.len(),
+                    adapter.current_token_count(),
+                    adapter.num_allocated_blocks()
+                ));
+            }
             adapter
                 .record_tokens(pass2_tokens)
                 .map_err(Error::from_reason)?;
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 paged_prefill_final_record_tokens_done current_tokens_after={} blocks_after={}",
+                    adapter.current_token_count(),
+                    adapter.num_allocated_blocks()
+                ));
+            }
         }
-        let pass2_first_position = cached_prefix_len + (suffix_len - 1);
         let pass2_cached_prefix_len = pass2_first_position;
+        let pass2_layer_loop_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 paged_prefill_final_layer_loop_start first_position={} cached_prefix_for_chunk={} tokens={}",
+                pass2_first_position,
+                pass2_cached_prefix_len,
+                pass2_tokens.len()
+            ));
+        }
         let mut hidden_states = self.run_paged_prefill_layer_loop(
             pass2_tokens,
             pass2_first_position,
             pass2_cached_prefix_len,
             &layer_kinds,
         )?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 paged_prefill_final_layer_loop_done first_position={} tokens={} elapsed_ms={:.1}",
+                pass2_first_position,
+                pass2_tokens.len(),
+                pass2_layer_loop_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
 
         // Final norm + lm_head + softcap (only for the final token).
         hidden_states = self.final_norm.forward(&hidden_states)?;
@@ -2673,6 +3069,13 @@ impl Gemma4Inner {
         let last = logits
             .slice_axis(1, last_seq_len - 1, last_seq_len)?
             .squeeze(Some(&[0, 1]))?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 paged_prefill_done suffix_tokens={} elapsed_ms={:.1}",
+                suffix_tokens.len(),
+                trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
         Ok(last)
     }
 
@@ -2709,6 +3112,17 @@ impl Gemma4Inner {
                 "run_paged_prefill_layer_loop: chunk_tokens must be non-empty",
             ));
         }
+        let trace_enabled = inference_trace_enabled();
+        let trace_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 paged_prefill_layer_loop_enter first_position={} cached_prefix_for_chunk={} tokens={} layers={}",
+                first_logical_position,
+                cached_prefix_len_for_chunk,
+                chunk_len,
+                self.layers.len()
+            ));
+        }
 
         let input_ids = MxArray::from_uint32(chunk_tokens, &[1, chunk_len as i64])?;
         let mut hidden_states = self.embed_tokens.forward(&input_ids)?;
@@ -2735,29 +3149,37 @@ impl Gemma4Inner {
             None
         };
 
-        // Build sliding mask if seq_len exceeds window. Mirrors
-        // `forward_body`'s mask logic.
+        // Build sliding masks against the bounded rotating-cache attention view,
+        // not the absolute prompt offset. This mirrors mlx-lm's
+        // RotatingKVCache.make_mask behavior and avoids huge long-context masks.
         let seq_len = chunk_len as i64;
-        let sliding_mask = if seq_len > 1 && seq_len > self.config.sliding_window as i64 {
-            let sliding_offset = self
-                .caches
-                .as_ref()
-                .and_then(|caches| {
-                    caches
-                        .iter()
-                        .enumerate()
-                        .find(|(i, _)| self.config.is_sliding_layer(*i))
-                        .map(|(_, c)| c.get_offset())
-                })
-                .unwrap_or(0);
-            Some(create_sliding_mask(
+        let sliding_offset = self
+            .caches
+            .as_ref()
+            .and_then(|caches| {
+                caches
+                    .iter()
+                    .enumerate()
+                    .find(|(i, _)| self.config.is_sliding_layer(*i))
+                    .map(|(_, c)| c.get_offset())
+            })
+            .unwrap_or(0);
+        let sliding_window = self.config.sliding_window as i64;
+        let sliding_mask_offset =
+            sliding_mask_offset_for_chunk(seq_len, sliding_offset, sliding_window);
+        if trace_enabled && (sliding_offset > 0 || sliding_mask_offset.is_some()) {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 paged_prefill_sliding_mask seq_len={} cache_offset={} mask_offset={} window={} explicit_mask={}",
                 seq_len,
                 sliding_offset,
-                self.config.sliding_window as i64,
-            )?)
-        } else {
-            None
-        };
+                sliding_mask_offset.unwrap_or(0),
+                sliding_window,
+                sliding_mask_offset.is_some()
+            ));
+        }
+        let sliding_mask = sliding_mask_offset
+            .map(|offset| create_sliding_mask(seq_len, offset, sliding_window))
+            .transpose()?;
 
         let has_kv_sharing = self.config.num_kv_shared_layers.is_some_and(|n| n > 0);
         let num_layers = self.layers.len();
@@ -2768,6 +3190,13 @@ impl Gemma4Inner {
         for layer_idx in 0..num_layers {
             crate::models::gemma4::diagnostic::set_layer(layer_idx);
             let kind = layer_kinds[layer_idx];
+            let layer_trace_start = trace_enabled.then(std::time::Instant::now);
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 paged_prefill_layer_start layer={} kind={:?} first_position={} cached_prefix_for_chunk={} tokens={}",
+                    layer_idx, kind, first_logical_position, cached_prefix_len_for_chunk, chunk_len
+                ));
+            }
             let layer: &Gemma4DecoderLayer = unsafe {
                 let ptr = self.layers.as_ptr().add(layer_idx);
                 &*ptr
@@ -2850,7 +3279,7 @@ impl Gemma4Inner {
                 _ => None,
             };
 
-            hidden_states = layer.forward_paged_or_flat(
+            let next_hidden_states = layer.forward_paged_or_flat(
                 &hidden_states,
                 kind,
                 adapter,
@@ -2863,6 +3292,15 @@ impl Gemma4Inner {
                 needs_stash,
                 shared_inputs,
             )?;
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 paged_prefill_layer_done layer={} kind={:?} elapsed_ms={:.1}",
+                    layer_idx,
+                    kind,
+                    layer_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
+            hidden_states = next_hidden_states;
 
             // After a Sliding anchor's forward, capture its stash so
             // downstream SharedOnSliding layers can attend over it.
@@ -2889,6 +3327,14 @@ impl Gemma4Inner {
             crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states);
         }
 
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 paged_prefill_layer_loop_exit first_position={} tokens={} elapsed_ms={:.1}",
+                first_logical_position,
+                chunk_len,
+                trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
         Ok(hidden_states)
     }
 
@@ -3074,7 +3520,7 @@ impl Gemma4Inner {
         let mut hidden_states = self.embed_tokens.forward(&input_ids)?;
         hidden_states = hidden_states.mul_scalar((self.config.hidden_size as f64).sqrt())?;
 
-        // Sliding mask if seq_len > window.
+        // Sliding mask if this prefix exceeds the rotating window.
         let seq_len = prefix_tokens.len() as i64;
 
         // Compute PLE for the prefix tokens. Without this, sliding-layer
@@ -3088,15 +3534,10 @@ impl Gemma4Inner {
         } else {
             None
         };
-        let sliding_mask = if seq_len > self.config.sliding_window as i64 {
-            Some(create_sliding_mask(
-                seq_len,
-                0,
-                self.config.sliding_window as i64,
-            )?)
-        } else {
-            None
-        };
+        let sliding_window = self.config.sliding_window as i64;
+        let sliding_mask = sliding_mask_offset_for_chunk(seq_len, 0, sliding_window)
+            .map(|offset| create_sliding_mask(seq_len, offset, sliding_window))
+            .transpose()?;
 
         let num_layers = self.layers.len();
         #[allow(clippy::needless_range_loop)]
@@ -3175,7 +3616,7 @@ impl Gemma4Inner {
 
         // Materialize sliding caches.
         if let Some(caches) = self.caches.as_ref() {
-            eval_gemma4_caches(caches);
+            eval_gemma4_caches(caches)?;
         }
         Ok(())
     }
@@ -3392,6 +3833,7 @@ impl Gemma4Inner {
 
         let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
         let sampling_config = make_sampling_config(&config, &self.config);
+        let repetition_cutoff = repetition_cutoff_from_config(&config);
         let eos_ids = self.config.eos_token_ids.clone();
 
         // Block-paged dispatch: when the adapter is configured the
@@ -3463,7 +3905,7 @@ impl Gemma4Inner {
                 &self.config,
             )?;
         }
-        eval_gemma4_caches(self.caches.as_ref().expect("caches checked is_some above"));
+        eval_gemma4_caches(self.caches.as_ref().expect("caches checked is_some above"))?;
 
         // Last token → logits
         let last_token =
@@ -3486,7 +3928,7 @@ impl Gemma4Inner {
         let logits = logits.squeeze(Some(&[1]))?;
         let y = sample_next_token(&logits, sampling_config)?;
         y.eval();
-        eval_gemma4_caches(self.caches.as_ref().expect("caches checked is_some above"));
+        eval_gemma4_caches(self.caches.as_ref().expect("caches checked is_some above"))?;
 
         let first_token_instant = std::time::Instant::now();
 
@@ -3524,6 +3966,12 @@ impl Gemma4Inner {
 
             if is_eos_token(token_id, &eos_ids, turn_end_id) {
                 finish_reason = "stop".to_string();
+                break;
+            }
+            if let Some(reason) =
+                check_gemma4_repetition_cutoff(&generated_tokens, repetition_cutoff)
+            {
+                finish_reason = reason.to_string();
                 break;
             }
             if let Some(next_token) = next_y {
@@ -3819,6 +4267,7 @@ impl Gemma4Inner {
         let turn_end_id = self.turn_end_id()?;
         let max_new_tokens = config.max_new_tokens.unwrap_or(2048);
         let sampling_config = make_sampling_config(&config, &self.config);
+        let repetition_cutoff = repetition_cutoff_from_config(&config);
         let eos_ids = self.config.eos_token_ids.clone();
 
         // Paged dispatch: same rationale as `chat_tokens_delta_sync` —
@@ -3874,7 +4323,7 @@ impl Gemma4Inner {
                 &self.config,
             )?;
         }
-        eval_gemma4_caches(self.caches.as_ref().expect("caches checked is_some above"));
+        eval_gemma4_caches(self.caches.as_ref().expect("caches checked is_some above"))?;
 
         let last_token =
             prompt.slice_axis(1, delta_tokens.len() as i64 - 1, delta_tokens.len() as i64)?;
@@ -3896,7 +4345,7 @@ impl Gemma4Inner {
         let logits = logits.squeeze(Some(&[1]))?;
         let y = sample_next_token(&logits, sampling_config)?;
         y.eval();
-        eval_gemma4_caches(self.caches.as_ref().expect("caches checked is_some above"));
+        eval_gemma4_caches(self.caches.as_ref().expect("caches checked is_some above"))?;
 
         let first_token_instant = std::time::Instant::now();
 
@@ -3958,6 +4407,12 @@ impl Gemma4Inner {
 
             if is_eos_token(token_id, &eos_ids, turn_end_id) {
                 finish_reason = "stop".to_string();
+                break;
+            }
+            if let Some(reason) =
+                check_gemma4_repetition_cutoff(&generated_tokens, repetition_cutoff)
+            {
+                finish_reason = reason.to_string();
                 break;
             }
             if let Some(next_token) = next_y {
@@ -4617,6 +5072,38 @@ fn is_eos_token(token: u32, eos_ids: &[i32], eos_token_id: u32) -> bool {
     eos_token_id == token
 }
 
+#[inline]
+fn should_trace_decode_step(step: i32) -> bool {
+    step < 8 || step % 64 == 63
+}
+
+#[derive(Clone, Copy)]
+struct Gemma4RepetitionCutoff {
+    max_consecutive_tokens: i32,
+    max_ngram_repeats: i32,
+    ngram_size: i32,
+}
+
+fn repetition_cutoff_from_config(config: &ChatConfig) -> Gemma4RepetitionCutoff {
+    Gemma4RepetitionCutoff {
+        max_consecutive_tokens: config.max_consecutive_tokens.unwrap_or(16),
+        max_ngram_repeats: config.max_ngram_repeats.unwrap_or(3),
+        ngram_size: config.ngram_size.unwrap_or(64),
+    }
+}
+
+fn check_gemma4_repetition_cutoff(
+    generated_tokens: &[u32],
+    cutoff: Gemma4RepetitionCutoff,
+) -> Option<&'static str> {
+    crate::sampling::check_repetition_cutoff(
+        generated_tokens,
+        cutoff.max_consecutive_tokens,
+        cutoff.max_ngram_repeats,
+        cutoff.ngram_size,
+    )
+}
+
 fn make_sampling_config(
     config: &ChatConfig,
     model_config: &Gemma4Config,
@@ -4765,10 +5252,10 @@ fn forward_body(
     // Matches mlx-vlm create_attention_mask behavior:
     //   global → "causal" string → fused kernel
     //   sliding → explicit mask with window constraint
-    // Sliding mask: only needed when seq_len > window_size.
-    // Matches Python create_attention_mask: when N <= window_size, returns "causal".
-    // When N > window_size, returns explicit causal+window mask.
-    let sliding_mask = if seq_len > 1 && seq_len > config.sliding_window as i64 {
+    // Sliding mask: only needed when the previous rotating-cache view plus the
+    // current chunk exceeds the window. Matches mlx-lm RotatingKVCache.make_mask.
+    let sliding_window = config.sliding_window as i64;
+    let sliding_mask_offset = if seq_len > 1 {
         let sliding_idx = (0..config.num_hidden_layers as usize)
             .find(|&i| config.is_sliding_layer(i))
             .unwrap_or(0);
@@ -4777,14 +5264,13 @@ fn forward_body(
         } else {
             0
         };
-        Some(create_sliding_mask(
-            seq_len,
-            offset,
-            config.sliding_window as i64,
-        )?)
+        sliding_mask_offset_for_chunk(seq_len, offset, sliding_window)
     } else {
         None
     };
+    let sliding_mask = sliding_mask_offset
+        .map(|offset| create_sliding_mask(seq_len, offset, sliding_window))
+        .transpose()?;
 
     // Step 5: Forward through layers with KV cache sharing
     let has_kv_sharing = config.num_kv_shared_layers.is_some_and(|n| n > 0);
@@ -5039,14 +5525,24 @@ const GEMMA4_PREFILL_STEP_SIZE: i64 = 512;
 
 /// Evaluate all Gemma4 cache arrays to materialize them on GPU.
 /// Must be called between prefill chunks to break lazy dependency chains.
-fn eval_gemma4_caches(caches: &[Gemma4LayerCache]) {
+fn eval_gemma4_caches(caches: &[Gemma4LayerCache]) -> Result<()> {
     let mut arrays: Vec<&MxArray> = Vec::new();
     for cache in caches {
         cache.collect_cache_arrays(&mut arrays);
     }
     if !arrays.is_empty() {
-        MxArray::eval_arrays(&arrays);
+        let trace_enabled = inference_trace_enabled();
+        let trace_start = trace_enabled.then(std::time::Instant::now);
+        MxArray::eval_arrays(&arrays)?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 eval_caches arrays={} elapsed_ms={:.1}",
+                arrays.len(),
+                trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
     }
+    Ok(())
 }
 
 /// Chunked prefill: process all tokens EXCEPT the last one.
@@ -5118,7 +5614,7 @@ fn prefill_body_gemma4(
             chunk_ple.as_ref(),
             config,
         )?;
-        eval_gemma4_caches(caches);
+        eval_gemma4_caches(caches)?;
         crate::array::clear_cache();
         offset += GEMMA4_PREFILL_STEP_SIZE;
     }
@@ -5161,14 +5657,24 @@ fn create_sliding_mask(seq_len: i64, offset: i32, window_size: i64) -> Result<Mx
     let in_window = distance.less(&window)?;
     let valid = causal.logical_and(&in_window)?;
 
-    let neg_inf = MxArray::full(
-        &[1],
-        Either::A(f64::NEG_INFINITY),
-        Some(crate::array::DType::Float32),
-    )?;
-    let zero_f = MxArray::full(&[1], Either::A(0.0), Some(crate::array::DType::Float32))?;
-    let mask = valid.where_(&zero_f, &neg_inf)?;
-    mask.reshape(&[1, 1, seq_len, total_len])
+    // MLX bool mask semantics are `true = keep`. Returning bool here keeps the
+    // mask dtype independent of Gemma4's BF16 residual stream; an additive
+    // float32 mask is rejected by `mx.fast.scaled_dot_product_attention` for
+    // BF16 Q/K/V because it would promote the output away from BF16.
+    valid.reshape(&[1, 1, seq_len, total_len])
+}
+
+fn sliding_mask_offset_for_chunk(seq_len: i64, cache_offset: i32, window_size: i64) -> Option<i32> {
+    if seq_len <= 1 || window_size <= 0 {
+        return None;
+    }
+
+    let prior_len = (cache_offset.max(0) as i64).min(window_size);
+    if prior_len + seq_len > window_size {
+        Some(prior_len as i32)
+    } else {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -5331,7 +5837,7 @@ fn prefill_body_gemma4_with_embeds(
             chunk_ple.as_ref(),
             config,
         )?;
-        eval_gemma4_caches(caches);
+        eval_gemma4_caches(caches)?;
         crate::array::clear_cache();
         offset += GEMMA4_PREFILL_STEP_SIZE;
     }
@@ -5362,6 +5868,33 @@ fn prefill_body_gemma4_with_embeds(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sliding_mask_is_valid_for_bf16_gqa_attention() {
+        let q = MxArray::zeros(&[1, 4, 4, 16], Some(DType::BFloat16)).unwrap();
+        let k = MxArray::zeros(&[1, 1, 6, 16], Some(DType::BFloat16)).unwrap();
+        let v = MxArray::zeros(&[1, 1, 6, 16], Some(DType::BFloat16)).unwrap();
+        let mask = create_sliding_mask(4, 2, 3).unwrap();
+
+        assert_eq!(mask.shape_at(0).unwrap(), 1);
+        assert_eq!(mask.shape_at(1).unwrap(), 1);
+        assert_eq!(mask.shape_at(2).unwrap(), 4);
+        assert_eq!(mask.shape_at(3).unwrap(), 6);
+
+        let out = crate::array::scaled_dot_product_attention(&q, &k, &v, 1.0, Some(&mask)).unwrap();
+        let values = out.to_float32().unwrap();
+        assert_eq!(values.len(), 4 * 4 * 16);
+        assert!(values.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn sliding_mask_offset_uses_rotating_window_view() {
+        assert_eq!(sliding_mask_offset_for_chunk(512, 16, 1024), None);
+        assert_eq!(sliding_mask_offset_for_chunk(512, 528, 1024), Some(528));
+        assert_eq!(sliding_mask_offset_for_chunk(512, 43_688, 1024), Some(1024));
+        assert_eq!(sliding_mask_offset_for_chunk(2048, 0, 1024), Some(0));
+        assert_eq!(sliding_mask_offset_for_chunk(1, 4096, 1024), None);
+    }
 
     #[test]
     fn test_gemma4_chat_manual_fallback_format() {

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -407,7 +407,8 @@ pub(crate) enum PrefixCacheDecision {
     Miss,
 }
 
-const GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT: usize = 16;
+const GEMMA4_SLIDING_PREFIX_CHECKPOINT_MIN_LIMIT: usize = 16;
+const GEMMA4_SLIDING_PREFIX_CHECKPOINT_MAX_DEFAULT_LIMIT: usize = 64;
 
 struct Gemma4SlidingPrefixCheckpoint {
     prefix_len: u32,
@@ -1062,7 +1063,8 @@ impl Gemma4Inner {
                 tokens: prefix_tokens,
                 snapshots,
             });
-        while self.sliding_prefix_checkpoints.len() > GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT {
+        let checkpoint_limit = gemma4_sliding_prefix_checkpoint_limit(&self.config, block_size);
+        while self.sliding_prefix_checkpoints.len() > checkpoint_limit {
             self.sliding_prefix_checkpoints.pop_front();
         }
         trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
@@ -1129,7 +1131,8 @@ impl Gemma4Inner {
                 tokens: prefix_tokens,
                 snapshots,
             });
-        while self.sliding_prefix_checkpoints.len() > GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT {
+        let checkpoint_limit = gemma4_sliding_prefix_checkpoint_limit(&self.config, block_size);
+        while self.sliding_prefix_checkpoints.len() > checkpoint_limit {
             self.sliding_prefix_checkpoints.pop_front();
         }
         trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
@@ -6707,6 +6710,50 @@ fn gemma4_large_sliding_restore_suppression_limit(cached_prefix_len: u32) -> Opt
     )
 }
 
+fn parse_gemma4_sliding_checkpoint_limit(value: &str) -> Option<usize> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    value.parse::<usize>().ok().filter(|limit| *limit > 0)
+}
+
+fn gemma4_sliding_checkpoint_limit_override() -> Option<usize> {
+    static OVERRIDE: OnceLock<Option<usize>> = OnceLock::new();
+    *OVERRIDE.get_or_init(|| {
+        std::env::var("MLX_GEMMA4_SLIDING_CHECKPOINT_LIMIT")
+            .ok()
+            .and_then(|value| parse_gemma4_sliding_checkpoint_limit(&value))
+    })
+}
+
+fn gemma4_sliding_prefix_checkpoint_limit_for_override(
+    config: &Gemma4Config,
+    block_size: u32,
+    override_limit: Option<usize>,
+) -> usize {
+    if let Some(limit) = override_limit {
+        return limit;
+    }
+    let sliding_window = config.sliding_window.max(0) as usize;
+    let block_size = block_size as usize;
+    if sliding_window == 0 || block_size == 0 {
+        return GEMMA4_SLIDING_PREFIX_CHECKPOINT_MIN_LIMIT;
+    }
+    sliding_window.div_ceil(block_size).clamp(
+        GEMMA4_SLIDING_PREFIX_CHECKPOINT_MIN_LIMIT,
+        GEMMA4_SLIDING_PREFIX_CHECKPOINT_MAX_DEFAULT_LIMIT,
+    )
+}
+
+fn gemma4_sliding_prefix_checkpoint_limit(config: &Gemma4Config, block_size: u32) -> usize {
+    gemma4_sliding_prefix_checkpoint_limit_for_override(
+        config,
+        block_size,
+        gemma4_sliding_checkpoint_limit_override(),
+    )
+}
+
 fn gemma4_paged_prefill_group_max_chunk() -> u32 {
     let configured_chunk_size = crate::array::paged_prefill_chunk_size();
     if configured_chunk_size > 0 {
@@ -8017,7 +8064,12 @@ mod tests {
             snapshots: vec![None; inner.config.num_hidden_layers as usize],
         });
 
-        for i in 0..(GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT + 3) {
+        let checkpoint_limit = super::gemma4_sliding_prefix_checkpoint_limit_for_override(
+            &inner.config,
+            block_size,
+            None,
+        );
+        for i in 0..(checkpoint_limit + 3) {
             let tokens: Vec<u32> = (0..16).map(|token| 100 + i as u32 + token).collect();
             inner
                 .sliding_prefix_checkpoints
@@ -8028,14 +8080,11 @@ mod tests {
                     tokens,
                     snapshots: vec![None; inner.config.num_hidden_layers as usize],
                 });
-            while inner.sliding_prefix_checkpoints.len() > GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT {
+            while inner.sliding_prefix_checkpoints.len() > checkpoint_limit {
                 inner.sliding_prefix_checkpoints.pop_front();
             }
         }
-        assert_eq!(
-            inner.sliding_prefix_checkpoints.len(),
-            GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT
-        );
+        assert_eq!(inner.sliding_prefix_checkpoints.len(), checkpoint_limit);
 
         let restored = inner
             .find_gemma4_sliding_prefix_checkpoint(&prompt, prompt.len() as u32, block_size, 0)
@@ -8102,7 +8151,12 @@ mod tests {
                     tokens,
                     snapshots: vec![None; inner.config.num_hidden_layers as usize],
                 });
-            while inner.sliding_prefix_checkpoints.len() > GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT {
+            let checkpoint_limit = super::gemma4_sliding_prefix_checkpoint_limit_for_override(
+                &inner.config,
+                block_size,
+                None,
+            );
+            while inner.sliding_prefix_checkpoints.len() > checkpoint_limit {
                 inner.sliding_prefix_checkpoints.pop_front();
             }
         }
@@ -8118,6 +8172,92 @@ mod tests {
         assert!(
             restored.is_some(),
             "decode checkpoints must retain the block needed after modest retokenization drift"
+        );
+    }
+
+    #[test]
+    fn test_gemma4_decode_checkpoint_retains_sliding_window_drift() {
+        let mut cfg = paged_tiny_config(Some(true));
+        cfg.sliding_window = 512;
+        let mut inner = match super::Gemma4Inner::new(cfg) {
+            Ok(i) => i,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("No Metal device found") {
+                    eprintln!("skipping (no Metal device): {msg}");
+                    return;
+                }
+                panic!("unexpected Gemma4Inner::new failure: {msg}");
+            }
+        };
+
+        let block_size = 16;
+        let checkpoint_limit = super::gemma4_sliding_prefix_checkpoint_limit_for_override(
+            &inner.config,
+            block_size,
+            None,
+        );
+        assert_eq!(
+            checkpoint_limit, 32,
+            "512-token sliding window with 16-token blocks should retain 32 decode checkpoints"
+        );
+        let target_tokens: Vec<u32> = (3000..3016).collect();
+        let target_hash = super::compute_gemma4_paged_prefix_block_hash(
+            &target_tokens,
+            target_tokens.len() as u32,
+            block_size,
+            0,
+        )
+        .expect("target hash");
+        inner
+            .sliding_prefix_checkpoints
+            .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                prefix_len: target_tokens.len() as u32,
+                block_size,
+                final_block_hash: target_hash,
+                tokens: target_tokens.clone(),
+                snapshots: vec![None; inner.config.num_hidden_layers as usize],
+            });
+
+        // The live 2026-05-09 Gemma4 trace needed a checkpoint eighteen
+        // block boundaries behind the final decode state (57072 requested
+        // after decode reached 57360). A one-window default retains that
+        // level of retokenization drift instead of forcing a full replay.
+        for i in 0..18 {
+            let token_base = 4000 + (i as u32 * block_size);
+            let tokens: Vec<u32> = (0..block_size).map(|token| token_base + token).collect();
+            let hash = super::compute_gemma4_paged_prefix_block_hash(
+                &tokens,
+                tokens.len() as u32,
+                block_size,
+                0,
+            )
+            .expect("newer hash");
+            inner
+                .sliding_prefix_checkpoints
+                .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                    prefix_len: tokens.len() as u32,
+                    block_size,
+                    final_block_hash: hash,
+                    tokens,
+                    snapshots: vec![None; inner.config.num_hidden_layers as usize],
+                });
+            while inner.sliding_prefix_checkpoints.len() > checkpoint_limit {
+                inner.sliding_prefix_checkpoints.pop_front();
+            }
+        }
+
+        let restored = inner
+            .find_gemma4_sliding_prefix_checkpoint(
+                &target_tokens,
+                target_tokens.len() as u32,
+                block_size,
+                0,
+            )
+            .expect("prefix lookup");
+        assert!(
+            restored.is_some(),
+            "decode checkpoints must retain one sliding-window worth of retokenization drift"
         );
     }
 

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -2602,7 +2602,8 @@ impl Gemma4Inner {
     // * Text-only — vision turns dispatch through the flat path.
     // * Sliding layers still use flat rotating caches; true paged sliding
     //   storage is a separate kernel/storage step.
-    // * Zero-delta prompts (every prompt token cached) are rejected.
+    // * Exact prefix hits are capped at `prompt_len - 1` so the final
+    //   prompt token is always recomputed to produce logits.
     // =================================================================
 
     fn suppress_large_sliding_prefix_reuse_if_needed(
@@ -2693,8 +2694,18 @@ impl Gemma4Inner {
                     reuse_cache
                 ));
             }
+            let max_cache_hit_tokens = total_budget.saturating_sub(1);
             let plan = adapter
-                .prepare_turn(seq_id, tokens, total_budget, reuse_cache, &[], 0, false)
+                .prepare_turn_with_max_cache_hit_tokens(
+                    seq_id,
+                    tokens,
+                    total_budget,
+                    reuse_cache,
+                    &[],
+                    0,
+                    false,
+                    max_cache_hit_tokens,
+                )
                 .map_err(Error::from_reason)?;
             if trace_enabled {
                 write_inference_trace(format_args!(

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
@@ -16,6 +16,11 @@ use crate::sampling::{SamplingConfig, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer};
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
+use crate::transformer::rotating_kv_cache::RotatingKVCacheSnapshot;
+use crate::transformer::{
+    AttentionKind, KVCacheDType, KVCacheGroup, KVCachePhysicalLayout, LayerKVCacheSpec,
+    derive_layer_kv_cache_routes, group_layer_kv_cache_specs,
+};
 
 use super::image_processor::{Gemma4ImageProcessor, ProcessedGemma4Image};
 use super::vision::{Gemma4MultimodalEmbedder, Gemma4VisionModel};
@@ -234,6 +239,8 @@ pub(crate) struct Gemma4Inner {
     /// when the config flag is unset, in which case the model falls
     /// back to the flat `Gemma4LayerCache` path.
     pub(crate) paged_adapter: Option<PagedKVCacheAdapter>,
+    sliding_prefix_checkpoints: VecDeque<Gemma4SlidingPrefixCheckpoint>,
+    sliding_last_history_checkpoint: Option<Gemma4SlidingHistoryCheckpoint>,
     pub(crate) model_id: u64,
 }
 
@@ -399,6 +406,178 @@ pub(crate) enum PrefixCacheDecision {
     Miss,
 }
 
+const GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT: usize = 4;
+
+struct Gemma4SlidingPrefixCheckpoint {
+    prefix_len: u32,
+    block_size: u32,
+    final_block_hash: u64,
+    tokens: Vec<u32>,
+    snapshots: Vec<Option<RotatingKVCacheSnapshot>>,
+}
+
+struct Gemma4SlidingHistoryCheckpoint {
+    tokens: Vec<u32>,
+    snapshots: Vec<Option<RotatingKVCacheSnapshot>>,
+}
+
+#[derive(Default)]
+struct Gemma4SlidingCheckpointStoreTrace {
+    stored: bool,
+    eval_ms: f64,
+    snapshot_ms: f64,
+    token_clone_ms: f64,
+    update_ms: f64,
+    total_ms: f64,
+}
+
+impl Gemma4SlidingCheckpointStoreTrace {
+    fn finish(mut self, start: Option<std::time::Instant>) -> Self {
+        self.total_ms = start.map(elapsed_ms).unwrap_or(0.0);
+        self
+    }
+}
+
+struct Gemma4SlidingPrefixPreparation {
+    state: &'static str,
+    already_primed: bool,
+}
+
+struct Gemma4PagedTurnPreparation {
+    cached_prefix_len: u32,
+    suffix_len: u32,
+    sliding_prefix_already_primed: bool,
+}
+
+fn compute_gemma4_paged_prefix_block_hash(
+    tokens: &[u32],
+    prefix_len: u32,
+    block_size: u32,
+    cache_salt: u64,
+) -> Option<u64> {
+    if prefix_len == 0 || block_size == 0 || !prefix_len.is_multiple_of(block_size) {
+        return None;
+    }
+
+    let prefix_len = prefix_len as usize;
+    let block_size = block_size as usize;
+    if prefix_len > tokens.len() {
+        return None;
+    }
+
+    let num_blocks = prefix_len / block_size;
+    let mut parent_hash = 0;
+    for block_idx in 0..num_blocks {
+        let start = block_idx * block_size;
+        let end = start + block_size;
+        parent_hash = if block_idx == 0 && cache_salt != 0 {
+            mlx_paged_attn::hash_tokens(&tokens[start..end], parent_hash, &[cache_salt])
+        } else {
+            mlx_paged_attn::hash_tokens(&tokens[start..end], parent_hash, &[])
+        };
+    }
+
+    Some(parent_hash)
+}
+
+fn gemma4_sliding_caches_ready_at(
+    config: &Gemma4Config,
+    caches: Option<&[Gemma4LayerCache]>,
+    offset: u32,
+) -> Result<bool> {
+    let Some(caches) = caches else {
+        return Ok(false);
+    };
+    if caches.len() != config.num_hidden_layers as usize {
+        return Ok(false);
+    }
+    for (layer_idx, cache) in caches.iter().enumerate() {
+        if !config.is_sliding_layer(layer_idx) {
+            continue;
+        }
+        if !cache.sliding_offset_matches(offset as i32)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn snapshot_gemma4_sliding_caches(
+    config: &Gemma4Config,
+    caches: &[Gemma4LayerCache],
+    expected_offset: u32,
+) -> Result<Option<Vec<Option<RotatingKVCacheSnapshot>>>> {
+    if !gemma4_sliding_caches_ready_at(config, Some(caches), expected_offset)? {
+        return Ok(None);
+    }
+
+    let mut snapshots = Vec::with_capacity(caches.len());
+    for (layer_idx, cache) in caches.iter().enumerate() {
+        if config.is_sliding_layer(layer_idx) {
+            let Some(snapshot) = cache.snapshot_sliding()? else {
+                return Ok(None);
+            };
+            snapshots.push(Some(snapshot));
+        } else {
+            snapshots.push(None);
+        }
+    }
+    Ok(Some(snapshots))
+}
+
+fn materialize_gemma4_sliding_snapshots(
+    snapshots: &mut [Option<RotatingKVCacheSnapshot>],
+) -> Result<()> {
+    for snapshot in snapshots
+        .iter_mut()
+        .filter_map(|snapshot| snapshot.as_mut())
+    {
+        snapshot.keys = snapshot.keys.copy()?;
+        snapshot.values = snapshot.values.copy()?;
+    }
+
+    let mut arrays: Vec<&MxArray> = Vec::new();
+    for snapshot in snapshots.iter().filter_map(|snapshot| snapshot.as_ref()) {
+        arrays.push(&snapshot.keys);
+        arrays.push(&snapshot.values);
+    }
+    MxArray::eval_arrays(&arrays)
+}
+
+fn restore_gemma4_sliding_caches(
+    config: &Gemma4Config,
+    snapshots: &[Option<RotatingKVCacheSnapshot>],
+    expected_offset: u32,
+) -> Result<Option<Vec<Gemma4LayerCache>>> {
+    if snapshots.len() != config.num_hidden_layers as usize {
+        return Ok(None);
+    }
+
+    let mut caches = init_caches_for_config(config);
+    for (layer_idx, cache) in caches
+        .iter_mut()
+        .enumerate()
+        .take(config.num_hidden_layers as usize)
+    {
+        if !config.is_sliding_layer(layer_idx) {
+            continue;
+        }
+        let Some(snapshot) = snapshots.get(layer_idx).and_then(|s| s.as_ref()) else {
+            return Ok(None);
+        };
+        if snapshot.offset != expected_offset as i32 {
+            return Ok(None);
+        }
+        cache.restore_sliding_snapshot(snapshot)?;
+    }
+
+    if !gemma4_sliding_caches_ready_at(config, Some(&caches), expected_offset)? {
+        return Ok(None);
+    }
+
+    Ok(Some(caches))
+}
+
 /// Test-only helper: decide what to do given the verifier's answer and
 /// the incoming prompt length. Exact-match (`cached_prefix_len ==
 /// tokens_len`) and zero-length prefix both route to
@@ -494,32 +673,57 @@ impl Gemma4Inner {
         // Block-paged KV adapter — default-on; opt out via
         // `use_block_paged_cache: false`.
         //
-        // Default-on adapter construction (2026-04-28 default flip).
-        // Text-only paged dispatch is active: every text-only chat-entry
-        // site (`chat_sync_core_paged`, `chat_stream_sync_core_paged`,
-        // `chat_tokens_delta_sync`, `chat_stream_tokens_delta_sync_inner`)
-        // routes through the paged adapter; vision turns still take the
-        // flat `Gemma4LayerCache::Sliding(RotatingKVCache)` path. Setting
-        // `use_block_paged_cache: false` in the model config is the
-        // explicit opt-out and reverts every layer to the legacy flat
-        // caches.
+        // The long-term source of truth is the model-independent
+        // LayerKVCacheSpec plan: Gemma4 declares full/sliding/shared KV
+        // requirements, common transformer code groups those specs, and model
+        // dispatch should consume opaque group metadata. Runtime still uses the
+        // existing single PagedKVCacheAdapter for full-attention groups while
+        // sliding-window groups stay on RotatingKVCache until true paged
+        // sliding eviction is wired.
         //
-        // Cache dtype: BFloat16 (Gemma4's production dtype).
-        // Per-layer head_dim: Gemma4 has variable head dims per layer
-        // type (sliding vs global). The pool covers ONLY global (full)
-        // attention layers — sliding layers continue to use the existing
-        // `Gemma4LayerCache::Sliding(RotatingKVCache)` path because their
-        // window-trimmed semantics don't map onto the paged pool. The
-        // pool's per-layer slot size therefore uses the global head_dim
-        // and global KV-head count.
+        // Cache dtype: BFloat16 (Gemma4's production dtype). KV-shared layers
+        // are aliases and do not consume physical pool slots; they resolve to
+        // their anchor's group ordinal through `compute_layer_kinds`.
         let paged_adapter = if config.use_block_paged_cache.unwrap_or(true) {
-            // Count GLOBAL layers — the paged pool only covers
-            // full_attention layers in their original layer order. A
-            // future paged-aware forward path indexes this pool by
-            // global-layer ordinal (NOT absolute decoder index).
-            let num_global_layers: u32 = (0..config.num_hidden_layers as usize)
-                .filter(|&i| config.is_global_layer(i))
-                .count() as u32;
+            let block_size = config.paged_block_size.unwrap_or(16);
+            let kv_cache_specs =
+                compute_layer_kv_cache_specs(&config, block_size, KVCacheDType::BFloat16).map_err(
+                    |e| {
+                        Error::from_reason(format!(
+                            "Gemma4 block-paged adapter: failed to build KV cache specs: {e}"
+                        ))
+                    },
+                )?;
+            let kv_cache_groups = compute_layer_kv_cache_groups(
+                &config,
+                block_size,
+                KVCacheDType::BFloat16,
+                gemma4_paged_prefill_group_max_chunk(),
+            )
+            .map_err(|e| {
+                Error::from_reason(format!(
+                    "Gemma4 block-paged adapter: failed to group KV cache specs: {e}"
+                ))
+            })?;
+            let full_groups: Vec<&KVCacheGroup> = kv_cache_groups
+                .iter()
+                .filter(|group| matches!(group.attention_kind, AttentionKind::Full))
+                .collect();
+            if full_groups.len() > 1 {
+                return Err(Error::from_reason(format!(
+                    "Gemma4 block-paged adapter currently supports one full-attention KV group, \
+                     but spec grouping produced {} groups. This model needs the grouped \
+                     HybridKVCacheManager path.",
+                    full_groups.len()
+                )));
+            }
+            let Some(full_group) = full_groups.first().copied() else {
+                return Err(napi::Error::from_reason(
+                    "Gemma4 block-paged adapter: config has no full_attention KV group; \
+                     paged KV cache requires at least one global attention layer",
+                ));
+            };
+            let num_global_layers = physical_full_attention_layer_count(&kv_cache_specs) as u32;
             if num_global_layers == 0 {
                 return Err(napi::Error::from_reason(
                     "Gemma4 block-paged adapter: config has no full_attention layers; \
@@ -527,20 +731,17 @@ impl Gemma4Inner {
                 ));
             }
 
-            let block_size = config.paged_block_size.unwrap_or(16);
             let gpu_memory_mb = config.paged_cache_memory_mb.unwrap_or(2048);
-            // Use global head_dim — sliding layers don't use the pool.
-            let head_size = config.effective_head_dim(true) as u32;
-            // Use global KV heads — sliding layers don't use the pool.
-            let num_kv_heads = config.effective_kv_heads(true) as u32;
+            let head_size = full_group.physical_layout.head_size;
+            let num_kv_heads = full_group.physical_layout.num_kv_heads;
 
             let pa_config = mlx_paged_attn::PagedAttentionConfig {
                 block_size,
                 gpu_memory_mb,
                 head_size,
                 num_kv_heads,
-                // Pool covers ONLY global attention layers — sliding
-                // layers continue to use Gemma4LayerCache::Sliding.
+                // Pool covers only physical full-attention layers. KV-shared
+                // aliases reuse their anchor's slot and do not allocate.
                 num_layers: num_global_layers,
                 use_fp8_cache: Some(false),
                 max_seq_len: Some(config.max_position_embeddings as u32),
@@ -576,9 +777,12 @@ impl Gemma4Inner {
                 })?;
 
             tracing::info!(
-                "Gemma4 block-paged adapter enabled (construction-only): num_blocks={num_blocks}, \
-                 block_size={block_size}, gpu_memory_mb={gpu_memory_mb}, num_global_layers={num_global_layers}, \
-                 cache_dtype=BFloat16"
+                "Gemma4 block-paged adapter enabled: num_blocks={num_blocks}, \
+                 block_size={block_size}, gpu_memory_mb={gpu_memory_mb}, \
+                 physical_full_layers={num_global_layers}, kv_groups={}, \
+                 full_group_max_admission_blocks={}, cache_dtype=BFloat16",
+                kv_cache_groups.len(),
+                full_group.max_admission_blocks
             );
             Some(adapter)
         } else {
@@ -601,6 +805,8 @@ impl Gemma4Inner {
             cached_token_history: Vec::new(),
             cached_image_key: None,
             paged_adapter,
+            sliding_prefix_checkpoints: VecDeque::new(),
+            sliding_last_history_checkpoint: None,
             model_id,
         })
     }
@@ -635,8 +841,12 @@ impl Gemma4Inner {
     /// See [`compute_layer_kinds`] (free helper) for full semantics.
     /// This wrapper is the on-`Gemma4Inner` entry point used by the
     /// chat-session forward dispatch.
-    pub(crate) fn compute_layer_kinds(&self) -> Vec<Gemma4LayerKind> {
-        compute_layer_kinds(&self.config)
+    pub(crate) fn compute_layer_kinds(&self) -> Result<Vec<Gemma4LayerKind>> {
+        compute_layer_kinds_from_kv_cache_specs(&self.config).map_err(|e| {
+            Error::from_reason(format!(
+                "Gemma4 compute_layer_kinds: failed to derive KV routes: {e}"
+            ))
+        })
     }
 
     /// Drop the live KV caches and clear reuse-tracking state.
@@ -663,6 +873,412 @@ impl Gemma4Inner {
     fn clear_reuse_state(&mut self) {
         self.cached_token_history.clear();
         self.cached_image_key = None;
+        self.sliding_prefix_checkpoints.clear();
+        self.sliding_last_history_checkpoint = None;
+    }
+
+    fn find_gemma4_sliding_history_checkpoint(
+        &self,
+        tokens: &[u32],
+        prefix_len: u32,
+    ) -> Result<Option<Vec<Gemma4LayerCache>>> {
+        let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
+            return Ok(None);
+        };
+        let Some(checkpoint) = self.sliding_last_history_checkpoint.as_ref() else {
+            return Ok(None);
+        };
+        if checkpoint.tokens.as_slice() != prefix_tokens {
+            return Ok(None);
+        }
+        restore_gemma4_sliding_caches(&self.config, &checkpoint.snapshots, prefix_len)
+    }
+
+    fn remember_gemma4_sliding_history_checkpoint(
+        &mut self,
+        history_tokens: &[u32],
+    ) -> Result<Gemma4SlidingCheckpointStoreTrace> {
+        let trace_enabled = inference_trace_enabled();
+        let total_start = trace_enabled.then(std::time::Instant::now);
+        let mut trace = Gemma4SlidingCheckpointStoreTrace::default();
+        if history_tokens.is_empty() {
+            self.sliding_last_history_checkpoint = None;
+            return Ok(trace.finish(total_start));
+        }
+
+        let expected_offset = history_tokens.len() as u32;
+        if !gemma4_sliding_caches_ready_at(&self.config, self.caches.as_deref(), expected_offset)? {
+            self.sliding_last_history_checkpoint = None;
+            return Ok(trace.finish(total_start));
+        }
+
+        let eval_start = trace_enabled.then(std::time::Instant::now);
+        eval_gemma4_caches(
+            self.caches
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Gemma4 sliding checkpoint caches missing"))?,
+        )?;
+        trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let snapshot_start = trace_enabled.then(std::time::Instant::now);
+        let Some(snapshots) = snapshot_gemma4_sliding_caches(
+            &self.config,
+            self.caches
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Gemma4 sliding checkpoint caches missing"))?,
+            expected_offset,
+        )?
+        else {
+            self.sliding_last_history_checkpoint = None;
+            trace.snapshot_ms = snapshot_start.map(elapsed_ms).unwrap_or(0.0);
+            return Ok(trace.finish(total_start));
+        };
+        trace.snapshot_ms = snapshot_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let token_clone_start = trace_enabled.then(std::time::Instant::now);
+        let tokens = history_tokens.to_vec();
+        trace.token_clone_ms = token_clone_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let update_start = trace_enabled.then(std::time::Instant::now);
+        self.sliding_last_history_checkpoint =
+            Some(Gemma4SlidingHistoryCheckpoint { tokens, snapshots });
+        trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
+        trace.stored = true;
+        Ok(trace.finish(total_start))
+    }
+
+    fn find_gemma4_sliding_prefix_checkpoint(
+        &self,
+        tokens: &[u32],
+        prefix_len: u32,
+        block_size: u32,
+        cache_salt: u64,
+    ) -> Result<Option<Vec<Gemma4LayerCache>>> {
+        let Some(final_block_hash) =
+            compute_gemma4_paged_prefix_block_hash(tokens, prefix_len, block_size, cache_salt)
+        else {
+            return Ok(None);
+        };
+        let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
+            return Ok(None);
+        };
+
+        for checkpoint in self.sliding_prefix_checkpoints.iter().rev() {
+            if checkpoint.prefix_len != prefix_len
+                || checkpoint.block_size != block_size
+                || checkpoint.final_block_hash != final_block_hash
+                || checkpoint.tokens.as_slice() != prefix_tokens
+            {
+                continue;
+            }
+            let Some(caches) =
+                restore_gemma4_sliding_caches(&self.config, &checkpoint.snapshots, prefix_len)?
+            else {
+                continue;
+            };
+            return Ok(Some(caches));
+        }
+
+        Ok(None)
+    }
+
+    fn remember_gemma4_sliding_prefix_checkpoint(
+        &mut self,
+        tokens: &[u32],
+        prefix_len: u32,
+        block_size: u32,
+        cache_salt: u64,
+    ) -> Result<Gemma4SlidingCheckpointStoreTrace> {
+        let trace_enabled = inference_trace_enabled();
+        let total_start = trace_enabled.then(std::time::Instant::now);
+        let mut trace = Gemma4SlidingCheckpointStoreTrace::default();
+        let Some(final_block_hash) =
+            compute_gemma4_paged_prefix_block_hash(tokens, prefix_len, block_size, cache_salt)
+        else {
+            return Ok(trace.finish(total_start));
+        };
+        let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
+            return Ok(trace.finish(total_start));
+        };
+        if !gemma4_sliding_caches_ready_at(&self.config, self.caches.as_deref(), prefix_len)? {
+            return Ok(trace.finish(total_start));
+        }
+
+        let eval_start = trace_enabled.then(std::time::Instant::now);
+        eval_gemma4_caches(
+            self.caches
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Gemma4 sliding prefix caches missing"))?,
+        )?;
+        trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let snapshot_start = trace_enabled.then(std::time::Instant::now);
+        let Some(snapshots) = snapshot_gemma4_sliding_caches(
+            &self.config,
+            self.caches
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Gemma4 sliding prefix caches missing"))?,
+            prefix_len,
+        )?
+        else {
+            trace.snapshot_ms = snapshot_start.map(elapsed_ms).unwrap_or(0.0);
+            return Ok(trace.finish(total_start));
+        };
+        trace.snapshot_ms = snapshot_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let token_clone_start = trace_enabled.then(std::time::Instant::now);
+        let prefix_tokens = prefix_tokens.to_vec();
+        trace.token_clone_ms = token_clone_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let update_start = trace_enabled.then(std::time::Instant::now);
+        self.sliding_prefix_checkpoints.retain(|checkpoint| {
+            !(checkpoint.prefix_len == prefix_len
+                && checkpoint.block_size == block_size
+                && checkpoint.final_block_hash == final_block_hash
+                && checkpoint.tokens == prefix_tokens)
+        });
+        self.sliding_prefix_checkpoints
+            .push_back(Gemma4SlidingPrefixCheckpoint {
+                prefix_len,
+                block_size,
+                final_block_hash,
+                tokens: prefix_tokens,
+                snapshots,
+            });
+        while self.sliding_prefix_checkpoints.len() > GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT {
+            self.sliding_prefix_checkpoints.pop_front();
+        }
+        trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
+        trace.stored = true;
+        Ok(trace.finish(total_start))
+    }
+
+    fn remember_gemma4_sliding_materialized_prefix_checkpoint(
+        &mut self,
+        tokens: &[u32],
+        prefix_len: u32,
+        block_size: u32,
+        cache_salt: u64,
+    ) -> Result<Gemma4SlidingCheckpointStoreTrace> {
+        let trace_enabled = inference_trace_enabled();
+        let total_start = trace_enabled.then(std::time::Instant::now);
+        let mut trace = Gemma4SlidingCheckpointStoreTrace::default();
+        let Some(final_block_hash) =
+            compute_gemma4_paged_prefix_block_hash(tokens, prefix_len, block_size, cache_salt)
+        else {
+            return Ok(trace.finish(total_start));
+        };
+        let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
+            return Ok(trace.finish(total_start));
+        };
+        if !gemma4_sliding_caches_ready_at(&self.config, self.caches.as_deref(), prefix_len)? {
+            return Ok(trace.finish(total_start));
+        }
+
+        let snapshot_start = trace_enabled.then(std::time::Instant::now);
+        let Some(mut snapshots) = snapshot_gemma4_sliding_caches(
+            &self.config,
+            self.caches
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Gemma4 sliding prefix caches missing"))?,
+            prefix_len,
+        )?
+        else {
+            trace.snapshot_ms = snapshot_start.map(elapsed_ms).unwrap_or(0.0);
+            return Ok(trace.finish(total_start));
+        };
+        trace.snapshot_ms = snapshot_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let eval_start = trace_enabled.then(std::time::Instant::now);
+        materialize_gemma4_sliding_snapshots(&mut snapshots)?;
+        trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let token_clone_start = trace_enabled.then(std::time::Instant::now);
+        let prefix_tokens = prefix_tokens.to_vec();
+        trace.token_clone_ms = token_clone_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let update_start = trace_enabled.then(std::time::Instant::now);
+        self.sliding_prefix_checkpoints.retain(|checkpoint| {
+            !(checkpoint.prefix_len == prefix_len
+                && checkpoint.block_size == block_size
+                && checkpoint.final_block_hash == final_block_hash
+                && checkpoint.tokens == prefix_tokens)
+        });
+        self.sliding_prefix_checkpoints
+            .push_back(Gemma4SlidingPrefixCheckpoint {
+                prefix_len,
+                block_size,
+                final_block_hash,
+                tokens: prefix_tokens,
+                snapshots,
+            });
+        while self.sliding_prefix_checkpoints.len() > GEMMA4_SLIDING_PREFIX_CHECKPOINT_LIMIT {
+            self.sliding_prefix_checkpoints.pop_front();
+        }
+        trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
+        trace.stored = true;
+        Ok(trace.finish(total_start))
+    }
+
+    fn maybe_remember_gemma4_sliding_decode_boundary_checkpoint(
+        &mut self,
+        trace_label: &str,
+        trace_enabled: bool,
+    ) -> Result<()> {
+        let Some(adapter) = self.paged_adapter.as_ref() else {
+            return Ok(());
+        };
+        let block_size = adapter.block_size();
+        let prefix_len = adapter.current_token_count();
+        if prefix_len == 0 || block_size == 0 || !prefix_len.is_multiple_of(block_size) {
+            return Ok(());
+        }
+        let request_tokens = adapter.request_tokens().to_vec();
+
+        let store_trace = self.remember_gemma4_sliding_materialized_prefix_checkpoint(
+            &request_tokens,
+            prefix_len,
+            block_size,
+            0,
+        )?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 {trace_label}_sliding_block_checkpoint boundary_tokens={} block_size={} stored={} materialize_ms={:.1} snapshot_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
+                prefix_len,
+                block_size,
+                store_trace.stored,
+                store_trace.eval_ms,
+                store_trace.snapshot_ms,
+                store_trace.token_clone_ms,
+                store_trace.update_ms,
+                store_trace.total_ms
+            ));
+        }
+        Ok(())
+    }
+
+    fn prepare_gemma4_sliding_prefix_state(
+        &mut self,
+        tokens: &[u32],
+        cached_prefix_len: u32,
+        continued_live_prefix: bool,
+    ) -> Result<Gemma4SlidingPrefixPreparation> {
+        let trace_enabled = inference_trace_enabled();
+        let prepare_start = trace_enabled.then(std::time::Instant::now);
+
+        if cached_prefix_len == 0 {
+            self.caches = Some(init_caches_for_config(&self.config));
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 sliding_prefix_prepare_done state=fresh cached_prefix_tokens=0 elapsed_ms={:.1}",
+                    prepare_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
+            return Ok(Gemma4SlidingPrefixPreparation {
+                state: "fresh",
+                already_primed: false,
+            });
+        }
+
+        if continued_live_prefix
+            && gemma4_sliding_caches_ready_at(
+                &self.config,
+                self.caches.as_deref(),
+                cached_prefix_len,
+            )?
+        {
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 sliding_prefix_prepare_done state=live cached_prefix_tokens={} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    prepare_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
+            return Ok(Gemma4SlidingPrefixPreparation {
+                state: "live",
+                already_primed: true,
+            });
+        }
+
+        let matches_live_history = self.cached_token_history.len() == cached_prefix_len as usize
+            && tokens.starts_with(&self.cached_token_history);
+        if matches_live_history
+            && gemma4_sliding_caches_ready_at(
+                &self.config,
+                self.caches.as_deref(),
+                cached_prefix_len,
+            )?
+        {
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 sliding_prefix_prepare_done state=last_history cached_prefix_tokens={} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    prepare_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
+            return Ok(Gemma4SlidingPrefixPreparation {
+                state: "last_history",
+                already_primed: true,
+            });
+        }
+
+        let history_lookup_start = trace_enabled.then(std::time::Instant::now);
+        if let Some(caches) =
+            self.find_gemma4_sliding_history_checkpoint(tokens, cached_prefix_len)?
+        {
+            self.caches = Some(caches);
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 sliding_prefix_prepare_done state=last_history_checkpoint cached_prefix_tokens={} history_lookup_ms={:.1} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    history_lookup_start.map(elapsed_ms).unwrap_or(0.0),
+                    prepare_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
+            return Ok(Gemma4SlidingPrefixPreparation {
+                state: "last_history_checkpoint",
+                already_primed: true,
+            });
+        }
+
+        let block_size = self
+            .paged_adapter
+            .as_ref()
+            .map(|adapter| adapter.block_size())
+            .unwrap_or(0);
+        let prefix_lookup_start = trace_enabled.then(std::time::Instant::now);
+        if let Some(caches) =
+            self.find_gemma4_sliding_prefix_checkpoint(tokens, cached_prefix_len, block_size, 0)?
+        {
+            self.caches = Some(caches);
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 sliding_prefix_prepare_done state=prefix_checkpoint cached_prefix_tokens={} prefix_lookup_ms={:.1} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    prefix_lookup_start.map(elapsed_ms).unwrap_or(0.0),
+                    prepare_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
+            return Ok(Gemma4SlidingPrefixPreparation {
+                state: "prefix_checkpoint",
+                already_primed: true,
+            });
+        }
+
+        self.caches = Some(init_caches_for_config(&self.config));
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 sliding_prefix_prepare_done state=replay cached_prefix_tokens={} history_lookup_ms={:.1} prefix_lookup_ms={:.1} elapsed_ms={:.1}",
+                cached_prefix_len,
+                history_lookup_start.map(elapsed_ms).unwrap_or(0.0),
+                prefix_lookup_start.map(elapsed_ms).unwrap_or(0.0),
+                prepare_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
+        Ok(Gemma4SlidingPrefixPreparation {
+            state: "replay",
+            already_primed: false,
+        })
     }
 
     pub(crate) fn set_tokenizer(&mut self, tokenizer: Arc<Qwen3Tokenizer>) {
@@ -1966,16 +2582,16 @@ impl Gemma4Inner {
     // Mirrors Qwen3's `chat_sync_core_paged` and LFM2's `forward_paged_or_flat`
     // pattern — sliding layers continue to use the existing flat
     // `Gemma4LayerCache::Sliding` path while global layers route through
-    // `PagedKVCacheAdapter`. KV-shared layers are wired in a follow-up
-    // commit; for now the dispatch surface returns an error if the
-    // config has any shared layers.
+    // `PagedKVCacheAdapter`. KV-shared layers are routed through their
+    // anchor's physical KV slot/stash using routes derived from
+    // `LayerKVCacheSpec`.
     //
     // Lifecycle (mirrors Qwen3 / LFM2):
     // 1. Adapter cold-start (or warm-continue when previous turn
     //    finalize_turn_keep_live'd a strict-prefix request).
-    // 2. Conv/sliding caches RESET each turn (paged path doesn't carry
-    //    sliding state across turns at this stage — same caveat as
-    //    LFM2's conv layers).
+    // 2. Sliding caches are restored from the live turn/checkpoint when
+    //    available; otherwise the cached prefix is replayed through sliding
+    //    layers before suffix prefill.
     // 3. Prefill via `run_paged_prefill_chunk` over the suffix.
     // 4. Decode loop via `run_paged_decode_step`.
     // 5. End-of-turn (success): `finalize_turn_keep_live` so the next
@@ -1984,7 +2600,8 @@ impl Gemma4Inner {
     //
     // Caveats / scope:
     // * Text-only — vision turns dispatch through the flat path.
-    // * Sliding layers re-prefill the cached prefix every turn.
+    // * Sliding layers still use flat rotating caches; true paged sliding
+    //   storage is a separate kernel/storage step.
     // * Zero-delta prompts (every prompt token cached) are rejected.
     // =================================================================
 
@@ -1997,16 +2614,17 @@ impl Gemma4Inner {
         cached_prefix_len: u32,
         trace_enabled: bool,
     ) -> Result<u32> {
-        let max_sliding_restore_tokens = self.config.sliding_window.max(0) as u32;
+        let max_sliding_restore_tokens =
+            gemma4_max_sliding_restore_tokens(self.config.sliding_window);
         if cached_prefix_len <= max_sliding_restore_tokens {
             return Ok(cached_prefix_len);
         }
 
         // Global K/V can be reused from the paged pool, but Gemma4 sliding
         // layers still need flat sliding caches reconstructed before prefill.
-        // The current reconstruction path replays the cached prefix through
-        // every sliding layer. For large hits, recomputing the whole prompt is
-        // cheaper and has a much lower transient graph/memory peak.
+        // Keep an upper bound because the restore pass still has to replay the
+        // residual stream through the prefix, even though global attention now
+        // reads paged K/V instead of rebuilding throwaway flat K/V.
         if trace_enabled {
             write_inference_trace(format_args!(
                 "[MLX_TRACE] gemma4 {}_prefix_reuse_suppressed reason=large_sliding_restore cached_prefix_tokens={} limit={}",
@@ -2043,6 +2661,104 @@ impl Gemma4Inner {
         Ok(0)
     }
 
+    fn prepare_gemma4_paged_turn(
+        &mut self,
+        trace_label: &str,
+        tokens: &[u32],
+        reuse_cache: bool,
+        total_budget: u32,
+        seq_id: u32,
+        trace_enabled: bool,
+    ) -> Result<Gemma4PagedTurnPreparation> {
+        let plan = {
+            let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
+                Error::from_reason(format!(
+                    "{trace_label}: paged_adapter is None while preparing paged turn"
+                ))
+            })?;
+            let adapter_live = adapter.is_live_for_continue();
+            let adapter_request_tokens = adapter.request_tokens().len();
+            let adapter_common_prefix = tokens
+                .iter()
+                .zip(adapter.request_tokens().iter())
+                .take_while(|(a, b)| a == b)
+                .count();
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 {trace_label}_adapter_prepare live={} request_tokens={} common_prefix={} total_budget={} reuse_cache={}",
+                    adapter_live,
+                    adapter_request_tokens,
+                    adapter_common_prefix,
+                    total_budget,
+                    reuse_cache
+                ));
+            }
+            let plan = adapter
+                .prepare_turn(seq_id, tokens, total_budget, reuse_cache, &[], 0, false)
+                .map_err(Error::from_reason)?;
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 {trace_label}_adapter_prepare_done reason={:?} cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={} continued_live={}",
+                    plan.reason,
+                    plan.cached_prefix_len,
+                    plan.cached_blocks,
+                    plan.allocated_blocks,
+                    adapter.current_token_count(),
+                    adapter.num_allocated_blocks(),
+                    plan.continued_live_prefix
+                ));
+            }
+            plan
+        };
+
+        let mut cached_prefix_len = plan.cached_prefix_len;
+        let mut sliding_preparation = self.prepare_gemma4_sliding_prefix_state(
+            tokens,
+            cached_prefix_len,
+            plan.continued_live_prefix,
+        )?;
+        if !sliding_preparation.already_primed {
+            let prepared_prefix_len = self.suppress_large_sliding_prefix_reuse_if_needed(
+                trace_label,
+                tokens,
+                total_budget,
+                seq_id,
+                cached_prefix_len,
+                trace_enabled,
+            )?;
+            if prepared_prefix_len != cached_prefix_len {
+                cached_prefix_len = prepared_prefix_len;
+                sliding_preparation =
+                    self.prepare_gemma4_sliding_prefix_state(tokens, cached_prefix_len, false)?;
+            } else {
+                cached_prefix_len = prepared_prefix_len;
+            }
+        }
+
+        let suffix_len = total_budget.checked_sub(cached_prefix_len).ok_or_else(|| {
+            Error::from_reason(format!(
+                "{trace_label}: cached_prefix_len {cached_prefix_len} exceeds total_budget \
+                 {total_budget}"
+            ))
+        })?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 {trace_label}_sliding_prefix_state state={} cached_prefix_tokens={} suffix_tokens={} already_primed={} continued_live={}",
+                sliding_preparation.state,
+                cached_prefix_len,
+                suffix_len,
+                sliding_preparation.already_primed,
+                plan.continued_live_prefix
+            ));
+        }
+
+        Ok(Gemma4PagedTurnPreparation {
+            cached_prefix_len,
+            suffix_len,
+            sliding_prefix_already_primed: sliding_preparation.already_primed,
+        })
+    }
+
     /// Block-paged variant of [`Self::chat_sync_core`].
     ///
     /// Reached when `paged_adapter.is_some()` AND the prompt has no
@@ -2070,81 +2786,18 @@ impl Gemma4Inner {
         let generation_start = std::time::Instant::now();
         let trace_enabled = inference_trace_enabled();
 
-        // === Adapter lifecycle: warm continuation OR cold start. ===
-        // See PagedKVCacheAdapter::finalize_turn_keep_live for why warm-
-        // continue preserves the partial trailing block's K/V across
-        // turns. Mirrors Qwen3 / LFM2.
         let seq_id: u32 = 0;
-        // Lazy decode allocation: pass the prompt length only.
         let total_budget = tokens.len() as u32;
-        let mut cached_prefix_len = {
-            let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
-                Error::from_reason(
-                    "chat_sync_core_paged: paged_adapter is None — caller must check \
-                     use_block_paged_cache before dispatch",
-                )
-            })?;
-
-            let can_continue = reuse_cache
-                && adapter.is_live_for_continue()
-                && tokens.starts_with(adapter.request_tokens());
-
-            if can_continue {
-                match adapter.continue_turn(&tokens, total_budget) {
-                    Ok((prior_token_count, _newly_alloc)) => prior_token_count,
-                    Err(_drift) => {
-                        let _ = adapter.release_request();
-                        adapter
-                            .reset_for_new_request(seq_id)
-                            .map_err(Error::from_reason)?;
-                        let prefix = adapter
-                            .find_cached_prefix(&tokens, &[], 0, false)
-                            .map_err(Error::from_reason)?;
-                        let cached = prefix.cached_token_count;
-                        adapter
-                            .allocate_suffix_blocks(total_budget)
-                            .map_err(Error::from_reason)?;
-                        cached
-                    }
-                }
-            } else {
-                if adapter.block_table().is_some() {
-                    let _ = adapter.release_request();
-                }
-                adapter
-                    .reset_for_new_request(seq_id)
-                    .map_err(Error::from_reason)?;
-                let prefix = adapter
-                    .find_cached_prefix(&tokens, &[], 0, false)
-                    .map_err(Error::from_reason)?;
-                let cached = prefix.cached_token_count;
-                adapter
-                    .allocate_suffix_blocks(total_budget)
-                    .map_err(Error::from_reason)?;
-                cached
-            }
-        };
-        cached_prefix_len = self.suppress_large_sliding_prefix_reuse_if_needed(
+        let paged_turn = self.prepare_gemma4_paged_turn(
             "sync_paged",
             &tokens,
+            reuse_cache,
             total_budget,
             seq_id,
-            cached_prefix_len,
             trace_enabled,
         )?;
-
-        // Reset sliding-layer flat caches for this turn — paged path
-        // does not carry sliding prefix state across turns.
-        self.reset_caches_sync()?;
-        self.init_caches_sync()?;
-
-        let total_prompt_tokens = tokens.len() as u32;
-        let suffix_len = total_prompt_tokens
-            .checked_sub(cached_prefix_len)
-            .ok_or_else(|| {
-                Error::from_reason("chat_sync_core_paged: cached_prefix_len > total_prompt_tokens")
-            })?;
-        if suffix_len == 0 {
+        let cached_prefix_len = paged_turn.cached_prefix_len;
+        if paged_turn.suffix_len == 0 {
             // Zero-delta: every prompt token cached. Same caveat as
             // Qwen3 / LFM2 — flat path required for this corner case.
             if let Some(adapter) = self.paged_adapter.as_mut() {
@@ -2160,6 +2813,7 @@ impl Gemma4Inner {
         let forward_result = self.chat_sync_core_paged_inner(
             &tokens,
             cached_prefix_len,
+            paged_turn.sliding_prefix_already_primed,
             sampling_config,
             max_new_tokens,
             eos_token_id,
@@ -2167,11 +2821,13 @@ impl Gemma4Inner {
             repetition_cutoff,
         );
 
+        let mut sliding_checkpoint_tokens: Option<Vec<u32>> = None;
         let (generated_tokens, finish_reason, first_token_instant) = match forward_result {
             Ok(t) => {
                 if let Some(adapter) = self.paged_adapter.as_mut() {
                     if reuse_cache {
                         let _ = adapter.finalize_turn_keep_live(&[], 0);
+                        sliding_checkpoint_tokens = Some(adapter.request_tokens().to_vec());
                     } else {
                         let _ = adapter.register_full_blocks_for_reuse(&[], 0);
                         let _ = adapter.release_request();
@@ -2202,8 +2858,25 @@ impl Gemma4Inner {
             new_history.extend(tokens.iter().copied());
             new_history.extend_from_slice(history_tokens);
             self.cached_token_history = new_history;
+            if let Some(tokens_for_checkpoint) = sliding_checkpoint_tokens {
+                let store_trace =
+                    self.remember_gemma4_sliding_history_checkpoint(&tokens_for_checkpoint)?;
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 sliding_history_checkpoint stored={} tokens={} eval_ms={:.1} snapshot_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
+                        store_trace.stored,
+                        tokens_for_checkpoint.len(),
+                        store_trace.eval_ms,
+                        store_trace.snapshot_ms,
+                        store_trace.token_clone_ms,
+                        store_trace.update_ms,
+                        store_trace.total_ms
+                    ));
+                }
+            }
         } else {
             self.cached_token_history.clear();
+            self.sliding_last_history_checkpoint = None;
         }
         self.cached_image_key = None;
 
@@ -2259,6 +2932,7 @@ impl Gemma4Inner {
         &mut self,
         tokens: &[u32],
         cached_prefix_len: u32,
+        sliding_prefix_already_primed: bool,
         sampling_config: Option<SamplingConfig>,
         max_new_tokens: i32,
         eos_token_id: u32,
@@ -2266,6 +2940,7 @@ impl Gemma4Inner {
         repetition_cutoff: Gemma4RepetitionCutoff,
     ) -> Result<(Vec<u32>, String, Option<std::time::Instant>)> {
         let suffix = &tokens[(cached_prefix_len as usize)..];
+        let trace_enabled = inference_trace_enabled();
 
         // Pin model weights in GPU memory; share generation stream.
         let generation_stream = Stream::new(DeviceType::Gpu);
@@ -2275,7 +2950,12 @@ impl Gemma4Inner {
         let last_logits = {
             let _stream_ctx = StreamContext::new(generation_stream);
             crate::models::gemma4::diagnostic::set_step(-1);
-            self.run_paged_prefill_chunk(tokens, suffix, cached_prefix_len)?
+            self.run_paged_prefill_chunk(
+                tokens,
+                suffix,
+                cached_prefix_len,
+                sliding_prefix_already_primed,
+            )?
         };
 
         let mut y = sample_next_token(&last_logits, sampling_config)?;
@@ -2325,6 +3005,10 @@ impl Gemma4Inner {
                 crate::models::gemma4::diagnostic::set_step(step);
                 self.run_paged_decode_step(token_id)?
             };
+            self.maybe_remember_gemma4_sliding_decode_boundary_checkpoint(
+                "sync_paged",
+                trace_enabled,
+            )?;
             let next_logits = next_logits.squeeze(Some(&[1]))?;
             y = sample_next_token(&next_logits, sampling_config)?;
             MxArray::async_eval_arrays(&[&y]);
@@ -2366,124 +3050,18 @@ impl Gemma4Inner {
             ));
         }
 
-        // Adapter lifecycle: warm continuation OR cold start (mirrors
-        // chat_sync_core_paged).
         let seq_id: u32 = 0;
-        // Lazy decode allocation: pass the prompt length only.
         let total_budget = tokens.len() as u32;
-        let mut cached_prefix_len = {
-            let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
-                Error::from_reason("chat_stream_sync_core_paged: paged_adapter is None")
-            })?;
-            let adapter_live = adapter.is_live_for_continue();
-            let adapter_request_tokens = adapter.request_tokens().len();
-            let adapter_common_prefix = tokens
-                .iter()
-                .zip(adapter.request_tokens().iter())
-                .take_while(|(a, b)| a == b)
-                .count();
-            let can_continue = reuse_cache
-                && adapter_live
-                && adapter_common_prefix == adapter_request_tokens
-                && adapter_request_tokens <= tokens.len();
-            if trace_enabled {
-                write_inference_trace(format_args!(
-                    "[MLX_TRACE] gemma4 stream_paged_adapter live={} request_tokens={} common_prefix={} can_continue={} total_budget={}",
-                    adapter_live,
-                    adapter_request_tokens,
-                    adapter_common_prefix,
-                    can_continue,
-                    total_budget
-                ));
-            }
-            if can_continue {
-                match adapter.continue_turn(&tokens, total_budget) {
-                    Ok((prior, _)) => prior,
-                    Err(_) => {
-                        if trace_enabled {
-                            write_inference_trace(format_args!(
-                                "[MLX_TRACE] gemma4 stream_paged_adapter_continue_failed release_reset_start prior_tokens={}",
-                                adapter_request_tokens
-                            ));
-                        }
-                        let _ = adapter.release_request();
-                        adapter
-                            .reset_for_new_request(seq_id)
-                            .map_err(Error::from_reason)?;
-                        let prefix = adapter
-                            .find_cached_prefix(&tokens, &[], 0, false)
-                            .map_err(Error::from_reason)?;
-                        let cached = prefix.cached_token_count;
-                        let allocated = adapter
-                            .allocate_suffix_blocks(total_budget)
-                            .map_err(Error::from_reason)?;
-                        if trace_enabled {
-                            write_inference_trace(format_args!(
-                                "[MLX_TRACE] gemma4 stream_paged_adapter_reset_done reason=continue_failed cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={}",
-                                cached,
-                                prefix.blocks.len(),
-                                allocated,
-                                adapter.current_token_count(),
-                                adapter.num_allocated_blocks()
-                            ));
-                        }
-                        cached
-                    }
-                }
-            } else {
-                if trace_enabled {
-                    write_inference_trace(format_args!(
-                        "[MLX_TRACE] gemma4 stream_paged_adapter_reset_start reason=not_continuation live={} prior_tokens={} common_prefix={}",
-                        adapter_live, adapter_request_tokens, adapter_common_prefix
-                    ));
-                }
-                if adapter.block_table().is_some() {
-                    let _ = adapter.release_request();
-                }
-                adapter
-                    .reset_for_new_request(seq_id)
-                    .map_err(Error::from_reason)?;
-                let prefix = adapter
-                    .find_cached_prefix(&tokens, &[], 0, false)
-                    .map_err(Error::from_reason)?;
-                let cached = prefix.cached_token_count;
-                let allocated = adapter
-                    .allocate_suffix_blocks(total_budget)
-                    .map_err(Error::from_reason)?;
-                if trace_enabled {
-                    write_inference_trace(format_args!(
-                        "[MLX_TRACE] gemma4 stream_paged_adapter_reset_done reason=not_continuation cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={}",
-                        cached,
-                        prefix.blocks.len(),
-                        allocated,
-                        adapter.current_token_count(),
-                        adapter.num_allocated_blocks()
-                    ));
-                }
-                cached
-            }
-        };
-        cached_prefix_len = self.suppress_large_sliding_prefix_reuse_if_needed(
+        let paged_turn = self.prepare_gemma4_paged_turn(
             "stream_paged",
             &tokens,
+            reuse_cache,
             total_budget,
             seq_id,
-            cached_prefix_len,
             trace_enabled,
         )?;
-
-        // Reset sliding flat caches.
-        self.reset_caches_sync()?;
-        self.init_caches_sync()?;
-
-        let total_prompt_tokens = tokens.len() as u32;
-        let suffix_len = total_prompt_tokens
-            .checked_sub(cached_prefix_len)
-            .ok_or_else(|| {
-                Error::from_reason(
-                    "chat_stream_sync_core_paged: cached_prefix_len > total_prompt_tokens",
-                )
-            })?;
+        let cached_prefix_len = paged_turn.cached_prefix_len;
+        let suffix_len = paged_turn.suffix_len;
         if suffix_len == 0 {
             if let Some(adapter) = self.paged_adapter.as_mut() {
                 let _ = adapter.release_request();
@@ -2495,13 +3073,14 @@ impl Gemma4Inner {
         if trace_enabled {
             write_inference_trace(format_args!(
                 "[MLX_TRACE] gemma4 stream_paged_prefill_dispatch cached_prefix_tokens={} suffix_tokens={} total_prompt_tokens={}",
-                cached_prefix_len, suffix_len, total_prompt_tokens
+                cached_prefix_len, suffix_len, total_budget
             ));
         }
 
         let stream_result = self.chat_stream_sync_core_paged_inner(
             &tokens,
             cached_prefix_len,
+            paged_turn.sliding_prefix_already_primed,
             sampling_config,
             max_new_tokens,
             eos_token_id,
@@ -2512,6 +3091,7 @@ impl Gemma4Inner {
             repetition_cutoff,
         );
 
+        let mut sliding_checkpoint_tokens: Option<Vec<u32>> = None;
         let (generated_tokens, finish_reason, first_token_instant) = match stream_result {
             Ok(t) => {
                 if trace_enabled {
@@ -2525,6 +3105,7 @@ impl Gemma4Inner {
                 if let Some(adapter) = self.paged_adapter.as_mut() {
                     if reuse_cache {
                         let _ = adapter.finalize_turn_keep_live(&[], 0);
+                        sliding_checkpoint_tokens = Some(adapter.request_tokens().to_vec());
                     } else {
                         let _ = adapter.register_full_blocks_for_reuse(&[], 0);
                         let _ = adapter.release_request();
@@ -2559,8 +3140,25 @@ impl Gemma4Inner {
             new_history.extend(tokens.iter().copied());
             new_history.extend_from_slice(history_tokens);
             self.cached_token_history = new_history;
+            if let Some(tokens_for_checkpoint) = sliding_checkpoint_tokens {
+                let store_trace =
+                    self.remember_gemma4_sliding_history_checkpoint(&tokens_for_checkpoint)?;
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 stream_sliding_history_checkpoint stored={} tokens={} eval_ms={:.1} snapshot_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
+                        store_trace.stored,
+                        tokens_for_checkpoint.len(),
+                        store_trace.eval_ms,
+                        store_trace.snapshot_ms,
+                        store_trace.token_clone_ms,
+                        store_trace.update_ms,
+                        store_trace.total_ms
+                    ));
+                }
+            }
         } else {
             self.cached_token_history.clear();
+            self.sliding_last_history_checkpoint = None;
         }
         self.cached_image_key = None;
 
@@ -2629,6 +3227,7 @@ impl Gemma4Inner {
         &mut self,
         tokens: &[u32],
         cached_prefix_len: u32,
+        sliding_prefix_already_primed: bool,
         sampling_config: Option<SamplingConfig>,
         max_new_tokens: i32,
         eos_token_id: u32,
@@ -2647,7 +3246,12 @@ impl Gemma4Inner {
 
         let last_logits = {
             let _stream_ctx = StreamContext::new(generation_stream);
-            self.run_paged_prefill_chunk(tokens, suffix, cached_prefix_len)?
+            self.run_paged_prefill_chunk(
+                tokens,
+                suffix,
+                cached_prefix_len,
+                sliding_prefix_already_primed,
+            )?
         };
 
         let mut y = sample_next_token(&last_logits, sampling_config)?;
@@ -2766,6 +3370,10 @@ impl Gemma4Inner {
                     step_trace_start.map(elapsed_ms).unwrap_or(0.0)
                 ));
             }
+            self.maybe_remember_gemma4_sliding_decode_boundary_checkpoint(
+                "stream_paged",
+                trace_enabled,
+            )?;
             let next_logits = next_logits.squeeze(Some(&[1]))?;
             y = sample_next_token(&next_logits, sampling_config)?;
             MxArray::async_eval_arrays(&[&y]);
@@ -2826,6 +3434,7 @@ impl Gemma4Inner {
         full_tokens: &[u32],
         suffix_tokens: &[u32],
         cached_prefix_len: u32,
+        sliding_prefix_already_primed: bool,
     ) -> Result<MxArray> {
         if suffix_tokens.is_empty() {
             return Err(Error::from_reason(
@@ -2834,7 +3443,7 @@ impl Gemma4Inner {
         }
 
         let suffix_len = suffix_tokens.len() as u32;
-        let layer_kinds = self.compute_layer_kinds();
+        let layer_kinds = self.compute_layer_kinds()?;
         let trace_enabled = inference_trace_enabled();
         let trace_start = trace_enabled.then(std::time::Instant::now);
         if trace_enabled {
@@ -2851,17 +3460,39 @@ impl Gemma4Inner {
         // we need to reprefill the cached prefix through them BEFORE the
         // suffix can attend. Run a "sliding-only" pass over the prefix
         // tokens, then the suffix passes below.
-        if cached_prefix_len > 0 {
+        if cached_prefix_len > 0 && !sliding_prefix_already_primed {
             let prefix = &full_tokens[..(cached_prefix_len as usize)];
             let sliding_trace_start = trace_enabled.then(std::time::Instant::now);
             self.run_sliding_only_prefill(prefix, &layer_kinds)?;
+            let block_size = self
+                .paged_adapter
+                .as_ref()
+                .map(|adapter| adapter.block_size())
+                .unwrap_or(0);
+            let store_trace = self.remember_gemma4_sliding_prefix_checkpoint(
+                full_tokens,
+                cached_prefix_len,
+                block_size,
+                0,
+            )?;
             if trace_enabled {
                 write_inference_trace(format_args!(
-                    "[MLX_TRACE] gemma4 paged_prefill_sliding_prefix_done prefix_tokens={} elapsed_ms={:.1}",
+                    "[MLX_TRACE] gemma4 paged_prefill_sliding_prefix_done prefix_tokens={} checkpoint_stored={} store_eval_ms={:.1} store_snapshot_ms={:.1} store_token_clone_ms={:.1} store_update_ms={:.1} store_ms={:.1} elapsed_ms={:.1}",
                     prefix.len(),
+                    store_trace.stored,
+                    store_trace.eval_ms,
+                    store_trace.snapshot_ms,
+                    store_trace.token_clone_ms,
+                    store_trace.update_ms,
+                    store_trace.total_ms,
                     sliding_trace_start.map(elapsed_ms).unwrap_or(0.0)
                 ));
             }
+        } else if cached_prefix_len > 0 && trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 paged_prefill_sliding_prefix_skipped cached_prefix_tokens={} reason=already_primed",
+                cached_prefix_len
+            ));
         }
 
         crate::models::gemma4::diagnostic::set_path("paged");
@@ -2885,30 +3516,79 @@ impl Gemma4Inner {
         if suffix_len > 1 {
             // --- Pass 1: all-but-last suffix tokens, chunked. ---
             let pass1_tokens = &suffix_tokens[..(suffix_len as usize - 1)];
-            let body_chunk_size = if configured_chunk_size > 0 {
-                (configured_chunk_size as i64).min(GEMMA4_PREFILL_STEP_SIZE) as usize
-            } else {
-                pass1_tokens.len()
-            };
-            let total_body_chunks = pass1_tokens.len().div_ceil(body_chunk_size);
+            let num_query_heads = u32::try_from(self.config.num_attention_heads).map_err(|_| {
+                Error::from_reason(format!(
+                    "Gemma4 paged prefill invalid num_attention_heads={}",
+                    self.config.num_attention_heads
+                ))
+            })?;
+            let global_head_size =
+                u32::try_from(self.config.effective_head_dim(true)).map_err(|_| {
+                    Error::from_reason(format!(
+                        "Gemma4 paged prefill invalid global head_dim={}",
+                        self.config.effective_head_dim(true)
+                    ))
+                })?;
+            let paged_attention_enabled =
+                gemma4_paged_prefill_paged_attention_enabled_for_chunking();
+            let body_chunk_plan = gemma4_paged_prefill_body_chunk_plan(
+                configured_chunk_size,
+                pass1_tokens.len(),
+                pass2_first_position,
+                num_query_heads,
+                global_head_size,
+                paged_attention_enabled,
+            )?;
+            let total_body_chunks = body_chunk_plan.len();
+            let first_body_chunk_size = body_chunk_plan.first().map(|chunk| chunk.len).unwrap_or(0);
+            let min_body_chunk_size = body_chunk_plan
+                .iter()
+                .map(|chunk| chunk.len)
+                .min()
+                .unwrap_or(0);
+            let max_body_chunk_size = body_chunk_plan
+                .iter()
+                .map(|chunk| chunk.len)
+                .max()
+                .unwrap_or(0);
+            let dynamic_v2_aux_caps = body_chunk_plan
+                .iter()
+                .filter(|chunk| chunk.capped_by_v2_aux_limit)
+                .count();
             if trace_enabled {
                 write_inference_trace(format_args!(
-                    "[MLX_TRACE] gemma4 paged_prefill_body_chunking body_tokens={} chunk_size={} configured_chunk_size={}",
+                    "[MLX_TRACE] gemma4 paged_prefill_body_chunking body_tokens={} chunk_size={} configured_chunk_size={} chunks={} min_chunk_size={} max_chunk_size={} dynamic_v2_aux_caps={} paged_attention_enabled={}",
                     pass1_tokens.len(),
-                    body_chunk_size,
-                    configured_chunk_size
+                    first_body_chunk_size,
+                    configured_chunk_size,
+                    total_body_chunks,
+                    min_body_chunk_size,
+                    max_body_chunk_size,
+                    dynamic_v2_aux_caps,
+                    paged_attention_enabled
                 ));
             }
-            for (chunk_idx, chunk) in pass1_tokens.chunks(body_chunk_size).enumerate() {
-                let chunk_first_position = pass2_first_position;
+            for (chunk_idx, chunk_plan) in body_chunk_plan.iter().enumerate() {
+                let chunk_end = chunk_plan
+                    .start
+                    .checked_add(chunk_plan.len)
+                    .ok_or_else(|| Error::from_reason("Gemma4 paged prefill chunk end overflow"))?;
+                let chunk = pass1_tokens
+                    .get(chunk_plan.start..chunk_end)
+                    .ok_or_else(|| {
+                        Error::from_reason("Gemma4 paged prefill chunk plan out of range")
+                    })?;
+                let chunk_first_position = chunk_plan.first_position;
+                debug_assert_eq!(chunk_first_position, pass2_first_position);
                 let chunk_trace_start = trace_enabled.then(std::time::Instant::now);
                 if trace_enabled {
                     write_inference_trace(format_args!(
-                        "[MLX_TRACE] gemma4 paged_prefill_body_chunk_start chunk={}/{} first_position={} tokens={}",
+                        "[MLX_TRACE] gemma4 paged_prefill_body_chunk_start chunk={}/{} first_position={} tokens={} capped_by_v2_aux_limit={}",
                         chunk_idx + 1,
                         total_body_chunks,
                         chunk_first_position,
-                        chunk.len()
+                        chunk.len(),
+                        chunk_plan.capped_by_v2_aux_limit
                     ));
                 }
                 {
@@ -2954,6 +3634,11 @@ impl Gemma4Inner {
                     chunk_first_position,
                     &layer_kinds,
                 )?;
+                if let Some(adapter) = self.paged_adapter.as_mut() {
+                    adapter
+                        .eval_pending_pool_writes()
+                        .map_err(Error::from_reason)?;
+                }
                 if trace_enabled {
                     write_inference_trace(format_args!(
                         "[MLX_TRACE] gemma4 paged_prefill_layer_loop_done chunk={}/{} first_position={} tokens={} elapsed_ms={:.1}",
@@ -2965,10 +3650,9 @@ impl Gemma4Inner {
                     ));
                 }
 
-                // Materialize sliding-cache writes from this body chunk before
-                // the next chunk reads through them. The paged pool's
-                // `update_keys_values` calls synchronize internally for
-                // global-layer K/V; the sliding flat caches are still lazy.
+                // Materialize writes from this body chunk before the next
+                // chunk reads through them. Native paged writes are lazy graph
+                // nodes; sliding flat caches are lazy too.
                 if let Some(caches) = self.caches.as_ref() {
                     eval_gemma4_caches(caches)?;
                 }
@@ -3032,6 +3716,11 @@ impl Gemma4Inner {
             pass2_cached_prefix_len,
             &layer_kinds,
         )?;
+        if let Some(adapter) = self.paged_adapter.as_mut() {
+            adapter
+                .eval_pending_pool_writes()
+                .map_err(Error::from_reason)?;
+        }
         if trace_enabled {
             write_inference_trace(format_args!(
                 "[MLX_TRACE] gemma4 paged_prefill_final_layer_loop_done first_position={} tokens={} elapsed_ms={:.1}",
@@ -3324,7 +4013,7 @@ impl Gemma4Inner {
             // from the cache pool. Without this the in-flight lazy graph
             // accumulates on long contexts before the post-prefill sync fires.
             // Cadence is `MLX_PAGED_PREFILL_EVAL_INTERVAL` (default 8).
-            crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states);
+            crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states)?;
         }
 
         if trace_enabled {
@@ -3355,7 +4044,7 @@ impl Gemma4Inner {
                 .map_err(Error::from_reason)?;
         }
 
-        let layer_kinds = self.compute_layer_kinds();
+        let layer_kinds = self.compute_layer_kinds()?;
 
         let input_ids = MxArray::from_uint32(&[token_id], &[1, 1])?;
         let mut hidden_states = self.embed_tokens.forward(&input_ids)?;
@@ -3500,14 +4189,14 @@ impl Gemma4Inner {
         Ok(logits)
     }
 
-    /// Forward the cached prefix tokens through SLIDING layers ONLY,
-    /// updating their flat caches in-place. Used to bring sliding-layer
-    /// state up to the paged cache's `cached_prefix_len` boundary
-    /// before the main `run_paged_prefill_chunk` continues with the
-    /// suffix.
+    /// Replay cached prefix tokens to reconstruct the flat sliding caches.
+    /// Used to bring sliding-layer state up to the paged cache's
+    /// `cached_prefix_len` boundary before the main `run_paged_prefill_chunk`
+    /// continues with the suffix.
     ///
-    /// Global layers are skipped — their K/V already lives in the
-    /// paged pool (the prefix-cache hit promised that).
+    /// Global layers run as read-only Q projections against their existing
+    /// paged K/V. That keeps hidden states flowing into later sliding layers
+    /// without rebuilding throwaway global K/V for the cached prefix.
     fn run_sliding_only_prefill(
         &mut self,
         prefix_tokens: &[u32],
@@ -3516,46 +4205,176 @@ impl Gemma4Inner {
         if prefix_tokens.is_empty() {
             return Ok(());
         }
-        let input_ids = MxArray::from_uint32(prefix_tokens, &[1, prefix_tokens.len() as i64])?;
+        let configured_chunk_size = crate::array::paged_prefill_chunk_size();
+        let num_query_heads = u32::try_from(self.config.num_attention_heads).map_err(|_| {
+            Error::from_reason(format!(
+                "Gemma4 sliding restore invalid num_attention_heads={}",
+                self.config.num_attention_heads
+            ))
+        })?;
+        let global_head_size =
+            u32::try_from(self.config.effective_head_dim(true)).map_err(|_| {
+                Error::from_reason(format!(
+                    "Gemma4 sliding restore invalid global head_dim={}",
+                    self.config.effective_head_dim(true)
+                ))
+            })?;
+        let paged_attention_enabled = gemma4_paged_prefill_paged_attention_enabled_for_chunking();
+        let mut chunk_plan = gemma4_paged_prefill_body_chunk_plan(
+            configured_chunk_size,
+            prefix_tokens.len(),
+            0,
+            num_query_heads,
+            global_head_size,
+            paged_attention_enabled,
+        )?;
+        gemma4_coalesce_single_token_restore_chunks(&mut chunk_plan);
+
+        let trace_enabled = inference_trace_enabled();
+        let total_trace_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            let first_chunk_size = chunk_plan.first().map(|chunk| chunk.len).unwrap_or(0);
+            let min_chunk_size = chunk_plan.iter().map(|chunk| chunk.len).min().unwrap_or(0);
+            let max_chunk_size = chunk_plan.iter().map(|chunk| chunk.len).max().unwrap_or(0);
+            let aux_caps = chunk_plan
+                .iter()
+                .filter(|chunk| chunk.capped_by_v2_aux_limit)
+                .count();
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 sliding_prefix_restore_start prefix_tokens={} chunks={} chunk_size={} min_chunk_size={} max_chunk_size={} configured_chunk_size={} dynamic_v2_aux_caps={} path=paged_global_readonly",
+                prefix_tokens.len(),
+                chunk_plan.len(),
+                first_chunk_size,
+                min_chunk_size,
+                max_chunk_size,
+                configured_chunk_size,
+                aux_caps
+            ));
+        }
+
+        let total_chunks = chunk_plan.len();
+        for (chunk_idx, chunk_plan) in chunk_plan.iter().enumerate() {
+            let chunk_end = chunk_plan
+                .start
+                .checked_add(chunk_plan.len)
+                .ok_or_else(|| Error::from_reason("Gemma4 sliding restore chunk end overflow"))?;
+            let chunk = prefix_tokens
+                .get(chunk_plan.start..chunk_end)
+                .ok_or_else(|| {
+                    Error::from_reason("Gemma4 sliding restore chunk plan out of range")
+                })?;
+            let chunk_trace_start = trace_enabled.then(std::time::Instant::now);
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 sliding_prefix_restore_chunk_start chunk={}/{} first_position={} tokens={} capped_by_v2_aux_limit={}",
+                    chunk_idx + 1,
+                    total_chunks,
+                    chunk_plan.first_position,
+                    chunk.len(),
+                    chunk_plan.capped_by_v2_aux_limit
+                ));
+            }
+
+            self.run_sliding_prefix_restore_layer_loop(
+                chunk,
+                chunk_plan.first_position,
+                layer_kinds,
+            )?;
+
+            if let Some(caches) = self.caches.as_ref() {
+                eval_gemma4_caches(caches)?;
+            }
+            crate::array::clear_cache();
+
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] gemma4 sliding_prefix_restore_chunk_done chunk={}/{} next_position={} elapsed_ms={:.1}",
+                    chunk_idx + 1,
+                    total_chunks,
+                    chunk_plan.first_position + chunk.len() as u32,
+                    chunk_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
+        }
+
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] gemma4 sliding_prefix_restore_done prefix_tokens={} chunks={} elapsed_ms={:.1}",
+                prefix_tokens.len(),
+                total_chunks,
+                total_trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
+        Ok(())
+    }
+
+    fn run_sliding_prefix_restore_layer_loop(
+        &mut self,
+        chunk_tokens: &[u32],
+        first_logical_position: u32,
+        layer_kinds: &[Gemma4LayerKind],
+    ) -> Result<()> {
+        let chunk_len = chunk_tokens.len() as u32;
+        if chunk_len == 0 {
+            return Ok(());
+        }
+
+        let input_ids = MxArray::from_uint32(chunk_tokens, &[1, chunk_len as i64])?;
         let mut hidden_states = self.embed_tokens.forward(&input_ids)?;
         hidden_states = hidden_states.mul_scalar((self.config.hidden_size as f64).sqrt())?;
 
-        // Sliding mask if this prefix exceeds the rotating window.
-        let seq_len = prefix_tokens.len() as i64;
-
-        // Compute PLE for the prefix tokens. Without this, sliding-layer
-        // K/V written here will diverge from the flat path's K/V because
-        // hidden_states fed into the sliding pre-norm depends on the
-        // PLE-augmented output of the prior layer. Same load-bearing
-        // residual as in `run_paged_prefill_chunk`.
         let projected_ple_prefix: Option<MxArray> = if let Some(ref ple) = self.ple {
             let pre_layer_h = hidden_states.clone();
-            Some(compute_ple(&input_ids, &pre_layer_h, ple, seq_len)?)
+            Some(compute_ple(
+                &input_ids,
+                &pre_layer_h,
+                ple,
+                chunk_len as i64,
+            )?)
         } else {
             None
         };
+
+        let sliding_offset = self
+            .caches
+            .as_ref()
+            .and_then(|caches| {
+                caches
+                    .iter()
+                    .enumerate()
+                    .find(|(i, _)| self.config.is_sliding_layer(*i))
+                    .map(|(_, c)| c.get_offset())
+            })
+            .unwrap_or(0);
+        if sliding_offset != first_logical_position as i32 {
+            return Err(Error::from_reason(format!(
+                "Gemma4 sliding restore cache offset mismatch: expected {} got {}",
+                first_logical_position, sliding_offset
+            )));
+        }
+
+        let seq_len = chunk_len as i64;
         let sliding_window = self.config.sliding_window as i64;
-        let sliding_mask = sliding_mask_offset_for_chunk(seq_len, 0, sliding_window)
+        let sliding_mask_offset =
+            sliding_mask_offset_for_chunk(seq_len, sliding_offset, sliding_window);
+        let sliding_mask = sliding_mask_offset
             .map(|offset| create_sliding_mask(seq_len, offset, sliding_window))
             .transpose()?;
 
-        let num_layers = self.layers.len();
+        let has_kv_sharing = self.config.num_kv_shared_layers.is_some_and(|n| n > 0);
+        let total_ctx = first_logical_position
+            .checked_add(chunk_len)
+            .ok_or_else(|| Error::from_reason("Gemma4 sliding restore total_ctx overflow"))?;
+        let mut sliding_shared_kv: HashMap<u32, (MxArray, MxArray)> = HashMap::new();
+
         #[allow(clippy::needless_range_loop)]
-        for layer_idx in 0..num_layers {
+        for layer_idx in 0..self.layers.len() {
+            crate::models::gemma4::diagnostic::set_layer(layer_idx);
             let kind = layer_kinds[layer_idx];
-            // For sliding layers we forward through the flat path; for
-            // global layers we use a NO-OP forward (skip — the K/V is
-            // already in the paged pool, hidden_states discarded).
-            // The hidden_states need to flow through ALL layers because
-            // the next sliding layer sees the previous global layer's
-            // output; we run global layers via the flat `forward` with
-            // a fresh KVCache that we throw away.
             let layer: &Gemma4DecoderLayer = unsafe {
                 let ptr = self.layers.as_ptr().add(layer_idx);
                 &*ptr
             };
-            // Slice this layer's PLE input ([B, T, num_layers, ple_dim] →
-            // [B, T, ple_dim]).
             let ple_input = projected_ple_prefix.as_ref().map(|p| {
                 p.slice_axis(2, layer_idx as i64, layer_idx as i64 + 1)
                     .and_then(|s| s.squeeze(Some(&[2])))
@@ -3564,12 +4383,17 @@ impl Gemma4Inner {
                 Some(Ok(arr)) => Some(arr),
                 _ => None,
             };
+
+            let needs_stash = has_kv_sharing
+                && matches!(kind, Gemma4LayerKind::Sliding)
+                && self.config.should_store_shared_kv(layer_idx);
+
             match kind {
                 Gemma4LayerKind::Sliding => {
                     let caches = unsafe {
                         let raw = self.caches.as_mut().ok_or_else(|| {
                             Error::from_reason(
-                                "run_sliding_only_prefill: sliding cache slot missing",
+                                "run_sliding_prefix_restore_layer_loop: sliding cache missing",
                             )
                         })? as *mut Vec<Gemma4LayerCache>;
                         &mut *raw
@@ -3579,45 +4403,99 @@ impl Gemma4Inner {
                         sliding_mask.as_ref(),
                         Some(&mut caches[layer_idx]),
                         ple_input_ref,
+                        needs_stash,
+                    )?;
+                    if needs_stash && let Some((k, v)) = caches[layer_idx].take_stashed_kv() {
+                        sliding_shared_kv.insert(layer_idx as u32, (k, v));
+                    }
+                }
+                Gemma4LayerKind::GlobalPaged { paged_idx } => {
+                    let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
+                        Error::from_reason(
+                            "run_sliding_prefix_restore_layer_loop: paged_adapter missing",
+                        )
+                    })?;
+                    hidden_states = layer.forward_paged_or_flat(
+                        &hidden_states,
+                        Gemma4LayerKind::SharedOnGlobal {
+                            anchor_paged_idx: paged_idx,
+                        },
+                        adapter,
+                        first_logical_position,
+                        first_logical_position,
+                        /* is_prefill */ true,
+                        /* mask */ None,
+                        /* flat_cache */ None,
+                        ple_input_ref,
                         /* needs_stash */ false,
+                        Some(super::decoder_layer::SharedKvInputs {
+                            cache_offset: first_logical_position as i32,
+                            total_ctx,
+                            keys: None,
+                            values: None,
+                        }),
                     )?;
                 }
-                Gemma4LayerKind::GlobalPaged { .. } => {
-                    // Build a throwaway global cache so we can run the
-                    // standard `forward(...)` over the prefix and let
-                    // hidden_states propagate. The cache is discarded
-                    // afterwards — the paged pool already holds K/V.
-                    let mut throwaway = Gemma4LayerCache::new_global();
-                    hidden_states = layer.forward(
+                Gemma4LayerKind::SharedOnGlobal { .. } => {
+                    let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
+                        Error::from_reason(
+                            "run_sliding_prefix_restore_layer_loop: paged_adapter missing",
+                        )
+                    })?;
+                    hidden_states = layer.forward_paged_or_flat(
                         &hidden_states,
+                        kind,
+                        adapter,
+                        first_logical_position,
+                        first_logical_position,
+                        /* is_prefill */ true,
                         /* mask */ None,
-                        Some(&mut throwaway),
+                        /* flat_cache */ None,
                         ple_input_ref,
-                        false,
+                        /* needs_stash */ false,
+                        Some(super::decoder_layer::SharedKvInputs {
+                            cache_offset: first_logical_position as i32,
+                            total_ctx,
+                            keys: None,
+                            values: None,
+                        }),
                     )?;
                 }
-                Gemma4LayerKind::SharedOnGlobal { .. }
-                | Gemma4LayerKind::SharedOnSliding { .. } => {
-                    // Shared layers don't write to caches and don't
-                    // affect the sliding-only re-prefill state. Use a
-                    // throwaway global cache so hidden_states still
-                    // flows through the layer.
-                    let mut throwaway = Gemma4LayerCache::new_global();
-                    hidden_states = layer.forward(
+                Gemma4LayerKind::SharedOnSliding { anchor_layer_idx } => {
+                    let (k, v) = sliding_shared_kv.get(&anchor_layer_idx).ok_or_else(|| {
+                        Error::from_reason(format!(
+                            "run_sliding_prefix_restore_layer_loop: SharedOnSliding anchor {} stash missing",
+                            anchor_layer_idx
+                        ))
+                    })?;
+                    hidden_states = layer.forward_paged_or_flat(
                         &hidden_states,
+                        kind,
+                        self.paged_adapter.as_mut().ok_or_else(|| {
+                            Error::from_reason(
+                                "run_sliding_prefix_restore_layer_loop: paged_adapter missing",
+                            )
+                        })?,
+                        first_logical_position,
+                        first_logical_position,
+                        /* is_prefill */ true,
                         /* mask */ None,
-                        Some(&mut throwaway),
+                        /* flat_cache */ None,
                         ple_input_ref,
-                        false,
+                        /* needs_stash */ false,
+                        Some(super::decoder_layer::SharedKvInputs {
+                            cache_offset: first_logical_position as i32,
+                            total_ctx: 0,
+                            keys: Some(k),
+                            values: Some(v),
+                        }),
                     )?;
                 }
             }
+
+            crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states)?;
         }
 
-        // Materialize sliding caches.
-        if let Some(caches) = self.caches.as_ref() {
-            eval_gemma4_caches(caches)?;
-        }
         Ok(())
     }
 
@@ -5459,62 +6337,179 @@ fn project_per_layer_inputs(
 ///   anchor is a sliding layer; reads K/V from the anchor's flat
 ///   cache stash.
 ///
-/// `paged_idx` counts only `full_attention` layers in their original
-/// decoder order — matches the `LayerKVPool` slot count from
-/// `Gemma4Inner::new`. KV-shared layers do NOT consume a paged slot
-/// (they reuse the anchor's K/V); the shared variants carry the
-/// anchor's index so the shared forward path can resolve it.
+/// `paged_idx` counts only physical non-shared `full_attention` layers in
+/// their original decoder order — matches the `LayerKVPool` slot count from
+/// `Gemma4Inner::new`. KV-shared layers do NOT consume a paged slot (they
+/// reuse the anchor's K/V); the shared variants carry the anchor's index so
+/// the shared forward path can resolve it.
 ///
 /// Lifted to a free helper so unit tests can drive it without owning a
 /// `Gemma4Inner` (which requires loaded weights). Mirrors LFM2's
 /// `compute_layer_kinds` pattern.
+#[cfg(test)]
 pub(crate) fn compute_layer_kinds(config: &Gemma4Config) -> Vec<Gemma4LayerKind> {
+    compute_layer_kinds_from_kv_cache_specs(config)
+        .expect("Gemma4 layer kinds must derive from valid KV cache specs")
+}
+
+pub(crate) fn compute_layer_kinds_from_kv_cache_specs(
+    config: &Gemma4Config,
+) -> std::result::Result<Vec<Gemma4LayerKind>, String> {
     let n = config.num_hidden_layers as usize;
+    let block_size = config.paged_block_size.unwrap_or(16);
+    let specs = compute_layer_kv_cache_specs(config, block_size, KVCacheDType::BFloat16)?;
+    let max_model_len = u32::try_from(config.max_position_embeddings).map_err(|_| {
+        format!(
+            "Gemma4 layer kind routes: invalid max_position_embeddings {}",
+            config.max_position_embeddings
+        )
+    })?;
+    let routes = derive_layer_kv_cache_routes(
+        &specs,
+        max_model_len,
+        gemma4_paged_prefill_group_max_chunk(),
+    )
+    .map_err(|e| format!("Gemma4 layer kind route derivation failed: {e}"))?;
 
-    // Pre-compute global -> paged_idx mapping so KV-shared layers can
-    // look up their anchor's pool slot.
-    let mut global_to_paged: Vec<Option<u32>> = vec![None; n];
-    let mut paged_idx: u32 = 0;
-    for (i, slot) in global_to_paged.iter_mut().enumerate().take(n) {
-        if config.is_global_layer(i) {
-            *slot = Some(paged_idx);
-            paged_idx += 1;
+    let mut kinds = vec![None; n];
+    for route in routes {
+        if route.layer_index >= n {
+            return Err(format!(
+                "Gemma4 layer kind route derivation produced out-of-range layer {} for {n} layers",
+                route.layer_index
+            ));
         }
+        let physical_ordinal = u32::try_from(route.physical_layer_ordinal).map_err(|_| {
+            format!(
+                "Gemma4 layer kind route ordinal {} does not fit u32",
+                route.physical_layer_ordinal
+            )
+        })?;
+        let kind = match (route.shared_kv_anchor, route.attention_kind) {
+            (Some(_), AttentionKind::Full) => Gemma4LayerKind::SharedOnGlobal {
+                anchor_paged_idx: physical_ordinal,
+            },
+            (Some(anchor), AttentionKind::SlidingWindow { .. }) => {
+                let anchor_layer_idx = u32::try_from(anchor).map_err(|_| {
+                    format!("Gemma4 shared sliding anchor layer {anchor} does not fit u32")
+                })?;
+                Gemma4LayerKind::SharedOnSliding { anchor_layer_idx }
+            }
+            (None, AttentionKind::Full) => Gemma4LayerKind::GlobalPaged {
+                paged_idx: physical_ordinal,
+            },
+            (None, AttentionKind::SlidingWindow { .. }) => Gemma4LayerKind::Sliding,
+        };
+        kinds[route.layer_index] = Some(kind);
     }
 
-    let mut kinds = Vec::with_capacity(n);
-    for i in 0..n {
-        let kind = if config.is_kv_shared_layer(i) {
-            match config.kv_shared_anchor(i) {
-                Some(anchor) if config.is_global_layer(anchor) => {
-                    let anchor_paged_idx = global_to_paged[anchor].unwrap_or(0);
-                    Gemma4LayerKind::SharedOnGlobal { anchor_paged_idx }
-                }
-                Some(anchor) => Gemma4LayerKind::SharedOnSliding {
-                    anchor_layer_idx: anchor as u32,
-                },
-                None => {
-                    // Fallback for malformed configs (no anchor
-                    // resolvable). Treat as flat sliding/global based
-                    // on the layer's own type so dispatch doesn't panic.
-                    if config.is_global_layer(i) {
-                        let pidx = global_to_paged[i].unwrap_or(0);
-                        Gemma4LayerKind::GlobalPaged { paged_idx: pidx }
-                    } else {
-                        Gemma4LayerKind::Sliding
-                    }
-                }
-            }
-        } else if config.is_global_layer(i) {
-            Gemma4LayerKind::GlobalPaged {
-                paged_idx: global_to_paged[i].unwrap_or(0),
-            }
-        } else {
-            Gemma4LayerKind::Sliding
-        };
-        kinds.push(kind);
-    }
     kinds
+        .into_iter()
+        .enumerate()
+        .map(|(layer_index, kind)| {
+            kind.ok_or_else(|| {
+                format!("Gemma4 layer kind route derivation missed layer {layer_index}")
+            })
+        })
+        .collect()
+}
+
+/// Build Gemma4's model-independent KV-cache specs.
+///
+/// The specs are the long-term source of truth for the paged/sliding cache
+/// architecture: models declare attention/cache requirements, and common
+/// transformer infrastructure groups layers and owns block tables. The current
+/// Gemma4 runtime still routes through `Gemma4LayerKind`, but both helpers must
+/// agree on physical storage ownership: KV-shared layers are aliases and do not
+/// allocate separate cache slots.
+pub(crate) fn compute_layer_kv_cache_specs(
+    config: &Gemma4Config,
+    block_size: u32,
+    cache_dtype: KVCacheDType,
+) -> std::result::Result<Vec<LayerKVCacheSpec>, String> {
+    if block_size == 0 {
+        return Err("Gemma4 KV cache specs require block_size > 0".to_string());
+    }
+    if config.sliding_window <= 0 {
+        return Err(format!(
+            "Gemma4 KV cache specs require sliding_window > 0, got {}",
+            config.sliding_window
+        ));
+    }
+
+    let n = config.num_hidden_layers as usize;
+    let mut specs = Vec::with_capacity(n);
+    for layer_index in 0..n {
+        let is_global = config.is_global_layer(layer_index);
+        let head_size = u32::try_from(config.effective_head_dim(is_global)).map_err(|_| {
+            format!(
+                "Gemma4 KV cache specs: layer {layer_index} has invalid head_dim {}",
+                config.effective_head_dim(is_global)
+            )
+        })?;
+        let num_kv_heads = u32::try_from(config.effective_kv_heads(is_global)).map_err(|_| {
+            format!(
+                "Gemma4 KV cache specs: layer {layer_index} has invalid num_kv_heads {}",
+                config.effective_kv_heads(is_global)
+            )
+        })?;
+        let layout = KVCachePhysicalLayout::new(block_size, num_kv_heads, head_size, cache_dtype);
+        if !layout.is_valid() {
+            return Err(format!(
+                "Gemma4 KV cache specs: layer {layer_index} has invalid physical layout \
+                 block_size={block_size}, num_kv_heads={num_kv_heads}, head_size={head_size}"
+            ));
+        }
+
+        let attention_kind = if is_global {
+            AttentionKind::Full
+        } else {
+            AttentionKind::SlidingWindow {
+                sliding_window: config.sliding_window as u32,
+            }
+        };
+        let mut spec = LayerKVCacheSpec::new(layer_index, attention_kind, layout);
+        if config.is_kv_shared_layer(layer_index) {
+            let anchor = config.kv_shared_anchor(layer_index).ok_or_else(|| {
+                format!(
+                    "Gemma4 KV cache specs: layer {layer_index} is KV-shared but has no \
+                     resolvable anchor"
+                )
+            })?;
+            spec = spec.shared_with_anchor(anchor);
+        }
+        specs.push(spec);
+    }
+
+    crate::transformer::validate_layer_kv_cache_specs(&specs)
+        .map_err(|e| format!("Gemma4 KV cache specs failed validation: {e}"))?;
+    Ok(specs)
+}
+
+pub(crate) fn compute_layer_kv_cache_groups(
+    config: &Gemma4Config,
+    block_size: u32,
+    cache_dtype: KVCacheDType,
+    max_chunk: u32,
+) -> std::result::Result<Vec<KVCacheGroup>, String> {
+    let specs = compute_layer_kv_cache_specs(config, block_size, cache_dtype)?;
+    let max_model_len = u32::try_from(config.max_position_embeddings).map_err(|_| {
+        format!(
+            "Gemma4 KV cache groups: invalid max_position_embeddings {}",
+            config.max_position_embeddings
+        )
+    })?;
+    group_layer_kv_cache_specs(&specs, max_model_len, max_chunk)
+        .map_err(|e| format!("Gemma4 KV cache grouping failed: {e}"))
+}
+
+fn physical_full_attention_layer_count(specs: &[LayerKVCacheSpec]) -> usize {
+    specs
+        .iter()
+        .filter(|spec| {
+            spec.shared_kv_anchor.is_none() && matches!(spec.attention_kind, AttentionKind::Full)
+        })
+        .count()
 }
 
 /// Default prefill chunk size (tokens per chunk).
@@ -5522,6 +6517,192 @@ pub(crate) fn compute_layer_kinds(config: &Gemma4Config) -> Vec<Gemma4LayerKind>
 /// which can GPU-timeout with very large graphs. Using 512 keeps individual
 /// command buffers under Metal's timeout limit.
 const GEMMA4_PREFILL_STEP_SIZE: i64 = 512;
+const GEMMA4_PAGED_ATTENTION_V2_PARTITION_SIZE: u64 = 512;
+const GEMMA4_PAGED_ATTENTION_V2_AUX_ELEM_LIMIT: u128 = i32::MAX as u128;
+const GEMMA4_SLIDING_RESTORE_DEFAULT_MAX_TOKENS: u32 = 32_768;
+const GEMMA4_SLIDING_RESTORE_DEFAULT_WINDOW_MULTIPLIER: u32 = 32;
+
+fn gemma4_max_sliding_restore_tokens(sliding_window: i32) -> u32 {
+    static OVERRIDE: OnceLock<Option<u32>> = OnceLock::new();
+    let sliding_window = sliding_window.max(0) as u32;
+    let default = sliding_window
+        .saturating_mul(GEMMA4_SLIDING_RESTORE_DEFAULT_WINDOW_MULTIPLIER)
+        .min(GEMMA4_SLIDING_RESTORE_DEFAULT_MAX_TOKENS)
+        .max(sliding_window);
+    OVERRIDE
+        .get_or_init(|| {
+            std::env::var("MLX_GEMMA4_MAX_SLIDING_RESTORE_TOKENS")
+                .ok()
+                .and_then(|value| value.trim().parse::<u32>().ok())
+        })
+        .unwrap_or(default)
+}
+
+fn gemma4_paged_prefill_group_max_chunk() -> u32 {
+    let configured_chunk_size = crate::array::paged_prefill_chunk_size();
+    if configured_chunk_size > 0 {
+        configured_chunk_size as u32
+    } else {
+        GEMMA4_PREFILL_STEP_SIZE as u32
+    }
+}
+
+fn gemma4_paged_prefill_body_chunk_size(configured_chunk_size: i32, body_tokens: usize) -> usize {
+    if configured_chunk_size > 0 {
+        configured_chunk_size as usize
+    } else {
+        body_tokens
+    }
+}
+
+fn gemma4_paged_prefill_paged_attention_enabled_for_chunking() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("MLX_GEMMA4_PAGED_PREFILL_PAGED_ATTENTION")
+            .map(|value| {
+                let normalized = value.trim().to_ascii_lowercase();
+                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+            })
+            .unwrap_or(true)
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Gemma4PagedPrefillBodyChunk {
+    start: usize,
+    len: usize,
+    first_position: u32,
+    capped_by_v2_aux_limit: bool,
+}
+
+fn gemma4_coalesce_single_token_restore_chunks(chunks: &mut Vec<Gemma4PagedPrefillBodyChunk>) {
+    if chunks.len() < 2 || chunks.iter().all(|chunk| chunk.len > 1) {
+        return;
+    }
+
+    let mut merged = Vec::with_capacity(chunks.len());
+    let mut idx = 0usize;
+    while idx < chunks.len() {
+        let mut chunk = chunks[idx].clone();
+        if chunk.len == 1 && idx + 1 < chunks.len() {
+            let next = &chunks[idx + 1];
+            chunk.len += next.len;
+            chunk.capped_by_v2_aux_limit |= next.capped_by_v2_aux_limit;
+            merged.push(chunk);
+            idx += 2;
+            continue;
+        }
+        if chunk.len == 1
+            && let Some(previous) = merged.last_mut()
+        {
+            previous.len += 1;
+            previous.capped_by_v2_aux_limit |= chunk.capped_by_v2_aux_limit;
+        } else {
+            merged.push(chunk);
+        }
+        idx += 1;
+    }
+    *chunks = merged;
+}
+
+fn gemma4_paged_attention_v2_aux_fits(
+    num_new_tokens: usize,
+    first_position: u32,
+    num_query_heads: u32,
+    head_size: u32,
+) -> bool {
+    if num_new_tokens == 0 || num_query_heads == 0 || head_size == 0 {
+        return false;
+    }
+
+    let max_context_len = first_position as u64 + num_new_tokens as u64;
+    if max_context_len <= GEMMA4_PAGED_ATTENTION_V2_PARTITION_SIZE {
+        return true;
+    }
+
+    let max_num_partitions = max_context_len.div_ceil(GEMMA4_PAGED_ATTENTION_V2_PARTITION_SIZE);
+    let exp_sums_size = (num_new_tokens as u128)
+        .saturating_mul(num_query_heads as u128)
+        .saturating_mul(max_num_partitions as u128);
+    let tmp_out_size = exp_sums_size.saturating_mul(head_size as u128);
+
+    exp_sums_size <= GEMMA4_PAGED_ATTENTION_V2_AUX_ELEM_LIMIT
+        && tmp_out_size <= GEMMA4_PAGED_ATTENTION_V2_AUX_ELEM_LIMIT
+}
+
+fn gemma4_paged_prefill_aux_limited_chunk_size(
+    configured_chunk_size: i32,
+    remaining_tokens: usize,
+    first_position: u32,
+    num_query_heads: u32,
+    head_size: u32,
+    paged_attention_enabled: bool,
+) -> (usize, bool) {
+    let base = gemma4_paged_prefill_body_chunk_size(configured_chunk_size, remaining_tokens)
+        .min(remaining_tokens)
+        .max(1);
+
+    if !paged_attention_enabled
+        || gemma4_paged_attention_v2_aux_fits(base, first_position, num_query_heads, head_size)
+    {
+        return (base, false);
+    }
+
+    let mut lo = 1usize;
+    let mut hi = base.saturating_sub(1).max(1);
+    while lo < hi {
+        let mid = lo + (hi - lo).div_ceil(2);
+        if gemma4_paged_attention_v2_aux_fits(mid, first_position, num_query_heads, head_size) {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+
+    (lo.max(1), true)
+}
+
+fn gemma4_paged_prefill_body_chunk_plan(
+    configured_chunk_size: i32,
+    body_tokens: usize,
+    first_position: u32,
+    num_query_heads: u32,
+    head_size: u32,
+    paged_attention_enabled: bool,
+) -> Result<Vec<Gemma4PagedPrefillBodyChunk>> {
+    let mut chunks = Vec::new();
+    let mut start = 0usize;
+    let mut position = first_position;
+    while start < body_tokens {
+        let remaining = body_tokens - start;
+        let (len, capped_by_v2_aux_limit) = gemma4_paged_prefill_aux_limited_chunk_size(
+            configured_chunk_size,
+            remaining,
+            position,
+            num_query_heads,
+            head_size,
+            paged_attention_enabled,
+        );
+        if len == 0 {
+            return Err(Error::from_reason(
+                "Gemma4 paged prefill dynamic chunking produced an empty chunk",
+            ));
+        }
+        chunks.push(Gemma4PagedPrefillBodyChunk {
+            start,
+            len,
+            first_position: position,
+            capped_by_v2_aux_limit,
+        });
+        start = start
+            .checked_add(len)
+            .ok_or_else(|| Error::from_reason("Gemma4 paged prefill chunk start overflow"))?;
+        position = position
+            .checked_add(len as u32)
+            .ok_or_else(|| Error::from_reason("Gemma4 paged prefill token position overflow"))?;
+    }
+    Ok(chunks)
+}
 
 /// Evaluate all Gemma4 cache arrays to materialize them on GPU.
 /// Must be called between prefill chunks to break lazy dependency chains.
@@ -5894,6 +7075,87 @@ mod tests {
         assert_eq!(sliding_mask_offset_for_chunk(512, 43_688, 1024), Some(1024));
         assert_eq!(sliding_mask_offset_for_chunk(2048, 0, 1024), Some(0));
         assert_eq!(sliding_mask_offset_for_chunk(1, 4096, 1024), None);
+    }
+
+    #[test]
+    fn test_gemma4_paged_prefill_body_chunk_size_honors_configured_size() {
+        assert_eq!(
+            super::gemma4_paged_prefill_body_chunk_size(4096, 27_938),
+            4096
+        );
+        assert_eq!(
+            super::gemma4_paged_prefill_body_chunk_size(512, 27_938),
+            512
+        );
+        assert_eq!(
+            super::gemma4_paged_prefill_body_chunk_size(0, 27_938),
+            27_938
+        );
+    }
+
+    #[test]
+    fn test_gemma4_paged_prefill_body_chunk_plan_caps_v2_aux() {
+        let plan =
+            super::gemma4_paged_prefill_body_chunk_plan(8192, 27_938, 16, 16, 512, true).unwrap();
+        assert_eq!(plan.first().unwrap().len, 8192);
+        assert!(plan.iter().any(|chunk| chunk.capped_by_v2_aux_limit));
+
+        let mut expected_start = 0usize;
+        let mut expected_position = 16u32;
+        for chunk in &plan {
+            assert_eq!(chunk.start, expected_start);
+            assert_eq!(chunk.first_position, expected_position);
+            assert!(super::gemma4_paged_attention_v2_aux_fits(
+                chunk.len,
+                chunk.first_position,
+                16,
+                512
+            ));
+            expected_start += chunk.len;
+            expected_position += chunk.len as u32;
+        }
+        assert_eq!(expected_start, 27_938);
+
+        let uncapped =
+            super::gemma4_paged_prefill_body_chunk_plan(8192, 27_938, 16, 16, 512, false).unwrap();
+        assert_eq!(uncapped.len(), 4);
+        assert!(uncapped.iter().all(|chunk| !chunk.capped_by_v2_aux_limit));
+    }
+
+    #[test]
+    fn test_gemma4_sliding_restore_chunk_plan_avoids_singletons() {
+        let mut plan =
+            super::gemma4_paged_prefill_body_chunk_plan(4, 9, 0, 16, 512, false).unwrap();
+        assert_eq!(
+            plan.iter().map(|chunk| chunk.len).collect::<Vec<_>>(),
+            vec![4, 4, 1]
+        );
+
+        super::gemma4_coalesce_single_token_restore_chunks(&mut plan);
+        assert_eq!(
+            plan.iter().map(|chunk| chunk.len).collect::<Vec<_>>(),
+            vec![4, 5]
+        );
+        assert_eq!(plan[1].start, 4);
+        assert_eq!(plan[1].first_position, 4);
+
+        let mut one_token_chunks =
+            super::gemma4_paged_prefill_body_chunk_plan(1, 5, 0, 16, 512, false).unwrap();
+        super::gemma4_coalesce_single_token_restore_chunks(&mut one_token_chunks);
+        assert_eq!(
+            one_token_chunks
+                .iter()
+                .map(|chunk| chunk.len)
+                .collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+        assert_eq!(one_token_chunks[1].first_position, 2);
+    }
+
+    #[test]
+    fn test_gemma4_sliding_restore_default_limit_is_bounded() {
+        assert_eq!(super::gemma4_max_sliding_restore_tokens(1024), 32_768);
+        assert_eq!(super::gemma4_max_sliding_restore_tokens(4096), 32_768);
     }
 
     #[test]
@@ -6425,7 +7687,7 @@ mod tests {
             }
         }
 
-        let last_logits = match inner.run_paged_prefill_chunk(&prompt, &prompt, 0) {
+        let last_logits = match inner.run_paged_prefill_chunk(&prompt, &prompt, 0, false) {
             Ok(l) => l,
             Err(e) => {
                 let msg = e.reason.to_string();
@@ -6500,11 +7762,8 @@ mod tests {
             kinds[3],
             super::Gemma4LayerKind::GlobalPaged { paged_idx: 1 }
         ));
-        // Shared layers 4..8 (note these still consume paged_idx slots
-        // because they ARE global layers themselves at the type level —
-        // but the LayerKVPool sizing in Gemma4Inner::new counts ALL
-        // global layers (both anchors and shared) so the indexing is
-        // consistent. SharedOnGlobal carries the ANCHOR's pool slot.
+        // Shared layers 4..8 are aliases. They do not consume paged slots;
+        // SharedOnGlobal carries the ANCHOR's pool slot, and
         // SharedOnSliding carries the anchor's absolute layer index.
         match kinds[4] {
             super::Gemma4LayerKind::SharedOnSliding { anchor_layer_idx } => {
@@ -6531,6 +7790,60 @@ mod tests {
             }
             ref other => panic!("layer 7: expected SharedOnGlobal, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_compute_layer_kv_cache_specs_group_full_sliding_and_shared_aliases() {
+        let layer_types: Vec<String> = (0..8)
+            .map(|i| {
+                if i % 2 == 1 {
+                    "full_attention".to_string()
+                } else {
+                    "sliding_attention".to_string()
+                }
+            })
+            .collect();
+        let cfg = super::Gemma4Config {
+            num_hidden_layers: 8,
+            layer_types,
+            num_kv_shared_layers: Some(4),
+            sliding_window: 17,
+            max_position_embeddings: 128,
+            ..paged_tiny_config(None)
+        };
+
+        let specs =
+            super::compute_layer_kv_cache_specs(&cfg, 8, super::KVCacheDType::BFloat16).unwrap();
+        assert_eq!(specs.len(), 8);
+        assert_eq!(specs[4].shared_kv_anchor, Some(2));
+        assert_eq!(specs[5].shared_kv_anchor, Some(3));
+        assert_eq!(super::physical_full_attention_layer_count(&specs), 2);
+
+        let groups =
+            super::compute_layer_kv_cache_groups(&cfg, 8, super::KVCacheDType::BFloat16, 32)
+                .unwrap();
+        let full_group = groups
+            .iter()
+            .find(|group| matches!(group.attention_kind, super::AttentionKind::Full))
+            .expect("full group");
+        assert_eq!(full_group.layer_indices, vec![1, 3, 5, 7]);
+        assert_eq!(full_group.physical_layer_indices, vec![1, 3]);
+
+        let sliding_group = groups
+            .iter()
+            .find(|group| {
+                matches!(
+                    group.attention_kind,
+                    super::AttentionKind::SlidingWindow { sliding_window: 17 }
+                )
+            })
+            .expect("sliding group");
+        assert_eq!(sliding_group.layer_indices, vec![0, 2, 4, 6]);
+        assert_eq!(sliding_group.physical_layer_indices, vec![0, 2]);
+        assert_eq!(
+            sliding_group.max_admission_blocks, 7,
+            "ceil((17 - 1 + 32) / 8) + one partial block"
+        );
     }
 }
 

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -133,62 +133,109 @@ impl StreamSender {
     }
 }
 
-/// Emit the text/reasoning deltas collected by the stream parser on this
-/// step, and fold any surfaced `ToolCall` segments into the shared
-/// accumulator. Tool calls do NOT stream out as deltas — they land on the
-/// terminal `done=true` chunk.
-fn dispatch_stream_segments(segments: Vec<super::output_parser::StreamSegment>, cb: &StreamSender) {
-    use super::output_parser::StreamSegment;
-    for seg in segments {
-        match seg {
-            StreamSegment::Text(text) => {
-                if text.is_empty() {
-                    continue;
+fn emit_stream_delta(text: String, is_reasoning: bool, cb: &StreamSender) {
+    if text.is_empty() {
+        return;
+    }
+    cb.call(
+        Ok(ChatStreamChunk {
+            text,
+            done: false,
+            finish_reason: None,
+            tool_calls: None,
+            thinking: None,
+            num_tokens: None,
+            prompt_tokens: None,
+            reasoning_tokens: None,
+            raw_text: None,
+            cached_tokens: None,
+            performance: None,
+            is_reasoning: Some(is_reasoning),
+        }),
+        ThreadsafeFunctionCallMode::NonBlocking,
+    );
+}
+
+/// Gemma4 marks both hidden reasoning and some answer-only turns with
+/// `<|channel>thought\n...<channel|>`. Once a reasoning delta has been
+/// streamed to Anthropic SSE we cannot re-label that content as visible
+/// text, so keep leading channel bytes pending until a visible text/tool
+/// segment proves the channel was real reasoning. If generation ends
+/// with only that pending channel body, surface it as normal text.
+#[derive(Default)]
+struct Gemma4StreamDispatchState {
+    pending_reasoning: String,
+    visible_text_emitted: bool,
+    tool_call_seen: bool,
+}
+
+impl Gemma4StreamDispatchState {
+    fn dispatch_segments(
+        &mut self,
+        segments: Vec<super::output_parser::StreamSegment>,
+        cb: &StreamSender,
+    ) {
+        use super::output_parser::StreamSegment;
+        for seg in segments {
+            match seg {
+                StreamSegment::Text(text) => {
+                    if text.is_empty() {
+                        continue;
+                    }
+                    self.flush_pending_reasoning(cb);
+                    self.visible_text_emitted = true;
+                    emit_stream_delta(text, false, cb);
                 }
-                cb.call(
-                    Ok(ChatStreamChunk {
-                        text,
-                        done: false,
-                        finish_reason: None,
-                        tool_calls: None,
-                        thinking: None,
-                        num_tokens: None,
-                        prompt_tokens: None,
-                        reasoning_tokens: None,
-                        raw_text: None,
-                        cached_tokens: None,
-                        performance: None,
-                        is_reasoning: Some(false),
-                    }),
-                    ThreadsafeFunctionCallMode::NonBlocking,
-                );
-            }
-            StreamSegment::Reasoning(text) => {
-                if text.is_empty() {
-                    continue;
+                StreamSegment::Reasoning(text) => {
+                    if text.is_empty() {
+                        continue;
+                    }
+                    if self.visible_text_emitted || self.tool_call_seen {
+                        emit_stream_delta(text, true, cb);
+                    } else {
+                        self.pending_reasoning.push_str(&text);
+                    }
                 }
-                cb.call(
-                    Ok(ChatStreamChunk {
-                        text,
-                        done: false,
-                        finish_reason: None,
-                        tool_calls: None,
-                        thinking: None,
-                        num_tokens: None,
-                        prompt_tokens: None,
-                        reasoning_tokens: None,
-                        raw_text: None,
-                        cached_tokens: None,
-                        performance: None,
-                        is_reasoning: Some(true),
-                    }),
-                    ThreadsafeFunctionCallMode::NonBlocking,
-                );
-            }
-            StreamSegment::ToolCall(_) => {
-                // Accumulated on `parser.tool_calls()` for the terminal chunk.
+                StreamSegment::ToolCall(_) => {
+                    self.tool_call_seen = true;
+                    self.flush_pending_reasoning(cb);
+                    // Accumulated on `parser.tool_calls()` for the terminal chunk.
+                }
             }
         }
+    }
+
+    fn finish(&mut self, cb: &StreamSender) {
+        if self.pending_reasoning.is_empty() {
+            return;
+        }
+        let text = std::mem::take(&mut self.pending_reasoning);
+        if self.visible_text_emitted || self.tool_call_seen {
+            emit_stream_delta(text, true, cb);
+        } else {
+            self.visible_text_emitted = true;
+            emit_stream_delta(text, false, cb);
+        }
+    }
+
+    fn flush_pending_reasoning(&mut self, cb: &StreamSender) {
+        if self.pending_reasoning.is_empty() {
+            return;
+        }
+        let text = std::mem::take(&mut self.pending_reasoning);
+        emit_stream_delta(text, true, cb);
+    }
+}
+
+fn promote_channel_only_output(parsed: &mut super::output_parser::Gemma4ParsedOutput) {
+    if parsed.text.trim().is_empty()
+        && parsed.tool_calls.is_empty()
+        && parsed
+            .thinking
+            .as_deref()
+            .is_some_and(|thinking| !thinking.trim().is_empty())
+    {
+        parsed.text = parsed.thinking.take().unwrap_or_default();
     }
 }
 
@@ -408,7 +455,10 @@ pub(crate) enum PrefixCacheDecision {
 }
 
 const GEMMA4_SLIDING_PREFIX_CHECKPOINT_MIN_LIMIT: usize = 16;
-const GEMMA4_SLIDING_PREFIX_CHECKPOINT_MAX_DEFAULT_LIMIT: usize = 64;
+const GEMMA4_SLIDING_PREFIX_CHECKPOINT_WINDOW_MULTIPLIER: usize = 2;
+const GEMMA4_SLIDING_PREFIX_CHECKPOINT_MAX_DEFAULT_LIMIT: usize = 128;
+const GEMMA4_PAGED_CACHE_MIN_DEFAULT_MEMORY_MB: u32 = 256;
+const BYTES_PER_MIB: u64 = 1024 * 1024;
 
 struct Gemma4SlidingPrefixCheckpoint {
     prefix_len: u32,
@@ -421,6 +471,11 @@ struct Gemma4SlidingPrefixCheckpoint {
 struct Gemma4SlidingHistoryCheckpoint {
     tokens: Vec<u32>,
     snapshots: Vec<Option<RotatingKVCacheSnapshot>>,
+}
+
+struct Gemma4SlidingPrefixCheckpointHit {
+    prefix_len: u32,
+    caches: Vec<Gemma4LayerCache>,
 }
 
 #[derive(Default)]
@@ -442,13 +497,13 @@ impl Gemma4SlidingCheckpointStoreTrace {
 
 struct Gemma4SlidingPrefixPreparation {
     state: &'static str,
-    already_primed: bool,
+    primed_prefix_len: u32,
 }
 
 struct Gemma4PagedTurnPreparation {
     cached_prefix_len: u32,
     suffix_len: u32,
-    sliding_prefix_already_primed: bool,
+    sliding_primed_prefix_len: u32,
 }
 
 fn compute_gemma4_paged_prefix_block_hash(
@@ -733,9 +788,32 @@ impl Gemma4Inner {
                 ));
             }
 
-            let gpu_memory_mb = config.paged_cache_memory_mb.unwrap_or(2048);
             let head_size = full_group.physical_layout.head_size;
             let num_kv_heads = full_group.physical_layout.num_kv_heads;
+            let max_seq_len = u32::try_from(config.max_position_embeddings).map_err(|_| {
+                napi::Error::from_reason(format!(
+                    "Gemma4 block-paged adapter: invalid max_position_embeddings={}",
+                    config.max_position_embeddings
+                ))
+            })?;
+            if max_seq_len == 0 {
+                return Err(napi::Error::from_reason(
+                    "Gemma4 block-paged adapter: max_position_embeddings must be > 0",
+                ));
+            }
+            let default_gpu_memory_mb = gemma4_default_paged_cache_memory_mb(
+                max_seq_len,
+                block_size,
+                head_size,
+                num_kv_heads,
+                num_global_layers,
+            );
+            let (gpu_memory_mb, paged_cache_memory_source) =
+                if let Some(configured_memory_mb) = config.paged_cache_memory_mb {
+                    (configured_memory_mb, "config")
+                } else {
+                    (default_gpu_memory_mb, "auto_full_context")
+                };
 
             let pa_config = mlx_paged_attn::PagedAttentionConfig {
                 block_size,
@@ -746,7 +824,7 @@ impl Gemma4Inner {
                 // aliases reuse their anchor's slot and do not allocate.
                 num_layers: num_global_layers,
                 use_fp8_cache: Some(false),
-                max_seq_len: Some(config.max_position_embeddings as u32),
+                max_seq_len: Some(max_seq_len),
                 max_batch_size: Some(32),
             };
 
@@ -781,8 +859,11 @@ impl Gemma4Inner {
             tracing::info!(
                 "Gemma4 block-paged adapter enabled: num_blocks={num_blocks}, \
                  block_size={block_size}, gpu_memory_mb={gpu_memory_mb}, \
+                 paged_cache_memory_source={paged_cache_memory_source}, \
+                 max_seq_len={max_seq_len}, max_cached_tokens={}, \
                  physical_full_layers={num_global_layers}, kv_groups={}, \
                  full_group_max_admission_blocks={}, cache_dtype=BFloat16",
+                num_blocks.saturating_mul(block_size),
                 kv_cache_groups.len(),
                 full_group.max_admission_blocks
             );
@@ -957,47 +1038,86 @@ impl Gemma4Inner {
         prefix_len: u32,
         block_size: u32,
         cache_salt: u64,
-    ) -> Result<Option<Vec<Gemma4LayerCache>>> {
-        let Some(final_block_hash) =
-            compute_gemma4_paged_prefix_block_hash(tokens, prefix_len, block_size, cache_salt)
-        else {
-            return Ok(None);
-        };
-        let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
-            return Ok(None);
-        };
-
-        if let Some(checkpoint) = self.sliding_prompt_boundary_checkpoint.as_ref() {
-            if checkpoint.prefix_len == prefix_len
-                && checkpoint.block_size == block_size
-                && checkpoint.final_block_hash == final_block_hash
-                && checkpoint.tokens.as_slice() == prefix_tokens
-            {
-                if let Some(caches) =
-                    restore_gemma4_sliding_caches(&self.config, &checkpoint.snapshots, prefix_len)?
-                {
-                    return Ok(Some(caches));
-                }
+    ) -> Result<Option<Gemma4SlidingPrefixCheckpointHit>> {
+        fn try_restore_checkpoint(
+            config: &Gemma4Config,
+            checkpoint: &Gemma4SlidingPrefixCheckpoint,
+            tokens: &[u32],
+            target_prefix_len: u32,
+            block_size: u32,
+            cache_salt: u64,
+        ) -> Result<Option<Gemma4SlidingPrefixCheckpointHit>> {
+            if checkpoint.prefix_len > target_prefix_len || checkpoint.block_size != block_size {
+                return Ok(None);
             }
+            let Some(prefix_tokens) = tokens.get(..checkpoint.prefix_len as usize) else {
+                return Ok(None);
+            };
+            if checkpoint.tokens.as_slice() != prefix_tokens {
+                return Ok(None);
+            }
+            let Some(final_block_hash) = compute_gemma4_paged_prefix_block_hash(
+                tokens,
+                checkpoint.prefix_len,
+                block_size,
+                cache_salt,
+            ) else {
+                return Ok(None);
+            };
+            if checkpoint.final_block_hash != final_block_hash {
+                return Ok(None);
+            }
+            let Some(caches) = restore_gemma4_sliding_caches(
+                config,
+                &checkpoint.snapshots,
+                checkpoint.prefix_len,
+            )?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(Gemma4SlidingPrefixCheckpointHit {
+                prefix_len: checkpoint.prefix_len,
+                caches,
+            }))
+        }
+
+        let mut best_hit: Option<Gemma4SlidingPrefixCheckpointHit> = None;
+        if let Some(checkpoint) = self.sliding_prompt_boundary_checkpoint.as_ref()
+            && let Some(hit) = try_restore_checkpoint(
+                &self.config,
+                checkpoint,
+                tokens,
+                prefix_len,
+                block_size,
+                cache_salt,
+            )?
+        {
+            best_hit = Some(hit);
         }
 
         for checkpoint in self.sliding_prefix_checkpoints.iter().rev() {
-            if checkpoint.prefix_len != prefix_len
-                || checkpoint.block_size != block_size
-                || checkpoint.final_block_hash != final_block_hash
-                || checkpoint.tokens.as_slice() != prefix_tokens
+            if best_hit
+                .as_ref()
+                .is_some_and(|hit| hit.prefix_len >= checkpoint.prefix_len)
             {
                 continue;
             }
-            let Some(caches) =
-                restore_gemma4_sliding_caches(&self.config, &checkpoint.snapshots, prefix_len)?
-            else {
-                continue;
-            };
-            return Ok(Some(caches));
+            if let Some(hit) = try_restore_checkpoint(
+                &self.config,
+                checkpoint,
+                tokens,
+                prefix_len,
+                block_size,
+                cache_salt,
+            )? {
+                if hit.prefix_len == prefix_len {
+                    return Ok(Some(hit));
+                }
+                best_hit = Some(hit);
+            }
         }
 
-        Ok(None)
+        Ok(best_hit)
     }
 
     fn remember_gemma4_sliding_prefix_checkpoint(
@@ -1064,9 +1184,11 @@ impl Gemma4Inner {
                 snapshots,
             });
         let checkpoint_limit = gemma4_sliding_prefix_checkpoint_limit(&self.config, block_size);
-        while self.sliding_prefix_checkpoints.len() > checkpoint_limit {
-            self.sliding_prefix_checkpoints.pop_front();
-        }
+        trim_gemma4_sliding_prefix_checkpoints(
+            &mut self.sliding_prefix_checkpoints,
+            checkpoint_limit,
+            trace_enabled,
+        );
         trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
         trace.stored = true;
         Ok(trace.finish(total_start))
@@ -1132,9 +1254,11 @@ impl Gemma4Inner {
                 snapshots,
             });
         let checkpoint_limit = gemma4_sliding_prefix_checkpoint_limit(&self.config, block_size);
-        while self.sliding_prefix_checkpoints.len() > checkpoint_limit {
-            self.sliding_prefix_checkpoints.pop_front();
-        }
+        trim_gemma4_sliding_prefix_checkpoints(
+            &mut self.sliding_prefix_checkpoints,
+            checkpoint_limit,
+            trace_enabled,
+        );
         trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
         trace.stored = true;
         Ok(trace.finish(total_start))
@@ -1211,7 +1335,12 @@ impl Gemma4Inner {
         };
         let block_size = adapter.block_size();
         let prefix_len = adapter.current_token_count();
-        if prefix_len == 0 || block_size == 0 || !prefix_len.is_multiple_of(block_size) {
+        let checkpoint_interval =
+            gemma4_sliding_decode_checkpoint_interval(&self.config, block_size);
+        if prefix_len == 0
+            || checkpoint_interval == 0
+            || !prefix_len.is_multiple_of(checkpoint_interval)
+        {
             return Ok(());
         }
         let request_tokens = adapter.request_tokens().to_vec();
@@ -1224,9 +1353,10 @@ impl Gemma4Inner {
         )?;
         if trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 {trace_label}_sliding_block_checkpoint boundary_tokens={} block_size={} stored={} materialize_ms={:.1} snapshot_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
+                "[MLX_TRACE] gemma4 {trace_label}_sliding_block_checkpoint boundary_tokens={} block_size={} checkpoint_interval={} stored={} materialize_ms={:.1} snapshot_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
                 prefix_len,
                 block_size,
+                checkpoint_interval,
                 store_trace.stored,
                 store_trace.eval_ms,
                 store_trace.snapshot_ms,
@@ -1294,7 +1424,7 @@ impl Gemma4Inner {
             }
             return Ok(Gemma4SlidingPrefixPreparation {
                 state: "fresh",
-                already_primed: false,
+                primed_prefix_len: 0,
             });
         }
 
@@ -1314,7 +1444,7 @@ impl Gemma4Inner {
             }
             return Ok(Gemma4SlidingPrefixPreparation {
                 state: "live",
-                already_primed: true,
+                primed_prefix_len: cached_prefix_len,
             });
         }
 
@@ -1336,7 +1466,7 @@ impl Gemma4Inner {
             }
             return Ok(Gemma4SlidingPrefixPreparation {
                 state: "last_history",
-                already_primed: true,
+                primed_prefix_len: cached_prefix_len,
             });
         }
 
@@ -1355,7 +1485,7 @@ impl Gemma4Inner {
             }
             return Ok(Gemma4SlidingPrefixPreparation {
                 state: "last_history_checkpoint",
-                already_primed: true,
+                primed_prefix_len: cached_prefix_len,
             });
         }
 
@@ -1365,21 +1495,30 @@ impl Gemma4Inner {
             .map(|adapter| adapter.block_size())
             .unwrap_or(0);
         let prefix_lookup_start = trace_enabled.then(std::time::Instant::now);
-        if let Some(caches) =
+        if let Some(hit) =
             self.find_gemma4_sliding_prefix_checkpoint(tokens, cached_prefix_len, block_size, 0)?
         {
-            self.caches = Some(caches);
+            let hit_prefix_len = hit.prefix_len;
+            self.caches = Some(hit.caches);
+            let state = if hit_prefix_len == cached_prefix_len {
+                "prefix_checkpoint"
+            } else {
+                "partial_prefix_checkpoint"
+            };
             if trace_enabled {
                 write_inference_trace(format_args!(
-                    "[MLX_TRACE] gemma4 sliding_prefix_prepare_done state=prefix_checkpoint cached_prefix_tokens={} prefix_lookup_ms={:.1} elapsed_ms={:.1}",
+                    "[MLX_TRACE] gemma4 sliding_prefix_prepare_done state={} cached_prefix_tokens={} primed_prefix_tokens={} replay_delta_tokens={} prefix_lookup_ms={:.1} elapsed_ms={:.1}",
+                    state,
                     cached_prefix_len,
+                    hit_prefix_len,
+                    cached_prefix_len.saturating_sub(hit_prefix_len),
                     prefix_lookup_start.map(elapsed_ms).unwrap_or(0.0),
                     prepare_start.map(elapsed_ms).unwrap_or(0.0)
                 ));
             }
             return Ok(Gemma4SlidingPrefixPreparation {
-                state: "prefix_checkpoint",
-                already_primed: true,
+                state,
+                primed_prefix_len: hit_prefix_len,
             });
         }
 
@@ -1395,7 +1534,7 @@ impl Gemma4Inner {
         }
         Ok(Gemma4SlidingPrefixPreparation {
             state: "replay",
-            already_primed: false,
+            primed_prefix_len: 0,
         })
     }
 
@@ -2076,7 +2215,7 @@ impl Gemma4Inner {
         let performance = Some(crate::profiling::PerformanceMetrics {
             ttft_ms,
             prefill_tokens_per_second: if ttft_ms > 0.0 {
-                prompt_token_count as f64 / (ttft_ms / 1000.0)
+                prefill_len as f64 / (ttft_ms / 1000.0)
             } else {
                 0.0
             },
@@ -2087,7 +2226,8 @@ impl Gemma4Inner {
             },
         });
 
-        let parsed = super::output_parser::parse_gemma4_output(&raw_text);
+        let mut parsed = super::output_parser::parse_gemma4_output(&raw_text);
+        promote_channel_only_output(&mut parsed);
         let finish_reason = if parsed.tool_calls.iter().any(|tc| tc.status == "ok") {
             "tool_calls".to_string()
         } else {
@@ -2410,6 +2550,7 @@ impl Gemma4Inner {
         let mut decode_stream = tokenizer.inner().decode_stream(false);
         let mut streamed_text_len = 0;
         let mut stream_parser = super::output_parser::Gemma4StreamParser::new();
+        let mut stream_dispatch = Gemma4StreamDispatchState::default();
 
         if use_compiled {
             let _compiled_guard = COMPILED_FORWARD_MUTEX.lock().unwrap();
@@ -2507,7 +2648,7 @@ impl Gemma4Inner {
                 streamed_text_len += token_text.len();
 
                 let segments = stream_parser.feed(&token_text);
-                dispatch_stream_segments(segments, cb);
+                stream_dispatch.dispatch_segments(segments, cb);
 
                 if is_eos_token(token_id, &eos_ids, eos_token_id) {
                     finish_reason = "stop".to_string();
@@ -2580,7 +2721,7 @@ impl Gemma4Inner {
                 streamed_text_len += token_text.len();
 
                 let segments = stream_parser.feed(&token_text);
-                dispatch_stream_segments(segments, cb);
+                stream_dispatch.dispatch_segments(segments, cb);
 
                 if is_eos_token(token_id, &eos_ids, eos_token_id) {
                     finish_reason = "stop".to_string();
@@ -2615,11 +2756,12 @@ impl Gemma4Inner {
             let residual = raw_text[streamed_text_len..].to_string();
             let mut segments = stream_parser.feed(&residual);
             segments.extend(stream_parser.flush());
-            dispatch_stream_segments(segments, cb);
+            stream_dispatch.dispatch_segments(segments, cb);
         } else {
             let tail = stream_parser.flush();
-            dispatch_stream_segments(tail, cb);
+            stream_dispatch.dispatch_segments(tail, cb);
         }
+        stream_dispatch.finish(cb);
 
         // Save session state so subsequent
         // `chat_stream_session_continue_sync` / `chat_session_continue_sync`
@@ -2650,7 +2792,7 @@ impl Gemma4Inner {
         let performance = Some(crate::profiling::PerformanceMetrics {
             ttft_ms,
             prefill_tokens_per_second: if ttft_ms > 0.0 {
-                prompt_token_count as f64 / (ttft_ms / 1000.0)
+                prefill_len as f64 / (ttft_ms / 1000.0)
             } else {
                 0.0
             },
@@ -2730,24 +2872,32 @@ impl Gemma4Inner {
         tokens: &[u32],
         total_budget: u32,
         seq_id: u32,
-        cached_prefix_len: u32,
+        restore_tokens: u32,
         trace_enabled: bool,
-    ) -> Result<u32> {
-        let Some(max_sliding_restore_tokens) =
-            gemma4_large_sliding_restore_suppression_limit(cached_prefix_len)
-        else {
-            return Ok(cached_prefix_len);
+    ) -> Result<bool> {
+        let block_size = self
+            .paged_adapter
+            .as_ref()
+            .map(|adapter| adapter.block_size())
+            .unwrap_or(0);
+        let Some(suppression) = gemma4_large_sliding_restore_suppression_limit(
+            &self.config,
+            block_size,
+            restore_tokens,
+        ) else {
+            return Ok(false);
         };
 
-        // Emergency operator override. By default, large prefix hits stay enabled:
-        // the sliding restore pass is chunked, and global attention reads paged K/V
-        // instead of rebuilding throwaway global K/V. If a deployment hits a
-        // restore-specific issue, MLX_GEMMA4_MAX_SLIDING_RESTORE_TOKENS can force
-        // full prefill above the configured limit.
+        // Sliding layers are recursive: without a close sliding checkpoint,
+        // restoring a large paged-prefix hit can be slower than simply
+        // recomputing the prompt. Keep prefix reuse only when the missing
+        // sliding delta fits within the normal checkpoint interval; otherwise
+        // fall back to a coherent cold prefill. Operators can set
+        // MLX_GEMMA4_MAX_SLIDING_RESTORE_TOKENS=off for debugging.
         if trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 {}_prefix_reuse_suppressed reason=large_sliding_restore_env_limit cached_prefix_tokens={} limit={}",
-                trace_label, cached_prefix_len, max_sliding_restore_tokens
+                "[MLX_TRACE] gemma4 {}_prefix_reuse_suppressed reason=large_sliding_restore_limit restore_tokens={} limit={} limit_source={} block_size={}",
+                trace_label, restore_tokens, suppression.limit, suppression.source, block_size
             ));
         }
         let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
@@ -2768,7 +2918,7 @@ impl Gemma4Inner {
             .map_err(Error::from_reason)?;
         if trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 {}_adapter_reset_done reason=large_sliding_restore_env_limit_suppressed cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={}",
+                "[MLX_TRACE] gemma4 {}_adapter_reset_done reason=large_sliding_restore_suppressed cached_prefix_tokens={} cached_blocks={} allocated_blocks={} request_tokens={} blocks={}",
                 trace_label,
                 prefix.cached_token_count,
                 prefix.blocks.len(),
@@ -2777,7 +2927,7 @@ impl Gemma4Inner {
                 adapter.num_allocated_blocks()
             ));
         }
-        Ok(0)
+        Ok(true)
     }
 
     fn prepare_gemma4_paged_turn(
@@ -2846,21 +2996,26 @@ impl Gemma4Inner {
             cached_prefix_len,
             plan.continued_live_prefix,
         )?;
-        if !sliding_preparation.already_primed {
-            let prepared_prefix_len = self.suppress_large_sliding_prefix_reuse_if_needed(
+        if sliding_preparation.primed_prefix_len < cached_prefix_len {
+            let suppressed = self.suppress_large_sliding_prefix_reuse_if_needed(
                 trace_label,
                 tokens,
                 total_budget,
                 seq_id,
-                cached_prefix_len,
+                cached_prefix_len.saturating_sub(sliding_preparation.primed_prefix_len),
                 trace_enabled,
             )?;
-            if prepared_prefix_len != cached_prefix_len {
-                cached_prefix_len = prepared_prefix_len;
+            if suppressed {
+                let previous_cached_prefix_len = cached_prefix_len;
+                cached_prefix_len = 0;
                 sliding_preparation =
                     self.prepare_gemma4_sliding_prefix_state(tokens, cached_prefix_len, false)?;
-            } else {
-                cached_prefix_len = prepared_prefix_len;
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] gemma4 {trace_label}_cached_prefix_reset previous_cached_prefix_tokens={} reason=sliding_restore_limit",
+                        previous_cached_prefix_len
+                    ));
+                }
             }
         }
 
@@ -2871,12 +3026,15 @@ impl Gemma4Inner {
             ))
         })?;
         if trace_enabled {
+            let already_primed = sliding_preparation.primed_prefix_len == cached_prefix_len;
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 {trace_label}_sliding_prefix_state state={} cached_prefix_tokens={} suffix_tokens={} already_primed={} continued_live={}",
+                "[MLX_TRACE] gemma4 {trace_label}_sliding_prefix_state state={} cached_prefix_tokens={} sliding_primed_prefix_tokens={} replay_delta_tokens={} suffix_tokens={} already_primed={} continued_live={}",
                 sliding_preparation.state,
                 cached_prefix_len,
+                sliding_preparation.primed_prefix_len,
+                cached_prefix_len.saturating_sub(sliding_preparation.primed_prefix_len),
                 suffix_len,
-                sliding_preparation.already_primed,
+                already_primed,
                 plan.continued_live_prefix
             ));
         }
@@ -2884,7 +3042,7 @@ impl Gemma4Inner {
         Ok(Gemma4PagedTurnPreparation {
             cached_prefix_len,
             suffix_len,
-            sliding_prefix_already_primed: sliding_preparation.already_primed,
+            sliding_primed_prefix_len: sliding_preparation.primed_prefix_len,
         })
     }
 
@@ -2914,6 +3072,20 @@ impl Gemma4Inner {
         let eos_ids = self.config.eos_token_ids.clone();
         let generation_start = std::time::Instant::now();
         let trace_enabled = inference_trace_enabled();
+        let effective_max_new_tokens = gemma4_context_limited_max_new_tokens(
+            max_new_tokens,
+            prompt_token_count,
+            self.config.max_position_embeddings,
+        )
+        .map_err(Error::from_reason)?;
+        gemma4_trace_context_limited_max_new_tokens(
+            "sync_paged",
+            max_new_tokens,
+            effective_max_new_tokens,
+            prompt_token_count,
+            self.config.max_position_embeddings,
+            trace_enabled,
+        );
 
         let seq_id: u32 = 0;
         let total_budget = tokens.len() as u32;
@@ -2942,9 +3114,9 @@ impl Gemma4Inner {
         let forward_result = self.chat_sync_core_paged_inner(
             &tokens,
             cached_prefix_len,
-            paged_turn.sliding_prefix_already_primed,
+            paged_turn.sliding_primed_prefix_len,
             sampling_config,
-            max_new_tokens,
+            effective_max_new_tokens,
             eos_token_id,
             &eos_ids,
             repetition_cutoff,
@@ -3018,7 +3190,7 @@ impl Gemma4Inner {
             .map(|fti| generation_end.duration_since(fti).as_secs_f64() * 1000.0)
             .unwrap_or(0.0);
         let gen_toks = generated_tokens.len() as f64;
-        let actual_prefill_count = (tokens.len() as f64) - cached_prefix_len as f64;
+        let actual_prefill_count = paged_turn.suffix_len as f64;
         let performance = Some(crate::profiling::PerformanceMetrics {
             ttft_ms,
             prefill_tokens_per_second: if ttft_ms > 0.0 {
@@ -3033,7 +3205,8 @@ impl Gemma4Inner {
             },
         });
 
-        let parsed = super::output_parser::parse_gemma4_output(&raw_text);
+        let mut parsed = super::output_parser::parse_gemma4_output(&raw_text);
+        promote_channel_only_output(&mut parsed);
         let finish_reason = if parsed.tool_calls.iter().any(|tc| tc.status == "ok") {
             "tool_calls".to_string()
         } else {
@@ -3061,7 +3234,7 @@ impl Gemma4Inner {
         &mut self,
         tokens: &[u32],
         cached_prefix_len: u32,
-        sliding_prefix_already_primed: bool,
+        sliding_primed_prefix_len: u32,
         sampling_config: Option<SamplingConfig>,
         max_new_tokens: i32,
         eos_token_id: u32,
@@ -3083,7 +3256,7 @@ impl Gemma4Inner {
                 tokens,
                 suffix,
                 cached_prefix_len,
-                sliding_prefix_already_primed,
+                sliding_primed_prefix_len,
             )?
         };
 
@@ -3172,10 +3345,24 @@ impl Gemma4Inner {
         let generation_start = std::time::Instant::now();
         let trace_enabled = inference_trace_enabled();
         let trace_start = trace_enabled.then(std::time::Instant::now);
+        let effective_max_new_tokens = gemma4_context_limited_max_new_tokens(
+            max_new_tokens,
+            prompt_token_count,
+            self.config.max_position_embeddings,
+        )
+        .map_err(Error::from_reason)?;
+        gemma4_trace_context_limited_max_new_tokens(
+            "stream_paged",
+            max_new_tokens,
+            effective_max_new_tokens,
+            prompt_token_count,
+            self.config.max_position_embeddings,
+            trace_enabled,
+        );
         if trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 stream_paged_start prompt_tokens={} reuse_cache={} max_new_tokens={}",
-                prompt_token_count, reuse_cache, max_new_tokens
+                "[MLX_TRACE] gemma4 stream_paged_start prompt_tokens={} reuse_cache={} max_new_tokens={} requested_max_new_tokens={}",
+                prompt_token_count, reuse_cache, effective_max_new_tokens, max_new_tokens
             ));
         }
 
@@ -3209,9 +3396,9 @@ impl Gemma4Inner {
         let stream_result = self.chat_stream_sync_core_paged_inner(
             &tokens,
             cached_prefix_len,
-            paged_turn.sliding_prefix_already_primed,
+            paged_turn.sliding_primed_prefix_len,
             sampling_config,
-            max_new_tokens,
+            effective_max_new_tokens,
             eos_token_id,
             &eos_ids,
             tokenizer.clone(),
@@ -3293,7 +3480,8 @@ impl Gemma4Inner {
 
         // Terminal stream chunk.
         let raw_text = tokenizer.decode_sync(&generated_tokens, false)?;
-        let parsed = super::output_parser::parse_gemma4_output(&raw_text);
+        let mut parsed = super::output_parser::parse_gemma4_output(&raw_text);
+        promote_channel_only_output(&mut parsed);
         let finish_reason = if parsed.tool_calls.iter().any(|tc| tc.status == "ok") {
             "tool_calls".to_string()
         } else {
@@ -3308,7 +3496,7 @@ impl Gemma4Inner {
             .map(|fti| generation_end.duration_since(fti).as_secs_f64() * 1000.0)
             .unwrap_or(0.0);
         let gen_toks = generated_tokens.len() as f64;
-        let actual_prefill_count = (tokens.len() as f64) - cached_prefix_len as f64;
+        let actual_prefill_count = suffix_len as f64;
         let performance = Some(crate::profiling::PerformanceMetrics {
             ttft_ms,
             prefill_tokens_per_second: if ttft_ms > 0.0 {
@@ -3356,7 +3544,7 @@ impl Gemma4Inner {
         &mut self,
         tokens: &[u32],
         cached_prefix_len: u32,
-        sliding_prefix_already_primed: bool,
+        sliding_primed_prefix_len: u32,
         sampling_config: Option<SamplingConfig>,
         max_new_tokens: i32,
         eos_token_id: u32,
@@ -3379,7 +3567,7 @@ impl Gemma4Inner {
                 tokens,
                 suffix,
                 cached_prefix_len,
-                sliding_prefix_already_primed,
+                sliding_primed_prefix_len,
             )?
         };
 
@@ -3403,6 +3591,7 @@ impl Gemma4Inner {
         // Streaming detokenizer + parser.
         let mut decode_stream = tokenizer.inner().decode_stream(false);
         let mut stream_parser = super::output_parser::Gemma4StreamParser::new();
+        let mut stream_dispatch = Gemma4StreamDispatchState::default();
 
         let mut generated_tokens: Vec<u32> = Vec::with_capacity(max_new_tokens.max(0) as usize);
         let mut finish_reason = String::from("length");
@@ -3444,7 +3633,7 @@ impl Gemma4Inner {
                 .map_err(|e| Error::from_reason(format!("decode_stream: {e}")))?
             {
                 let segments = stream_parser.feed(&piece);
-                dispatch_stream_segments(segments, cb);
+                stream_dispatch.dispatch_segments(segments, cb);
             }
 
             if is_eos_token(token_id, eos_ids, eos_token_id) {
@@ -3513,7 +3702,8 @@ impl Gemma4Inner {
         // Flush any residual segments accumulated by the parser but not
         // yet emitted.
         let residual_segments = stream_parser.flush();
-        dispatch_stream_segments(residual_segments, cb);
+        stream_dispatch.dispatch_segments(residual_segments, cb);
+        stream_dispatch.finish(cb);
         if trace_enabled {
             write_inference_trace(format_args!(
                 "[MLX_TRACE] gemma4 stream_paged_decode_done finish_reason={} generated_tokens={} elapsed_ms={:.1}",
@@ -3563,12 +3753,18 @@ impl Gemma4Inner {
         full_tokens: &[u32],
         suffix_tokens: &[u32],
         cached_prefix_len: u32,
-        sliding_prefix_already_primed: bool,
+        sliding_primed_prefix_len: u32,
     ) -> Result<MxArray> {
         if suffix_tokens.is_empty() {
             return Err(Error::from_reason(
                 "run_paged_prefill_chunk called with empty suffix",
             ));
+        }
+        if sliding_primed_prefix_len > cached_prefix_len {
+            return Err(Error::from_reason(format!(
+                "Gemma4 paged prefill sliding_primed_prefix_len {} exceeds cached_prefix_len {}",
+                sliding_primed_prefix_len, cached_prefix_len
+            )));
         }
 
         let suffix_len = suffix_tokens.len() as u32;
@@ -3586,13 +3782,14 @@ impl Gemma4Inner {
 
         // For sliding layers we need state at position cached_prefix_len.
         // Sliding layers are restored each turn via reset_caches_sync, so
-        // we need to reprefill the cached prefix through them BEFORE the
-        // suffix can attend. Run a "sliding-only" pass over the prefix
-        // tokens, then the suffix passes below.
-        if cached_prefix_len > 0 && !sliding_prefix_already_primed {
-            let prefix = &full_tokens[..(cached_prefix_len as usize)];
+        // we need to reprefill any unprimed cached-prefix delta through
+        // them BEFORE the suffix can attend. When a sparse checkpoint hits,
+        // this is only the delta from that checkpoint to cached_prefix_len.
+        if sliding_primed_prefix_len < cached_prefix_len {
+            let prefix =
+                &full_tokens[(sliding_primed_prefix_len as usize)..(cached_prefix_len as usize)];
             let sliding_trace_start = trace_enabled.then(std::time::Instant::now);
-            self.run_sliding_only_prefill(prefix, &layer_kinds)?;
+            self.run_sliding_only_prefill(prefix, sliding_primed_prefix_len, &layer_kinds)?;
             let block_size = self
                 .paged_adapter
                 .as_ref()
@@ -3606,7 +3803,9 @@ impl Gemma4Inner {
             )?;
             if trace_enabled {
                 write_inference_trace(format_args!(
-                    "[MLX_TRACE] gemma4 paged_prefill_sliding_prefix_done prefix_tokens={} checkpoint_stored={} store_eval_ms={:.1} store_snapshot_ms={:.1} store_token_clone_ms={:.1} store_update_ms={:.1} store_ms={:.1} elapsed_ms={:.1}",
+                    "[MLX_TRACE] gemma4 paged_prefill_sliding_prefix_done cached_prefix_tokens={} restored_prefix_tokens={} replay_tokens={} checkpoint_stored={} store_eval_ms={:.1} store_snapshot_ms={:.1} store_token_clone_ms={:.1} store_update_ms={:.1} store_ms={:.1} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    sliding_primed_prefix_len,
                     prefix.len(),
                     store_trace.stored,
                     store_trace.eval_ms,
@@ -3619,8 +3818,8 @@ impl Gemma4Inner {
             }
         } else if cached_prefix_len > 0 && trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 paged_prefill_sliding_prefix_skipped cached_prefix_tokens={} reason=already_primed",
-                cached_prefix_len
+                "[MLX_TRACE] gemma4 paged_prefill_sliding_prefix_skipped cached_prefix_tokens={} sliding_primed_prefix_tokens={} reason=already_primed",
+                cached_prefix_len, sliding_primed_prefix_len
             ));
         }
 
@@ -3665,19 +3864,24 @@ impl Gemma4Inner {
                 .as_ref()
                 .map(|adapter| adapter.block_size())
                 .unwrap_or(0);
-            let prompt_checkpoint_boundary_len = if block_size > 0 {
-                (full_tokens.len() as u32 / block_size) * block_size
-            } else {
-                0
-            };
-            let mut body_chunk_plan = gemma4_paged_prefill_body_chunk_plan(
-                configured_chunk_size,
-                pass1_tokens.len(),
-                pass2_first_position,
-                num_query_heads,
-                global_head_size,
-                paged_attention_enabled,
-            )?;
+            let full_tokens_len = u32::try_from(full_tokens.len())
+                .map_err(|_| Error::from_reason("Gemma4 paged prefill token count exceeds u32"))?;
+            let prompt_checkpoint_boundary_len = full_tokens_len
+                .checked_div(block_size)
+                .map(|blocks| blocks.saturating_mul(block_size))
+                .unwrap_or(0);
+            let checkpoint_interval =
+                gemma4_sliding_decode_checkpoint_interval(&self.config, block_size);
+            let mut body_chunk_plan =
+                gemma4_paged_prefill_body_chunk_plan_with_checkpoint_interval(
+                    configured_chunk_size,
+                    pass1_tokens.len(),
+                    pass2_first_position,
+                    num_query_heads,
+                    global_head_size,
+                    paged_attention_enabled,
+                    checkpoint_interval,
+                )?;
             gemma4_split_body_chunk_plan_at_position(
                 &mut body_chunk_plan,
                 prompt_checkpoint_boundary_len,
@@ -3805,6 +4009,16 @@ impl Gemma4Inner {
                     .ok_or_else(|| {
                         Error::from_reason("Gemma4 paged prefill token position overflow")
                     })?;
+                // Global paged-cache hits can land at any prior full-block
+                // prefix, not just the previous prompt boundary. Persist
+                // sliding snapshots at the normal window stride during
+                // prefill too, so a later branch switch can restore from a
+                // nearby sliding state instead of replaying tens of thousands
+                // of sliding tokens or falling back to a full cold prefill.
+                self.maybe_remember_gemma4_sliding_decode_boundary_checkpoint(
+                    "paged_prefill",
+                    trace_enabled,
+                )?;
                 if pass2_first_position == prompt_checkpoint_boundary_len {
                     self.maybe_remember_gemma4_sliding_prompt_boundary_checkpoint(
                         "paged_prefill",
@@ -4358,6 +4572,7 @@ impl Gemma4Inner {
     fn run_sliding_only_prefill(
         &mut self,
         prefix_tokens: &[u32],
+        first_logical_position: u32,
         layer_kinds: &[Gemma4LayerKind],
     ) -> Result<()> {
         if prefix_tokens.is_empty() {
@@ -4381,7 +4596,7 @@ impl Gemma4Inner {
         let mut chunk_plan = gemma4_paged_prefill_body_chunk_plan(
             configured_chunk_size,
             prefix_tokens.len(),
-            0,
+            first_logical_position,
             num_query_heads,
             global_head_size,
             paged_attention_enabled,
@@ -4399,7 +4614,8 @@ impl Gemma4Inner {
                 .filter(|chunk| chunk.capped_by_v2_aux_limit)
                 .count();
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 sliding_prefix_restore_start prefix_tokens={} chunks={} chunk_size={} min_chunk_size={} max_chunk_size={} configured_chunk_size={} dynamic_v2_aux_caps={} path=paged_global_readonly",
+                "[MLX_TRACE] gemma4 sliding_prefix_restore_start first_position={} prefix_tokens={} chunks={} chunk_size={} min_chunk_size={} max_chunk_size={} configured_chunk_size={} dynamic_v2_aux_caps={} path=paged_global_readonly",
+                first_logical_position,
                 prefix_tokens.len(),
                 chunk_plan.len(),
                 first_chunk_size,
@@ -4457,7 +4673,8 @@ impl Gemma4Inner {
 
         if trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] gemma4 sliding_prefix_restore_done prefix_tokens={} chunks={} elapsed_ms={:.1}",
+                "[MLX_TRACE] gemma4 sliding_prefix_restore_done first_position={} prefix_tokens={} chunks={} elapsed_ms={:.1}",
+                first_logical_position,
                 prefix_tokens.len(),
                 total_chunks,
                 total_trace_start.map(elapsed_ms).unwrap_or(0.0)
@@ -5063,7 +5280,8 @@ impl Gemma4Inner {
             },
         });
 
-        let parsed = super::output_parser::parse_gemma4_output(&raw_text);
+        let mut parsed = super::output_parser::parse_gemma4_output(&raw_text);
+        promote_channel_only_output(&mut parsed);
         let finish_reason = if parsed.tool_calls.iter().any(|tc| tc.status == "ok") {
             "tool_calls".to_string()
         } else {
@@ -5393,6 +5611,7 @@ impl Gemma4Inner {
         let mut decode_stream = tokenizer.inner().decode_stream(false);
         let mut streamed_text_len = 0;
         let mut stream_parser = super::output_parser::Gemma4StreamParser::new();
+        let mut stream_dispatch = Gemma4StreamDispatchState::default();
 
         let mut current_y = y;
         for step in 0..max_new_tokens {
@@ -5439,7 +5658,7 @@ impl Gemma4Inner {
             streamed_text_len += token_text.len();
 
             let segments = stream_parser.feed(&token_text);
-            dispatch_stream_segments(segments, cb);
+            stream_dispatch.dispatch_segments(segments, cb);
 
             if is_eos_token(token_id, &eos_ids, turn_end_id) {
                 finish_reason = "stop".to_string();
@@ -5469,11 +5688,12 @@ impl Gemma4Inner {
             let residual = raw_text[streamed_text_len..].to_string();
             let mut segments = stream_parser.feed(&residual);
             segments.extend(stream_parser.flush());
-            dispatch_stream_segments(segments, cb);
+            stream_dispatch.dispatch_segments(segments, cb);
         } else {
             let tail = stream_parser.flush();
-            dispatch_stream_segments(tail, cb);
+            stream_dispatch.dispatch_segments(tail, cb);
         }
+        stream_dispatch.finish(cb);
 
         // Save cache state for the next session turn.
         let history_tokens: &[u32] = if finish_reason != "length" && !generated_tokens.is_empty() {
@@ -6670,6 +6890,75 @@ fn physical_full_attention_layer_count(specs: &[LayerKVCacheSpec]) -> usize {
         .count()
 }
 
+fn gemma4_default_paged_cache_memory_mb(
+    max_seq_len: u32,
+    block_size: u32,
+    head_size: u32,
+    num_kv_heads: u32,
+    num_layers: u32,
+) -> u32 {
+    if max_seq_len == 0 || block_size == 0 || head_size == 0 || num_kv_heads == 0 || num_layers == 0
+    {
+        return GEMMA4_PAGED_CACHE_MIN_DEFAULT_MEMORY_MB;
+    }
+
+    let max_blocks = u64::from(max_seq_len.div_ceil(block_size));
+    let bytes_per_block = 2u64
+        .saturating_mul(u64::from(num_kv_heads))
+        .saturating_mul(u64::from(head_size))
+        .saturating_mul(u64::from(block_size))
+        .saturating_mul(2)
+        .saturating_mul(u64::from(num_layers));
+    let required_mb = bytes_per_block
+        .saturating_mul(max_blocks)
+        .div_ceil(BYTES_PER_MIB)
+        .max(u64::from(GEMMA4_PAGED_CACHE_MIN_DEFAULT_MEMORY_MB));
+    u32::try_from(required_mb).unwrap_or(u32::MAX)
+}
+
+fn gemma4_context_limited_max_new_tokens(
+    requested_max_new_tokens: i32,
+    prompt_tokens: usize,
+    max_position_embeddings: i32,
+) -> std::result::Result<i32, String> {
+    if requested_max_new_tokens <= 0 {
+        return Ok(0);
+    }
+    let max_positions = u32::try_from(max_position_embeddings)
+        .map_err(|_| format!("Gemma4 invalid max_position_embeddings={max_position_embeddings}"))?;
+    if max_positions == 0 {
+        return Err("Gemma4 max_position_embeddings must be > 0".to_string());
+    }
+    let prompt_tokens_u32 = u32::try_from(prompt_tokens)
+        .map_err(|_| format!("Gemma4 prompt token count {prompt_tokens} exceeds u32"))?;
+    if prompt_tokens_u32 > max_positions {
+        return Err(format!(
+            "Gemma4 prompt_tokens={prompt_tokens_u32} exceeds max_position_embeddings={max_positions}"
+        ));
+    }
+    let remaining = max_positions - prompt_tokens_u32;
+    Ok(requested_max_new_tokens.min(i32::try_from(remaining).unwrap_or(i32::MAX)))
+}
+
+fn gemma4_trace_context_limited_max_new_tokens(
+    trace_label: &str,
+    requested_max_new_tokens: i32,
+    effective_max_new_tokens: i32,
+    prompt_tokens: usize,
+    max_position_embeddings: i32,
+    trace_enabled: bool,
+) {
+    if trace_enabled && effective_max_new_tokens != requested_max_new_tokens {
+        write_inference_trace(format_args!(
+            "[MLX_TRACE] gemma4 {trace_label}_max_new_tokens_clamped requested={} effective={} prompt_tokens={} max_position_embeddings={}",
+            requested_max_new_tokens,
+            effective_max_new_tokens,
+            prompt_tokens,
+            max_position_embeddings
+        ));
+    }
+}
+
 /// Default prefill chunk size (tokens per chunk).
 /// Note: mlx-lm uses 2048 but the first eval triggers Metal shader compilation
 /// which can GPU-timeout with very large graphs. Using 512 keeps individual
@@ -6678,16 +6967,37 @@ const GEMMA4_PREFILL_STEP_SIZE: i64 = 512;
 const GEMMA4_PAGED_ATTENTION_V2_PARTITION_SIZE: u64 = 512;
 const GEMMA4_PAGED_ATTENTION_V2_AUX_ELEM_LIMIT: u128 = i32::MAX as u128;
 
-fn parse_gemma4_sliding_restore_limit(value: &str) -> Option<u32> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Gemma4SlidingRestoreLimitOverride {
+    Cap(u32),
+    Uncapped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Gemma4SlidingRestoreSuppression {
+    limit: u32,
+    source: &'static str,
+}
+
+fn parse_gemma4_sliding_restore_limit(value: &str) -> Option<Gemma4SlidingRestoreLimitOverride> {
     let value = value.trim();
     if value.is_empty() {
         return None;
     }
-    value.parse::<u32>().ok()
+    if matches!(
+        value.to_ascii_lowercase().as_str(),
+        "off" | "none" | "false" | "no" | "unlimited" | "uncapped"
+    ) {
+        return Some(Gemma4SlidingRestoreLimitOverride::Uncapped);
+    }
+    value
+        .parse::<u32>()
+        .ok()
+        .map(Gemma4SlidingRestoreLimitOverride::Cap)
 }
 
-fn gemma4_sliding_restore_limit_override() -> Option<u32> {
-    static OVERRIDE: OnceLock<Option<u32>> = OnceLock::new();
+fn gemma4_sliding_restore_limit_override() -> Option<Gemma4SlidingRestoreLimitOverride> {
+    static OVERRIDE: OnceLock<Option<Gemma4SlidingRestoreLimitOverride>> = OnceLock::new();
     *OVERRIDE.get_or_init(|| {
         std::env::var("MLX_GEMMA4_MAX_SLIDING_RESTORE_TOKENS")
             .ok()
@@ -6695,18 +7005,38 @@ fn gemma4_sliding_restore_limit_override() -> Option<u32> {
     })
 }
 
-fn gemma4_large_sliding_restore_suppression_limit_for_override(
-    override_limit: Option<u32>,
-    cached_prefix_len: u32,
-) -> Option<u32> {
-    let limit = override_limit?;
-    (cached_prefix_len > limit).then_some(limit)
+fn gemma4_default_sliding_restore_limit(config: &Gemma4Config, block_size: u32) -> Option<u32> {
+    let interval = gemma4_sliding_decode_checkpoint_interval(config, block_size);
+    (interval > 0).then_some(interval)
 }
 
-fn gemma4_large_sliding_restore_suppression_limit(cached_prefix_len: u32) -> Option<u32> {
+fn gemma4_large_sliding_restore_suppression_limit_for_override(
+    config: &Gemma4Config,
+    block_size: u32,
+    override_limit: Option<Gemma4SlidingRestoreLimitOverride>,
+    restore_tokens: u32,
+) -> Option<Gemma4SlidingRestoreSuppression> {
+    let (limit, source) = match override_limit {
+        Some(Gemma4SlidingRestoreLimitOverride::Uncapped) => return None,
+        Some(Gemma4SlidingRestoreLimitOverride::Cap(limit)) => (limit, "env"),
+        None => (
+            gemma4_default_sliding_restore_limit(config, block_size)?,
+            "default",
+        ),
+    };
+    (restore_tokens > limit).then_some(Gemma4SlidingRestoreSuppression { limit, source })
+}
+
+fn gemma4_large_sliding_restore_suppression_limit(
+    config: &Gemma4Config,
+    block_size: u32,
+    restore_tokens: u32,
+) -> Option<Gemma4SlidingRestoreSuppression> {
     gemma4_large_sliding_restore_suppression_limit_for_override(
+        config,
+        block_size,
         gemma4_sliding_restore_limit_override(),
-        cached_prefix_len,
+        restore_tokens,
     )
 }
 
@@ -6740,10 +7070,13 @@ fn gemma4_sliding_prefix_checkpoint_limit_for_override(
     if sliding_window == 0 || block_size == 0 {
         return GEMMA4_SLIDING_PREFIX_CHECKPOINT_MIN_LIMIT;
     }
-    sliding_window.div_ceil(block_size).clamp(
-        GEMMA4_SLIDING_PREFIX_CHECKPOINT_MIN_LIMIT,
-        GEMMA4_SLIDING_PREFIX_CHECKPOINT_MAX_DEFAULT_LIMIT,
-    )
+    sliding_window
+        .div_ceil(block_size)
+        .saturating_mul(GEMMA4_SLIDING_PREFIX_CHECKPOINT_WINDOW_MULTIPLIER)
+        .clamp(
+            GEMMA4_SLIDING_PREFIX_CHECKPOINT_MIN_LIMIT,
+            GEMMA4_SLIDING_PREFIX_CHECKPOINT_MAX_DEFAULT_LIMIT,
+        )
 }
 
 fn gemma4_sliding_prefix_checkpoint_limit(config: &Gemma4Config, block_size: u32) -> usize {
@@ -6752,6 +7085,45 @@ fn gemma4_sliding_prefix_checkpoint_limit(config: &Gemma4Config, block_size: u32
         block_size,
         gemma4_sliding_checkpoint_limit_override(),
     )
+}
+
+fn gemma4_sliding_decode_checkpoint_interval(config: &Gemma4Config, block_size: u32) -> u32 {
+    if block_size == 0 {
+        return 0;
+    }
+    let sliding_window = config.sliding_window.max(0) as u32;
+    let target = sliding_window.max(block_size);
+    target.div_ceil(block_size).saturating_mul(block_size)
+}
+
+fn trim_gemma4_sliding_prefix_checkpoints(
+    checkpoints: &mut VecDeque<Gemma4SlidingPrefixCheckpoint>,
+    limit: usize,
+    trace_enabled: bool,
+) {
+    if limit == 0 {
+        return;
+    }
+    let mut evicted = 0usize;
+    let mut first_prefix_len = None;
+    let mut last_prefix_len = None;
+    while checkpoints.len() > limit {
+        if let Some(checkpoint) = checkpoints.pop_front() {
+            first_prefix_len.get_or_insert(checkpoint.prefix_len);
+            last_prefix_len = Some(checkpoint.prefix_len);
+            evicted += 1;
+        }
+    }
+    if trace_enabled && evicted > 0 {
+        write_inference_trace(format_args!(
+            "[MLX_TRACE] gemma4 sliding_prefix_checkpoint_evict evicted={} limit={} remaining={} first_prefix_tokens={} last_prefix_tokens={}",
+            evicted,
+            limit,
+            checkpoints.len(),
+            first_prefix_len.unwrap_or(0),
+            last_prefix_len.unwrap_or(0)
+        ));
+    }
 }
 
 fn gemma4_paged_prefill_group_max_chunk() -> u32 {
@@ -6915,12 +7287,52 @@ fn gemma4_paged_prefill_body_chunk_plan(
     head_size: u32,
     paged_attention_enabled: bool,
 ) -> Result<Vec<Gemma4PagedPrefillBodyChunk>> {
+    gemma4_paged_prefill_body_chunk_plan_inner(
+        configured_chunk_size,
+        body_tokens,
+        first_position,
+        num_query_heads,
+        head_size,
+        paged_attention_enabled,
+        0,
+    )
+}
+
+fn gemma4_paged_prefill_body_chunk_plan_with_checkpoint_interval(
+    configured_chunk_size: i32,
+    body_tokens: usize,
+    first_position: u32,
+    num_query_heads: u32,
+    head_size: u32,
+    paged_attention_enabled: bool,
+    checkpoint_interval: u32,
+) -> Result<Vec<Gemma4PagedPrefillBodyChunk>> {
+    gemma4_paged_prefill_body_chunk_plan_inner(
+        configured_chunk_size,
+        body_tokens,
+        first_position,
+        num_query_heads,
+        head_size,
+        paged_attention_enabled,
+        checkpoint_interval,
+    )
+}
+
+fn gemma4_paged_prefill_body_chunk_plan_inner(
+    configured_chunk_size: i32,
+    body_tokens: usize,
+    first_position: u32,
+    num_query_heads: u32,
+    head_size: u32,
+    paged_attention_enabled: bool,
+    checkpoint_interval: u32,
+) -> Result<Vec<Gemma4PagedPrefillBodyChunk>> {
     let mut chunks = Vec::new();
     let mut start = 0usize;
     let mut position = first_position;
     while start < body_tokens {
         let remaining = body_tokens - start;
-        let (len, capped_by_v2_aux_limit) = gemma4_paged_prefill_aux_limited_chunk_size(
+        let (mut len, capped_by_v2_aux_limit) = gemma4_paged_prefill_aux_limited_chunk_size(
             configured_chunk_size,
             remaining,
             position,
@@ -6928,6 +7340,23 @@ fn gemma4_paged_prefill_body_chunk_plan(
             head_size,
             paged_attention_enabled,
         );
+        if checkpoint_interval > 0 {
+            let position_u64 = position as u64;
+            let interval_u64 = checkpoint_interval as u64;
+            let chunk_end = position_u64
+                .checked_add(len as u64)
+                .ok_or_else(|| Error::from_reason("Gemma4 paged prefill chunk end overflow"))?;
+            let next_checkpoint = ((position_u64 / interval_u64) + 1)
+                .checked_mul(interval_u64)
+                .ok_or_else(|| {
+                    Error::from_reason("Gemma4 paged prefill checkpoint boundary overflow")
+                })?;
+            if next_checkpoint > position_u64 && next_checkpoint < chunk_end {
+                len = usize::try_from(next_checkpoint - position_u64).map_err(|_| {
+                    Error::from_reason("Gemma4 paged prefill checkpoint chunk length overflow")
+                })?;
+            }
+        }
         if len == 0 {
             return Err(Error::from_reason(
                 "Gemma4 paged prefill dynamic chunking produced an empty chunk",
@@ -7294,6 +7723,86 @@ fn prefill_body_gemma4_with_embeds(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::gemma4::output_parser::{StreamSegment, parse_gemma4_output};
+
+    #[test]
+    fn stream_dispatch_promotes_channel_only_output_to_visible_text() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let sender = StreamSender(tx);
+        let mut state = Gemma4StreamDispatchState::default();
+
+        state.dispatch_segments(
+            vec![StreamSegment::Reasoning("final answer".into())],
+            &sender,
+        );
+        assert!(rx.try_recv().is_err());
+
+        state.finish(&sender);
+        let chunk = rx.try_recv().unwrap().unwrap();
+        assert_eq!(chunk.text, "final answer");
+        assert_eq!(chunk.is_reasoning, Some(false));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn stream_dispatch_keeps_reasoning_when_visible_text_follows() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let sender = StreamSender(tx);
+        let mut state = Gemma4StreamDispatchState::default();
+
+        state.dispatch_segments(
+            vec![
+                StreamSegment::Reasoning("scratch".into()),
+                StreamSegment::Text("answer".into()),
+            ],
+            &sender,
+        );
+        state.finish(&sender);
+
+        let reasoning = rx.try_recv().unwrap().unwrap();
+        assert_eq!(reasoning.text, "scratch");
+        assert_eq!(reasoning.is_reasoning, Some(true));
+
+        let text = rx.try_recv().unwrap().unwrap();
+        assert_eq!(text.text, "answer");
+        assert_eq!(text.is_reasoning, Some(false));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn stream_dispatch_keeps_reasoning_when_tool_call_follows() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let sender = StreamSender(tx);
+        let mut state = Gemma4StreamDispatchState::default();
+
+        state.dispatch_segments(
+            vec![
+                StreamSegment::Reasoning("scratch".into()),
+                StreamSegment::ToolCall(crate::tools::ToolCallResult::ok(
+                    "tool".into(),
+                    serde_json::json!({}),
+                    String::new(),
+                )),
+            ],
+            &sender,
+        );
+        state.finish(&sender);
+
+        let reasoning = rx.try_recv().unwrap().unwrap();
+        assert_eq!(reasoning.text, "scratch");
+        assert_eq!(reasoning.is_reasoning, Some(true));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn promote_channel_only_output_moves_thinking_to_text() {
+        let mut parsed = parse_gemma4_output("<|channel>thought\nvisible answer<channel|>");
+        promote_channel_only_output(&mut parsed);
+
+        assert_eq!(parsed.text, "visible answer");
+        assert!(parsed.thinking.is_none());
+        assert!(parsed.tool_calls.is_empty());
+    }
 
     #[test]
     fn sliding_mask_is_valid_for_bf16_gqa_attention() {
@@ -7424,43 +7933,112 @@ mod tests {
     }
 
     #[test]
-    fn test_gemma4_sliding_restore_default_is_uncapped() {
+    fn test_gemma4_paged_prefill_chunk_plan_splits_decode_checkpoint_boundaries() {
+        let plan = super::gemma4_paged_prefill_body_chunk_plan_with_checkpoint_interval(
+            1024, 3000, 16, 16, 512, false, 1024,
+        )
+        .unwrap();
+
         assert_eq!(
-            super::gemma4_large_sliding_restore_suppression_limit_for_override(None, 44_512),
+            plan.iter().map(|chunk| chunk.len).collect::<Vec<_>>(),
+            vec![1008, 1024, 968]
+        );
+        assert_eq!(
+            plan.iter()
+                .map(|chunk| chunk.first_position)
+                .collect::<Vec<_>>(),
+            vec![16, 1024, 2048]
+        );
+        assert_eq!(
+            plan.iter().map(|chunk| chunk.start).collect::<Vec<_>>(),
+            vec![0, 1008, 2032]
+        );
+
+        let capped = super::gemma4_paged_prefill_body_chunk_plan_with_checkpoint_interval(
+            512, 1600, 768, 16, 512, false, 1024,
+        )
+        .unwrap();
+        assert_eq!(
+            capped.iter().map(|chunk| chunk.len).collect::<Vec<_>>(),
+            vec![256, 512, 512, 320]
+        );
+        assert!(capped.iter().all(|chunk| chunk.len <= 512));
+    }
+
+    #[test]
+    fn test_gemma4_sliding_restore_default_is_checkpoint_bounded() {
+        let cfg = super::Gemma4Config {
+            sliding_window: 1024,
+            ..paged_tiny_config(Some(true))
+        };
+
+        assert_eq!(
+            super::gemma4_large_sliding_restore_suppression_limit_for_override(
+                &cfg, 16, None, 1024
+            ),
             None
         );
         assert_eq!(
-            super::gemma4_large_sliding_restore_suppression_limit_for_override(None, 1_000_000),
-            None
+            super::gemma4_large_sliding_restore_suppression_limit_for_override(
+                &cfg, 16, None, 24_336
+            ),
+            Some(super::Gemma4SlidingRestoreSuppression {
+                limit: 1024,
+                source: "default"
+            })
         );
     }
 
     #[test]
-    fn test_gemma4_sliding_restore_env_limit_is_opt_in() {
+    fn test_gemma4_sliding_restore_env_limit_overrides_default() {
+        let cfg = super::Gemma4Config {
+            sliding_window: 1024,
+            ..paged_tiny_config(Some(true))
+        };
+
         assert_eq!(
             super::parse_gemma4_sliding_restore_limit("32768"),
-            Some(32_768)
+            Some(super::Gemma4SlidingRestoreLimitOverride::Cap(32_768))
         );
         assert_eq!(
             super::parse_gemma4_sliding_restore_limit(" 44512 "),
-            Some(44_512)
+            Some(super::Gemma4SlidingRestoreLimitOverride::Cap(44_512))
         );
         assert_eq!(super::parse_gemma4_sliding_restore_limit(""), None);
-        assert_eq!(super::parse_gemma4_sliding_restore_limit("off"), None);
+        assert_eq!(
+            super::parse_gemma4_sliding_restore_limit("off"),
+            Some(super::Gemma4SlidingRestoreLimitOverride::Uncapped)
+        );
 
         assert_eq!(
             super::gemma4_large_sliding_restore_suppression_limit_for_override(
-                Some(32_768),
+                &cfg,
+                16,
+                Some(super::Gemma4SlidingRestoreLimitOverride::Cap(32_768)),
                 32_768
             ),
             None
         );
         assert_eq!(
             super::gemma4_large_sliding_restore_suppression_limit_for_override(
-                Some(32_768),
+                &cfg,
+                16,
+                Some(super::Gemma4SlidingRestoreLimitOverride::Cap(32_768)),
                 44_512
             ),
-            Some(32_768)
+            Some(super::Gemma4SlidingRestoreSuppression {
+                limit: 32_768,
+                source: "env"
+            })
+        );
+        assert_eq!(
+            super::gemma4_large_sliding_restore_suppression_limit_for_override(
+                &cfg,
+                16,
+                Some(super::Gemma4SlidingRestoreLimitOverride::Uncapped),
+                1_000_000
+            ),
+            None
         );
     }
 
@@ -7753,6 +8331,65 @@ mod tests {
         assert_eq!(cfg.use_block_paged_cache, Some(true));
     }
 
+    #[test]
+    fn test_default_paged_cache_memory_covers_gemma4_full_context() {
+        let memory_mb = super::gemma4_default_paged_cache_memory_mb(131_072, 16, 512, 2, 5);
+        assert_eq!(
+            memory_mb, 2560,
+            "Gemma4 26B-A4B global KV cache needs 2560MiB to cover 128k tokens"
+        );
+
+        let cfg = mlx_paged_attn::PagedAttentionConfig {
+            block_size: 16,
+            gpu_memory_mb: memory_mb,
+            head_size: 512,
+            num_kv_heads: 2,
+            num_layers: 5,
+            use_fp8_cache: Some(false),
+            max_seq_len: Some(131_072),
+            max_batch_size: Some(32),
+        };
+        assert_eq!(cfg.calculate_num_blocks(), 8192);
+        assert_eq!(cfg.max_cached_tokens(), 131_072);
+
+        let undersized_cfg = mlx_paged_attn::PagedAttentionConfig {
+            gpu_memory_mb: 2048,
+            ..cfg
+        };
+        assert!(
+            undersized_cfg.max_cached_tokens() < 124_920,
+            "the previous fixed 2048MiB default cannot hold the failed 124,920-token prompt"
+        );
+    }
+
+    #[test]
+    fn test_default_paged_cache_memory_respects_minimum() {
+        assert_eq!(
+            super::gemma4_default_paged_cache_memory_mb(128, 16, 32, 2, 2),
+            256
+        );
+    }
+
+    #[test]
+    fn test_context_limited_max_new_tokens_clamps_to_remaining_window() {
+        assert_eq!(
+            super::gemma4_context_limited_max_new_tokens(128_000, 124_920, 131_072)
+                .expect("limit max_new_tokens"),
+            6_152
+        );
+        assert_eq!(
+            super::gemma4_context_limited_max_new_tokens(2048, 1_000, 131_072)
+                .expect("unchanged max_new_tokens"),
+            2048
+        );
+        assert_eq!(
+            super::gemma4_context_limited_max_new_tokens(-1, 1_000, 131_072)
+                .expect("negative max_new_tokens"),
+            0
+        );
+        assert!(super::gemma4_context_limited_max_new_tokens(1, 131_073, 131_072).is_err());
+    }
+
     /// Explicit opt-out (`Some(false)`) must NOT allocate the block-paged
     /// adapter. The previous "None means no adapter" assertion was removed
     /// when the default flipped from `unwrap_or(false)` to `unwrap_or(true)`
@@ -7993,7 +8630,7 @@ mod tests {
             }
         }
 
-        let last_logits = match inner.run_paged_prefill_chunk(&prompt, &prompt, 0, false) {
+        let last_logits = match inner.run_paged_prefill_chunk(&prompt, &prompt, 0, 0) {
             Ok(l) => l,
             Err(e) => {
                 let msg = e.reason.to_string();
@@ -8198,8 +8835,8 @@ mod tests {
             None,
         );
         assert_eq!(
-            checkpoint_limit, 32,
-            "512-token sliding window with 16-token blocks should retain 32 decode checkpoints"
+            checkpoint_limit, 64,
+            "512-token sliding window with 16-token blocks should retain two windows of decode checkpoints"
         );
         let target_tokens: Vec<u32> = (3000..3016).collect();
         let target_hash = super::compute_gemma4_paged_prefix_block_hash(
@@ -8259,6 +8896,278 @@ mod tests {
             restored.is_some(),
             "decode checkpoints must retain one sliding-window worth of retokenization drift"
         );
+    }
+
+    #[test]
+    fn test_gemma4_decode_checkpoint_retains_auxiliary_branch_interleaving() {
+        let mut cfg = paged_tiny_config(Some(true));
+        cfg.sliding_window = 1024;
+        let mut inner = match super::Gemma4Inner::new(cfg) {
+            Ok(i) => i,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("No Metal device found") {
+                    eprintln!("skipping (no Metal device): {msg}");
+                    return;
+                }
+                panic!("unexpected Gemma4Inner::new failure: {msg}");
+            }
+        };
+
+        let block_size = 16;
+        let checkpoint_limit = super::gemma4_sliding_prefix_checkpoint_limit_for_override(
+            &inner.config,
+            block_size,
+            None,
+        );
+        assert_eq!(
+            checkpoint_limit, 128,
+            "1024-token sliding window with 16-token blocks should retain two windows"
+        );
+        let target_tokens: Vec<u32> = (10_000..10_016).collect();
+        let target_hash = super::compute_gemma4_paged_prefix_block_hash(
+            &target_tokens,
+            target_tokens.len() as u32,
+            block_size,
+            0,
+        )
+        .expect("target hash");
+        inner
+            .sliding_prefix_checkpoints
+            .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                prefix_len: target_tokens.len() as u32,
+                block_size,
+                final_block_hash: target_hash,
+                tokens: target_tokens.clone(),
+                snapshots: vec![None; inner.config.num_hidden_layers as usize],
+            });
+
+        // The 2026-05-09 live trace stored the needed 48,416-token
+        // checkpoint, then 93 checkpoints from auxiliary 29k/33k branches
+        // before the main branch asked for 48,416 again. A one-window FIFO
+        // cap evicted it; two windows retains it without unbounded growth.
+        for i in 0..93 {
+            let token_base = 20_000 + (i as u32 * block_size);
+            let tokens: Vec<u32> = (0..block_size).map(|token| token_base + token).collect();
+            let hash = super::compute_gemma4_paged_prefix_block_hash(
+                &tokens,
+                tokens.len() as u32,
+                block_size,
+                0,
+            )
+            .expect("newer hash");
+            inner
+                .sliding_prefix_checkpoints
+                .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                    prefix_len: tokens.len() as u32,
+                    block_size,
+                    final_block_hash: hash,
+                    tokens,
+                    snapshots: vec![None; inner.config.num_hidden_layers as usize],
+                });
+            super::trim_gemma4_sliding_prefix_checkpoints(
+                &mut inner.sliding_prefix_checkpoints,
+                checkpoint_limit,
+                false,
+            );
+        }
+
+        let restored = inner
+            .find_gemma4_sliding_prefix_checkpoint(
+                &target_tokens,
+                target_tokens.len() as u32,
+                block_size,
+                0,
+            )
+            .expect("prefix lookup");
+        assert!(
+            restored.is_some(),
+            "decode checkpoints must survive auxiliary branch interleaving seen in live sessions"
+        );
+    }
+
+    #[test]
+    fn test_gemma4_sliding_decode_checkpoint_interval_uses_window_stride() {
+        let mut cfg = paged_tiny_config(Some(true));
+        cfg.sliding_window = 1024;
+        assert_eq!(
+            super::gemma4_sliding_decode_checkpoint_interval(&cfg, 16),
+            1024
+        );
+
+        cfg.sliding_window = 1000;
+        assert_eq!(
+            super::gemma4_sliding_decode_checkpoint_interval(&cfg, 16),
+            1008,
+            "checkpoint interval should stay aligned to paged block boundaries"
+        );
+    }
+
+    #[test]
+    fn test_gemma4_sliding_prefix_checkpoint_restores_nearest_prefix() {
+        let cfg = paged_tiny_config(Some(true));
+        let mut inner = match super::Gemma4Inner::new(cfg) {
+            Ok(i) => i,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("No Metal device found") {
+                    eprintln!("skipping (no Metal device): {msg}");
+                    return;
+                }
+                panic!("unexpected Gemma4Inner::new failure: {msg}");
+            }
+        };
+
+        let block_size = 16;
+        let tokens: Vec<u32> = (0..1280).map(|token| 50_000 + token).collect();
+        let checkpoint_len = 1024;
+        let checkpoint_hash =
+            super::compute_gemma4_paged_prefix_block_hash(&tokens, checkpoint_len, block_size, 0)
+                .expect("checkpoint hash");
+        inner
+            .sliding_prefix_checkpoints
+            .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                prefix_len: checkpoint_len,
+                block_size,
+                final_block_hash: checkpoint_hash,
+                tokens: tokens[..checkpoint_len as usize].to_vec(),
+                snapshots: vec![None; inner.config.num_hidden_layers as usize],
+            });
+
+        let hit = inner
+            .find_gemma4_sliding_prefix_checkpoint(&tokens, tokens.len() as u32, block_size, 0)
+            .expect("prefix lookup")
+            .expect("nearest checkpoint hit");
+        assert_eq!(hit.prefix_len, checkpoint_len);
+    }
+
+    #[test]
+    fn test_gemma4_mid_prompt_prefix_hit_uses_near_prefill_checkpoint() {
+        let mut cfg = paged_tiny_config(Some(true));
+        cfg.sliding_window = 1024;
+        let mut inner = match super::Gemma4Inner::new(cfg) {
+            Ok(i) => i,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("No Metal device found") {
+                    eprintln!("skipping (no Metal device): {msg}");
+                    return;
+                }
+                panic!("unexpected Gemma4Inner::new failure: {msg}");
+            }
+        };
+
+        let block_size = 16;
+        let cached_prefix_len = 24_352;
+        let checkpoint_len = 23_552;
+        let tokens: Vec<u32> = (0..cached_prefix_len).map(|token| 90_000 + token).collect();
+        let checkpoint_hash =
+            super::compute_gemma4_paged_prefix_block_hash(&tokens, checkpoint_len, block_size, 0)
+                .expect("checkpoint hash");
+        inner
+            .sliding_prefix_checkpoints
+            .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                prefix_len: checkpoint_len,
+                block_size,
+                final_block_hash: checkpoint_hash,
+                tokens: tokens[..checkpoint_len as usize].to_vec(),
+                snapshots: vec![None; inner.config.num_hidden_layers as usize],
+            });
+
+        let hit = inner
+            .find_gemma4_sliding_prefix_checkpoint(&tokens, cached_prefix_len, block_size, 0)
+            .expect("prefix lookup")
+            .expect("near checkpoint hit");
+        assert_eq!(hit.prefix_len, checkpoint_len);
+        assert_eq!(cached_prefix_len - hit.prefix_len, 800);
+        assert_eq!(
+            super::gemma4_large_sliding_restore_suppression_limit(
+                &inner.config,
+                block_size,
+                cached_prefix_len - hit.prefix_len
+            ),
+            None,
+            "a one-window prefill checkpoint should prevent cold-prefill suppression"
+        );
+    }
+
+    #[test]
+    fn test_gemma4_window_stride_checkpoints_retain_old_branch_prefix() {
+        let mut cfg = paged_tiny_config(Some(true));
+        cfg.sliding_window = 1024;
+        let mut inner = match super::Gemma4Inner::new(cfg) {
+            Ok(i) => i,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("No Metal device found") {
+                    eprintln!("skipping (no Metal device): {msg}");
+                    return;
+                }
+                panic!("unexpected Gemma4Inner::new failure: {msg}");
+            }
+        };
+
+        let block_size = 16;
+        let target_len = 36_096;
+        let target_tokens: Vec<u32> = (0..target_len).map(|token| 70_000 + token).collect();
+        let target_hash = super::compute_gemma4_paged_prefix_block_hash(
+            &target_tokens,
+            target_len,
+            block_size,
+            0,
+        )
+        .expect("target hash");
+        inner
+            .sliding_prefix_checkpoints
+            .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                prefix_len: target_len,
+                block_size,
+                final_block_hash: target_hash,
+                tokens: target_tokens.clone(),
+                snapshots: vec![None; inner.config.num_hidden_layers as usize],
+            });
+
+        let checkpoint_limit = super::gemma4_sliding_prefix_checkpoint_limit_for_override(
+            &inner.config,
+            block_size,
+            None,
+        );
+        let interval = super::gemma4_sliding_decode_checkpoint_interval(&inner.config, block_size);
+        assert_eq!(interval, 1024);
+        assert_eq!(checkpoint_limit, 128);
+
+        for i in 0..96 {
+            let prefix_len = 80_000 + i as u32 * interval;
+            let tokens: Vec<u32> = (0..prefix_len).map(|token| 200_000 + token).collect();
+            let hash =
+                super::compute_gemma4_paged_prefix_block_hash(&tokens, prefix_len, block_size, 0)
+                    .expect("newer hash");
+            inner
+                .sliding_prefix_checkpoints
+                .push_back(super::Gemma4SlidingPrefixCheckpoint {
+                    prefix_len,
+                    block_size,
+                    final_block_hash: hash,
+                    tokens,
+                    snapshots: vec![None; inner.config.num_hidden_layers as usize],
+                });
+            super::trim_gemma4_sliding_prefix_checkpoints(
+                &mut inner.sliding_prefix_checkpoints,
+                checkpoint_limit,
+                false,
+            );
+        }
+
+        let hit = inner
+            .find_gemma4_sliding_prefix_checkpoint(
+                &target_tokens,
+                target_tokens.len() as u32,
+                block_size,
+                0,
+            )
+            .expect("prefix lookup")
+            .expect("old branch checkpoint hit");
+        assert_eq!(hit.prefix_len, target_len);
     }
 
     /// KV-shared layers must resolve their anchor's pool slot

--- a/crates/mlx-core/src/models/gemma4/output_parser.rs
+++ b/crates/mlx-core/src/models/gemma4/output_parser.rs
@@ -4,6 +4,8 @@
 //!
 //! * `<|channel>thought\n...\n<channel|>` — reasoning/"chain-of-thought" block
 //! * `<|tool_call>call:NAME{K:V,K:V,...}<tool_call|>` — zero or more tool calls
+//! * `<|turn>role\n...\n<turn|>` — chat-template turn framing, stripped
+//!   defensively if the decode includes it.
 //! * `<|tool_response>...<tool_response|>`, `<|tool>...<tool|>` — input-only
 //!   tokens that should not appear on the model's output; this module still
 //!   strips them defensively if it ever sees them so they never leak through
@@ -47,6 +49,8 @@ const CHANNEL_OPEN: &str = "<|channel>";
 const CHANNEL_CLOSE: &str = "<channel|>";
 const TOOL_CALL_OPEN: &str = "<|tool_call>";
 const TOOL_CALL_CLOSE: &str = "<tool_call|>";
+const TURN_OPEN: &str = "<|turn>";
+const TURN_CLOSE: &str = "<turn|>";
 /// Input-only token — stripped defensively on output.
 const TOOL_RESPONSE_OPEN: &str = "<|tool_response>";
 /// Input-only token — stripped defensively on output.
@@ -58,10 +62,29 @@ const TOOL_CLOSE: &str = "<tool|>";
 /// String-delimiter used inside the DSL: `<|"|>str<|"|>`.
 const DSL_STRING_DELIM: &str = "<|\"|>";
 
-/// The set of opening delimiters the stream parser must watch for. Ordered
-/// longest-first so an in-progress prefix of a longer token is preferred
-/// over a shorter prefix that is always ambiguous (e.g. a literal `<`).
-const OPEN_MARKERS: &[&str] = &[TOOL_RESPONSE_OPEN, TOOL_CALL_OPEN, CHANNEL_OPEN, TOOL_OPEN];
+/// Closing delimiters are normally consumed only after their matching open
+/// marker. Keep watching for them in message state too so a malformed
+/// generation or a prompt/template mismatch cannot leak a bare structural
+/// close token into the user-visible text stream.
+const CLOSE_MARKERS: &[&str] = &[
+    TURN_CLOSE,
+    TOOL_RESPONSE_CLOSE,
+    TOOL_CALL_CLOSE,
+    CHANNEL_CLOSE,
+    TOOL_CLOSE,
+];
+const MESSAGE_MARKERS: &[&str] = &[
+    TURN_OPEN,
+    TURN_CLOSE,
+    TOOL_RESPONSE_OPEN,
+    TOOL_RESPONSE_CLOSE,
+    TOOL_CALL_OPEN,
+    TOOL_CALL_CLOSE,
+    CHANNEL_OPEN,
+    CHANNEL_CLOSE,
+    TOOL_OPEN,
+    TOOL_CLOSE,
+];
 
 // ---------------------------------------------------------------------------
 // DSL parsing
@@ -543,15 +566,15 @@ impl Gemma4StreamParser {
         }
     }
 
-    /// Message state: emit plain text up to the next opening marker, or
+    /// Message state: emit plain text up to the next marker, or
     /// buffer a possible partial marker at the tail. Returns `true` if
     /// the state transitioned (another iteration of the outer loop is
     /// needed) or the buffer is fully drained; `false` if we're waiting
     /// for more input.
     fn drain_until_open_marker(&mut self, out: &mut Vec<StreamSegment>, flushing: bool) -> bool {
-        // Search for the earliest opening marker.
+        // Search for the earliest message-state marker.
         let mut best: Option<(usize, &'static str)> = None;
-        for marker in OPEN_MARKERS {
+        for marker in MESSAGE_MARKERS {
             if let Some(idx) = self.pending.find(marker) {
                 match best {
                     Some((bi, _)) if bi <= idx => {}
@@ -567,6 +590,10 @@ impl Gemma4StreamParser {
             }
             // Consume the marker.
             self.pending.drain(..marker.len());
+            if CLOSE_MARKERS.contains(&marker) {
+                // Stray close marker. Drop it and keep scanning in Message.
+                return true;
+            }
             self.state = match marker {
                 m if m == CHANNEL_OPEN => {
                     self.saw_channel = true;
@@ -585,7 +612,8 @@ impl Gemma4StreamParser {
                     close: TOOL_RESPONSE_CLOSE,
                 },
                 m if m == TOOL_OPEN => StreamState::Swallow { close: TOOL_CLOSE },
-                _ => unreachable!("OPEN_MARKERS entry without matching branch"),
+                m if m == TURN_OPEN => StreamState::Swallow { close: "\n" },
+                _ => unreachable!("MESSAGE_MARKERS entry without matching branch"),
             };
             return true;
         }
@@ -599,7 +627,7 @@ impl Gemma4StreamParser {
             }
             return false;
         }
-        let hold = longest_prefix_hold(&self.pending, OPEN_MARKERS);
+        let hold = longest_prefix_hold(&self.pending, MESSAGE_MARKERS);
         if hold > 0 {
             let emit_len = self.pending.len() - hold;
             if emit_len > 0 {
@@ -1292,6 +1320,53 @@ mod tests {
             "short body that isn't the full label passes through unchanged",
         );
         assert_eq!(parser.thinking().as_deref(), Some("tho"));
+    }
+
+    #[test]
+    fn stream_parser_swallows_stray_close_markers_in_message_state() {
+        let mut parser = Gemma4StreamParser::new();
+        let mut all = Vec::new();
+        all.extend(parser.feed("before<chan"));
+        all.extend(parser.feed("nel|>middle<tool_call|>after"));
+        all.extend(parser.flush());
+
+        let text: String = all
+            .iter()
+            .filter_map(|s| {
+                if let StreamSegment::Text(t) = s {
+                    Some(t.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(text, "beforemiddleafter");
+        assert!(parser.thinking().is_none());
+        assert!(parser.tool_calls().is_empty());
+    }
+
+    #[test]
+    fn stream_parser_swallows_stray_turn_markers_in_message_state() {
+        let mut parser = Gemma4StreamParser::new();
+        let mut all = Vec::new();
+        all.extend(parser.feed("before<tu"));
+        all.extend(parser.feed("rn|>middle<|tu"));
+        all.extend(parser.feed("rn>model\ninside<turn|>after"));
+        all.extend(parser.flush());
+
+        let text: String = all
+            .iter()
+            .filter_map(|s| {
+                if let StreamSegment::Text(t) = s {
+                    Some(t.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(text, "beforemiddleinsideafter");
+        assert!(parser.thinking().is_none());
+        assert!(parser.tool_calls().is_empty());
     }
 
     #[test]

--- a/crates/mlx-core/src/models/gemma4/output_parser.rs
+++ b/crates/mlx-core/src/models/gemma4/output_parser.rs
@@ -85,6 +85,7 @@ const MESSAGE_MARKERS: &[&str] = &[
     TOOL_OPEN,
     TOOL_CLOSE,
 ];
+const TOOL_CALL_CLOSE_MARKERS: &[&str] = &[TOOL_CALL_CLOSE, TURN_CLOSE];
 
 // ---------------------------------------------------------------------------
 // DSL parsing
@@ -249,6 +250,7 @@ impl<'a> DslParser<'a> {
             _ if bytes_starts_with(self.src, self.pos, DSL_STRING_DELIM) => {
                 self.parse_quoted_string().map(Value::String)
             }
+            Some(b'"') => self.parse_json_quoted_string().map(Value::String),
             _ => self.parse_bare_value(),
         }
     }
@@ -304,6 +306,41 @@ impl<'a> DslParser<'a> {
         Ok(body.to_string())
     }
 
+    fn parse_json_quoted_string(&mut self) -> Result<String, DslParseError> {
+        let start = self.pos;
+        self.pos += 1; // opening quote
+        let bytes = self.src.as_bytes();
+        let mut escaped = false;
+        while self.pos < bytes.len() {
+            let b = bytes[self.pos];
+            if escaped {
+                escaped = false;
+                self.pos += 1;
+                continue;
+            }
+            if b == b'\\' {
+                escaped = true;
+                self.pos += 1;
+                continue;
+            }
+            if b == b'"' {
+                self.pos += 1;
+                let raw = &self.src[start..self.pos];
+                return serde_json::from_str::<String>(raw).map_err(|e| {
+                    DslParseError(format!(
+                        "invalid quoted string at position {}: {}",
+                        start, e
+                    ))
+                });
+            }
+            self.pos += 1;
+        }
+        Err(DslParseError(format!(
+            "unterminated quoted string at position {}",
+            start
+        )))
+    }
+
     /// Parse a bare value — number, bool, null, or bare string. A bare
     /// string runs up to the next `,`, `}`, or `]` at the current nesting
     /// level (which is always 0 inside this helper, since nested objects /
@@ -332,19 +369,29 @@ fn bare_scalar_to_json(raw: &str) -> Value {
     match raw {
         "true" => Value::Bool(true),
         "false" => Value::Bool(false),
-        "null" => Value::Null,
+        _ if raw.eq_ignore_ascii_case("null")
+            || raw.eq_ignore_ascii_case("none")
+            || raw.eq_ignore_ascii_case("nil") =>
+        {
+            Value::Null
+        }
         _ => {
-            // Try integer first to preserve precision for large ints.
-            if let Ok(n) = raw.parse::<i64>() {
-                return Value::from(n);
-            }
-            if let Ok(n) = raw.parse::<u64>() {
-                return Value::from(n);
-            }
-            if let Ok(f) = raw.parse::<f64>()
-                && let Some(n) = serde_json::Number::from_f64(f)
-            {
-                return Value::Number(n);
+            if raw.contains('.') {
+                if let Ok(f) = raw.parse::<f64>()
+                    && let Some(n) = serde_json::Number::from_f64(f)
+                {
+                    return Value::Number(n);
+                }
+            } else {
+                // Try integer first to preserve precision for large ints. Match
+                // vLLM's scanner by leaving exponent-only values like `1e3` as
+                // strings unless they include a decimal point.
+                if let Ok(n) = raw.parse::<i64>() {
+                    return Value::from(n);
+                }
+                if let Ok(n) = raw.parse::<u64>() {
+                    return Value::from(n);
+                }
             }
             Value::String(raw.to_string())
         }
@@ -421,6 +468,11 @@ enum StreamState {
     /// Inside a `<|channel>...<channel|>` block. Bytes flow out as
     /// `Reasoning` segments and accumulate into `thinking`.
     Channel,
+    /// Some Gemma4 generations omit the `<|channel>` opener and start with the
+    /// fixed channel label (`thought\n`) before a tool call. Treat everything
+    /// after that bare label as provisional reasoning until a structural marker
+    /// or end-of-stream proves where the segment ends.
+    BareChannel,
     /// Inside a `<|tool_call>...<tool_call|>` block. Bytes are buffered in
     /// `tool_call_buf` until the closing marker is seen, then parsed and
     /// emitted as a single `ToolCall` segment.
@@ -552,6 +604,11 @@ impl Gemma4StreamParser {
                         return;
                     }
                 }
+                StreamState::BareChannel => {
+                    if !self.drain_bare_channel(out, flushing) {
+                        return;
+                    }
+                }
                 StreamState::ToolCall => {
                     if !self.drain_tool_call(out, flushing) {
                         return;
@@ -583,38 +640,20 @@ impl Gemma4StreamParser {
             }
         }
 
+        if best.is_none()
+            && let Some(entered) = self.maybe_enter_bare_channel(flushing)
+        {
+            return entered;
+        }
+
         if let Some((idx, marker)) = best {
             if idx > 0 {
                 let prefix: String = self.pending.drain(..idx).collect();
-                out.push(StreamSegment::Text(prefix));
+                self.emit_message_prefix_before_marker(out, prefix, marker);
             }
             // Consume the marker.
             self.pending.drain(..marker.len());
-            if CLOSE_MARKERS.contains(&marker) {
-                // Stray close marker. Drop it and keep scanning in Message.
-                return true;
-            }
-            self.state = match marker {
-                m if m == CHANNEL_OPEN => {
-                    self.saw_channel = true;
-                    // Fresh channel block — arm the label stripper so
-                    // the first reasoning emit consumes the hardcoded
-                    // `thought\n` label the chat template re-emits on
-                    // echo. See `strip_channel_label`.
-                    self.channel_label_stripped = false;
-                    StreamState::Channel
-                }
-                m if m == TOOL_CALL_OPEN => {
-                    self.tool_call_buf.clear();
-                    StreamState::ToolCall
-                }
-                m if m == TOOL_RESPONSE_OPEN => StreamState::Swallow {
-                    close: TOOL_RESPONSE_CLOSE,
-                },
-                m if m == TOOL_OPEN => StreamState::Swallow { close: TOOL_CLOSE },
-                m if m == TURN_OPEN => StreamState::Swallow { close: "\n" },
-                _ => unreachable!("MESSAGE_MARKERS entry without matching branch"),
-            };
+            self.transition_after_message_marker(marker);
             return true;
         }
 
@@ -639,6 +678,85 @@ impl Gemma4StreamParser {
             out.push(StreamSegment::Text(emit));
         }
         false
+    }
+
+    fn emit_message_prefix_before_marker(
+        &mut self,
+        out: &mut Vec<StreamSegment>,
+        prefix: String,
+        marker: &'static str,
+    ) {
+        if marker == TOOL_CALL_OPEN
+            && let Some(body) = strip_bare_thought_label(&prefix)
+        {
+            self.saw_channel = true;
+            self.channel_label_stripped = true;
+            self.emit_reasoning(out, body.to_string());
+            return;
+        }
+        out.push(StreamSegment::Text(prefix));
+    }
+
+    fn maybe_enter_bare_channel(&mut self, flushing: bool) -> Option<bool> {
+        const BARE_THOUGHT_LABEL: &str = "thought";
+        if !flushing && !self.pending.is_empty() && BARE_THOUGHT_LABEL.starts_with(&self.pending) {
+            return Some(false);
+        }
+        if !self.pending.starts_with(BARE_THOUGHT_LABEL) {
+            return None;
+        }
+
+        let Some(separator_len) = bare_thought_label_separator_len(&self.pending) else {
+            if !flushing && self.pending.len() == BARE_THOUGHT_LABEL.len() {
+                return Some(false);
+            }
+            return None;
+        };
+        if separator_len == 0 {
+            if !flushing {
+                return Some(false);
+            }
+            return None;
+        }
+        if !flushing && self.pending.len() == BARE_THOUGHT_LABEL.len() {
+            return Some(false);
+        }
+
+        self.pending
+            .drain(..BARE_THOUGHT_LABEL.len() + separator_len);
+        self.saw_channel = true;
+        self.channel_label_stripped = true;
+        self.state = StreamState::BareChannel;
+        Some(true)
+    }
+
+    fn transition_after_message_marker(&mut self, marker: &'static str) {
+        if CLOSE_MARKERS.contains(&marker) {
+            // Stray close marker. Drop it and keep scanning in Message.
+            self.state = StreamState::Message;
+            return;
+        }
+        self.state = match marker {
+            m if m == CHANNEL_OPEN => {
+                self.saw_channel = true;
+                // Fresh channel block — arm the label stripper so
+                // the first reasoning emit consumes the hardcoded
+                // `thought\n` label the chat template re-emits on
+                // echo. See `strip_channel_label`.
+                self.channel_label_stripped = false;
+                StreamState::Channel
+            }
+            m if m == TOOL_CALL_OPEN => {
+                self.tool_call_buf.clear();
+                StreamState::ToolCall
+            }
+            m if m == TOOL_RESPONSE_OPEN => StreamState::Swallow {
+                close: TOOL_RESPONSE_CLOSE,
+            },
+            m if m == TOOL_OPEN => StreamState::Swallow { close: TOOL_CLOSE },
+            m if m == TURN_OPEN => StreamState::Swallow { close: "\n" },
+            _ => unreachable!("MESSAGE_MARKERS entry without matching branch"),
+        };
     }
 
     /// Emit a reasoning chunk, stripping the hardcoded `thought\n`
@@ -740,14 +858,58 @@ impl Gemma4StreamParser {
         false
     }
 
+    fn drain_bare_channel(&mut self, out: &mut Vec<StreamSegment>, flushing: bool) -> bool {
+        let mut best: Option<(usize, &'static str)> = None;
+        for marker in MESSAGE_MARKERS {
+            if let Some(idx) = self.pending.find(marker) {
+                match best {
+                    Some((bi, _)) if bi <= idx => {}
+                    _ => best = Some((idx, marker)),
+                }
+            }
+        }
+
+        if let Some((idx, marker)) = best {
+            if idx > 0 {
+                let body: String = self.pending.drain(..idx).collect();
+                self.emit_reasoning(out, body);
+            }
+            self.pending.drain(..marker.len());
+            self.transition_after_message_marker(marker);
+            return true;
+        }
+
+        if flushing {
+            if !self.pending.is_empty() {
+                let body = std::mem::take(&mut self.pending);
+                self.emit_reasoning(out, body);
+            }
+            self.state = StreamState::Message;
+            return false;
+        }
+
+        let hold = longest_prefix_hold(&self.pending, MESSAGE_MARKERS);
+        if hold == self.pending.len() {
+            return false;
+        }
+        let emit_len = self.pending.len() - hold;
+        if emit_len > 0 {
+            let body: String = self.pending.drain(..emit_len).collect();
+            self.emit_reasoning(out, body);
+        }
+        false
+    }
+
     /// Drain bytes in the tool-call state: accumulate into `tool_call_buf`
     /// until the closing marker is seen, then parse and emit a single
     /// `ToolCall` segment. Bytes do NOT stream out incrementally — a
     /// partial tool call is useless without its closing brace.
     fn drain_tool_call(&mut self, out: &mut Vec<StreamSegment>, flushing: bool) -> bool {
-        if let Some(idx) = self.pending.find(TOOL_CALL_CLOSE) {
+        if let Some((idx, close_marker)) =
+            find_earliest_marker(&self.pending, TOOL_CALL_CLOSE_MARKERS)
+        {
             let body: String = self.pending.drain(..idx).collect();
-            self.pending.drain(..TOOL_CALL_CLOSE.len());
+            self.pending.drain(..close_marker.len());
             self.tool_call_buf.push_str(&body);
             let raw = std::mem::take(&mut self.tool_call_buf);
             let tc = parse_tool_call_body(&raw);
@@ -765,7 +927,7 @@ impl Gemma4StreamParser {
             self.state = StreamState::Message;
             return false;
         }
-        let hold = longest_prefix_hold(&self.pending, &[TOOL_CALL_CLOSE]);
+        let hold = longest_prefix_hold(&self.pending, TOOL_CALL_CLOSE_MARKERS);
         if hold == self.pending.len() {
             return false;
         }
@@ -805,6 +967,26 @@ fn strip_channel_label(body: &str) -> &str {
     body.strip_prefix(THOUGHT_LABEL).unwrap_or(body)
 }
 
+fn bare_thought_label_separator_len(body: &str) -> Option<usize> {
+    const THOUGHT_LABEL: &str = "thought";
+    let rest = body.strip_prefix(THOUGHT_LABEL)?;
+    if rest.starts_with("\r\n") {
+        Some(2)
+    } else if rest.starts_with('\n') || rest.starts_with('\r') {
+        Some(1)
+    } else if rest.is_empty() {
+        Some(0)
+    } else {
+        None
+    }
+}
+
+fn strip_bare_thought_label(body: &str) -> Option<&str> {
+    const THOUGHT_LABEL: &str = "thought";
+    let separator_len = bare_thought_label_separator_len(body)?;
+    Some(&body[THOUGHT_LABEL.len() + separator_len..])
+}
+
 /// Longest suffix of `buf` that is a non-empty prefix of any marker in
 /// `markers`. Used by the stream parser to hold back ambiguous tail bytes
 /// across feed boundaries.
@@ -825,6 +1007,19 @@ fn longest_prefix_hold(buf: &str, markers: &[&str]) -> usize {
         }
     }
     0
+}
+
+fn find_earliest_marker<'a>(buf: &str, markers: &'a [&'static str]) -> Option<(usize, &'a str)> {
+    let mut best: Option<(usize, &'a str)> = None;
+    for marker in markers {
+        if let Some(idx) = buf.find(marker) {
+            match best {
+                Some((best_idx, _)) if best_idx <= idx => {}
+                _ => best = Some((idx, *marker)),
+            }
+        }
+    }
+    best
 }
 
 /// Parse the body of a tool-call block: `call:NAME{K:V,...}`.
@@ -982,6 +1177,27 @@ mod tests {
     }
 
     #[test]
+    fn parse_tool_call_accepts_dotted_and_hyphenated_name() {
+        let parsed = parse_gemma4_output("<|tool_call>call:my-tool.search{query:test}<tool_call|>");
+
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(parsed.tool_calls[0].name, "my-tool.search");
+        let args = parsed.tool_calls[0].arguments.as_object().unwrap();
+        assert_eq!(args.get("query").and_then(|v| v.as_str()), Some("test"));
+    }
+
+    #[test]
+    fn parse_tool_call_accepts_turn_close_marker() {
+        let parsed = parse_gemma4_output("<|tool_call>call:bash{command:ls}<turn|>");
+
+        assert_eq!(parsed.text, "");
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(parsed.tool_calls[0].name, "bash");
+        let args = parsed.tool_calls[0].arguments.as_object().unwrap();
+        assert_eq!(args.get("command").and_then(|v| v.as_str()), Some("ls"));
+    }
+
+    #[test]
     fn parse_tool_call_with_array() {
         let parsed = parse_gemma4_output(
             "<|tool_call>call:edit{path:/a,edits:[{oldText:x,newText:y}]}<tool_call|>",
@@ -1010,6 +1226,30 @@ mod tests {
         let tc = &parsed.tool_calls[0];
         assert_eq!(tc.name, "bash");
         assert_eq!(tc.status, "ok");
+    }
+
+    #[test]
+    fn parse_bare_thought_before_tool_call_as_reasoning() {
+        let parsed = parse_gemma4_output(
+            "thought\nThe user wants me to inspect logs.\n<|tool_call>call:bash{command:ls}<tool_call|>",
+        );
+
+        assert_eq!(parsed.text, "");
+        assert_eq!(
+            parsed.thinking.as_deref(),
+            Some("The user wants me to inspect logs.")
+        );
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(parsed.tool_calls[0].name, "bash");
+    }
+
+    #[test]
+    fn parse_plain_text_starting_with_thoughtful_stays_text() {
+        let parsed = parse_gemma4_output("thoughtful answer without a tool call");
+
+        assert_eq!(parsed.text, "thoughtful answer without a tool call");
+        assert!(parsed.thinking.is_none());
+        assert!(parsed.tool_calls.is_empty());
     }
 
     #[test]
@@ -1165,6 +1405,30 @@ mod tests {
     }
 
     #[test]
+    fn stream_parser_tool_call_closes_on_split_turn_marker() {
+        let mut parser = Gemma4StreamParser::new();
+        let mut all = Vec::new();
+        all.extend(parser.feed("before<|tool_call>"));
+        all.extend(parser.feed("call:bash{command:ls}<tu"));
+        all.extend(parser.feed("rn|>after"));
+        all.extend(parser.flush());
+
+        let text: String = all
+            .iter()
+            .filter_map(|s| {
+                if let StreamSegment::Text(t) = s {
+                    Some(t.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(text, "beforeafter");
+        assert_eq!(parser.tool_calls().len(), 1);
+        assert_eq!(parser.tool_calls()[0].name, "bash");
+    }
+
+    #[test]
     fn stream_parser_flush_empties_buffer() {
         // Pure trailing text that was never followed by a marker should
         // show up on flush().
@@ -1260,6 +1524,100 @@ mod tests {
             parser.thinking().as_deref(),
             Some("The user wants me to upgrade"),
         );
+    }
+
+    #[test]
+    fn stream_parser_preserves_channel_body_when_thought_prefix_diverges() {
+        let mut parser = Gemma4StreamParser::new();
+        let mut all = Vec::new();
+
+        for chunk in [
+            "<|channel>",
+            "thoughtful output from the model",
+            "\n<channel|>",
+            "rest",
+        ] {
+            all.extend(parser.feed(chunk));
+        }
+        all.extend(parser.flush());
+
+        let reasoning: String = all
+            .iter()
+            .filter_map(|s| {
+                if let StreamSegment::Reasoning(t) = s {
+                    Some(t.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(reasoning, "thoughtful output from the model\n");
+        assert_eq!(
+            parser.thinking().as_deref(),
+            Some("thoughtful output from the model"),
+        );
+    }
+
+    #[test]
+    fn stream_parser_recovers_bare_thought_before_tool_call() {
+        let mut parser = Gemma4StreamParser::new();
+        let mut all = Vec::new();
+
+        for chunk in [
+            "thought",
+            "\n",
+            "The user wants",
+            " me to research.",
+            "\n<|tool_call>",
+            "call:Agent{description:Explore}",
+            "<tool_call|>",
+        ] {
+            all.extend(parser.feed(chunk));
+        }
+        all.extend(parser.flush());
+
+        let text: String = all
+            .iter()
+            .filter_map(|s| {
+                if let StreamSegment::Text(t) = s {
+                    Some(t.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let reasoning: String = all
+            .iter()
+            .filter_map(|s| {
+                if let StreamSegment::Reasoning(t) = s {
+                    Some(t.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(text, "");
+        assert_eq!(reasoning, "The user wants me to research.\n");
+        assert_eq!(
+            parser.thinking().as_deref(),
+            Some("The user wants me to research."),
+        );
+        assert_eq!(parser.tool_calls().len(), 1);
+    }
+
+    #[test]
+    fn stream_parser_keeps_partial_thought_prefix_until_disambiguated() {
+        let mut parser = Gemma4StreamParser::new();
+
+        assert!(parser.feed("tho").is_empty());
+        let all = parser.feed("ughtful answer");
+
+        assert_eq!(all.len(), 1);
+        match &all[0] {
+            StreamSegment::Text(text) => assert_eq!(text, "thoughtful answer"),
+            other => panic!("expected text, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1419,6 +1777,19 @@ mod tests {
         assert_eq!(m.get("active").and_then(|v| v.as_bool()), Some(true));
         assert_eq!(m.get("flag").and_then(|v| v.as_bool()), Some(false));
         assert!(m.get("empty").unwrap().is_null());
+    }
+
+    #[test]
+    fn parse_dsl_args_matches_vllm_scalar_edges() {
+        let v =
+            parse_gemma4_dsl_args(r#"a:none,b:nil,c:NULL,d:1e3,e:1.5,f:"quoted\nvalue""#).unwrap();
+        let m = v.as_object().unwrap();
+        assert!(m.get("a").unwrap().is_null());
+        assert!(m.get("b").unwrap().is_null());
+        assert!(m.get("c").unwrap().is_null());
+        assert_eq!(m.get("d").and_then(|v| v.as_str()), Some("1e3"));
+        assert_eq!(m.get("e").and_then(|v| v.as_f64()), Some(1.5));
+        assert_eq!(m.get("f").and_then(|v| v.as_str()), Some("quoted\nvalue"));
     }
 
     #[test]

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -1307,7 +1307,7 @@ impl Gemma4Inner {
         // references and every decode step re-reads ~48GB from disk.
         {
             let weight_refs: Vec<&MxArray> = params.values().collect();
-            crate::array::memory::materialize_weights(&weight_refs);
+            crate::array::memory::materialize_weights(&weight_refs)?;
         }
 
         // Register weights with C++ compiled forward pass

--- a/crates/mlx-core/src/models/lfm2/attention.rs
+++ b/crates/mlx-core/src/models/lfm2/attention.rs
@@ -298,8 +298,7 @@ impl Lfm2Attention {
                     /* softcap */ 1.0,
                 )
                 .map_err(napi::Error::from_reason)?;
-            // Cast back to x's dtype so the residual stays homogeneous
-            // (gather currently returns Float32).
+            // Cast back to x's dtype so the residual stays homogeneous.
             let target_dtype = x.dtype()?;
             let attn_3d = attn_3d.astype(target_dtype)?;
             // Reshape [1, H, D] -> [1, H, 1, D] for the standard

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -1162,7 +1162,7 @@ impl Lfm2Inner {
             // from the cache pool. Without this the in-flight lazy graph
             // accumulates on long contexts before the post-prefill sync
             // fires. Cadence is `MLX_PAGED_PREFILL_EVAL_INTERVAL` (default 8).
-            crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states);
+            crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states)?;
         }
 
         // Output norm + lm_head.

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -372,7 +372,7 @@ impl Lfm2Inner {
                 let _stream_ctx = StreamContext::new(generation_stream);
                 let _logits = self.forward(&chunk)?;
             }
-            eval_lfm2_caches(&self.caches);
+            eval_lfm2_caches(&self.caches)?;
             crate::array::clear_cache();
             offset += PREFILL_STEP_SIZE;
         }
@@ -600,7 +600,7 @@ impl Lfm2Inner {
         y.eval();
 
         // Eval all caches after prefill
-        eval_lfm2_caches(&self.caches);
+        eval_lfm2_caches(&self.caches)?;
 
         // Mark first token time
         if report_perf {
@@ -1839,7 +1839,7 @@ impl Lfm2Inner {
         let last_logits = apply_all_penalties(last_logits, &token_history, &p)?;
         let mut y = sample(&last_logits, sampling_config)?;
         y.eval();
-        eval_lfm2_caches(&self.caches);
+        eval_lfm2_caches(&self.caches)?;
 
         if report_perf {
             first_token_instant = Some(std::time::Instant::now());
@@ -2181,7 +2181,7 @@ impl Lfm2Inner {
         y.eval();
 
         // Eval all caches after prefill so the prefix is materialized.
-        eval_lfm2_caches(&self.caches);
+        eval_lfm2_caches(&self.caches)?;
 
         if report_perf {
             first_token_instant = Some(std::time::Instant::now());
@@ -2666,7 +2666,7 @@ impl Lfm2Inner {
         let last_logits = apply_all_penalties(last_logits, &token_history, &p)?;
         let mut y = sample(&last_logits, sampling_config)?;
         y.eval();
-        eval_lfm2_caches(&self.caches);
+        eval_lfm2_caches(&self.caches)?;
 
         if report_perf {
             first_token_instant = Some(std::time::Instant::now());
@@ -2945,14 +2945,15 @@ fn init_caches(config: &Lfm2Config) -> Vec<Lfm2LayerCache> {
 const PREFILL_STEP_SIZE: i64 = 2048;
 
 /// Evaluate all cache arrays (after prefill).
-fn eval_lfm2_caches(caches: &[Lfm2LayerCache]) {
+fn eval_lfm2_caches(caches: &[Lfm2LayerCache]) -> Result<()> {
     let mut arrays: Vec<&MxArray> = Vec::new();
     for cache in caches {
         cache.collect_arrays(&mut arrays);
     }
     if !arrays.is_empty() {
-        MxArray::eval_arrays(&arrays);
+        MxArray::eval_arrays(&arrays)?;
     }
+    Ok(())
 }
 
 /// LFM2 language model (LFM2.5-1.2B-Thinking).

--- a/crates/mlx-core/src/models/lfm2/persistence.rs
+++ b/crates/mlx-core/src/models/lfm2/persistence.rs
@@ -427,7 +427,7 @@ impl Lfm2Inner {
         // timeouts. Without this, weights remain as lazy mmap references.
         {
             let weight_refs: Vec<&MxArray> = params.values().collect();
-            crate::array::memory::materialize_weights(&weight_refs);
+            crate::array::memory::materialize_weights(&weight_refs)?;
         }
 
         // NOTE: the cache-limit coordinator registration happens in

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -2755,7 +2755,7 @@ impl Qwen3Inner {
             // from the cache pool. Without this the in-flight lazy graph
             // accumulates ~50 GB on long contexts before the post-prefill
             // sync fires. Cadence is `MLX_PAGED_PREFILL_EVAL_INTERVAL` (default 8).
-            crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states);
+            crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states)?;
         }
         Ok(hidden_states)
     }

--- a/crates/mlx-core/src/models/qwen3/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3/persistence.rs
@@ -604,7 +604,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3Model> {
                     // Materialize all mmap-backed weight arrays
                     {
                         let arrays: Vec<&MxArray> = mapped_params.values().collect();
-                        crate::array::memory::materialize_weights(&arrays);
+                        crate::array::memory::materialize_weights(&arrays)?;
                     }
 
                     // Deterministic weight-byte total for the cache-limit

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -44,14 +44,25 @@ pub struct Qwen3_5Attention {
 fn paged_prefill_paged_attention_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        // Experimental: latest long-context traces show this bridge is slower
-        // than the materialized K/V path on prefill, so keep it opt-in.
         std::env::var("MLX_PAGED_PREFILL_PAGED_ATTENTION")
             .map(|value| {
                 let normalized = value.trim().to_ascii_lowercase();
                 !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
             })
-            .unwrap_or(false)
+            .unwrap_or(true)
+    })
+}
+
+fn native_kv_write_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("MLX_QWEN35_NATIVE_KV_WRITE")
+            .or_else(|_| std::env::var("MLX_NATIVE_KV_WRITE"))
+            .map(|value| {
+                let normalized = value.trim().to_ascii_lowercase();
+                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+            })
+            .unwrap_or(true)
     })
 }
 
@@ -332,14 +343,57 @@ impl Qwen3_5Attention {
             self.head_dim as i64,
         ])?;
 
-        adapter
-            .update_keys_values(
+        let trace_enabled = inference_trace_enabled();
+        let write_trace_start = trace_enabled.then(Instant::now);
+        let write_path = if native_kv_write_enabled() {
+            match adapter.update_keys_values_native(
                 attn_layer_idx,
                 &keys_paged,
                 &values_paged,
                 first_logical_position,
-            )
-            .map_err(napi::Error::from_reason)?;
+            ) {
+                Ok(()) => "native",
+                Err(err) => {
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] qwen3.5-attn paged_kv_write_fallback \
+                             layer={} first_position={} seq_len={} error={}",
+                            attn_layer_idx, first_logical_position, seq_len, err
+                        ));
+                    }
+                    adapter
+                        .update_keys_values(
+                            attn_layer_idx,
+                            &keys_paged,
+                            &values_paged,
+                            first_logical_position,
+                        )
+                        .map_err(napi::Error::from_reason)?;
+                    "legacy"
+                }
+            }
+        } else {
+            adapter
+                .update_keys_values(
+                    attn_layer_idx,
+                    &keys_paged,
+                    &values_paged,
+                    first_logical_position,
+                )
+                .map_err(napi::Error::from_reason)?;
+            "legacy"
+        };
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-attn paged_kv_write_done \
+                 layer={} first_position={} seq_len={} path={} elapsed_ms={:.1}",
+                attn_layer_idx,
+                first_logical_position,
+                seq_len,
+                write_path,
+                write_trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
 
         // Compute attention output.
         let attn_bhtd = if is_prefill {
@@ -369,8 +423,6 @@ impl Qwen3_5Attention {
                 // so the suffix attends directly against the pool without
                 // host-side K/V materialization.
                 let total_ctx = cached_prefix_len + (seq_len as u32);
-                let trace_enabled = inference_trace_enabled();
-
                 let maybe_paged_attn = if batch == 1 && paged_prefill_paged_attention_enabled() {
                     let paged_trace_start = trace_enabled.then(Instant::now);
                     let queries_paged =
@@ -465,30 +517,52 @@ impl Qwen3_5Attention {
                 }
             }
         } else {
-            // Decode: dispatch `gather_kv_for_decode` Metal kernel
-            // directly against the on-GPU paged buffers. Avoids the
-            // per-step host roundtrip (~57 MB per layer per K/V on long
-            // contexts) that `read_kv_range` performs and that was
-            // driving a ~40 GB memory regression in long-context decode
-            // (see Fix #2 spec). Mirrors Qwen3 / Gemma4 / LFM2 paged decode.
-            //
-            // `gather_kv_for_decode` expects `[1, num_query_heads,
-            // head_size]` queries (3-D); squeeze T=1 from `queries_bhtd`
-            // and reshape. Returns `[1, n_heads, head_dim]` which we cast
-            // to x's dtype and reshape to the standard `[B, H, T, D]` tail.
+            // Decode: prefer graph-native paged attention so native K/V
+            // writes and attention reads remain in one MLX dependency graph.
             let queries_3d = queries_bhtd.squeeze(Some(&[2]))?.reshape(&[
                 1,
                 self.num_heads as i64,
                 self.head_dim as i64,
             ])?;
-            let attn_3d = adapter
-                .gather_kv_for_decode(
-                    attn_layer_idx,
-                    &queries_3d,
-                    self.scale,
-                    /* softcap */ 1.0,
-                )
-                .map_err(napi::Error::from_reason)?;
+            let gather_trace_start = trace_enabled.then(Instant::now);
+            let attn_3d = match adapter.gather_kv_for_decode_graph(
+                attn_layer_idx,
+                &queries_3d,
+                self.scale,
+                /* softcap */ 1.0,
+            ) {
+                Ok(attn_3d) => {
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] qwen3.5-attn decode_gather_done \
+                             layer={} path=graph total_ctx={} elapsed_ms={:.1}",
+                            attn_layer_idx,
+                            adapter.current_token_count(),
+                            gather_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                        ));
+                    }
+                    attn_3d
+                }
+                Err(err) => {
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] qwen3.5-attn decode_gather_fallback \
+                             layer={} path=raw total_ctx={} error={}",
+                            attn_layer_idx,
+                            adapter.current_token_count(),
+                            err
+                        ));
+                    }
+                    adapter
+                        .gather_kv_for_decode(
+                            attn_layer_idx,
+                            &queries_3d,
+                            self.scale,
+                            /* softcap */ 1.0,
+                        )
+                        .map_err(napi::Error::from_reason)?
+                }
+            };
             let target_dtype = x.dtype()?;
             let attn_3d = attn_3d.astype(target_dtype)?;
             attn_3d.reshape(&[1, self.num_heads as i64, 1, self.head_dim as i64])?

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 
 use crate::array::MxArray;
 use crate::array::attention::{scaled_dot_product_attention, scaled_dot_product_attention_causal};
+use crate::array::mask::create_causal_mask;
 use crate::inference_trace::{
     elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
 };
@@ -421,7 +422,7 @@ impl Qwen3_5Attention {
                     None
                 };
 
-                let attn = match maybe_paged_attn {
+                match maybe_paged_attn {
                     Some(attn) => attn,
                     None => {
                         let read_trace_start = trace_enabled.then(Instant::now);
@@ -429,32 +430,39 @@ impl Qwen3_5Attention {
                             .read_kv_range(attn_layer_idx, 0, total_ctx)
                             .map_err(napi::Error::from_reason)?;
                         let read_kv_range_ms = read_trace_start.map(elapsed_ms);
+                        let mask_trace_start = trace_enabled.then(Instant::now);
+                        let mask = create_causal_mask(
+                            seq_len as i32,
+                            Some(cached_prefix_len as i32),
+                            None,
+                        )?;
+                        let mask_ms = mask_trace_start.map(elapsed_ms);
                         let sdpa_trace_start = trace_enabled.then(Instant::now);
-                        let attn = scaled_dot_product_attention_causal(
+                        let attn = scaled_dot_product_attention(
                             &queries_bhtd,
                             &k_full,
                             &v_full,
                             self.scale as f64,
+                            Some(&mask),
                         )?;
                         if trace_enabled {
                             write_inference_trace(format_args!(
                                 "[MLX_TRACE] qwen3.5-attn cache_hit_prefill \
                                  layer={} suffix_tokens={} cached_prefix_tokens={} total_ctx={} \
-                                 path=read_kv_range read_kv_range_ms={:.1} mask_ms=0.0 \
-                                 sdpa_mode=causal sdpa_graph_ms={:.1}",
+                                 path=read_kv_range read_kv_range_ms={:.1} mask_ms={:.1} \
+                                 sdpa_mode=explicit_mask sdpa_graph_ms={:.1}",
                                 attn_layer_idx,
                                 seq_len,
                                 cached_prefix_len,
                                 total_ctx,
                                 read_kv_range_ms.unwrap_or(0.0),
+                                mask_ms.unwrap_or(0.0),
                                 sdpa_trace_start.map(elapsed_ms).unwrap_or(0.0)
                             ));
                         }
                         attn
                     }
-                };
-
-                attn
+                }
             }
         } else {
             // Decode: dispatch `gather_kv_for_decode` Metal kernel

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -44,12 +44,10 @@ pub struct Qwen3_5Attention {
 fn paged_prefill_paged_attention_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("MLX_PAGED_PREFILL_PAGED_ATTENTION")
-            .map(|value| {
-                let normalized = value.trim().to_ascii_lowercase();
-                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
-            })
-            .unwrap_or(true)
+        crate::inference_trace::env_flag_enabled_or_default(
+            "MLX_PAGED_PREFILL_PAGED_ATTENTION",
+            true,
+        )
     })
 }
 
@@ -58,10 +56,7 @@ fn native_kv_write_enabled() -> bool {
     *ENABLED.get_or_init(|| {
         std::env::var("MLX_QWEN35_NATIVE_KV_WRITE")
             .or_else(|_| std::env::var("MLX_NATIVE_KV_WRITE"))
-            .map(|value| {
-                let normalized = value.trim().to_ascii_lowercase();
-                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
-            })
+            .map(|value| crate::inference_trace::env_flag_value_enabled(&value))
             .unwrap_or(true)
     })
 }

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -1,6 +1,11 @@
+use std::sync::OnceLock;
+use std::time::Instant;
+
 use crate::array::MxArray;
 use crate::array::attention::{scaled_dot_product_attention, scaled_dot_product_attention_causal};
-use crate::array::mask::create_causal_mask;
+use crate::inference_trace::{
+    elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
+};
 use crate::models::paddleocr_vl::language::{MultimodalRoPE, apply_multimodal_rotary_pos_emb};
 use crate::nn::{Activations, Linear, RMSNorm, RoPE};
 use crate::transformer::KVCache;
@@ -33,6 +38,20 @@ pub struct Qwen3_5Attention {
     num_kv_heads: i32,
     head_dim: i32,
     scale: f32,
+}
+
+fn paged_prefill_paged_attention_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        // Experimental: latest long-context traces show this bridge is slower
+        // than the materialized K/V path on prefill, so keep it opt-in.
+        std::env::var("MLX_PAGED_PREFILL_PAGED_ATTENTION")
+            .map(|value| {
+                let normalized = value.trim().to_ascii_lowercase();
+                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+            })
+            .unwrap_or(false)
+    })
 }
 
 impl Qwen3_5Attention {
@@ -344,20 +363,98 @@ impl Qwen3_5Attention {
                 }
             } else {
                 // Cache-hit prefill: read full [0, total_ctx) K/V back
-                // from the pool. The suffix was just written above.
+                // from the pool. The suffix was just written above. When
+                // explicitly enabled, try the MLX paged-attention bridge first
+                // so the suffix attends directly against the pool without
+                // host-side K/V materialization.
                 let total_ctx = cached_prefix_len + (seq_len as u32);
-                let (k_full, v_full) = adapter
-                    .read_kv_range(attn_layer_idx, 0, total_ctx)
-                    .map_err(napi::Error::from_reason)?;
-                let mask =
-                    create_causal_mask(seq_len as i32, Some(cached_prefix_len as i32), None)?;
-                scaled_dot_product_attention(
-                    &queries_bhtd,
-                    &k_full,
-                    &v_full,
-                    self.scale as f64,
-                    Some(&mask),
-                )?
+                let trace_enabled = inference_trace_enabled();
+
+                let maybe_paged_attn = if batch == 1 && paged_prefill_paged_attention_enabled() {
+                    let paged_trace_start = trace_enabled.then(Instant::now);
+                    let queries_paged =
+                        queries.reshape(&[seq_len, self.num_heads as i64, self.head_dim as i64])?;
+                    match adapter.gather_kv_for_prefill_chunk(
+                        attn_layer_idx,
+                        &queries_paged,
+                        cached_prefix_len,
+                        self.scale,
+                    ) {
+                        Ok(attn_t_h_d) => {
+                            let target_dtype = x.dtype()?;
+                            let attn_t_h_d = attn_t_h_d.astype(target_dtype)?;
+                            let attn = attn_t_h_d.reshape(&[
+                                batch,
+                                seq_len,
+                                self.num_heads as i64,
+                                self.head_dim as i64,
+                            ])?;
+                            let attn = attn.transpose(Some(&[0, 2, 1, 3]))?;
+                            if trace_enabled {
+                                write_inference_trace(format_args!(
+                                    "[MLX_TRACE] qwen3.5-attn cache_hit_prefill \
+                                     layer={} suffix_tokens={} cached_prefix_tokens={} total_ctx={} \
+                                     path=paged_attention bridge_ms={:.1} read_kv_range_ms=0.0 \
+                                     mask_ms=0.0 sdpa_mode=none sdpa_graph_ms=0.0",
+                                    attn_layer_idx,
+                                    seq_len,
+                                    cached_prefix_len,
+                                    total_ctx,
+                                    paged_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                                ));
+                            }
+                            Some(attn)
+                        }
+                        Err(err) => {
+                            if trace_enabled {
+                                write_inference_trace(format_args!(
+                                    "[MLX_TRACE] qwen3.5-attn cache_hit_prefill_paged_fallback \
+                                     layer={} suffix_tokens={} cached_prefix_tokens={} total_ctx={} \
+                                     error={}",
+                                    attn_layer_idx, seq_len, cached_prefix_len, total_ctx, err
+                                ));
+                            }
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                let attn = match maybe_paged_attn {
+                    Some(attn) => attn,
+                    None => {
+                        let read_trace_start = trace_enabled.then(Instant::now);
+                        let (k_full, v_full) = adapter
+                            .read_kv_range(attn_layer_idx, 0, total_ctx)
+                            .map_err(napi::Error::from_reason)?;
+                        let read_kv_range_ms = read_trace_start.map(elapsed_ms);
+                        let sdpa_trace_start = trace_enabled.then(Instant::now);
+                        let attn = scaled_dot_product_attention_causal(
+                            &queries_bhtd,
+                            &k_full,
+                            &v_full,
+                            self.scale as f64,
+                        )?;
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] qwen3.5-attn cache_hit_prefill \
+                                 layer={} suffix_tokens={} cached_prefix_tokens={} total_ctx={} \
+                                 path=read_kv_range read_kv_range_ms={:.1} mask_ms=0.0 \
+                                 sdpa_mode=causal sdpa_graph_ms={:.1}",
+                                attn_layer_idx,
+                                seq_len,
+                                cached_prefix_len,
+                                total_ctx,
+                                read_kv_range_ms.unwrap_or(0.0),
+                                sdpa_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                            ));
+                        }
+                        attn
+                    }
+                };
+
+                attn
             }
         } else {
             // Decode: dispatch `gather_kv_for_decode` Metal kernel

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -8162,11 +8162,15 @@ mod paged_construction_tests {
     //! / `chat_stream_sync_core_paged`; these tests cover the
     //! Inner-construction surface in isolation.
     //!
-    //! Tests that allocate a `LayerKVPool` require Metal and are
-    //! `#[ignore]`-marked behind `MLX_TEST_PAGED=1`.
+    //! Tests that allocate a `LayerKVPool` require Metal. Construction-only
+    //! cases are `#[ignore]`-marked behind `MLX_TEST_PAGED=1`; forward-path
+    //! checks are also ignored because no-Metal hosts can abort inside MLX
+    //! before Rust receives an `Err`.
 
     use super::*;
+    use crate::array::DType;
     use crate::models::qwen3_5::config::Qwen3_5Config;
+    use crate::models::qwen3_5::decoder_layer::{self, AttentionType};
 
     fn tiny_cfg(use_block_paged: bool) -> Qwen3_5Config {
         Qwen3_5Config {
@@ -8195,6 +8199,200 @@ mod paged_construction_tests {
             paged_cache_memory_mb: Some(64),
             paged_block_size: Some(16),
             use_block_paged_cache: if use_block_paged { Some(true) } else { None },
+        }
+    }
+
+    fn tiny_paged_forward_cfg() -> Qwen3_5Config {
+        let mut cfg = tiny_cfg(true);
+        // Paged attention's Metal kernels require head_dim=32+; keep the
+        // production-forward tests on a separate shape so construction tests
+        // preserve their smaller historical config.
+        cfg.hidden_size = 128;
+        cfg.intermediate_size = 256;
+        cfg.head_dim = 32;
+        cfg.linear_key_head_dim = 32;
+        cfg.linear_value_head_dim = 32;
+        cfg.paged_cache_memory_mb = Some(256);
+        cfg
+    }
+
+    fn paged_inner_or_skip(test_name: &str) -> Option<(Qwen35Inner, Qwen3_5Config)> {
+        let cfg = tiny_paged_forward_cfg();
+        match Qwen35Inner::new(cfg.clone()) {
+            Ok(inner) => Some((inner, cfg)),
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("Metal") || msg.contains("device") || msg.contains("LayerKVPool") {
+                    eprintln!("skipping {test_name} (paged adapter unavailable): {msg}");
+                    None
+                } else {
+                    panic!("unexpected Qwen35Inner::new failure in {test_name}: {msg}");
+                }
+            }
+        }
+    }
+
+    fn cast_qwen35_inner_weights_bf16(inner: &mut Qwen35Inner) {
+        let cast = |a: &MxArray| -> MxArray { a.astype(DType::BFloat16).expect("astype bf16") };
+
+        let w = inner.embedding.get_weight();
+        inner.embedding.set_weight(&cast(&w)).expect("set embed");
+
+        let w = inner.final_norm.get_weight();
+        inner
+            .final_norm
+            .set_weight(&cast(&w))
+            .expect("set final_norm");
+
+        if let Some(head) = inner.lm_head.as_mut() {
+            let w = head.get_weight();
+            head.set_weight(&cast(&w)).expect("set lm_head");
+        }
+
+        for layer in inner.layers.iter_mut() {
+            let w = layer.get_input_layernorm_weight();
+            layer
+                .set_input_layernorm_weight(&cast(&w))
+                .expect("set input_layernorm");
+            let w = layer.get_post_attention_layernorm_weight();
+            layer
+                .set_post_attention_layernorm_weight(&cast(&w))
+                .expect("set post_attention_layernorm");
+
+            match &mut layer.attn {
+                AttentionType::Linear(gdn) => {
+                    let w = gdn.get_dt_bias();
+                    gdn.set_dt_bias(&cast(&w));
+                    let w = gdn.get_a_log();
+                    gdn.set_a_log(&cast(&w)).expect("set a_log");
+                    let w = gdn.get_in_proj_qkvz_weight();
+                    gdn.set_in_proj_qkvz_weight(&cast(&w))
+                        .expect("set in_proj_qkvz");
+                    let w = gdn.get_in_proj_ba_weight();
+                    gdn.set_in_proj_ba_weight(&cast(&w))
+                        .expect("set in_proj_ba");
+                    let w = gdn.get_conv1d_weight();
+                    gdn.set_conv1d_weight(&cast(&w)).expect("set conv1d");
+                    let w = gdn.get_norm_weight();
+                    gdn.set_norm_weight(&cast(&w)).expect("set gdn norm");
+                    let w = gdn.get_out_proj_weight();
+                    gdn.set_out_proj_weight(&cast(&w)).expect("set out_proj");
+                }
+                AttentionType::Full(attn) => {
+                    let w = attn.get_q_proj_weight();
+                    attn.set_q_proj_weight(&cast(&w)).expect("set q_proj");
+                    let w = attn.get_k_proj_weight();
+                    attn.set_k_proj_weight(&cast(&w)).expect("set k_proj");
+                    let w = attn.get_v_proj_weight();
+                    attn.set_v_proj_weight(&cast(&w)).expect("set v_proj");
+                    let w = attn.get_o_proj_weight();
+                    attn.set_o_proj_weight(&cast(&w)).expect("set o_proj");
+                    let w = attn.get_q_norm_weight();
+                    attn.set_q_norm_weight(&cast(&w)).expect("set q_norm");
+                    let w = attn.get_k_norm_weight();
+                    attn.set_k_norm_weight(&cast(&w)).expect("set k_norm");
+                }
+            }
+
+            let w = layer.mlp.get_gate_proj_weight();
+            layer
+                .mlp
+                .set_gate_proj_weight(&cast(&w))
+                .expect("set gate_proj");
+            let w = layer.mlp.get_up_proj_weight();
+            layer
+                .mlp
+                .set_up_proj_weight(&cast(&w))
+                .expect("set up_proj");
+            let w = layer.mlp.get_down_proj_weight();
+            layer
+                .mlp
+                .set_down_proj_weight(&cast(&w))
+                .expect("set down_proj");
+        }
+    }
+
+    fn reset_paged_request(inner: &mut Qwen35Inner, prompt: &[u32]) {
+        inner.caches = Some(
+            (0..inner.config.num_layers as usize)
+                .map(|i| {
+                    if inner.config.is_linear_layer(i) {
+                        Qwen3_5LayerCache::new_linear()
+                    } else {
+                        Qwen3_5LayerCache::new_full_attention()
+                    }
+                })
+                .collect(),
+        );
+
+        let adapter = inner.paged_adapter.as_mut().expect("paged_adapter");
+        if adapter.block_table().is_some() {
+            adapter.release_request().expect("release_request");
+        }
+        adapter.reset_for_new_request(0).expect("reset request");
+        let prefix = adapter
+            .find_cached_prefix(prompt, &[], 0, false)
+            .expect("find_cached_prefix");
+        assert_eq!(
+            prefix.cached_token_count, 0,
+            "dense chunking tests must start from a cold adapter prefix"
+        );
+        adapter
+            .allocate_suffix_blocks(prompt.len() as u32)
+            .expect("allocate suffix blocks");
+    }
+
+    fn run_dense_paged_prefill_with_size(
+        inner: &mut Qwen35Inner,
+        full_tokens: &[u32],
+        suffix_tokens: &[u32],
+        cached_prefix_len: u32,
+        chunk_size: i32,
+    ) -> Result<MxArray> {
+        let layer_kinds =
+            decoder_layer::compute_layer_kinds(inner.config.num_layers as usize, |i| {
+                inner.config.is_linear_layer(i)
+            });
+        let embed = inner.embedding.clone();
+        let embedding_weight = embed.get_weight();
+        let caches = inner.caches.as_mut().expect("qwen35 caches initialized");
+        let adapter = inner.paged_adapter.as_mut().expect("paged_adapter");
+
+        super::super::paged_forward::run_paged_prefill_chunk_with_size(
+            full_tokens,
+            suffix_tokens,
+            cached_prefix_len,
+            &embed,
+            &mut inner.layers,
+            caches,
+            &inner.final_norm,
+            &inner.lm_head,
+            &embedding_weight,
+            &layer_kinds,
+            adapter,
+            chunk_size,
+        )
+    }
+
+    fn logits_to_f32_vec(logits: &MxArray) -> Vec<f32> {
+        let f32_arr = logits.astype(DType::Float32).expect("astype f32");
+        f32_arr.eval();
+        let n = f32_arr.shape_at(0).expect("shape_at(0)") as usize;
+        (0..n)
+            .map(|i| f32_arr.item_at_float32(i).expect("item_at_float32"))
+            .collect()
+    }
+
+    fn assert_finite_vocab_logits(logits: &MxArray, vocab_size: i32, context: &str) {
+        assert_eq!(logits.ndim().expect("ndim"), 1, "{context}: logits ndim");
+        assert_eq!(
+            logits.shape_at(0).expect("shape_at(0)"),
+            vocab_size as i64,
+            "{context}: logits shape"
+        );
+        let values = logits_to_f32_vec(logits);
+        for (i, v) in values.iter().enumerate() {
+            assert!(v.is_finite(), "{context}: logits[{i}] is not finite: {v}");
         }
     }
 
@@ -8448,6 +8646,166 @@ mod paged_construction_tests {
              the dispatcher gate at chat_sync_core_paged_inner / chat_stream_sync_core_paged_inner \
              relies on this inequality to fall back to the pure-Rust paged path"
         );
+    }
+
+    /// Dense Qwen3.5 paged-prefill chunking state test. This drives the
+    /// production chunk-size worker once and asserts the adapter cursor,
+    /// request token log, and block table cover the whole prompt after all
+    /// chunks have been recorded.
+    #[test]
+    #[ignore = "requires Metal GPU; run with --ignored"]
+    fn test_dense_paged_prefill_chunks_advance_adapter_state() {
+        let Some((mut inner, cfg)) =
+            paged_inner_or_skip("test_dense_paged_prefill_chunks_advance_adapter_state")
+        else {
+            return;
+        };
+        cast_qwen35_inner_weights_bf16(&mut inner);
+
+        let prompt: Vec<u32> = (0u32..64).map(|i| (i * 5 + 7) % 257).collect();
+        reset_paged_request(&mut inner, &prompt);
+
+        let logits = match run_dense_paged_prefill_with_size(
+            &mut inner, &prompt, &prompt, 0, /* chunk_size */ 16,
+        ) {
+            Ok(logits) => logits,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("Metal GPU not available") || msg.contains("No Metal device") {
+                    eprintln!(
+                        "skipping test_dense_paged_prefill_chunks_advance_adapter_state: {msg}"
+                    );
+                    return;
+                }
+                panic!("unexpected dense paged chunk failure: {msg}");
+            }
+        };
+
+        let adapter = inner.paged_adapter.as_ref().expect("paged_adapter");
+        assert_eq!(
+            adapter.current_token_count() as usize,
+            prompt.len(),
+            "adapter cursor after chunked prefill"
+        );
+        assert_eq!(
+            adapter.request_tokens(),
+            prompt.as_slice(),
+            "request token log after chunked prefill"
+        );
+        let block_table = adapter.block_table().expect("block_table");
+        let expected_min_blocks = prompt.len().div_ceil(adapter.block_size() as usize);
+        assert!(
+            block_table.num_blocks() >= expected_min_blocks,
+            "block table has {} blocks, expected at least {expected_min_blocks}",
+            block_table.num_blocks()
+        );
+        assert_finite_vocab_logits(&logits, cfg.vocab_size, "final dense paged chunk prefill");
+
+        let adapter = inner.paged_adapter.as_mut().expect("paged_adapter");
+        let _ = adapter.register_full_blocks_for_reuse(&[], 0);
+        adapter.release_request().expect("release_request");
+    }
+
+    /// Uneven-tail coverage for dense Qwen3.5 paged prefill: a 33-token
+    /// prompt with chunk_size=16 must record two full chunks plus a
+    /// one-token tail and return valid logits for the tail chunk.
+    #[test]
+    #[ignore = "requires Metal GPU; run with --ignored"]
+    fn test_dense_paged_prefill_chunks_handle_uneven_tail() {
+        let Some((mut inner, cfg)) =
+            paged_inner_or_skip("test_dense_paged_prefill_chunks_handle_uneven_tail")
+        else {
+            return;
+        };
+        cast_qwen35_inner_weights_bf16(&mut inner);
+
+        let prompt: Vec<u32> = (0u32..33).map(|i| (i * 11 + 3) % 257).collect();
+        reset_paged_request(&mut inner, &prompt);
+
+        let final_logits = run_dense_paged_prefill_with_size(
+            &mut inner, &prompt, &prompt, 0, /* chunk_size */ 16,
+        )
+        .expect("dense paged uneven-tail chunked prefill");
+
+        assert_eq!(
+            prompt.len(),
+            33,
+            "test setup must exercise a one-token tail"
+        );
+        let adapter = inner.paged_adapter.as_ref().expect("paged_adapter");
+        assert_eq!(
+            adapter.current_token_count(),
+            33,
+            "adapter cursor must include the uneven tail"
+        );
+        assert_eq!(
+            adapter.request_tokens(),
+            prompt.as_slice(),
+            "request token log must include the uneven tail"
+        );
+        assert_finite_vocab_logits(
+            &final_logits,
+            cfg.vocab_size,
+            "uneven-tail dense paged chunk prefill",
+        );
+
+        let adapter = inner.paged_adapter.as_mut().expect("paged_adapter");
+        let _ = adapter.register_full_blocks_for_reuse(&[], 0);
+        adapter.release_request().expect("release_request");
+    }
+
+    /// Compatibility guard for the current/default dense Qwen3.5 paged
+    /// prefill behavior: a full suffix passed in one call remains a valid
+    /// single-shot prefill and is stable across a fresh adapter reset.
+    #[test]
+    #[ignore = "requires Metal GPU; run with --ignored"]
+    fn test_dense_paged_prefill_single_shot_default_still_works() {
+        let Some((mut inner, cfg)) =
+            paged_inner_or_skip("test_dense_paged_prefill_single_shot_default_still_works")
+        else {
+            return;
+        };
+        cast_qwen35_inner_weights_bf16(&mut inner);
+
+        let prompt: Vec<u32> = vec![5, 11, 21, 33, 47, 60, 71, 83];
+
+        reset_paged_request(&mut inner, &prompt);
+        let logits_a = run_dense_paged_prefill_with_size(
+            &mut inner, &prompt, &prompt, 0, /* chunk_size */ 0,
+        )
+        .expect("single-shot A");
+        assert_finite_vocab_logits(&logits_a, cfg.vocab_size, "single-shot A");
+        {
+            let adapter = inner.paged_adapter.as_ref().expect("paged_adapter");
+            assert_eq!(
+                adapter.current_token_count() as usize,
+                prompt.len(),
+                "single-shot cursor"
+            );
+            assert_eq!(adapter.request_tokens(), prompt.as_slice());
+        }
+
+        reset_paged_request(&mut inner, &prompt);
+        let logits_b = run_dense_paged_prefill_with_size(
+            &mut inner, &prompt, &prompt, 0, /* chunk_size */ 0,
+        )
+        .expect("single-shot B");
+        let a = logits_to_f32_vec(&logits_a);
+        let b = logits_to_f32_vec(&logits_b);
+        assert_eq!(a.len(), cfg.vocab_size as usize);
+        assert_eq!(b.len(), cfg.vocab_size as usize);
+        for (i, (left, right)) in a.iter().zip(b.iter()).enumerate() {
+            let abs_diff = (left - right).abs();
+            assert!(
+                abs_diff <= 1e-6,
+                "single-shot dense paged prefill changed after fresh reset at index {i}: \
+                 first={left}, second={right}, abs_diff={abs_diff}"
+            );
+        }
+
+        let adapter = inner.paged_adapter.as_mut().expect("paged_adapter");
+        let _ = adapter.register_full_blocks_for_reuse(&[], 0);
+        adapter.release_request().expect("release_request");
     }
 
     /// Phase 5 piece 1: the C++ FFI returns `int32_t` (0 success / -1

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
@@ -8,6 +8,9 @@ use napi_derive::napi;
 use tracing::{info, warn};
 
 use crate::array::MxArray;
+use crate::inference_trace::{
+    elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
+};
 use crate::model_thread::{ResponseTx, StreamTx};
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::sampling::{SamplingConfig, sample};
@@ -63,6 +66,224 @@ pub(crate) static COMPILED_WEIGHTS_RWLOCK: std::sync::RwLock<()> = std::sync::Rw
 /// calls from different model threads can collide on process-wide globals.
 static DENSE_COMPILED_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+fn fresh_dense_layer_caches(config: &Qwen3_5Config) -> Vec<Qwen3_5LayerCache> {
+    (0..config.num_layers as usize)
+        .map(|i| {
+            if config.is_linear_layer(i) {
+                Qwen3_5LayerCache::new_linear()
+            } else {
+                Qwen3_5LayerCache::new_full_attention()
+            }
+        })
+        .collect()
+}
+
+const DENSE_GDN_PREFIX_CHECKPOINT_LIMIT: usize = 8;
+
+struct DenseGdnPrefixCheckpoint {
+    prefix_len: u32,
+    block_size: u32,
+    final_block_hash: u64,
+    tokens: Vec<u32>,
+    caches: Vec<Qwen3_5LayerCache>,
+}
+
+struct DenseGdnHistoryCheckpoint {
+    tokens: Vec<u32>,
+    caches: Vec<Qwen3_5LayerCache>,
+}
+
+struct DenseGdnPrefixPreparation {
+    state: &'static str,
+    already_primed: bool,
+}
+
+#[derive(Default)]
+struct DenseGdnCheckpointStoreTrace {
+    stored: bool,
+    hash_ms: f64,
+    eval_ms: f64,
+    clone_ms: f64,
+    token_clone_ms: f64,
+    update_ms: f64,
+    total_ms: f64,
+}
+
+impl DenseGdnCheckpointStoreTrace {
+    fn finish(mut self, start: Option<std::time::Instant>) -> Self {
+        self.total_ms = start.map(elapsed_ms).unwrap_or(0.0);
+        self
+    }
+}
+
+fn dense_gdn_store_replayed_prefix_checkpoint_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("MLX_DENSE_GDN_REPLAY_PREFIX_CHECKPOINT")
+            .map(|value| {
+                let normalized = value.trim().to_ascii_lowercase();
+                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+            })
+            .unwrap_or(false)
+    })
+}
+
+#[derive(Clone, Copy)]
+struct TokenPrefixMismatchTrace {
+    index: i64,
+    prompt_token: i64,
+    cached_token: i64,
+}
+
+impl Default for TokenPrefixMismatchTrace {
+    fn default() -> Self {
+        Self {
+            index: -1,
+            prompt_token: -1,
+            cached_token: -1,
+        }
+    }
+}
+
+fn token_prefix_mismatch_trace(prompt: &[u32], cached: &[u32]) -> TokenPrefixMismatchTrace {
+    let common_len = prompt.len().min(cached.len());
+    for i in 0..common_len {
+        if prompt[i] != cached[i] {
+            return TokenPrefixMismatchTrace {
+                index: i as i64,
+                prompt_token: prompt[i] as i64,
+                cached_token: cached[i] as i64,
+            };
+        }
+    }
+
+    TokenPrefixMismatchTrace {
+        index: common_len as i64,
+        prompt_token: prompt.get(common_len).map_or(-1, |token| *token as i64),
+        cached_token: cached.get(common_len).map_or(-1, |token| *token as i64),
+    }
+}
+
+fn dense_paged_linear_caches_ready(
+    config: &Qwen3_5Config,
+    caches: Option<&[Qwen3_5LayerCache]>,
+) -> bool {
+    let Some(caches) = caches else {
+        return false;
+    };
+    if caches.len() != config.num_layers as usize {
+        return false;
+    }
+    for (i, cache) in caches.iter().enumerate() {
+        if !config.is_linear_layer(i) {
+            continue;
+        }
+        let Qwen3_5LayerCache::Linear(arrays) = cache else {
+            return false;
+        };
+        if arrays.get(0).is_none() || arrays.get(1).is_none() {
+            return false;
+        }
+    }
+    true
+}
+
+fn clone_dense_linear_layer_caches(
+    config: &Qwen3_5Config,
+    caches: &[Qwen3_5LayerCache],
+) -> Option<Vec<Qwen3_5LayerCache>> {
+    if !dense_paged_linear_caches_ready(config, Some(caches)) {
+        return None;
+    }
+
+    let mut cloned = fresh_dense_layer_caches(config);
+    for i in 0..config.num_layers as usize {
+        if !config.is_linear_layer(i) {
+            continue;
+        }
+        let Qwen3_5LayerCache::Linear(arrays) = &caches[i] else {
+            return None;
+        };
+        cloned[i] = Qwen3_5LayerCache::Linear(arrays.clone());
+    }
+    Some(cloned)
+}
+
+fn compute_paged_prefix_block_hash(
+    tokens: &[u32],
+    prefix_len: u32,
+    block_size: u32,
+    extra_keys_per_block: &[Vec<u64>],
+    cache_salt: u64,
+) -> Option<u64> {
+    if prefix_len == 0 || block_size == 0 || !prefix_len.is_multiple_of(block_size) {
+        return None;
+    }
+
+    let prefix_len = prefix_len as usize;
+    let block_size = block_size as usize;
+    if prefix_len > tokens.len() {
+        return None;
+    }
+
+    let num_blocks = prefix_len / block_size;
+    let mut parent_hash = 0;
+    for block_idx in 0..num_blocks {
+        let extra_keys = extra_keys_per_block.get(block_idx)?;
+        let start = block_idx * block_size;
+        let end = start + block_size;
+        parent_hash = if block_idx == 0 && cache_salt != 0 {
+            let mut salted_keys = Vec::with_capacity(extra_keys.len() + 1);
+            salted_keys.extend_from_slice(extra_keys);
+            salted_keys.push(cache_salt);
+            mlx_paged_attn::hash_tokens(&tokens[start..end], parent_hash, &salted_keys)
+        } else {
+            mlx_paged_attn::hash_tokens(&tokens[start..end], parent_hash, extra_keys)
+        };
+    }
+
+    Some(parent_hash)
+}
+
+fn export_paged_dense_linear_caches(
+    config: &Qwen3_5Config,
+) -> Result<Option<Vec<Qwen3_5LayerCache>>> {
+    let num_layers = config.num_layers as usize;
+    let expected = num_layers
+        .checked_mul(2)
+        .ok_or_else(|| Error::from_reason("paged dense cache export size overflow"))?;
+    let mut export_ptrs: Vec<*mut mlx_sys::mlx_array> = vec![std::ptr::null_mut(); expected];
+    let exported = unsafe {
+        mlx_sys::mlx_qwen35_export_paged_linear_caches(export_ptrs.as_mut_ptr(), expected as i32)
+    };
+    if exported == 0 {
+        return Ok(None);
+    }
+    if exported != expected as i32 {
+        return Err(Error::from_reason(format!(
+            "paged dense linear cache export returned {exported} arrays; expected {expected}"
+        )));
+    }
+
+    let cache_offset = unsafe { mlx_sys::mlx_qwen35_get_paged_cache_offset() };
+    let mut new_caches = fresh_dense_layer_caches(config);
+    for i in 0..num_layers {
+        if !config.is_linear_layer(i) {
+            continue;
+        }
+        let p0 = export_ptrs[i * 2];
+        let p1 = export_ptrs[i * 2 + 1];
+        if p0.is_null() || p1.is_null() {
+            return Err(Error::from_reason(format!(
+                "paged dense linear cache export missing layer {i}"
+            )));
+        }
+        new_caches[i].import_ptrs(p0, p1, cache_offset);
+    }
+
+    Ok(Some(new_caches))
+}
+
 /// Internal model state owned exclusively by the dedicated model thread.
 ///
 /// No `Arc<RwLock<>>` — the model thread has sole ownership of all inference
@@ -83,6 +304,8 @@ pub(crate) struct Qwen35Inner {
     pub(crate) cached_image_key: Option<u64>,
     pub(crate) cached_rope_deltas: Option<i32>,
     pub(crate) model_id: u64,
+    gdn_prefix_checkpoints: VecDeque<DenseGdnPrefixCheckpoint>,
+    gdn_last_history_checkpoint: Option<DenseGdnHistoryCheckpoint>,
     /// Block-paged KV adapter (vLLM-style refcounted prefix cache) for
     /// full-attention layers.
     ///
@@ -641,6 +864,8 @@ impl Qwen35Inner {
             cached_image_key: None,
             cached_rope_deltas: None,
             model_id,
+            gdn_prefix_checkpoints: VecDeque::new(),
+            gdn_last_history_checkpoint: None,
             paged_adapter,
             training_state: None,
         })
@@ -648,16 +873,7 @@ impl Qwen35Inner {
 
     /// Initialize KV caches.
     pub(crate) fn init_caches_sync(&mut self) -> Result<()> {
-        let caches = (0..self.config.num_layers as usize)
-            .map(|i| {
-                if self.config.is_linear_layer(i) {
-                    Qwen3_5LayerCache::new_linear()
-                } else {
-                    Qwen3_5LayerCache::new_full_attention()
-                }
-            })
-            .collect();
-        self.caches = Some(caches);
+        self.caches = Some(fresh_dense_layer_caches(&self.config));
         self.clear_reuse_state();
         Ok(())
     }
@@ -679,6 +895,8 @@ impl Qwen35Inner {
         self.cached_token_history.clear();
         self.cached_image_key = None;
         self.cached_rope_deltas = None;
+        self.gdn_prefix_checkpoints.clear();
+        self.gdn_last_history_checkpoint = None;
     }
 
     /// Take the KV cache from the model, returning a `PromptCache` handle.
@@ -689,6 +907,8 @@ impl Qwen35Inner {
             return None;
         }
         let caches = self.caches.take()?;
+        self.gdn_prefix_checkpoints.clear();
+        self.gdn_last_history_checkpoint = None;
         Some(crate::models::qwen3_5::prompt_cache::PromptCache::new(
             caches,
             self.cached_token_history.clone(),
@@ -712,7 +932,347 @@ impl Qwen35Inner {
         self.cached_token_history = cache.token_history().to_vec();
         self.cached_image_key = cache.image_cache_key();
         self.cached_rope_deltas = cache.rope_deltas();
+        self.gdn_prefix_checkpoints.clear();
+        self.gdn_last_history_checkpoint = None;
         Ok(())
+    }
+
+    fn find_dense_gdn_history_checkpoint(
+        &self,
+        tokens: &[u32],
+        prefix_len: u32,
+    ) -> Option<Vec<Qwen3_5LayerCache>> {
+        let prefix_tokens = tokens.get(..prefix_len as usize)?;
+        let checkpoint = self.gdn_last_history_checkpoint.as_ref()?;
+        if checkpoint.tokens.as_slice() != prefix_tokens {
+            return None;
+        }
+        clone_dense_linear_layer_caches(&self.config, &checkpoint.caches)
+    }
+
+    fn remember_dense_gdn_history_checkpoint(&mut self) -> Result<DenseGdnCheckpointStoreTrace> {
+        let trace_enabled = inference_trace_enabled();
+        let total_start = trace_enabled.then(std::time::Instant::now);
+        let mut trace = DenseGdnCheckpointStoreTrace::default();
+        if self.cached_token_history.is_empty() {
+            self.gdn_last_history_checkpoint = None;
+            return Ok(trace.finish(total_start));
+        }
+
+        let eval_start = trace_enabled.then(std::time::Instant::now);
+        eval_layer_caches(&self.caches)?;
+        trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
+        let clone_start = trace_enabled.then(std::time::Instant::now);
+        let Some(caches) = self
+            .caches
+            .as_ref()
+            .and_then(|caches| clone_dense_linear_layer_caches(&self.config, caches))
+        else {
+            self.gdn_last_history_checkpoint = None;
+            trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
+            return Ok(trace.finish(total_start));
+        };
+        trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
+        let token_clone_start = trace_enabled.then(std::time::Instant::now);
+        let tokens = self.cached_token_history.clone();
+        trace.token_clone_ms = token_clone_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let update_start = trace_enabled.then(std::time::Instant::now);
+        self.gdn_last_history_checkpoint = Some(DenseGdnHistoryCheckpoint { tokens, caches });
+        trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
+        trace.stored = true;
+        Ok(trace.finish(total_start))
+    }
+
+    fn find_dense_gdn_prefix_checkpoint(
+        &self,
+        tokens: &[u32],
+        prefix_len: u32,
+        block_size: u32,
+        extra_keys_per_block: &[Vec<u64>],
+        cache_salt: u64,
+    ) -> Option<Vec<Qwen3_5LayerCache>> {
+        let final_block_hash = compute_paged_prefix_block_hash(
+            tokens,
+            prefix_len,
+            block_size,
+            extra_keys_per_block,
+            cache_salt,
+        )?;
+        let prefix_tokens = tokens.get(..prefix_len as usize)?;
+
+        self.gdn_prefix_checkpoints
+            .iter()
+            .rev()
+            .find(|checkpoint| {
+                checkpoint.prefix_len == prefix_len
+                    && checkpoint.block_size == block_size
+                    && checkpoint.final_block_hash == final_block_hash
+                    && checkpoint.tokens.as_slice() == prefix_tokens
+                    && dense_paged_linear_caches_ready(&self.config, Some(&checkpoint.caches))
+            })
+            .and_then(|checkpoint| {
+                clone_dense_linear_layer_caches(&self.config, &checkpoint.caches)
+            })
+    }
+
+    fn remember_dense_gdn_prefix_checkpoint(
+        &mut self,
+        tokens: &[u32],
+        prefix_len: u32,
+        block_size: u32,
+        extra_keys_per_block: &[Vec<u64>],
+        cache_salt: u64,
+    ) -> Result<DenseGdnCheckpointStoreTrace> {
+        let trace_enabled = inference_trace_enabled();
+        let total_start = trace_enabled.then(std::time::Instant::now);
+        let mut trace = DenseGdnCheckpointStoreTrace::default();
+        let hash_start = trace_enabled.then(std::time::Instant::now);
+        let Some(final_block_hash) = compute_paged_prefix_block_hash(
+            tokens,
+            prefix_len,
+            block_size,
+            extra_keys_per_block,
+            cache_salt,
+        ) else {
+            trace.hash_ms = hash_start.map(elapsed_ms).unwrap_or(0.0);
+            return Ok(trace.finish(total_start));
+        };
+        trace.hash_ms = hash_start.map(elapsed_ms).unwrap_or(0.0);
+        let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
+            return Ok(trace.finish(total_start));
+        };
+
+        let eval_start = trace_enabled.then(std::time::Instant::now);
+        eval_layer_caches(&self.caches)?;
+        trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
+        let clone_start = trace_enabled.then(std::time::Instant::now);
+        let Some(caches) = self
+            .caches
+            .as_ref()
+            .and_then(|caches| clone_dense_linear_layer_caches(&self.config, caches))
+        else {
+            trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
+            return Ok(trace.finish(total_start));
+        };
+        trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
+        let token_clone_start = trace_enabled.then(std::time::Instant::now);
+        let prefix_tokens = prefix_tokens.to_vec();
+        trace.token_clone_ms = token_clone_start.map(elapsed_ms).unwrap_or(0.0);
+
+        let update_start = trace_enabled.then(std::time::Instant::now);
+        self.gdn_prefix_checkpoints.retain(|checkpoint| {
+            !(checkpoint.prefix_len == prefix_len
+                && checkpoint.block_size == block_size
+                && checkpoint.final_block_hash == final_block_hash
+                && checkpoint.tokens == prefix_tokens)
+        });
+        self.gdn_prefix_checkpoints
+            .push_back(DenseGdnPrefixCheckpoint {
+                prefix_len,
+                block_size,
+                final_block_hash,
+                tokens: prefix_tokens,
+                caches,
+            });
+        while self.gdn_prefix_checkpoints.len() > DENSE_GDN_PREFIX_CHECKPOINT_LIMIT {
+            self.gdn_prefix_checkpoints.pop_front();
+        }
+        trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
+        trace.stored = true;
+
+        Ok(trace.finish(total_start))
+    }
+
+    fn prepare_dense_gdn_prefix_state(
+        &mut self,
+        tokens: &[u32],
+        cached_prefix_len: u32,
+        block_size: u32,
+        extra_keys_per_block: &[Vec<u64>],
+        cache_salt: u64,
+        continued_live_prefix: bool,
+    ) -> Result<DenseGdnPrefixPreparation> {
+        let trace_enabled = inference_trace_enabled();
+        let prepare_trace_start = trace_enabled.then(std::time::Instant::now);
+        let gdn_caches_ready =
+            dense_paged_linear_caches_ready(&self.config, self.caches.as_deref());
+        if gdn_caches_ready && continued_live_prefix {
+            if let Some(start) = prepare_trace_start {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-dense gdn_prefix_prepare_done state=live \
+                     cached_prefix_tokens={} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    elapsed_ms(start)
+                ));
+            }
+            return Ok(DenseGdnPrefixPreparation {
+                state: "live",
+                already_primed: true,
+            });
+        }
+
+        let gdn_prefix_from_history = cached_prefix_len > 0
+            && self.cached_token_history.len() == cached_prefix_len as usize
+            && tokens.starts_with(&self.cached_token_history);
+        if gdn_caches_ready && gdn_prefix_from_history {
+            if let Some(start) = prepare_trace_start {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-dense gdn_prefix_prepare_done state=last_history \
+                     cached_prefix_tokens={} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    elapsed_ms(start)
+                ));
+            }
+            return Ok(DenseGdnPrefixPreparation {
+                state: "last_history",
+                already_primed: true,
+            });
+        }
+
+        if cached_prefix_len > 0 {
+            let history_lookup_start = trace_enabled.then(std::time::Instant::now);
+            let history_checkpoint =
+                self.find_dense_gdn_history_checkpoint(tokens, cached_prefix_len);
+            let history_lookup_ms = history_lookup_start.map(elapsed_ms);
+            if let Some(checkpoint) = history_checkpoint {
+                self.caches = Some(checkpoint);
+                if let Some(start) = prepare_trace_start {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-dense gdn_prefix_prepare_done \
+                         state=last_history_checkpoint cached_prefix_tokens={} \
+                         history_lookup_ms={:.1} elapsed_ms={:.1}",
+                        cached_prefix_len,
+                        history_lookup_ms.unwrap_or(0.0),
+                        elapsed_ms(start)
+                    ));
+                }
+                return Ok(DenseGdnPrefixPreparation {
+                    state: "last_history_checkpoint",
+                    already_primed: true,
+                });
+            } else if trace_enabled {
+                let history_checkpoint_len = self
+                    .gdn_last_history_checkpoint
+                    .as_ref()
+                    .map_or(0, |checkpoint| checkpoint.tokens.len());
+                let history_mismatch =
+                    token_prefix_mismatch_trace(tokens, &self.cached_token_history);
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-dense gdn_history_checkpoint_miss \
+                     cached_prefix_tokens={} history_len={} checkpoint_len={} \
+                     history_match={} history_mismatch_at={} prompt_token={} \
+                     history_token={} history_lookup_ms={:.1}",
+                    cached_prefix_len,
+                    self.cached_token_history.len(),
+                    history_checkpoint_len,
+                    gdn_prefix_from_history,
+                    history_mismatch.index,
+                    history_mismatch.prompt_token,
+                    history_mismatch.cached_token,
+                    history_lookup_ms.unwrap_or(0.0)
+                ));
+            }
+        }
+
+        let prefix_lookup_start = trace_enabled.then(std::time::Instant::now);
+        let prefix_checkpoint = self.find_dense_gdn_prefix_checkpoint(
+            tokens,
+            cached_prefix_len,
+            block_size,
+            extra_keys_per_block,
+            cache_salt,
+        );
+        let prefix_lookup_ms = prefix_lookup_start.map(elapsed_ms);
+        if let Some(checkpoint) = prefix_checkpoint {
+            self.caches = Some(checkpoint);
+            if let Some(start) = prepare_trace_start {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-dense gdn_prefix_prepare_done state=checkpoint \
+                     cached_prefix_tokens={} prefix_lookup_ms={:.1} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    prefix_lookup_ms.unwrap_or(0.0),
+                    elapsed_ms(start)
+                ));
+            }
+            return Ok(DenseGdnPrefixPreparation {
+                state: "checkpoint",
+                already_primed: true,
+            });
+        }
+
+        self.caches = Some(fresh_dense_layer_caches(&self.config));
+        if cached_prefix_len == 0 {
+            if let Some(start) = prepare_trace_start {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-dense gdn_prefix_prepare_done state=replay \
+                     cached_prefix_tokens=0 prefix_lookup_ms={:.1} elapsed_ms={:.1}",
+                    prefix_lookup_ms.unwrap_or(0.0),
+                    elapsed_ms(start)
+                ));
+            }
+            return Ok(DenseGdnPrefixPreparation {
+                state: "replay",
+                already_primed: false,
+            });
+        }
+
+        let prefix = tokens.get(..cached_prefix_len as usize).ok_or_else(|| {
+            Error::from_reason("dense paged GDN prefix replay length exceeds prompt length")
+        })?;
+        let embed = self.embedding.clone();
+        let caches_ref = self
+            .caches
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("dense paged GDN prefix caches not initialized"))?;
+        let replay_trace_start = trace_enabled.then(std::time::Instant::now);
+        super::paged_forward::run_gdn_only_prefill(prefix, &embed, &mut self.layers, caches_ref)?;
+        let replay_ms = replay_trace_start.map(elapsed_ms);
+        let store_trace = if dense_gdn_store_replayed_prefix_checkpoint_enabled() {
+            self.remember_dense_gdn_prefix_checkpoint(
+                tokens,
+                cached_prefix_len,
+                block_size,
+                extra_keys_per_block,
+                cache_salt,
+            )?
+        } else {
+            DenseGdnCheckpointStoreTrace::default()
+        };
+        if let Some(start) = prepare_trace_start {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-dense gdn_prefix_prepare_done state={} \
+                 cached_prefix_tokens={} prefix_lookup_ms={:.1} replay_ms={:.1} stored={} \
+                 store_hash_ms={:.1} store_eval_ms={:.1} store_clone_ms={:.1} \
+                 store_token_clone_ms={:.1} store_update_ms={:.1} store_ms={:.1} \
+                 elapsed_ms={:.1}",
+                if store_trace.stored {
+                    "replay_store"
+                } else {
+                    "replay"
+                },
+                cached_prefix_len,
+                prefix_lookup_ms.unwrap_or(0.0),
+                replay_ms.unwrap_or(0.0),
+                store_trace.stored,
+                store_trace.hash_ms,
+                store_trace.eval_ms,
+                store_trace.clone_ms,
+                store_trace.token_clone_ms,
+                store_trace.update_ms,
+                store_trace.total_ms,
+                elapsed_ms(start)
+            ));
+        }
+
+        Ok(DenseGdnPrefixPreparation {
+            state: if store_trace.stored {
+                "replay_store"
+            } else {
+                "replay"
+            },
+            already_primed: true,
+        })
     }
 
     /// Save model weights and configuration to a directory (synchronous).
@@ -1999,8 +2559,8 @@ impl Qwen35Inner {
     /// 1. Adapter lifecycle: warm-continue when the prior turn ended
     ///    via `finalize_turn_keep_live`; cold-start (reset →
     ///    find_cached_prefix → allocate_suffix) otherwise.
-    /// 2. Reset GDN caches and the cached token history. The paged
-    ///    path does not carry GDN state across turns.
+    /// 2. Prepare GDN prefix state from live/session checkpoints when
+    ///    available; otherwise replay the cached prefix through GDN.
     /// 3. Prefill via `paged_forward::run_paged_prefill_chunk`.
     /// 4. Decode loop via `paged_forward::run_paged_decode_step`.
     /// 5. End-of-turn: `finalize_turn_keep_live` keeps the partial
@@ -2009,8 +2569,9 @@ impl Qwen35Inner {
     ///
     /// Limitations:
     /// * VLM is rejected upstream — paged dispatch is text-only.
-    /// * Cross-turn GDN prefix reuse is NOT supported — every paged
-    ///   turn re-prefills GDN state from token 0.
+    /// * Cross-turn GDN prefix reuse is limited to live/history/prefix
+    ///   checkpoints whose identity matches the paged KV prefix. Misses
+    ///   fall back to GDN replay from token 0.
     /// * Pure-cache prompt (every prompt token already in the paged
     ///   pool) is rejected — same caveat as LFM2 / Qwen3 paged paths.
     /// * The compiled C++ forward path is bypassed — paged turns run
@@ -2045,6 +2606,7 @@ impl Qwen35Inner {
             None
         };
         let mut first_token_instant: Option<std::time::Instant> = None;
+        let trace_enabled = inference_trace_enabled();
 
         // Detect availability of the C++ compiled paged decode path.
         // Mirrors the MoE paged path: if the weights for this model are
@@ -2095,7 +2657,12 @@ impl Qwen35Inner {
             adapter.block_size()
         };
         let lookup_extra_keys = chat_common::build_paged_extra_keys(tokens.len(), block_size, &[]);
-        let cached_prefix_len = {
+        let cache_salt = 0;
+        let live_ready;
+        let live_prefix_match;
+        let live_tokens_len;
+        let mut live_mismatch = TokenPrefixMismatchTrace::default();
+        let (cached_prefix_len, continued_live_prefix) = {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason(
                     "chat_sync_core_paged: paged_adapter is None — caller must check \
@@ -2103,25 +2670,36 @@ impl Qwen35Inner {
                 )
             })?;
 
-            let can_continue =
-                adapter.is_live_for_continue() && tokens.starts_with(adapter.request_tokens());
+            live_ready = adapter.is_live_for_continue();
+            let live_tokens = adapter.request_tokens();
+            live_tokens_len = live_tokens.len();
+            live_prefix_match = tokens.starts_with(live_tokens);
+            if trace_enabled && live_ready && !live_prefix_match {
+                live_mismatch = token_prefix_mismatch_trace(&tokens, live_tokens);
+            }
+            let can_continue = live_ready && live_prefix_match;
 
             if can_continue {
                 match adapter.continue_turn(&tokens, total_budget) {
-                    Ok((prior_token_count, _newly_alloc)) => prior_token_count,
+                    Ok((prior_token_count, _newly_alloc)) => (prior_token_count, true),
                     Err(_drift) => {
                         let _ = adapter.release_request();
                         adapter
                             .reset_for_new_request(seq_id)
                             .map_err(Error::from_reason)?;
                         let prefix = adapter
-                            .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, 0, false)
+                            .find_cached_prefix_per_block(
+                                &tokens,
+                                &lookup_extra_keys,
+                                cache_salt,
+                                false,
+                            )
                             .map_err(Error::from_reason)?;
                         let cached = prefix.cached_token_count;
                         adapter
                             .allocate_suffix_blocks(total_budget)
                             .map_err(Error::from_reason)?;
-                        cached
+                        (cached, false)
                     }
                 }
             } else {
@@ -2132,30 +2710,41 @@ impl Qwen35Inner {
                     .reset_for_new_request(seq_id)
                     .map_err(Error::from_reason)?;
                 let prefix = adapter
-                    .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, 0, false)
+                    .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, cache_salt, false)
                     .map_err(Error::from_reason)?;
                 let cached = prefix.cached_token_count;
                 adapter
                     .allocate_suffix_blocks(total_budget)
                     .map_err(Error::from_reason)?;
-                cached
+                (cached, false)
             }
         };
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-dense paged_prefix_lookup prompt_tokens={} \
+                 cached_prefix_tokens={} continued_live_prefix={} live_ready={} \
+                 live_match={} live_tokens={} live_mismatch_at={} prompt_token={} live_token={}",
+                tokens.len(),
+                cached_prefix_len,
+                continued_live_prefix,
+                live_ready,
+                live_prefix_match,
+                live_tokens_len,
+                live_mismatch.index,
+                live_mismatch.prompt_token,
+                live_mismatch.cached_token
+            ));
+        }
 
-        // Reset GDN state for this turn. The paged path does not carry
-        // GDN prefix state across turns — every turn re-prefills GDN
-        // state over the entire prompt (see method docstring).
-        self.caches = Some(
-            (0..self.config.num_layers as usize)
-                .map(|i| {
-                    if self.config.is_linear_layer(i) {
-                        Qwen3_5LayerCache::new_linear()
-                    } else {
-                        Qwen3_5LayerCache::new_full_attention()
-                    }
-                })
-                .collect(),
-        );
+        let gdn_prefix_preparation = self.prepare_dense_gdn_prefix_state(
+            &tokens,
+            cached_prefix_len,
+            block_size,
+            &lookup_extra_keys,
+            cache_salt,
+            continued_live_prefix,
+        )?;
+        let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         self.cached_token_history.clear();
         self.cached_image_key = None;
         self.cached_rope_deltas = None;
@@ -2177,6 +2766,7 @@ impl Qwen35Inner {
             report_perf,
             &mut first_token_instant,
             use_cpp_paged,
+            gdn_prefix_already_primed,
         );
 
         let (generated_tokens, finish_reason) = match forward_result {
@@ -2218,6 +2808,20 @@ impl Qwen35Inner {
             full_history.extend_from_slice(&generated_tokens[..upto]);
         }
         self.cached_token_history = full_history;
+        let gdn_history_checkpoint_store = self.remember_dense_gdn_history_checkpoint()?;
+        if inference_trace_enabled() {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-dense gdn_history_checkpoint stored={} tokens={} \
+                 eval_ms={:.1} clone_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
+                gdn_history_checkpoint_store.stored,
+                self.cached_token_history.len(),
+                gdn_history_checkpoint_store.eval_ms,
+                gdn_history_checkpoint_store.clone_ms,
+                gdn_history_checkpoint_store.token_clone_ms,
+                gdn_history_checkpoint_store.update_ms,
+                gdn_history_checkpoint_store.total_ms
+            ));
+        }
 
         let performance = if report_perf {
             compute_performance_metrics(
@@ -2271,6 +2875,7 @@ impl Qwen35Inner {
         report_perf: bool,
         first_token_instant: &mut Option<std::time::Instant>,
         use_cpp_paged: bool,
+        gdn_prefix_already_primed: bool,
     ) -> Result<(Vec<u32>, String)> {
         if suffix_len == 0 {
             return Err(Error::from_reason(
@@ -2299,6 +2904,7 @@ impl Qwen35Inner {
                 tokens,
                 suffix,
                 cached_prefix_len,
+                gdn_prefix_already_primed,
                 &embed,
                 &mut self.layers,
                 caches_ref,
@@ -2556,6 +3162,31 @@ impl Qwen35Inner {
             crate::array::maybe_clear_cache_for_paged_step(step);
         }
 
+        if cpp_compiled_step_completed {
+            match export_paged_dense_linear_caches(&self.config) {
+                Ok(Some(new_caches)) => {
+                    self.caches = Some(new_caches);
+                    eval_layer_caches(&self.caches)?;
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-dense paged_linear_cache_export ok=true"
+                    ));
+                }
+                Ok(None) => {
+                    self.caches = None;
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-dense paged_linear_cache_export ok=false reason=not_initialized"
+                    ));
+                }
+                Err(err) => {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-dense paged_linear_cache_export ok=false error={}",
+                        err
+                    ));
+                    self.caches = None;
+                }
+            }
+        }
+
         Ok((generated_tokens, finish_reason))
     }
 
@@ -2598,6 +3229,7 @@ impl Qwen35Inner {
             None
         };
         let mut first_token_instant: Option<std::time::Instant> = None;
+        let trace_enabled = inference_trace_enabled();
 
         // Streaming decode state.
         let mut decode_stream = tokenizer.inner().decode_stream(true);
@@ -2644,7 +3276,12 @@ impl Qwen35Inner {
             adapter.block_size()
         };
         let lookup_extra_keys = chat_common::build_paged_extra_keys(tokens.len(), block_size, &[]);
-        let cached_prefix_len = {
+        let cache_salt = 0;
+        let live_ready;
+        let live_prefix_match;
+        let live_tokens_len;
+        let mut live_mismatch = TokenPrefixMismatchTrace::default();
+        let (cached_prefix_len, continued_live_prefix) = {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason(
                     "chat_stream_sync_core_paged: paged_adapter is None — caller must check \
@@ -2652,25 +3289,36 @@ impl Qwen35Inner {
                 )
             })?;
 
-            let can_continue =
-                adapter.is_live_for_continue() && tokens.starts_with(adapter.request_tokens());
+            live_ready = adapter.is_live_for_continue();
+            let live_tokens = adapter.request_tokens();
+            live_tokens_len = live_tokens.len();
+            live_prefix_match = tokens.starts_with(live_tokens);
+            if trace_enabled && live_ready && !live_prefix_match {
+                live_mismatch = token_prefix_mismatch_trace(&tokens, live_tokens);
+            }
+            let can_continue = live_ready && live_prefix_match;
 
             if can_continue {
                 match adapter.continue_turn(&tokens, total_budget) {
-                    Ok((prior_token_count, _newly_alloc)) => prior_token_count,
+                    Ok((prior_token_count, _newly_alloc)) => (prior_token_count, true),
                     Err(_drift) => {
                         let _ = adapter.release_request();
                         adapter
                             .reset_for_new_request(seq_id)
                             .map_err(Error::from_reason)?;
                         let prefix = adapter
-                            .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, 0, false)
+                            .find_cached_prefix_per_block(
+                                &tokens,
+                                &lookup_extra_keys,
+                                cache_salt,
+                                false,
+                            )
                             .map_err(Error::from_reason)?;
                         let cached = prefix.cached_token_count;
                         adapter
                             .allocate_suffix_blocks(total_budget)
                             .map_err(Error::from_reason)?;
-                        cached
+                        (cached, false)
                     }
                 }
             } else {
@@ -2681,27 +3329,42 @@ impl Qwen35Inner {
                     .reset_for_new_request(seq_id)
                     .map_err(Error::from_reason)?;
                 let prefix = adapter
-                    .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, 0, false)
+                    .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, cache_salt, false)
                     .map_err(Error::from_reason)?;
                 let cached = prefix.cached_token_count;
                 adapter
                     .allocate_suffix_blocks(total_budget)
                     .map_err(Error::from_reason)?;
-                cached
+                (cached, false)
             }
         };
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-dense paged_prefix_lookup prompt_tokens={} \
+                 cached_prefix_tokens={} continued_live_prefix={} live_ready={} \
+                 live_match={} live_tokens={} live_mismatch_at={} prompt_token={} live_token={}",
+                tokens.len(),
+                cached_prefix_len,
+                continued_live_prefix,
+                live_ready,
+                live_prefix_match,
+                live_tokens_len,
+                live_mismatch.index,
+                live_mismatch.prompt_token,
+                live_mismatch.cached_token
+            ));
+        }
 
-        self.caches = Some(
-            (0..self.config.num_layers as usize)
-                .map(|i| {
-                    if self.config.is_linear_layer(i) {
-                        Qwen3_5LayerCache::new_linear()
-                    } else {
-                        Qwen3_5LayerCache::new_full_attention()
-                    }
-                })
-                .collect(),
-        );
+        let gdn_prefix_preparation = self.prepare_dense_gdn_prefix_state(
+            &tokens,
+            cached_prefix_len,
+            block_size,
+            &lookup_extra_keys,
+            cache_salt,
+            continued_live_prefix,
+        )?;
+        let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
+        let gdn_prefix_state = gdn_prefix_preparation.state;
         self.cached_token_history.clear();
         self.cached_image_key = None;
         self.cached_rope_deltas = None;
@@ -2713,6 +3376,24 @@ impl Qwen35Inner {
                     "chat_stream_sync_core_paged: cached_prefix_len > total_prompt_tokens",
                 )
             })?;
+
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-dense stream_paged_start prompt_tokens={} \
+                 cached_prefix_tokens={} suffix_tokens={} block_size={} \
+                 prefill_chunk_size={} prefill_eval_interval={} decode_clear_interval={} \
+                 cpp_paged_candidate={} gdn_prefix_state={}",
+                prompt_token_count,
+                cached_prefix_len,
+                suffix_len,
+                block_size,
+                crate::array::paged_prefill_chunk_size(),
+                crate::array::paged_prefill_eval_interval(),
+                crate::array::paged_decode_cache_clear_interval(),
+                use_cpp_paged,
+                gdn_prefix_state
+            ));
+        }
 
         let result = self.chat_stream_sync_core_paged_inner(
             &tokens,
@@ -2731,6 +3412,7 @@ impl Qwen35Inner {
             cb,
             cancelled,
             use_cpp_paged,
+            gdn_prefix_already_primed,
         );
 
         let (generated_tokens, finish_reason) = match result {
@@ -2763,6 +3445,20 @@ impl Qwen35Inner {
             full_history.extend_from_slice(&generated_tokens[..upto]);
         }
         self.cached_token_history = full_history;
+        let gdn_history_checkpoint_store = self.remember_dense_gdn_history_checkpoint()?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-dense gdn_history_checkpoint stored={} tokens={} \
+                 eval_ms={:.1} clone_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
+                gdn_history_checkpoint_store.stored,
+                self.cached_token_history.len(),
+                gdn_history_checkpoint_store.eval_ms,
+                gdn_history_checkpoint_store.clone_ms,
+                gdn_history_checkpoint_store.token_clone_ms,
+                gdn_history_checkpoint_store.update_ms,
+                gdn_history_checkpoint_store.total_ms
+            ));
+        }
 
         // Flush residual buffered bytes (mirrors flat streaming).
         let full_text = tokenizer
@@ -2875,6 +3571,7 @@ impl Qwen35Inner {
         cb: &StreamSender,
         cancelled: &Arc<AtomicBool>,
         use_cpp_paged: bool,
+        gdn_prefix_already_primed: bool,
     ) -> Result<(Vec<u32>, String)> {
         if suffix_len == 0 {
             return Err(Error::from_reason(
@@ -2902,6 +3599,7 @@ impl Qwen35Inner {
                 tokens,
                 suffix,
                 cached_prefix_len,
+                gdn_prefix_already_primed,
                 &embed,
                 &mut self.layers,
                 caches_ref,
@@ -3161,6 +3859,31 @@ impl Qwen35Inner {
             y.eval();
 
             crate::array::maybe_clear_cache_for_paged_step(step);
+        }
+
+        if cpp_compiled_step_completed {
+            match export_paged_dense_linear_caches(&self.config) {
+                Ok(Some(new_caches)) => {
+                    self.caches = Some(new_caches);
+                    eval_layer_caches(&self.caches)?;
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-dense paged_linear_cache_export ok=true"
+                    ));
+                }
+                Ok(None) => {
+                    self.caches = None;
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-dense paged_linear_cache_export ok=false reason=not_initialized"
+                    ));
+                }
+                Err(err) => {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-dense paged_linear_cache_export ok=false error={}",
+                        err
+                    ));
+                    self.caches = None;
+                }
+            }
         }
 
         Ok((generated_tokens, finish_reason))
@@ -8362,6 +9085,7 @@ mod paged_construction_tests {
             full_tokens,
             suffix_tokens,
             cached_prefix_len,
+            false,
             &embed,
             &mut inner.layers,
             caches,
@@ -8467,6 +9191,77 @@ mod paged_construction_tests {
         assert!(
             inner.paged_adapter.is_none(),
             "paged_adapter must be None when use_block_paged_cache is None"
+        );
+    }
+
+    #[test]
+    fn test_fresh_dense_layer_caches_are_not_gdn_reuse_ready() {
+        let cfg = tiny_cfg(true);
+        let caches = fresh_dense_layer_caches(&cfg);
+        assert_eq!(caches.len(), cfg.num_layers as usize);
+        assert!(
+            !dense_paged_linear_caches_ready(&cfg, Some(&caches)),
+            "fresh linear caches have empty conv/recurrent slots, so a live continuation must replay GDN"
+        );
+        assert!(matches!(caches[0], Qwen3_5LayerCache::Linear(_)));
+        assert!(matches!(caches[3], Qwen3_5LayerCache::FullAttention(_)));
+    }
+
+    #[test]
+    fn test_paged_dense_linear_cache_export_uninitialized_returns_none() {
+        unsafe {
+            mlx_sys::mlx_qwen35_compiled_reset();
+        }
+        let cfg = tiny_cfg(true);
+        let exported = export_paged_dense_linear_caches(&cfg)
+            .expect("uninitialized paged dense export should not fail");
+        assert!(exported.is_none());
+    }
+
+    #[test]
+    fn test_dense_paged_prefix_block_hash_matches_allocator_chain() {
+        let tokens: Vec<u32> = (1..=12).collect();
+        let per_block = vec![vec![11], vec![], vec![33, 44]];
+
+        let h0 = mlx_paged_attn::hash_tokens(&tokens[0..4], 0, &per_block[0]);
+        let h1 = mlx_paged_attn::hash_tokens(&tokens[4..8], h0, &per_block[1]);
+        let h2 = mlx_paged_attn::hash_tokens(&tokens[8..12], h1, &per_block[2]);
+
+        assert_eq!(
+            compute_paged_prefix_block_hash(&tokens, 12, 4, &per_block, 0),
+            Some(h2)
+        );
+    }
+
+    #[test]
+    fn test_dense_paged_prefix_block_hash_applies_salt_to_first_block_only() {
+        let tokens: Vec<u32> = (1..=8).collect();
+        let per_block = vec![vec![11], vec![22]];
+        let salt = 99;
+
+        let mut first_block_keys = per_block[0].clone();
+        first_block_keys.push(salt);
+        let h0 = mlx_paged_attn::hash_tokens(&tokens[0..4], 0, &first_block_keys);
+        let h1 = mlx_paged_attn::hash_tokens(&tokens[4..8], h0, &per_block[1]);
+
+        assert_eq!(
+            compute_paged_prefix_block_hash(&tokens, 8, 4, &per_block, salt),
+            Some(h1)
+        );
+    }
+
+    #[test]
+    fn test_dense_paged_prefix_block_hash_rejects_non_full_or_unkeyed_prefix() {
+        let tokens: Vec<u32> = (1..=8).collect();
+        let per_block = vec![vec![]];
+
+        assert_eq!(
+            compute_paged_prefix_block_hash(&tokens, 6, 4, &per_block, 0),
+            None
+        );
+        assert_eq!(
+            compute_paged_prefix_block_hash(&tokens, 8, 4, &per_block, 0),
+            None
         );
     }
 

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -119,12 +119,7 @@ impl DenseGdnCheckpointStoreTrace {
 fn dense_gdn_store_replayed_prefix_checkpoint_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("MLX_DENSE_GDN_REPLAY_PREFIX_CHECKPOINT")
-            .map(|value| {
-                let normalized = value.trim().to_ascii_lowercase();
-                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
-            })
-            .unwrap_or(false)
+        crate::inference_trace::env_flag_enabled("MLX_DENSE_GDN_REPLAY_PREFIX_CHECKPOINT")
     })
 }
 

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1873,7 +1873,7 @@ impl Qwen35Inner {
                     // compile init would feed stale handles to the GPU —
                     // triggering Metal page-faults / innocent-victim hangs
                     // on the first forward of the next turn.
-                    eval_layer_caches(&self.caches);
+                    eval_layer_caches(&self.caches)?;
                 }
             }
         } else {
@@ -3689,7 +3689,7 @@ impl Qwen35Inner {
                     // See `chat_with_caches_inner` for rationale: force-eval
                     // the exported lazy handles before `CompiledResetGuard`
                     // clears `g_compiled_caches` at end of scope.
-                    eval_layer_caches(&self.caches);
+                    eval_layer_caches(&self.caches)?;
                 }
             }
         } else {
@@ -4249,7 +4249,7 @@ impl Qwen35Inner {
                     // See `chat_with_caches_inner` for rationale: force-eval
                     // the exported lazy handles before `CompiledResetGuard`
                     // clears `g_compiled_caches` at end of scope.
-                    eval_layer_caches(&self.caches);
+                    eval_layer_caches(&self.caches)?;
                 }
             }
         } else {
@@ -6585,14 +6585,15 @@ const PREFILL_STEP_SIZE: i64 = 2048;
 
 /// Evaluate all cache arrays across all layers to materialize them on GPU.
 /// Must be called between prefill chunks to break lazy dependency chains.
-pub(crate) fn eval_layer_caches(caches: &Option<Vec<Qwen3_5LayerCache>>) {
+pub(crate) fn eval_layer_caches(caches: &Option<Vec<Qwen3_5LayerCache>>) -> Result<()> {
     if let Some(caches) = caches {
         let mut arrays: Vec<&MxArray> = Vec::new();
         for cache in caches.iter() {
             cache.collect_arrays(&mut arrays);
         }
-        MxArray::eval_arrays(&arrays);
+        MxArray::eval_arrays(&arrays)?;
     }
+    Ok(())
 }
 
 /// Chunked prefill: process prompt in chunks of `PREFILL_STEP_SIZE`, evaluating
@@ -6627,7 +6628,7 @@ fn chunked_prefill(
                 embedding_weight_t,
             )?;
         }
-        eval_layer_caches(caches);
+        eval_layer_caches(caches)?;
         crate::array::clear_cache();
         offset += PREFILL_STEP_SIZE;
     }

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -33,14 +33,31 @@
 //!   For the **no-cache** case (cached_prefix_len = 0), pass 1 is
 //!   skipped entirely and the result is exact.
 
+use std::time::Instant;
+
 use napi::bindgen_prelude::*;
 
 use crate::array::MxArray;
+use crate::inference_trace::{
+    elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
+};
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
 
 use super::decoder_layer::{DecoderLayer, Qwen3_5LayerKind};
 use super::layer_cache::Qwen3_5LayerCache;
+
+fn bytes_to_mib(bytes: f64) -> f64 {
+    bytes / (1024.0 * 1024.0)
+}
+
+fn trace_memory_mib() -> (f64, f64, f64) {
+    (
+        bytes_to_mib(crate::array::get_active_memory()),
+        bytes_to_mib(crate::array::get_cache_memory()),
+        bytes_to_mib(crate::array::get_peak_memory()),
+    )
+}
 
 /// Forward the cached-prefix tokens through GDN layers ONLY. Used as
 /// "pass 1" of the paged prefill when there is a non-zero cached
@@ -104,73 +121,261 @@ pub(crate) fn run_paged_prefill_chunk(
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
 ) -> Result<MxArray> {
+    let chunk_size = crate::array::paged_prefill_chunk_size();
+    run_paged_prefill_chunk_with_size(
+        full_tokens,
+        suffix_tokens,
+        cached_prefix_len,
+        embed,
+        layers,
+        caches,
+        final_norm,
+        lm_head,
+        embedding_weight,
+        layer_kinds,
+        paged_adapter,
+        chunk_size,
+    )
+}
+
+/// Chunk-size-parameterized worker for `run_paged_prefill_chunk`.
+///
+/// `chunk_size <= 0` keeps the single-shot path. Positive chunk sizes split
+/// only the uncached suffix. Each chunk writes its K/V into the paged adapter,
+/// attends over the cumulative cached range, then clears MLX's transient graph
+/// before the next chunk. This matches the Qwen3/Qwen3.5 MoE driver shape and
+/// keeps dense Qwen from building one giant prefill graph for 30k+ suffixes.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_paged_prefill_chunk_with_size(
+    full_tokens: &[u32],
+    suffix_tokens: &[u32],
+    cached_prefix_len: u32,
+    embed: &Embedding,
+    layers: &mut [DecoderLayer],
+    caches: &mut [Qwen3_5LayerCache],
+    final_norm: &RMSNorm,
+    lm_head: &Option<Linear>,
+    embedding_weight: &MxArray,
+    layer_kinds: &[Qwen3_5LayerKind],
+    paged_adapter: &mut PagedKVCacheAdapter,
+    chunk_size: i32,
+) -> Result<MxArray> {
     if suffix_tokens.is_empty() {
         return Err(Error::from_reason(
             "run_paged_prefill_chunk called with empty suffix",
         ));
     }
 
-    // 1. Record SUFFIX tokens in the paged adapter (the cached prefix
-    //    already lives in the pool from a prior request).
+    if chunk_size <= 0 || suffix_tokens.len() <= chunk_size as usize {
+        return run_paged_prefill_single_shot(
+            full_tokens,
+            suffix_tokens,
+            cached_prefix_len,
+            embed,
+            layers,
+            caches,
+            final_norm,
+            lm_head,
+            embedding_weight,
+            layer_kinds,
+            paged_adapter,
+        );
+    }
+
+    let trace_enabled = inference_trace_enabled();
+    let chunk_size_usize = chunk_size as usize;
+
+    // Pass 1: GDN-only prefill over the cached prefix. This runs once before
+    // suffix chunking; GDN recurrent state then advances in-place across chunks.
+    if cached_prefix_len > 0 {
+        let gdn_trace_start = trace_enabled.then(Instant::now);
+        let prefix = &full_tokens[..(cached_prefix_len as usize)];
+        run_gdn_only_prefill(prefix, embed, layers, caches)?;
+        if let Some(start) = gdn_trace_start {
+            let (active_mib, cache_mib, peak_mib) = trace_memory_mib();
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-dense paged_prefill_gdn_prefix_done \
+                 prefix_tokens={} elapsed_ms={:.1} active_mib={:.1} cache_mib={:.1} peak_mib={:.1}",
+                cached_prefix_len,
+                elapsed_ms(start),
+                active_mib,
+                cache_mib,
+                peak_mib
+            ));
+        }
+    }
+
+    let total_chunks = suffix_tokens.len().div_ceil(chunk_size_usize);
+    let mut last_logits: Option<MxArray> = None;
+    let mut chunk_start_position = cached_prefix_len;
+
+    for (chunk_idx, chunk) in suffix_tokens.chunks(chunk_size_usize).enumerate() {
+        let is_last_chunk = chunk_idx + 1 == total_chunks;
+        let chunk_trace_start = trace_enabled.then(Instant::now);
+
+        paged_adapter
+            .record_tokens(chunk)
+            .map_err(Error::from_reason)?;
+
+        let hidden_states = run_paged_prefill_one_chunk(
+            chunk,
+            chunk_start_position,
+            embed,
+            layers,
+            caches,
+            layer_kinds,
+            paged_adapter,
+        )?;
+
+        if is_last_chunk {
+            last_logits = Some(project_last_token_logits(
+                &hidden_states,
+                final_norm,
+                lm_head,
+                embedding_weight,
+            )?);
+            if let Some(start) = chunk_trace_start {
+                let chunk_elapsed_ms = elapsed_ms(start);
+                let (active_mib, cache_mib, peak_mib) = trace_memory_mib();
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-dense paged_prefill_chunk_final_graph_built \
+                     chunk_index={} total_chunks={} chunk_tokens={} context_before={} context_after={} \
+                     elapsed_ms={:.1} active_mib={:.1} cache_mib={:.1} peak_mib={:.1}",
+                    chunk_idx + 1,
+                    total_chunks,
+                    chunk.len(),
+                    chunk_start_position,
+                    chunk_start_position + chunk.len() as u32,
+                    chunk_elapsed_ms,
+                    active_mib,
+                    cache_mib,
+                    peak_mib
+                ));
+            }
+        } else {
+            hidden_states.eval();
+            crate::array::synchronize_and_clear_cache();
+            if let Some(start) = chunk_trace_start {
+                let chunk_elapsed_ms = elapsed_ms(start);
+                let chunk_tok_s = if chunk_elapsed_ms > 0.0 {
+                    chunk.len() as f64 / (chunk_elapsed_ms / 1000.0)
+                } else {
+                    0.0
+                };
+                let (active_mib, cache_mib, peak_mib) = trace_memory_mib();
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-dense paged_prefill_chunk_done \
+                     chunk_index={} total_chunks={} chunk_tokens={} context_before={} context_after={} \
+                     elapsed_ms={:.1} tok_s={:.2} active_mib={:.1} cache_mib={:.1} peak_mib={:.1}",
+                    chunk_idx + 1,
+                    total_chunks,
+                    chunk.len(),
+                    chunk_start_position,
+                    chunk_start_position + chunk.len() as u32,
+                    chunk_elapsed_ms,
+                    chunk_tok_s,
+                    active_mib,
+                    cache_mib,
+                    peak_mib
+                ));
+            }
+        }
+
+        chunk_start_position += chunk.len() as u32;
+    }
+
+    last_logits.ok_or_else(|| {
+        Error::from_reason(
+            "chunked prefill produced no last chunk (unreachable for non-empty suffix)",
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_paged_prefill_single_shot(
+    full_tokens: &[u32],
+    suffix_tokens: &[u32],
+    cached_prefix_len: u32,
+    embed: &Embedding,
+    layers: &mut [DecoderLayer],
+    caches: &mut [Qwen3_5LayerCache],
+    final_norm: &RMSNorm,
+    lm_head: &Option<Linear>,
+    embedding_weight: &MxArray,
+    layer_kinds: &[Qwen3_5LayerKind],
+    paged_adapter: &mut PagedKVCacheAdapter,
+) -> Result<MxArray> {
     paged_adapter
         .record_tokens(suffix_tokens)
         .map_err(Error::from_reason)?;
 
-    // 2. Pass 1: GDN-only prefill over the cached prefix (no-op when
-    //    cached_prefix_len == 0).
     if cached_prefix_len > 0 {
         let prefix = &full_tokens[..(cached_prefix_len as usize)];
         run_gdn_only_prefill(prefix, embed, layers, caches)?;
     }
 
-    // 3. Pass 2: full forward (GDN + paged-attention) over the
-    //    suffix.
-    let suffix_len = suffix_tokens.len() as i64;
-    let input_ids = MxArray::from_uint32(suffix_tokens, &[1, suffix_len])?;
+    let hidden_states = run_paged_prefill_one_chunk(
+        suffix_tokens,
+        cached_prefix_len,
+        embed,
+        layers,
+        caches,
+        layer_kinds,
+        paged_adapter,
+    )?;
+
+    project_last_token_logits(&hidden_states, final_norm, lm_head, embedding_weight)
+}
+
+fn run_paged_prefill_one_chunk(
+    chunk_tokens: &[u32],
+    chunk_first_position: u32,
+    embed: &Embedding,
+    layers: &mut [DecoderLayer],
+    caches: &mut [Qwen3_5LayerCache],
+    layer_kinds: &[Qwen3_5LayerKind],
+    paged_adapter: &mut PagedKVCacheAdapter,
+) -> Result<MxArray> {
+    debug_assert_eq!(layers.len(), caches.len());
+    debug_assert_eq!(layers.len(), layer_kinds.len());
+
+    let chunk_len = chunk_tokens.len() as i64;
+    let input_ids = MxArray::from_uint32(chunk_tokens, &[1, chunk_len])?;
     let mut hidden_states = embed.forward(&input_ids)?;
 
-    let num_layers = layers.len();
-    let first_logical_position = cached_prefix_len;
-
-    #[allow(clippy::needless_range_loop)]
-    for layer_idx in 0..num_layers {
-        let kind = layer_kinds[layer_idx];
-
-        // Split-borrow: layers[layer_idx] (mutable per layer) +
-        // caches[layer_idx] (mutable for GDN) + paged_adapter
-        // (mutable for attention).
-        let layer = unsafe {
-            let ptr = layers.as_mut_ptr().add(layer_idx);
-            &mut *ptr
-        };
-        let cache_slot = unsafe {
-            let ptr = caches.as_mut_ptr().add(layer_idx);
-            &mut *ptr
-        };
-
+    for (layer_idx, ((layer, cache_slot), kind)) in layers
+        .iter_mut()
+        .zip(caches.iter_mut())
+        .zip(layer_kinds.iter().copied())
+        .enumerate()
+    {
         hidden_states = layer.forward_paged_or_flat(
             &hidden_states,
             kind,
             paged_adapter,
-            first_logical_position,
-            cached_prefix_len,
+            chunk_first_position,
+            chunk_first_position,
             /* is_prefill */ true,
             /* mask */ None,
             Some(cache_slot),
             /* position_ids */ None,
             /* use_kernel */ true,
         )?;
-        // Smooth the prefill memory peak: every K layers, materialize the
-        // residual stream so MLX can release the upstream graph nodes
-        // (embedding + every prior layer's attention/MLP intermediates)
-        // from the cache pool. Without this the in-flight lazy graph
-        // accumulates ~50 GB on long contexts before the post-prefill
-        // sync fires. Cadence is `MLX_PAGED_PREFILL_EVAL_INTERVAL` (default 8).
         crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states)?;
     }
+    Ok(hidden_states)
+}
 
-    // 4. Output norm + lm_head / tied embeddings.
-    let h = final_norm.forward(&hidden_states)?;
+fn project_last_token_logits(
+    hidden_states: &MxArray,
+    final_norm: &RMSNorm,
+    lm_head: &Option<Linear>,
+    embedding_weight: &MxArray,
+) -> Result<MxArray> {
+    let seq_len = hidden_states.shape_at(1)?;
+    let last_hidden = hidden_states.slice_axis(1, seq_len - 1, seq_len)?;
+
+    let h = final_norm.forward(&last_hidden)?;
     let logits = if let Some(head) = lm_head {
         head.forward(&h)?
     } else {
@@ -178,11 +383,7 @@ pub(crate) fn run_paged_prefill_chunk(
         h.matmul(&weight_t)?
     };
 
-    let seq_len = logits.shape_at(1)?;
-    let last = logits
-        .slice_axis(1, seq_len - 1, seq_len)?
-        .squeeze(Some(&[0, 1]))?;
-    Ok(last)
+    logits.squeeze(Some(&[0, 1]))
 }
 
 /// Run one paged decode step: feed `[token_id]` through the model.

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -166,7 +166,7 @@ pub(crate) fn run_paged_prefill_chunk(
         // from the cache pool. Without this the in-flight lazy graph
         // accumulates ~50 GB on long contexts before the post-prefill
         // sync fires. Cadence is `MLX_PAGED_PREFILL_EVAL_INTERVAL` (default 8).
-        crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states);
+        crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states)?;
     }
 
     // 4. Output norm + lm_head / tied embeddings.

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -16,11 +16,11 @@
 //! The decode step is a single-token forward through every layer,
 //! gathering K/V from the paged pool for attention layers.
 //!
-//! Strategy notes (mirrors LFM2):
-//! * GDN layers do NOT participate in cross-request prefix reuse — the
-//!   recurrent state cannot be rewound, so each paged turn re-prefills
-//!   GDN over the entire prompt. Only the attention layers benefit
-//!   from the paged adapter's refcounted block reuse.
+//! Strategy notes (mirrors LFM2/Qwen3.5-MoE):
+//! * Full-attention layers reuse K/V through the paged adapter. GDN
+//!   layers can only skip prefix replay when the caller has restored a
+//!   matching sidecar checkpoint (`gdn_prefix_already_primed=true`);
+//!   otherwise this helper replays the cached prefix through GDN.
 //! * The two-pass scheme is approximate for GDN over the cached
 //!   prefix: the prefix's GDN forward sees a hidden-state stream
 //!   produced by passing through ALL layers (including attention)
@@ -112,6 +112,7 @@ pub(crate) fn run_paged_prefill_chunk(
     full_tokens: &[u32],
     suffix_tokens: &[u32],
     cached_prefix_len: u32,
+    gdn_prefix_already_primed: bool,
     embed: &Embedding,
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
@@ -126,6 +127,7 @@ pub(crate) fn run_paged_prefill_chunk(
         full_tokens,
         suffix_tokens,
         cached_prefix_len,
+        gdn_prefix_already_primed,
         embed,
         layers,
         caches,
@@ -150,6 +152,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
     full_tokens: &[u32],
     suffix_tokens: &[u32],
     cached_prefix_len: u32,
+    gdn_prefix_already_primed: bool,
     embed: &Embedding,
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
@@ -171,6 +174,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
             full_tokens,
             suffix_tokens,
             cached_prefix_len,
+            gdn_prefix_already_primed,
             embed,
             layers,
             caches,
@@ -187,7 +191,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
 
     // Pass 1: GDN-only prefill over the cached prefix. This runs once before
     // suffix chunking; GDN recurrent state then advances in-place across chunks.
-    if cached_prefix_len > 0 {
+    if cached_prefix_len > 0 && !gdn_prefix_already_primed {
         let gdn_trace_start = trace_enabled.then(Instant::now);
         let prefix = &full_tokens[..(cached_prefix_len as usize)];
         run_gdn_only_prefill(prefix, embed, layers, caches)?;
@@ -296,6 +300,7 @@ fn run_paged_prefill_single_shot(
     full_tokens: &[u32],
     suffix_tokens: &[u32],
     cached_prefix_len: u32,
+    gdn_prefix_already_primed: bool,
     embed: &Embedding,
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
@@ -309,7 +314,7 @@ fn run_paged_prefill_single_shot(
         .record_tokens(suffix_tokens)
         .map_err(Error::from_reason)?;
 
-    if cached_prefix_len > 0 {
+    if cached_prefix_len > 0 && !gdn_prefix_already_primed {
         let prefix = &full_tokens[..(cached_prefix_len as usize)];
         run_gdn_only_prefill(prefix, embed, layers, caches)?;
     }

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -752,16 +752,11 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
                     &per_layer_quant,
                 )?;
 
-                // Register weights with C++
-                if !is_quantized_checkpoint(&params) && !is_mxfp8_checkpoint(&params) {
-                    register_weights_with_cpp(&params, inner.model_id);
-                } else {
-                    info!(
-                        "Skipping C++ compiled path for quantized model (using Rust quantized_matmul)"
-                    );
-                    let _guard = super::model::COMPILED_WEIGHTS_RWLOCK.write().unwrap();
-                    unsafe { mlx_sys::mlx_clear_weights() };
-                }
+                // Register weights with C++. The dense compiled graph uses the
+                // shared quant-aware `linear_proj` helper for projections, so
+                // Q8/MXFP8 checkpoints can take the same compiled decode path
+                // as bf16 checkpoints.
+                register_weights_with_cpp(&params, inner.model_id);
 
                 // Materialize mmap-backed weights
                 {

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -766,7 +766,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
                 // Materialize mmap-backed weights
                 {
                     let arrays: Vec<&MxArray> = params.values().collect();
-                    crate::array::memory::materialize_weights(&arrays);
+                    crate::array::memory::materialize_weights(&arrays)?;
                 }
 
                 // Set tokenizer

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1,6 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
@@ -36,6 +38,200 @@ use crate::sampling::{SamplingConfig, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
+
+fn inference_trace_enabled() -> bool {
+    inference_trace_file().is_some()
+}
+
+fn inference_trace_file() -> Option<&'static str> {
+    static TRACE_FILE: OnceLock<Option<String>> = OnceLock::new();
+    TRACE_FILE
+        .get_or_init(|| {
+            let enabled = match std::env::var("MLX_INFERENCE_TRACE") {
+                Ok(value) => matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                ),
+                Err(_) => false,
+            };
+            if !enabled {
+                return None;
+            }
+            std::env::var("MLX_INFERENCE_TRACE_FILE")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .as_deref()
+}
+
+fn write_inference_trace(args: std::fmt::Arguments<'_>) {
+    let Some(path) = inference_trace_file() else {
+        return;
+    };
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(file, "{args}");
+    }
+}
+
+fn elapsed_ms(start: std::time::Instant) -> f64 {
+    start.elapsed().as_secs_f64() * 1000.0
+}
+
+fn fresh_moe_layer_caches(config: &Qwen3_5MoeConfig) -> Vec<Qwen3_5LayerCache> {
+    (0..config.num_layers as usize)
+        .map(|i| {
+            if config.is_linear_layer(i) {
+                Qwen3_5LayerCache::new_linear()
+            } else {
+                Qwen3_5LayerCache::new_full_attention()
+            }
+        })
+        .collect()
+}
+
+const MOE_GDN_PREFIX_CHECKPOINT_LIMIT: usize = 8;
+
+struct MoeGdnPrefixCheckpoint {
+    prefix_len: u32,
+    block_size: u32,
+    final_block_hash: u64,
+    tokens: Vec<u32>,
+    caches: Vec<Qwen3_5LayerCache>,
+}
+
+struct MoeGdnHistoryCheckpoint {
+    tokens: Vec<u32>,
+    caches: Vec<Qwen3_5LayerCache>,
+}
+
+struct MoeGdnPrefixPreparation {
+    state: &'static str,
+    already_primed: bool,
+}
+
+fn moe_paged_linear_caches_ready(
+    config: &Qwen3_5MoeConfig,
+    caches: Option<&[Qwen3_5LayerCache]>,
+) -> bool {
+    let Some(caches) = caches else {
+        return false;
+    };
+    if caches.len() != config.num_layers as usize {
+        return false;
+    }
+    for (i, cache) in caches.iter().enumerate() {
+        if !config.is_linear_layer(i) {
+            continue;
+        }
+        let Qwen3_5LayerCache::Linear(arrays) = cache else {
+            return false;
+        };
+        if arrays.get(0).is_none() || arrays.get(1).is_none() {
+            return false;
+        }
+    }
+    true
+}
+
+fn clone_moe_linear_layer_caches(
+    config: &Qwen3_5MoeConfig,
+    caches: &[Qwen3_5LayerCache],
+) -> Option<Vec<Qwen3_5LayerCache>> {
+    if !moe_paged_linear_caches_ready(config, Some(caches)) {
+        return None;
+    }
+
+    let mut cloned = fresh_moe_layer_caches(config);
+    for i in 0..config.num_layers as usize {
+        if !config.is_linear_layer(i) {
+            continue;
+        }
+        let Qwen3_5LayerCache::Linear(arrays) = &caches[i] else {
+            return None;
+        };
+        cloned[i] = Qwen3_5LayerCache::Linear(arrays.clone());
+    }
+    Some(cloned)
+}
+
+fn compute_paged_prefix_block_hash(
+    tokens: &[u32],
+    prefix_len: u32,
+    block_size: u32,
+    extra_keys_per_block: &[Vec<u64>],
+    cache_salt: u64,
+) -> Option<u64> {
+    if prefix_len == 0 || block_size == 0 || prefix_len % block_size != 0 {
+        return None;
+    }
+
+    let prefix_len = prefix_len as usize;
+    let block_size = block_size as usize;
+    if prefix_len > tokens.len() {
+        return None;
+    }
+
+    let num_blocks = prefix_len / block_size;
+    let mut parent_hash = 0;
+    for block_idx in 0..num_blocks {
+        let extra_keys = extra_keys_per_block.get(block_idx)?;
+        let start = block_idx * block_size;
+        let end = start + block_size;
+        parent_hash = if block_idx == 0 && cache_salt != 0 {
+            let mut salted_keys = Vec::with_capacity(extra_keys.len() + 1);
+            salted_keys.extend_from_slice(extra_keys);
+            salted_keys.push(cache_salt);
+            mlx_paged_attn::hash_tokens(&tokens[start..end], parent_hash, &salted_keys)
+        } else {
+            mlx_paged_attn::hash_tokens(&tokens[start..end], parent_hash, extra_keys)
+        };
+    }
+
+    Some(parent_hash)
+}
+
+fn export_paged_moe_linear_caches(
+    config: &Qwen3_5MoeConfig,
+) -> Result<Option<Vec<Qwen3_5LayerCache>>> {
+    let num_layers = config.num_layers as usize;
+    let expected = num_layers
+        .checked_mul(2)
+        .ok_or_else(|| Error::from_reason("paged MoE cache export size overflow"))?;
+    let mut export_ptrs: Vec<*mut mlx_sys::mlx_array> = vec![std::ptr::null_mut(); expected];
+    let exported = unsafe {
+        mlx_sys::mlx_qwen35_moe_export_paged_linear_caches(
+            export_ptrs.as_mut_ptr(),
+            expected as i32,
+        )
+    };
+    if exported == 0 {
+        return Ok(None);
+    }
+    if exported != expected as i32 {
+        return Err(Error::from_reason(format!(
+            "paged MoE linear cache export returned {exported} arrays; expected {expected}"
+        )));
+    }
+
+    let cache_offset = unsafe { mlx_sys::mlx_qwen35_moe_get_paged_cache_offset() };
+    let mut new_caches = fresh_moe_layer_caches(config);
+    for i in 0..num_layers {
+        if !config.is_linear_layer(i) {
+            continue;
+        }
+        let p0 = export_ptrs[i * 2];
+        let p1 = export_ptrs[i * 2 + 1];
+        if p0.is_null() || p1.is_null() {
+            return Err(Error::from_reason(format!(
+                "paged MoE linear cache export missing layer {i}"
+            )));
+        }
+        new_caches[i].import_ptrs(p0, p1, cache_offset);
+    }
+
+    Ok(Some(new_caches))
+}
 
 // Import the shared model ID counter from the dense module — dense and MoE
 // share the same C++ weight map, so IDs must be globally unique.
@@ -83,6 +279,8 @@ pub(crate) struct Qwen35MoeInner {
     pub(crate) cached_image_key: Option<u64>,
     pub(crate) cached_rope_deltas: Option<i32>,
     pub(crate) model_id: u64,
+    gdn_prefix_checkpoints: VecDeque<MoeGdnPrefixCheckpoint>,
+    gdn_last_history_checkpoint: Option<MoeGdnHistoryCheckpoint>,
     /// Block-paged KV adapter (vLLM-style refcounted prefix cache) for
     /// full-attention layers — same semantics as the dense model.
     /// **Opt-in via `Qwen3_5MoeConfig::use_block_paged_cache`.**
@@ -578,6 +776,8 @@ impl Qwen35MoeInner {
             cached_image_key: None,
             cached_rope_deltas: None,
             model_id,
+            gdn_prefix_checkpoints: VecDeque::new(),
+            gdn_last_history_checkpoint: None,
             paged_adapter,
             training_state: None,
         })
@@ -616,6 +816,8 @@ impl Qwen35MoeInner {
         self.cached_token_history.clear();
         self.cached_image_key = None;
         self.cached_rope_deltas = None;
+        self.gdn_prefix_checkpoints.clear();
+        self.gdn_last_history_checkpoint = None;
     }
 
     /// Take the KV cache from the model, returning a `PromptCache` handle.
@@ -626,6 +828,8 @@ impl Qwen35MoeInner {
             return None;
         }
         let caches = self.caches.take()?;
+        self.gdn_prefix_checkpoints.clear();
+        self.gdn_last_history_checkpoint = None;
         Some(crate::models::qwen3_5::prompt_cache::PromptCache::new(
             caches,
             self.cached_token_history.clone(),
@@ -649,7 +853,226 @@ impl Qwen35MoeInner {
         self.cached_token_history = cache.token_history().to_vec();
         self.cached_image_key = cache.image_cache_key();
         self.cached_rope_deltas = cache.rope_deltas();
+        self.gdn_prefix_checkpoints.clear();
+        self.gdn_last_history_checkpoint = None;
         Ok(())
+    }
+
+    fn find_moe_gdn_history_checkpoint(
+        &self,
+        tokens: &[u32],
+        prefix_len: u32,
+    ) -> Option<Vec<Qwen3_5LayerCache>> {
+        let prefix_tokens = tokens.get(..prefix_len as usize)?;
+        let checkpoint = self.gdn_last_history_checkpoint.as_ref()?;
+        if checkpoint.tokens.as_slice() != prefix_tokens {
+            return None;
+        }
+        clone_moe_linear_layer_caches(&self.config, &checkpoint.caches)
+    }
+
+    fn remember_moe_gdn_history_checkpoint(&mut self) -> bool {
+        if self.cached_token_history.is_empty() {
+            self.gdn_last_history_checkpoint = None;
+            return false;
+        }
+
+        eval_layer_caches(&self.caches);
+        let Some(caches) = self
+            .caches
+            .as_ref()
+            .and_then(|caches| clone_moe_linear_layer_caches(&self.config, caches))
+        else {
+            self.gdn_last_history_checkpoint = None;
+            return false;
+        };
+
+        self.gdn_last_history_checkpoint = Some(MoeGdnHistoryCheckpoint {
+            tokens: self.cached_token_history.clone(),
+            caches,
+        });
+        true
+    }
+
+    fn find_moe_gdn_prefix_checkpoint(
+        &self,
+        tokens: &[u32],
+        prefix_len: u32,
+        block_size: u32,
+        extra_keys_per_block: &[Vec<u64>],
+        cache_salt: u64,
+    ) -> Option<Vec<Qwen3_5LayerCache>> {
+        let final_block_hash = compute_paged_prefix_block_hash(
+            tokens,
+            prefix_len,
+            block_size,
+            extra_keys_per_block,
+            cache_salt,
+        )?;
+        let prefix_len_usize = prefix_len as usize;
+        let prefix_tokens = tokens.get(..prefix_len_usize)?;
+
+        self.gdn_prefix_checkpoints
+            .iter()
+            .rev()
+            .find(|checkpoint| {
+                checkpoint.prefix_len == prefix_len
+                    && checkpoint.block_size == block_size
+                    && checkpoint.final_block_hash == final_block_hash
+                    && checkpoint.tokens.as_slice() == prefix_tokens
+                    && moe_paged_linear_caches_ready(&self.config, Some(&checkpoint.caches))
+            })
+            .and_then(|checkpoint| clone_moe_linear_layer_caches(&self.config, &checkpoint.caches))
+    }
+
+    fn remember_moe_gdn_prefix_checkpoint(
+        &mut self,
+        tokens: &[u32],
+        prefix_len: u32,
+        block_size: u32,
+        extra_keys_per_block: &[Vec<u64>],
+        cache_salt: u64,
+    ) -> bool {
+        let Some(final_block_hash) = compute_paged_prefix_block_hash(
+            tokens,
+            prefix_len,
+            block_size,
+            extra_keys_per_block,
+            cache_salt,
+        ) else {
+            return false;
+        };
+        let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
+            return false;
+        };
+
+        eval_layer_caches(&self.caches);
+        let Some(caches) = self
+            .caches
+            .as_ref()
+            .and_then(|caches| clone_moe_linear_layer_caches(&self.config, caches))
+        else {
+            return false;
+        };
+        let prefix_tokens = prefix_tokens.to_vec();
+
+        self.gdn_prefix_checkpoints.retain(|checkpoint| {
+            !(checkpoint.prefix_len == prefix_len
+                && checkpoint.block_size == block_size
+                && checkpoint.final_block_hash == final_block_hash
+                && checkpoint.tokens == prefix_tokens)
+        });
+        self.gdn_prefix_checkpoints
+            .push_back(MoeGdnPrefixCheckpoint {
+                prefix_len,
+                block_size,
+                final_block_hash,
+                tokens: prefix_tokens,
+                caches,
+            });
+        while self.gdn_prefix_checkpoints.len() > MOE_GDN_PREFIX_CHECKPOINT_LIMIT {
+            self.gdn_prefix_checkpoints.pop_front();
+        }
+
+        true
+    }
+
+    fn prepare_moe_gdn_prefix_state(
+        &mut self,
+        tokens: &[u32],
+        cached_prefix_len: u32,
+        block_size: u32,
+        extra_keys_per_block: &[Vec<u64>],
+        cache_salt: u64,
+        continued_live_prefix: bool,
+    ) -> Result<MoeGdnPrefixPreparation> {
+        let gdn_caches_ready = moe_paged_linear_caches_ready(&self.config, self.caches.as_deref());
+        if gdn_caches_ready && continued_live_prefix {
+            return Ok(MoeGdnPrefixPreparation {
+                state: "live",
+                already_primed: true,
+            });
+        }
+
+        let gdn_prefix_from_history = cached_prefix_len > 0
+            && self.cached_token_history.len() == cached_prefix_len as usize
+            && tokens.starts_with(&self.cached_token_history);
+        if gdn_caches_ready && gdn_prefix_from_history {
+            return Ok(MoeGdnPrefixPreparation {
+                state: "last_history",
+                already_primed: true,
+            });
+        }
+        if cached_prefix_len > 0 {
+            if let Some(checkpoint) =
+                self.find_moe_gdn_history_checkpoint(tokens, cached_prefix_len)
+            {
+                self.caches = Some(checkpoint);
+                return Ok(MoeGdnPrefixPreparation {
+                    state: "last_history_checkpoint",
+                    already_primed: true,
+                });
+            } else if inference_trace_enabled() {
+                let history_checkpoint_len = self
+                    .gdn_last_history_checkpoint
+                    .as_ref()
+                    .map_or(0, |checkpoint| checkpoint.tokens.len());
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint_miss \
+                     cached_prefix_tokens={} history_len={} checkpoint_len={} \
+                     history_match={}",
+                    cached_prefix_len,
+                    self.cached_token_history.len(),
+                    history_checkpoint_len,
+                    gdn_prefix_from_history
+                ));
+            }
+        }
+
+        if let Some(checkpoint) = self.find_moe_gdn_prefix_checkpoint(
+            tokens,
+            cached_prefix_len,
+            block_size,
+            extra_keys_per_block,
+            cache_salt,
+        ) {
+            self.caches = Some(checkpoint);
+            return Ok(MoeGdnPrefixPreparation {
+                state: "checkpoint",
+                already_primed: true,
+            });
+        }
+
+        self.caches = Some(fresh_moe_layer_caches(&self.config));
+        if cached_prefix_len == 0 {
+            return Ok(MoeGdnPrefixPreparation {
+                state: "replay",
+                already_primed: false,
+            });
+        }
+
+        let cached_prefix_len_usize = cached_prefix_len as usize;
+        let prefix = tokens.get(..cached_prefix_len_usize).ok_or_else(|| {
+            Error::from_reason("MoE paged GDN prefix replay length exceeds prompt length")
+        })?;
+        let embed = self.embedding.clone();
+        let caches_ref = self
+            .caches
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("MoE paged GDN prefix caches not initialized"))?;
+        super::paged_forward::run_gdn_only_prefill(prefix, &embed, &mut self.layers, caches_ref)?;
+        let stored = self.remember_moe_gdn_prefix_checkpoint(
+            tokens,
+            cached_prefix_len,
+            block_size,
+            extra_keys_per_block,
+            cache_salt,
+        );
+
+        Ok(MoeGdnPrefixPreparation {
+            state: if stored { "replay_store" } else { "replay" },
+            already_primed: true,
+        })
     }
 
     /// Set the tokenizer.
@@ -1335,7 +1758,8 @@ impl Qwen35MoeInner {
             adapter.block_size()
         };
         let lookup_extra_keys = chat_common::build_paged_extra_keys(tokens.len(), block_size, &[]);
-        let cached_prefix_len = {
+        let cache_salt = 0;
+        let (cached_prefix_len, continued_live_prefix) = {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason("MoE chat_sync_core_paged: paged_adapter is None")
             })?;
@@ -1343,20 +1767,25 @@ impl Qwen35MoeInner {
                 adapter.is_live_for_continue() && tokens.starts_with(adapter.request_tokens());
             if can_continue {
                 match adapter.continue_turn(&tokens, total_budget) {
-                    Ok((prior, _)) => prior,
+                    Ok((prior, _)) => (prior, true),
                     Err(_) => {
                         let _ = adapter.release_request();
                         adapter
                             .reset_for_new_request(seq_id)
                             .map_err(Error::from_reason)?;
                         let prefix = adapter
-                            .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, 0, false)
+                            .find_cached_prefix_per_block(
+                                &tokens,
+                                &lookup_extra_keys,
+                                cache_salt,
+                                false,
+                            )
                             .map_err(Error::from_reason)?;
                         let cached = prefix.cached_token_count;
                         adapter
                             .allocate_suffix_blocks(total_budget)
                             .map_err(Error::from_reason)?;
-                        cached
+                        (cached, false)
                     }
                 }
             } else {
@@ -1367,27 +1796,25 @@ impl Qwen35MoeInner {
                     .reset_for_new_request(seq_id)
                     .map_err(Error::from_reason)?;
                 let prefix = adapter
-                    .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, 0, false)
+                    .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, cache_salt, false)
                     .map_err(Error::from_reason)?;
                 let cached = prefix.cached_token_count;
                 adapter
                     .allocate_suffix_blocks(total_budget)
                     .map_err(Error::from_reason)?;
-                cached
+                (cached, false)
             }
         };
 
-        self.caches = Some(
-            (0..self.config.num_layers as usize)
-                .map(|i| {
-                    if self.config.is_linear_layer(i) {
-                        Qwen3_5LayerCache::new_linear()
-                    } else {
-                        Qwen3_5LayerCache::new_full_attention()
-                    }
-                })
-                .collect(),
-        );
+        let gdn_prefix_preparation = self.prepare_moe_gdn_prefix_state(
+            &tokens,
+            cached_prefix_len,
+            block_size,
+            &lookup_extra_keys,
+            cache_salt,
+            continued_live_prefix,
+        )?;
+        let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         self.cached_token_history.clear();
         self.cached_image_key = None;
         self.cached_rope_deltas = None;
@@ -1411,6 +1838,7 @@ impl Qwen35MoeInner {
             report_perf,
             &mut first_token_instant,
             use_cpp_paged,
+            gdn_prefix_already_primed,
         );
 
         let (generated_tokens, finish_reason) = match forward_result {
@@ -1442,6 +1870,14 @@ impl Qwen35MoeInner {
             full_history.extend_from_slice(&generated_tokens[..upto]);
         }
         self.cached_token_history = full_history;
+        let gdn_history_checkpoint_stored = self.remember_moe_gdn_history_checkpoint();
+        if inference_trace_enabled() {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint stored={} tokens={}",
+                gdn_history_checkpoint_stored,
+                self.cached_token_history.len()
+            ));
+        }
 
         let performance = if report_perf {
             compute_performance_metrics(
@@ -1483,6 +1919,7 @@ impl Qwen35MoeInner {
         report_perf: bool,
         first_token_instant: &mut Option<std::time::Instant>,
         use_cpp_paged: bool,
+        gdn_prefix_already_primed: bool,
     ) -> Result<(Vec<u32>, String)> {
         if suffix_len == 0 {
             return Err(Error::from_reason(
@@ -1514,6 +1951,7 @@ impl Qwen35MoeInner {
                 tokens,
                 suffix,
                 cached_prefix_len,
+                gdn_prefix_already_primed,
                 &embed,
                 &mut self.layers,
                 caches_ref,
@@ -1605,12 +2043,12 @@ impl Qwen35MoeInner {
         // during this turn. After a successful compiled step the C++
         // side has advanced its per-layer GDN linear-cache globals
         // (conv_state / recurrent_state) but those updates are never
-        // imported back into `self.caches`. Falling back to pure-Rust
-        // decode after that point would run from stale pre-step GDN
-        // state while `paged_adapter` and `token_history` have already
-        // advanced — silently corrupting the rest of the request. The
-        // mid-turn fallback below is therefore only safe BEFORE the
-        // first successful compiled step.
+        // imported back into `self.caches` until the loop finishes.
+        // Falling back to pure-Rust decode after that point would run
+        // from stale pre-step GDN state while `paged_adapter` and
+        // `token_history` have already advanced — silently corrupting
+        // the rest of the request. The mid-turn fallback below is
+        // therefore only safe BEFORE the first successful compiled step.
         let mut cpp_compiled_step_completed = false;
 
         let max_new_tokens = p.max_new_tokens;
@@ -1781,6 +2219,25 @@ impl Qwen35MoeInner {
             crate::array::maybe_clear_cache_for_paged_step(step);
         }
 
+        if cpp_compiled_step_completed {
+            match export_paged_moe_linear_caches(&self.config) {
+                Ok(Some(new_caches)) => {
+                    self.caches = Some(new_caches);
+                    eval_layer_caches(&self.caches);
+                }
+                Ok(None) => {
+                    self.caches = None;
+                }
+                Err(err) => {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-moe paged_linear_cache_export_error error={}",
+                        err
+                    ));
+                    self.caches = None;
+                }
+            }
+        }
+
         Ok((generated_tokens, finish_reason))
     }
 
@@ -1804,6 +2261,8 @@ impl Qwen35MoeInner {
         }
 
         let prompt_token_count = tokens.len() as u32;
+        let trace_enabled = inference_trace_enabled();
+        let request_trace_start = trace_enabled.then(std::time::Instant::now);
         let sampling_config = p.sampling_config;
         let include_reasoning = p.include_reasoning;
 
@@ -1861,7 +2320,8 @@ impl Qwen35MoeInner {
             adapter.block_size()
         };
         let lookup_extra_keys = chat_common::build_paged_extra_keys(tokens.len(), block_size, &[]);
-        let cached_prefix_len = {
+        let cache_salt = 0;
+        let (cached_prefix_len, continued_live_prefix) = {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason("MoE chat_stream_sync_core_paged: paged_adapter is None")
             })?;
@@ -1869,20 +2329,25 @@ impl Qwen35MoeInner {
                 adapter.is_live_for_continue() && tokens.starts_with(adapter.request_tokens());
             if can_continue {
                 match adapter.continue_turn(&tokens, total_budget) {
-                    Ok((prior, _)) => prior,
+                    Ok((prior, _)) => (prior, true),
                     Err(_) => {
                         let _ = adapter.release_request();
                         adapter
                             .reset_for_new_request(seq_id)
                             .map_err(Error::from_reason)?;
                         let prefix = adapter
-                            .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, 0, false)
+                            .find_cached_prefix_per_block(
+                                &tokens,
+                                &lookup_extra_keys,
+                                cache_salt,
+                                false,
+                            )
                             .map_err(Error::from_reason)?;
                         let cached = prefix.cached_token_count;
                         adapter
                             .allocate_suffix_blocks(total_budget)
                             .map_err(Error::from_reason)?;
-                        cached
+                        (cached, false)
                     }
                 }
             } else {
@@ -1893,27 +2358,27 @@ impl Qwen35MoeInner {
                     .reset_for_new_request(seq_id)
                     .map_err(Error::from_reason)?;
                 let prefix = adapter
-                    .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, 0, false)
+                    .find_cached_prefix_per_block(&tokens, &lookup_extra_keys, cache_salt, false)
                     .map_err(Error::from_reason)?;
                 let cached = prefix.cached_token_count;
                 adapter
                     .allocate_suffix_blocks(total_budget)
                     .map_err(Error::from_reason)?;
-                cached
+                (cached, false)
             }
         };
 
-        self.caches = Some(
-            (0..self.config.num_layers as usize)
-                .map(|i| {
-                    if self.config.is_linear_layer(i) {
-                        Qwen3_5LayerCache::new_linear()
-                    } else {
-                        Qwen3_5LayerCache::new_full_attention()
-                    }
-                })
-                .collect(),
-        );
+        let prefill_trace_start = trace_enabled.then(std::time::Instant::now);
+        let gdn_prefix_preparation = self.prepare_moe_gdn_prefix_state(
+            &tokens,
+            cached_prefix_len,
+            block_size,
+            &lookup_extra_keys,
+            cache_salt,
+            continued_live_prefix,
+        )?;
+        let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
+        let gdn_prefix_state = gdn_prefix_preparation.state;
         self.cached_token_history.clear();
         self.cached_image_key = None;
         self.cached_rope_deltas = None;
@@ -1925,6 +2390,24 @@ impl Qwen35MoeInner {
                     "MoE chat_stream_sync_core_paged: cached_prefix_len > total_prompt_tokens",
                 )
             })?;
+
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe stream_paged_start prompt_tokens={} \
+                 cached_prefix_tokens={} suffix_tokens={} block_size={} \
+                 prefill_chunk_size={} prefill_eval_interval={} decode_clear_interval={} \
+                 cpp_paged_candidate={} gdn_prefix_state={}",
+                prompt_token_count,
+                cached_prefix_len,
+                suffix_len,
+                block_size,
+                crate::array::paged_prefill_chunk_size(),
+                crate::array::paged_prefill_eval_interval(),
+                crate::array::paged_decode_cache_clear_interval(),
+                use_cpp_paged,
+                gdn_prefix_state
+            ));
+        }
 
         let result = self.chat_stream_sync_core_paged_inner(
             &tokens,
@@ -1943,7 +2426,30 @@ impl Qwen35MoeInner {
             cb,
             cancelled,
             use_cpp_paged,
+            gdn_prefix_already_primed,
+            prefill_trace_start,
         );
+
+        if let Some(start) = request_trace_start {
+            match &result {
+                Ok((generated_tokens, finish_reason)) => {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-moe stream_paged_done generated_tokens={} \
+                         finish_reason={} elapsed_ms={:.1}",
+                        generated_tokens.len(),
+                        finish_reason,
+                        elapsed_ms(start)
+                    ));
+                }
+                Err(err) => {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-moe stream_paged_error elapsed_ms={:.1} error={}",
+                        elapsed_ms(start),
+                        err
+                    ));
+                }
+            }
+        }
 
         let (generated_tokens, finish_reason) = match result {
             Ok(t) => {
@@ -1974,6 +2480,14 @@ impl Qwen35MoeInner {
             full_history.extend_from_slice(&generated_tokens[..upto]);
         }
         self.cached_token_history = full_history;
+        let gdn_history_checkpoint_stored = self.remember_moe_gdn_history_checkpoint();
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint stored={} tokens={}",
+                gdn_history_checkpoint_stored,
+                self.cached_token_history.len()
+            ));
+        }
 
         let full_text = tokenizer
             .decode_sync(&generated_tokens, true)
@@ -2076,6 +2590,8 @@ impl Qwen35MoeInner {
         cb: &StreamSender,
         cancelled: &Arc<AtomicBool>,
         use_cpp_paged: bool,
+        gdn_prefix_already_primed: bool,
+        prefill_trace_start: Option<std::time::Instant>,
     ) -> Result<(Vec<u32>, String)> {
         if suffix_len == 0 {
             return Err(Error::from_reason(
@@ -2083,6 +2599,7 @@ impl Qwen35MoeInner {
             ));
         }
 
+        let trace_enabled = inference_trace_enabled();
         let suffix = &tokens[(cached_prefix_len as usize)..];
         let layer_kinds = crate::models::qwen3_5::decoder_layer::compute_layer_kinds(
             self.config.num_layers as usize,
@@ -2105,6 +2622,7 @@ impl Qwen35MoeInner {
                 tokens,
                 suffix,
                 cached_prefix_len,
+                gdn_prefix_already_primed,
                 &embed,
                 &mut self.layers,
                 caches_ref,
@@ -2125,6 +2643,17 @@ impl Qwen35MoeInner {
         // starts allocating (see chat_sync_core_paged_inner for rationale).
         crate::array::synchronize_and_clear_cache();
 
+        if let Some(start) = prefill_trace_start {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe paged_first_token_ready prompt_tokens={} \
+                 cached_prefix_tokens={} suffix_tokens={} prefill_to_first_token_ms={:.1}",
+                tokens.len(),
+                cached_prefix_len,
+                suffix_len,
+                elapsed_ms(start)
+            ));
+        }
+
         if report_perf {
             *first_token_instant = Some(std::time::Instant::now());
         }
@@ -2132,6 +2661,7 @@ impl Qwen35MoeInner {
         // C++ compiled paged decode setup (see sync twin for full
         // explanation). Mirrors the sync path so streaming and sync
         // dispatchers behave identically when both paths are available.
+        let decode_setup_trace_start = trace_enabled.then(std::time::Instant::now);
         let mut cpp_session_ready = if use_cpp_paged {
             let caches_ref = self.caches.as_ref().ok_or_else(|| {
                 Error::from_reason(
@@ -2165,6 +2695,22 @@ impl Qwen35MoeInner {
         } else {
             false
         };
+        if let Some(start) = decode_setup_trace_start {
+            let adapter_block_size = self
+                .paged_adapter
+                .as_ref()
+                .map(|adapter| adapter.block_size())
+                .unwrap_or(0);
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe paged_decode_setup cpp_requested={} cpp_ready={} \
+                 block_size={} compiled_required_block_size={} setup_ms={:.1}",
+                use_cpp_paged,
+                cpp_session_ready,
+                adapter_block_size,
+                CPP_PAGED_REQUIRED_BLOCK_SIZE,
+                elapsed_ms(start)
+            ));
+        }
 
         // Even if a later forward fails and we flip
         // `cpp_session_ready=false`, the guard still runs at scope exit.
@@ -2173,16 +2719,17 @@ impl Qwen35MoeInner {
         // Tracks whether ANY compiled C++ paged step has succeeded
         // during this turn. After a successful compiled step the C++
         // GDN linear-cache globals (conv_state / recurrent_state) have
-        // advanced but are never imported back into `self.caches`, so a
-        // pure-Rust fallback would read stale pre-step state. The
-        // mid-turn fallback below is therefore only safe BEFORE the
-        // first successful compiled step. See sync sibling
+        // advanced but are not imported back into `self.caches` until
+        // the loop finishes, so a pure-Rust fallback would read stale
+        // pre-step state. The mid-turn fallback below is therefore only
+        // safe BEFORE the first successful compiled step. See sync sibling
         // `chat_sync_core_paged_inner` for the full rationale.
         let mut cpp_compiled_step_completed = false;
 
         let max_new_tokens = p.max_new_tokens;
         let mut generated_tokens: Vec<u32> = Vec::with_capacity(max_new_tokens.max(0) as usize);
         let mut finish_reason = String::from("length");
+        let decode_trace_start = trace_enabled.then(std::time::Instant::now);
 
         let max_blocks_per_seq: u32 = {
             let adapter = self.paged_adapter.as_ref().ok_or_else(|| {
@@ -2364,6 +2911,42 @@ impl Qwen35MoeInner {
             y.eval();
 
             crate::array::maybe_clear_cache_for_paged_step(step);
+        }
+
+        if let Some(start) = decode_trace_start {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe paged_decode_done generated_tokens={} finish_reason={} \
+                 decode_loop_ms={:.1} cpp_compiled_step_completed={}",
+                generated_tokens.len(),
+                finish_reason,
+                elapsed_ms(start),
+                cpp_compiled_step_completed
+            ));
+        }
+
+        if cpp_compiled_step_completed {
+            match export_paged_moe_linear_caches(&self.config) {
+                Ok(Some(new_caches)) => {
+                    self.caches = Some(new_caches);
+                    eval_layer_caches(&self.caches);
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-moe paged_linear_cache_export ok=true"
+                    ));
+                }
+                Ok(None) => {
+                    self.caches = None;
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-moe paged_linear_cache_export ok=false reason=not_initialized"
+                    ));
+                }
+                Err(err) => {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-moe paged_linear_cache_export ok=false error={}",
+                        err
+                    ));
+                    self.caches = None;
+                }
+            }
         }
 
         Ok((generated_tokens, finish_reason))
@@ -7244,6 +7827,77 @@ mod paged_construction_tests {
         let inner = Qwen35MoeInner::new(cfg)
             .expect("Qwen35MoeInner::new must succeed without paged adapter");
         assert!(inner.paged_adapter.is_none());
+    }
+
+    #[test]
+    fn test_fresh_moe_layer_caches_are_not_gdn_reuse_ready() {
+        let cfg = tiny_moe_cfg(true);
+        let caches = fresh_moe_layer_caches(&cfg);
+        assert_eq!(caches.len(), cfg.num_layers as usize);
+        assert!(
+            !moe_paged_linear_caches_ready(&cfg, Some(&caches)),
+            "fresh linear caches have empty conv/recurrent slots, so a live continuation must replay GDN"
+        );
+        assert!(matches!(caches[0], Qwen3_5LayerCache::Linear(_)));
+        assert!(matches!(caches[3], Qwen3_5LayerCache::FullAttention(_)));
+    }
+
+    #[test]
+    fn test_paged_moe_linear_cache_export_uninitialized_returns_none() {
+        unsafe {
+            mlx_sys::mlx_qwen35_moe_reset();
+        }
+        let cfg = tiny_moe_cfg(true);
+        let exported = export_paged_moe_linear_caches(&cfg)
+            .expect("uninitialized paged export should not fail");
+        assert!(exported.is_none());
+    }
+
+    #[test]
+    fn test_paged_prefix_block_hash_matches_allocator_chain() {
+        let tokens: Vec<u32> = (1..=12).collect();
+        let per_block = vec![vec![11], vec![], vec![33, 44]];
+
+        let h0 = mlx_paged_attn::hash_tokens(&tokens[0..4], 0, &per_block[0]);
+        let h1 = mlx_paged_attn::hash_tokens(&tokens[4..8], h0, &per_block[1]);
+        let h2 = mlx_paged_attn::hash_tokens(&tokens[8..12], h1, &per_block[2]);
+
+        assert_eq!(
+            compute_paged_prefix_block_hash(&tokens, 12, 4, &per_block, 0),
+            Some(h2)
+        );
+    }
+
+    #[test]
+    fn test_paged_prefix_block_hash_applies_salt_to_first_block_only() {
+        let tokens: Vec<u32> = (1..=8).collect();
+        let per_block = vec![vec![11], vec![22]];
+        let salt = 99;
+
+        let mut first_block_keys = per_block[0].clone();
+        first_block_keys.push(salt);
+        let h0 = mlx_paged_attn::hash_tokens(&tokens[0..4], 0, &first_block_keys);
+        let h1 = mlx_paged_attn::hash_tokens(&tokens[4..8], h0, &per_block[1]);
+
+        assert_eq!(
+            compute_paged_prefix_block_hash(&tokens, 8, 4, &per_block, salt),
+            Some(h1)
+        );
+    }
+
+    #[test]
+    fn test_paged_prefix_block_hash_rejects_non_full_or_unkeyed_prefix() {
+        let tokens: Vec<u32> = (1..=8).collect();
+        let per_block = vec![vec![]];
+
+        assert_eq!(
+            compute_paged_prefix_block_hash(&tokens, 6, 4, &per_block, 0),
+            None
+        );
+        assert_eq!(
+            compute_paged_prefix_block_hash(&tokens, 8, 4, &per_block, 0),
+            None
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -899,17 +899,17 @@ impl Qwen35MoeInner {
         clone_moe_linear_layer_caches(&self.config, &checkpoint.caches)
     }
 
-    fn remember_moe_gdn_history_checkpoint(&mut self) -> MoeGdnCheckpointStoreTrace {
+    fn remember_moe_gdn_history_checkpoint(&mut self) -> Result<MoeGdnCheckpointStoreTrace> {
         let trace_enabled = inference_trace_enabled();
         let total_start = trace_enabled.then(std::time::Instant::now);
         let mut trace = MoeGdnCheckpointStoreTrace::default();
         if self.cached_token_history.is_empty() {
             self.gdn_last_history_checkpoint = None;
-            return trace.finish(total_start);
+            return Ok(trace.finish(total_start));
         }
 
         let eval_start = trace_enabled.then(std::time::Instant::now);
-        eval_layer_caches(&self.caches);
+        eval_layer_caches(&self.caches)?;
         trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
         let clone_start = trace_enabled.then(std::time::Instant::now);
         let Some(caches) = self
@@ -919,7 +919,7 @@ impl Qwen35MoeInner {
         else {
             self.gdn_last_history_checkpoint = None;
             trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
-            return trace.finish(total_start);
+            return Ok(trace.finish(total_start));
         };
         trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
         let token_clone_start = trace_enabled.then(std::time::Instant::now);
@@ -930,7 +930,7 @@ impl Qwen35MoeInner {
         self.gdn_last_history_checkpoint = Some(MoeGdnHistoryCheckpoint { tokens, caches });
         trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
         trace.stored = true;
-        trace.finish(total_start)
+        Ok(trace.finish(total_start))
     }
 
     fn find_moe_gdn_prefix_checkpoint(
@@ -971,7 +971,7 @@ impl Qwen35MoeInner {
         block_size: u32,
         extra_keys_per_block: &[Vec<u64>],
         cache_salt: u64,
-    ) -> MoeGdnCheckpointStoreTrace {
+    ) -> Result<MoeGdnCheckpointStoreTrace> {
         let trace_enabled = inference_trace_enabled();
         let total_start = trace_enabled.then(std::time::Instant::now);
         let mut trace = MoeGdnCheckpointStoreTrace::default();
@@ -984,15 +984,15 @@ impl Qwen35MoeInner {
             cache_salt,
         ) else {
             trace.hash_ms = hash_start.map(elapsed_ms).unwrap_or(0.0);
-            return trace.finish(total_start);
+            return Ok(trace.finish(total_start));
         };
         trace.hash_ms = hash_start.map(elapsed_ms).unwrap_or(0.0);
         let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
-            return trace.finish(total_start);
+            return Ok(trace.finish(total_start));
         };
 
         let eval_start = trace_enabled.then(std::time::Instant::now);
-        eval_layer_caches(&self.caches);
+        eval_layer_caches(&self.caches)?;
         trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
         let clone_start = trace_enabled.then(std::time::Instant::now);
         let Some(caches) = self
@@ -1001,7 +1001,7 @@ impl Qwen35MoeInner {
             .and_then(|caches| clone_moe_linear_layer_caches(&self.config, caches))
         else {
             trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
-            return trace.finish(total_start);
+            return Ok(trace.finish(total_start));
         };
         trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
         let token_clone_start = trace_enabled.then(std::time::Instant::now);
@@ -1029,7 +1029,7 @@ impl Qwen35MoeInner {
         trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
         trace.stored = true;
 
-        trace.finish(total_start)
+        Ok(trace.finish(total_start))
     }
 
     fn prepare_moe_gdn_prefix_state(
@@ -1181,7 +1181,7 @@ impl Qwen35MoeInner {
                 block_size,
                 extra_keys_per_block,
                 cache_salt,
-            )
+            )?
         } else {
             MoeGdnCheckpointStoreTrace::default()
         };
@@ -1721,7 +1721,7 @@ impl Qwen35MoeInner {
                     // compile init would feed stale handles to the GPU —
                     // triggering Metal page-faults / innocent-victim hangs
                     // on the first forward of the next turn.
-                    eval_layer_caches(&self.caches);
+                    eval_layer_caches(&self.caches)?;
                 }
             }
             // _moe_guard dropped here, calling mlx_qwen35_moe_reset()
@@ -2043,7 +2043,7 @@ impl Qwen35MoeInner {
             full_history.extend_from_slice(&generated_tokens[..upto]);
         }
         self.cached_token_history = full_history;
-        let gdn_history_checkpoint_store = self.remember_moe_gdn_history_checkpoint();
+        let gdn_history_checkpoint_store = self.remember_moe_gdn_history_checkpoint()?;
         if inference_trace_enabled() {
             write_inference_trace(format_args!(
                 "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint stored={} tokens={} \
@@ -2402,7 +2402,7 @@ impl Qwen35MoeInner {
             match export_paged_moe_linear_caches(&self.config) {
                 Ok(Some(new_caches)) => {
                     self.caches = Some(new_caches);
-                    eval_layer_caches(&self.caches);
+                    eval_layer_caches(&self.caches)?;
                 }
                 Ok(None) => {
                     self.caches = None;
@@ -2685,7 +2685,7 @@ impl Qwen35MoeInner {
             full_history.extend_from_slice(&generated_tokens[..upto]);
         }
         self.cached_token_history = full_history;
-        let gdn_history_checkpoint_store = self.remember_moe_gdn_history_checkpoint();
+        let gdn_history_checkpoint_store = self.remember_moe_gdn_history_checkpoint()?;
         if trace_enabled {
             write_inference_trace(format_args!(
                 "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint stored={} tokens={} \
@@ -3232,7 +3232,7 @@ impl Qwen35MoeInner {
             match export_paged_moe_linear_caches(&self.config) {
                 Ok(Some(new_caches)) => {
                     self.caches = Some(new_caches);
-                    eval_layer_caches(&self.caches);
+                    eval_layer_caches(&self.caches)?;
                     write_inference_trace(format_args!(
                         "[MLX_TRACE] qwen3.5-moe paged_linear_cache_export ok=true"
                     ));
@@ -3702,7 +3702,7 @@ impl Qwen35MoeInner {
                     // See the chat path for rationale: force-eval the
                     // exported lazy handles before `MoeResetGuard` clears
                     // `g_compiled_caches_moe` at end of scope.
-                    eval_layer_caches(&self.caches);
+                    eval_layer_caches(&self.caches)?;
                 }
             }
             // _moe_guard dropped here
@@ -4223,7 +4223,7 @@ impl Qwen35MoeInner {
                     // See the chat path for rationale: force-eval the
                     // exported lazy handles before `MoeResetGuard` clears
                     // `g_compiled_caches_moe` at end of scope.
-                    eval_layer_caches(&self.caches);
+                    eval_layer_caches(&self.caches)?;
                 }
             }
             // _moe_guard dropped here, calling mlx_qwen35_moe_reset()
@@ -4883,7 +4883,7 @@ impl Qwen35MoeInner {
                     // See the chat path for rationale: force-eval the
                     // exported lazy handles before `MoeResetGuard` clears
                     // `g_compiled_caches_moe` at end of scope.
-                    eval_layer_caches(&self.caches);
+                    eval_layer_caches(&self.caches)?;
                 }
             }
             // _moe_guard dropped here
@@ -7478,7 +7478,7 @@ fn chunked_prefill_with_size(
         }
         // Materialize all cache arrays on GPU so the next chunk doesn't
         // extend a giant lazy graph rooted at the prior chunk's inputs.
-        eval_layer_caches(caches);
+        eval_layer_caches(caches)?;
         crate::array::clear_cache();
         offset += chunk_size;
     }

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1,6 +1,4 @@
 use std::collections::{HashMap, VecDeque};
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -9,6 +7,9 @@ use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
 use tracing::{info, warn};
 
+use crate::inference_trace::{
+    elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
+};
 use crate::model_thread::{ResponseTx, StreamTx};
 use crate::models::paddleocr_vl::processing::ProcessedImages;
 use crate::models::qwen3_5::model::{
@@ -38,45 +39,6 @@ use crate::sampling::{SamplingConfig, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer, ToolDefinition};
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
-
-fn inference_trace_enabled() -> bool {
-    inference_trace_file().is_some()
-}
-
-fn inference_trace_file() -> Option<&'static str> {
-    static TRACE_FILE: OnceLock<Option<String>> = OnceLock::new();
-    TRACE_FILE
-        .get_or_init(|| {
-            let enabled = match std::env::var("MLX_INFERENCE_TRACE") {
-                Ok(value) => matches!(
-                    value.trim().to_ascii_lowercase().as_str(),
-                    "1" | "true" | "yes" | "on"
-                ),
-                Err(_) => false,
-            };
-            if !enabled {
-                return None;
-            }
-            std::env::var("MLX_INFERENCE_TRACE_FILE")
-                .ok()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty())
-        })
-        .as_deref()
-}
-
-fn write_inference_trace(args: std::fmt::Arguments<'_>) {
-    let Some(path) = inference_trace_file() else {
-        return;
-    };
-    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
-        let _ = writeln!(file, "{args}");
-    }
-}
-
-fn elapsed_ms(start: std::time::Instant) -> f64 {
-    start.elapsed().as_secs_f64() * 1000.0
-}
 
 fn fresh_moe_layer_caches(config: &Qwen3_5MoeConfig) -> Vec<Qwen3_5LayerCache> {
     (0..config.num_layers as usize)
@@ -108,6 +70,72 @@ struct MoeGdnHistoryCheckpoint {
 struct MoeGdnPrefixPreparation {
     state: &'static str,
     already_primed: bool,
+}
+
+#[derive(Default)]
+struct MoeGdnCheckpointStoreTrace {
+    stored: bool,
+    hash_ms: f64,
+    eval_ms: f64,
+    clone_ms: f64,
+    token_clone_ms: f64,
+    update_ms: f64,
+    total_ms: f64,
+}
+
+impl MoeGdnCheckpointStoreTrace {
+    fn finish(mut self, start: Option<std::time::Instant>) -> Self {
+        self.total_ms = start.map(elapsed_ms).unwrap_or(0.0);
+        self
+    }
+}
+
+fn moe_gdn_store_replayed_prefix_checkpoint_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("MLX_MOE_GDN_REPLAY_PREFIX_CHECKPOINT")
+            .map(|value| {
+                let normalized = value.trim().to_ascii_lowercase();
+                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+            })
+            .unwrap_or(false)
+    })
+}
+
+#[derive(Clone, Copy)]
+struct TokenPrefixMismatchTrace {
+    index: i64,
+    prompt_token: i64,
+    cached_token: i64,
+}
+
+impl Default for TokenPrefixMismatchTrace {
+    fn default() -> Self {
+        Self {
+            index: -1,
+            prompt_token: -1,
+            cached_token: -1,
+        }
+    }
+}
+
+fn token_prefix_mismatch_trace(prompt: &[u32], cached: &[u32]) -> TokenPrefixMismatchTrace {
+    let common_len = prompt.len().min(cached.len());
+    for i in 0..common_len {
+        if prompt[i] != cached[i] {
+            return TokenPrefixMismatchTrace {
+                index: i as i64,
+                prompt_token: prompt[i] as i64,
+                cached_token: cached[i] as i64,
+            };
+        }
+    }
+
+    TokenPrefixMismatchTrace {
+        index: common_len as i64,
+        prompt_token: prompt.get(common_len).map_or(-1, |token| *token as i64),
+        cached_token: cached.get(common_len).map_or(-1, |token| *token as i64),
+    }
 }
 
 fn moe_paged_linear_caches_ready(
@@ -871,27 +899,38 @@ impl Qwen35MoeInner {
         clone_moe_linear_layer_caches(&self.config, &checkpoint.caches)
     }
 
-    fn remember_moe_gdn_history_checkpoint(&mut self) -> bool {
+    fn remember_moe_gdn_history_checkpoint(&mut self) -> MoeGdnCheckpointStoreTrace {
+        let trace_enabled = inference_trace_enabled();
+        let total_start = trace_enabled.then(std::time::Instant::now);
+        let mut trace = MoeGdnCheckpointStoreTrace::default();
         if self.cached_token_history.is_empty() {
             self.gdn_last_history_checkpoint = None;
-            return false;
+            return trace.finish(total_start);
         }
 
+        let eval_start = trace_enabled.then(std::time::Instant::now);
         eval_layer_caches(&self.caches);
+        trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
+        let clone_start = trace_enabled.then(std::time::Instant::now);
         let Some(caches) = self
             .caches
             .as_ref()
             .and_then(|caches| clone_moe_linear_layer_caches(&self.config, caches))
         else {
             self.gdn_last_history_checkpoint = None;
-            return false;
+            trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
+            return trace.finish(total_start);
         };
+        trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
+        let token_clone_start = trace_enabled.then(std::time::Instant::now);
+        let tokens = self.cached_token_history.clone();
+        trace.token_clone_ms = token_clone_start.map(elapsed_ms).unwrap_or(0.0);
 
-        self.gdn_last_history_checkpoint = Some(MoeGdnHistoryCheckpoint {
-            tokens: self.cached_token_history.clone(),
-            caches,
-        });
-        true
+        let update_start = trace_enabled.then(std::time::Instant::now);
+        self.gdn_last_history_checkpoint = Some(MoeGdnHistoryCheckpoint { tokens, caches });
+        trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
+        trace.stored = true;
+        trace.finish(total_start)
     }
 
     fn find_moe_gdn_prefix_checkpoint(
@@ -932,7 +971,11 @@ impl Qwen35MoeInner {
         block_size: u32,
         extra_keys_per_block: &[Vec<u64>],
         cache_salt: u64,
-    ) -> bool {
+    ) -> MoeGdnCheckpointStoreTrace {
+        let trace_enabled = inference_trace_enabled();
+        let total_start = trace_enabled.then(std::time::Instant::now);
+        let mut trace = MoeGdnCheckpointStoreTrace::default();
+        let hash_start = trace_enabled.then(std::time::Instant::now);
         let Some(final_block_hash) = compute_paged_prefix_block_hash(
             tokens,
             prefix_len,
@@ -940,22 +983,32 @@ impl Qwen35MoeInner {
             extra_keys_per_block,
             cache_salt,
         ) else {
-            return false;
+            trace.hash_ms = hash_start.map(elapsed_ms).unwrap_or(0.0);
+            return trace.finish(total_start);
         };
+        trace.hash_ms = hash_start.map(elapsed_ms).unwrap_or(0.0);
         let Some(prefix_tokens) = tokens.get(..prefix_len as usize) else {
-            return false;
+            return trace.finish(total_start);
         };
 
+        let eval_start = trace_enabled.then(std::time::Instant::now);
         eval_layer_caches(&self.caches);
+        trace.eval_ms = eval_start.map(elapsed_ms).unwrap_or(0.0);
+        let clone_start = trace_enabled.then(std::time::Instant::now);
         let Some(caches) = self
             .caches
             .as_ref()
             .and_then(|caches| clone_moe_linear_layer_caches(&self.config, caches))
         else {
-            return false;
+            trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
+            return trace.finish(total_start);
         };
+        trace.clone_ms = clone_start.map(elapsed_ms).unwrap_or(0.0);
+        let token_clone_start = trace_enabled.then(std::time::Instant::now);
         let prefix_tokens = prefix_tokens.to_vec();
+        trace.token_clone_ms = token_clone_start.map(elapsed_ms).unwrap_or(0.0);
 
+        let update_start = trace_enabled.then(std::time::Instant::now);
         self.gdn_prefix_checkpoints.retain(|checkpoint| {
             !(checkpoint.prefix_len == prefix_len
                 && checkpoint.block_size == block_size
@@ -973,8 +1026,10 @@ impl Qwen35MoeInner {
         while self.gdn_prefix_checkpoints.len() > MOE_GDN_PREFIX_CHECKPOINT_LIMIT {
             self.gdn_prefix_checkpoints.pop_front();
         }
+        trace.update_ms = update_start.map(elapsed_ms).unwrap_or(0.0);
+        trace.stored = true;
 
-        true
+        trace.finish(total_start)
     }
 
     fn prepare_moe_gdn_prefix_state(
@@ -986,8 +1041,18 @@ impl Qwen35MoeInner {
         cache_salt: u64,
         continued_live_prefix: bool,
     ) -> Result<MoeGdnPrefixPreparation> {
+        let trace_enabled = inference_trace_enabled();
+        let prepare_trace_start = trace_enabled.then(std::time::Instant::now);
         let gdn_caches_ready = moe_paged_linear_caches_ready(&self.config, self.caches.as_deref());
         if gdn_caches_ready && continued_live_prefix {
+            if let Some(start) = prepare_trace_start {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-moe gdn_prefix_prepare_done state=live \
+                     cached_prefix_tokens={} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    elapsed_ms(start)
+                ));
+            }
             return Ok(MoeGdnPrefixPreparation {
                 state: "live",
                 already_primed: true,
@@ -998,45 +1063,83 @@ impl Qwen35MoeInner {
             && self.cached_token_history.len() == cached_prefix_len as usize
             && tokens.starts_with(&self.cached_token_history);
         if gdn_caches_ready && gdn_prefix_from_history {
+            if let Some(start) = prepare_trace_start {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-moe gdn_prefix_prepare_done state=last_history \
+                     cached_prefix_tokens={} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    elapsed_ms(start)
+                ));
+            }
             return Ok(MoeGdnPrefixPreparation {
                 state: "last_history",
                 already_primed: true,
             });
         }
         if cached_prefix_len > 0 {
-            if let Some(checkpoint) =
-                self.find_moe_gdn_history_checkpoint(tokens, cached_prefix_len)
-            {
+            let history_lookup_start = trace_enabled.then(std::time::Instant::now);
+            let history_checkpoint =
+                self.find_moe_gdn_history_checkpoint(tokens, cached_prefix_len);
+            let history_lookup_ms = history_lookup_start.map(elapsed_ms);
+            if let Some(checkpoint) = history_checkpoint {
                 self.caches = Some(checkpoint);
+                if let Some(start) = prepare_trace_start {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3.5-moe gdn_prefix_prepare_done state=last_history_checkpoint \
+                         cached_prefix_tokens={} history_lookup_ms={:.1} elapsed_ms={:.1}",
+                        cached_prefix_len,
+                        history_lookup_ms.unwrap_or(0.0),
+                        elapsed_ms(start)
+                    ));
+                }
                 return Ok(MoeGdnPrefixPreparation {
                     state: "last_history_checkpoint",
                     already_primed: true,
                 });
-            } else if inference_trace_enabled() {
+            } else if trace_enabled {
                 let history_checkpoint_len = self
                     .gdn_last_history_checkpoint
                     .as_ref()
                     .map_or(0, |checkpoint| checkpoint.tokens.len());
+                let history_mismatch =
+                    token_prefix_mismatch_trace(tokens, &self.cached_token_history);
                 write_inference_trace(format_args!(
                     "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint_miss \
                      cached_prefix_tokens={} history_len={} checkpoint_len={} \
-                     history_match={}",
+                     history_match={} history_mismatch_at={} prompt_token={} \
+                     history_token={} history_lookup_ms={:.1}",
                     cached_prefix_len,
                     self.cached_token_history.len(),
                     history_checkpoint_len,
-                    gdn_prefix_from_history
+                    gdn_prefix_from_history,
+                    history_mismatch.index,
+                    history_mismatch.prompt_token,
+                    history_mismatch.cached_token,
+                    history_lookup_ms.unwrap_or(0.0)
                 ));
             }
         }
 
-        if let Some(checkpoint) = self.find_moe_gdn_prefix_checkpoint(
+        let prefix_lookup_start = trace_enabled.then(std::time::Instant::now);
+        let prefix_checkpoint = self.find_moe_gdn_prefix_checkpoint(
             tokens,
             cached_prefix_len,
             block_size,
             extra_keys_per_block,
             cache_salt,
-        ) {
+        );
+        let prefix_lookup_ms = prefix_lookup_start.map(elapsed_ms);
+        if let Some(checkpoint) = prefix_checkpoint {
             self.caches = Some(checkpoint);
+            if let Some(start) = prepare_trace_start {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-moe gdn_prefix_prepare_done state=checkpoint \
+                     cached_prefix_tokens={} prefix_lookup_ms={:.1} elapsed_ms={:.1}",
+                    cached_prefix_len,
+                    prefix_lookup_ms.unwrap_or(0.0),
+                    elapsed_ms(start)
+                ));
+            }
             return Ok(MoeGdnPrefixPreparation {
                 state: "checkpoint",
                 already_primed: true,
@@ -1045,6 +1148,14 @@ impl Qwen35MoeInner {
 
         self.caches = Some(fresh_moe_layer_caches(&self.config));
         if cached_prefix_len == 0 {
+            if let Some(start) = prepare_trace_start {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-moe gdn_prefix_prepare_done state=replay \
+                     cached_prefix_tokens=0 prefix_lookup_ms={:.1} elapsed_ms={:.1}",
+                    prefix_lookup_ms.unwrap_or(0.0),
+                    elapsed_ms(start)
+                ));
+            }
             return Ok(MoeGdnPrefixPreparation {
                 state: "replay",
                 already_primed: false,
@@ -1060,17 +1171,52 @@ impl Qwen35MoeInner {
             .caches
             .as_mut()
             .ok_or_else(|| Error::from_reason("MoE paged GDN prefix caches not initialized"))?;
+        let replay_trace_start = trace_enabled.then(std::time::Instant::now);
         super::paged_forward::run_gdn_only_prefill(prefix, &embed, &mut self.layers, caches_ref)?;
-        let stored = self.remember_moe_gdn_prefix_checkpoint(
-            tokens,
-            cached_prefix_len,
-            block_size,
-            extra_keys_per_block,
-            cache_salt,
-        );
+        let replay_ms = replay_trace_start.map(elapsed_ms);
+        let store_trace = if moe_gdn_store_replayed_prefix_checkpoint_enabled() {
+            self.remember_moe_gdn_prefix_checkpoint(
+                tokens,
+                cached_prefix_len,
+                block_size,
+                extra_keys_per_block,
+                cache_salt,
+            )
+        } else {
+            MoeGdnCheckpointStoreTrace::default()
+        };
+        if let Some(start) = prepare_trace_start {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe gdn_prefix_prepare_done state={} \
+                 cached_prefix_tokens={} prefix_lookup_ms={:.1} replay_ms={:.1} stored={} \
+                 store_hash_ms={:.1} store_eval_ms={:.1} store_clone_ms={:.1} \
+                 store_token_clone_ms={:.1} store_update_ms={:.1} store_ms={:.1} \
+                 elapsed_ms={:.1}",
+                if store_trace.stored {
+                    "replay_store"
+                } else {
+                    "replay"
+                },
+                cached_prefix_len,
+                prefix_lookup_ms.unwrap_or(0.0),
+                replay_ms.unwrap_or(0.0),
+                store_trace.stored,
+                store_trace.hash_ms,
+                store_trace.eval_ms,
+                store_trace.clone_ms,
+                store_trace.token_clone_ms,
+                store_trace.update_ms,
+                store_trace.total_ms,
+                elapsed_ms(start)
+            ));
+        }
 
         Ok(MoeGdnPrefixPreparation {
-            state: if stored { "replay_store" } else { "replay" },
+            state: if store_trace.stored {
+                "replay_store"
+            } else {
+                "replay"
+            },
             already_primed: true,
         })
     }
@@ -1692,6 +1838,7 @@ impl Qwen35MoeInner {
         }
 
         let prompt_token_count = tokens.len() as u32;
+        let trace_enabled = inference_trace_enabled();
         let sampling_config = p.sampling_config;
 
         let think_end_id = tokenizer.think_end_id();
@@ -1759,12 +1906,22 @@ impl Qwen35MoeInner {
         };
         let lookup_extra_keys = chat_common::build_paged_extra_keys(tokens.len(), block_size, &[]);
         let cache_salt = 0;
+        let live_ready;
+        let live_prefix_match;
+        let live_tokens_len;
+        let mut live_mismatch = TokenPrefixMismatchTrace::default();
         let (cached_prefix_len, continued_live_prefix) = {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason("MoE chat_sync_core_paged: paged_adapter is None")
             })?;
-            let can_continue =
-                adapter.is_live_for_continue() && tokens.starts_with(adapter.request_tokens());
+            live_ready = adapter.is_live_for_continue();
+            let live_tokens = adapter.request_tokens();
+            live_tokens_len = live_tokens.len();
+            live_prefix_match = tokens.starts_with(live_tokens);
+            if trace_enabled && live_ready && !live_prefix_match {
+                live_mismatch = token_prefix_mismatch_trace(&tokens, live_tokens);
+            }
+            let can_continue = live_ready && live_prefix_match;
             if can_continue {
                 match adapter.continue_turn(&tokens, total_budget) {
                     Ok((prior, _)) => (prior, true),
@@ -1805,6 +1962,22 @@ impl Qwen35MoeInner {
                 (cached, false)
             }
         };
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe paged_prefix_lookup prompt_tokens={} \
+                 cached_prefix_tokens={} continued_live_prefix={} live_ready={} \
+                 live_match={} live_tokens={} live_mismatch_at={} prompt_token={} live_token={}",
+                tokens.len(),
+                cached_prefix_len,
+                continued_live_prefix,
+                live_ready,
+                live_prefix_match,
+                live_tokens_len,
+                live_mismatch.index,
+                live_mismatch.prompt_token,
+                live_mismatch.cached_token
+            ));
+        }
 
         let gdn_prefix_preparation = self.prepare_moe_gdn_prefix_state(
             &tokens,
@@ -1870,12 +2043,18 @@ impl Qwen35MoeInner {
             full_history.extend_from_slice(&generated_tokens[..upto]);
         }
         self.cached_token_history = full_history;
-        let gdn_history_checkpoint_stored = self.remember_moe_gdn_history_checkpoint();
+        let gdn_history_checkpoint_store = self.remember_moe_gdn_history_checkpoint();
         if inference_trace_enabled() {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint stored={} tokens={}",
-                gdn_history_checkpoint_stored,
-                self.cached_token_history.len()
+                "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint stored={} tokens={} \
+                 eval_ms={:.1} clone_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
+                gdn_history_checkpoint_store.stored,
+                self.cached_token_history.len(),
+                gdn_history_checkpoint_store.eval_ms,
+                gdn_history_checkpoint_store.clone_ms,
+                gdn_history_checkpoint_store.token_clone_ms,
+                gdn_history_checkpoint_store.update_ms,
+                gdn_history_checkpoint_store.total_ms
             ));
         }
 
@@ -2321,12 +2500,22 @@ impl Qwen35MoeInner {
         };
         let lookup_extra_keys = chat_common::build_paged_extra_keys(tokens.len(), block_size, &[]);
         let cache_salt = 0;
+        let live_ready;
+        let live_prefix_match;
+        let live_tokens_len;
+        let mut live_mismatch = TokenPrefixMismatchTrace::default();
         let (cached_prefix_len, continued_live_prefix) = {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason("MoE chat_stream_sync_core_paged: paged_adapter is None")
             })?;
-            let can_continue =
-                adapter.is_live_for_continue() && tokens.starts_with(adapter.request_tokens());
+            live_ready = adapter.is_live_for_continue();
+            let live_tokens = adapter.request_tokens();
+            live_tokens_len = live_tokens.len();
+            live_prefix_match = tokens.starts_with(live_tokens);
+            if trace_enabled && live_ready && !live_prefix_match {
+                live_mismatch = token_prefix_mismatch_trace(&tokens, live_tokens);
+            }
+            let can_continue = live_ready && live_prefix_match;
             if can_continue {
                 match adapter.continue_turn(&tokens, total_budget) {
                     Ok((prior, _)) => (prior, true),
@@ -2367,6 +2556,22 @@ impl Qwen35MoeInner {
                 (cached, false)
             }
         };
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe paged_prefix_lookup prompt_tokens={} \
+                 cached_prefix_tokens={} continued_live_prefix={} live_ready={} \
+                 live_match={} live_tokens={} live_mismatch_at={} prompt_token={} live_token={}",
+                tokens.len(),
+                cached_prefix_len,
+                continued_live_prefix,
+                live_ready,
+                live_prefix_match,
+                live_tokens_len,
+                live_mismatch.index,
+                live_mismatch.prompt_token,
+                live_mismatch.cached_token
+            ));
+        }
 
         let prefill_trace_start = trace_enabled.then(std::time::Instant::now);
         let gdn_prefix_preparation = self.prepare_moe_gdn_prefix_state(
@@ -2480,12 +2685,18 @@ impl Qwen35MoeInner {
             full_history.extend_from_slice(&generated_tokens[..upto]);
         }
         self.cached_token_history = full_history;
-        let gdn_history_checkpoint_stored = self.remember_moe_gdn_history_checkpoint();
+        let gdn_history_checkpoint_store = self.remember_moe_gdn_history_checkpoint();
         if trace_enabled {
             write_inference_trace(format_args!(
-                "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint stored={} tokens={}",
-                gdn_history_checkpoint_stored,
-                self.cached_token_history.len()
+                "[MLX_TRACE] qwen3.5-moe gdn_history_checkpoint stored={} tokens={} \
+                 eval_ms={:.1} clone_ms={:.1} token_clone_ms={:.1} update_ms={:.1} total_ms={:.1}",
+                gdn_history_checkpoint_store.stored,
+                self.cached_token_history.len(),
+                gdn_history_checkpoint_store.eval_ms,
+                gdn_history_checkpoint_store.clone_ms,
+                gdn_history_checkpoint_store.token_clone_ms,
+                gdn_history_checkpoint_store.update_ms,
+                gdn_history_checkpoint_store.total_ms
             ));
         }
 
@@ -2730,6 +2941,18 @@ impl Qwen35MoeInner {
         let mut generated_tokens: Vec<u32> = Vec::with_capacity(max_new_tokens.max(0) as usize);
         let mut finish_reason = String::from("length");
         let decode_trace_start = trace_enabled.then(std::time::Instant::now);
+        let decode_progress_interval = if trace_enabled {
+            crate::array::paged_decode_cache_clear_interval().max(1) as usize
+        } else {
+            usize::MAX
+        };
+        let mut decode_progress_last = decode_trace_start.unwrap_or_else(std::time::Instant::now);
+        let mut decode_progress_last_count = 0usize;
+        let mut decode_build_inputs_ms = 0.0;
+        let mut decode_forward_ms = 0.0;
+        let mut decode_sample_build_ms = 0.0;
+        let mut decode_token_eval_ms = 0.0;
+        let mut decode_cache_clear_ms = 0.0;
 
         let max_blocks_per_seq: u32 = {
             let adapter = self.paged_adapter.as_ref().ok_or_else(|| {
@@ -2810,11 +3033,20 @@ impl Qwen35MoeInner {
                 adapter
                     .record_tokens(&[token_id])
                     .map_err(Error::from_reason)?;
+                let build_inputs_trace_start = trace_enabled.then(std::time::Instant::now);
                 let inputs = adapter
                     .build_paged_attention_inputs(1, 1, max_blocks_per_seq)
                     .map_err(Error::from_reason)?;
+                if let Some(start) = build_inputs_trace_start {
+                    decode_build_inputs_ms += elapsed_ms(start);
+                }
                 let input_ids = MxArray::from_uint32(&[token_id], &[1, 1])?;
-                match forward_moe_cpp_paged(&input_ids, &embedding_weight, &inputs) {
+                let forward_trace_start = trace_enabled.then(std::time::Instant::now);
+                let forward_result = forward_moe_cpp_paged(&input_ids, &embedding_weight, &inputs);
+                if let Some(start) = forward_trace_start {
+                    decode_forward_ms += elapsed_ms(start);
+                }
+                match forward_result {
                     Ok(logits) => {
                         cpp_compiled_step_completed = true;
                         logits
@@ -2857,6 +3089,7 @@ impl Qwen35MoeInner {
                                 "MoE chat_stream_sync_core_paged_inner: paged_adapter dropped during cpp fallback",
                             )
                         })?;
+                        let fallback_trace_start = trace_enabled.then(std::time::Instant::now);
                         let logits = super::paged_forward::run_paged_decode_step(
                             token_id,
                             &embed,
@@ -2868,6 +3101,9 @@ impl Qwen35MoeInner {
                             &layer_kinds,
                             adapter_mut,
                         )?;
+                        if let Some(start) = fallback_trace_start {
+                            decode_forward_ms += elapsed_ms(start);
+                        }
                         logits.squeeze(Some(&[1]))?
                     }
                 }
@@ -2884,6 +3120,7 @@ impl Qwen35MoeInner {
                         "MoE chat_stream_sync_core_paged_inner: paged_adapter dropped mid-decode",
                     )
                 })?;
+                let forward_trace_start = trace_enabled.then(std::time::Instant::now);
                 let logits = super::paged_forward::run_paged_decode_step(
                     token_id,
                     &embed,
@@ -2895,6 +3132,9 @@ impl Qwen35MoeInner {
                     &layer_kinds,
                     adapter,
                 )?;
+                if let Some(start) = forward_trace_start {
+                    decode_forward_ms += elapsed_ms(start);
+                }
                 logits.squeeze(Some(&[1]))?
             };
 
@@ -2907,20 +3147,84 @@ impl Qwen35MoeInner {
                 apply_all_penalties(next_logits, &token_history, p)?
             };
 
+            let sample_trace_start = trace_enabled.then(std::time::Instant::now);
             y = sample(&next_logits, sampling_config)?;
+            if let Some(start) = sample_trace_start {
+                decode_sample_build_ms += elapsed_ms(start);
+            }
+            let token_eval_trace_start = trace_enabled.then(std::time::Instant::now);
             y.eval();
+            if let Some(start) = token_eval_trace_start {
+                decode_token_eval_ms += elapsed_ms(start);
+            }
 
+            let cache_clear_trace_start = trace_enabled.then(std::time::Instant::now);
             crate::array::maybe_clear_cache_for_paged_step(step);
+            if let Some(start) = cache_clear_trace_start {
+                decode_cache_clear_ms += elapsed_ms(start);
+            }
+            if trace_enabled
+                && generated_tokens
+                    .len()
+                    .is_multiple_of(decode_progress_interval)
+            {
+                let window_ms = elapsed_ms(decode_progress_last);
+                let window_tokens = generated_tokens
+                    .len()
+                    .saturating_sub(decode_progress_last_count);
+                let window_tok_s = if window_ms > 0.0 {
+                    window_tokens as f64 / (window_ms / 1000.0)
+                } else {
+                    0.0
+                };
+                let elapsed_decode_ms = decode_trace_start.map(elapsed_ms).unwrap_or(0.0);
+                let active_mib = crate::array::get_active_memory() / (1024.0 * 1024.0);
+                let cache_mib = crate::array::get_cache_memory() / (1024.0 * 1024.0);
+                let peak_mib = crate::array::get_peak_memory() / (1024.0 * 1024.0);
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-moe paged_decode_progress generated_tokens={} \
+                     context_tokens={} window_tokens={} window_ms={:.1} window_tok_s={:.2} \
+                     elapsed_ms={:.1} cpp_ready={} build_inputs_ms={:.1} forward_ms={:.1} \
+                     sample_ms={:.1} sample_build_ms={:.1} token_eval_ms={:.1} \
+                     cache_clear_ms={:.1} active_mib={:.1} cache_mib={:.1} peak_mib={:.1}",
+                    generated_tokens.len(),
+                    token_history.len(),
+                    window_tokens,
+                    window_ms,
+                    window_tok_s,
+                    elapsed_decode_ms,
+                    cpp_session_ready,
+                    decode_build_inputs_ms,
+                    decode_forward_ms,
+                    decode_sample_build_ms + decode_token_eval_ms,
+                    decode_sample_build_ms,
+                    decode_token_eval_ms,
+                    decode_cache_clear_ms,
+                    active_mib,
+                    cache_mib,
+                    peak_mib
+                ));
+                decode_progress_last = std::time::Instant::now();
+                decode_progress_last_count = generated_tokens.len();
+            }
         }
 
         if let Some(start) = decode_trace_start {
             write_inference_trace(format_args!(
                 "[MLX_TRACE] qwen3.5-moe paged_decode_done generated_tokens={} finish_reason={} \
-                 decode_loop_ms={:.1} cpp_compiled_step_completed={}",
+                 decode_loop_ms={:.1} cpp_compiled_step_completed={} build_inputs_ms={:.1} \
+                 forward_ms={:.1} sample_ms={:.1} sample_build_ms={:.1} \
+                 token_eval_ms={:.1} cache_clear_ms={:.1}",
                 generated_tokens.len(),
                 finish_reason,
                 elapsed_ms(start),
-                cpp_compiled_step_completed
+                cpp_compiled_step_completed,
+                decode_build_inputs_ms,
+                decode_forward_ms,
+                decode_sample_build_ms + decode_token_eval_ms,
+                decode_sample_build_ms,
+                decode_token_eval_ms,
+                decode_cache_clear_ms
             ));
         }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -190,7 +190,7 @@ fn compute_paged_prefix_block_hash(
     extra_keys_per_block: &[Vec<u64>],
     cache_salt: u64,
 ) -> Option<u64> {
-    if prefix_len == 0 || block_size == 0 || prefix_len % block_size != 0 {
+    if prefix_len == 0 || block_size == 0 || !prefix_len.is_multiple_of(block_size) {
         return None;
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -93,12 +93,7 @@ impl MoeGdnCheckpointStoreTrace {
 fn moe_gdn_store_replayed_prefix_checkpoint_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("MLX_MOE_GDN_REPLAY_PREFIX_CHECKPOINT")
-            .map(|value| {
-                let normalized = value.trim().to_ascii_lowercase();
-                !matches!(normalized.as_str(), "0" | "false" | "no" | "off")
-            })
-            .unwrap_or(false)
+        crate::inference_trace::env_flag_enabled("MLX_MOE_GDN_REPLAY_PREFIX_CHECKPOINT")
     })
 }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
@@ -4,15 +4,32 @@
 //! the MoE `DecoderLayer` (which holds an MoE/dense MLP variant) and
 //! its own `forward_paged_or_flat` method.
 
+use std::time::Instant;
+
 use napi::bindgen_prelude::*;
 
 use crate::array::MxArray;
+use crate::inference_trace::{
+    elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
+};
 use crate::nn::{Embedding, RMSNorm};
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
 
 use super::decoder_layer::{DecoderLayer, Qwen3_5LayerKind};
 use super::layer_cache::Qwen3_5LayerCache;
 use super::quantized_linear::LinearProj;
+
+fn bytes_to_mib(bytes: f64) -> f64 {
+    bytes / (1024.0 * 1024.0)
+}
+
+fn trace_memory_mib() -> (f64, f64, f64) {
+    (
+        bytes_to_mib(crate::array::get_active_memory()),
+        bytes_to_mib(crate::array::get_cache_memory()),
+        bytes_to_mib(crate::array::get_peak_memory()),
+    )
+}
 
 /// Forward the cached-prefix tokens through GDN (linear-attention)
 /// layers ONLY. Same pattern as the dense helper.
@@ -155,6 +172,8 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
         ));
     }
 
+    let trace_enabled = inference_trace_enabled();
+
     if chunk_size <= 0 || suffix_tokens.len() <= chunk_size as usize {
         return run_paged_prefill_single_shot(
             full_tokens,
@@ -178,8 +197,21 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
     // chunking. The GDN linear-attention layers consume the prefix in
     // one shot (existing approximation; orthogonal to chunking).
     if cached_prefix_len > 0 && !gdn_prefix_already_primed {
+        let gdn_trace_start = trace_enabled.then(Instant::now);
         let prefix = &full_tokens[..(cached_prefix_len as usize)];
         run_gdn_only_prefill(prefix, embed, layers, caches)?;
+        if let Some(start) = gdn_trace_start {
+            let (active_mib, cache_mib, peak_mib) = trace_memory_mib();
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3.5-moe paged_prefill_gdn_prefix_done \
+                 prefix_tokens={} elapsed_ms={:.1} active_mib={:.1} cache_mib={:.1} peak_mib={:.1}",
+                cached_prefix_len,
+                elapsed_ms(start),
+                active_mib,
+                cache_mib,
+                peak_mib
+            ));
+        }
     }
 
     let total_chunks = suffix_tokens.len().div_ceil(chunk_size_usize);
@@ -188,6 +220,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
 
     for (chunk_idx, chunk) in suffix_tokens.chunks(chunk_size_usize).enumerate() {
         let is_last_chunk = chunk_idx + 1 == total_chunks;
+        let chunk_trace_start = trace_enabled.then(Instant::now);
 
         // 1. Advance cursor + grow blocks for this chunk. Must happen
         //    BEFORE calling the per-chunk helper so `update_keys_values`
@@ -225,6 +258,24 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
                 lm_head,
                 embedding_weight,
             )?);
+            if let Some(start) = chunk_trace_start {
+                let chunk_elapsed_ms = elapsed_ms(start);
+                let (active_mib, cache_mib, peak_mib) = trace_memory_mib();
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-moe paged_prefill_chunk_final_graph_built \
+                     chunk_index={} total_chunks={} chunk_tokens={} context_before={} context_after={} \
+                     elapsed_ms={:.1} active_mib={:.1} cache_mib={:.1} peak_mib={:.1}",
+                    chunk_idx + 1,
+                    total_chunks,
+                    chunk.len(),
+                    chunk_start_position,
+                    chunk_start_position + chunk.len() as u32,
+                    chunk_elapsed_ms,
+                    active_mib,
+                    cache_mib,
+                    peak_mib
+                ));
+            }
         } else {
             // Force materialize the residual stream so MLX can release
             // the upstream graph nodes (embedding + every prior layer's
@@ -236,6 +287,30 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
             // skip — those projections would be discarded anyway.
             hidden.eval();
             crate::array::synchronize_and_clear_cache();
+            if let Some(start) = chunk_trace_start {
+                let chunk_elapsed_ms = elapsed_ms(start);
+                let (active_mib, cache_mib, peak_mib) = trace_memory_mib();
+                let chunk_tok_s = if chunk_elapsed_ms > 0.0 {
+                    chunk.len() as f64 / (chunk_elapsed_ms / 1000.0)
+                } else {
+                    0.0
+                };
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] qwen3.5-moe paged_prefill_chunk_done \
+                     chunk_index={} total_chunks={} chunk_tokens={} context_before={} context_after={} \
+                     elapsed_ms={:.1} tok_s={:.2} active_mib={:.1} cache_mib={:.1} peak_mib={:.1}",
+                    chunk_idx + 1,
+                    total_chunks,
+                    chunk.len(),
+                    chunk_start_position,
+                    chunk_start_position + chunk.len() as u32,
+                    chunk_elapsed_ms,
+                    chunk_tok_s,
+                    active_mib,
+                    cache_mib,
+                    peak_mib
+                ));
+            }
         }
 
         chunk_start_position += chunk.len() as u32;

--- a/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
@@ -69,6 +69,7 @@ pub(crate) fn run_paged_prefill_chunk(
     full_tokens: &[u32],
     suffix_tokens: &[u32],
     cached_prefix_len: u32,
+    gdn_prefix_already_primed: bool,
     embed: &Embedding,
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
@@ -83,6 +84,7 @@ pub(crate) fn run_paged_prefill_chunk(
         full_tokens,
         suffix_tokens,
         cached_prefix_len,
+        gdn_prefix_already_primed,
         embed,
         layers,
         caches,
@@ -106,7 +108,10 @@ pub(crate) fn run_paged_prefill_chunk(
 /// 1. **GDN pre-pass runs ONCE, before any chunking.** The GDN
 ///    linear-attention layers consume the cached prefix in one shot
 ///    (this is the existing approximation — orthogonal to suffix
-///    chunking).
+///    chunking). Live continuation callers can pass
+///    `gdn_prefix_already_primed = true` when `caches` already contain
+///    the linear-attention state for `cached_prefix_len`, avoiding this
+///    replay.
 ///
 /// 2. **GDN state propagates in-place across chunks.** When the layer
 ///    loop calls `layer.forward_paged_or_flat` with a Linear-kind
@@ -133,6 +138,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
     full_tokens: &[u32],
     suffix_tokens: &[u32],
     cached_prefix_len: u32,
+    gdn_prefix_already_primed: bool,
     embed: &Embedding,
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
@@ -154,6 +160,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
             full_tokens,
             suffix_tokens,
             cached_prefix_len,
+            gdn_prefix_already_primed,
             embed,
             layers,
             caches,
@@ -170,7 +177,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
     // GDN pre-pass over the cached prefix runs ONCE, before any suffix
     // chunking. The GDN linear-attention layers consume the prefix in
     // one shot (existing approximation; orthogonal to chunking).
-    if cached_prefix_len > 0 {
+    if cached_prefix_len > 0 && !gdn_prefix_already_primed {
         let prefix = &full_tokens[..(cached_prefix_len as usize)];
         run_gdn_only_prefill(prefix, embed, layers, caches)?;
     }
@@ -259,6 +266,7 @@ pub(crate) fn run_paged_prefill_single_shot(
     full_tokens: &[u32],
     suffix_tokens: &[u32],
     cached_prefix_len: u32,
+    gdn_prefix_already_primed: bool,
     embed: &Embedding,
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
@@ -272,7 +280,7 @@ pub(crate) fn run_paged_prefill_single_shot(
         .record_tokens(suffix_tokens)
         .map_err(Error::from_reason)?;
 
-    if cached_prefix_len > 0 {
+    if cached_prefix_len > 0 && !gdn_prefix_already_primed {
         let prefix = &full_tokens[..(cached_prefix_len as usize)];
         run_gdn_only_prefill(prefix, embed, layers, caches)?;
     }
@@ -737,6 +745,7 @@ mod tests {
                 prompt,
                 prompt,
                 0,
+                false,
                 &embed,
                 &mut inner.layers,
                 caches_ref,
@@ -1110,6 +1119,7 @@ mod tests {
                 &prompt,
                 &prompt,
                 0,
+                false,
                 &embed,
                 &mut inner.layers,
                 caches_ref,
@@ -1169,6 +1179,7 @@ mod tests {
                 &prompt,
                 &prompt,
                 0,
+                false,
                 &embed,
                 &mut inner.layers,
                 caches_ref,

--- a/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
@@ -443,7 +443,7 @@ fn run_paged_prefill_one_chunk_moe(
         // from the cache pool. Without this the in-flight lazy graph
         // accumulates ~50 GB on long contexts before the post-prefill
         // sync fires. Cadence is `MLX_PAGED_PREFILL_EVAL_INTERVAL` (default 8).
-        crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden);
+        crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden)?;
     }
     Ok(hidden)
 }

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -951,7 +951,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5MoeModel> {
                     // Materialize mmap-backed weights
                     {
                         let arrays: Vec<&MxArray> = params.values().collect();
-                        crate::array::memory::materialize_weights(&arrays);
+                        crate::array::memory::materialize_weights(&arrays)?;
                     }
 
                     // Set tokenizer

--- a/crates/mlx-core/src/transformer/block.rs
+++ b/crates/mlx-core/src/transformer/block.rs
@@ -481,10 +481,10 @@ impl TransformerBlock {
             // `read_kv_range` performs and that was driving a ~40 GB
             // memory regression in long-context decode (see Fix #2 spec).
             //
-            // The kernel returns Float32; cast back to x's dtype so the
-            // rest of the block stays homogeneous (matches LFM2's paged
-            // decode path). This is a zero-extra-host-buffer path — the
-            // K/V are not materialized as MxArrays at all.
+            // The kernel returns the query/io dtype. Cast back to x's dtype
+            // so the rest of the block stays homogeneous. This is a
+            // zero-extra-host-buffer path — the K/V are not materialized as
+            // MxArrays at all.
             //
             // `gather_kv_for_decode` expects queries shape
             // `[1, num_query_heads, head_size]` (3-D). `qkv.queries` from
@@ -501,7 +501,7 @@ impl TransformerBlock {
                 )
                 .map_err(napi::Error::from_reason)?;
 
-            // Cast back to x's dtype (gather currently returns Float32).
+            // Cast back to x's dtype.
             // `gather_kv_for_decode` returns `[1, n_heads, head_dim]`, which
             // is exactly the layout `output_projection` expects for
             // `batch * seq_len = 1`.

--- a/crates/mlx-core/src/transformer/hybrid_kv_cache_manager.rs
+++ b/crates/mlx-core/src/transformer/hybrid_kv_cache_manager.rs
@@ -1,0 +1,468 @@
+//! Model-neutral KV-cache grouping and admission policy.
+//!
+//! This is the vLLM-inspired boundary for hybrid models: model code declares
+//! per-layer KV-cache specs, while common transformer infrastructure owns group
+//! layout, layer-to-group mapping, storage ordinals, and sliding-window
+//! admission arithmetic.
+
+use std::collections::HashMap;
+
+#[cfg(all(target_os = "macos", not(test)))]
+use std::sync::{Arc, Mutex};
+
+use crate::transformer::kv_cache_spec::{
+    AttentionKind, KVCacheDType, KVCacheGroup, LayerKVCacheRoute, LayerKVCacheSpec,
+    derive_layer_kv_cache_routes_from_groups, group_layer_kv_cache_specs,
+};
+#[cfg(all(target_os = "macos", not(test)))]
+use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
+
+/// Stable identifier for a KV-cache group.
+pub type KVCacheGroupId = usize;
+
+/// Cache behavior for a physical KV-cache group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerKVCacheKind {
+    Full,
+    SlidingWindow { window_size: u32 },
+}
+
+impl LayerKVCacheKind {
+    pub fn sliding_window(self) -> Option<u32> {
+        match self {
+            Self::SlidingWindow { window_size } => Some(window_size),
+            Self::Full => None,
+        }
+    }
+}
+
+impl From<AttentionKind> for LayerKVCacheKind {
+    fn from(kind: AttentionKind) -> Self {
+        match kind {
+            AttentionKind::Full => Self::Full,
+            AttentionKind::SlidingWindow { sliding_window } => Self::SlidingWindow {
+                window_size: sliding_window,
+            },
+        }
+    }
+}
+
+/// Immutable per-group configuration derived from layer specs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KVCacheGroupConfig {
+    pub group_id: KVCacheGroupId,
+    pub kind: LayerKVCacheKind,
+    /// Logical layer indices that use this group. Shared-KV aliases are kept
+    /// here so model runners can resolve their group metadata.
+    pub layers: Vec<usize>,
+    /// Logical layer indices that own physical KV storage. Shared-KV aliases
+    /// are omitted because they reuse their anchor's K/V.
+    pub physical_layers: Vec<usize>,
+    pub block_size: u32,
+    pub num_blocks: u32,
+    pub head_size: u32,
+    pub num_kv_heads: u32,
+    pub cache_dtype: KVCacheDType,
+    pub max_admission_blocks: u32,
+    pub max_model_len: u32,
+    pub max_chunk: u32,
+    pub gpu_memory_mb: u32,
+    pub max_batch_size: Option<u32>,
+}
+
+impl KVCacheGroupConfig {
+    /// Current adapter storage supports full-attention groups. Sliding-window
+    /// groups are represented here first; true paged sliding eviction is the
+    /// next integration step.
+    pub fn is_paged_adapter_group(&self) -> bool {
+        !self.physical_layers.is_empty() && matches!(self.kind, LayerKVCacheKind::Full)
+    }
+
+    pub fn max_cached_tokens(&self) -> u64 {
+        self.num_blocks as u64 * self.block_size as u64
+    }
+
+    pub fn sliding_window(&self) -> Option<u32> {
+        self.kind.sliding_window()
+    }
+}
+
+/// Runtime state for one group.
+pub struct KVCacheGroupState {
+    pub config: KVCacheGroupConfig,
+    #[cfg(all(target_os = "macos", not(test)))]
+    pub adapter: Option<PagedKVCacheAdapter>,
+}
+
+impl KVCacheGroupState {
+    #[cfg(any(not(target_os = "macos"), test))]
+    fn new(config: KVCacheGroupConfig) -> Self {
+        Self { config }
+    }
+
+    #[cfg(all(target_os = "macos", not(test)))]
+    fn new(config: KVCacheGroupConfig, adapter: Option<PagedKVCacheAdapter>) -> Self {
+        Self { config, adapter }
+    }
+}
+
+/// Common grouped manager for hybrid KV-cache layouts.
+pub struct HybridKVCacheManager {
+    groups: Vec<KVCacheGroupState>,
+    layer_to_group: HashMap<usize, KVCacheGroupId>,
+    group_id_to_index: HashMap<KVCacheGroupId, usize>,
+    group_layer_ordinals: HashMap<usize, usize>,
+    layer_routes: HashMap<usize, LayerKVCacheRoute>,
+}
+
+impl HybridKVCacheManager {
+    pub fn from_kv_cache_specs(
+        specs: &[LayerKVCacheSpec],
+        max_model_len: u32,
+        max_chunk: u32,
+        gpu_memory_mb: u32,
+        max_batch_size: Option<u32>,
+        num_blocks_override: Option<u32>,
+    ) -> Result<Self, String> {
+        let shared_groups = group_layer_kv_cache_specs(specs, max_model_len, max_chunk)
+            .map_err(|e| format!("failed to group KV cache specs: {e}"))?;
+        Self::from_groups(
+            specs,
+            shared_groups,
+            max_model_len,
+            max_chunk,
+            gpu_memory_mb,
+            max_batch_size,
+            num_blocks_override,
+        )
+    }
+
+    fn from_groups(
+        specs: &[LayerKVCacheSpec],
+        shared_groups: Vec<KVCacheGroup>,
+        max_model_len: u32,
+        max_chunk: u32,
+        gpu_memory_mb: u32,
+        max_batch_size: Option<u32>,
+        num_blocks_override: Option<u32>,
+    ) -> Result<Self, String> {
+        if shared_groups.is_empty() {
+            return Err("HybridKVCacheManager requires at least one KV group".to_string());
+        }
+        let routes = derive_layer_kv_cache_routes_from_groups(specs, &shared_groups)
+            .map_err(|e| format!("failed to derive KV cache routes: {e}"))?;
+
+        let by_layer: HashMap<usize, &LayerKVCacheSpec> =
+            specs.iter().map(|spec| (spec.layer_index, spec)).collect();
+        let mut groups = Vec::with_capacity(shared_groups.len());
+        let mut layer_to_group = HashMap::with_capacity(specs.len());
+        let mut group_id_to_index = HashMap::with_capacity(shared_groups.len());
+        let mut group_layer_ordinals = HashMap::with_capacity(specs.len());
+        let layer_routes: HashMap<usize, LayerKVCacheRoute> = routes
+            .into_iter()
+            .map(|route| (route.layer_index, route))
+            .collect();
+
+        for shared_group in shared_groups {
+            let physical_layers = shared_group.physical_layer_indices.clone();
+            let layout = shared_group.physical_layout;
+            let num_blocks = if let Some(num_blocks) = num_blocks_override {
+                num_blocks
+            } else {
+                mlx_paged_attn::PagedAttentionConfig {
+                    block_size: layout.block_size,
+                    gpu_memory_mb,
+                    head_size: layout.head_size,
+                    num_kv_heads: layout.num_kv_heads,
+                    num_layers: physical_layers.len().max(1) as u32,
+                    use_fp8_cache: Some(matches!(layout.cache_dtype, KVCacheDType::Fp8)),
+                    max_seq_len: Some(max_model_len),
+                    max_batch_size,
+                }
+                .calculate_num_blocks()
+            };
+            if num_blocks == 0 {
+                return Err(format!(
+                    "KV group {}: computed num_blocks is 0",
+                    shared_group.group_id
+                ));
+            }
+
+            let mut physical_ordinals = HashMap::with_capacity(physical_layers.len());
+            for (ordinal, layer_idx) in physical_layers.iter().copied().enumerate() {
+                physical_ordinals.insert(layer_idx, ordinal);
+            }
+            for layer_idx in &shared_group.layer_indices {
+                layer_to_group.insert(*layer_idx, shared_group.group_id);
+                let spec = by_layer.get(layer_idx).ok_or_else(|| {
+                    format!(
+                        "KV group {} references missing layer {}",
+                        shared_group.group_id, layer_idx
+                    )
+                })?;
+                let physical_layer = spec.shared_kv_anchor.unwrap_or(*layer_idx);
+                if let Some(ordinal) = physical_ordinals.get(&physical_layer) {
+                    group_layer_ordinals.insert(*layer_idx, *ordinal);
+                }
+            }
+
+            let config = KVCacheGroupConfig {
+                group_id: shared_group.group_id,
+                kind: shared_group.attention_kind.into(),
+                layers: shared_group.layer_indices,
+                physical_layers,
+                block_size: layout.block_size,
+                num_blocks,
+                head_size: layout.head_size,
+                num_kv_heads: layout.num_kv_heads,
+                cache_dtype: layout.cache_dtype,
+                max_admission_blocks: shared_group.max_admission_blocks,
+                max_model_len,
+                max_chunk,
+                gpu_memory_mb,
+                max_batch_size,
+            };
+
+            #[cfg(any(not(target_os = "macos"), test))]
+            let state = KVCacheGroupState::new(config);
+
+            #[cfg(all(target_os = "macos", not(test)))]
+            let state = {
+                let adapter = if config.is_paged_adapter_group() {
+                    Some(build_paged_adapter(&config)?)
+                } else {
+                    None
+                };
+                KVCacheGroupState::new(config, adapter)
+            };
+
+            group_id_to_index.insert(state.config.group_id, groups.len());
+            groups.push(state);
+        }
+
+        Ok(Self {
+            groups,
+            layer_to_group,
+            group_id_to_index,
+            group_layer_ordinals,
+            layer_routes,
+        })
+    }
+
+    pub fn groups(&self) -> &[KVCacheGroupState] {
+        &self.groups
+    }
+
+    pub fn group_config(&self, group_id: KVCacheGroupId) -> Option<&KVCacheGroupConfig> {
+        self.group_id_to_index
+            .get(&group_id)
+            .and_then(|idx| self.groups.get(*idx))
+            .map(|state| &state.config)
+    }
+
+    pub fn group_for_layer(&self, layer_idx: usize) -> Option<KVCacheGroupId> {
+        self.layer_to_group.get(&layer_idx).copied()
+    }
+
+    pub fn route_for_layer(&self, layer_idx: usize) -> Option<&LayerKVCacheRoute> {
+        self.layer_routes.get(&layer_idx)
+    }
+
+    /// Physical cache ordinal within the layer's group. Shared-KV aliases map
+    /// to their anchor's ordinal.
+    pub fn group_layer_ordinal(&self, layer_idx: usize) -> Option<usize> {
+        self.group_layer_ordinals.get(&layer_idx).copied()
+    }
+
+    pub fn max_admission_blocks_for_group(&self, group_id: KVCacheGroupId) -> Option<u32> {
+        self.group_config(group_id)
+            .map(|config| config.max_admission_blocks)
+    }
+
+    /// Number of currently needed blocks for a group at `logical_tokens`.
+    ///
+    /// Full-attention groups grow with the full context. Sliding-window groups
+    /// need only the active local tail; `max_admission_blocks` remains the
+    /// startup/runtime upper admission bound for chunked scheduling.
+    pub fn live_block_count_for_group(
+        &self,
+        group_id: KVCacheGroupId,
+        logical_tokens: u32,
+    ) -> Option<u32> {
+        let config = self.group_config(group_id)?;
+        Some(Self::live_block_count(config, logical_tokens))
+    }
+
+    pub fn live_block_count(config: &KVCacheGroupConfig, logical_tokens: u32) -> u32 {
+        let admitted_tokens = config
+            .sliding_window()
+            .map_or(logical_tokens, |window| logical_tokens.min(window));
+        ceil_div(admitted_tokens, config.block_size)
+            .min(config.num_blocks)
+            .min(config.max_admission_blocks)
+    }
+
+    /// Number of oldest computed tokens that a sliding-window group can drop
+    /// before the next allocation. Mirrors vLLM's
+    /// `max(0, num_computed_tokens - sliding_window + 1)`.
+    pub fn sliding_window_skipped_tokens_for_group(
+        &self,
+        group_id: KVCacheGroupId,
+        num_computed_tokens: u32,
+    ) -> Option<u32> {
+        let config = self.group_config(group_id)?;
+        Some(Self::sliding_window_skipped_tokens(
+            config,
+            num_computed_tokens,
+        ))
+    }
+
+    pub fn sliding_window_skipped_tokens(
+        config: &KVCacheGroupConfig,
+        num_computed_tokens: u32,
+    ) -> u32 {
+        config.sliding_window().map_or(0, |window| {
+            num_computed_tokens
+                .saturating_sub(window)
+                .saturating_add(if num_computed_tokens >= window { 1 } else { 0 })
+        })
+    }
+}
+
+fn ceil_div(n: u32, d: u32) -> u32 {
+    debug_assert!(d > 0);
+    if n == 0 { 0 } else { ((n - 1) / d) + 1 }
+}
+
+#[cfg(all(target_os = "macos", not(test)))]
+fn build_paged_adapter(config: &KVCacheGroupConfig) -> Result<PagedKVCacheAdapter, String> {
+    let pa_config = mlx_paged_attn::PagedAttentionConfig {
+        block_size: config.block_size,
+        gpu_memory_mb: config.gpu_memory_mb,
+        head_size: config.head_size,
+        num_kv_heads: config.num_kv_heads,
+        num_layers: config.physical_layers.len() as u32,
+        use_fp8_cache: Some(matches!(config.cache_dtype, KVCacheDType::Fp8)),
+        max_seq_len: Some(config.max_model_len),
+        max_batch_size: config.max_batch_size,
+    };
+
+    let cache_dtype = match config.cache_dtype {
+        KVCacheDType::Float16 => mlx_paged_attn::metal::MetalDtype::Float16,
+        KVCacheDType::BFloat16 => mlx_paged_attn::metal::MetalDtype::BFloat16,
+        KVCacheDType::Fp8 => mlx_paged_attn::metal::MetalDtype::UChar,
+    };
+    let allocator = Arc::new(Mutex::new(mlx_paged_attn::BlockAllocator::new(
+        config.num_blocks,
+        config.block_size,
+    )));
+    let pool = mlx_paged_attn::LayerKVPool::new(pa_config, config.num_blocks, cache_dtype)?;
+
+    PagedKVCacheAdapter::new(allocator, Arc::new(pool), config.block_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transformer::kv_cache_spec::{
+        KVCacheDType, KVCachePhysicalLayout, LayerKVCacheSpec,
+    };
+
+    fn layout(block_size: u32) -> KVCachePhysicalLayout {
+        KVCachePhysicalLayout::new(block_size, 4, 128, KVCacheDType::BFloat16)
+    }
+
+    #[test]
+    fn maps_layers_to_groups_and_physical_ordinals() {
+        let specs = vec![
+            LayerKVCacheSpec::sliding_window(0, 16, layout(8)),
+            LayerKVCacheSpec::sliding_window(1, 16, layout(8)),
+            LayerKVCacheSpec::full(2, layout(8)),
+            LayerKVCacheSpec::full(4, layout(8)),
+            LayerKVCacheSpec::full(5, layout(8)).shared_with_anchor(2),
+        ];
+
+        let manager =
+            HybridKVCacheManager::from_kv_cache_specs(&specs, 128, 32, 2048, Some(32), Some(8))
+                .unwrap();
+
+        assert_eq!(manager.groups().len(), 2);
+        let sliding_group = manager.group_for_layer(0).unwrap();
+        let full_group = manager.group_for_layer(2).unwrap();
+        assert_eq!(manager.group_for_layer(1), Some(sliding_group));
+        assert_eq!(manager.group_for_layer(4), Some(full_group));
+        assert_eq!(manager.group_for_layer(5), Some(full_group));
+        assert_eq!(manager.group_for_layer(99), None);
+        assert_eq!(manager.group_layer_ordinal(2), Some(0));
+        assert_eq!(manager.group_layer_ordinal(4), Some(1));
+        assert_eq!(
+            manager.group_layer_ordinal(5),
+            Some(0),
+            "shared layer maps to anchor physical ordinal"
+        );
+    }
+
+    #[test]
+    fn full_attention_admits_full_context_up_to_capacity() {
+        let specs = vec![LayerKVCacheSpec::full(0, layout(8))];
+        let manager =
+            HybridKVCacheManager::from_kv_cache_specs(&specs, 128, 32, 2048, Some(32), Some(3))
+                .unwrap();
+        let group_id = manager.group_for_layer(0).unwrap();
+
+        assert_eq!(manager.live_block_count_for_group(group_id, 0), Some(0));
+        assert_eq!(manager.live_block_count_for_group(group_id, 1), Some(1));
+        assert_eq!(manager.live_block_count_for_group(group_id, 16), Some(2));
+        assert_eq!(manager.live_block_count_for_group(group_id, 25), Some(3));
+        assert_eq!(manager.live_block_count_for_group(group_id, 128), Some(3));
+        assert_eq!(
+            manager.sliding_window_skipped_tokens_for_group(group_id, 128),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn sliding_window_uses_vllm_admission_cap_and_skip_math() {
+        let specs = vec![LayerKVCacheSpec::sliding_window(0, 17, layout(8))];
+        let manager =
+            HybridKVCacheManager::from_kv_cache_specs(&specs, 128, 32, 2048, Some(32), Some(8))
+                .unwrap();
+        let group_id = manager.group_for_layer(0).unwrap();
+
+        assert_eq!(
+            manager.max_admission_blocks_for_group(group_id),
+            Some(7),
+            "ceil((17 - 1 + 32) / 8) + 1"
+        );
+        assert_eq!(manager.live_block_count_for_group(group_id, 16), Some(2));
+        assert_eq!(manager.live_block_count_for_group(group_id, 17), Some(3));
+        assert_eq!(manager.live_block_count_for_group(group_id, 64), Some(3));
+        assert_eq!(
+            manager.sliding_window_skipped_tokens_for_group(group_id, 16),
+            Some(0)
+        );
+        assert_eq!(
+            manager.sliding_window_skipped_tokens_for_group(group_id, 17),
+            Some(1)
+        );
+        assert_eq!(
+            manager.sliding_window_skipped_tokens_for_group(group_id, 64),
+            Some(48)
+        );
+    }
+
+    #[test]
+    fn grouping_splits_incompatible_layouts() {
+        let specs = vec![
+            LayerKVCacheSpec::full(0, layout(8)),
+            LayerKVCacheSpec::full(1, layout(16)),
+        ];
+
+        let manager =
+            HybridKVCacheManager::from_kv_cache_specs(&specs, 128, 32, 2048, Some(32), Some(8))
+                .unwrap();
+
+        assert_eq!(manager.groups().len(), 2);
+        assert_ne!(manager.group_for_layer(0), manager.group_for_layer(1));
+    }
+}

--- a/crates/mlx-core/src/transformer/kv_cache_spec.rs
+++ b/crates/mlx-core/src/transformer/kv_cache_spec.rs
@@ -1,0 +1,729 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+/// Cache element type used for physical KV storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum KVCacheDType {
+    Float16,
+    BFloat16,
+    Fp8,
+}
+
+/// Physical cache layout. Layers with equal layouts can share a cache group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct KVCachePhysicalLayout {
+    pub block_size: u32,
+    pub num_kv_heads: u32,
+    pub head_size: u32,
+    pub cache_dtype: KVCacheDType,
+}
+
+impl KVCachePhysicalLayout {
+    pub fn new(
+        block_size: u32,
+        num_kv_heads: u32,
+        head_size: u32,
+        cache_dtype: KVCacheDType,
+    ) -> Self {
+        Self {
+            block_size,
+            num_kv_heads,
+            head_size,
+            cache_dtype,
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.block_size > 0 && self.num_kv_heads > 0 && self.head_size > 0
+    }
+
+    pub fn is_compatible_with(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+/// Attention behavior that determines KV admission pressure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AttentionKind {
+    Full,
+    SlidingWindow { sliding_window: u32 },
+}
+
+impl AttentionKind {
+    pub fn full_attention_max_blocks(
+        max_model_len: u32,
+        block_size: u32,
+    ) -> Result<u32, KVCacheSpecError> {
+        if block_size == 0 {
+            return Err(KVCacheSpecError::InvalidBlockSize { block_size });
+        }
+        Ok(div_ceil(max_model_len, block_size))
+    }
+
+    /// vLLM-style admission bound for sliding-window layers.
+    ///
+    /// A chunk can attend to the previous `sliding_window - 1` tokens plus the
+    /// new chunk. The token bound is capped by `max_model_len`, rounded up to
+    /// blocks, then one extra block is admitted for the trailing partial block.
+    pub fn sliding_window_max_admission_blocks(
+        sliding_window: u32,
+        max_model_len: u32,
+        max_chunk: u32,
+        block_size: u32,
+    ) -> Result<u32, KVCacheSpecError> {
+        if block_size == 0 {
+            return Err(KVCacheSpecError::InvalidBlockSize { block_size });
+        }
+        if sliding_window == 0 {
+            return Err(KVCacheSpecError::InvalidSlidingWindow { sliding_window });
+        }
+        let uncapped = sliding_window.saturating_sub(1).saturating_add(max_chunk);
+        let admitted_tokens = uncapped.min(max_model_len);
+        Ok(div_ceil(admitted_tokens, block_size).saturating_add(1))
+    }
+
+    pub fn max_admission_blocks(
+        self,
+        max_model_len: u32,
+        max_chunk: u32,
+        block_size: u32,
+    ) -> Result<u32, KVCacheSpecError> {
+        match self {
+            Self::Full => Self::full_attention_max_blocks(max_model_len, block_size),
+            Self::SlidingWindow { sliding_window } => Self::sliding_window_max_admission_blocks(
+                sliding_window,
+                max_model_len,
+                max_chunk,
+                block_size,
+            ),
+        }
+    }
+}
+
+/// Model-independent per-layer KV cache requirements.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LayerKVCacheSpec {
+    pub layer_index: usize,
+    pub attention_kind: AttentionKind,
+    pub physical_layout: KVCachePhysicalLayout,
+    /// `Some(anchor)` means this logical layer reuses the anchor layer's
+    /// physical KV cache and should not allocate a second cache of its own.
+    pub shared_kv_anchor: Option<usize>,
+}
+
+impl LayerKVCacheSpec {
+    pub fn new(
+        layer_index: usize,
+        attention_kind: AttentionKind,
+        physical_layout: KVCachePhysicalLayout,
+    ) -> Self {
+        Self {
+            layer_index,
+            attention_kind,
+            physical_layout,
+            shared_kv_anchor: None,
+        }
+    }
+
+    pub fn full(layer_index: usize, physical_layout: KVCachePhysicalLayout) -> Self {
+        Self::new(layer_index, AttentionKind::Full, physical_layout)
+    }
+
+    pub fn sliding_window(
+        layer_index: usize,
+        sliding_window: u32,
+        physical_layout: KVCachePhysicalLayout,
+    ) -> Self {
+        Self::new(
+            layer_index,
+            AttentionKind::SlidingWindow { sliding_window },
+            physical_layout,
+        )
+    }
+
+    pub fn shared_with_anchor(mut self, anchor_layer_index: usize) -> Self {
+        self.shared_kv_anchor = Some(anchor_layer_index);
+        self
+    }
+
+    pub fn physical_layer_index(&self) -> usize {
+        self.shared_kv_anchor.unwrap_or(self.layer_index)
+    }
+
+    pub fn is_physical_layout_compatible_with(&self, other: &Self) -> bool {
+        self.physical_layout
+            .is_compatible_with(&other.physical_layout)
+    }
+
+    pub fn max_admission_blocks(
+        &self,
+        max_model_len: u32,
+        max_chunk: u32,
+    ) -> Result<u32, KVCacheSpecError> {
+        self.attention_kind.max_admission_blocks(
+            max_model_len,
+            max_chunk,
+            self.physical_layout.block_size,
+        )
+    }
+}
+
+/// A group of layers that can be served by a compatible physical cache pool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KVCacheGroup {
+    pub group_id: usize,
+    pub attention_kind: AttentionKind,
+    pub physical_layout: KVCachePhysicalLayout,
+    pub layer_indices: Vec<usize>,
+    /// Logical layers with `shared_kv_anchor` are omitted here because their
+    /// anchor layer owns the physical KV storage.
+    pub physical_layer_indices: Vec<usize>,
+    pub max_admission_blocks: u32,
+}
+
+/// Model-neutral per-layer route into a grouped KV cache.
+///
+/// This is the stable boundary model code should consume after declaring
+/// `LayerKVCacheSpec`s: it resolves logical layer index, group id, physical
+/// storage owner, and the owner's ordinal inside the group. Shared-KV aliases
+/// map to their anchor's physical layer and ordinal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LayerKVCacheRoute {
+    pub layer_index: usize,
+    pub group_id: usize,
+    pub attention_kind: AttentionKind,
+    pub physical_layout: KVCachePhysicalLayout,
+    pub physical_layer_index: usize,
+    pub physical_layer_ordinal: usize,
+    pub shared_kv_anchor: Option<usize>,
+}
+
+impl LayerKVCacheRoute {
+    pub fn is_shared(&self) -> bool {
+        self.shared_kv_anchor.is_some()
+    }
+
+    pub fn is_full_attention(&self) -> bool {
+        matches!(self.attention_kind, AttentionKind::Full)
+    }
+
+    pub fn sliding_window(&self) -> Option<u32> {
+        match self.attention_kind {
+            AttentionKind::Full => None,
+            AttentionKind::SlidingWindow { sliding_window } => Some(sliding_window),
+        }
+    }
+}
+
+/// Per-group prefix cache hit used by hybrid cache coordinators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KVCacheGroupPrefixHit {
+    pub group_id: usize,
+    pub cached_tokens: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KVCacheSpecError {
+    DuplicateLayerIndex {
+        layer_index: usize,
+    },
+    InvalidPhysicalLayout {
+        layer_index: usize,
+    },
+    InvalidBlockSize {
+        block_size: u32,
+    },
+    InvalidSlidingWindow {
+        sliding_window: u32,
+    },
+    MissingSharedKVAnchor {
+        layer_index: usize,
+        anchor_layer_index: usize,
+    },
+    SharedKVAnchorIsAlias {
+        layer_index: usize,
+        anchor_layer_index: usize,
+        root_anchor_layer_index: usize,
+    },
+    SharedKVIncompatible {
+        layer_index: usize,
+        anchor_layer_index: usize,
+    },
+    MissingPhysicalLayerOrdinal {
+        layer_index: usize,
+        physical_layer_index: usize,
+    },
+}
+
+impl fmt::Display for KVCacheSpecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateLayerIndex { layer_index } => {
+                write!(f, "duplicate KV cache spec for layer {layer_index}")
+            }
+            Self::InvalidPhysicalLayout { layer_index } => {
+                write!(
+                    f,
+                    "invalid KV cache physical layout for layer {layer_index}"
+                )
+            }
+            Self::InvalidBlockSize { block_size } => {
+                write!(f, "invalid KV cache block_size {block_size}")
+            }
+            Self::InvalidSlidingWindow { sliding_window } => {
+                write!(f, "invalid sliding_window {sliding_window}")
+            }
+            Self::MissingSharedKVAnchor {
+                layer_index,
+                anchor_layer_index,
+            } => write!(
+                f,
+                "layer {layer_index} shares KV with missing anchor layer {anchor_layer_index}"
+            ),
+            Self::SharedKVAnchorIsAlias {
+                layer_index,
+                anchor_layer_index,
+                root_anchor_layer_index,
+            } => write!(
+                f,
+                "layer {layer_index} shares KV with alias layer {anchor_layer_index}; \
+                 use root anchor layer {root_anchor_layer_index}"
+            ),
+            Self::SharedKVIncompatible {
+                layer_index,
+                anchor_layer_index,
+            } => write!(
+                f,
+                "layer {layer_index} is not KV-cache compatible with shared anchor \
+                 layer {anchor_layer_index}"
+            ),
+            Self::MissingPhysicalLayerOrdinal {
+                layer_index,
+                physical_layer_index,
+            } => write!(
+                f,
+                "layer {layer_index} maps to physical KV layer {physical_layer_index}, \
+                 but that physical layer is not present in its KV group"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for KVCacheSpecError {}
+
+/// Group layer specs by attention behavior and physical layout.
+///
+/// The returned order is deterministic: groups are sorted by
+/// `(attention_kind, physical_layout)`, and each group's layer lists are sorted
+/// by layer index.
+pub fn group_layer_kv_cache_specs(
+    specs: &[LayerKVCacheSpec],
+    max_model_len: u32,
+    max_chunk: u32,
+) -> Result<Vec<KVCacheGroup>, KVCacheSpecError> {
+    validate_layer_kv_cache_specs(specs)?;
+
+    let mut groups: BTreeMap<(AttentionKind, KVCachePhysicalLayout), Vec<&LayerKVCacheSpec>> =
+        BTreeMap::new();
+    for spec in specs {
+        groups
+            .entry((spec.attention_kind, spec.physical_layout))
+            .or_default()
+            .push(spec);
+    }
+
+    groups
+        .into_iter()
+        .enumerate()
+        .map(
+            |(group_id, ((attention_kind, physical_layout), mut layers))| {
+                layers.sort_by_key(|spec| spec.layer_index);
+                let layer_indices = layers.iter().map(|spec| spec.layer_index).collect();
+                let physical_layer_indices = layers
+                    .iter()
+                    .filter(|spec| spec.shared_kv_anchor.is_none())
+                    .map(|spec| spec.layer_index)
+                    .collect();
+                let max_admission_blocks = attention_kind.max_admission_blocks(
+                    max_model_len,
+                    max_chunk,
+                    physical_layout.block_size,
+                )?;
+
+                Ok(KVCacheGroup {
+                    group_id,
+                    attention_kind,
+                    physical_layout,
+                    layer_indices,
+                    physical_layer_indices,
+                    max_admission_blocks,
+                })
+            },
+        )
+        .collect()
+}
+
+pub fn derive_layer_kv_cache_routes(
+    specs: &[LayerKVCacheSpec],
+    max_model_len: u32,
+    max_chunk: u32,
+) -> Result<Vec<LayerKVCacheRoute>, KVCacheSpecError> {
+    let groups = group_layer_kv_cache_specs(specs, max_model_len, max_chunk)?;
+    derive_layer_kv_cache_routes_from_groups(specs, &groups)
+}
+
+pub fn derive_layer_kv_cache_routes_from_groups(
+    specs: &[LayerKVCacheSpec],
+    groups: &[KVCacheGroup],
+) -> Result<Vec<LayerKVCacheRoute>, KVCacheSpecError> {
+    validate_layer_kv_cache_specs(specs)?;
+
+    let by_layer: BTreeMap<usize, &LayerKVCacheSpec> =
+        specs.iter().map(|spec| (spec.layer_index, spec)).collect();
+    let mut routes: BTreeMap<usize, LayerKVCacheRoute> = BTreeMap::new();
+
+    for group in groups {
+        let physical_ordinals: BTreeMap<usize, usize> = group
+            .physical_layer_indices
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(ordinal, layer_index)| (layer_index, ordinal))
+            .collect();
+
+        for layer_index in &group.layer_indices {
+            let spec = by_layer
+                .get(layer_index)
+                .expect("group_layer_kv_cache_specs returned an unknown layer");
+            let physical_layer_index = spec.physical_layer_index();
+            let physical_layer_ordinal = physical_ordinals
+                .get(&physical_layer_index)
+                .copied()
+                .ok_or(KVCacheSpecError::MissingPhysicalLayerOrdinal {
+                    layer_index: *layer_index,
+                    physical_layer_index,
+                })?;
+
+            routes.insert(
+                *layer_index,
+                LayerKVCacheRoute {
+                    layer_index: *layer_index,
+                    group_id: group.group_id,
+                    attention_kind: group.attention_kind,
+                    physical_layout: group.physical_layout,
+                    physical_layer_index,
+                    physical_layer_ordinal,
+                    shared_kv_anchor: spec.shared_kv_anchor,
+                },
+            );
+        }
+    }
+
+    Ok(routes.into_values().collect())
+}
+
+pub fn common_kv_cache_block_alignment(groups: &[KVCacheGroup]) -> u32 {
+    groups
+        .iter()
+        .map(|group| group.physical_layout.block_size)
+        .filter(|block_size| *block_size > 0)
+        .fold(1, lcm_u32)
+}
+
+pub fn align_prefix_len_to_kv_cache_groups(prefix_len: u32, groups: &[KVCacheGroup]) -> u32 {
+    let alignment = common_kv_cache_block_alignment(groups);
+    if alignment == 0 {
+        return prefix_len;
+    }
+    prefix_len / alignment * alignment
+}
+
+/// Intersect per-group prefix hits using vLLM's hybrid-cache rule: every
+/// active group must accept the prefix, then the result is aligned to a block
+/// boundary that is valid for every group.
+pub fn intersect_kv_cache_group_prefix_hits(
+    groups: &[KVCacheGroup],
+    hits: &[KVCacheGroupPrefixHit],
+) -> u32 {
+    if groups.is_empty() || hits.is_empty() {
+        return 0;
+    }
+
+    let by_group: BTreeMap<usize, u32> = hits
+        .iter()
+        .map(|hit| (hit.group_id, hit.cached_tokens))
+        .collect();
+    let mut candidate = u32::MAX;
+    for group in groups {
+        let Some(hit) = by_group.get(&group.group_id) else {
+            return 0;
+        };
+        candidate = candidate.min(*hit);
+    }
+
+    align_prefix_len_to_kv_cache_groups(candidate, groups)
+}
+
+pub fn validate_layer_kv_cache_specs(specs: &[LayerKVCacheSpec]) -> Result<(), KVCacheSpecError> {
+    let mut seen = BTreeSet::new();
+    let by_layer: BTreeMap<usize, &LayerKVCacheSpec> =
+        specs.iter().map(|spec| (spec.layer_index, spec)).collect();
+
+    for spec in specs {
+        if !seen.insert(spec.layer_index) {
+            return Err(KVCacheSpecError::DuplicateLayerIndex {
+                layer_index: spec.layer_index,
+            });
+        }
+        if !spec.physical_layout.is_valid() {
+            return Err(KVCacheSpecError::InvalidPhysicalLayout {
+                layer_index: spec.layer_index,
+            });
+        }
+        let Some(anchor_layer_index) = spec.shared_kv_anchor else {
+            continue;
+        };
+        let Some(anchor) = by_layer.get(&anchor_layer_index) else {
+            return Err(KVCacheSpecError::MissingSharedKVAnchor {
+                layer_index: spec.layer_index,
+                anchor_layer_index,
+            });
+        };
+        if let Some(root_anchor_layer_index) = anchor.shared_kv_anchor {
+            return Err(KVCacheSpecError::SharedKVAnchorIsAlias {
+                layer_index: spec.layer_index,
+                anchor_layer_index,
+                root_anchor_layer_index,
+            });
+        }
+        if spec.attention_kind != anchor.attention_kind
+            || !spec.is_physical_layout_compatible_with(anchor)
+        {
+            return Err(KVCacheSpecError::SharedKVIncompatible {
+                layer_index: spec.layer_index,
+                anchor_layer_index,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn div_ceil(n: u32, d: u32) -> u32 {
+    if n == 0 { 0 } else { 1 + (n - 1) / d }
+}
+
+fn gcd_u32(mut a: u32, mut b: u32) -> u32 {
+    while b != 0 {
+        let rem = a % b;
+        a = b;
+        b = rem;
+    }
+    a
+}
+
+fn lcm_u32(a: u32, b: u32) -> u32 {
+    if a == 0 || b == 0 {
+        return 0;
+    }
+    a / gcd_u32(a, b) * b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layout(block_size: u32) -> KVCachePhysicalLayout {
+        KVCachePhysicalLayout::new(block_size, 4, 128, KVCacheDType::BFloat16)
+    }
+
+    #[test]
+    fn physical_layout_compatibility_is_exact() {
+        let a = layout(16);
+        let b = layout(16);
+        let c = KVCachePhysicalLayout::new(32, 4, 128, KVCacheDType::BFloat16);
+
+        assert!(a.is_compatible_with(&b));
+        assert!(!a.is_compatible_with(&c));
+    }
+
+    #[test]
+    fn full_attention_max_blocks_rounds_up_to_model_len() {
+        assert_eq!(
+            AttentionKind::full_attention_max_blocks(4096, 16).unwrap(),
+            256
+        );
+        assert_eq!(
+            AttentionKind::full_attention_max_blocks(4097, 16).unwrap(),
+            257
+        );
+    }
+
+    #[test]
+    fn sliding_window_max_blocks_uses_window_chunk_cap_and_partial_block() {
+        // sliding_window - 1 + max_chunk = 127 + 32 = 159.
+        // ceil(159 / 16) + 1 partial block = 11.
+        assert_eq!(
+            AttentionKind::sliding_window_max_admission_blocks(128, 4096, 32, 16).unwrap(),
+            11
+        );
+
+        // Cap by max_model_len before block rounding.
+        assert_eq!(
+            AttentionKind::sliding_window_max_admission_blocks(4096, 512, 256, 16).unwrap(),
+            33
+        );
+    }
+
+    #[test]
+    fn shared_kv_anchor_omits_alias_from_physical_layers() {
+        let specs = vec![
+            LayerKVCacheSpec::full(0, layout(16)),
+            LayerKVCacheSpec::full(1, layout(16)).shared_with_anchor(0),
+            LayerKVCacheSpec::full(2, layout(16)),
+        ];
+
+        let groups = group_layer_kv_cache_specs(&specs, 128, 32).unwrap();
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].layer_indices, vec![0, 1, 2]);
+        assert_eq!(groups[0].physical_layer_indices, vec![0, 2]);
+        assert_eq!(groups[0].max_admission_blocks, 8);
+    }
+
+    #[test]
+    fn grouping_splits_attention_kind_and_layout() {
+        let specs = vec![
+            LayerKVCacheSpec::full(0, layout(16)),
+            LayerKVCacheSpec::sliding_window(1, 128, layout(16)),
+            LayerKVCacheSpec::full(2, layout(32)),
+            LayerKVCacheSpec::sliding_window(3, 128, layout(16)),
+        ];
+
+        let groups = group_layer_kv_cache_specs(&specs, 256, 32).unwrap();
+
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0].attention_kind, AttentionKind::Full);
+        assert_eq!(groups[0].physical_layout.block_size, 16);
+        assert_eq!(groups[0].layer_indices, vec![0]);
+        assert_eq!(groups[1].attention_kind, AttentionKind::Full);
+        assert_eq!(groups[1].physical_layout.block_size, 32);
+        assert_eq!(groups[1].layer_indices, vec![2]);
+        assert_eq!(
+            groups[2].attention_kind,
+            AttentionKind::SlidingWindow {
+                sliding_window: 128
+            }
+        );
+        assert_eq!(groups[2].layer_indices, vec![1, 3]);
+    }
+
+    #[test]
+    fn routes_map_shared_layers_to_anchor_physical_ordinals() {
+        let specs = vec![
+            LayerKVCacheSpec::sliding_window(0, 128, layout(16)),
+            LayerKVCacheSpec::full(1, layout(16)),
+            LayerKVCacheSpec::sliding_window(2, 128, layout(16)),
+            LayerKVCacheSpec::full(3, layout(16)),
+            LayerKVCacheSpec::sliding_window(4, 128, layout(16)).shared_with_anchor(2),
+            LayerKVCacheSpec::full(5, layout(16)).shared_with_anchor(3),
+        ];
+
+        let routes = derive_layer_kv_cache_routes(&specs, 4096, 512).unwrap();
+
+        assert_eq!(routes.len(), 6);
+        assert_eq!(routes[0].layer_index, 0);
+        assert_eq!(routes[0].physical_layer_ordinal, 0);
+        assert_eq!(routes[2].physical_layer_ordinal, 1);
+        assert_eq!(routes[4].shared_kv_anchor, Some(2));
+        assert_eq!(routes[4].physical_layer_index, 2);
+        assert_eq!(routes[4].physical_layer_ordinal, 1);
+        assert_eq!(routes[5].shared_kv_anchor, Some(3));
+        assert_eq!(routes[5].physical_layer_index, 3);
+        assert_eq!(routes[5].physical_layer_ordinal, 1);
+    }
+
+    #[test]
+    fn hybrid_prefix_hits_intersect_and_align_to_common_block() {
+        let specs = vec![
+            LayerKVCacheSpec::full(0, layout(16)),
+            LayerKVCacheSpec::sliding_window(
+                1,
+                128,
+                KVCachePhysicalLayout::new(32, 4, 128, KVCacheDType::BFloat16),
+            ),
+        ];
+        let groups = group_layer_kv_cache_specs(&specs, 4096, 512).unwrap();
+
+        assert_eq!(common_kv_cache_block_alignment(&groups), 32);
+        assert_eq!(
+            intersect_kv_cache_group_prefix_hits(
+                &groups,
+                &[
+                    KVCacheGroupPrefixHit {
+                        group_id: groups[0].group_id,
+                        cached_tokens: 160,
+                    },
+                    KVCacheGroupPrefixHit {
+                        group_id: groups[1].group_id,
+                        cached_tokens: 96,
+                    },
+                ],
+            ),
+            96
+        );
+        assert_eq!(
+            intersect_kv_cache_group_prefix_hits(
+                &groups,
+                &[KVCacheGroupPrefixHit {
+                    group_id: groups[0].group_id,
+                    cached_tokens: 160,
+                }],
+            ),
+            0,
+            "missing a group hit means the hybrid prefix cannot be reused"
+        );
+    }
+
+    #[test]
+    fn shared_kv_anchor_must_exist_and_match() {
+        let missing = vec![LayerKVCacheSpec::full(1, layout(16)).shared_with_anchor(0)];
+        assert_eq!(
+            validate_layer_kv_cache_specs(&missing),
+            Err(KVCacheSpecError::MissingSharedKVAnchor {
+                layer_index: 1,
+                anchor_layer_index: 0
+            })
+        );
+
+        let incompatible = vec![
+            LayerKVCacheSpec::full(0, layout(16)),
+            LayerKVCacheSpec::sliding_window(1, 128, layout(16)).shared_with_anchor(0),
+        ];
+        assert_eq!(
+            validate_layer_kv_cache_specs(&incompatible),
+            Err(KVCacheSpecError::SharedKVIncompatible {
+                layer_index: 1,
+                anchor_layer_index: 0
+            })
+        );
+    }
+
+    #[test]
+    fn shared_kv_anchor_cannot_chain_through_alias() {
+        let specs = vec![
+            LayerKVCacheSpec::full(0, layout(16)),
+            LayerKVCacheSpec::full(1, layout(16)).shared_with_anchor(0),
+            LayerKVCacheSpec::full(2, layout(16)).shared_with_anchor(1),
+        ];
+
+        assert_eq!(
+            validate_layer_kv_cache_specs(&specs),
+            Err(KVCacheSpecError::SharedKVAnchorIsAlias {
+                layer_index: 2,
+                anchor_layer_index: 1,
+                root_anchor_layer_index: 0
+            })
+        );
+    }
+}

--- a/crates/mlx-core/src/transformer/mod.rs
+++ b/crates/mlx-core/src/transformer/mod.rs
@@ -15,7 +15,9 @@ mod attention_vjp_test;
 pub mod batch_kv_cache;
 pub mod block;
 pub mod fused_attention;
+pub mod hybrid_kv_cache_manager;
 pub mod kv_cache;
+pub mod kv_cache_spec;
 pub mod mlp;
 #[cfg(test)]
 mod mlp_test;
@@ -32,7 +34,19 @@ pub use attention::{Attention, QKVResult};
 pub use batch_kv_cache::BatchKVCache;
 pub use block::TransformerBlock;
 pub use fused_attention::FusedAttention;
+pub use hybrid_kv_cache_manager::{
+    HybridKVCacheManager, KVCacheGroupConfig as HybridKVCacheGroupConfig,
+    KVCacheGroupId as HybridKVCacheGroupId, KVCacheGroupState as HybridKVCacheGroupState,
+    LayerKVCacheKind as HybridLayerKVCacheKind,
+};
 pub use kv_cache::KVCache;
+pub use kv_cache_spec::{
+    AttentionKind, KVCacheDType, KVCacheGroup, KVCacheGroupPrefixHit, KVCachePhysicalLayout,
+    KVCacheSpecError, LayerKVCacheRoute, LayerKVCacheSpec, align_prefix_len_to_kv_cache_groups,
+    common_kv_cache_block_alignment, derive_layer_kv_cache_routes,
+    derive_layer_kv_cache_routes_from_groups, group_layer_kv_cache_specs,
+    intersect_kv_cache_group_prefix_hits, validate_layer_kv_cache_specs,
+};
 pub use mlp::MLP;
 pub use paged_attention::{
     CompletedSequence, ContinuousBatchingScheduler, MemoryStats, PagedAttentionConfig,

--- a/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
+++ b/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
@@ -89,6 +89,32 @@ use crate::inference_trace::{
     elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
 };
 
+const PAGED_ATTENTION_V2_PARTITION_SIZE: u64 = 512;
+const PAGED_ATTENTION_V2_AUX_ELEM_LIMIT: u128 = i32::MAX as u128;
+
+fn paged_attention_v2_aux_fits(
+    num_new_tokens: u32,
+    num_query_heads: u32,
+    max_context_len: u32,
+    head_size: u32,
+) -> bool {
+    if num_new_tokens == 0 || num_query_heads == 0 || max_context_len == 0 || head_size == 0 {
+        return false;
+    }
+    if max_context_len as u64 <= PAGED_ATTENTION_V2_PARTITION_SIZE {
+        return true;
+    }
+
+    let max_num_partitions = (max_context_len as u64).div_ceil(PAGED_ATTENTION_V2_PARTITION_SIZE);
+    let exp_sums_size = (num_new_tokens as u128)
+        .saturating_mul(num_query_heads as u128)
+        .saturating_mul(max_num_partitions as u128);
+    let tmp_out_size = exp_sums_size.saturating_mul(head_size as u128);
+
+    exp_sums_size <= PAGED_ATTENTION_V2_AUX_ELEM_LIMIT
+        && tmp_out_size <= PAGED_ATTENTION_V2_AUX_ELEM_LIMIT
+}
+
 /// Outcome of `validate_kv_input`: the (kernel-input dtype, num_tokens) tuple
 /// the caller needs after a successful validation. Splitting validation off
 /// `update_keys_values` lets us assert all shape/dtype rejection paths in
@@ -388,6 +414,40 @@ pub(crate) fn build_decode_block_ids(table: &SequenceBlockTable) -> Vec<i32> {
     table.blocks().iter().map(|b| b.block_id as i32).collect()
 }
 
+/// Build the `block_ids` array for a paged-attention prefill dispatch that
+/// only needs the first `required_tokens` logical tokens from a request's block
+/// table. Normal suffix prefill records exactly through the current chunk; a
+/// cached-prefix replay can have `block_table.num_tokens()` already advanced to
+/// the full cached prefix while each replay chunk attends over a subrange.
+fn build_prefill_block_ids_for_total(
+    table: &SequenceBlockTable,
+    required_tokens: u32,
+    block_size: u32,
+) -> Result<Vec<i32>, String> {
+    if block_size == 0 {
+        return Err("block_size must be > 0".to_string());
+    }
+    if required_tokens == 0 {
+        return Ok(Vec::new());
+    }
+
+    let required_blocks = required_tokens.div_ceil(block_size) as usize;
+    if table.blocks().len() < required_blocks {
+        return Err(format!(
+            "block table has {} blocks, but {required_tokens} tokens at block_size \
+             {block_size} require {required_blocks} blocks",
+            table.blocks().len()
+        ));
+    }
+
+    Ok(table
+        .blocks()
+        .iter()
+        .take(required_blocks)
+        .map(|b| b.block_id as i32)
+        .collect())
+}
+
 /// Result of a prefix-cache lookup.
 #[derive(Debug)]
 pub struct CachedPrefix {
@@ -395,6 +455,24 @@ pub struct CachedPrefix {
     pub blocks: Vec<Arc<PhysicalBlock>>,
     /// Number of tokens covered by `blocks` (always a multiple of `block_size`).
     pub cached_token_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PagedTurnPlanReason {
+    ContinuedLivePrefix,
+    ContinueFailedReset,
+    FreshReset,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PagedTurnPlan {
+    pub cached_prefix_len: u32,
+    pub continued_live_prefix: bool,
+    pub allocated_blocks: u32,
+    pub cached_blocks: usize,
+    pub total_budget: u32,
+    pub suffix_len: u32,
+    pub reason: PagedTurnPlanReason,
 }
 
 /// Per-model session-friendly KV cache adapter.
@@ -459,6 +537,27 @@ pub struct PagedKVCacheAdapter {
     /// optimized prefill path pay avoidable host allocation/upload cost.
     #[cfg(target_os = "macos")]
     prefill_attention_inputs_cache: Option<PrefillPagedAttentionInputsCache>,
+
+    /// Cached per-decode-token metadata for the MLX `paged_attention` bridge.
+    /// Decode calls every full-attention layer with the same active block table
+    /// and seq_len after `record_tokens(&[token])`; cache the small metadata
+    /// arrays across those layer calls.
+    #[cfg(target_os = "macos")]
+    decode_attention_inputs_cache: Option<DecodePagedAttentionInputsCache>,
+
+    /// Per-layer MLX views of the K/V pool that carry native
+    /// `paged_kv_write` dependencies. When a native write returns
+    /// `(k_pool', v_pool')`, later MLX paged-attention calls must consume
+    /// those arrays instead of fresh raw pool views, otherwise MLX has no
+    /// write-before-read graph edge.
+    #[cfg(target_os = "macos")]
+    native_pool_arrays: Vec<Option<NativePoolArrays>>,
+
+    /// Cached exact slot mapping for the current write chunk. Gemma4 has five
+    /// global layers that write the same token positions, so this avoids
+    /// rebuilding and re-evaluating identical int64 metadata per layer.
+    #[cfg(target_os = "macos")]
+    write_slot_mapping_cache: Option<WriteSlotMappingCache>,
 }
 
 #[cfg(target_os = "macos")]
@@ -471,10 +570,56 @@ struct PrefillPagedAttentionInputsCache {
     seq_lens: MxArray,
 }
 
+#[cfg(target_os = "macos")]
+struct DecodePagedAttentionInputsCache {
+    token_count: u32,
+    block_count: u32,
+    block_table: MxArray,
+    seq_lens: MxArray,
+}
+
+#[cfg(target_os = "macos")]
+struct NativePoolArrays {
+    key: MxArray,
+    value: MxArray,
+    dirty: bool,
+}
+
+#[cfg(target_os = "macos")]
+struct WriteSlotMappingCache {
+    token_count: u32,
+    first_logical_position: u32,
+    num_tokens: u32,
+    block_count: usize,
+    first_slot: i64,
+    last_slot: i64,
+    slot_mapping: MxArray,
+}
+
 impl PagedKVCacheAdapter {
     #[cfg(target_os = "macos")]
     fn clear_prefill_attention_inputs_cache(&mut self) {
         self.prefill_attention_inputs_cache = None;
+    }
+
+    #[cfg(target_os = "macos")]
+    fn clear_decode_attention_inputs_cache(&mut self) {
+        self.decode_attention_inputs_cache = None;
+    }
+
+    #[cfg(target_os = "macos")]
+    fn clear_attention_inputs_caches(&mut self) {
+        self.clear_prefill_attention_inputs_cache();
+        self.clear_decode_attention_inputs_cache();
+    }
+
+    #[cfg(target_os = "macos")]
+    fn clear_native_graph_state(&mut self) {
+        self.native_pool_arrays
+            .iter_mut()
+            .for_each(|slot| *slot = None);
+        self.clear_attention_inputs_caches();
+        self.write_slot_mapping_cache = None;
     }
 
     /// Construct a new adapter sharing the given allocator and layer
@@ -519,6 +664,8 @@ impl PagedKVCacheAdapter {
                 layer_kv_pool.num_blocks()
             ));
         }
+        #[cfg(target_os = "macos")]
+        let num_layers = layer_kv_pool.num_layers();
         Ok(Self {
             allocator,
             layer_kv_pool,
@@ -532,6 +679,12 @@ impl PagedKVCacheAdapter {
             scale_manager: None,
             #[cfg(target_os = "macos")]
             prefill_attention_inputs_cache: None,
+            #[cfg(target_os = "macos")]
+            decode_attention_inputs_cache: None,
+            #[cfg(target_os = "macos")]
+            native_pool_arrays: (0..num_layers).map(|_| None).collect(),
+            #[cfg(target_os = "macos")]
+            write_slot_mapping_cache: None,
         })
     }
 
@@ -550,12 +703,98 @@ impl PagedKVCacheAdapter {
         #[cfg(target_os = "macos")]
         {
             self.prefill_attention_inputs_cache = None;
+            self.clear_native_graph_state();
         }
         // Reset registration flag AFTER release so a subsequent
         // register_full_blocks_for_reuse on the new request runs.
         self.already_registered = false;
         self.prefix_lookup_done = false;
         Ok(())
+    }
+
+    /// Prepare an active turn using the adapter lifecycle shared by paged
+    /// model integrations.
+    ///
+    /// This chooses between a live continuation (the previous turn called
+    /// `finalize_turn_keep_live`, preserving the partial trailing block) and
+    /// a fresh prefix-cache lookup. It does not record suffix tokens; callers
+    /// still feed those through `record_tokens` in their prefill loop.
+    pub fn prepare_turn(
+        &mut self,
+        seq_id: u32,
+        prompt_tokens: &[u32],
+        total_budget: u32,
+        reuse_cache: bool,
+        extra_keys: &[u64],
+        cache_salt: u64,
+        skip_lookup: bool,
+    ) -> Result<PagedTurnPlan, String> {
+        let can_continue = reuse_cache
+            && self.is_live_for_continue()
+            && prompt_tokens.starts_with(self.request_tokens());
+
+        let (cached_prefix_len, continued_live_prefix, allocated_blocks, cached_blocks, reason) =
+            if can_continue {
+                match self.continue_turn(prompt_tokens, total_budget) {
+                    Ok((prior_token_count, newly_allocated)) => (
+                        prior_token_count,
+                        true,
+                        newly_allocated,
+                        self.num_allocated_blocks(),
+                        PagedTurnPlanReason::ContinuedLivePrefix,
+                    ),
+                    Err(_) => {
+                        let _ = self.release_request();
+                        self.reset_for_new_request(seq_id)?;
+                        let prefix = self.find_cached_prefix(
+                            prompt_tokens,
+                            extra_keys,
+                            cache_salt,
+                            skip_lookup,
+                        )?;
+                        let allocated = self.allocate_suffix_blocks(total_budget)?;
+                        (
+                            prefix.cached_token_count,
+                            false,
+                            allocated,
+                            prefix.blocks.len(),
+                            PagedTurnPlanReason::ContinueFailedReset,
+                        )
+                    }
+                }
+            } else {
+                if self.block_table().is_some() {
+                    let _ = self.release_request();
+                }
+                self.reset_for_new_request(seq_id)?;
+                let prefix =
+                    self.find_cached_prefix(prompt_tokens, extra_keys, cache_salt, skip_lookup)?;
+                let allocated = self.allocate_suffix_blocks(total_budget)?;
+                (
+                    prefix.cached_token_count,
+                    false,
+                    allocated,
+                    prefix.blocks.len(),
+                    PagedTurnPlanReason::FreshReset,
+                )
+            };
+
+        let suffix_len = total_budget.checked_sub(cached_prefix_len).ok_or_else(|| {
+            format!(
+                "prepare_turn: cached_prefix_len {cached_prefix_len} exceeds total_budget \
+                 {total_budget}"
+            )
+        })?;
+
+        Ok(PagedTurnPlan {
+            cached_prefix_len,
+            continued_live_prefix,
+            allocated_blocks,
+            cached_blocks,
+            total_budget,
+            suffix_len,
+            reason,
+        })
     }
 
     /// Look up the longest cached prefix matching `prompt_tokens` and
@@ -980,7 +1219,7 @@ impl PagedKVCacheAdapter {
         block_table.set_num_tokens(new_total);
         #[cfg(target_os = "macos")]
         {
-            self.prefill_attention_inputs_cache = None;
+            self.clear_attention_inputs_caches();
         }
         Ok(())
     }
@@ -1020,7 +1259,7 @@ impl PagedKVCacheAdapter {
         block_table.set_num_tokens(new_len);
         #[cfg(target_os = "macos")]
         {
-            self.prefill_attention_inputs_cache = None;
+            self.clear_attention_inputs_caches();
         }
         Ok(())
     }
@@ -1062,6 +1301,225 @@ impl PagedKVCacheAdapter {
             slot_mapping.push(slot);
         }
         Ok(slot_mapping)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn raw_key_pool_array(&self, layer_idx: u32) -> Result<MxArray, String> {
+        let raw = self.layer_kv_pool.key_cache_array_raw(layer_idx)?;
+        MxArray::from_handle(raw, "key_pool_array").map_err(|e| format!("key_pool_array: {e}"))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn raw_value_pool_array(&self, layer_idx: u32) -> Result<MxArray, String> {
+        let raw = self.layer_kv_pool.value_cache_array_raw(layer_idx)?;
+        MxArray::from_handle(raw, "value_pool_array").map_err(|e| format!("value_pool_array: {e}"))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn native_pool_arrays_for_layer(
+        &mut self,
+        layer_idx: u32,
+    ) -> Result<(MxArray, MxArray), String> {
+        let idx = layer_idx as usize;
+        if idx >= self.layer_kv_pool.num_layers() {
+            return Err(format!(
+                "native_pool_arrays_for_layer: layer_idx {layer_idx} out of range \
+                 (num_layers = {})",
+                self.layer_kv_pool.num_layers()
+            ));
+        }
+        if self.native_pool_arrays[idx].is_none() {
+            let key = self.raw_key_pool_array(layer_idx)?;
+            let value = self.raw_value_pool_array(layer_idx)?;
+            self.native_pool_arrays[idx] = Some(NativePoolArrays {
+                key,
+                value,
+                dirty: false,
+            });
+        }
+        let state = self.native_pool_arrays[idx]
+            .as_ref()
+            .expect("native pool arrays initialized above");
+        Ok((state.key.clone(), state.value.clone()))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn replace_native_pool_arrays(
+        &mut self,
+        layer_idx: u32,
+        key: MxArray,
+        value: MxArray,
+    ) -> Result<(), String> {
+        let idx = layer_idx as usize;
+        if idx >= self.native_pool_arrays.len() {
+            return Err(format!(
+                "replace_native_pool_arrays: layer_idx {layer_idx} out of range \
+                 (num_layers = {})",
+                self.native_pool_arrays.len()
+            ));
+        }
+        self.native_pool_arrays[idx] = Some(NativePoolArrays {
+            key,
+            value,
+            dirty: true,
+        });
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn clear_native_pool_arrays_for_layer(&mut self, layer_idx: u32) -> Result<(), String> {
+        let idx = layer_idx as usize;
+        if idx >= self.native_pool_arrays.len() {
+            return Err(format!(
+                "clear_native_pool_arrays_for_layer: layer_idx {layer_idx} out of range \
+                 (num_layers = {})",
+                self.native_pool_arrays.len()
+            ));
+        }
+        self.native_pool_arrays[idx] = None;
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn write_slot_mapping_array(
+        &mut self,
+        first_logical_position: u32,
+        num_tokens: u32,
+    ) -> Result<(MxArray, i64, i64), String> {
+        let token_count = self.request_tokens.len() as u32;
+        let block_count = self.num_allocated_blocks();
+        if let Some(cache) = self.write_slot_mapping_cache.as_ref()
+            && cache.token_count == token_count
+            && cache.first_logical_position == first_logical_position
+            && cache.num_tokens == num_tokens
+            && cache.block_count == block_count
+        {
+            return Ok((
+                cache.slot_mapping.clone(),
+                cache.first_slot,
+                cache.last_slot,
+            ));
+        }
+
+        let slot_mapping = self.build_slot_mapping(first_logical_position, num_tokens)?;
+        let first_slot = slot_mapping.first().copied().unwrap_or(-1);
+        let last_slot = slot_mapping.last().copied().unwrap_or(-1);
+        let slot_mapping_arr = MxArray::from_int64(&slot_mapping, &[num_tokens as i64])
+            .map_err(|e| format!("update_keys_values_native slot_mapping: {e}"))?;
+        MxArray::eval_arrays(&[&slot_mapping_arr])
+            .map_err(|e| format!("update_keys_values_native slot_mapping eval: {e}"))?;
+
+        self.write_slot_mapping_cache = Some(WriteSlotMappingCache {
+            token_count,
+            first_logical_position,
+            num_tokens,
+            block_count,
+            first_slot,
+            last_slot,
+            slot_mapping: slot_mapping_arr,
+        });
+        let cache = self
+            .write_slot_mapping_cache
+            .as_ref()
+            .expect("write_slot_mapping_cache was just populated");
+        Ok((
+            cache.slot_mapping.clone(),
+            cache.first_slot,
+            cache.last_slot,
+        ))
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn eval_pending_pool_writes(&mut self) -> Result<(), String> {
+        let mut dirty_layers = Vec::new();
+        let mut arrays: Vec<MxArray> = Vec::new();
+        for (layer_idx, state) in self.native_pool_arrays.iter().enumerate() {
+            let Some(state) = state.as_ref() else {
+                continue;
+            };
+            if state.dirty {
+                dirty_layers.push(layer_idx);
+                arrays.push(state.key.clone());
+                arrays.push(state.value.clone());
+            }
+        }
+        if arrays.is_empty() {
+            return Ok(());
+        }
+        let trace_enabled = inference_trace_enabled();
+        let trace_start = trace_enabled.then(Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv eval_pending_pool_writes_start layers={:?} arrays={}",
+                dirty_layers,
+                arrays.len()
+            ));
+        }
+        let refs: Vec<&MxArray> = arrays.iter().collect();
+        MxArray::eval_arrays(&refs).map_err(|e| format!("eval_pending_pool_writes: {e}"))?;
+        for state in self.native_pool_arrays.iter_mut().flatten() {
+            state.dirty = false;
+        }
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv eval_pending_pool_writes_done layers={:?} arrays={} elapsed_ms={:.1}",
+                dirty_layers,
+                arrays.len(),
+                trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn eval_pending_pool_write_for_layer(&mut self, layer_idx: u32) -> Result<(), String> {
+        let idx = layer_idx as usize;
+        let Some(Some(state)) = self.native_pool_arrays.get(idx) else {
+            return Ok(());
+        };
+        if !state.dirty {
+            return Ok(());
+        }
+        let key = state.key.clone();
+        let value = state.value.clone();
+        let trace_enabled = inference_trace_enabled();
+        let trace_start = trace_enabled.then(Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv eval_pending_pool_write_for_layer_start layer={}",
+                layer_idx
+            ));
+        }
+        MxArray::eval_arrays(&[&key, &value])
+            .map_err(|e| format!("eval_pending_pool_write_for_layer: {e}"))?;
+        if let Some(Some(state)) = self.native_pool_arrays.get_mut(idx) {
+            state.dirty = false;
+        }
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv eval_pending_pool_write_for_layer_done layer={} elapsed_ms={:.1}",
+                layer_idx,
+                trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn kv_dtype_raw(&self) -> Result<u8, String> {
+        match self.layer_kv_pool.cache_dtype() {
+            mlx_paged_attn::metal::MetalDtype::Float16 => Ok(0),
+            mlx_paged_attn::metal::MetalDtype::BFloat16 => Ok(1),
+            mlx_paged_attn::metal::MetalDtype::UChar => Ok(2),
+            mlx_paged_attn::metal::MetalDtype::Float32 => {
+                Err("Float32 KV cache is unsupported".to_string())
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    pub fn eval_pending_pool_writes(&mut self) -> Result<(), String> {
+        Ok(())
     }
 
     /// Write a chunk of K/V tokens into the layer's paged Metal buffers
@@ -1157,7 +1615,13 @@ impl PagedKVCacheAdapter {
             ));
         }
 
-        // 5. Build slot mapping and dispatch.
+        // 5. Build slot mapping and dispatch. The raw Metal writer runs
+        // outside MLX's graph scheduler, so if this layer has a pending
+        // graph-native write chain, force that chain first. After the raw
+        // writer completes synchronously, clear the graph view for this layer
+        // so later graph attention wraps the physical pool after the raw
+        // mutation instead of reusing a stale dependency-carrying view.
+        self.eval_pending_pool_write_for_layer(layer_idx)?;
         let slot_mapping = self.build_slot_mapping(first_logical_position, num_tokens)?;
         let trace_enabled = inference_trace_enabled();
         let write_trace_start = trace_enabled.then(Instant::now);
@@ -1205,6 +1669,149 @@ impl PagedKVCacheAdapter {
                 write_trace_start.map(elapsed_ms).unwrap_or(0.0)
             ));
         }
+        self.clear_native_pool_arrays_for_layer(layer_idx)?;
+        Ok(())
+    }
+
+    /// Graph-native variant of [`Self::update_keys_values`]. Instead of
+    /// extracting Metal buffers from `keys` / `values` and synchronizing MLX,
+    /// this emits the C++ `paged_kv_write` custom primitive and stores the
+    /// returned pool arrays so later MLX paged-attention reads depend on the
+    /// write in the same graph.
+    #[cfg(target_os = "macos")]
+    pub fn update_keys_values_native(
+        &mut self,
+        layer_idx: u32,
+        keys: &MxArray,
+        values: &MxArray,
+        first_logical_position: u32,
+    ) -> Result<(), String> {
+        if self.block_table.is_none() {
+            return Err(
+                "update_keys_values_native called before reset_for_new_request \
+                 (no active request)"
+                    .to_string(),
+            );
+        }
+
+        let num_layers = self.layer_kv_pool.num_layers();
+        if (layer_idx as usize) >= num_layers {
+            return Err(format!(
+                "update_keys_values_native: layer_idx {layer_idx} out of range \
+                 (num_layers = {num_layers})"
+            ));
+        }
+
+        let keys_meta = KvTensorMeta::from_array(keys, "keys")?;
+        let values_meta = KvTensorMeta::from_array(values, "values")?;
+        let info = validate_kv_input(&keys_meta, &values_meta, self.layer_kv_pool.config())?;
+        let num_tokens = info.num_tokens;
+        if num_tokens == 0 {
+            return Ok(());
+        }
+
+        let current = self.request_tokens.len() as u32;
+        let expected_first = current.checked_sub(num_tokens).ok_or_else(|| {
+            format!(
+                "update_keys_values_native: chunk has {num_tokens} tokens but only {current} \
+                 have been recorded (call record_tokens first)"
+            )
+        })?;
+        if first_logical_position != expected_first {
+            return Err(format!(
+                "update_keys_values_native: first_logical_position {first_logical_position} \
+                 does not align with the recorded suffix (expected {expected_first} based on \
+                 current_token_count {current} and chunk size {num_tokens}). The chunk must \
+                 cover the most recently recorded tokens."
+            ));
+        }
+
+        let trace_enabled = inference_trace_enabled();
+        let write_trace_start = trace_enabled.then(Instant::now);
+        let metadata_trace_start = trace_enabled.then(Instant::now);
+        let (slot_mapping, first_slot, last_slot) =
+            self.write_slot_mapping_array(first_logical_position, num_tokens)?;
+        let metadata_ms = metadata_trace_start.map(elapsed_ms).unwrap_or(0.0);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv update_keys_values_native_start layer={} first_position={} num_tokens={} current_tokens={} blocks={} first_slot={} last_slot={} metadata_ms={:.1}",
+                layer_idx,
+                first_logical_position,
+                num_tokens,
+                self.request_tokens.len(),
+                self.num_allocated_blocks(),
+                first_slot,
+                last_slot,
+                metadata_ms
+            ));
+        }
+
+        let (k_pool, v_pool) = self.native_pool_arrays_for_layer(layer_idx)?;
+        let k_scale = self.k_scale_array(layer_idx)?;
+        let v_scale = self.v_scale_array(layer_idx)?;
+        let kv_dtype_raw = self.kv_dtype_raw()?;
+
+        let ffi_trace_start = trace_enabled.then(Instant::now);
+        let mut out_k_pool: *mut mlx_sys::mlx_array = std::ptr::null_mut();
+        let mut out_v_pool: *mut mlx_sys::mlx_array = std::ptr::null_mut();
+        let ok = unsafe {
+            mlx_sys::mlx_paged_kv_write_forward(
+                k_pool.as_raw_ptr(),
+                v_pool.as_raw_ptr(),
+                keys.as_raw_ptr(),
+                values.as_raw_ptr(),
+                slot_mapping.as_raw_ptr(),
+                k_scale.as_raw_ptr(),
+                v_scale.as_raw_ptr(),
+                self.block_size as i32,
+                self.layer_kv_pool.config().num_kv_heads as i32,
+                self.layer_kv_pool.config().head_size as i32,
+                kv_dtype_raw,
+                &mut out_k_pool,
+                &mut out_v_pool,
+            )
+        };
+        if !ok || out_k_pool.is_null() || out_v_pool.is_null() {
+            unsafe {
+                if !out_k_pool.is_null() {
+                    mlx_sys::mlx_array_delete(out_k_pool);
+                }
+                if !out_v_pool.is_null() {
+                    mlx_sys::mlx_array_delete(out_v_pool);
+                }
+            }
+            if trace_enabled {
+                write_inference_trace(format_args!(
+                    "[MLX_TRACE] paged_kv update_keys_values_native_fallback layer={} first_position={} num_tokens={} ffi_ms={:.1}",
+                    layer_idx,
+                    first_logical_position,
+                    num_tokens,
+                    ffi_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                ));
+            }
+            return Err(format!(
+                "update_keys_values_native: mlx_paged_kv_write_forward returned null \
+                 (layer={layer_idx}, num_tokens={num_tokens})"
+            ));
+        }
+
+        let k_out = MxArray::from_handle(out_k_pool, "paged_kv_write_forward k_pool")
+            .map_err(|e| format!("update_keys_values_native: failed to wrap k_pool output: {e}"))?;
+        let v_out = MxArray::from_handle(out_v_pool, "paged_kv_write_forward v_pool")
+            .map_err(|e| format!("update_keys_values_native: failed to wrap v_pool output: {e}"))?;
+        self.replace_native_pool_arrays(layer_idx, k_out, v_out)?;
+
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv update_keys_values_native_done layer={} first_position={} num_tokens={} metadata_ms={:.1} ffi_ms={:.1} elapsed_ms={:.1}",
+                layer_idx,
+                first_logical_position,
+                num_tokens,
+                metadata_ms,
+                ffi_trace_start.map(elapsed_ms).unwrap_or(0.0),
+                write_trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
         Ok(())
     }
 
@@ -1222,41 +1829,199 @@ impl PagedKVCacheAdapter {
         Err("update_keys_values is only supported on macOS (Metal backend)".to_string())
     }
 
-    /// Run paged attention against this layer's K/V buffers for a single
-    /// decode step on the active request, returning the attention output.
-    ///
-    /// `queries` shape: `[1, num_query_heads, head_size]`. `queries.dtype`
-    /// MUST equal the pool's `cache_dtype` for non-FP8 caches (the metal
-    /// source only instantiates same-dtype `(io_t, cache_t)` pairs for
-    /// non-FP8); for FP8 caches the io dtype can independently be Float16
-    /// or BFloat16 (the kernel dequantizes internally). The dtype is
-    /// extracted from the queries tensor and forwarded to
-    /// `LayerKVPool::gather_attention` so the kernel-name lookup picks the
-    /// right `(io_t, cache_t)` instantiation. Mismatched dtype is rejected
-    /// at the API boundary by `LayerKVPool::gather_attention`.
-    ///
-    /// `scale`: typically `1.0 / sqrt(head_size as f32)`.
-    /// `softcap`: `1.0` disables softcapping.
-    ///
-    /// Returns the attention output as an `MxArray` of shape
-    /// `[1, num_query_heads, head_size]`, in the kernel's io dtype (matching
-    /// the queries dtype). The returned array is a retained MLX view over the
-    /// Metal output buffer, so decode stays on-device.
-    ///
-    /// ## Single-request semantics
-    ///
-    /// Always runs with `num_seqs = 1`. The adapter is per-request — the
-    /// block_table holds exactly the active request's blocks and the
-    /// context_lens entry is the request's `num_tokens()`.
+    #[cfg(not(target_os = "macos"))]
+    pub fn update_keys_values_native(
+        &mut self,
+        _layer_idx: u32,
+        _keys: &MxArray,
+        _values: &MxArray,
+        _first_logical_position: u32,
+    ) -> Result<(), String> {
+        Err("update_keys_values_native is only supported on macOS (Metal backend)".to_string())
+    }
+
+    /// Build and cache the small metadata arrays used by graph-native decode
+    /// paged attention for the active request.
+    /// Always emits `num_seqs = 1`: the adapter is per request, so the
+    /// block table contains exactly the active sequence and `seq_lens[0]`
+    /// is the request's recorded token count.
+    #[cfg(target_os = "macos")]
+    fn decode_attention_inputs(&mut self) -> Result<(MxArray, MxArray, u32), String> {
+        let block_table = self.block_table.as_ref().ok_or_else(|| {
+            "gather_kv_for_decode_graph called before reset_for_new_request".to_string()
+        })?;
+        let recorded = block_table.num_tokens();
+        if recorded == 0 {
+            return Err("gather_kv_for_decode_graph called before any tokens recorded".to_string());
+        }
+        let block_ids = build_decode_block_ids(block_table);
+        if block_ids.is_empty() {
+            return Err(
+                "gather_kv_for_decode_graph: active request has no allocated blocks".to_string(),
+            );
+        }
+        let block_count = u32::try_from(block_ids.len()).map_err(|_| {
+            format!(
+                "gather_kv_for_decode_graph: too many blocks for i32 shape: {}",
+                block_ids.len()
+            )
+        })?;
+        let pool_block_count = self.layer_kv_pool.num_blocks();
+        for (idx, &block_id) in block_ids.iter().enumerate() {
+            if block_id < 0 || block_id as u32 >= pool_block_count {
+                return Err(format!(
+                    "gather_kv_for_decode_graph: block_table[{idx}]={block_id} out of \
+                     range for pool block count {pool_block_count}"
+                ));
+            }
+        }
+        let max_seq_len = block_count
+            .checked_mul(self.block_size)
+            .ok_or_else(|| "gather_kv_for_decode_graph: max seq len overflow".to_string())?;
+        if recorded > max_seq_len {
+            return Err(format!(
+                "gather_kv_for_decode_graph: recorded token count {recorded} exceeds \
+                 block table capacity {block_count} * {} = {max_seq_len}",
+                self.block_size
+            ));
+        }
+
+        if let Some(cache) = self.decode_attention_inputs_cache.as_ref()
+            && cache.token_count == recorded
+            && cache.block_count == block_count
+        {
+            return Ok((
+                cache.block_table.clone(),
+                cache.seq_lens.clone(),
+                cache.block_count,
+            ));
+        }
+
+        let block_table_arr = MxArray::from_int32(&block_ids, &[1, block_count as i64])
+            .map_err(|e| format!("gather_kv_for_decode_graph block_table: {e}"))?;
+        let seq_lens_arr = MxArray::from_int32(&[recorded as i32], &[1])
+            .map_err(|e| format!("gather_kv_for_decode_graph seq_lens: {e}"))?;
+        MxArray::eval_arrays(&[&block_table_arr, &seq_lens_arr])
+            .map_err(|e| format!("gather_kv_for_decode_graph metadata eval: {e}"))?;
+
+        self.decode_attention_inputs_cache = Some(DecodePagedAttentionInputsCache {
+            token_count: recorded,
+            block_count,
+            block_table: block_table_arr,
+            seq_lens: seq_lens_arr,
+        });
+        let cache = self
+            .decode_attention_inputs_cache
+            .as_ref()
+            .expect("decode_attention_inputs_cache was just populated");
+        Ok((
+            cache.block_table.clone(),
+            cache.seq_lens.clone(),
+            cache.block_count,
+        ))
+    }
+
+    /// Graph-native decode attention. Unlike [`Self::gather_kv_for_decode`],
+    /// this consumes the MLX K/V pool arrays tracked in `native_pool_arrays`,
+    /// so a lazy native `paged_kv_write` can feed the attention read through
+    /// normal graph dependencies without a per-layer synchronization point.
+    #[cfg(target_os = "macos")]
+    pub fn gather_kv_for_decode_graph(
+        &mut self,
+        layer_idx: u32,
+        queries: &MxArray,
+        scale: f32,
+        softcap: f32,
+    ) -> Result<MxArray, String> {
+        if self.block_table.is_none() {
+            return Err(
+                "gather_kv_for_decode_graph called before reset_for_new_request".to_string(),
+            );
+        }
+
+        let q_meta = KvTensorMeta::from_array(queries, "queries")?;
+        let info = validate_query_input(
+            &q_meta,
+            self.layer_kv_pool.config(),
+            self.layer_kv_pool.num_layers(),
+            layer_idx,
+        )?;
+        let num_query_heads = info.num_query_heads;
+        let query_dtype = match q_meta.dtype {
+            DType::Float16 => mlx_paged_attn::metal::MetalDtype::Float16,
+            DType::BFloat16 => mlx_paged_attn::metal::MetalDtype::BFloat16,
+            other => {
+                return Err(format!(
+                    "gather_kv_for_decode_graph: unsupported query dtype {other:?} \
+                     (validate_query_input should have rejected this)"
+                ));
+            }
+        };
+        let cache_dtype = self.layer_kv_pool.cache_dtype();
+        if !cache_dtype.is_fp8() && query_dtype != cache_dtype {
+            return Err(format!(
+                "gather_kv_for_decode_graph: query_dtype ({query_dtype:?}) must equal \
+                 cache_dtype ({cache_dtype:?}) for non-FP8 caches"
+            ));
+        }
+
+        let (block_table, seq_lens, block_count) = self.decode_attention_inputs()?;
+        let k_pool = self.key_pool_array(layer_idx)?;
+        let v_pool = self.value_pool_array(layer_idx)?;
+        let k_scale = self.k_scale_array(layer_idx)?;
+        let v_scale = self.v_scale_array(layer_idx)?;
+        let kv_dtype_raw = self.kv_dtype_raw()?;
+        let graph_softcap = if softcap == 1.0 { 0.0 } else { softcap };
+
+        let raw = unsafe {
+            mlx_sys::mlx_paged_attention_forward(
+                queries.as_raw_ptr(),
+                k_pool.as_raw_ptr(),
+                v_pool.as_raw_ptr(),
+                block_table.as_raw_ptr(),
+                seq_lens.as_raw_ptr(),
+                k_scale.as_raw_ptr(),
+                v_scale.as_raw_ptr(),
+                scale,
+                graph_softcap,
+                0,
+                self.block_size as i32,
+                num_query_heads as i32,
+                self.layer_kv_pool.config().num_kv_heads as i32,
+                self.layer_kv_pool.config().head_size as i32,
+                kv_dtype_raw,
+            )
+        };
+        if raw.is_null() {
+            return Err(format!(
+                "gather_kv_for_decode_graph: mlx_paged_attention_forward returned null \
+                 (layer={layer_idx}, token_count={}, block_count={block_count})",
+                self.current_token_count()
+            ));
+        }
+
+        MxArray::from_handle(raw, "gather_kv_for_decode_graph")
+            .map_err(|e| format!("gather_kv_for_decode_graph: failed to wrap output array: {e}"))
+    }
+
     #[cfg(target_os = "macos")]
     pub fn gather_kv_for_decode(
-        &self,
+        &mut self,
         layer_idx: u32,
         queries: &MxArray,
         scale: f32,
         softcap: f32,
     ) -> Result<MxArray, String> {
         // 1. Active request?
+        if self.block_table.is_none() {
+            return Err("gather_kv_for_decode called before reset_for_new_request".to_string());
+        }
+
+        // Raw Metal gather reads the pool outside MLX's graph scheduler. If a
+        // prior native `paged_kv_write` for this layer is still lazy, force it
+        // now so the gather sees the just-written K/V.
+        self.eval_pending_pool_write_for_layer(layer_idx)?;
+
         let block_table = self.block_table.as_ref().ok_or_else(|| {
             "gather_kv_for_decode called before reset_for_new_request".to_string()
         })?;
@@ -1358,6 +2123,7 @@ impl PagedKVCacheAdapter {
                 num_query_heads,
                 scale,
                 softcap,
+                0,
                 k_scale,
                 v_scale,
             )?
@@ -1374,8 +2140,10 @@ impl PagedKVCacheAdapter {
     /// Run MLX-graph paged attention for a multi-token prefill suffix chunk.
     ///
     /// `queries` must be `[num_new_tokens, num_query_heads, head_size]`.
-    /// The current request must already have recorded the whole chunk, so the
-    /// active block table covers `cached_prefix_len + num_new_tokens` tokens.
+    /// Normal suffix prefill must have recorded the whole chunk already, so
+    /// the active block table covers `cached_prefix_len + num_new_tokens`.
+    /// Cached-prefix restore may replay an earlier subrange while the active
+    /// request has already been seeded to the full cached prefix length.
     ///
     /// This represents each suffix token as one paged-attention "sequence"
     /// with a different `seq_len`, which gives token `i` access to
@@ -1425,11 +2193,29 @@ impl PagedKVCacheAdapter {
             return Err("gather_kv_for_prefill_chunk: num_query_heads must be > 0".to_string());
         }
 
-        let expected_head_size = self.layer_kv_pool.config().head_size as i64;
-        if q_meta.shape[2] != expected_head_size {
+        let expected_head_size = self.layer_kv_pool.config().head_size;
+        if q_meta.shape[2] != expected_head_size as i64 {
             return Err(format!(
                 "gather_kv_for_prefill_chunk: query head_size {} != expected {}",
                 q_meta.shape[2], expected_head_size
+            ));
+        }
+        let max_context_len = cached_prefix_len
+            .checked_add(num_new_tokens)
+            .ok_or_else(|| {
+                "gather_kv_for_prefill_chunk: max context length overflow".to_string()
+            })?;
+        if !paged_attention_v2_aux_fits(
+            num_new_tokens,
+            num_query_heads,
+            max_context_len,
+            expected_head_size,
+        ) {
+            return Err(format!(
+                "gather_kv_for_prefill_chunk: paged-attention V2 auxiliary buffer would exceed \
+                 INT_MAX (num_new_tokens={num_new_tokens}, num_query_heads={num_query_heads}, \
+                 max_context_len={max_context_len}, head_size={expected_head_size}); \
+                 reduce MLX_PAGED_PREFILL_CHUNK_SIZE or let Gemma4 dynamic chunking split the request"
             ));
         }
 
@@ -1510,9 +2296,9 @@ impl PagedKVCacheAdapter {
         let expected_total = cached_prefix_len
             .checked_add(num_new_tokens)
             .ok_or_else(|| "gather_kv_for_prefill_chunk: token count overflow".to_string())?;
-        if recorded != expected_total {
+        if recorded < expected_total {
             return Err(format!(
-                "gather_kv_for_prefill_chunk: recorded token count {recorded} != \
+                "gather_kv_for_prefill_chunk: recorded token count {recorded} is less than \
                  cached_prefix_len + num_new_tokens ({cached_prefix_len} + {num_new_tokens} = \
                  {expected_total}); call record_tokens for the whole chunk first"
             ));
@@ -1530,7 +2316,9 @@ impl PagedKVCacheAdapter {
             ));
         }
 
-        let block_ids = build_decode_block_ids(block_table);
+        let block_ids =
+            build_prefill_block_ids_for_total(block_table, expected_total, self.block_size)
+                .map_err(|e| format!("gather_kv_for_prefill_chunk: {e}"))?;
         if block_ids.is_empty() {
             return Err(
                 "gather_kv_for_prefill_chunk: active request has no allocated blocks".to_string(),
@@ -1561,6 +2349,12 @@ impl PagedKVCacheAdapter {
                 self.block_size
             ));
         }
+        if recorded > expected_total && inference_trace_enabled() {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv prefill_attention_inputs_prefix_replay recorded_tokens={} required_tokens={} cached_prefix={} num_new_tokens={} block_count={}",
+                recorded, expected_total, cached_prefix_len, num_new_tokens, block_count
+            ));
+        }
 
         let num_new_usize = num_new_tokens as usize;
         let block_count_usize = block_count as usize;
@@ -1584,9 +2378,10 @@ impl PagedKVCacheAdapter {
         .map_err(|e| format!("gather_kv_for_prefill_chunk block_table: {e}"))?;
         let seq_lens_arr = MxArray::from_int32(&seq_lens, &[num_new_tokens as i64])
             .map_err(|e| format!("gather_kv_for_prefill_chunk seq_lens: {e}"))?;
-        // The paged-attention output is lazy and may not evaluate until after
-        // this function returns. Materialize host-built metadata before the
-        // Rust backing Vecs are dropped so eval_gpu cannot observe stale data.
+        // Keep the metadata MxArrays cached for the whole prefill chunk. The
+        // FFI bridge consumes these exact arrays; it must not wrap them in lazy
+        // metadata copies before `PagedAttention::eval_gpu` performs host-side
+        // bounds checks.
         MxArray::eval_arrays(&[&block_table_arr, &seq_lens_arr])
             .map_err(|e| format!("gather_kv_for_prefill_chunk metadata eval: {e}"))?;
 
@@ -1611,8 +2406,19 @@ impl PagedKVCacheAdapter {
 
     /// Non-macOS stub.
     #[cfg(not(target_os = "macos"))]
+    pub fn gather_kv_for_decode_graph(
+        &mut self,
+        _layer_idx: u32,
+        _queries: &MxArray,
+        _scale: f32,
+        _softcap: f32,
+    ) -> Result<MxArray, String> {
+        Err("gather_kv_for_decode_graph is only supported on macOS (Metal backend)".to_string())
+    }
+
+    #[cfg(not(target_os = "macos"))]
     pub fn gather_kv_for_decode(
-        &self,
+        &mut self,
         _layer_idx: u32,
         _queries: &MxArray,
         _scale: f32,
@@ -1661,12 +2467,20 @@ impl PagedKVCacheAdapter {
     /// length × `num_kv_heads * head_size` (typically a few MB per layer).
     #[cfg(target_os = "macos")]
     pub fn read_kv_range(
-        &self,
+        &mut self,
         layer_idx: u32,
         start_pos: u32,
         num_tokens: u32,
     ) -> Result<(MxArray, MxArray), String> {
         // 1. Active request?
+        if self.block_table.is_none() {
+            return Err("read_kv_range called before reset_for_new_request".to_string());
+        }
+
+        // This host read bypasses MLX graph scheduling, so materialize any
+        // pending native write for the layer first.
+        self.eval_pending_pool_write_for_layer(layer_idx)?;
+
         let block_table = self
             .block_table
             .as_ref()
@@ -1904,7 +2718,7 @@ impl PagedKVCacheAdapter {
     /// Non-macOS stub.
     #[cfg(not(target_os = "macos"))]
     pub fn read_kv_range(
-        &self,
+        &mut self,
         _layer_idx: u32,
         _start_pos: u32,
         _num_tokens: u32,
@@ -1980,6 +2794,9 @@ impl PagedKVCacheAdapter {
         if self.already_registered {
             return Ok(0);
         }
+
+        #[cfg(target_os = "macos")]
+        self.eval_pending_pool_writes()?;
 
         let block_table = self.block_table.as_ref().ok_or_else(|| {
             "register_full_blocks_for_reuse called before reset_for_new_request".to_string()
@@ -2091,6 +2908,9 @@ impl PagedKVCacheAdapter {
         if self.already_registered {
             return Ok(0);
         }
+        #[cfg(target_os = "macos")]
+        self.eval_pending_pool_writes()?;
+
         let block_table = self.block_table.as_ref().ok_or_else(|| {
             "register_full_blocks_for_reuse_per_block called before reset_for_new_request"
                 .to_string()
@@ -2187,6 +3007,7 @@ impl PagedKVCacheAdapter {
         #[cfg(target_os = "macos")]
         {
             self.prefill_attention_inputs_cache = None;
+            self.clear_native_graph_state();
         }
         // Defense-in-depth: clear the registration flag so a subsequent
         // reset_for_new_request → register flow on this adapter works
@@ -2266,7 +3087,7 @@ impl PagedKVCacheAdapter {
         // a duplicate finalize after an error path doesn't double-register).
         if self.already_registered {
             #[cfg(target_os = "macos")]
-            self.clear_prefill_attention_inputs_cache();
+            self.clear_attention_inputs_caches();
             return Ok(0);
         }
         // Reuse `register_full_blocks_for_reuse`'s implementation for the
@@ -2274,7 +3095,7 @@ impl PagedKVCacheAdapter {
         // `release_request` after it.
         let result = self.register_full_blocks_for_reuse(extra_keys, cache_salt);
         #[cfg(target_os = "macos")]
-        self.clear_prefill_attention_inputs_cache();
+        self.clear_attention_inputs_caches();
         result
     }
 
@@ -2308,13 +3129,13 @@ impl PagedKVCacheAdapter {
     ) -> Result<u32, String> {
         if self.already_registered {
             #[cfg(target_os = "macos")]
-            self.clear_prefill_attention_inputs_cache();
+            self.clear_attention_inputs_caches();
             return Ok(0);
         }
         let result =
             self.register_full_blocks_for_reuse_per_block(extra_keys_per_block, cache_salt);
         #[cfg(target_os = "macos")]
-        self.clear_prefill_attention_inputs_cache();
+        self.clear_attention_inputs_caches();
         result
     }
 
@@ -2446,7 +3267,7 @@ impl PagedKVCacheAdapter {
         self.prefix_lookup_done = true; // already implicitly "done" — no fresh lookup is allowed
         #[cfg(target_os = "macos")]
         {
-            self.prefill_attention_inputs_cache = None;
+            self.clear_attention_inputs_caches();
         }
 
         Ok((prior_token_count, newly_allocated))
@@ -2659,16 +3480,20 @@ impl PagedKVCacheAdapter {
     /// the buffer refcount that keeps the GPU memory alive.
     #[cfg(target_os = "macos")]
     pub fn key_pool_array(&self, layer_idx: u32) -> Result<MxArray, String> {
-        let raw = self.layer_kv_pool.key_cache_array_raw(layer_idx)?;
-        MxArray::from_handle(raw, "key_pool_array").map_err(|e| format!("key_pool_array: {e}"))
+        if let Some(Some(state)) = self.native_pool_arrays.get(layer_idx as usize) {
+            return Ok(state.key.clone());
+        }
+        self.raw_key_pool_array(layer_idx)
     }
 
     /// Wrap the V cache buffer for `layer_idx` as a zero-copy MxArray view.
     /// See [`Self::key_pool_array`] for ownership semantics.
     #[cfg(target_os = "macos")]
     pub fn value_pool_array(&self, layer_idx: u32) -> Result<MxArray, String> {
-        let raw = self.layer_kv_pool.value_cache_array_raw(layer_idx)?;
-        MxArray::from_handle(raw, "value_pool_array").map_err(|e| format!("value_pool_array: {e}"))
+        if let Some(Some(state)) = self.native_pool_arrays.get(layer_idx as usize) {
+            return Ok(state.value.clone());
+        }
+        self.raw_value_pool_array(layer_idx)
     }
 
     /// Non-macOS stub for `key_pool_array`.
@@ -2939,6 +3764,13 @@ pub fn compute_per_block_image_extra_keys(
 mod tests {
     use super::*;
     use half::f16;
+
+    #[test]
+    fn test_paged_attention_v2_aux_limit_matches_gemma4_overflow_shape() {
+        assert!(paged_attention_v2_aux_fits(8192, 16, 8208, 512));
+        assert!(!paged_attention_v2_aux_fits(8192, 16, 16400, 512));
+        assert!(paged_attention_v2_aux_fits(8176, 16, 16384, 512));
+    }
 
     fn new_allocator(num_blocks: u32, block_size: u32) -> Arc<Mutex<BlockAllocator>> {
         Arc::new(Mutex::new(BlockAllocator::new(num_blocks, block_size)))
@@ -4697,7 +5529,7 @@ mod tests {
     /// validation-test pool (graceful skip on no-Metal hosts).
     #[test]
     fn test_gather_kv_no_active_request() {
-        let Some(adapter) = maybe_adapter(new_allocator(8, 4), 4) else {
+        let Some(mut adapter) = maybe_adapter(new_allocator(8, 4), 4) else {
             eprintln!("skipping test_gather_kv_no_active_request: Metal unavailable");
             return;
         };
@@ -4783,6 +5615,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_prefill_block_table_marshalling_truncates_to_required_prefix() {
+        let allocator = new_allocator(64, 4);
+        let mut table = SequenceBlockTable::new(0, 4);
+
+        let mut all = Vec::with_capacity(64);
+        {
+            let mut g = allocator.lock().unwrap();
+            for _ in 0..64 {
+                all.push(g.allocate().expect("alloc"));
+            }
+        }
+        let want = [42u32, 3, 17, 5];
+        for &idx in &want {
+            let block = Arc::clone(&all[idx as usize]);
+            table.add_block(block);
+        }
+        table.set_num_tokens(16);
+
+        let marshalled = build_prefill_block_ids_for_total(&table, 9, 4)
+            .expect("9 tokens at block_size 4 require the first 3 blocks");
+        assert_eq!(
+            marshalled,
+            vec![42i32, 3, 17],
+            "prefix replay metadata must not include blocks beyond required_tokens"
+        );
+    }
+
+    #[test]
+    fn test_prefill_block_table_marshalling_rejects_missing_blocks() {
+        let allocator = new_allocator(2, 4);
+        let mut table = SequenceBlockTable::new(0, 4);
+        {
+            let mut g = allocator.lock().unwrap();
+            table.add_block(g.allocate().expect("alloc"));
+        }
+
+        let err = build_prefill_block_ids_for_total(&table, 5, 4)
+            .expect_err("5 tokens at block_size 4 require 2 blocks");
+        assert!(
+            err.contains("require 2 blocks"),
+            "error should state the required block count, got: {err}"
+        );
+    }
+
     /// Happy-path Metal dispatch on a tiny pool. Allocate 4 tokens worth
     /// (block_size 8 → 1 block fits), record them, write zero-K/V, and
     /// dispatch `gather_kv_for_decode`. Validates the kernel name lookup,
@@ -4858,6 +5735,84 @@ mod tests {
         assert_eq!(out.shape_at(1).unwrap(), 2);
         assert_eq!(out.shape_at(2).unwrap(), 64);
         assert_eq!(out.dtype().unwrap(), DType::Float16);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_gather_kv_for_decode_graph_reads_lazy_native_write_on_metal() {
+        let cfg = mlx_paged_attn::PagedAttentionConfig {
+            block_size: 8,
+            num_kv_heads: 1,
+            head_size: 64,
+            num_layers: 2,
+            gpu_memory_mb: 256,
+            use_fp8_cache: Some(false),
+            max_seq_len: Some(64),
+            max_batch_size: Some(2),
+        };
+        let pool = match mlx_paged_attn::LayerKVPool::new(
+            cfg.clone(),
+            4,
+            mlx_paged_attn::metal::MetalDtype::Float16,
+        ) {
+            Ok(p) => Arc::new(p),
+            Err(e) => {
+                eprintln!(
+                    "skipping test_gather_kv_for_decode_graph_reads_lazy_native_write_on_metal: {e}"
+                );
+                return;
+            }
+        };
+        let allocator = Arc::new(Mutex::new(BlockAllocator::new(4, 8)));
+        let mut adapter = PagedKVCacheAdapter::new(allocator, pool, 8).expect("adapter");
+        adapter.reset_for_new_request(7).unwrap();
+        adapter.allocate_suffix_blocks(4).unwrap();
+        adapter.record_tokens(&[1, 2, 3, 4]).unwrap();
+
+        // Leave the native write lazy. The graph decode path must consume the
+        // dependency-carrying pool arrays and still observe V=1.0 without an
+        // explicit eval_pending_pool_write_for_layer sync.
+        let k = MxArray::zeros(&[4, 1, 64], Some(DType::Float16)).expect("k zeros");
+        let v = MxArray::ones(&[4, 1, 64], Some(DType::Float16)).expect("v ones");
+        match adapter.update_keys_values_native(0, &k, &v, 0) {
+            Ok(()) => {}
+            Err(e) if e.contains("Metal GPU not available") => {
+                eprintln!(
+                    "skipping test_gather_kv_for_decode_graph_reads_lazy_native_write_on_metal: {e}"
+                );
+                return;
+            }
+            Err(e) => panic!("unexpected error from update_keys_values_native: {e}"),
+        }
+
+        // With Q=0 and K=0, attention is uniform over the four context tokens;
+        // V is all ones, so every output element should be one.
+        let q = MxArray::zeros(&[1, 2, 64], Some(DType::Float16)).expect("q zeros");
+        let scale = 1.0_f32 / (64.0_f32).sqrt();
+        let out = match adapter.gather_kv_for_decode_graph(0, &q, scale, 1.0) {
+            Ok(arr) => arr,
+            Err(e) if e.contains("Metal GPU not available") => {
+                eprintln!(
+                    "skipping test_gather_kv_for_decode_graph_reads_lazy_native_write_on_metal: {e}"
+                );
+                return;
+            }
+            Err(e) => panic!("unexpected error from gather_kv_for_decode_graph: {e}"),
+        };
+
+        assert_eq!(out.ndim().unwrap(), 3, "output must be 3-D");
+        assert_eq!(out.shape_at(0).unwrap(), 1);
+        assert_eq!(out.shape_at(1).unwrap(), 2);
+        assert_eq!(out.shape_at(2).unwrap(), 64);
+        assert_eq!(out.dtype().unwrap(), DType::Float16);
+
+        let values = out.to_float32().expect("decode graph output to_float32");
+        for (i, actual) in values.iter().copied().enumerate() {
+            assert!(
+                (actual - 1.0).abs() < 0.05,
+                "output[{i}] = {actual}, expected 1.0 from lazy native write"
+            );
+        }
     }
 
     #[cfg(target_os = "macos")]
@@ -5190,7 +6145,7 @@ mod tests {
     /// `read_kv_range` must reject calls before any request is active.
     #[test]
     fn test_read_kv_range_no_active_request() {
-        let Some(adapter) = maybe_adapter(new_allocator(8, 4), 4) else {
+        let Some(mut adapter) = maybe_adapter(new_allocator(8, 4), 4) else {
             eprintln!("skipping test_read_kv_range_no_active_request: Metal unavailable");
             return;
         };
@@ -5543,6 +6498,49 @@ mod tests {
             "continue_turn must clear already_registered so the next \
              finalize_turn_keep_live runs"
         );
+
+        adapter.release_request().unwrap();
+    }
+
+    #[test]
+    fn test_prepare_turn_uses_live_continuation_then_fresh_reset_on_divergence() {
+        let allocator = new_allocator(8, 4);
+        let Some(mut adapter) = maybe_adapter(Arc::clone(&allocator), 4) else {
+            eprintln!(
+                "skipping test_prepare_turn_uses_live_continuation_then_fresh_reset_on_divergence: Metal unavailable"
+            );
+            return;
+        };
+
+        let tokens_t1: [u32; 5] = [10, 20, 30, 40, 50];
+        adapter.reset_for_new_request(0).unwrap();
+        let _ = adapter.find_cached_prefix(&[], &[], 0, false).unwrap();
+        adapter
+            .allocate_suffix_blocks(tokens_t1.len() as u32)
+            .unwrap();
+        adapter.record_tokens(&tokens_t1).unwrap();
+        adapter.finalize_turn_keep_live(&[], 0).unwrap();
+
+        let tokens_t2: [u32; 6] = [10, 20, 30, 40, 50, 60];
+        let plan = adapter
+            .prepare_turn(0, &tokens_t2, tokens_t2.len() as u32, true, &[], 0, false)
+            .unwrap();
+        assert_eq!(plan.reason, PagedTurnPlanReason::ContinuedLivePrefix);
+        assert!(plan.continued_live_prefix);
+        assert_eq!(plan.cached_prefix_len, 5);
+        assert_eq!(plan.suffix_len, 1);
+
+        adapter.record_tokens(&tokens_t2[5..]).unwrap();
+        adapter.finalize_turn_keep_live(&[], 0).unwrap();
+
+        let diverged: [u32; 6] = [10, 20, 30, 41, 50, 60];
+        let plan = adapter
+            .prepare_turn(0, &diverged, diverged.len() as u32, true, &[], 0, false)
+            .unwrap();
+        assert_eq!(plan.reason, PagedTurnPlanReason::FreshReset);
+        assert!(!plan.continued_live_prefix);
+        assert_eq!(plan.cached_prefix_len, 0);
+        assert_eq!(plan.suffix_len, diverged.len() as u32);
 
         adapter.release_request().unwrap();
     }

--- a/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
+++ b/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
@@ -76,6 +76,7 @@
 //! flat path. See `finalize_turn_keep_live` for full discussion.
 
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 #[cfg(target_os = "macos")]
 use mlx_paged_attn::metal::KvScaleManager;
@@ -84,6 +85,9 @@ use mlx_paged_attn::{
 };
 
 use crate::array::{DType, MxArray};
+use crate::inference_trace::{
+    elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
+};
 
 /// Outcome of `validate_kv_input`: the (kernel-input dtype, num_tokens) tuple
 /// the caller needs after a successful validation. Splitting validation off
@@ -448,9 +452,31 @@ pub struct PagedKVCacheAdapter {
     /// `Mutex` is the conservative choice over `RwLock` here.
     #[cfg(target_os = "macos")]
     scale_manager: Option<Arc<Mutex<KvScaleManager>>>,
+
+    /// Cached per-prefill-chunk metadata for the MLX `paged_attention`
+    /// bridge. The metadata is identical for every full-attention layer in a
+    /// chunk, so rebuilding a duplicated block table per layer would make the
+    /// optimized prefill path pay avoidable host allocation/upload cost.
+    #[cfg(target_os = "macos")]
+    prefill_attention_inputs_cache: Option<PrefillPagedAttentionInputsCache>,
+}
+
+#[cfg(target_os = "macos")]
+struct PrefillPagedAttentionInputsCache {
+    token_count: u32,
+    cached_prefix_len: u32,
+    num_new_tokens: u32,
+    block_count: u32,
+    block_table: MxArray,
+    seq_lens: MxArray,
 }
 
 impl PagedKVCacheAdapter {
+    #[cfg(target_os = "macos")]
+    fn clear_prefill_attention_inputs_cache(&mut self) {
+        self.prefill_attention_inputs_cache = None;
+    }
+
     /// Construct a new adapter sharing the given allocator and layer
     /// KV-buffer pool.
     ///
@@ -504,6 +530,8 @@ impl PagedKVCacheAdapter {
             prefix_lookup_done: false,
             #[cfg(target_os = "macos")]
             scale_manager: None,
+            #[cfg(target_os = "macos")]
+            prefill_attention_inputs_cache: None,
         })
     }
 
@@ -519,6 +547,10 @@ impl PagedKVCacheAdapter {
         self.block_table = Some(SequenceBlockTable::new(seq_id, self.block_size));
         self.cached_token_count = 0;
         self.request_tokens.clear();
+        #[cfg(target_os = "macos")]
+        {
+            self.prefill_attention_inputs_cache = None;
+        }
         // Reset registration flag AFTER release so a subsequent
         // register_full_blocks_for_reuse on the new request runs.
         self.already_registered = false;
@@ -946,6 +978,10 @@ impl PagedKVCacheAdapter {
             .ok_or_else(|| "record_tokens: block_table disappeared mid-call".to_string())?;
         self.request_tokens.extend_from_slice(tokens);
         block_table.set_num_tokens(new_total);
+        #[cfg(target_os = "macos")]
+        {
+            self.prefill_attention_inputs_cache = None;
+        }
         Ok(())
     }
 
@@ -982,6 +1018,10 @@ impl PagedKVCacheAdapter {
         let new_len = prior_len - n;
         self.request_tokens.truncate(new_len as usize);
         block_table.set_num_tokens(new_len);
+        #[cfg(target_os = "macos")]
+        {
+            self.prefill_attention_inputs_cache = None;
+        }
         Ok(())
     }
 
@@ -1309,6 +1349,239 @@ impl PagedKVCacheAdapter {
             .map_err(|e| format!("gather_kv_for_decode: failed to wrap output array: {e}"))
     }
 
+    /// Run MLX-graph paged attention for a multi-token prefill suffix chunk.
+    ///
+    /// `queries` must be `[num_new_tokens, num_query_heads, head_size]`.
+    /// The current request must already have recorded the whole chunk, so the
+    /// active block table covers `cached_prefix_len + num_new_tokens` tokens.
+    ///
+    /// This represents each suffix token as one paged-attention "sequence"
+    /// with a different `seq_len`, which gives token `i` access to
+    /// `[0, cached_prefix_len + i]` and preserves causal prefill semantics
+    /// without reading full K/V back through host memory.
+    #[cfg(target_os = "macos")]
+    pub fn gather_kv_for_prefill_chunk(
+        &mut self,
+        layer_idx: u32,
+        queries: &MxArray,
+        cached_prefix_len: u32,
+        scale: f32,
+    ) -> Result<MxArray, String> {
+        let q_meta = KvTensorMeta::from_array(queries, "prefill_queries")?;
+        if (layer_idx as usize) >= self.layer_kv_pool.num_layers() {
+            return Err(format!(
+                "gather_kv_for_prefill_chunk: layer_idx {layer_idx} out of range \
+                 (num_layers = {})",
+                self.layer_kv_pool.num_layers()
+            ));
+        }
+        if q_meta.ndim != 3 || q_meta.shape.len() < 3 {
+            return Err(format!(
+                "gather_kv_for_prefill_chunk: queries must be rank 3 \
+                 [num_new_tokens, num_query_heads, head_size]; got ndim={} shape_len={}",
+                q_meta.ndim,
+                q_meta.shape.len()
+            ));
+        }
+
+        let num_new_tokens = u32::try_from(q_meta.shape[0]).map_err(|_| {
+            format!(
+                "gather_kv_for_prefill_chunk: num_new_tokens shape is negative/too large: {}",
+                q_meta.shape[0]
+            )
+        })?;
+        if num_new_tokens == 0 {
+            return Err("gather_kv_for_prefill_chunk: num_new_tokens must be > 0".to_string());
+        }
+        let num_query_heads = u32::try_from(q_meta.shape[1]).map_err(|_| {
+            format!(
+                "gather_kv_for_prefill_chunk: num_query_heads shape is negative/too large: {}",
+                q_meta.shape[1]
+            )
+        })?;
+        if num_query_heads == 0 {
+            return Err("gather_kv_for_prefill_chunk: num_query_heads must be > 0".to_string());
+        }
+
+        let expected_head_size = self.layer_kv_pool.config().head_size as i64;
+        if q_meta.shape[2] != expected_head_size {
+            return Err(format!(
+                "gather_kv_for_prefill_chunk: query head_size {} != expected {}",
+                q_meta.shape[2], expected_head_size
+            ));
+        }
+
+        let query_dtype = match q_meta.dtype {
+            DType::Float16 => mlx_paged_attn::metal::MetalDtype::Float16,
+            DType::BFloat16 => mlx_paged_attn::metal::MetalDtype::BFloat16,
+            other => {
+                return Err(format!(
+                    "gather_kv_for_prefill_chunk: query dtype {other:?} is not supported"
+                ));
+            }
+        };
+        let cache_dtype = self.layer_kv_pool.cache_dtype();
+        if !cache_dtype.is_fp8() && query_dtype != cache_dtype {
+            return Err(format!(
+                "gather_kv_for_prefill_chunk: query_dtype ({query_dtype:?}) must equal \
+                 cache_dtype ({cache_dtype:?}) for non-FP8 caches"
+            ));
+        }
+        let kv_dtype_raw = match cache_dtype {
+            mlx_paged_attn::metal::MetalDtype::Float16 => 0u8,
+            mlx_paged_attn::metal::MetalDtype::BFloat16 => 1u8,
+            mlx_paged_attn::metal::MetalDtype::UChar => 2u8,
+            mlx_paged_attn::metal::MetalDtype::Float32 => {
+                return Err(
+                    "gather_kv_for_prefill_chunk: Float32 KV cache is unsupported".to_string(),
+                );
+            }
+        };
+
+        let (block_table, seq_lens, block_count) =
+            self.prefill_attention_inputs(cached_prefix_len, num_new_tokens)?;
+        let k_pool = self.key_pool_array(layer_idx)?;
+        let v_pool = self.value_pool_array(layer_idx)?;
+        let k_scale = self.k_scale_array(layer_idx)?;
+        let v_scale = self.v_scale_array(layer_idx)?;
+
+        let raw = unsafe {
+            mlx_sys::mlx_paged_attention_forward(
+                queries.as_raw_ptr(),
+                k_pool.as_raw_ptr(),
+                v_pool.as_raw_ptr(),
+                block_table.as_raw_ptr(),
+                seq_lens.as_raw_ptr(),
+                k_scale.as_raw_ptr(),
+                v_scale.as_raw_ptr(),
+                scale,
+                0.0, // softcap disabled in the MLX C++ paged_attention factory.
+                0,   // sliding-window disabled for Qwen3.5 full attention.
+                self.block_size as i32,
+                num_query_heads as i32,
+                self.layer_kv_pool.config().num_kv_heads as i32,
+                self.layer_kv_pool.config().head_size as i32,
+                kv_dtype_raw,
+            )
+        };
+        if raw.is_null() {
+            return Err(format!(
+                "gather_kv_for_prefill_chunk: mlx_paged_attention_forward returned null \
+                 (layer={layer_idx}, num_new_tokens={num_new_tokens}, block_count={block_count})"
+            ));
+        }
+
+        MxArray::from_handle(raw, "gather_kv_for_prefill_chunk")
+            .map_err(|e| format!("gather_kv_for_prefill_chunk: failed to wrap output array: {e}"))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn prefill_attention_inputs(
+        &mut self,
+        cached_prefix_len: u32,
+        num_new_tokens: u32,
+    ) -> Result<(MxArray, MxArray, u32), String> {
+        let block_table = self.block_table.as_ref().ok_or_else(|| {
+            "gather_kv_for_prefill_chunk called before reset_for_new_request".to_string()
+        })?;
+        let recorded = block_table.num_tokens();
+        let expected_total = cached_prefix_len
+            .checked_add(num_new_tokens)
+            .ok_or_else(|| "gather_kv_for_prefill_chunk: token count overflow".to_string())?;
+        if recorded != expected_total {
+            return Err(format!(
+                "gather_kv_for_prefill_chunk: recorded token count {recorded} != \
+                 cached_prefix_len + num_new_tokens ({cached_prefix_len} + {num_new_tokens} = \
+                 {expected_total}); call record_tokens for the whole chunk first"
+            ));
+        }
+
+        if let Some(cache) = self.prefill_attention_inputs_cache.as_ref()
+            && cache.token_count == recorded
+            && cache.cached_prefix_len == cached_prefix_len
+            && cache.num_new_tokens == num_new_tokens
+        {
+            return Ok((
+                cache.block_table.clone(),
+                cache.seq_lens.clone(),
+                cache.block_count,
+            ));
+        }
+
+        let block_ids = build_decode_block_ids(block_table);
+        if block_ids.is_empty() {
+            return Err(
+                "gather_kv_for_prefill_chunk: active request has no allocated blocks".to_string(),
+            );
+        }
+        let block_count = u32::try_from(block_ids.len()).map_err(|_| {
+            format!(
+                "gather_kv_for_prefill_chunk: too many blocks for i32 shape: {}",
+                block_ids.len()
+            )
+        })?;
+        let pool_block_count = self.layer_kv_pool.num_blocks();
+        for (idx, &block_id) in block_ids.iter().enumerate() {
+            if block_id < 0 || block_id as u32 >= pool_block_count {
+                return Err(format!(
+                    "gather_kv_for_prefill_chunk: block_table[{idx}]={block_id} out of \
+                     range for pool block count {pool_block_count}"
+                ));
+            }
+        }
+        let max_seq_len = block_count
+            .checked_mul(self.block_size)
+            .ok_or_else(|| "gather_kv_for_prefill_chunk: max seq len overflow".to_string())?;
+        if expected_total > max_seq_len {
+            return Err(format!(
+                "gather_kv_for_prefill_chunk: expected total tokens {expected_total} exceeds \
+                 block table capacity {block_count} * {} = {max_seq_len}",
+                self.block_size
+            ));
+        }
+
+        let num_new_usize = num_new_tokens as usize;
+        let block_count_usize = block_count as usize;
+        let mut duplicated_blocks = Vec::with_capacity(num_new_usize * block_count_usize);
+        for _ in 0..num_new_tokens {
+            duplicated_blocks.extend_from_slice(&block_ids);
+        }
+
+        let mut seq_lens = Vec::with_capacity(num_new_usize);
+        for i in 0..num_new_tokens {
+            let seq_len = cached_prefix_len
+                .checked_add(i + 1)
+                .ok_or_else(|| "gather_kv_for_prefill_chunk: seq_len overflow".to_string())?;
+            seq_lens.push(seq_len as i32);
+        }
+
+        let block_table_arr = MxArray::from_int32(
+            &duplicated_blocks,
+            &[num_new_tokens as i64, block_count as i64],
+        )
+        .map_err(|e| format!("gather_kv_for_prefill_chunk block_table: {e}"))?;
+        let seq_lens_arr = MxArray::from_int32(&seq_lens, &[num_new_tokens as i64])
+            .map_err(|e| format!("gather_kv_for_prefill_chunk seq_lens: {e}"))?;
+
+        self.prefill_attention_inputs_cache = Some(PrefillPagedAttentionInputsCache {
+            token_count: recorded,
+            cached_prefix_len,
+            num_new_tokens,
+            block_count,
+            block_table: block_table_arr,
+            seq_lens: seq_lens_arr,
+        });
+        let cache = self
+            .prefill_attention_inputs_cache
+            .as_ref()
+            .expect("prefill_attention_inputs_cache was just populated");
+        Ok((
+            cache.block_table.clone(),
+            cache.seq_lens.clone(),
+            cache.block_count,
+        ))
+    }
+
     /// Non-macOS stub.
     #[cfg(not(target_os = "macos"))]
     pub fn gather_kv_for_decode(
@@ -1319,6 +1592,17 @@ impl PagedKVCacheAdapter {
         _softcap: f32,
     ) -> Result<MxArray, String> {
         Err("gather_kv_for_decode is only supported on macOS (Metal backend)".to_string())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    pub fn gather_kv_for_prefill_chunk(
+        &mut self,
+        _layer_idx: u32,
+        _queries: &MxArray,
+        _cached_prefix_len: u32,
+        _scale: f32,
+    ) -> Result<MxArray, String> {
+        Err("gather_kv_for_prefill_chunk is only supported on macOS (Metal backend)".to_string())
     }
 
     /// Read K/V back from the pool for a contiguous range of logical
@@ -1428,9 +1712,13 @@ impl PagedKVCacheAdapter {
 
         // 5. Read blocks. Returns concat'd bytes per block in the order
         //    requested.
+        let trace_enabled = inference_trace_enabled();
+        let trace_start = trace_enabled.then(Instant::now);
+        let read_blocks_start = trace_enabled.then(Instant::now);
         let (key_bytes, value_bytes) = self
             .layer_kv_pool
             .read_blocks_to_host(layer_idx, &block_ids)?;
+        let read_blocks_ms = read_blocks_start.map(elapsed_ms);
 
         // 6. Layout constants.
         // Cache dtype is 2 bytes per element here (we rejected FP8 above).
@@ -1462,6 +1750,7 @@ impl PagedKVCacheAdapter {
         // 8. Per-token gather. For token at logical position `pos`:
         //    block_table_idx = pos / block_size, offset_in_block = pos % block_size,
         //    block_id_local_idx (within `block_ids`) = block_table_idx - first_table_idx.
+        let unpack_start = trace_enabled.then(Instant::now);
         for t in 0..num_tokens_us {
             let pos = start_pos as usize + t;
             let table_idx = pos / block_size_us;
@@ -1513,10 +1802,12 @@ impl PagedKVCacheAdapter {
                 }
             }
         }
+        let unpack_ms = unpack_start.map(elapsed_ms);
 
         // 9. Construct MxArrays in [1, num_kv_heads, num_tokens, head_size]
         //    layout. Use the dtype-matching constructor so the bits are
         //    interpreted correctly (`from_float16` for FP16 cache, etc).
+        let array_build_start = trace_enabled.then(Instant::now);
         let shape: [i64; 4] = [1, num_kv_heads as i64, num_tokens as i64, head_size as i64];
         let (k_arr, v_arr) = match cache_dtype {
             mlx_paged_attn::metal::MetalDtype::Float16 => (
@@ -1542,6 +1833,23 @@ impl PagedKVCacheAdapter {
                 ));
             }
         };
+        let array_build_ms = array_build_start.map(elapsed_ms);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv read_kv_range layer={} start_pos={} num_tokens={} \
+                 block_count={} block_size={} read_blocks_ms={:.1} unpack_ms={:.1} \
+                 array_build_ms={:.1} elapsed_ms={:.1}",
+                layer_idx,
+                start_pos,
+                num_tokens,
+                block_ids.len(),
+                block_size,
+                read_blocks_ms.unwrap_or(0.0),
+                unpack_ms.unwrap_or(0.0),
+                array_build_ms.unwrap_or(0.0),
+                trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
         Ok((k_arr, v_arr))
     }
 
@@ -1828,6 +2136,10 @@ impl PagedKVCacheAdapter {
 
         self.cached_token_count = 0;
         self.request_tokens.clear();
+        #[cfg(target_os = "macos")]
+        {
+            self.prefill_attention_inputs_cache = None;
+        }
         // Defense-in-depth: clear the registration flag so a subsequent
         // reset_for_new_request → register flow on this adapter works
         // even if the caller skips the explicit reset.
@@ -1905,12 +2217,17 @@ impl PagedKVCacheAdapter {
         // failure (the caller flow becomes: forward → finalize_turn_keep_live;
         // a duplicate finalize after an error path doesn't double-register).
         if self.already_registered {
+            #[cfg(target_os = "macos")]
+            self.clear_prefill_attention_inputs_cache();
             return Ok(0);
         }
         // Reuse `register_full_blocks_for_reuse`'s implementation for the
         // registration half; the only difference is that we do NOT call
         // `release_request` after it.
-        self.register_full_blocks_for_reuse(extra_keys, cache_salt)
+        let result = self.register_full_blocks_for_reuse(extra_keys, cache_salt);
+        #[cfg(target_os = "macos")]
+        self.clear_prefill_attention_inputs_cache();
+        result
     }
 
     /// Per-block-extra_keys variant of [`Self::finalize_turn_keep_live`].
@@ -1942,9 +2259,15 @@ impl PagedKVCacheAdapter {
         cache_salt: u64,
     ) -> Result<u32, String> {
         if self.already_registered {
+            #[cfg(target_os = "macos")]
+            self.clear_prefill_attention_inputs_cache();
             return Ok(0);
         }
-        self.register_full_blocks_for_reuse_per_block(extra_keys_per_block, cache_salt)
+        let result =
+            self.register_full_blocks_for_reuse_per_block(extra_keys_per_block, cache_salt);
+        #[cfg(target_os = "macos")]
+        self.clear_prefill_attention_inputs_cache();
+        result
     }
 
     /// Continue the current session with a new turn whose full prompt
@@ -2073,6 +2396,10 @@ impl PagedKVCacheAdapter {
         // future caller that mixes patterns isn't tripped by stale state.
         self.already_registered = false;
         self.prefix_lookup_done = true; // already implicitly "done" — no fresh lookup is allowed
+        #[cfg(target_os = "macos")]
+        {
+            self.prefill_attention_inputs_cache = None;
+        }
 
         Ok((prior_token_count, newly_allocated))
     }
@@ -2563,6 +2890,7 @@ pub fn compute_per_block_image_extra_keys(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use half::f16;
 
     fn new_allocator(num_blocks: u32, block_size: u32) -> Arc<Mutex<BlockAllocator>> {
         Arc::new(Mutex::new(BlockAllocator::new(num_blocks, block_size)))
@@ -4489,6 +4817,161 @@ mod tests {
             "to_mlx_array materializes Float32 (GPU host roundtrip); P1C-3 \
              follow-up: zero-copy via mlx_array_from_metal_buffer"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_gather_kv_for_prefill_chunk_writes_succeed_on_metal() {
+        let cfg = mlx_paged_attn::PagedAttentionConfig {
+            block_size: 8,
+            num_kv_heads: 1,
+            head_size: 64,
+            num_layers: 2,
+            gpu_memory_mb: 256,
+            use_fp8_cache: Some(false),
+            max_seq_len: Some(64),
+            max_batch_size: Some(2),
+        };
+        let pool = match mlx_paged_attn::LayerKVPool::new(
+            cfg.clone(),
+            4,
+            mlx_paged_attn::metal::MetalDtype::Float16,
+        ) {
+            Ok(p) => Arc::new(p),
+            Err(e) => {
+                eprintln!("skipping test_gather_kv_for_prefill_chunk_writes_succeed_on_metal: {e}");
+                return;
+            }
+        };
+        let allocator = Arc::new(Mutex::new(BlockAllocator::new(4, 8)));
+        let mut adapter = PagedKVCacheAdapter::new(allocator, pool, 8).expect("adapter");
+        adapter.reset_for_new_request(7).unwrap();
+        adapter.allocate_suffix_blocks(4).unwrap();
+        adapter.record_tokens(&[1, 2, 3, 4]).unwrap();
+
+        let k = MxArray::zeros(&[4, 1, 64], Some(DType::Float16)).expect("k zeros");
+        let v = MxArray::zeros(&[4, 1, 64], Some(DType::Float16)).expect("v zeros");
+        k.eval();
+        v.eval();
+        match adapter.update_keys_values(0, &k, &v, 0) {
+            Ok(()) => {}
+            Err(e) if e.contains("Metal GPU not available") => {
+                eprintln!("skipping test_gather_kv_for_prefill_chunk_writes_succeed_on_metal: {e}");
+                return;
+            }
+            Err(e) => panic!("unexpected error from update_keys_values: {e}"),
+        }
+
+        let q = MxArray::zeros(&[2, 2, 64], Some(DType::Float16)).expect("q zeros");
+        q.eval();
+        let scale = 1.0_f32 / (64.0_f32).sqrt();
+        let out = match adapter.gather_kv_for_prefill_chunk(0, &q, 2, scale) {
+            Ok(arr) => arr,
+            Err(e) if e.contains("Metal GPU not available") => {
+                eprintln!("skipping test_gather_kv_for_prefill_chunk_writes_succeed_on_metal: {e}");
+                return;
+            }
+            Err(e) => panic!("unexpected error from gather_kv_for_prefill_chunk: {e}"),
+        };
+
+        assert_eq!(out.ndim().unwrap(), 3, "output must be 3-D");
+        assert_eq!(out.shape_at(0).unwrap(), 2);
+        assert_eq!(out.shape_at(1).unwrap(), 2);
+        assert_eq!(out.shape_at(2).unwrap(), 64);
+        assert_eq!(
+            out.dtype().unwrap(),
+            DType::Float16,
+            "MLX paged_attention bridge should keep output on-device in the IO dtype"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_gather_kv_for_prefill_chunk_respects_causal_prefix_lengths() {
+        let cfg = mlx_paged_attn::PagedAttentionConfig {
+            block_size: 8,
+            num_kv_heads: 1,
+            head_size: 64,
+            num_layers: 2,
+            gpu_memory_mb: 256,
+            use_fp8_cache: Some(false),
+            max_seq_len: Some(64),
+            max_batch_size: Some(2),
+        };
+        let pool = match mlx_paged_attn::LayerKVPool::new(
+            cfg.clone(),
+            4,
+            mlx_paged_attn::metal::MetalDtype::Float16,
+        ) {
+            Ok(p) => Arc::new(p),
+            Err(e) => {
+                eprintln!(
+                    "skipping test_gather_kv_for_prefill_chunk_respects_causal_prefix_lengths: {e}"
+                );
+                return;
+            }
+        };
+        let allocator = Arc::new(Mutex::new(BlockAllocator::new(4, 8)));
+        let mut adapter = PagedKVCacheAdapter::new(allocator, pool, 8).expect("adapter");
+        adapter.reset_for_new_request(7).unwrap();
+        adapter.allocate_suffix_blocks(4).unwrap();
+        adapter.record_tokens(&[1, 2, 3, 4]).unwrap();
+
+        // Q/K = 0 makes attention scores uniform. V[token] = token + 1, so
+        // the first suffix token at prefix len 2 should average [1,2,3] = 2,
+        // and the second should average [1,2,3,4] = 2.5.
+        let k = MxArray::zeros(&[4, 1, 64], Some(DType::Float16)).expect("k zeros");
+        let mut v_bits = Vec::with_capacity(4 * 64);
+        for token_idx in 0..4 {
+            let bits = f16::from_f32((token_idx + 1) as f32).to_bits();
+            v_bits.extend(std::iter::repeat(bits).take(64));
+        }
+        let v = MxArray::from_float16(&v_bits, &[4, 1, 64]).expect("v values");
+        k.eval();
+        v.eval();
+        match adapter.update_keys_values(0, &k, &v, 0) {
+            Ok(()) => {}
+            Err(e) if e.contains("Metal GPU not available") => {
+                eprintln!(
+                    "skipping test_gather_kv_for_prefill_chunk_respects_causal_prefix_lengths: {e}"
+                );
+                return;
+            }
+            Err(e) => panic!("unexpected error from update_keys_values: {e}"),
+        }
+
+        let q = MxArray::zeros(&[2, 2, 64], Some(DType::Float16)).expect("q zeros");
+        q.eval();
+        let scale = 1.0_f32 / (64.0_f32).sqrt();
+        let out = match adapter.gather_kv_for_prefill_chunk(0, &q, 2, scale) {
+            Ok(arr) => arr,
+            Err(e) if e.contains("Metal GPU not available") => {
+                eprintln!(
+                    "skipping test_gather_kv_for_prefill_chunk_respects_causal_prefix_lengths: {e}"
+                );
+                return;
+            }
+            Err(e) => panic!("unexpected error from gather_kv_for_prefill_chunk: {e}"),
+        };
+
+        assert_eq!(out.ndim().unwrap(), 3, "output must be 3-D");
+        assert_eq!(out.shape_at(0).unwrap(), 2);
+        assert_eq!(out.shape_at(1).unwrap(), 2);
+        assert_eq!(out.shape_at(2).unwrap(), 64);
+
+        let values = out.to_float32().expect("prefill output to_float32");
+        let expected_by_token = [2.0_f32, 2.5_f32];
+        for token_idx in 0..2 {
+            for head_idx in 0..2 {
+                let base = (token_idx * 2 + head_idx) * 64;
+                let actual = values[base];
+                let expected = expected_by_token[token_idx];
+                assert!(
+                    (actual - expected).abs() < 0.05,
+                    "token {token_idx} head {head_idx}: got {actual}, expected {expected}"
+                );
+            }
+        }
     }
 
     /// **BF16 numerical correctness on Metal.** Production Qwen3.5 runs in

--- a/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
+++ b/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
@@ -1159,6 +1159,20 @@ impl PagedKVCacheAdapter {
 
         // 5. Build slot mapping and dispatch.
         let slot_mapping = self.build_slot_mapping(first_logical_position, num_tokens)?;
+        let trace_enabled = inference_trace_enabled();
+        let write_trace_start = trace_enabled.then(Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv update_keys_values_start layer={} first_position={} num_tokens={} current_tokens={} blocks={} first_slot={} last_slot={}",
+                layer_idx,
+                first_logical_position,
+                num_tokens,
+                self.request_tokens.len(),
+                self.num_allocated_blocks(),
+                slot_mapping.first().copied().unwrap_or(-1),
+                slot_mapping.last().copied().unwrap_or(-1)
+            ));
+        }
 
         // Phase 10: read per-layer FP8 scales from `KvScaleManager` when
         // configured. Defaults to 1.0 (no-op for non-FP8 caches) when no
@@ -1181,7 +1195,17 @@ impl PagedKVCacheAdapter {
                 k_scale,
                 v_scale,
             )
+        }?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv update_keys_values_done layer={} first_position={} num_tokens={} elapsed_ms={:.1}",
+                layer_idx,
+                first_logical_position,
+                num_tokens,
+                write_trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
         }
+        Ok(())
     }
 
     /// Non-macOS stub: the underlying Metal kernel is macOS-only. Calling
@@ -1215,11 +1239,9 @@ impl PagedKVCacheAdapter {
     /// `softcap`: `1.0` disables softcapping.
     ///
     /// Returns the attention output as an `MxArray` of shape
-    /// `[1, num_query_heads, head_size]`, dtype Float32. The kernel writes
-    /// io-typed elements (matching the queries dtype); we copy GPU → host
-    /// → MLX as Float32 to keep the conversion trivial — **P1C-3
-    /// follow-up**: replace with zero-copy `mlx_array_from_metal_buffer`
-    /// so the result stays on-device in its native precision.
+    /// `[1, num_query_heads, head_size]`, in the kernel's io dtype (matching
+    /// the queries dtype). The returned array is a retained MLX view over the
+    /// Metal output buffer, so decode stays on-device.
     ///
     /// ## Single-request semantics
     ///
@@ -1318,9 +1340,8 @@ impl PagedKVCacheAdapter {
         //     of silently falling back to 1.0 — see Finding 2.
         let (k_scale, v_scale) = self.read_layer_scales(layer_idx)?;
 
-        // 6. Dispatch and wrap output in MxArray. P1C-3 follow-up:
-        //    `to_mlx_array` does GPU → host → MLX as Float32; replace with
-        //    zero-copy `mlx_array_from_metal_buffer` for on-device decode.
+        // 6. Dispatch and wrap output in an MLX view over the Metal buffer.
+        //    This avoids the old GPU → host → MLX copy in the decode hot path.
         // SAFETY:
         // - queries.as_raw_ptr() is borrowed from `queries: &MxArray` and
         //   stays valid for the synchronous dispatch.
@@ -1342,9 +1363,10 @@ impl PagedKVCacheAdapter {
             )?
         };
 
-        // SAFETY: `to_mlx_array` materializes a fresh mlx_array (heap
-        // allocated by mlx_sys); ownership transfers to the MxArray below.
-        let raw = unsafe { output.to_mlx_array()? };
+        // SAFETY: `to_mlx_array_view` materializes a fresh mlx_array wrapper
+        // and retains the underlying Metal buffer. Ownership transfers to the
+        // MxArray below.
+        let raw = unsafe { output.to_mlx_array_view()? };
         MxArray::from_handle(raw, "gather_kv_for_decode")
             .map_err(|e| format!("gather_kv_for_decode: failed to wrap output array: {e}"))
     }
@@ -1562,6 +1584,11 @@ impl PagedKVCacheAdapter {
         .map_err(|e| format!("gather_kv_for_prefill_chunk block_table: {e}"))?;
         let seq_lens_arr = MxArray::from_int32(&seq_lens, &[num_new_tokens as i64])
             .map_err(|e| format!("gather_kv_for_prefill_chunk seq_lens: {e}"))?;
+        // The paged-attention output is lazy and may not evaluate until after
+        // this function returns. Materialize host-built metadata before the
+        // Rust backing Vecs are dropped so eval_gpu cannot observe stale data.
+        MxArray::eval_arrays(&[&block_table_arr, &seq_lens_arr])
+            .map_err(|e| format!("gather_kv_for_prefill_chunk metadata eval: {e}"))?;
 
         self.prefill_attention_inputs_cache = Some(PrefillPagedAttentionInputsCache {
             token_count: recorded,
@@ -1715,10 +1742,31 @@ impl PagedKVCacheAdapter {
         let trace_enabled = inference_trace_enabled();
         let trace_start = trace_enabled.then(Instant::now);
         let read_blocks_start = trace_enabled.then(Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv read_kv_range_start layer={} start_pos={} num_tokens={} block_count={} block_size={} cache_dtype={:?}",
+                layer_idx,
+                start_pos,
+                num_tokens,
+                block_ids.len(),
+                block_size,
+                cache_dtype
+            ));
+        }
         let (key_bytes, value_bytes) = self
             .layer_kv_pool
             .read_blocks_to_host(layer_idx, &block_ids)?;
         let read_blocks_ms = read_blocks_start.map(elapsed_ms);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] paged_kv read_kv_range_blocks_done layer={} block_count={} key_bytes={} value_bytes={} elapsed_ms={:.1}",
+                layer_idx,
+                block_ids.len(),
+                key_bytes.len(),
+                value_bytes.len(),
+                read_blocks_ms.unwrap_or(0.0)
+            ));
+        }
 
         // 6. Layout constants.
         // Cache dtype is 2 bytes per element here (we rejected FP8 above).
@@ -4804,19 +4852,12 @@ mod tests {
         };
 
         // Output shape: [1, num_query_heads, head_size]. The kernel writes
-        // Float16 internally; `PagedAttentionOutput::to_mlx_array` does a
-        // GPU → host → MLX-Float32 conversion (P1C-3 follow-up: zero-copy
-        // via mlx_array_from_metal_buffer).
+        // Float16 and the adapter wraps that Metal buffer as an MLX view.
         assert_eq!(out.ndim().unwrap(), 3, "output must be 3-D");
         assert_eq!(out.shape_at(0).unwrap(), 1);
         assert_eq!(out.shape_at(1).unwrap(), 2);
         assert_eq!(out.shape_at(2).unwrap(), 64);
-        assert_eq!(
-            out.dtype().unwrap(),
-            DType::Float32,
-            "to_mlx_array materializes Float32 (GPU host roundtrip); P1C-3 \
-             follow-up: zero-copy via mlx_array_from_metal_buffer"
-        );
+        assert_eq!(out.dtype().unwrap(), DType::Float16);
     }
 
     #[cfg(target_os = "macos")]
@@ -5052,20 +5093,22 @@ mod tests {
             Err(e) => panic!("unexpected error from gather_kv_for_decode (BF16): {e}"),
         };
 
-        // `to_mlx_array` materializes Float32 via the host roundtrip.
+        // The zero-copy output view preserves the BF16 io dtype.
         assert_eq!(out.ndim().unwrap(), 3, "output must be 3-D");
         assert_eq!(out.shape_at(0).unwrap(), 1);
         assert_eq!(out.shape_at(1).unwrap(), 1);
         assert_eq!(out.shape_at(2).unwrap(), 64);
-        assert_eq!(out.dtype().unwrap(), DType::Float32);
+        assert_eq!(out.dtype().unwrap(), DType::BFloat16);
 
         // The misrouted path (BF16 cache → half kernel) would produce
         // ~1.875 per element (half(0x3F80) = 1.875). Correct routing
         // produces 1.0 exactly. Any value below 1.5 is unambiguously the
         // correct route.
         let mut max_diff = 0.0_f32;
+        let out_f32 = out.astype(DType::Float32).expect("astype f32");
+        out_f32.eval();
         for i in 0..64 {
-            let v = out
+            let v = out_f32
                 .item_at_float32(i)
                 .unwrap_or_else(|e| panic!("item_at_float32({i}): {e}"));
             // 1.0 with BF16 round-trip + accumulator noise is ≤ 0.05 off.

--- a/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
+++ b/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
@@ -729,9 +729,68 @@ impl PagedKVCacheAdapter {
         cache_salt: u64,
         skip_lookup: bool,
     ) -> Result<PagedTurnPlan, String> {
+        self.prepare_turn_inner(
+            seq_id,
+            prompt_tokens,
+            total_budget,
+            reuse_cache,
+            extra_keys,
+            cache_salt,
+            skip_lookup,
+            None,
+        )
+    }
+
+    /// Variant of [`Self::prepare_turn`] that caps the cache-hit prefix length.
+    ///
+    /// This mirrors vLLM's exact-prefix handling: when all prompt tokens are
+    /// cached, the model still needs to recompute at least the final prompt
+    /// token to produce logits. Callers can pass `prompt_len - 1`; because the
+    /// block cache is block-granular, the actual hit length is rounded down by
+    /// the allocator to full blocks.
+    #[allow(clippy::too_many_arguments)]
+    pub fn prepare_turn_with_max_cache_hit_tokens(
+        &mut self,
+        seq_id: u32,
+        prompt_tokens: &[u32],
+        total_budget: u32,
+        reuse_cache: bool,
+        extra_keys: &[u64],
+        cache_salt: u64,
+        skip_lookup: bool,
+        max_cache_hit_tokens: u32,
+    ) -> Result<PagedTurnPlan, String> {
+        self.prepare_turn_inner(
+            seq_id,
+            prompt_tokens,
+            total_budget,
+            reuse_cache,
+            extra_keys,
+            cache_salt,
+            skip_lookup,
+            Some(max_cache_hit_tokens),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_turn_inner(
+        &mut self,
+        seq_id: u32,
+        prompt_tokens: &[u32],
+        total_budget: u32,
+        reuse_cache: bool,
+        extra_keys: &[u64],
+        cache_salt: u64,
+        skip_lookup: bool,
+        max_cache_hit_tokens: Option<u32>,
+    ) -> Result<PagedTurnPlan, String> {
+        let max_live_continue_tokens = max_cache_hit_tokens
+            .map(|n| usize::try_from(n).unwrap_or(usize::MAX))
+            .unwrap_or(usize::MAX);
         let can_continue = reuse_cache
             && self.is_live_for_continue()
-            && prompt_tokens.starts_with(self.request_tokens());
+            && prompt_tokens.starts_with(self.request_tokens())
+            && self.request_tokens().len() <= max_live_continue_tokens;
 
         let (cached_prefix_len, continued_live_prefix, allocated_blocks, cached_blocks, reason) =
             if can_continue {
@@ -746,11 +805,12 @@ impl PagedKVCacheAdapter {
                     Err(_) => {
                         let _ = self.release_request();
                         self.reset_for_new_request(seq_id)?;
-                        let prefix = self.find_cached_prefix(
+                        let prefix = self.find_cached_prefix_inner(
                             prompt_tokens,
                             extra_keys,
                             cache_salt,
                             skip_lookup,
+                            max_cache_hit_tokens,
                         )?;
                         let allocated = self.allocate_suffix_blocks(total_budget)?;
                         (
@@ -767,8 +827,13 @@ impl PagedKVCacheAdapter {
                     let _ = self.release_request();
                 }
                 self.reset_for_new_request(seq_id)?;
-                let prefix =
-                    self.find_cached_prefix(prompt_tokens, extra_keys, cache_salt, skip_lookup)?;
+                let prefix = self.find_cached_prefix_inner(
+                    prompt_tokens,
+                    extra_keys,
+                    cache_salt,
+                    skip_lookup,
+                    max_cache_hit_tokens,
+                )?;
                 let allocated = self.allocate_suffix_blocks(total_budget)?;
                 (
                     prefix.cached_token_count,
@@ -872,6 +937,37 @@ impl PagedKVCacheAdapter {
         cache_salt: u64,
         skip_lookup: bool,
     ) -> Result<CachedPrefix, String> {
+        self.find_cached_prefix_inner(prompt_tokens, extra_keys, cache_salt, skip_lookup, None)
+    }
+
+    /// Variant of [`Self::find_cached_prefix`] that caps the lookup length
+    /// before touching the allocator. This prevents over-incrementing block
+    /// refcounts for cached blocks the caller plans to recompute.
+    pub fn find_cached_prefix_with_max_tokens(
+        &mut self,
+        prompt_tokens: &[u32],
+        extra_keys: &[u64],
+        cache_salt: u64,
+        skip_lookup: bool,
+        max_cache_hit_tokens: u32,
+    ) -> Result<CachedPrefix, String> {
+        self.find_cached_prefix_inner(
+            prompt_tokens,
+            extra_keys,
+            cache_salt,
+            skip_lookup,
+            Some(max_cache_hit_tokens),
+        )
+    }
+
+    fn find_cached_prefix_inner(
+        &mut self,
+        prompt_tokens: &[u32],
+        extra_keys: &[u64],
+        cache_salt: u64,
+        skip_lookup: bool,
+        max_cache_hit_tokens: Option<u32>,
+    ) -> Result<CachedPrefix, String> {
         // Reject re-entrant calls BEFORE touching the allocator. The flag
         // tracks lookup-already-ran regardless of hit/miss outcome, so a
         // miss-then-call sequence is rejected too — block_table.num_blocks()
@@ -907,19 +1003,28 @@ impl PagedKVCacheAdapter {
             });
         }
 
+        let lookup_len = max_cache_hit_tokens
+            .map(|max_tokens| {
+                usize::try_from(max_tokens)
+                    .unwrap_or(usize::MAX)
+                    .min(prompt_tokens.len())
+            })
+            .unwrap_or(prompt_tokens.len());
+        let lookup_tokens = &prompt_tokens[..lookup_len];
+
         let (blocks, cached_tokens) = {
             let mut guard = self
                 .allocator
                 .lock()
                 .map_err(|e| format!("BlockAllocator mutex poisoned: {e}"))?;
-            guard.find_longest_cache_hit(prompt_tokens, self.block_size, extra_keys, cache_salt)
+            guard.find_longest_cache_hit(lookup_tokens, self.block_size, extra_keys, cache_salt)
         };
 
         for block in &blocks {
             block_table.add_block(Arc::clone(block));
         }
 
-        let cached_token_count = cached_tokens as u32;
+        let cached_token_count = cached_tokens.min(lookup_len) as u32;
         self.cached_token_count = cached_token_count;
 
         // Seed `request_tokens` with the cached prefix so subsequent
@@ -3996,6 +4101,32 @@ mod tests {
     }
 
     #[test]
+    fn test_find_cached_prefix_with_max_tokens_caps_before_lookup() {
+        let allocator = new_allocator(8, 4);
+        let tokens: Vec<u32> = (0..8).collect();
+        seed_prefix_cache(&allocator, &tokens, 4, &[]);
+
+        let Some(mut adapter) = maybe_adapter(allocator, 4) else {
+            eprintln!(
+                "skipping test_find_cached_prefix_with_max_tokens_caps_before_lookup: Metal unavailable"
+            );
+            return;
+        };
+        adapter.reset_for_new_request(1).unwrap();
+
+        // Exact 8-token prompt with max hit length 7 should reuse only the
+        // first 4-token block. The final block must be recomputed.
+        let res = adapter
+            .find_cached_prefix_with_max_tokens(&tokens, &[], 0, false, 7)
+            .unwrap();
+        assert_eq!(res.blocks.len(), 1);
+        assert_eq!(res.cached_token_count, 4);
+        assert_eq!(adapter.cached_token_count(), 4);
+        assert_eq!(adapter.current_token_count(), 4);
+        assert_eq!(adapter.block_table().unwrap().num_blocks(), 1);
+    }
+
+    #[test]
     fn test_allocate_suffix_blocks_no_prefix() {
         let allocator = new_allocator(8, 4);
         let Some(mut adapter) = maybe_adapter(allocator, 4) else {
@@ -6541,6 +6672,45 @@ mod tests {
         assert!(!plan.continued_live_prefix);
         assert_eq!(plan.cached_prefix_len, 0);
         assert_eq!(plan.suffix_len, diverged.len() as u32);
+
+        adapter.release_request().unwrap();
+    }
+
+    #[test]
+    fn test_prepare_turn_with_max_cache_hit_tokens_recomputes_exact_live_suffix() {
+        let allocator = new_allocator(8, 4);
+        let Some(mut adapter) = maybe_adapter(Arc::clone(&allocator), 4) else {
+            eprintln!(
+                "skipping test_prepare_turn_with_max_cache_hit_tokens_recomputes_exact_live_suffix: Metal unavailable"
+            );
+            return;
+        };
+
+        let tokens: [u32; 5] = [10, 20, 30, 40, 50];
+        adapter.reset_for_new_request(0).unwrap();
+        let _ = adapter.find_cached_prefix(&[], &[], 0, false).unwrap();
+        adapter.allocate_suffix_blocks(tokens.len() as u32).unwrap();
+        adapter.record_tokens(&tokens).unwrap();
+        adapter.finalize_turn_keep_live(&[], 0).unwrap();
+
+        let plan = adapter
+            .prepare_turn_with_max_cache_hit_tokens(
+                0,
+                &tokens,
+                tokens.len() as u32,
+                true,
+                &[],
+                0,
+                false,
+                tokens.len() as u32 - 1,
+            )
+            .unwrap();
+
+        assert_eq!(plan.reason, PagedTurnPlanReason::FreshReset);
+        assert!(!plan.continued_live_prefix);
+        assert_eq!(plan.cached_prefix_len, 4);
+        assert_eq!(plan.suffix_len, 1);
+        assert_eq!(adapter.current_token_count(), 4);
 
         adapter.release_request().unwrap();
     }

--- a/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
+++ b/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
@@ -4924,7 +4924,7 @@ mod tests {
         let mut v_bits = Vec::with_capacity(4 * 64);
         for token_idx in 0..4 {
             let bits = f16::from_f32((token_idx + 1) as f32).to_bits();
-            v_bits.extend(std::iter::repeat(bits).take(64));
+            v_bits.extend(std::iter::repeat_n(bits, 64));
         }
         let v = MxArray::from_float16(&v_bits, &[4, 1, 64]).expect("v values");
         k.eval();
@@ -4961,11 +4961,10 @@ mod tests {
 
         let values = out.to_float32().expect("prefill output to_float32");
         let expected_by_token = [2.0_f32, 2.5_f32];
-        for token_idx in 0..2 {
+        for (token_idx, expected) in expected_by_token.iter().copied().enumerate() {
             for head_idx in 0..2 {
                 let base = (token_idx * 2 + head_idx) * 64;
                 let actual = values[base];
-                let expected = expected_by_token[token_idx];
                 assert!(
                     (actual - expected).abs() < 0.05,
                     "token {token_idx} head {head_idx}: got {actual}, expected {expected}"

--- a/crates/mlx-core/src/transformer/rotating_kv_cache.rs
+++ b/crates/mlx-core/src/transformer/rotating_kv_cache.rs
@@ -138,6 +138,13 @@ impl RotatingKVCache {
         let current_len = ordered_keys.shape_at(2)? as i32;
         self.idx = current_len;
 
+        // For multi-token prefill, attention must see the previous sliding
+        // window plus the entire current chunk. Store the trimmed rotating
+        // window below, but return the untrimmed attention view just like the
+        // empty-cache branch does for an over-window initial prefill.
+        let attention_keys = MxArray::concatenate(&ordered_keys, keys, 2)?;
+        let attention_values = MxArray::concatenate(&ordered_values, values, 2)?;
+
         let total = current_len + seq_len;
         let trim_size = if total > self.max_size {
             total - self.max_size
@@ -153,7 +160,7 @@ impl RotatingKVCache {
         self.offset += seq_len;
         self.idx = new_keys.shape_at(2)? as i32;
 
-        Ok(vec![new_keys, new_values])
+        Ok(vec![attention_keys, attention_values])
     }
 
     /// Update in-place (single-token updates)
@@ -545,7 +552,12 @@ mod tests {
 
         let k2 = MxArray::ones(&[1, 1, 6, 4], None).unwrap();
         let v2 = k2.clone();
-        cache.update_and_fetch(&k2, &v2).unwrap();
+        let r2 = cache.update_and_fetch(&k2, &v2).unwrap();
+        assert_eq!(
+            r2[0].shape_at(2).unwrap(),
+            12,
+            "prefill attention sees previous window plus current chunk"
+        );
 
         // Single token after should yield window-bounded cache
         let k3 = MxArray::ones(&[1, 1, 1, 4], None).unwrap();
@@ -554,6 +566,11 @@ mod tests {
         assert!(
             r[0].shape_at(2).unwrap() <= 8,
             "cache must not exceed window"
+        );
+        let (stored_k, _) = cache.fetch_current_kv().unwrap();
+        assert!(
+            stored_k.shape_at(2).unwrap() <= 8,
+            "stored rotating cache must remain window bounded"
         );
     }
 }

--- a/crates/mlx-core/src/transformer/rotating_kv_cache.rs
+++ b/crates/mlx-core/src/transformer/rotating_kv_cache.rs
@@ -14,6 +14,36 @@ pub struct RotatingKVCache {
     idx: i32,
 }
 
+/// Cheap snapshot of a [`RotatingKVCache`] valid K/V tail.
+///
+/// `keys` and `values` are MLX arrays in temporal attention order. Cloning this
+/// struct clones array handles; it does not read K/V data back to the host.
+#[derive(Clone)]
+pub struct RotatingKVCacheSnapshot {
+    pub keys: MxArray,
+    pub values: MxArray,
+    /// Total number of tokens processed by the cache when snapshotted.
+    pub offset: i32,
+    /// Sliding window size used by the source cache.
+    pub max_size: i32,
+    /// Number of leading tokens preserved by the source cache.
+    pub keep: i32,
+    /// Number of valid cached tokens stored in `keys`/`values`.
+    pub cached_tokens: i32,
+}
+
+/// Lightweight logical state for validating a rotating cache without reading
+/// tensor contents.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RotatingKVCacheState {
+    pub offset: i32,
+    pub window_size: i32,
+    pub keep: i32,
+    pub idx: i32,
+    pub cached_tokens: i32,
+    pub initialized: bool,
+}
+
 impl RotatingKVCache {
     /// Creates a new rotating KV cache.
     pub fn new(max_size: i32, keep: Option<i32>) -> Self {
@@ -33,6 +63,38 @@ impl RotatingKVCache {
 
     pub fn values_ref(&self) -> Option<&MxArray> {
         self.values.as_ref()
+    }
+
+    fn validate_config(max_size: i32, keep: i32) -> Result<()> {
+        if max_size <= 0 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("RotatingKVCache max_size must be positive, got {max_size}"),
+            ));
+        }
+        if keep < 0 || keep > max_size {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "RotatingKVCache keep must be in [0, max_size], got keep={keep} max_size={max_size}"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn expected_cached_tokens(offset: i32, max_size: i32) -> Result<i32> {
+        if offset < 0 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!("RotatingKVCache offset must be non-negative, got {offset}"),
+            ));
+        }
+        if offset == 0 {
+            Ok(0)
+        } else {
+            Ok(std::cmp::min(offset, max_size))
+        }
     }
 
     /// Helper: Trim cache by removing middle section
@@ -60,6 +122,33 @@ impl RotatingKVCache {
 
         let refs: Vec<&MxArray> = to_cat.iter().collect();
         MxArray::concatenate_many(refs, Some(2))
+    }
+
+    /// Select the bounded K/V tail that should remain stored after a
+    /// multi-token append. The attention view may be larger than `max_size`
+    /// (`previous_window + current_chunk`), but the rotating cache storage
+    /// itself must stay within `max_size`.
+    fn bounded_storage_from_attention_view(&self, attention: &MxArray) -> Result<MxArray> {
+        let shape = attention.shape()?;
+        let total_len = shape[2] as i32;
+        if total_len <= self.max_size {
+            return Ok(attention.clone());
+        }
+
+        if self.keep > 0 {
+            let keep_len = self.keep.min(self.max_size);
+            let tail_len = self.max_size - keep_len;
+            let keep = attention.slice_axis(2, 0, keep_len as i64)?;
+            if tail_len == 0 {
+                return Ok(keep);
+            }
+            let tail_start = (total_len - tail_len) as i64;
+            let tail = attention.slice_axis(2, tail_start, total_len as i64)?;
+            MxArray::concatenate(&keep, &tail, 2)
+        } else {
+            let start = (total_len - self.max_size) as i64;
+            attention.slice_axis(2, start, total_len as i64)
+        }
     }
 
     /// Helper: Rearrange cache into temporal order
@@ -145,15 +234,8 @@ impl RotatingKVCache {
         let attention_keys = MxArray::concatenate(&ordered_keys, keys, 2)?;
         let attention_values = MxArray::concatenate(&ordered_values, values, 2)?;
 
-        let total = current_len + seq_len;
-        let trim_size = if total > self.max_size {
-            total - self.max_size
-        } else {
-            0
-        };
-
-        let new_keys = self.trim(trim_size, &ordered_keys, Some(keys))?;
-        let new_values = self.trim(trim_size, &ordered_values, Some(values))?;
+        let new_keys = self.bounded_storage_from_attention_view(&attention_keys)?;
+        let new_values = self.bounded_storage_from_attention_view(&attention_values)?;
 
         self.keys = Some(new_keys.clone());
         self.values = Some(new_values.clone());
@@ -293,6 +375,11 @@ impl RotatingKVCache {
         self.idx = 0;
     }
 
+    /// Returns whether the cache has allocated K/V arrays.
+    pub fn is_initialized(&self) -> bool {
+        self.keys.is_some() && self.values.is_some()
+    }
+
     /// Returns the current offset.
     pub fn get_offset(&self) -> i32 {
         self.offset
@@ -311,6 +398,153 @@ impl RotatingKVCache {
     /// Returns the current write index.
     pub fn get_idx(&self) -> i32 {
         self.idx
+    }
+
+    /// Returns the logical number of valid cached tokens.
+    ///
+    /// This can be smaller than the raw backing array length after single-token
+    /// growth because the backing array may be preallocated ahead of `offset`.
+    pub fn get_cached_token_count(&self) -> Result<i32> {
+        if !self.is_initialized() {
+            return Ok(0);
+        }
+        Self::expected_cached_tokens(self.offset, self.max_size)
+    }
+
+    /// Returns a compact state summary suitable for offset/window validation.
+    pub fn state(&self) -> Result<RotatingKVCacheState> {
+        Ok(RotatingKVCacheState {
+            offset: self.offset,
+            window_size: self.max_size,
+            keep: self.keep,
+            idx: self.idx,
+            cached_tokens: self.get_cached_token_count()?,
+            initialized: self.is_initialized(),
+        })
+    }
+
+    /// Snapshot the current valid K/V tail in temporal attention order.
+    ///
+    /// Returns `None` for an empty cache. The returned arrays are lazy MLX array
+    /// views/concats over existing device state; no host K/V readback happens.
+    pub fn snapshot(&self) -> Result<Option<RotatingKVCacheSnapshot>> {
+        Self::validate_config(self.max_size, self.keep)?;
+        if self.offset == 0 {
+            return Ok(None);
+        }
+
+        let keys = self.keys.as_ref().ok_or_else(|| {
+            Error::new(
+                Status::InvalidArg,
+                "RotatingKVCache snapshot requested with offset but no keys",
+            )
+        })?;
+        let values = self.values.as_ref().ok_or_else(|| {
+            Error::new(
+                Status::InvalidArg,
+                "RotatingKVCache snapshot requested with offset but no values",
+            )
+        })?;
+
+        let ordered_keys = self.temporal_order(keys)?;
+        let ordered_values = self.temporal_order(values)?;
+        let cached_tokens = ordered_keys.shape_at(2)? as i32;
+        let value_cached_tokens = ordered_values.shape_at(2)? as i32;
+        let expected_cached_tokens = Self::expected_cached_tokens(self.offset, self.max_size)?;
+
+        if cached_tokens != value_cached_tokens {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "RotatingKVCache snapshot K/V token counts differ: keys={cached_tokens} values={value_cached_tokens}"
+                ),
+            ));
+        }
+        if cached_tokens != expected_cached_tokens {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "RotatingKVCache snapshot has {cached_tokens} cached tokens but expected {expected_cached_tokens} for offset={} max_size={}",
+                    self.offset, self.max_size
+                ),
+            ));
+        }
+
+        Ok(Some(RotatingKVCacheSnapshot {
+            keys: ordered_keys,
+            values: ordered_values,
+            offset: self.offset,
+            max_size: self.max_size,
+            keep: self.keep,
+            cached_tokens,
+        }))
+    }
+
+    /// Restore a previously snapshotted ordered K/V tail.
+    ///
+    /// The restored cache has the same logical `offset` as the source cache and
+    /// stores the snapshot in temporal order. Setting `idx` to the cached length
+    /// makes the next append observe the same attention view as a cache that had
+    /// naturally processed the prefix.
+    pub fn restore_snapshot(&mut self, snapshot: &RotatingKVCacheSnapshot) -> Result<()> {
+        Self::validate_config(snapshot.max_size, snapshot.keep)?;
+        if snapshot.max_size != self.max_size || snapshot.keep != self.keep {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "RotatingKVCache snapshot config mismatch: cache max_size={} keep={} snapshot max_size={} keep={}",
+                    self.max_size, self.keep, snapshot.max_size, snapshot.keep
+                ),
+            ));
+        }
+
+        let keys_shape = snapshot.keys.shape()?;
+        let values_shape = snapshot.values.shape()?;
+        if keys_shape.len() != 4 || values_shape.len() != 4 {
+            let keys_shape_vec = keys_shape.to_vec();
+            let values_shape_vec = values_shape.to_vec();
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "RotatingKVCache snapshot expects 4D K/V tensors, got keys={keys_shape_vec:?} values={values_shape_vec:?}"
+                ),
+            ));
+        }
+        if keys_shape[0] != values_shape[0]
+            || keys_shape[1] != values_shape[1]
+            || keys_shape[2] != values_shape[2]
+        {
+            let keys_shape_vec = keys_shape.to_vec();
+            let values_shape_vec = values_shape.to_vec();
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "RotatingKVCache snapshot K/V leading shapes differ: keys={keys_shape_vec:?} values={values_shape_vec:?}"
+                ),
+            ));
+        }
+
+        let cached_tokens = keys_shape[2] as i32;
+        let expected_cached_tokens =
+            Self::expected_cached_tokens(snapshot.offset, snapshot.max_size)?;
+        if cached_tokens != snapshot.cached_tokens
+            || cached_tokens != expected_cached_tokens
+            || cached_tokens == 0
+        {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "RotatingKVCache snapshot token count mismatch: shape_tokens={cached_tokens} snapshot_tokens={} expected={expected_cached_tokens}",
+                    snapshot.cached_tokens
+                ),
+            ));
+        }
+
+        self.keys = Some(snapshot.keys.clone());
+        self.values = Some(snapshot.values.clone());
+        self.offset = snapshot.offset;
+        self.idx = cached_tokens;
+        Ok(())
     }
 
     /// Get the current cached K/V in temporal order.
@@ -348,6 +582,12 @@ mod tests {
         for (i, &exp) in expected.iter().enumerate() {
             assert_eq!(shape[i], exp, "Shape mismatch at dimension {}", i);
         }
+    }
+
+    fn assert_float_data(arr: &MxArray, expected: &[f32]) {
+        arr.eval();
+        let data = arr.to_float32().unwrap().to_vec();
+        assert_eq!(data, expected);
     }
 
     #[test]
@@ -572,5 +812,109 @@ mod tests {
             stored_k.shape_at(2).unwrap() <= 8,
             "stored rotating cache must remain window bounded"
         );
+    }
+
+    #[test]
+    fn test_multi_token_append_larger_than_window_stores_only_tail() {
+        let mut cache = RotatingKVCache::new(4, None);
+
+        let prefix_keys = MxArray::from_float32(&[1.0], &[1, 1, 1, 1]).unwrap();
+        let prefix_values = MxArray::from_float32(&[10.0], &[1, 1, 1, 1]).unwrap();
+        cache
+            .update_and_fetch(&prefix_keys, &prefix_values)
+            .unwrap();
+
+        let chunk1_keys =
+            MxArray::from_float32(&[2.0, 3.0, 4.0, 5.0, 6.0, 7.0], &[1, 1, 6, 1]).unwrap();
+        let chunk1_values =
+            MxArray::from_float32(&[20.0, 30.0, 40.0, 50.0, 60.0, 70.0], &[1, 1, 6, 1]).unwrap();
+        let chunk1_attention = cache
+            .update_and_fetch(&chunk1_keys, &chunk1_values)
+            .unwrap();
+        assert_shape(&chunk1_attention[0], &[1, 1, 7, 1]);
+
+        let (stored_after_chunk1, _) = cache.fetch_current_kv().unwrap();
+        assert_shape(&stored_after_chunk1, &[1, 1, 4, 1]);
+        assert_float_data(&stored_after_chunk1, &[4.0, 5.0, 6.0, 7.0]);
+
+        let chunk2_keys =
+            MxArray::from_float32(&[8.0, 9.0, 10.0, 11.0, 12.0, 13.0], &[1, 1, 6, 1]).unwrap();
+        let chunk2_values =
+            MxArray::from_float32(&[80.0, 90.0, 100.0, 110.0, 120.0, 130.0], &[1, 1, 6, 1])
+                .unwrap();
+        let chunk2_attention = cache
+            .update_and_fetch(&chunk2_keys, &chunk2_values)
+            .unwrap();
+
+        assert_shape(&chunk2_attention[0], &[1, 1, 10, 1]);
+        assert_float_data(
+            &chunk2_attention[0],
+            &[4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0],
+        );
+
+        let (stored_after_chunk2, _) = cache.fetch_current_kv().unwrap();
+        assert_shape(&stored_after_chunk2, &[1, 1, 4, 1]);
+        assert_float_data(&stored_after_chunk2, &[10.0, 11.0, 12.0, 13.0]);
+        assert_eq!(cache.get_offset(), 13);
+        assert_eq!(cache.get_cached_token_count().unwrap(), 4);
+    }
+
+    #[test]
+    fn test_snapshot_restore_after_wrap_preserves_temporal_tail() {
+        let mut source = RotatingKVCache::new(4, None);
+        let keys1 = MxArray::from_float32(&[1.0, 2.0, 3.0, 4.0], &[1, 1, 4, 1]).unwrap();
+        let values1 = MxArray::from_float32(&[10.0, 20.0, 30.0, 40.0], &[1, 1, 4, 1]).unwrap();
+        source.update_and_fetch(&keys1, &values1).unwrap();
+
+        let keys2 = MxArray::from_float32(&[5.0], &[1, 1, 1, 1]).unwrap();
+        let values2 = MxArray::from_float32(&[50.0], &[1, 1, 1, 1]).unwrap();
+        source.update_and_fetch(&keys2, &values2).unwrap();
+
+        let keys3 = MxArray::from_float32(&[6.0], &[1, 1, 1, 1]).unwrap();
+        let values3 = MxArray::from_float32(&[60.0], &[1, 1, 1, 1]).unwrap();
+        source.update_and_fetch(&keys3, &values3).unwrap();
+
+        let snapshot = source.snapshot().unwrap().unwrap();
+        assert_eq!(snapshot.offset, 6);
+        assert_eq!(snapshot.max_size, 4);
+        assert_eq!(snapshot.cached_tokens, 4);
+        assert_float_data(&snapshot.keys, &[3.0, 4.0, 5.0, 6.0]);
+        assert_float_data(&snapshot.values, &[30.0, 40.0, 50.0, 60.0]);
+
+        let mut restored = RotatingKVCache::new(4, None);
+        restored.restore_snapshot(&snapshot).unwrap();
+
+        let state = restored.state().unwrap();
+        assert!(state.initialized);
+        assert_eq!(state.offset, 6);
+        assert_eq!(state.cached_tokens, 4);
+        assert_eq!(state.window_size, 4);
+
+        let (restored_keys, restored_values) = restored.fetch_current_kv().unwrap();
+        assert_float_data(&restored_keys, &[3.0, 4.0, 5.0, 6.0]);
+        assert_float_data(&restored_values, &[30.0, 40.0, 50.0, 60.0]);
+
+        let append_keys = MxArray::from_float32(&[7.0, 8.0], &[1, 1, 2, 1]).unwrap();
+        let append_values = MxArray::from_float32(&[70.0, 80.0], &[1, 1, 2, 1]).unwrap();
+
+        let source_attention = source
+            .update_and_fetch(&append_keys, &append_values)
+            .unwrap();
+        let restored_attention = restored
+            .update_and_fetch(&append_keys, &append_values)
+            .unwrap();
+
+        assert_float_data(&source_attention[0], &[3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+        assert_float_data(&source_attention[1], &[30.0, 40.0, 50.0, 60.0, 70.0, 80.0]);
+        assert_float_data(&restored_attention[0], &[3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+        assert_float_data(
+            &restored_attention[1],
+            &[30.0, 40.0, 50.0, 60.0, 70.0, 80.0],
+        );
+
+        let (source_tail, _) = source.fetch_current_kv().unwrap();
+        let (restored_tail, _) = restored.fetch_current_kv().unwrap();
+        assert_float_data(&source_tail, &[5.0, 6.0, 7.0, 8.0]);
+        assert_float_data(&restored_tail, &[5.0, 6.0, 7.0, 8.0]);
     }
 }

--- a/crates/mlx-core/tests/adapter_e2e_validation.rs
+++ b/crates/mlx-core/tests/adapter_e2e_validation.rs
@@ -208,9 +208,9 @@ fn reference_attention_f32(
 
 /// Run the FULL adapter flow: reset, find_cached_prefix (miss), allocate
 /// suffix, record_tokens, batch update_keys_values, gather_kv_for_decode.
-/// Returns the gather output as `Vec<f32>` (gather output is f32 — the
-/// adapter currently routes through `PagedAttentionOutput::to_mlx_array`
-/// which does GPU → host → MLX as f32).
+/// Returns the gather output as `Vec<f32>` for comparison. The adapter's
+/// decode output stays in the query/io dtype, so tests cast before copying
+/// back to host.
 #[allow(clippy::too_many_arguments)]
 fn run_adapter(
     fixture: &mut Fixture,
@@ -303,9 +303,11 @@ fn run_adapter(
     out.eval();
     synchronize();
 
-    // gather_kv_for_decode returns f32 (PagedAttentionOutput::to_mlx_array
-    // path). Pull straight to host.
-    let out_f32 = out.to_float32().expect("to_float32");
+    let out_f32 = out
+        .astype(DType::Float32)
+        .expect("astype f32")
+        .to_float32()
+        .expect("to_float32");
     let result: Vec<f32> = (out_f32.as_ref() as &[f32]).to_vec();
 
     if register_for_reuse {

--- a/crates/mlx-paged-attn/src/block_allocator.rs
+++ b/crates/mlx-paged-attn/src/block_allocator.rs
@@ -45,8 +45,12 @@
 //!
 //! Mitigations:
 //! - `cache_full_blocks` aborts registration on the first colliding
-//!   block (so we don't WRITE a corrupted chain), see `register_prefix`
-//!   `bool` return.
+//!   block (so we don't WRITE a corrupted chain), unless the existing
+//!   entry carries verified identical block identity metadata. In that
+//!   case the caller is recomputing an already-cached prefix and can
+//!   continue publishing the new tail.
+//! - `find_longest_cache_hit` verifies stored block identity metadata
+//!   when available before returning a cache hit.
 //! - For multi-tenant deployments and adversarial settings, switch to
 //!   SHA-256 by replacing `hash_tokens`'s hasher (small mechanical
 //!   change). Tracked as future work.
@@ -122,6 +126,16 @@ pub struct BlockAllocator {
     /// Prefix cache: hash -> block for reuse
     prefix_cache: HashMap<u64, Arc<PhysicalBlock>>,
 
+    /// Prefix-cache block identity metadata for entries registered
+    /// through `cache_full_blocks`.
+    ///
+    /// Direct `register_prefix` callers do not provide enough context to
+    /// populate this table, so absence means "unknown" rather than
+    /// "matching". The metadata lets a cold-prefill replay skip an
+    /// already-cached leading prefix while still rejecting true hash
+    /// collisions.
+    prefix_cache_identities: HashMap<u64, PrefixCacheBlockIdentity>,
+
     /// Reverse mapping: block_id -> hash (for cleanup during free)
     block_hashes: HashMap<u32, u64>,
 
@@ -130,6 +144,48 @@ pub struct BlockAllocator {
 
     /// Maximum entries in prefix cache
     max_prefix_cache_entries: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PrefixCacheBlockIdentity {
+    token_ids: Vec<u32>,
+    parent_hash: u64,
+    extra_keys: Vec<u64>,
+    cache_salt: u64,
+    block_index: usize,
+}
+
+impl PrefixCacheBlockIdentity {
+    fn new(
+        token_ids: &[u32],
+        parent_hash: u64,
+        extra_keys: &[u64],
+        cache_salt: u64,
+        block_index: usize,
+    ) -> Self {
+        Self {
+            token_ids: token_ids.to_vec(),
+            parent_hash,
+            extra_keys: extra_keys.to_vec(),
+            cache_salt,
+            block_index,
+        }
+    }
+
+    fn matches(
+        &self,
+        token_ids: &[u32],
+        parent_hash: u64,
+        extra_keys: &[u64],
+        cache_salt: u64,
+        block_index: usize,
+    ) -> bool {
+        self.token_ids.as_slice() == token_ids
+            && self.parent_hash == parent_hash
+            && self.extra_keys.as_slice() == extra_keys
+            && self.cache_salt == cache_salt
+            && self.block_index == block_index
+    }
 }
 
 impl BlockAllocator {
@@ -147,6 +203,7 @@ impl BlockAllocator {
             num_blocks,
             block_size,
             prefix_cache: HashMap::new(),
+            prefix_cache_identities: HashMap::new(),
             block_hashes: HashMap::new(),
             lru_order: VecDeque::new(),
             // Scale the prefix-cache capacity to `num_blocks` so the cache
@@ -219,6 +276,7 @@ impl BlockAllocator {
             let _ = block.decref();
             // Remove all bookkeeping for this entry.
             self.prefix_cache.remove(&hash);
+            self.prefix_cache_identities.remove(&hash);
             self.block_hashes.remove(&block_id);
             self.lru_order.retain(|&h| h != hash);
             self.allocated.remove(&block_id);
@@ -241,6 +299,7 @@ impl BlockAllocator {
             // Remove from prefix cache if present
             if let Some(hash) = self.block_hashes.remove(&block_id) {
                 self.prefix_cache.remove(&hash);
+                self.prefix_cache_identities.remove(&hash);
                 self.lru_order.retain(|&h| h != hash);
             }
 
@@ -381,6 +440,7 @@ impl BlockAllocator {
             && existing_hash != hash
         {
             if self.prefix_cache.remove(&existing_hash).is_some() {
+                self.prefix_cache_identities.remove(&existing_hash);
                 // Decref the cache's logical reference for the old alias.
                 // We deliberately ignore a true return here: callers that
                 // re-register a block they still hold (the common case)
@@ -411,6 +471,7 @@ impl BlockAllocator {
                         // drops ref_count to 0 the block goes back to the
                         // free pool — same cleanup `free()` performs.
                         if let Some(evicted_block) = self.prefix_cache.remove(&old_hash) {
+                            self.prefix_cache_identities.remove(&old_hash);
                             let evicted_id = evicted_block.block_id;
                             self.block_hashes.remove(&evicted_id);
                             if evicted_block.decref() {
@@ -439,6 +500,11 @@ impl BlockAllocator {
         self.block_hashes.insert(block.block_id, hash);
 
         if is_new_insertion {
+            // Direct register_prefix callers do not provide enough
+            // identity material to verify future duplicate-hash attempts.
+            // cache_full_blocks repopulates this immediately after a
+            // successful insertion.
+            self.prefix_cache_identities.remove(&hash);
             block.incref();
         }
 
@@ -462,6 +528,59 @@ impl BlockAllocator {
         } else {
             None
         }
+    }
+
+    fn prefix_identity_matches(
+        &self,
+        hash: u64,
+        token_ids: &[u32],
+        parent_hash: u64,
+        extra_keys: &[u64],
+        cache_salt: u64,
+        block_index: usize,
+    ) -> bool {
+        self.prefix_cache_identities
+            .get(&hash)
+            .is_some_and(|identity| {
+                identity.matches(token_ids, parent_hash, extra_keys, cache_salt, block_index)
+            })
+    }
+
+    fn prefix_identity_mismatches(
+        &self,
+        hash: u64,
+        token_ids: &[u32],
+        parent_hash: u64,
+        extra_keys: &[u64],
+        cache_salt: u64,
+        block_index: usize,
+    ) -> bool {
+        self.prefix_cache_identities
+            .get(&hash)
+            .is_some_and(|identity| {
+                !identity.matches(token_ids, parent_hash, extra_keys, cache_salt, block_index)
+            })
+    }
+
+    fn remember_prefix_identity(
+        &mut self,
+        hash: u64,
+        token_ids: &[u32],
+        parent_hash: u64,
+        extra_keys: &[u64],
+        cache_salt: u64,
+        block_index: usize,
+    ) {
+        self.prefix_cache_identities.insert(
+            hash,
+            PrefixCacheBlockIdentity::new(
+                token_ids,
+                parent_hash,
+                extra_keys,
+                cache_salt,
+                block_index,
+            ),
+        );
     }
 
     /// Walk a token sequence in `block_size`-aligned chunks, looking up each
@@ -507,14 +626,20 @@ impl BlockAllocator {
         for n in 0..num_full_blocks {
             let start = n * block_size_us;
             let end = start + block_size_us;
+            let block_tokens = &token_ids[start..end];
             let parent_hash = if n == 0 { 0 } else { previous_block_hash };
-            let block_hash = hash_block(
-                &token_ids[start..end],
+            let block_hash = hash_block(block_tokens, parent_hash, extra_keys, cache_salt, n);
+
+            if self.prefix_identity_mismatches(
+                block_hash,
+                block_tokens,
                 parent_hash,
                 extra_keys,
                 cache_salt,
                 n,
-            );
+            ) {
+                break;
+            }
 
             match self.lookup_prefix(block_hash) {
                 Some(block) => {
@@ -580,14 +705,20 @@ impl BlockAllocator {
             };
             let start = n * block_size_us;
             let end = start + block_size_us;
+            let block_tokens = &token_ids[start..end];
             let parent_hash = if n == 0 { 0 } else { previous_block_hash };
-            let block_hash = hash_block(
-                &token_ids[start..end],
+            let block_hash = hash_block(block_tokens, parent_hash, per_block, cache_salt, n);
+
+            if self.prefix_identity_mismatches(
+                block_hash,
+                block_tokens,
                 parent_hash,
                 per_block,
                 cache_salt,
                 n,
-            );
+            ) {
+                break;
+            }
 
             match self.lookup_prefix(block_hash) {
                 Some(block) => {
@@ -627,22 +758,31 @@ impl BlockAllocator {
     ///
     /// Mirrors vLLM `vllm/v1/core/block_pool.py:211-320` (`cache_full_blocks`).
     ///
-    /// # Aborting on collision
+    /// # Collision and duplicate-prefix handling
     ///
     /// If `register_prefix` rejects a block partway through the chain
     /// (Case 2 hash collision — `hash_n` is already authoritative for a
-    /// different block), the chain is aborted immediately. We do NOT
-    /// continue computing `hash_{n+1} = H(hash_n, ...)` and registering
-    /// later blocks — those would link to a predecessor (`hash_n`) that
-    /// resolves to someone else's block, so a future
-    /// `find_longest_cache_hit` walking the chain would mix blocks
-    /// across registration intents (silent KV corruption).
+    /// different block), we continue only when the existing cache entry
+    /// has verified-identical block identity metadata. That is the normal
+    /// cold-prefill replay case: the prefix was already cached under old
+    /// physical blocks, and this request recomputed the same leading
+    /// blocks before producing a new tail. The duplicate leading blocks
+    /// are skipped, and later tail blocks can still be published.
+    ///
+    /// If identity is missing or different, the chain is aborted
+    /// immediately. We do NOT continue computing
+    /// `hash_{n+1} = H(hash_n, ...)` and registering later blocks — those
+    /// would link to a predecessor (`hash_n`) that resolves to someone
+    /// else's block, so a future `find_longest_cache_hit` walking the
+    /// chain would mix blocks across registration intents (silent KV
+    /// corruption).
     ///
     /// Returns the number of blocks actually registered. May be less than
-    /// `blocks.len()` if the chain was aborted mid-way; callers can treat
-    /// any value as success — the partial registration is still
-    /// internally consistent. Subsequent lookups simply miss at the first
-    /// dropped block, which forces a fresh prefill (correct behavior).
+    /// `blocks.len()` if the chain was aborted mid-way or if verified
+    /// duplicate leading blocks were skipped; callers can treat any value
+    /// as success — the partial registration is still internally
+    /// consistent. Subsequent lookups simply miss at the first dropped
+    /// block, which forces a fresh prefill (correct behavior).
     pub fn cache_full_blocks(
         &mut self,
         token_ids: &[u32],
@@ -665,23 +805,43 @@ impl BlockAllocator {
         for (n, block) in blocks.iter().enumerate() {
             let start = n * block_size_us;
             let end = start + block_size_us;
+            let block_tokens = &token_ids[start..end];
             let parent_hash = if n == 0 { 0 } else { previous_block_hash };
-            let block_hash = hash_block(
-                &token_ids[start..end],
+            let block_hash = hash_block(block_tokens, parent_hash, extra_keys, cache_salt, n);
+            if !self.register_prefix(Arc::clone(block), block_hash) {
+                if self.prefix_identity_matches(
+                    block_hash,
+                    block_tokens,
+                    parent_hash,
+                    extra_keys,
+                    cache_salt,
+                    n,
+                ) {
+                    // The same logical block is already cached under a
+                    // different physical block. This happens after a cold
+                    // prefill recomputes an existing prefix: skip the
+                    // duplicate leading block but keep walking so the new
+                    // tail can be published.
+                    previous_block_hash = block_hash;
+                    continue;
+                } else {
+                    // Chain broke (collision drop or cache disabled). Stop
+                    // here: any further block we register would chain off a
+                    // hash that resolves to someone else's block, which
+                    // corrupts future find_longest_cache_hit walks. Return
+                    // the count of accepted registrations up to (but not
+                    // including) the dropped block.
+                    break;
+                }
+            }
+            self.remember_prefix_identity(
+                block_hash,
+                block_tokens,
                 parent_hash,
                 extra_keys,
                 cache_salt,
                 n,
             );
-            if !self.register_prefix(Arc::clone(block), block_hash) {
-                // Chain broke (collision drop or cache disabled). Stop
-                // here: any further block we register would chain off a
-                // hash that resolves to someone else's block, which
-                // corrupts future find_longest_cache_hit walks. Return
-                // the count of accepted registrations up to (but not
-                // including) the dropped block.
-                break;
-            }
             previous_block_hash = block_hash;
             registered += 1;
         }
@@ -703,7 +863,8 @@ impl BlockAllocator {
     /// token positions to their owning block.
     ///
     /// Returns the number of blocks actually registered. May be less than
-    /// `blocks.len()` if the chain aborted on a hash collision mid-way.
+    /// `blocks.len()` if the chain aborted on a hash collision mid-way or
+    /// skipped verified duplicate leading blocks.
     ///
     /// `cache_salt` is mixed into the FIRST block's hash only (when it is
     /// non-zero), with the same semantics as
@@ -735,17 +896,33 @@ impl BlockAllocator {
         for (n, block) in blocks.iter().enumerate() {
             let start = n * block_size_us;
             let end = start + block_size_us;
+            let block_tokens = &token_ids[start..end];
+            let extra_keys = &extra_keys_per_block[n];
             let parent_hash = if n == 0 { 0 } else { previous_block_hash };
-            let block_hash = hash_block(
-                &token_ids[start..end],
+            let block_hash = hash_block(block_tokens, parent_hash, extra_keys, cache_salt, n);
+            if !self.register_prefix(Arc::clone(block), block_hash) {
+                if self.prefix_identity_matches(
+                    block_hash,
+                    block_tokens,
+                    parent_hash,
+                    extra_keys,
+                    cache_salt,
+                    n,
+                ) {
+                    previous_block_hash = block_hash;
+                    continue;
+                } else {
+                    break;
+                }
+            }
+            self.remember_prefix_identity(
+                block_hash,
+                block_tokens,
                 parent_hash,
-                &extra_keys_per_block[n],
+                extra_keys,
                 cache_salt,
                 n,
             );
-            if !self.register_prefix(Arc::clone(block), block_hash) {
-                break;
-            }
             previous_block_hash = block_hash;
             registered += 1;
         }
@@ -833,12 +1010,12 @@ impl BlockAllocator {
 ///
 // FIXME(p1c-followup): SipHash u64 is not cryptographically collision-resistant.
 // `find_longest_cache_hit` walks chained block hashes via `lookup_prefix`, so a
-// mid-chain collision between two different token chains can cause a
-// mixed-prefix lookup → silent KV corruption. The `cache_full_blocks` chain
-// abort prevents WRITING a corrupted chain, but lookup-side defense requires
-// switching to SHA-256 (cryptographic) or storing per-block content metadata
-// for verification on lookup. See the module-level "SipHash collision
-// limitation" doc above for details.
+// mid-chain collision between two different token chains could cause a
+// mixed-prefix lookup for entries registered without block identity metadata.
+// cache_full_blocks/cache_full_blocks_per_block entries are verified on lookup
+// and duplicate registration, but direct register_prefix callers still have no
+// token/extra-key metadata. See the module-level "SipHash collision limitation"
+// doc above for details.
 pub fn hash_tokens(tokens: &[u32], parent_hash: u64, extra_keys: &[u64]) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -2254,6 +2431,66 @@ mod tests {
         // The key invariant we're testing is that we did NOT register
         // ghost descendants — chain_b2's hash isn't cached.
         assert!(!allocator.prefix_cache.contains_key(&block2_hash));
+    }
+
+    /// Cold-prefill replay can recompute a leading prefix whose blocks are
+    /// already cached under older physical blocks. That must not abort the
+    /// whole registration chain; otherwise the newly computed tail never
+    /// becomes reusable and the next request keeps falling back to cold
+    /// prefill at the same stale prefix.
+    #[test]
+    fn test_cache_full_blocks_continues_past_verified_existing_prefix() {
+        let mut allocator = BlockAllocator::new(12, 4);
+        let block_size = 4u32;
+
+        let old_tokens: Vec<u32> = (0..8).collect();
+        let old_blocks: Vec<_> = (0..2).map(|_| allocator.allocate().unwrap()).collect();
+        let old_ids: Vec<_> = old_blocks.iter().map(|block| block.block_id).collect();
+        let old_registered = allocator
+            .cache_full_blocks(&old_tokens, &old_blocks, block_size, &[], 0)
+            .unwrap();
+        assert_eq!(old_registered, 2);
+
+        // Simulate end-of-request: the prefix cache keeps the old blocks
+        // alive while the request's direct handles are released.
+        for block in old_blocks {
+            allocator.free(block);
+        }
+
+        let new_tokens: Vec<u32> = (0..16).collect();
+        let new_blocks: Vec<_> = (0..4).map(|_| allocator.allocate().unwrap()).collect();
+        let new_ids: Vec<_> = new_blocks.iter().map(|block| block.block_id).collect();
+        assert_ne!(new_ids[0], old_ids[0]);
+        assert_ne!(new_ids[1], old_ids[1]);
+
+        let new_registered = allocator
+            .cache_full_blocks(&new_tokens, &new_blocks, block_size, &[], 0)
+            .unwrap();
+        assert_eq!(
+            new_registered, 2,
+            "only the new tail blocks should be newly registered"
+        );
+
+        let (hits, cached_tokens) =
+            allocator.find_longest_cache_hit(&new_tokens, block_size, &[], 0);
+        assert_eq!(cached_tokens, new_tokens.len());
+        let hit_ids: Vec<_> = hits.iter().map(|block| block.block_id).collect();
+        assert_eq!(
+            hit_ids,
+            vec![old_ids[0], old_ids[1], new_ids[2], new_ids[3]],
+            "lookup should reuse the old cached prefix and the newly published tail"
+        );
+
+        assert!(
+            !allocator.block_hashes.contains_key(&new_ids[0]),
+            "duplicate leading block 0 must not be inserted as a cache alias"
+        );
+        assert!(
+            !allocator.block_hashes.contains_key(&new_ids[1]),
+            "duplicate leading block 1 must not be inserted as a cache alias"
+        );
+        assert!(allocator.block_hashes.contains_key(&new_ids[2]));
+        assert!(allocator.block_hashes.contains_key(&new_ids[3]));
     }
 
     // -------------------------------------------------------------------

--- a/crates/mlx-paged-attn/src/layer_kv_pool.rs
+++ b/crates/mlx-paged-attn/src/layer_kv_pool.rs
@@ -36,6 +36,54 @@ use crate::metal::MetalDtype;
 #[cfg(target_os = "macos")]
 use metal::Buffer;
 
+#[cfg(target_os = "macos")]
+fn inference_trace_file() -> Option<&'static str> {
+    static TRACE_FILE: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    TRACE_FILE
+        .get_or_init(|| {
+            let enabled = match std::env::var("MLX_INFERENCE_TRACE") {
+                Ok(value) => matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                ),
+                Err(_) => false,
+            };
+            if !enabled {
+                return None;
+            }
+            std::env::var("MLX_INFERENCE_TRACE_FILE")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .as_deref()
+}
+
+#[cfg(target_os = "macos")]
+fn inference_trace_enabled() -> bool {
+    inference_trace_file().is_some()
+}
+
+#[cfg(target_os = "macos")]
+fn write_inference_trace(args: std::fmt::Arguments<'_>) {
+    let Some(path) = inference_trace_file() else {
+        return;
+    };
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        use std::io::Write;
+        let _ = writeln!(file, "{args}");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn elapsed_ms(start: std::time::Instant) -> f64 {
+    start.elapsed().as_secs_f64() * 1000.0
+}
+
 /// Convert a `MetalDtype` to the matching `BridgeDType` code understood by
 /// `mlx_array_from_metal_buffer_view`. Mirrors the enum in
 /// `crates/mlx-sys/src/mlx_common.h`:
@@ -648,23 +696,79 @@ impl LayerKVPool {
             return Ok(());
         }
 
+        let trace_enabled = inference_trace_enabled();
+        let trace_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] layer_kv_pool write_kv_start layer={} num_tokens={} input_dtype={:?} cache_dtype={:?} first_slot={} last_slot={}",
+                layer_idx,
+                slot_mapping.len(),
+                input_dtype,
+                self.cache_dtype,
+                slot_mapping.first().copied().unwrap_or(-1),
+                slot_mapping.last().copied().unwrap_or(-1)
+            ));
+        }
+
         // Synchronize MLX so the K/V tensors are materialized before we
         // dereference their backing buffers.
+        let sync_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] layer_kv_pool write_kv_mlx_sync_start layer={} num_tokens={}",
+                layer_idx,
+                slot_mapping.len()
+            ));
+        }
         synchronize_mlx();
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] layer_kv_pool write_kv_mlx_sync_done layer={} elapsed_ms={:.1}",
+                layer_idx,
+                sync_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
 
         // SAFETY: caller guarantees handles are valid + evaluated.
+        let extract_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] layer_kv_pool write_kv_extract_start layer={}",
+                layer_idx
+            ));
+        }
         let key_info = unsafe { MlxMetalBuffer::from_mlx_array(keys) }
             .ok_or_else(|| "Failed to extract Metal buffer from keys".to_string())?;
         let value_info = unsafe { MlxMetalBuffer::from_mlx_array(values) }
             .ok_or_else(|| "Failed to extract Metal buffer from values".to_string())?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] layer_kv_pool write_kv_extract_done layer={} key_offset={} key_bytes={} value_offset={} value_bytes={} elapsed_ms={:.1}",
+                layer_idx,
+                key_info.offset,
+                key_info.data_size,
+                value_info.offset,
+                value_info.data_size,
+                extract_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
 
         // Upload slot_mapping as a shared Metal buffer (kernel expects i64).
+        let slot_upload_start = trace_enabled.then(std::time::Instant::now);
         let state = MetalState::get()?;
         let slot_buffer = state.device.new_buffer_with_data(
             slot_mapping.as_ptr() as *const _,
             std::mem::size_of_val(slot_mapping) as u64,
             MTLResourceOptions::StorageModeShared,
         );
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] layer_kv_pool write_kv_slot_upload_done layer={} bytes={} elapsed_ms={:.1}",
+                layer_idx,
+                std::mem::size_of_val(slot_mapping),
+                slot_upload_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
 
         // `x` follows the cache element width: 8 for 2-byte (half/bf16),
         // 16 for 1-byte (FP8). Mirrors the cache-buffer math in
@@ -715,6 +819,20 @@ impl LayerKVPool {
         // SAFETY: all buffer pointers are extracted above; they remain
         // valid until command_buffer.wait_until_completed inside the
         // dispatcher returns.
+        let dispatch_start = trace_enabled.then(std::time::Instant::now);
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] layer_kv_pool write_kv_dispatch_start layer={} num_tokens={} block_size={} heads={} head_size={} x={} input_dtype={:?} cache_dtype={:?}",
+                layer_idx,
+                params.num_tokens,
+                params.block_size,
+                params.num_heads,
+                params.head_size,
+                params.x,
+                input_dtype,
+                cache_dtype
+            ));
+        }
         unsafe {
             dispatch_reshape_and_cache_raw(
                 &key_raw,
@@ -726,7 +844,16 @@ impl LayerKVPool {
                 input_dtype,
                 cache_dtype,
             )
+        }?;
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] layer_kv_pool write_kv_dispatch_done layer={} elapsed_ms={:.1} total_ms={:.1}",
+                layer_idx,
+                dispatch_start.map(elapsed_ms).unwrap_or(0.0),
+                trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
         }
+        Ok(())
     }
 
     /// Run paged attention against this layer's K/V buffers for a single
@@ -755,8 +882,8 @@ impl LayerKVPool {
     /// → half misroute on the gather side (the corresponding `write_kv` was
     /// already fixed in P1C-2).
     ///
-    /// Returns the attention output as a `PagedAttentionOutput`. The caller
-    /// converts to an `MxArray` via `to_mlx_array` (GPU → host roundtrip).
+    /// Returns the attention output as a `PagedAttentionOutput`. Hot-path
+    /// callers convert it to an `MxArray` view without a host roundtrip.
     ///
     /// # Safety
     /// - `queries` must be a valid evaluated `mlx_array` pointer with shape

--- a/crates/mlx-paged-attn/src/layer_kv_pool.rs
+++ b/crates/mlx-paged-attn/src/layer_kv_pool.rs
@@ -906,6 +906,7 @@ impl LayerKVPool {
         num_query_heads: u32,
         scale: f32,
         softcap: f32,
+        sliding_window: i32,
         k_scale: f32,
         v_scale: f32,
     ) -> Result<crate::metal::PagedAttentionOutput, String> {
@@ -998,10 +999,9 @@ impl LayerKVPool {
             // passes 1.0 when no manager is configured (non-FP8 path).
             k_scale,
             v_scale,
-            // Phase 7: LayerKVPool's direct attention helper is used by
-            // pure-Rust paged forwards that don't need sliding-window
-            // masking yet; default off.
-            sliding_window: 0,
+            // Phase 7: 0 means full context; positive values mask K/V older
+            // than `context_len - sliding_window`.
+            sliding_window,
         };
 
         // Cache dtype is the one declared at pool construction time; for

--- a/crates/mlx-paged-attn/src/metal/paged_attention.rs
+++ b/crates/mlx-paged-attn/src/metal/paged_attention.rs
@@ -616,6 +616,39 @@ impl PagedAttentionOutput {
 
         Ok(arr)
     }
+
+    /// Convert output to an MLX array view without a GPU → host roundtrip.
+    ///
+    /// The returned MLX array retains the underlying `MTL::Buffer` through
+    /// `mlx_array_from_metal_buffer_view`, so it remains valid after this
+    /// `PagedAttentionOutput` wrapper is dropped.
+    ///
+    /// # Safety
+    /// The returned pointer must be managed by the caller (typically wrapped in
+    /// `MxArray`).
+    pub unsafe fn to_mlx_array_view(&self) -> Result<*mut mlx_sys::mlx_array, String> {
+        let shape = self.shape();
+        let dtype_code = match self.dtype {
+            MetalDtype::Float32 => 0,
+            MetalDtype::Float16 => 2,
+            MetalDtype::BFloat16 => 3,
+            MetalDtype::UChar => 5,
+        };
+        let arr = unsafe {
+            mlx_sys::mlx_array_from_metal_buffer_view(
+                self.buffer_ptr(),
+                shape.as_ptr(),
+                shape.len(),
+                dtype_code,
+            )
+        };
+        if arr.is_null() {
+            return Err(
+                "Failed to create zero-copy MLX view from paged attention output".to_string(),
+            );
+        }
+        Ok(arr)
+    }
 }
 
 /// Dispatch paged_attention V1 with raw buffer pointers

--- a/crates/mlx-paged-attn/tests/paged_ops_smoke.rs
+++ b/crates/mlx-paged-attn/tests/paged_ops_smoke.rs
@@ -1604,6 +1604,67 @@ fn paged_attention_factory_rejects_non_contiguous_seq_lens() {
     );
 }
 
+#[test]
+fn paged_attention_forward_rejects_non_contiguous_metadata() {
+    let rc = unsafe { mlx_sys::mlx_paged_attention_forward_rejects_non_contiguous_metadata() };
+    if rc == -3 {
+        eprintln!(
+            "paged_attention_forward_rejects_non_contiguous_metadata: \
+             Metal not available; skipping"
+        );
+        return;
+    }
+    assert_eq!(
+        rc, 1,
+        "mlx_paged_attention_forward must reject sliced metadata (got rc={rc}); \
+         the bridge must not mask block_table/seq_lens views with lazy \
+         contiguous copies because eval_gpu reads metadata host-side."
+    );
+}
+
+#[test]
+fn paged_attention_forward_accepts_materialized_metadata() {
+    let rc = unsafe { mlx_sys::mlx_paged_attention_forward_eval_accepts_materialized_metadata() };
+    if rc == -3 {
+        eprintln!(
+            "paged_attention_forward_accepts_materialized_metadata: \
+             Metal not available; skipping"
+        );
+        return;
+    }
+    assert_ne!(
+        rc, -1,
+        "mlx_paged_attention_forward valid-metadata helper hit an internal error"
+    );
+    assert_eq!(
+        rc, 1,
+        "mlx_paged_attention_forward must accept materialized, row-contiguous \
+         block_table/seq_lens and evaluate the lazy output successfully \
+         (got rc={rc})."
+    );
+}
+
+#[test]
+fn paged_kv_write_forward_accepts_materialized_metadata() {
+    let rc = unsafe { mlx_sys::mlx_paged_kv_write_forward_eval_smoke() };
+    if rc == -3 {
+        eprintln!(
+            "paged_kv_write_forward_accepts_materialized_metadata: \
+             Metal not available; skipping"
+        );
+        return;
+    }
+    assert_ne!(
+        rc, -1,
+        "mlx_paged_kv_write_forward smoke hit an eval-time error"
+    );
+    assert_eq!(
+        rc, 1,
+        "mlx_paged_kv_write_forward must accept materialized slot_mapping \
+         metadata and evaluate the lazy pool outputs successfully (got rc={rc})."
+    );
+}
+
 // =============================================================================
 // Phase 1 review-round-9: compile-cached eval_gpu must mirror the
 // factory's row-contiguous / zero-offset check.

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -345,7 +345,7 @@ unsafe extern "C-unwind" {
     ) -> *mut mlx_array;
     pub fn mlx_array_eval(handle: *mut mlx_array);
     pub fn mlx_async_eval(handles: *mut *mut mlx_array, count: usize);
-    pub fn mlx_eval(handles: *mut *mut mlx_array, count: usize);
+    pub fn mlx_eval(handles: *mut *mut mlx_array, count: usize) -> bool;
     pub fn mlx_array_size(handle: *mut mlx_array) -> usize;
     pub fn mlx_array_ndim(handle: *mut mlx_array) -> usize;
     pub fn mlx_array_shape(handle: *mut mlx_array, out: *mut i64);
@@ -700,9 +700,9 @@ unsafe extern "C-unwind" {
 
     // Wrap an existing MTL::Buffer (`void*` MTLBuffer pointer — the same
     // shape `mlx_array_get_metal_buffer` returns) as an MLX `array` view.
-    // Zero-copy: the deleter is a no-op so dropping the resulting array
-    // does NOT free the buffer. Caller (typically LayerKVPool) retains
-    // ownership and must keep the buffer alive for the array's lifetime.
+    // Zero-copy: the returned array retains the underlying MTL::Buffer and
+    // releases that retain when the array is dropped, so the view survives the
+    // original Rust buffer holder.
     //
     // - `metal_buffer_ptr`: MTL::Buffer* as `void*`
     // - `dims`/`ndim`: view shape (caller validates element-count vs

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -1736,6 +1736,21 @@ unsafe extern "C-unwind" {
     /// Returns number of arrays exported, or 0 if not initialized.
     pub fn mlx_qwen35_moe_export_caches(out_ptrs: *mut *mut mlx_array, max_count: i32) -> i32;
 
+    /// Export paged MoE linear-attention caches for live-session continuation.
+    /// Full-attention K/V stays in the Rust paged adapter pools; this returns
+    /// the paged graph's per-layer `(conv_state, recurrent_state)` slots so
+    /// Rust can seed the next turn without replaying the cached prefix through
+    /// GDN. Returns number of arrays exported, or 0 if paged state is not
+    /// initialized.
+    pub fn mlx_qwen35_moe_export_paged_linear_caches(
+        out_ptrs: *mut *mut mlx_array,
+        max_count: i32,
+    ) -> i32;
+
+    /// Get current paged MoE cache offset (tokens processed by the compiled
+    /// paged decode graph).
+    pub fn mlx_qwen35_moe_get_paged_cache_offset() -> i32;
+
     /// Get current MoE cache offset (tokens processed).
     pub fn mlx_qwen35_moe_get_cache_offset() -> i32;
 

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -893,6 +893,26 @@ unsafe extern "C-unwind" {
         kv_dtype: u8,
     ) -> *mut mlx_array;
 
+    /// Emit the MLX C++ `paged_kv_write(...)` Custom primitive and return the
+    /// lazy K/V pool output arrays through `out_k_pool` / `out_v_pool`.
+    /// Returns false for bridge/factory validation errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn mlx_paged_kv_write_forward(
+        k_pool: *mut mlx_array,
+        v_pool: *mut mlx_array,
+        new_k: *mut mlx_array,
+        new_v: *mut mlx_array,
+        slot_mapping: *mut mlx_array,
+        k_scale: *mut mlx_array,
+        v_scale: *mut mlx_array,
+        block_size: i32,
+        num_kv_heads: i32,
+        head_size: i32,
+        kv_dtype: u8,
+        out_k_pool: *mut *mut mlx_array,
+        out_v_pool: *mut *mut mlx_array,
+    ) -> bool;
+
     /// Compare two `PagedKVWrite` primitives via `is_equivalent`.
     /// Returns `true` iff both are equivalent (same scalar state).
     pub fn mlx_paged_kv_write_is_equivalent(
@@ -1214,6 +1234,18 @@ unsafe extern "C-unwind" {
     /// seq_lens sliced as `seq_lens[1:]` (nonzero offset) must be
     /// rejected by the `paged_attention` factory.
     pub fn mlx_paged_attention_factory_rejects_non_contiguous_seq_lens() -> i32;
+
+    /// Production FFI bridge must reject non-contiguous metadata instead
+    /// of hiding it behind lazy `contiguous(...)` metadata copies.
+    pub fn mlx_paged_attention_forward_rejects_non_contiguous_metadata() -> i32;
+
+    /// Production FFI bridge must accept already-materialized metadata and
+    /// evaluate the returned lazy paged-attention output successfully.
+    pub fn mlx_paged_attention_forward_eval_accepts_materialized_metadata() -> i32;
+
+    /// Production FFI bridge must emit and evaluate lazy paged-kv-write pool
+    /// outputs without forcing Rust-side Metal buffer extraction.
+    pub fn mlx_paged_kv_write_forward_eval_smoke() -> i32;
 
     // =============================================================================
     // Phase 1 review-round-9 finding: PagedKVWrite::eval_gpu and

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -870,6 +870,29 @@ unsafe extern "C-unwind" {
 // ================================================================================
 
 unsafe extern "C-unwind" {
+    /// Emit the MLX C++ `paged_attention(...)` Custom primitive and return the
+    /// lazy on-device output array. Returns null for bridge/factory validation
+    /// errors so callers can fall back to a conservative attention path. GPU
+    /// dispatch errors still occur later when MLX evaluates the returned array.
+    #[allow(clippy::too_many_arguments)]
+    pub fn mlx_paged_attention_forward(
+        q: *mut mlx_array,
+        k_pool: *mut mlx_array,
+        v_pool: *mut mlx_array,
+        block_table: *mut mlx_array,
+        seq_lens: *mut mlx_array,
+        k_scale: *mut mlx_array,
+        v_scale: *mut mlx_array,
+        scale: f32,
+        softcap: f32,
+        sliding_window: i32,
+        block_size: i32,
+        num_q_heads: i32,
+        num_kv_heads: i32,
+        head_size: i32,
+        kv_dtype: u8,
+    ) -> *mut mlx_array;
+
     /// Compare two `PagedKVWrite` primitives via `is_equivalent`.
     /// Returns `true` iff both are equivalent (same scalar state).
     pub fn mlx_paged_kv_write_is_equivalent(

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -1631,6 +1631,21 @@ unsafe extern "C-unwind" {
     /// Get current compiled cache offset (tokens processed).
     pub fn mlx_qwen35_get_cache_offset() -> i32;
 
+    /// Export paged dense linear-attention caches for live-session continuation.
+    /// Full-attention K/V stays in the Rust paged adapter pools; this returns
+    /// the paged graph's per-layer `(conv_state, recurrent_state)` slots so
+    /// Rust can seed the next turn without replaying the cached prefix through
+    /// GDN. Returns number of arrays exported, or 0 if paged state is not
+    /// initialized.
+    pub fn mlx_qwen35_export_paged_linear_caches(
+        out_ptrs: *mut *mut mlx_array,
+        max_count: i32,
+    ) -> i32;
+
+    /// Get current paged dense cache offset (tokens processed by the compiled
+    /// paged decode graph).
+    pub fn mlx_qwen35_get_paged_cache_offset() -> i32;
+
     // ============================================
     // Phase 5 piece 1: paged Dense forward (coexists with the flat
     // compiled path). The Rust dispatcher decides per-turn which graph

--- a/crates/mlx-sys/src/mlx_common.h
+++ b/crates/mlx-sys/src/mlx_common.h
@@ -13,9 +13,13 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <cstdint>
+#include <cctype>
 #include <cstring>
+#include <fstream>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 #include <iostream>
@@ -116,6 +120,31 @@ using mlx::core::sum;
 using mlx::core::take;
 using mlx::core::transpose;
 using mlx::core::zeros;
+
+inline bool mlx_env_flag_enabled(const char* value) {
+  if (!value) return false;
+  std::string v(value);
+  std::transform(v.begin(), v.end(), v.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return v == "1" || v == "true" || v == "yes" || v == "on";
+}
+
+inline void mlx_trace_native_error(const char* context, const char* detail) {
+  if (!mlx_env_flag_enabled(std::getenv("MLX_INFERENCE_TRACE"))) return;
+  const char* path = std::getenv("MLX_INFERENCE_TRACE_FILE");
+  if (!path || !*path) return;
+  std::ofstream out(path, std::ios::app);
+  if (!out) return;
+  out << "native_error context=" << (context ? context : "unknown") << " detail=\"";
+  if (detail) {
+    for (const char* p = detail; *p; ++p) {
+      char c = *p;
+      out << ((c == '\n' || c == '\r' || c == '"') ? ' ' : c);
+    }
+  }
+  out << "\"\n";
+}
 
 // Comparison operations
 using mlx::core::equal;

--- a/crates/mlx-sys/src/mlx_nn_ops.cpp
+++ b/crates/mlx-sys/src/mlx_nn_ops.cpp
@@ -31,9 +31,9 @@ void mlx_array_eval(mlx_array* handle) {
       arr->eval();
     }
   } catch (const std::exception& e) {
-    std::cerr << "[MLX] Exception in array_eval: " << e.what() << std::endl;
+    mlx_trace_native_error("array_eval", e.what());
   } catch (...) {
-    std::cerr << "[MLX] Unknown exception in array_eval" << std::endl;
+    mlx_trace_native_error("array_eval", "unknown exception");
   }
 }
 
@@ -48,23 +48,32 @@ void mlx_async_eval(mlx_array** handles, size_t count) {
     }
     mlx::core::async_eval(std::move(arrays));
   } catch (const std::exception& e) {
-    std::cerr << "[MLX] Exception in async_eval: " << e.what() << std::endl;
+    mlx_trace_native_error("async_eval", e.what());
   } catch (...) {
-    std::cerr << "[MLX] Unknown exception in async_eval" << std::endl;
+    mlx_trace_native_error("async_eval", "unknown exception");
   }
 }
 
 // Synchronous eval — matches Python's mx.eval(arrays).
 // Unlike async_eval, this blocks until all arrays are materialized.
-void mlx_eval(mlx_array** handles, size_t count) {
-  std::vector<array> arrays;
-  arrays.reserve(count);
-  for (size_t i = 0; i < count; ++i) {
-    if (handles[i]) {
-      arrays.push_back(*reinterpret_cast<array*>(handles[i]));
+bool mlx_eval(mlx_array** handles, size_t count) {
+  try {
+    std::vector<array> arrays;
+    arrays.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+      if (handles[i]) {
+        arrays.push_back(*reinterpret_cast<array*>(handles[i]));
+      }
     }
+    mlx::core::eval(std::move(arrays));
+    return true;
+  } catch (const std::exception& e) {
+    mlx_trace_native_error("eval", e.what());
+    return false;
+  } catch (...) {
+    mlx_trace_native_error("eval", "unknown exception");
+    return false;
   }
-  mlx::core::eval(std::move(arrays));
 }
 
 size_t mlx_array_size(mlx_array* handle) {
@@ -932,9 +941,17 @@ mlx_array* mlx_fast_scaled_dot_product_attention(mlx_array* queries,
     }
   }
 
-  array result = fast::scaled_dot_product_attention(
-      *q, *k, *v, scale, mask_mode, mask_arr, std::nullopt);
-  return reinterpret_cast<mlx_array*>(new array(std::move(result)));
+  try {
+    array result = fast::scaled_dot_product_attention(
+        *q, *k, *v, scale, mask_mode, mask_arr, std::nullopt);
+    return reinterpret_cast<mlx_array*>(new array(std::move(result)));
+  } catch (const std::exception& e) {
+    mlx_trace_native_error("fast_scaled_dot_product_attention", e.what());
+    return nullptr;
+  } catch (...) {
+    mlx_trace_native_error("fast_scaled_dot_product_attention", "unknown exception");
+    return nullptr;
+  }
 }
 
 mlx_array* mlx_fast_rms_norm(mlx_array* x,

--- a/crates/mlx-sys/src/mlx_paged_ops.cpp
+++ b/crates/mlx-sys/src/mlx_paged_ops.cpp
@@ -1366,7 +1366,11 @@ mlx_array* mlx_paged_attention_forward(
         kv_dtype);
 
     return reinterpret_cast<mlx_array*>(new array(std::move(out)));
+  } catch (const std::exception& e) {
+    mlx_trace_native_error("paged_attention_forward", e.what());
+    return nullptr;
   } catch (...) {
+    mlx_trace_native_error("paged_attention_forward", "unknown exception");
     return nullptr;
   }
 }

--- a/crates/mlx-sys/src/mlx_paged_ops.cpp
+++ b/crates/mlx-sys/src/mlx_paged_ops.cpp
@@ -1343,17 +1343,22 @@ mlx_array* mlx_paged_attention_forward(
 
     // The public factory rejects non-row-contiguous/nonzero-offset inputs.
     // `q` is often produced by reshape/slice/rope chains in Rust model code,
-    // so materialize cheap metadata tensors and q explicitly at this bridge.
+    // so materialize q explicitly at this bridge.
+    //
+    // Metadata is different: `PagedAttention::eval_gpu` performs host-side
+    // content checks on block_table/seq_lens before dispatch. Wrapping those
+    // arrays in lazy `contiguous(...)` nodes can make the validator read lazy
+    // metadata copies rather than the adapter-owned materialized arrays. Keep
+    // the metadata contract strict here: Rust owns materialized, row-contiguous,
+    // zero-offset metadata arrays, and the factory validates that contract.
     auto q = contiguous(q_raw);
-    auto block_table = contiguous(block_table_raw);
-    auto seq_lens = contiguous(seq_lens_raw);
 
     auto out = paged_attention(
         q,
         k_pool,
         v_pool,
-        block_table,
-        seq_lens,
+        block_table_raw,
+        seq_lens_raw,
         k_scale,
         v_scale,
         scale,
@@ -1372,6 +1377,89 @@ mlx_array* mlx_paged_attention_forward(
   } catch (...) {
     mlx_trace_native_error("paged_attention_forward", "unknown exception");
     return nullptr;
+  }
+}
+
+/// Production FFI: emit a `PagedKVWrite` MLX Custom primitive and return the
+/// dependency-carrying K/V pool output arrays. The returned arrays share the
+/// same Metal buffers as the input pools, but they also carry the MLX graph edge
+/// from `new_k/new_v` -> cache write. Rust callers must feed these arrays into
+/// subsequent MLX paged-attention reads, or explicitly eval them before raw
+/// Metal readers touch the pool.
+///
+/// Returns false on bridge/factory validation errors. GPU dispatch errors still
+/// surface later when MLX evaluates the returned arrays.
+bool mlx_paged_kv_write_forward(
+    mlx_array* k_pool_ptr,
+    mlx_array* v_pool_ptr,
+    mlx_array* new_k_ptr,
+    mlx_array* new_v_ptr,
+    mlx_array* slot_mapping_ptr,
+    mlx_array* k_scale_ptr,
+    mlx_array* v_scale_ptr,
+    int block_size,
+    int num_kv_heads,
+    int head_size,
+    uint8_t kv_dtype_raw,
+    mlx_array** out_k_pool_ptr,
+    mlx_array** out_v_pool_ptr) {
+  if (out_k_pool_ptr) {
+    *out_k_pool_ptr = nullptr;
+  }
+  if (out_v_pool_ptr) {
+    *out_v_pool_ptr = nullptr;
+  }
+  if (!k_pool_ptr || !v_pool_ptr || !new_k_ptr || !new_v_ptr ||
+      !slot_mapping_ptr || !k_scale_ptr || !v_scale_ptr || !out_k_pool_ptr ||
+      !out_v_pool_ptr) {
+    return false;
+  }
+
+  try {
+    using namespace mlx::core;
+    using namespace mlx::core::fast;
+
+    auto& k_pool       = *reinterpret_cast<array*>(k_pool_ptr);
+    auto& v_pool       = *reinterpret_cast<array*>(v_pool_ptr);
+    auto& new_k_raw    = *reinterpret_cast<array*>(new_k_ptr);
+    auto& new_v_raw    = *reinterpret_cast<array*>(new_v_ptr);
+    auto& slot_mapping = *reinterpret_cast<array*>(slot_mapping_ptr);
+    auto& k_scale      = *reinterpret_cast<array*>(k_scale_ptr);
+    auto& v_scale      = *reinterpret_cast<array*>(v_scale_ptr);
+
+    auto kv_dtype = static_cast<KvDtype>(kv_dtype_raw);
+
+    // Rust model code commonly produces K/V via transpose/reshape chains.
+    // Keep these as lazy MLX `contiguous(...)` nodes instead of extracting
+    // Metal buffers on the Rust side; this is the point of the bridge.
+    auto new_k = contiguous(new_k_raw);
+    auto new_v = contiguous(new_v_raw);
+
+    auto out = paged_kv_write(
+        k_pool,
+        v_pool,
+        new_k,
+        new_v,
+        slot_mapping,
+        k_scale,
+        v_scale,
+        block_size,
+        num_kv_heads,
+        head_size,
+        x_pack_for(kv_dtype),
+        kv_dtype);
+
+    *out_k_pool_ptr = reinterpret_cast<mlx_array*>(
+        new array(std::move(out.first)));
+    *out_v_pool_ptr = reinterpret_cast<mlx_array*>(
+        new array(std::move(out.second)));
+    return true;
+  } catch (const std::exception& e) {
+    mlx_trace_native_error("paged_kv_write_forward", e.what());
+    return false;
+  } catch (...) {
+    mlx_trace_native_error("paged_kv_write_forward", "unknown exception");
+    return false;
   }
 }
 
@@ -3805,6 +3893,185 @@ int mlx_paged_attention_factory_rejects_non_contiguous_seq_lens() {
     return 0;
   }
   return 0;
+}
+
+/// Regression for the production FFI bridge: it must not hide invalid
+/// metadata views by wrapping block_table/seq_lens in `contiguous(...)`.
+/// Metadata is host-read inside `PagedAttention::eval_gpu`, so the bridge
+/// preserves the adapter-owned metadata arrays and lets the factory reject
+/// non-row-contiguous / nonzero-offset metadata. Returns 1 when the bridge
+/// rejects the sliced block_table, 0 if it incorrectly returns a lazy output,
+/// and -3 if Metal is unavailable for slice materialization.
+int mlx_paged_attention_forward_rejects_non_contiguous_metadata() {
+  using namespace mlx::core;
+
+  if (!mlx::core::metal::is_available()) {
+    return -3;
+  }
+
+  array bt_full = make_int32_zeros(Shape{2, 4});
+  eval(bt_full);
+  array bt_sliced = mlx::core::slice(
+      bt_full,
+      Shape{1, 0},
+      Shape{2, 4},
+      Shape{1, 1});
+  eval(bt_sliced);
+
+  array q = make_bf16_zeros(Shape{1, 8, 64});
+  array k_pool = make_bf16_zeros(Shape{4, 4, 8, 16, 8});
+  array v_pool = make_bf16_zeros(Shape{4, 4, 64, 16});
+  std::vector<int32_t> seq_host = {1};
+  array seq_lens(seq_host.data(), Shape{1}, int32);
+  array k_scale(1.0f, float32);
+  array v_scale(1.0f, float32);
+
+  auto* out_ptr = mlx_paged_attention_forward(
+      reinterpret_cast<mlx_array*>(&q),
+      reinterpret_cast<mlx_array*>(&k_pool),
+      reinterpret_cast<mlx_array*>(&v_pool),
+      reinterpret_cast<mlx_array*>(&bt_sliced),
+      reinterpret_cast<mlx_array*>(&seq_lens),
+      reinterpret_cast<mlx_array*>(&k_scale),
+      reinterpret_cast<mlx_array*>(&v_scale),
+      /*scale=*/0.125f,
+      /*softcap=*/0.0f,
+      /*sliding_window=*/0,
+      /*block_size=*/16,
+      /*num_q_heads=*/8,
+      /*num_kv_heads=*/4,
+      /*head_size=*/64,
+      /*kv_dtype_raw=*/1);
+
+  if (out_ptr == nullptr) {
+    return 1;
+  }
+  delete reinterpret_cast<array*>(out_ptr);
+  return 0;
+}
+
+/// Valid bridge smoke: materialized, row-contiguous metadata should survive
+/// the FFI wrapper and evaluate later as a lazy paged-attention output.
+/// Returns 1 on success, 0 on eval-time metadata validation failure, -1 on
+/// internal setup/dispatch errors, and -3 if Metal is unavailable.
+int mlx_paged_attention_forward_eval_accepts_materialized_metadata() {
+  using namespace mlx::core;
+
+  if (!mlx::core::metal::is_available()) {
+    return -3;
+  }
+
+  array q = make_bf16_zeros(Shape{2, 8, 64});
+  array k_pool = make_bf16_zeros(Shape{4, 4, 8, 16, 8});
+  array v_pool = make_bf16_zeros(Shape{4, 4, 64, 16});
+  std::vector<int32_t> blocks = {
+      0, -1, -1, -1,
+      0,  1, -1, -1,
+  };
+  std::vector<int32_t> seqs = {1, 17};
+  array block_table(blocks.data(), Shape{2, 4}, int32);
+  array seq_lens(seqs.data(), Shape{2}, int32);
+  array k_scale(1.0f, float32);
+  array v_scale(1.0f, float32);
+
+  auto* out_ptr = mlx_paged_attention_forward(
+      reinterpret_cast<mlx_array*>(&q),
+      reinterpret_cast<mlx_array*>(&k_pool),
+      reinterpret_cast<mlx_array*>(&v_pool),
+      reinterpret_cast<mlx_array*>(&block_table),
+      reinterpret_cast<mlx_array*>(&seq_lens),
+      reinterpret_cast<mlx_array*>(&k_scale),
+      reinterpret_cast<mlx_array*>(&v_scale),
+      /*scale=*/0.125f,
+      /*softcap=*/0.0f,
+      /*sliding_window=*/0,
+      /*block_size=*/16,
+      /*num_q_heads=*/8,
+      /*num_kv_heads=*/4,
+      /*head_size=*/64,
+      /*kv_dtype_raw=*/1);
+
+  if (out_ptr == nullptr) {
+    return -1;
+  }
+
+  auto* out = reinterpret_cast<array*>(out_ptr);
+  try {
+    eval(*out);
+  } catch (const std::invalid_argument& e) {
+    fprintf(stderr, "[paged_attention_forward_valid_metadata] %s\n", e.what());
+    delete out;
+    return 0;
+  } catch (const std::exception& e) {
+    fprintf(stderr, "[paged_attention_forward_valid_metadata] %s\n", e.what());
+    delete out;
+    return -1;
+  } catch (...) {
+    delete out;
+    return -1;
+  }
+
+  delete out;
+  return 1;
+}
+
+/// Valid bridge smoke: materialized metadata and lazy K/V inputs should emit
+/// dependency-carrying pool outputs and evaluate successfully.
+/// Returns 1 on success, 0 when the production bridge rejects the setup, -1 on
+/// eval-time failure, and -3 if Metal is unavailable.
+int mlx_paged_kv_write_forward_eval_smoke() {
+  using namespace mlx::core;
+
+  if (!mlx::core::metal::is_available()) {
+    return -3;
+  }
+
+  try {
+    array k_pool = make_bf16_zeros(Shape{4, 4, 8, 16, 8});
+    array v_pool = make_bf16_zeros(Shape{4, 4, 64, 16});
+    array new_k = make_bf16_zeros(Shape{2, 4, 64});
+    array new_v = make_bf16_zeros(Shape{2, 4, 64});
+    std::vector<int64_t> slots = {0, 1};
+    array slot_mapping(slots.data(), Shape{2}, int64);
+    array k_scale(1.0f, float32);
+    array v_scale(1.0f, float32);
+    eval(slot_mapping);
+
+    mlx_array* out_k = nullptr;
+    mlx_array* out_v = nullptr;
+    bool ok = mlx_paged_kv_write_forward(
+        reinterpret_cast<mlx_array*>(&k_pool),
+        reinterpret_cast<mlx_array*>(&v_pool),
+        reinterpret_cast<mlx_array*>(&new_k),
+        reinterpret_cast<mlx_array*>(&new_v),
+        reinterpret_cast<mlx_array*>(&slot_mapping),
+        reinterpret_cast<mlx_array*>(&k_scale),
+        reinterpret_cast<mlx_array*>(&v_scale),
+        /*block_size=*/16,
+        /*num_kv_heads=*/4,
+        /*head_size=*/64,
+        /*kv_dtype_raw=*/1,
+        &out_k,
+        &out_v);
+    if (!ok || out_k == nullptr || out_v == nullptr) {
+      if (out_k) {
+        delete reinterpret_cast<array*>(out_k);
+      }
+      if (out_v) {
+        delete reinterpret_cast<array*>(out_v);
+      }
+      return 0;
+    }
+
+    auto* k_out = reinterpret_cast<array*>(out_k);
+    auto* v_out = reinterpret_cast<array*>(out_v);
+    eval(*k_out, *v_out);
+    delete k_out;
+    delete v_out;
+    return 1;
+  } catch (...) {
+    return -1;
+  }
 }
 
 } // extern "C"

--- a/crates/mlx-sys/src/mlx_paged_ops.cpp
+++ b/crates/mlx-sys/src/mlx_paged_ops.cpp
@@ -1295,6 +1295,82 @@ array paged_attention(
 
 } // namespace mlx::core::fast
 
+extern "C" {
+
+/// Production FFI: emit a `PagedAttention` MLX Custom primitive and return
+/// the resulting on-device array. This is intentionally a tiny bridge over
+/// the C++ factory so Rust model code can use the same MLX-graph paged
+/// attention primitive as the compiled Qwen path without copying attention
+/// outputs through host memory.
+///
+/// Returns nullptr on bridge/factory validation errors; Rust callers keep the
+/// existing read_kv_range + SDPA path as fallback. The returned array is still
+/// lazy, so GPU dispatch errors surface later when MLX evaluates the graph.
+mlx_array* mlx_paged_attention_forward(
+    mlx_array* q_ptr,
+    mlx_array* k_pool_ptr,
+    mlx_array* v_pool_ptr,
+    mlx_array* block_table_ptr,
+    mlx_array* seq_lens_ptr,
+    mlx_array* k_scale_ptr,
+    mlx_array* v_scale_ptr,
+    float scale,
+    float softcap,
+    int sliding_window,
+    int block_size,
+    int num_q_heads,
+    int num_kv_heads,
+    int head_size,
+    uint8_t kv_dtype_raw) {
+  if (!q_ptr || !k_pool_ptr || !v_pool_ptr || !block_table_ptr ||
+      !seq_lens_ptr || !k_scale_ptr || !v_scale_ptr) {
+    return nullptr;
+  }
+
+  try {
+    using namespace mlx::core;
+    using namespace mlx::core::fast;
+
+    auto& q_raw           = *reinterpret_cast<array*>(q_ptr);
+    auto& k_pool          = *reinterpret_cast<array*>(k_pool_ptr);
+    auto& v_pool          = *reinterpret_cast<array*>(v_pool_ptr);
+    auto& block_table_raw = *reinterpret_cast<array*>(block_table_ptr);
+    auto& seq_lens_raw    = *reinterpret_cast<array*>(seq_lens_ptr);
+    auto& k_scale         = *reinterpret_cast<array*>(k_scale_ptr);
+    auto& v_scale         = *reinterpret_cast<array*>(v_scale_ptr);
+
+    auto kv_dtype = static_cast<KvDtype>(kv_dtype_raw);
+
+    // The public factory rejects non-row-contiguous/nonzero-offset inputs.
+    // `q` is often produced by reshape/slice/rope chains in Rust model code,
+    // so materialize cheap metadata tensors and q explicitly at this bridge.
+    auto q = contiguous(q_raw);
+    auto block_table = contiguous(block_table_raw);
+    auto seq_lens = contiguous(seq_lens_raw);
+
+    auto out = paged_attention(
+        q,
+        k_pool,
+        v_pool,
+        block_table,
+        seq_lens,
+        k_scale,
+        v_scale,
+        scale,
+        softcap,
+        sliding_window,
+        block_size,
+        num_q_heads,
+        num_kv_heads,
+        head_size,
+        kv_dtype);
+
+    return reinterpret_cast<mlx_array*>(new array(std::move(out)));
+  } catch (...) {
+    return nullptr;
+  }
+}
+
 // =============================================================================
 // FFI test helpers (Phase 1 only)
 //
@@ -1305,8 +1381,6 @@ array paged_attention(
 // these once the dispatch path is C++-native and unit tests live in
 // mlx-sys directly.
 // =============================================================================
-
-extern "C" {
 
 /// Construct two `PagedKVWrite` primitives with the supplied scalar
 /// state and return whether `lhs.is_equivalent(rhs)` is true.

--- a/crates/mlx-sys/src/mlx_qwen35.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35.cpp
@@ -61,6 +61,11 @@ static std::vector<array> g_dense_paged_linear_caches;  // [num_layers * 2]
 static int g_dense_paged_offset_int = 0;
 static bool g_dense_paged_inited = false;
 
+static bool dense_paged_is_linear_layer(int layer) {
+  int interval = g_dense_paged_config.full_attention_interval;
+  return interval <= 0 || ((layer + 1) % interval != 0);
+}
+
 // =============================================================================
 // The compilable forward function
 // inputs: [h, offset_arr, cache[0].a, cache[0].b, ..., cache[N-1].a, cache[N-1].b]
@@ -114,18 +119,18 @@ static std::vector<array> qwen35_decode_fn(const std::vector<array>& inputs) {
     // MLP (SwiGLU)
     std::string mp = lp + ".mlp.";
     auto mlp_in  = fast::rms_norm(h, get_weight(lp + ".post_attention_layernorm.weight"), cfg.rms_norm_eps);
-    auto gate    = matmul(mlp_in, get_weight_t(mp + "gate_proj.weight"));
-    auto up      = matmul(mlp_in, get_weight_t(mp + "up_proj.weight"));
-    auto mlp_out = matmul(swiglu(gate, up), get_weight_t(mp + "down_proj.weight"));
+    auto gate    = linear_proj(mlp_in, mp + "gate_proj");
+    auto up      = linear_proj(mlp_in, mp + "up_proj");
+    auto mlp_out = linear_proj(swiglu(gate, up), mp + "down_proj");
     h = h + mlp_out;
   }
 
   // Final norm + LM head
   h = fast::rms_norm(h, get_weight("final_norm.weight"), cfg.rms_norm_eps);
   if (cfg.tie_word_embeddings) {
-    h = matmul(h, get_weight_t("embedding.weight"));
+    h = linear_proj(h, "embedding");
   } else {
-    h = matmul(h, get_weight_t("lm_head.weight"));
+    h = linear_proj(h, "lm_head");
   }
 
   auto new_offset = array(offset + 1, mlx::core::int32);
@@ -254,18 +259,18 @@ static std::vector<array> dense_compiled_decode_fn_paged(const std::vector<array
     // Dense MLP (SwiGLU) — no MoE routing.
     std::string mp = lp + ".mlp.";
     auto mlp_in  = fast::rms_norm(h, get_weight(lp + ".post_attention_layernorm.weight"), cfg.rms_norm_eps);
-    auto gate    = matmul(mlp_in, get_weight_t(mp + "gate_proj.weight"));
-    auto up      = matmul(mlp_in, get_weight_t(mp + "up_proj.weight"));
-    auto mlp_out = matmul(swiglu(gate, up), get_weight_t(mp + "down_proj.weight"));
+    auto gate    = linear_proj(mlp_in, mp + "gate_proj");
+    auto up      = linear_proj(mlp_in, mp + "up_proj");
+    auto mlp_out = linear_proj(swiglu(gate, up), mp + "down_proj");
     h = h + mlp_out;
   }
 
   // Final norm + LM head
   h = fast::rms_norm(h, get_weight("final_norm.weight"), cfg.rms_norm_eps);
   if (cfg.tie_word_embeddings) {
-    h = matmul(h, get_weight_t("embedding.weight"));
+    h = linear_proj(h, "embedding");
   } else {
-    h = matmul(h, get_weight_t("lm_head.weight"));
+    h = linear_proj(h, "lm_head");
   }
 
   auto new_offset = offset_arr + array(1, mlx::core::int32);
@@ -485,6 +490,27 @@ int mlx_qwen35_get_cache_offset() {
   return g_offset_int;
 }
 
+int mlx_qwen35_export_paged_linear_caches(mlx_array** out_ptrs, int max_count) {
+  if (!g_dense_paged_inited || g_dense_paged_linear_caches.empty()) return 0;
+  int expected = static_cast<int>(g_dense_paged_linear_caches.size());
+  int count = std::min(expected, max_count);
+  for (int i = 0; i < count; i++) {
+    out_ptrs[i] = nullptr;
+  }
+  for (int layer = 0; layer < g_dense_paged_config.num_layers; layer++) {
+    int base = layer * 2;
+    if (base + 1 >= count) break;
+    if (!dense_paged_is_linear_layer(layer)) continue;
+    out_ptrs[base] = reinterpret_cast<mlx_array*>(new array(g_dense_paged_linear_caches[base]));
+    out_ptrs[base + 1] = reinterpret_cast<mlx_array*>(new array(g_dense_paged_linear_caches[base + 1]));
+  }
+  return count;
+}
+
+int mlx_qwen35_get_paged_cache_offset() {
+  return g_dense_paged_offset_int;
+}
+
 // =============================================================================
 // Phase 5 piece 1: paged Dense forward FFI.
 //
@@ -588,7 +614,7 @@ int32_t mlx_qwen35_init_paged(
     auto f32_placeholder  = []() { return array(1.0f, mlx::core::float32); };
 
     for (int i = 0; i < num_layers; i++) {
-      bool is_linear = !((i + 1) % full_attention_interval == 0);
+      bool is_linear = dense_paged_is_linear_layer(i);
 
       // Pool / scale slots: meaningful for full-attn layers only.
       if (!is_linear) {
@@ -636,7 +662,7 @@ int32_t mlx_qwen35_init_paged(
       std::vector<array> probe;
       probe.reserve(num_layers * 4 + 1);
       for (int i = 0; i < num_layers; i++) {
-        bool is_linear = !((i + 1) % full_attention_interval == 0);
+        bool is_linear = dense_paged_is_linear_layer(i);
         if (is_linear) continue;
         // Validate dtype contract: pools must be bf16, scales must be f32.
         if (g_dense_k_pools[i].dtype() != mlx::core::bfloat16) {
@@ -779,7 +805,7 @@ void mlx_qwen35_forward_paged(
     fn_inputs.push_back(num_valid_blocks);
     fn_inputs.push_back(seq_lens);
     for (int i = 0; i < cfg.num_layers; i++) {
-      bool is_linear = !((i + 1) % cfg.full_attention_interval == 0);
+      bool is_linear = dense_paged_is_linear_layer(i);
       if (is_linear) {
         fn_inputs.push_back(g_dense_paged_linear_caches[i * 2]);
         fn_inputs.push_back(g_dense_paged_linear_caches[i * 2 + 1]);
@@ -803,7 +829,7 @@ void mlx_qwen35_forward_paged(
     g_dense_paged_offset_int++;
     // Stash post-step caches back into the per-layer slots.
     for (int i = 0; i < cfg.num_layers; i++) {
-      bool is_linear = !((i + 1) % cfg.full_attention_interval == 0);
+      bool is_linear = dense_paged_is_linear_layer(i);
       auto& a = outputs[2 + i * 2];
       auto& b = outputs[2 + i * 2 + 1];
       if (is_linear) {

--- a/crates/mlx-sys/src/mlx_qwen35_moe.cpp
+++ b/crates/mlx-sys/src/mlx_qwen35_moe.cpp
@@ -980,6 +980,35 @@ int mlx_qwen35_moe_export_caches(mlx_array** out_ptrs, int max_count) {
   return count;
 }
 
+// Export paged linear-attention caches for live-session continuation.
+//
+// The block-paged path keeps full-attention K/V in the Rust adapter pools, but
+// compiled paged decode advances GDN conv/recurrent state in
+// `g_paged_linear_caches`. Rust needs those arrays back before
+// `mlx_qwen35_moe_reset()` clears the globals, otherwise the next turn has to
+// replay the whole cached prefix through GDN.
+int mlx_qwen35_moe_export_paged_linear_caches(mlx_array** out_ptrs, int max_count) {
+  if (!g_paged_inited || g_paged_linear_caches.empty()) return 0;
+  int expected = static_cast<int>(g_paged_linear_caches.size());
+  int count = std::min(expected, max_count);
+  for (int i = 0; i < count; i++) {
+    out_ptrs[i] = nullptr;
+  }
+  for (int layer = 0; layer < g_paged_config.num_layers; layer++) {
+    int base = layer * 2;
+    if (base + 1 >= count) break;
+    bool is_linear = !((layer + 1) % g_paged_config.full_attention_interval == 0);
+    if (!is_linear) continue;
+    out_ptrs[base] = reinterpret_cast<mlx_array*>(new array(g_paged_linear_caches[base]));
+    out_ptrs[base + 1] = reinterpret_cast<mlx_array*>(new array(g_paged_linear_caches[base + 1]));
+  }
+  return count;
+}
+
+int mlx_qwen35_moe_get_paged_cache_offset() {
+  return g_paged_offset_int;
+}
+
 // Get current MoE cache offset (number of tokens processed).
 int mlx_qwen35_moe_get_cache_offset() {
   return g_moe_offset_int;

--- a/example-tools.js
+++ b/example-tools.js
@@ -1,0 +1,122 @@
+const BASE_URL = 'http://localhost:8080/v1';
+const MODEL = 'qwen3.5-9b';
+
+async function callResponses(input, options = {}) {
+  const res = await fetch(`${BASE_URL}/responses`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: MODEL,
+      input,
+      reasoning: { effort: 'none' },
+      ...options,
+    }),
+  });
+  return res.json();
+}
+
+// Define tools
+const tools = [
+  {
+    type: 'function',
+    name: 'get_weather',
+    description: 'Get the current weather for a given location.',
+    parameters: {
+      type: 'object',
+      properties: {
+        location: { type: 'string', description: 'City name, e.g. "San Francisco"' },
+        unit: { type: 'string', enum: ['celsius', 'fahrenheit'], description: 'Temperature unit' },
+      },
+      required: ['location'],
+    },
+  },
+  {
+    type: 'function',
+    name: 'search_web',
+    description: 'Search the web for information.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'The search query' },
+      },
+      required: ['query'],
+    },
+  },
+];
+
+// Fake tool implementations
+function executeToolCall(name, args) {
+  switch (name) {
+    case 'get_weather':
+      return JSON.stringify({
+        temperature: 18,
+        condition: 'sunny',
+        location: args.location,
+        unit: args.unit ?? 'celsius',
+      });
+    case 'search_web':
+      return JSON.stringify({ results: [`Result 1 for "${args.query}"`, `Result 2 for "${args.query}"`] });
+    default:
+      return JSON.stringify({ error: `Unknown tool: ${name}` });
+  }
+}
+
+async function main() {
+  // Step 1: Send a message with tools
+  console.log('--- Step 1: Ask a question that needs tools ---');
+  const response1 = await callResponses('What is the weather in Tokyo and San Francisco?', { tools });
+
+  console.log('Status:', response1.status);
+  console.log(
+    'Output items:',
+    response1.output.map((o) => `${o.type}${o.name ? ` (${o.name})` : ''}`),
+  );
+
+  // Step 2: If the model made tool calls, execute them and send results back
+  const functionCalls = response1.output.filter((o) => o.type === 'function_call');
+
+  if (functionCalls.length === 0) {
+    console.log('No tool calls — model answered directly:');
+    console.log(response1.output_text);
+    return;
+  }
+
+  console.log(`\n--- Step 2: Execute ${functionCalls.length} tool call(s) ---`);
+
+  // Build input items: echo back the function calls + provide results
+  const toolResultItems = [];
+  for (const fc of functionCalls) {
+    const args = JSON.parse(fc.arguments);
+    const result = executeToolCall(fc.name, args);
+    console.log(`  ${fc.name}(${JSON.stringify(args)}) => ${result}`);
+
+    // Echo the function_call back
+    toolResultItems.push({
+      type: 'function_call',
+      id: fc.id,
+      call_id: fc.call_id,
+      name: fc.name,
+      arguments: fc.arguments,
+    });
+
+    // Provide the result
+    toolResultItems.push({
+      type: 'function_call_output',
+      call_id: fc.call_id,
+      output: result,
+    });
+  }
+
+  // Step 3: Send tool results back using previous_response_id
+  console.log('\n--- Step 3: Send tool results back ---');
+  const response2 = await callResponses(toolResultItems, {
+    tools,
+    previous_response_id: response1.id,
+  });
+
+  console.log('Status:', response2.status);
+  console.log('Response:', response2.output_text);
+  console.log('\nUsage:', response2.usage);
+}
+
+main().catch(console.error);

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -59,6 +59,12 @@ Options:
                                   Defaults to 64.
     MLX_PAGED_CACHE_MEMORY_MB      Paged KV cache memory budget override for
                                   paged-aware Qwen3.5 launch.
+    MLX_GEMMA4_NATIVE_KV_WRITE    Set to 0/false/off to disable graph-native
+                                  Gemma4 global KV writes.
+    MLX_GEMMA4_MAX_SLIDING_RESTORE_TOKENS
+                                  Max cached Gemma4 prefix tokens to replay
+                                  for sliding-cache restore. Defaults to 32768
+                                  for the 1024-token sliding window.
     MLX_INFERENCE_TRACE           Set to 1/true/on to write native inference
                                   phase traces to a file.
     MLX_INFERENCE_TRACE_FILE      Override the native trace file path.

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -47,10 +47,10 @@ Options:
 
   Environment variables:
     MLX_PAGED_PREFILL_CHUNK_SIZE  Tokens per paged-prefill chunk. Defaults to
-                                  4096 under \`mlx launch claude\` to bound
+                                  1024 under \`mlx launch claude\` to bound
                                   cold-prefill memory peaks; set to 0 to
-                                  disable chunking, or to a smaller value
-                                  (e.g. 1024 / 512) if 4096 still peaks.
+                                  disable chunking, or tune explicitly for
+                                  your workload.
     MLX_PAGED_PREFILL_EVAL_INTERVAL
                                   Layer cadence for eval+clear during paged
                                   prefill. Defaults to 8.
@@ -149,19 +149,16 @@ export async function run(argv: string[]): Promise<void> {
     return;
   }
 
-  // Bound paged-prefill memory peak by chunking the prompt: default of
-  // 4096 tokens/chunk caps per-chunk SDPA + MoE intermediates to
-  // chunk-sized tiles instead of full-prompt tiles. Empirically 4096
-  // keeps Qwen3.6-35b-a3b 28-43K-token cold prefills at ~50 GB wired
-  // memory with zero swap (vs. the unchunked 117 GB / 39 GB swap), and
-  // halves the per-chunk synchronize_and_clear_cache + host-roundtrip
-  // K/V replay overhead vs. 1024. Respect any user-provided value (set
-  // in shell) so power users can tune down (e.g. 1024 / 512) if a
-  // larger context still peaks. The MLX env var is read via OnceLock on
-  // first paged-prefill call, so setting `process.env` here — before any
-  // model loads — is sufficient to apply the default.
+  // Bound paged-prefill memory peak by chunking the prompt. Keep this as a
+  // launcher default, not a Rust default: the shared native env var still uses
+  // 0 as "disable chunking", and non-Claude callers may want single-shot
+  // behavior. On Gemma4 26B Q8, a 36K-token cold-prefill sweep on this machine
+  // measured 1024 faster than 512 / 2048 / 4096 while preserving the same
+  // final-token split. Respect any user-provided value (set in shell). The MLX
+  // env var is read via OnceLock on first paged-prefill call, so setting
+  // `process.env` here before model load is sufficient.
   if (process.env.MLX_PAGED_PREFILL_CHUNK_SIZE == null) {
-    process.env.MLX_PAGED_PREFILL_CHUNK_SIZE = '4096';
+    process.env.MLX_PAGED_PREFILL_CHUNK_SIZE = '1024';
   }
 
   const modelsDir = resolveModelsDir(args['models-dir']);

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -51,6 +51,14 @@ Options:
 	                                cold-prefill memory peaks; set to 0 to
 	                                disable chunking, or to a smaller value
 	                                (e.g. 1024 / 512) if 4096 still peaks.
+	  MLX_PAGED_PREFILL_EVAL_INTERVAL
+	                                Layer cadence for eval+clear during paged
+	                                prefill. Defaults to 8.
+	  MLX_PAGED_DECODE_CACHE_CLEAR_INTERVAL
+	                                Token cadence for paged decode cache clear.
+	                                Defaults to 64.
+	  MLX_PAGED_CACHE_MEMORY_MB      Paged KV cache memory budget override for
+	                                paged-aware Qwen3.5 launch.
 	  MLX_INFERENCE_TRACE           Set to 1/true/on to write native inference
 	                                phase traces to a file.
 	  MLX_INFERENCE_TRACE_FILE      Override the native trace file path.
@@ -222,35 +230,6 @@ export async function run(argv: string[]): Promise<void> {
 
   console.log(
     `[mlx] models dir: ${modelsDir} | listening on http://${host}:${port} | discovered ${discovered.length} model(s) | default: ${boundModel.name}`,
-  );
-  // Mirror the Rust-side parser in crates/mlx-core/src/array/memory.rs::
-  // paged_prefill_chunk_size: trim whitespace, parse i32, reject negative
-  // and unparseable; fall back to 0 (disabled). Logging the EFFECTIVE value
-  // — not the raw env string — prevents misleading "abc tokens" output when
-  // the user typo'd a non-numeric value (which the parser silently maps to
-  // 0/disabled).
-  const rawChunkSize = process.env.MLX_PAGED_PREFILL_CHUNK_SIZE;
-  let effectiveChunkSize = 0;
-  if (rawChunkSize != null) {
-    const trimmed = rawChunkSize.trim();
-    // Mirror Rust's `s.trim().parse::<i32>()`: integer-only, signed,
-    // i32 range [-2^31, 2^31). The TS parser must reject anything Rust
-    // would, otherwise the log shows "N tokens" while chunking is
-    // actually disabled.
-    const I32_MAX = 0x7fff_ffff;
-    // Rust's parse::<i32>() accepts an optional leading '+' or '-'.
-    const parsed = /^[+-]?\d+$/.test(trimmed) ? Number.parseInt(trimmed, 10) : Number.NaN;
-    if (Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= I32_MAX) {
-      effectiveChunkSize = parsed;
-    } else {
-      console.warn(
-        `[mlx] warning: MLX_PAGED_PREFILL_CHUNK_SIZE=${JSON.stringify(rawChunkSize)} is not a non-negative i32 integer; treating as 0 (disabled)`,
-      );
-    }
-  }
-  const chunkLabel = effectiveChunkSize === 0 ? '0 (disabled)' : String(effectiveChunkSize);
-  console.log(
-    `[mlx] paged-prefill chunk size: ${chunkLabel} tokens (set MLX_PAGED_PREFILL_CHUNK_SIZE=N to override; 0 disables)`,
   );
   if (logger) {
     console.log(`[mlx] verbose logging → ${logger.logDir}`);

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -62,9 +62,9 @@ Options:
     MLX_GEMMA4_NATIVE_KV_WRITE    Set to 0/false/off to disable graph-native
                                   Gemma4 global KV writes.
     MLX_GEMMA4_MAX_SLIDING_RESTORE_TOKENS
-                                  Max cached Gemma4 prefix tokens to replay
-                                  for sliding-cache restore. Defaults to 32768
-                                  for the 1024-token sliding window.
+                                  Optional emergency cap on cached Gemma4
+                                  prefix tokens replayed for sliding-cache
+                                  restore. Unset by default.
     MLX_INFERENCE_TRACE           Set to 1/true/on to write native inference
                                   phase traces to a file.
     MLX_INFERENCE_TRACE_FILE      Override the native trace file path.

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -45,12 +45,16 @@ Options:
   --                 Everything after this separator is forwarded to the
                      spawned \`claude\` binary verbatim.
 
-Environment variables:
-  MLX_PAGED_PREFILL_CHUNK_SIZE  Tokens per paged-prefill chunk. Defaults to
-                                4096 under \`mlx launch claude\` to bound
-                                cold-prefill memory peaks; set to 0 to
-                                disable chunking, or to a smaller value
-                                (e.g. 1024 / 512) if 4096 still peaks.
+	Environment variables:
+	  MLX_PAGED_PREFILL_CHUNK_SIZE  Tokens per paged-prefill chunk. Defaults to
+	                                4096 under \`mlx launch claude\` to bound
+	                                cold-prefill memory peaks; set to 0 to
+	                                disable chunking, or to a smaller value
+	                                (e.g. 1024 / 512) if 4096 still peaks.
+	  MLX_INFERENCE_TRACE           Set to 1/true/on to write native inference
+	                                phase traces to a file.
+	  MLX_INFERENCE_TRACE_FILE      Override the native trace file path.
+	                                Defaults to <log-dir>/inference-trace.log.
 
 Examples:
   mlx launch claude
@@ -94,6 +98,19 @@ function findClaudeOnPath(): string | null {
     }
   }
   return null;
+}
+
+function envFlagEnabled(value: string | undefined): boolean {
+  if (value == null) return false;
+  switch (value.trim().toLowerCase()) {
+    case '1':
+    case 'true':
+    case 'yes':
+    case 'on':
+      return true;
+    default:
+      return false;
+  }
 }
 
 export async function run(argv: string[]): Promise<void> {
@@ -189,10 +206,17 @@ export async function run(argv: string[]): Promise<void> {
   // Verbose logging: attach AFTER `createServer` so we wrap every
   // incoming request (including `GET /v1/models` which claude fires
   // on startup). `--log-dir` implies `--verbose`.
-  const verbose = args.verbose || args['log-dir'] != null || process.env.MLX_LOG_DIR != null;
+  const traceRequested = envFlagEnabled(process.env.MLX_INFERENCE_TRACE);
+  const verbose = args.verbose || args['log-dir'] != null || process.env.MLX_LOG_DIR != null || traceRequested;
   let logger: Logger | null = null;
   if (verbose) {
     const logDir = resolveLogDir(args['log-dir'], resolveMlxNodeHome());
+    if (
+      traceRequested &&
+      (process.env.MLX_INFERENCE_TRACE_FILE == null || process.env.MLX_INFERENCE_TRACE_FILE.trim() === '')
+    ) {
+      process.env.MLX_INFERENCE_TRACE_FILE = join(logDir, 'inference-trace.log');
+    }
     logger = attachLogger(server.server, logDir);
   }
 

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -45,24 +45,24 @@ Options:
   --                 Everything after this separator is forwarded to the
                      spawned \`claude\` binary verbatim.
 
-	Environment variables:
-	  MLX_PAGED_PREFILL_CHUNK_SIZE  Tokens per paged-prefill chunk. Defaults to
-	                                4096 under \`mlx launch claude\` to bound
-	                                cold-prefill memory peaks; set to 0 to
-	                                disable chunking, or to a smaller value
-	                                (e.g. 1024 / 512) if 4096 still peaks.
-	  MLX_PAGED_PREFILL_EVAL_INTERVAL
-	                                Layer cadence for eval+clear during paged
-	                                prefill. Defaults to 8.
-	  MLX_PAGED_DECODE_CACHE_CLEAR_INTERVAL
-	                                Token cadence for paged decode cache clear.
-	                                Defaults to 64.
-	  MLX_PAGED_CACHE_MEMORY_MB      Paged KV cache memory budget override for
-	                                paged-aware Qwen3.5 launch.
-	  MLX_INFERENCE_TRACE           Set to 1/true/on to write native inference
-	                                phase traces to a file.
-	  MLX_INFERENCE_TRACE_FILE      Override the native trace file path.
-	                                Defaults to <log-dir>/inference-trace.log.
+  Environment variables:
+    MLX_PAGED_PREFILL_CHUNK_SIZE  Tokens per paged-prefill chunk. Defaults to
+                                  4096 under \`mlx launch claude\` to bound
+                                  cold-prefill memory peaks; set to 0 to
+                                  disable chunking, or to a smaller value
+                                  (e.g. 1024 / 512) if 4096 still peaks.
+    MLX_PAGED_PREFILL_EVAL_INTERVAL
+                                  Layer cadence for eval+clear during paged
+                                  prefill. Defaults to 8.
+    MLX_PAGED_DECODE_CACHE_CLEAR_INTERVAL
+                                  Token cadence for paged decode cache clear.
+                                  Defaults to 64.
+    MLX_PAGED_CACHE_MEMORY_MB      Paged KV cache memory budget override for
+                                  paged-aware Qwen3.5 launch.
+    MLX_INFERENCE_TRACE           Set to 1/true/on to write native inference
+                                  phase traces to a file.
+    MLX_INFERENCE_TRACE_FILE      Override the native trace file path.
+                                  Defaults to <log-dir>/inference-trace.log.
 
 Examples:
   mlx launch claude

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -65,6 +65,10 @@ Options:
                                   Optional emergency cap on cached Gemma4
                                   prefix tokens replayed for sliding-cache
                                   restore. Unset by default.
+    MLX_GEMMA4_SLIDING_CHECKPOINT_LIMIT
+                                  Override retained Gemma4 sliding-cache
+                                  checkpoints. Defaults dynamically from the
+                                  sliding window and paged block size.
     MLX_INFERENCE_TRACE           Set to 1/true/on to write native inference
                                   phase traces to a file.
     MLX_INFERENCE_TRACE_FILE      Override the native trace file path.

--- a/packages/cli/src/commands/launch-claude/index.ts
+++ b/packages/cli/src/commands/launch-claude/index.ts
@@ -47,7 +47,7 @@ Options:
 
   Environment variables:
     MLX_PAGED_PREFILL_CHUNK_SIZE  Tokens per paged-prefill chunk. Defaults to
-                                  1024 under \`mlx launch claude\` to bound
+                                  2048 under \`mlx launch claude\` to bound
                                   cold-prefill memory peaks; set to 0 to
                                   disable chunking, or tune explicitly for
                                   your workload.
@@ -156,13 +156,13 @@ export async function run(argv: string[]): Promise<void> {
   // Bound paged-prefill memory peak by chunking the prompt. Keep this as a
   // launcher default, not a Rust default: the shared native env var still uses
   // 0 as "disable chunking", and non-Claude callers may want single-shot
-  // behavior. On Gemma4 26B Q8, a 36K-token cold-prefill sweep on this machine
-  // measured 1024 faster than 512 / 2048 / 4096 while preserving the same
-  // final-token split. Respect any user-provided value (set in shell). The MLX
-  // env var is read via OnceLock on first paged-prefill call, so setting
-  // `process.env` here before model load is sufficient.
+  // behavior. 2048 matches the mlx-lm / mlx-vlm default and reduces per-chunk
+  // overhead versus the previous 1024 default for long Qwen dense contexts.
+  // Respect any user-provided value (set in shell). The MLX env var is read via
+  // OnceLock on first paged-prefill call, so setting `process.env` here before
+  // model load is sufficient.
   if (process.env.MLX_PAGED_PREFILL_CHUNK_SIZE == null) {
-    process.env.MLX_PAGED_PREFILL_CHUNK_SIZE = '1024';
+    process.env.MLX_PAGED_PREFILL_CHUNK_SIZE = '2048';
   }
 
   const modelsDir = resolveModelsDir(args['models-dir']);

--- a/packages/cli/src/commands/launch-claude/logger.ts
+++ b/packages/cli/src/commands/launch-claude/logger.ts
@@ -23,6 +23,133 @@ export interface Logger {
   close(): Promise<void>;
 }
 
+interface UsageSummary {
+  input_tokens?: number;
+  cache_read_input_tokens?: number;
+  input_tokens_details?: { cached_tokens?: number };
+  output_tokens?: number;
+  time_to_first_token_ms?: number;
+  prefill_tokens_per_second?: number;
+  decode_tokens_per_second?: number;
+  server_inference_elapsed_ms?: number;
+  prefill_input_tokens?: number;
+  cached_prefix_tokens?: number;
+  server_model_resolve_ms?: number;
+  server_queue_ms?: number;
+  server_pre_inference_ms?: number;
+}
+
+function parseJsonObject(value: string | null): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return parsed != null && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function asUsage(value: unknown): UsageSummary | undefined {
+  return value != null && typeof value === 'object' ? (value as UsageSummary) : undefined;
+}
+
+function fmtMs(ms: number | undefined): string | undefined {
+  return typeof ms === 'number' && Number.isFinite(ms) ? `${Math.round(ms)}ms` : undefined;
+}
+
+function fmtRate(rate: number | undefined): string | undefined {
+  return typeof rate === 'number' && Number.isFinite(rate) ? `${rate.toFixed(2)}/s` : undefined;
+}
+
+function extractUsageSummary(resBody: string): { model?: string; usage?: UsageSummary; stop?: string } {
+  let model: string | undefined;
+  let usage: UsageSummary | undefined;
+  let stop: string | undefined;
+
+  const trimmed = resBody.trimStart();
+  if (trimmed.startsWith('{')) {
+    const json = parseJsonObject(trimmed);
+    if (json) {
+      const response =
+        json.response != null && typeof json.response === 'object' ? (json.response as Record<string, unknown>) : json;
+      model = typeof response.model === 'string' ? response.model : undefined;
+      usage = asUsage(response.usage);
+      stop = typeof response.stop_reason === 'string' ? response.stop_reason : undefined;
+      return { model, usage, stop };
+    }
+  }
+
+  for (const line of resBody.split('\n')) {
+    if (!line.startsWith('data: ')) continue;
+    const payload = line.slice(6);
+    if (payload === '[DONE]') continue;
+    const event = parseJsonObject(payload);
+    if (!event) continue;
+    if (event.type === 'message_start' && event.message != null && typeof event.message === 'object') {
+      const message = event.message as Record<string, unknown>;
+      if (typeof message.model === 'string') model = message.model;
+    }
+    if (event.type === 'message_delta') {
+      usage = asUsage(event.usage) ?? usage;
+      const delta =
+        event.delta != null && typeof event.delta === 'object' ? (event.delta as Record<string, unknown>) : null;
+      if (typeof delta?.stop_reason === 'string') stop = delta.stop_reason;
+    }
+    if (
+      (event.type === 'response.completed' || event.type === 'response.failed') &&
+      event.response != null &&
+      typeof event.response === 'object'
+    ) {
+      const response = event.response as Record<string, unknown>;
+      if (typeof response.model === 'string') model = response.model;
+      usage = asUsage(response.usage) ?? usage;
+      if (typeof response.status === 'string') stop = response.status;
+    }
+  }
+
+  return { model, usage, stop };
+}
+
+function buildTimingSummary(reqBody: string, resBody: string): string {
+  const request = parseJsonObject(reqBody);
+  const response = extractUsageSummary(resBody);
+  const model = typeof request?.model === 'string' ? request.model : response.model;
+  const usage = response.usage;
+  if (!usage && !model) return '';
+
+  const parts: string[] = [];
+  if (model) parts.push(`model=${model}`);
+  if (usage) {
+    const cachedTokens =
+      usage.cache_read_input_tokens ?? usage.cached_prefix_tokens ?? usage.input_tokens_details?.cached_tokens;
+    const tokenParts = [
+      typeof usage.input_tokens === 'number' ? `in=${usage.input_tokens}` : undefined,
+      typeof cachedTokens === 'number' ? `cache=${cachedTokens}` : undefined,
+      typeof usage.prefill_input_tokens === 'number' ? `prefill=${usage.prefill_input_tokens}` : undefined,
+      typeof usage.output_tokens === 'number' ? `out=${usage.output_tokens}` : undefined,
+    ].filter((part): part is string => part != null);
+    if (tokenParts.length > 0) parts.push(`tok(${tokenParts.join(' ')})`);
+
+    const timingParts = [
+      fmtMs(usage.time_to_first_token_ms) ? `ttft=${fmtMs(usage.time_to_first_token_ms)}` : undefined,
+      fmtRate(usage.prefill_tokens_per_second) ? `prefill=${fmtRate(usage.prefill_tokens_per_second)}` : undefined,
+      fmtRate(usage.decode_tokens_per_second) ? `decode=${fmtRate(usage.decode_tokens_per_second)}` : undefined,
+      fmtMs(usage.server_inference_elapsed_ms) ? `infer=${fmtMs(usage.server_inference_elapsed_ms)}` : undefined,
+    ].filter((part): part is string => part != null);
+    if (timingParts.length > 0) parts.push(`perf(${timingParts.join(' ')})`);
+
+    const serverParts = [
+      fmtMs(usage.server_model_resolve_ms) ? `resolve=${fmtMs(usage.server_model_resolve_ms)}` : undefined,
+      fmtMs(usage.server_queue_ms) ? `queue=${fmtMs(usage.server_queue_ms)}` : undefined,
+      fmtMs(usage.server_pre_inference_ms) ? `pre=${fmtMs(usage.server_pre_inference_ms)}` : undefined,
+    ].filter((part): part is string => part != null);
+    if (serverParts.length > 0) parts.push(`server(${serverParts.join(' ')})`);
+  }
+  if (response.stop) parts.push(`stop=${response.stop}`);
+
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+}
+
 /**
  * Attach request/response capture to `server`. The caller is responsible
  * for calling `close()` before `server.close()` completes so the tail of
@@ -45,6 +172,9 @@ export function attachLogger(server: Server, logDir: string): Logger {
   writePretty(`[logging] writing to ${logDir}`);
   writePretty(`[logging]   requests.ndjson  — one JSON line per HTTP turn (full body in/out, SSE chunks)`);
   writePretty(`[logging]   session.log      — human-readable chronological trace`);
+  if (process.env.MLX_INFERENCE_TRACE_FILE) {
+    writePretty(`[logging]   inference trace — ${process.env.MLX_INFERENCE_TRACE_FILE}`);
+  }
 
   // Node's http.Server multicasts request events — our listener fires
   // alongside the createServer handler. Dedupe in case the same
@@ -129,8 +259,9 @@ export function attachLogger(server: Server, logDir: string): Logger {
       } catch {
         /* never block the response */
       }
+      const timingSummary = buildTimingSummary(reqBody, resBody);
       writePretty(
-        `[req ${rid}] ${res.statusCode} ${req.method ?? '?'} ${req.url ?? '?'} ${entry.elapsedMs}ms ${resBody.length}B`,
+        `[req ${rid}] ${res.statusCode} ${req.method ?? '?'} ${req.url ?? '?'} ${entry.elapsedMs}ms ${resBody.length}B${timingSummary}`,
       );
     };
     req.on('end', () => {

--- a/packages/cli/src/commands/launch-claude/logger.ts
+++ b/packages/cli/src/commands/launch-claude/logger.ts
@@ -32,6 +32,7 @@ interface UsageSummary {
   prefill_tokens_per_second?: number;
   decode_tokens_per_second?: number;
   server_inference_elapsed_ms?: number;
+  server_total_time_to_first_token_ms?: number;
   prefill_input_tokens?: number;
   cached_prefix_tokens?: number;
   server_model_resolve_ms?: number;
@@ -62,6 +63,12 @@ function fmtMs(ms: number | undefined): string | undefined {
 
 function fmtRate(rate: number | undefined): string | undefined {
   return typeof rate === 'number' && Number.isFinite(rate) ? `${rate.toFixed(2)}/s` : undefined;
+}
+
+function addMs(left: number | undefined, right: number | undefined): number | undefined {
+  return typeof left === 'number' && Number.isFinite(left) && typeof right === 'number' && Number.isFinite(right)
+    ? left + right
+    : undefined;
 }
 
 function extractUsageSummary(resBody: string): { model?: string; usage?: UsageSummary; stop?: string } {
@@ -133,7 +140,10 @@ function buildTimingSummary(reqBody: string, resBody: string): string {
     ].filter((part): part is string => part != null);
     if (tokenParts.length > 0) parts.push(`tok(${tokenParts.join(' ')})`);
 
+    const totalFirstTokenMs =
+      usage.server_total_time_to_first_token_ms ?? addMs(usage.server_pre_inference_ms, usage.time_to_first_token_ms);
     const timingParts = [
+      fmtMs(totalFirstTokenMs) ? `ttfb=${fmtMs(totalFirstTokenMs)}` : undefined,
       fmtMs(usage.time_to_first_token_ms) ? `ttft=${fmtMs(usage.time_to_first_token_ms)}` : undefined,
       fmtRate(usage.prefill_tokens_per_second) ? `prefill=${fmtRate(usage.prefill_tokens_per_second)}` : undefined,
       fmtRate(usage.decode_tokens_per_second) ? `decode=${fmtRate(usage.decode_tokens_per_second)}` : undefined,
@@ -162,6 +172,25 @@ function buildTimingSummary(reqBody: string, resBody: string): string {
     if (tuningParts.length > 0) parts.push(`tune(${tuningParts.join(' ')})`);
   }
   if (response.stop) parts.push(`stop=${response.stop}`);
+
+  return parts.length > 0 ? ` ${parts.join(' ')}` : '';
+}
+
+function buildRequestBodySummary(reqBody: string): string {
+  const request = parseJsonObject(reqBody);
+  if (!request) return '';
+
+  const parts: string[] = [];
+  if (typeof request.model === 'string') parts.push(`model=${request.model}`);
+  if (typeof request.max_tokens === 'number') parts.push(`max_tokens=${request.max_tokens}`);
+  if (typeof request.stream === 'boolean') parts.push(`stream=${request.stream}`);
+  if (Array.isArray(request.messages)) parts.push(`messages=${request.messages.length}`);
+  if (Array.isArray(request.tools)) parts.push(`tools=${request.tools.length}`);
+  if (typeof request.system === 'string') {
+    parts.push(`system=string`);
+  } else if (Array.isArray(request.system)) {
+    parts.push(`system=blocks:${request.system.length}`);
+  }
 
   return parts.length > 0 ? ` ${parts.join(' ')}` : '';
 }
@@ -254,6 +283,14 @@ export function attachLogger(server: Server, logDir: string): Logger {
     let reqDone = false;
     let resDone = false;
     let emitted = false;
+    let requestBodyLogged = false;
+    const logRequestBody = (phase: 'end' | 'close'): void => {
+      if (requestBodyLogged) return;
+      requestBodyLogged = true;
+      writePretty(
+        `[req ${rid}] request_body_${phase} ${Buffer.byteLength(reqBody, 'utf8')}B${buildRequestBodySummary(reqBody)}`,
+      );
+    };
     const tryEmit = (): void => {
       if (emitted || !reqDone || !resDone) return;
       emitted = true;
@@ -282,11 +319,13 @@ export function attachLogger(server: Server, logDir: string): Logger {
     };
     req.on('end', () => {
       reqDone = true;
+      logRequestBody('end');
       tryEmit();
     });
     req.on('close', () => {
       // Client may drop the body mid-flight; emit whatever we have.
       reqDone = true;
+      logRequestBody('close');
       tryEmit();
     });
     res.on('finish', () => {

--- a/packages/cli/src/commands/launch-claude/logger.ts
+++ b/packages/cli/src/commands/launch-claude/logger.ts
@@ -37,6 +37,9 @@ interface UsageSummary {
   server_model_resolve_ms?: number;
   server_queue_ms?: number;
   server_pre_inference_ms?: number;
+  server_paged_prefill_chunk_size?: number;
+  server_paged_prefill_eval_interval?: number;
+  server_paged_decode_cache_clear_interval?: number;
 }
 
 function parseJsonObject(value: string | null): Record<string, unknown> | null {
@@ -144,6 +147,19 @@ function buildTimingSummary(reqBody: string, resBody: string): string {
       fmtMs(usage.server_pre_inference_ms) ? `pre=${fmtMs(usage.server_pre_inference_ms)}` : undefined,
     ].filter((part): part is string => part != null);
     if (serverParts.length > 0) parts.push(`server(${serverParts.join(' ')})`);
+
+    const tuningParts = [
+      typeof usage.server_paged_prefill_chunk_size === 'number'
+        ? `prefill_chunk=${usage.server_paged_prefill_chunk_size}`
+        : undefined,
+      typeof usage.server_paged_prefill_eval_interval === 'number'
+        ? `prefill_eval=${usage.server_paged_prefill_eval_interval}`
+        : undefined,
+      typeof usage.server_paged_decode_cache_clear_interval === 'number'
+        ? `decode_clear=${usage.server_paged_decode_cache_clear_interval}`
+        : undefined,
+    ].filter((part): part is string => part != null);
+    if (tuningParts.length > 0) parts.push(`tune(${tuningParts.join(' ')})`);
   }
   if (response.stop) parts.push(`stop=${response.stop}`);
 

--- a/packages/cli/src/commands/launch-claude/swap.ts
+++ b/packages/cli/src/commands/launch-claude/swap.ts
@@ -139,6 +139,7 @@ export function makeSwapController(
               const oldEntry = byName.get(oldResident.name);
               registry.register(oldResident.name, oldInstance, {
                 samplingDefaults: oldEntry?.preset.sampling,
+                maxOutputTokens: oldEntry?.preset.maxOutputTokens,
               });
               resident = oldResident;
             }
@@ -148,6 +149,7 @@ export function makeSwapController(
         instance = loaded as unknown as SessionCapableModel;
         registry.register(targetEntry.name, instance, {
           samplingDefaults: targetEntry.preset.sampling,
+          maxOutputTokens: targetEntry.preset.maxOutputTokens,
         });
         resident = { name: targetEntry.name };
       } else if (!resident) {
@@ -163,6 +165,7 @@ export function makeSwapController(
         if (aliasName === targetEntry.name) continue;
         registry.register(aliasName, instance, {
           samplingDefaults: targetEntry.preset.sampling,
+          maxOutputTokens: targetEntry.preset.maxOutputTokens,
         });
         aliases.add(aliasName);
       }
@@ -172,6 +175,7 @@ export function makeSwapController(
       if (isAlias) {
         registry.register(name, instance, {
           samplingDefaults: targetEntry.preset.sampling,
+          maxOutputTokens: targetEntry.preset.maxOutputTokens,
         });
         aliases.add(name);
       }

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, copyFile, readdir, stat } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { NapiCli, createBuildCommand } from '@napi-rs/cli';
@@ -35,6 +35,7 @@ for (const output of outputs) {
   }
 }
 
+await copyNativeAddon(outputs);
 // Copy mlx.metallib for colocated Metal shader loading
 // MLX looks for metallib next to the binary, so we copy it here.
 // Also copy paged_attn.metallib (Phase 2 of the paged-attention
@@ -62,6 +63,25 @@ for (const output of outputs) {
 // surfaces immediately rather than as a runtime throw at first use
 // in a published install.
 await copyMetallibs();
+
+async function copyNativeAddon(outputs: Awaited<typeof task>) {
+  const nodeOutput = outputs.find((output) => output.kind === 'node');
+  if (!nodeOutput) {
+    throw new Error('[build.ts smoke check] native addon output missing from napi build');
+  }
+  const expectedName = 'mlx-core.darwin-arm64.node';
+  const actualName = basename(nodeOutput.path);
+  if (actualName !== expectedName) {
+    throw new Error(
+      `[build.ts smoke check] expected native addon output ${expectedName}, got ${actualName} at ${nodeOutput.path}`,
+    );
+  }
+
+  const npmDarwinDir = join(__dirname, 'npm', 'darwin-arm64');
+  const dst = join(npmDarwinDir, expectedName);
+  await copyFile(nodeOutput.path, dst);
+  console.log(`Copied ${expectedName} -> ${dst}`);
+}
 
 async function copyMetallibs() {
   const npmDarwinDir = join(__dirname, 'npm', 'darwin-arm64');

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -3007,7 +3007,8 @@ export interface Gemma4Config {
   /**
    * GPU memory budget for paged KV cache in megabytes.
    * Only used when `use_block_paged_cache` is true.
-   * Default: 2048 (2GB).
+   * Default: auto-sized to cover `max_position_embeddings` for the
+   * physical full-attention layers.
    */
   pagedCacheMemoryMb?: number | undefined;
   /**

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -3019,14 +3019,13 @@ export interface Gemma4Config {
   /**
    * Use the new block-paged KV cache adapter (`PagedKVCacheAdapter`).
    *
-   * When `Some(true)` or unset (the default), `Gemma4Inner` allocates
-   * a `BlockAllocator` + `LayerKVPool` pair and constructs a
-   * `PagedKVCacheAdapter`. Sliding-window layers stay on the existing
-   * flat `RotatingKVCache` path (window-trimmed semantics don't map
-   * onto the paged pool), while full_attention (global) layers route
-   * through the adapter — including `KV-shared` layers whose anchor
-   * is global (read via `read_kv_range`) and KV-shared layers whose
-   * anchor is sliding (pull from the flat anchor's stash).
+   * When `Some(true)` or unset (the default), `Gemma4Inner` builds
+   * model-independent KV-cache specs, groups them, and allocates a
+   * `BlockAllocator` + `LayerKVPool` pair for physical full-attention
+   * layers. Sliding-window layers still use `RotatingKVCache` until
+   * true paged sliding-window groups are wired. KV-shared layers are
+   * aliases: they reuse their anchor's cache slot and do not allocate
+   * separate physical storage.
    *
    * Default: `true` (paged adapter on; opt-out via
    * `use_block_paged_cache: false` in `config.json` to fall back to

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -83,7 +83,7 @@
  * await session.reset();
  * ```
  */
-import type { ChatConfig, ChatMessage, ChatResult, ToolCall, ToolCallResult } from '@mlx-node/core';
+import type { ChatConfig, ChatMessage, ChatResult, ToolCall, ToolCallResult, ToolDefinition } from '@mlx-node/core';
 
 import type { ChatStreamEvent } from './stream.js';
 
@@ -181,6 +181,17 @@ function countOkToolCalls(toolCalls: readonly ToolCallResult[] | undefined): num
  * fully structural.
  */
 export interface SessionCapableModel {
+  /**
+   * Optional non-generating chat-template tokenizer. Exposed by
+   * wrappers that can count prompt tokens without running inference
+   * (used by Anthropic `/v1/messages/count_tokens`).
+   */
+  applyChatTemplate?(
+    messages: ChatMessage[],
+    addGenerationPrompt?: boolean | null,
+    tools?: ToolDefinition[] | null,
+    enableThinking?: boolean | null,
+  ): Promise<Uint32Array> | Uint32Array;
   chatSessionStart(messages: ChatMessage[], config?: ChatConfig | null): Promise<ChatResult>;
   chatSessionContinue(
     userMessage: string,

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -1,6 +1,9 @@
+import { join } from 'node:path';
+
 import {
   Gemma4Model as Gemma4ModelNative,
   Lfm2Model as Lfm2ModelNative,
+  Qwen3Tokenizer,
   Qwen3Model as Qwen3ModelNative,
   Qwen35Model as Qwen35ModelNative,
   Qwen35MoeModel as Qwen35MoeModelNative,
@@ -11,6 +14,7 @@ import type {
   ChatStreamChunk,
   ChatStreamHandle,
   PerformanceMetrics,
+  ToolDefinition,
   ToolCallResult,
 } from '@mlx-node/core';
 
@@ -59,6 +63,33 @@ export interface ChatStreamFinal {
 }
 
 export type ChatStreamEvent = ChatStreamDelta | ChatStreamFinal;
+
+const modelPathsForTokenizers = new WeakMap<object, string>();
+const tokenizerPromises = new WeakMap<object, Promise<Qwen3Tokenizer>>();
+
+function rememberModelPath(model: object, modelPath: string): void {
+  modelPathsForTokenizers.set(model, modelPath);
+}
+
+async function applyChatTemplateFromModelPath(
+  model: object,
+  messages: ChatMessage[],
+  addGenerationPrompt?: boolean | null,
+  tools?: ToolDefinition[] | null,
+  enableThinking?: boolean | null,
+): Promise<Uint32Array> {
+  const modelPath = modelPathsForTokenizers.get(model);
+  if (modelPath == null) {
+    throw new Error('applyChatTemplate unavailable: model path was not recorded when this model was loaded');
+  }
+  let tokenizerPromise = tokenizerPromises.get(model);
+  if (tokenizerPromise == null) {
+    tokenizerPromise = Qwen3Tokenizer.fromPretrained(join(modelPath, 'tokenizer.json'));
+    tokenizerPromises.set(model, tokenizerPromise);
+  }
+  const tokenizer = await tokenizerPromise;
+  return tokenizer.applyChatTemplate(messages, addGenerationPrompt, tools, enableThinking);
+}
 
 // Save references to the native callback-based session streaming methods
 // before we override them. The legacy `chatStream` surface was removed in
@@ -302,7 +333,17 @@ export class Qwen35Model extends Qwen35ModelNative {
   static override async load(modelPath: string): Promise<Qwen35Model> {
     const instance = await Qwen35ModelNative.load(modelPath);
     Object.setPrototypeOf(instance, Qwen35Model.prototype);
+    rememberModelPath(instance, modelPath);
     return instance as unknown as Qwen35Model;
+  }
+
+  applyChatTemplate(
+    messages: ChatMessage[],
+    addGenerationPrompt?: boolean | null,
+    tools?: ToolDefinition[] | null,
+    enableThinking?: boolean | null,
+  ): Promise<Uint32Array> {
+    return applyChatTemplateFromModelPath(this, messages, addGenerationPrompt, tools, enableThinking);
   }
 
   /**
@@ -392,7 +433,17 @@ export class Qwen35MoeModel extends Qwen35MoeModelNative {
   static override async load(modelPath: string): Promise<Qwen35MoeModel> {
     const instance = await Qwen35MoeModelNative.load(modelPath);
     Object.setPrototypeOf(instance, Qwen35MoeModel.prototype);
+    rememberModelPath(instance, modelPath);
     return instance as unknown as Qwen35MoeModel;
+  }
+
+  applyChatTemplate(
+    messages: ChatMessage[],
+    addGenerationPrompt?: boolean | null,
+    tools?: ToolDefinition[] | null,
+    enableThinking?: boolean | null,
+  ): Promise<Uint32Array> {
+    return applyChatTemplateFromModelPath(this, messages, addGenerationPrompt, tools, enableThinking);
   }
 
   /** Streaming variant of {@link Qwen35MoeModel#chatSessionStart}. */
@@ -451,7 +502,17 @@ export class Lfm2Model extends Lfm2ModelNative {
   static override async load(modelPath: string): Promise<Lfm2Model> {
     const instance = await Lfm2ModelNative.load(modelPath);
     Object.setPrototypeOf(instance, Lfm2Model.prototype);
+    rememberModelPath(instance, modelPath);
     return instance as unknown as Lfm2Model;
+  }
+
+  applyChatTemplate(
+    messages: ChatMessage[],
+    addGenerationPrompt?: boolean | null,
+    tools?: ToolDefinition[] | null,
+    enableThinking?: boolean | null,
+  ): Promise<Uint32Array> {
+    return applyChatTemplateFromModelPath(this, messages, addGenerationPrompt, tools, enableThinking);
   }
 
   /** Streaming variant of {@link Lfm2Model#chatSessionStart}. */
@@ -510,7 +571,17 @@ export class Gemma4Model extends Gemma4ModelNative {
   static override async load(modelPath: string): Promise<Gemma4Model> {
     const instance = await Gemma4ModelNative.load(modelPath);
     Object.setPrototypeOf(instance, Gemma4Model.prototype);
+    rememberModelPath(instance, modelPath);
     return instance as unknown as Gemma4Model;
+  }
+
+  applyChatTemplate(
+    messages: ChatMessage[],
+    addGenerationPrompt?: boolean | null,
+    tools?: ToolDefinition[] | null,
+    enableThinking?: boolean | null,
+  ): Promise<Uint32Array> {
+    return applyChatTemplateFromModelPath(this, messages, addGenerationPrompt, tools, enableThinking);
   }
 
   /** Streaming variant of {@link Gemma4Model#chatSessionStart}. */
@@ -570,6 +641,7 @@ export class Qwen3Model extends Qwen3ModelNative {
   static override async load(modelPath: string): Promise<Qwen3Model> {
     const instance = await Qwen3ModelNative.load(modelPath);
     Object.setPrototypeOf(instance, Qwen3Model.prototype);
+    rememberModelPath(instance, modelPath);
     return instance as unknown as Qwen3Model;
   }
 

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -67,6 +67,14 @@ export type ChatStreamEvent = ChatStreamDelta | ChatStreamFinal;
 const modelPathsForTokenizers = new WeakMap<object, string>();
 const tokenizerPromises = new WeakMap<object, Promise<Qwen3Tokenizer>>();
 
+function getNativeIsReasoning(chunk: ChatStreamChunk): boolean | undefined {
+  if (typeof chunk.isReasoning === 'boolean') {
+    return chunk.isReasoning;
+  }
+  const snakeCaseChunk = chunk as ChatStreamChunk & { is_reasoning?: unknown };
+  return typeof snakeCaseChunk.is_reasoning === 'boolean' ? snakeCaseChunk.is_reasoning : undefined;
+}
+
 function rememberModelPath(model: object, modelPath: string): void {
   modelPathsForTokenizers.set(model, modelPath);
 }
@@ -304,7 +312,12 @@ export async function* _runChatStream(
           yield finalEvent;
           return;
         }
-        yield { text: chunk.text, done: false, isReasoning: chunk.isReasoning ?? undefined } as ChatStreamDelta;
+        const delta: ChatStreamDelta = { text: chunk.text, done: false };
+        const isReasoning = getNativeIsReasoning(chunk);
+        if (isReasoning !== undefined) {
+          delta.isReasoning = isReasoning;
+        }
+        yield delta;
       }
     }
   } finally {

--- a/packages/server/src/endpoints/messages-count-tokens.ts
+++ b/packages/server/src/endpoints/messages-count-tokens.ts
@@ -1,0 +1,107 @@
+/** POST /v1/messages/count_tokens — Anthropic Messages token-count endpoint. */
+
+import type { ServerResponse } from 'node:http';
+
+import type { ChatMessage, ToolDefinition } from '@mlx-node/core';
+
+import {
+  sendAnthropicBadRequest,
+  sendAnthropicInternalError,
+  sendAnthropicNotFound,
+  sendAnthropicNotImplemented,
+} from '../errors.js';
+import type { IdleSweeper } from '../idle-sweeper.js';
+import { mapAnthropicRequest } from '../mappers/anthropic-request.js';
+import type { ModelRegistry, ServableModel } from '../registry.js';
+import type { AnthropicCountTokensRequest, AnthropicCountTokensResponse } from '../types-anthropic.js';
+
+interface ChatTemplateTokenCounter {
+  applyChatTemplate(
+    messages: ChatMessage[],
+    addGenerationPrompt?: boolean | null,
+    tools?: ToolDefinition[] | null,
+    enableThinking?: boolean | null,
+  ): Promise<Uint32Array> | Uint32Array;
+}
+
+function getChatTemplateTokenCounter(model: ServableModel): ChatTemplateTokenCounter | null {
+  const candidate = model as ServableModel & Partial<ChatTemplateTokenCounter>;
+  return typeof candidate.applyChatTemplate === 'function' ? (candidate as ChatTemplateTokenCounter) : null;
+}
+
+function endJson(res: ServerResponse, body: AnthropicCountTokensResponse): void {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+export async function handleCountMessageTokens(
+  res: ServerResponse,
+  body: AnthropicCountTokensRequest,
+  registry: ModelRegistry,
+  idleSweeper?: IdleSweeper | null,
+  resolveModel?: (name: string) => Promise<void>,
+): Promise<void> {
+  if (body == null || typeof body !== 'object') {
+    sendAnthropicBadRequest(res, 'Request body must be a JSON object');
+    return;
+  }
+  if (!body.model) {
+    sendAnthropicBadRequest(res, 'Missing required field: model');
+    return;
+  }
+  if (!body.messages || !Array.isArray(body.messages) || body.messages.length === 0) {
+    sendAnthropicBadRequest(res, 'Missing required field: messages');
+    return;
+  }
+
+  for (const msg of body.messages) {
+    if (msg == null || typeof msg !== 'object') {
+      sendAnthropicBadRequest(res, 'Each message must be a non-null object');
+      return;
+    }
+  }
+
+  let mapped: ReturnType<typeof mapAnthropicRequest>;
+  try {
+    mapped = mapAnthropicRequest(body);
+  } catch (err) {
+    sendAnthropicBadRequest(res, err instanceof Error ? err.message : 'Invalid request');
+    return;
+  }
+
+  if (resolveModel) {
+    try {
+      if (idleSweeper) {
+        await idleSweeper.withSuspendedDrains(() => resolveModel(body.model));
+      } else {
+        await resolveModel(body.model);
+      }
+    } catch (err) {
+      sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to resolve model');
+      return;
+    }
+  }
+
+  const model = registry.get(body.model);
+  if (!model) {
+    sendAnthropicNotFound(res, `Model "${body.model}" not found`);
+    return;
+  }
+
+  const counter = getChatTemplateTokenCounter(model);
+  if (!counter) {
+    sendAnthropicNotImplemented(
+      res,
+      `Model "${body.model}" does not expose applyChatTemplate(); token counting requires a ` +
+        `non-generating chat-template tokenizer API on the registered model.`,
+    );
+    return;
+  }
+
+  try {
+    const tokens = await counter.applyChatTemplate(mapped.messages, true, mapped.config.tools ?? null);
+    endJson(res, { input_tokens: tokens.length });
+  } catch (err) {
+    sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to count tokens');
+  }
+}

--- a/packages/server/src/endpoints/messages-count-tokens.ts
+++ b/packages/server/src/endpoints/messages-count-tokens.ts
@@ -12,6 +12,7 @@ import {
 } from '../errors.js';
 import type { IdleSweeper } from '../idle-sweeper.js';
 import { mapAnthropicRequest } from '../mappers/anthropic-request.js';
+import type { ModelWorkCoordinator } from '../model-work-coordinator.js';
 import type { ModelRegistry, ServableModel } from '../registry.js';
 import type { AnthropicCountTokensRequest, AnthropicCountTokensResponse } from '../types-anthropic.js';
 
@@ -40,6 +41,7 @@ export async function handleCountMessageTokens(
   registry: ModelRegistry,
   idleSweeper?: IdleSweeper | null,
   resolveModel?: (name: string) => Promise<void>,
+  modelWorkCoordinator?: ModelWorkCoordinator,
 ): Promise<void> {
   if (body == null || typeof body !== 'object') {
     sendAnthropicBadRequest(res, 'Request body must be a JSON object');
@@ -71,11 +73,10 @@ export async function handleCountMessageTokens(
 
   if (resolveModel) {
     try {
-      if (idleSweeper) {
-        await idleSweeper.withSuspendedDrains(() => resolveModel(body.model));
-      } else {
-        await resolveModel(body.model);
-      }
+      const runResolve = () =>
+        idleSweeper ? idleSweeper.withSuspendedDrains(() => resolveModel(body.model)) : resolveModel(body.model);
+      if (modelWorkCoordinator) await modelWorkCoordinator.withModelLoad(runResolve);
+      else await runResolve();
     } catch (err) {
       sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to resolve model');
       return;

--- a/packages/server/src/endpoints/messages-count-tokens.ts
+++ b/packages/server/src/endpoints/messages-count-tokens.ts
@@ -9,11 +9,13 @@ import {
   sendAnthropicInternalError,
   sendAnthropicNotFound,
   sendAnthropicNotImplemented,
+  sendAnthropicRateLimit,
 } from '../errors.js';
 import type { IdleSweeper } from '../idle-sweeper.js';
 import { mapAnthropicRequest } from '../mappers/anthropic-request.js';
 import type { ModelWorkCoordinator } from '../model-work-coordinator.js';
 import type { ModelRegistry, ServableModel } from '../registry.js';
+import { QueueFullError } from '../session-registry.js';
 import type { AnthropicCountTokensRequest, AnthropicCountTokensResponse } from '../types-anthropic.js';
 
 interface ChatTemplateTokenCounter {
@@ -83,26 +85,84 @@ export async function handleCountMessageTokens(
     }
   }
 
-  const model = registry.get(body.model);
-  if (!model) {
+  const lease = registry.acquireDispatchLease(body.model);
+  if (!lease) {
+    if (registry.get(body.model) != null) {
+      sendAnthropicInternalError(res, 'session registry missing for registered model');
+      return;
+    }
     sendAnthropicNotFound(res, `Model "${body.model}" not found`);
     return;
   }
-
-  const counter = getChatTemplateTokenCounter(model);
-  if (!counter) {
-    sendAnthropicNotImplemented(
-      res,
-      `Model "${body.model}" does not expose applyChatTemplate(); token counting requires a ` +
-        `non-generating chat-template tokenizer API on the registered model.`,
-    );
-    return;
-  }
+  const leaseModel = lease.model;
+  const sessionReg = lease.registry;
+  const preLockInstanceId = lease.instanceId;
 
   try {
-    const tokens = await counter.applyChatTemplate(mapped.messages, true, mapped.config.tools ?? null);
-    endJson(res, { input_tokens: tokens.length });
+    const bindingStillMatchesLease = () => {
+      const lockedSessionReg = registry.getSessionRegistry(body.model);
+      const lockedInstanceId = registry.getInstanceId(body.model);
+      return (
+        lockedSessionReg !== undefined &&
+        lockedInstanceId !== undefined &&
+        lockedSessionReg === sessionReg &&
+        lockedInstanceId === preLockInstanceId
+      );
+    };
+
+    const rejectChangedBinding = (phase: string) => {
+      sendAnthropicBadRequest(
+        res,
+        `Model "${body.model}" binding changed while the token-count request was ${phase}. ` +
+          `A concurrent register() re-pointed the name at a different model instance ` +
+          `(or released it entirely), so counting against the leased model would use ` +
+          `a stale model object. Retry the request — if the swap was intentional, the ` +
+          `new binding will service the retry cleanly.`,
+      );
+    };
+
+    const runCount = () =>
+      sessionReg.withExclusive(async () => {
+        const runCountWithModelRead = async () => {
+          if (!bindingStillMatchesLease()) {
+            rejectChangedBinding('queued behind the per-model execution mutex');
+            return;
+          }
+
+          const counter = getChatTemplateTokenCounter(leaseModel);
+          if (!counter) {
+            sendAnthropicNotImplemented(
+              res,
+              `Model "${body.model}" does not expose applyChatTemplate(); token counting requires a ` +
+                `non-generating chat-template tokenizer API on the registered model.`,
+            );
+            return;
+          }
+
+          try {
+            const tokens = await counter.applyChatTemplate(mapped.messages, true, mapped.config.tools ?? null);
+            if (!bindingStillMatchesLease()) {
+              rejectChangedBinding('running');
+              return;
+            }
+            endJson(res, { input_tokens: tokens.length });
+          } catch (err) {
+            sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to count tokens');
+          }
+        };
+
+        if (modelWorkCoordinator) await modelWorkCoordinator.withInference(runCountWithModelRead);
+        else await runCountWithModelRead();
+      });
+
+    await runCount();
   } catch (err) {
-    sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to count tokens');
+    if (err instanceof QueueFullError) {
+      sendAnthropicRateLimit(res, `Model queue full: ${err.queuedCount} waiting (limit ${err.limit}). Retry after 1s.`);
+    } else {
+      sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to count tokens');
+    }
+  } finally {
+    registry.releaseDispatchLease(leaseModel);
   }
 }

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -119,6 +119,19 @@ function hasSuppressedToolCalls(result: Pick<ChatResult, 'toolCalls'>, body: Ant
   return !requestAllowsToolUse(body) && result.toolCalls.some((t) => t.status === 'ok');
 }
 
+function applyOutputTokenLimit(config: ChatConfig, limit: number | undefined): ChatConfig {
+  if (
+    limit == null ||
+    !Number.isFinite(limit) ||
+    limit <= 0 ||
+    config.maxNewTokens == null ||
+    config.maxNewTokens <= limit
+  ) {
+    return config;
+  }
+  return { ...config, maxNewTokens: Math.floor(limit) };
+}
+
 // Non-streaming path
 
 async function handleNonStreaming(
@@ -283,7 +296,10 @@ async function handleStreamingNative(
             writeSSEEvent(
               res,
               'content_block_start',
-              buildContentBlockStart(contentBlockIndex, { type: 'text', text: '' }),
+              buildContentBlockStart(contentBlockIndex, {
+                type: 'text',
+                text: '',
+              }),
             );
           }
           emittedText += remainingText;
@@ -291,7 +307,10 @@ async function handleStreamingNative(
           writeSSEEvent(
             res,
             'content_block_delta',
-            buildContentBlockDelta(contentBlockIndex, { type: 'text_delta', text: remainingText }),
+            buildContentBlockDelta(contentBlockIndex, {
+              type: 'text_delta',
+              text: remainingText,
+            }),
           );
         }
 
@@ -317,14 +336,20 @@ async function handleStreamingNative(
           writeSSEEvent(
             res,
             'content_block_start',
-            buildContentBlockStart(contentBlockIndex, { type: 'text', text: '' }),
+            buildContentBlockStart(contentBlockIndex, {
+              type: 'text',
+              text: '',
+            }),
           );
           emittedText += finalText;
           emittedTextLength += finalText.length;
           writeSSEEvent(
             res,
             'content_block_delta',
-            buildContentBlockDelta(contentBlockIndex, { type: 'text_delta', text: finalText }),
+            buildContentBlockDelta(contentBlockIndex, {
+              type: 'text_delta',
+              text: finalText,
+            }),
           );
         } else if (
           tagBuffer.suppressed &&
@@ -363,7 +388,10 @@ async function handleStreamingNative(
             writeSSEEvent(
               res,
               'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, { type: 'text_delta', text: unsent }),
+              buildContentBlockDelta(contentBlockIndex, {
+                type: 'text_delta',
+                text: unsent,
+              }),
             );
           }
         } else if (hasEmittedText && finalText && !emittedText.includes(finalText)) {
@@ -386,7 +414,10 @@ async function handleStreamingNative(
             writeSSEEvent(
               res,
               'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, { type: 'text_delta', text: unsent }),
+              buildContentBlockDelta(contentBlockIndex, {
+                type: 'text_delta',
+                text: unsent,
+              }),
             );
           }
         }
@@ -401,14 +432,20 @@ async function handleStreamingNative(
           writeSSEEvent(
             res,
             'content_block_start',
-            buildContentBlockStart(contentBlockIndex, { type: 'text', text: '' }),
+            buildContentBlockStart(contentBlockIndex, {
+              type: 'text',
+              text: '',
+            }),
           );
           emittedText += finalText;
           emittedTextLength += finalText.length;
           writeSSEEvent(
             res,
             'content_block_delta',
-            buildContentBlockDelta(contentBlockIndex, { type: 'text_delta', text: finalText }),
+            buildContentBlockDelta(contentBlockIndex, {
+              type: 'text_delta',
+              text: finalText,
+            }),
           );
           writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
           contentBlockIndex++;
@@ -424,7 +461,12 @@ async function handleStreamingNative(
           writeSSEEvent(
             res,
             'content_block_start',
-            buildContentBlockStart(contentBlockIndex, { type: 'tool_use', id: toolId, name: tc.name, input: {} }),
+            buildContentBlockStart(contentBlockIndex, {
+              type: 'tool_use',
+              id: toolId,
+              name: tc.name,
+              input: {},
+            }),
           );
           writeSSEEvent(
             res,
@@ -459,14 +501,20 @@ async function handleStreamingNative(
           writeSSEEvent(
             res,
             'content_block_start',
-            buildContentBlockStart(contentBlockIndex, { type: 'thinking', thinking: '' }),
+            buildContentBlockStart(contentBlockIndex, {
+              type: 'thinking',
+              thinking: '',
+            }),
           );
           contentBlockIndex++;
         }
         writeSSEEvent(
           res,
           'content_block_delta',
-          buildContentBlockDelta(contentBlockIndex - 1, { type: 'thinking_delta', thinking: deltaText }),
+          buildContentBlockDelta(contentBlockIndex - 1, {
+            type: 'thinking_delta',
+            thinking: deltaText,
+          }),
         );
       } else {
         // Text delta with `<tool_call>` buffering. Requests that did not
@@ -481,7 +529,10 @@ async function handleStreamingNative(
               writeSSEEvent(
                 res,
                 'content_block_start',
-                buildContentBlockStart(contentBlockIndex, { type: 'text', text: '' }),
+                buildContentBlockStart(contentBlockIndex, {
+                  type: 'text',
+                  text: '',
+                }),
               );
             }
             emittedText += event.text;
@@ -489,7 +540,10 @@ async function handleStreamingNative(
             writeSSEEvent(
               res,
               'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, { type: 'text_delta', text: event.text }),
+              buildContentBlockDelta(contentBlockIndex, {
+                type: 'text_delta',
+                text: event.text,
+              }),
             );
           }
           continue;
@@ -506,7 +560,10 @@ async function handleStreamingNative(
               writeSSEEvent(
                 res,
                 'content_block_start',
-                buildContentBlockStart(contentBlockIndex, { type: 'text', text: '' }),
+                buildContentBlockStart(contentBlockIndex, {
+                  type: 'text',
+                  text: '',
+                }),
               );
             }
             emittedText += cleanPrefix;
@@ -514,7 +571,10 @@ async function handleStreamingNative(
             writeSSEEvent(
               res,
               'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, { type: 'text_delta', text: cleanPrefix }),
+              buildContentBlockDelta(contentBlockIndex, {
+                type: 'text_delta',
+                text: cleanPrefix,
+              }),
             );
           }
         } else if (safeText) {
@@ -526,7 +586,10 @@ async function handleStreamingNative(
             writeSSEEvent(
               res,
               'content_block_start',
-              buildContentBlockStart(contentBlockIndex, { type: 'text', text: '' }),
+              buildContentBlockStart(contentBlockIndex, {
+                type: 'text',
+                text: '',
+              }),
             );
           }
           emittedText += safeText;
@@ -534,7 +597,10 @@ async function handleStreamingNative(
           writeSSEEvent(
             res,
             'content_block_delta',
-            buildContentBlockDelta(contentBlockIndex, { type: 'text_delta', text: safeText }),
+            buildContentBlockDelta(contentBlockIndex, {
+              type: 'text_delta',
+              text: safeText,
+            }),
           );
         }
       }
@@ -881,6 +947,7 @@ export async function handleCreateMessage(
   };
   try {
     const sessionReg: SessionRegistry = lease.registry;
+    mappedConfig = applyOutputTokenLimit(mappedConfig, sessionReg.outputTokenLimit);
     // Snapshot the monotonic instance id so the in-mutex re-read can detect a
     // hot-swap that lands between lease acquisition and mutex entry. Unlike
     // `/v1/responses`, the Anthropic handler has no stored-identity check
@@ -1249,7 +1316,9 @@ export async function handleCreateMessage(
             // SSE: best-effort streaming `error`, but only if no terminal landed
             // (a double terminal would confuse the client state machine).
             if (!visibility.terminalEmitted) {
-              writeFallbackErrorSSE(res, 'error', { error: { type: 'api_error', message } });
+              writeFallbackErrorSSE(res, 'error', {
+                error: { type: 'api_error', message },
+              });
             }
             try {
               endSSE(res);

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -86,6 +86,7 @@ import type { ModelRegistry } from '../registry.js';
 import { QueueFullError, type SessionRegistry } from '../session-registry.js';
 import { beginSSE, endSSE, writeSSEEvent } from '../streaming.js';
 import { longestSuffixPrefixOverlap } from '../text-recovery.js';
+import type { ServerTimingForUsage } from '../timing.js';
 import { ToolCallTagBuffer } from '../tool-call-buffer.js';
 import {
   createVisibility,
@@ -110,6 +111,14 @@ import { validateAndCanonicalizeHistoryToolOrder } from './responses.js';
  */
 const MESSAGES_WARM_SLOT_ID = '__msg_warm__';
 
+function requestAllowsToolUse(body: AnthropicMessagesRequest): boolean {
+  return Array.isArray(body.tools) && body.tools.length > 0;
+}
+
+function hasSuppressedToolCalls(result: Pick<ChatResult, 'toolCalls'>, body: AnthropicMessagesRequest): boolean {
+  return !requestAllowsToolUse(body) && result.toolCalls.some((t) => t.status === 'ok');
+}
+
 // Non-streaming path
 
 async function handleNonStreaming(
@@ -117,6 +126,7 @@ async function handleNonStreaming(
   result: ChatResult,
   body: AnthropicMessagesRequest,
   visibility: TransportVisibility,
+  serverTiming?: ServerTimingForUsage,
 ): Promise<void> {
   const messageId = genId('msg_');
   // `result.performance` is only populated when `reportPerformance: true`
@@ -125,7 +135,14 @@ async function handleNonStreaming(
   // launcher wires the flag on for verbose-log builds and leaves it off
   // by default, matching how `cachedTokens` is treated through
   // `buildAnthropicResponse`.
-  const response = buildAnthropicResponse(result, body, messageId, result.performance);
+  const response = buildAnthropicResponse(
+    result,
+    body,
+    messageId,
+    result.performance,
+    requestAllowsToolUse(body),
+    serverTiming,
+  );
 
   // Native `chatSession*` has no AbortSignal surface yet, so a client that
   // disconnects mid-decode still burns every remaining token under the
@@ -148,6 +165,7 @@ async function handleNonStreaming(
  */
 interface MessagesStreamingHandlerResult {
   ok: boolean;
+  suppressedToolCalls: boolean;
 }
 
 async function handleStreamingNative(
@@ -157,6 +175,7 @@ async function handleStreamingNative(
   wasCommitted: () => boolean,
   httpReq: IncomingMessage | undefined,
   visibility: TransportVisibility,
+  serverTiming?: ServerTimingForUsage,
 ): Promise<MessagesStreamingHandlerResult> {
   const messageId = genId('msg_');
   beginSSE(res);
@@ -207,6 +226,8 @@ async function handleStreamingNative(
   // than emitting zeros.
   let terminalPerformance: PerformanceMetrics | undefined;
   let terminalErrorMessage: string | null = null;
+  const allowToolUse = requestAllowsToolUse(body);
+  let suppressedToolCalls = false;
 
   // `thrownError` sticks on a generator throw; `clientAborted` sticks on
   // HTTP `close`/`error` on req, res, or res.socket. Either one routes the
@@ -278,8 +299,15 @@ async function handleStreamingNative(
           writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
         }
 
-        const finalText = event.text;
-        const okToolCalls = event.toolCalls.filter((t) => t.status === 'ok');
+        const parsedToolCalls = event.toolCalls.filter((t) => t.status === 'ok');
+        if (!allowToolUse && parsedToolCalls.length > 0) {
+          suppressedToolCalls = true;
+        }
+        const finalText =
+          !allowToolUse && event.text.length === 0 && parsedToolCalls.length > 0 && event.rawText.includes('<tool_call')
+            ? event.rawText
+            : event.text;
+        const okToolCalls = allowToolUse ? parsedToolCalls : [];
         const hasToolCalls = okToolCalls.length > 0;
 
         // Recovery: suppression triggered but no tool calls parsed — emit final text as a text block.
@@ -441,7 +469,32 @@ async function handleStreamingNative(
           buildContentBlockDelta(contentBlockIndex - 1, { type: 'thinking_delta', thinking: deltaText }),
         );
       } else {
-        // Text delta with `<tool_call>` buffering.
+        // Text delta with `<tool_call>` buffering. Requests that did not
+        // advertise tools must treat model-emitted markup as literal text.
+        if (!allowToolUse) {
+          if (event.text) {
+            if (!hasEmittedText) {
+              if (hasEmittedThinking) {
+                writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
+              }
+              hasEmittedText = true;
+              writeSSEEvent(
+                res,
+                'content_block_start',
+                buildContentBlockStart(contentBlockIndex, { type: 'text', text: '' }),
+              );
+            }
+            emittedText += event.text;
+            emittedTextLength += event.text.length;
+            writeSSEEvent(
+              res,
+              'content_block_delta',
+              buildContentBlockDelta(contentBlockIndex, { type: 'text_delta', text: event.text }),
+            );
+          }
+          continue;
+        }
+
         const { safeText, tagFound, cleanPrefix } = tagBuffer.push(event.text);
         if (tagFound) {
           if (cleanPrefix.trim()) {
@@ -516,7 +569,14 @@ async function handleStreamingNative(
     writeSSEEvent(
       res,
       'message_delta',
-      buildMessageDelta(stopReason, terminalNumTokens, terminalPromptTokens, terminalCachedTokens, terminalPerformance),
+      buildMessageDelta(
+        stopReason,
+        terminalNumTokens,
+        terminalPromptTokens,
+        terminalCachedTokens,
+        terminalPerformance,
+        serverTiming,
+      ),
     );
     // HTTP/1.1 chunked-encoding trailer: report the engine's cache-hit
     // count once the SSE stream has settled. The header has to wait
@@ -537,7 +597,7 @@ async function handleStreamingNative(
     }
     await flushTerminalSSE(res, 'message_stop', buildMessageStop(), visibility);
     endSSE(res);
-    return { ok: true };
+    return { ok: true, suppressedToolCalls };
   }
   // Close any dangling content block so the error frame lands at a clean state,
   // then emit the streaming error. Never emit `message_stop` here — pairing it
@@ -562,7 +622,7 @@ async function handleStreamingNative(
   // The streaming `error` event is the Anthropic terminal on the failure path.
   await flushTerminalSSE(res, 'error', { type: 'error', error: { type: 'api_error', message } }, visibility);
   endSSE(res);
-  return { ok: false };
+  return { ok: false, suppressedToolCalls };
 }
 
 // Session routing
@@ -585,11 +645,11 @@ async function runSessionNonStreaming(
   session: ChatSession<SessionCapableModel>,
   messages: ChatMessage[],
   config: ChatConfig,
-  isFreshSession: boolean,
+  resetNativeCache: boolean,
 ): Promise<MessagesNonStreamingOutcome> {
-  // Dual-branch reset gated on the registry lookup outcome:
+  // Dual-branch reset gated by the caller's native-cache policy:
   //
-  //   * MISS (`isFreshSession === true`) — we MUST run a full
+  //   * Full native reset (`resetNativeCache === true`) — run a full
   //     `session.reset()`. A fresh JS session does NOT imply a fresh
   //     native cache — the underlying `SessionCapableModel` is shared
   //     across `ChatSession` lifetimes via `ModelRegistry`, and its
@@ -603,13 +663,14 @@ async function runSessionNonStreaming(
   //     `responses.ts` (around the matching `runSessionNonStreaming`
   //     branches). Only registry HITS are authorized for cache reuse.
   //
-  //   * HIT (`isFreshSession === false`) — we run the JS-only
+  //   * Preserve native cache (`resetNativeCache === false`) — run the JS-only
   //     `resetPreservingNativeCacheForWarmReuse` so the registry-leased
-  //     native KV cache stays alive for `verify_cache_prefix_direct` to
-  //     recover the reused prefix on this turn. `primeHistory`
-  //     requires `turnCount === 0`, which the helper guarantees by
-  //     wiping JS-side state only.
-  if (isFreshSession) {
+  //     native KV cache stays alive for `verify_cache_prefix_direct` or
+  //     the paged adapter's content-addressed prefix lookup to recover
+  //     the reused prefix on this turn. `primeHistory` requires
+  //     `turnCount === 0`, which the helper guarantees by wiping
+  //     JS-side state only.
+  if (resetNativeCache) {
     await session.reset();
   } else {
     await resetPreservingNativeCacheForWarmReuse(session);
@@ -646,15 +707,16 @@ async function runSessionStreaming(
   messages: ChatMessage[],
   config: ChatConfig,
   signal: AbortSignal | undefined,
-  isFreshSession: boolean,
+  resetNativeCache: boolean,
 ): Promise<MessagesStreamingOutcome> {
-  // Same dual-branch reset as `runSessionNonStreaming`: MISS wipes
-  // both JS and native state to block the cross-request
-  // cache-affinity leak described at length in `responses.ts`; HIT
-  // wipes JS-only so `verify_cache_prefix_direct` can recover the
-  // leased native prefix. `initialTurns` MUST be captured AFTER the
-  // reset zeroes `turns` so the committed check reads correctly.
-  if (isFreshSession) {
+  // Same dual-branch reset as `runSessionNonStreaming`: native-reset
+  // requests wipe both JS and native state to block the cross-request
+  // cache-affinity leak described at length in `responses.ts`; native-
+  // preserving requests wipe JS-only so the non-paged warm slot or the
+  // paged content-addressed cache can recover a verified native prefix.
+  // `initialTurns` MUST be captured AFTER the reset zeroes `turns` so
+  // the committed check reads correctly.
+  if (resetNativeCache) {
     await session.reset();
   } else {
     await resetPreservingNativeCacheForWarmReuse(session);
@@ -677,6 +739,9 @@ export async function handleCreateMessage(
   idleSweeper?: IdleSweeper | null,
   resolveModel?: (name: string) => Promise<void>,
 ): Promise<void> {
+  const handlerStartedAt = Date.now();
+  let serverModelResolveMs: number | undefined;
+
   if (body == null || typeof body !== 'object') {
     sendAnthropicBadRequest(res, 'Request body must be a JSON object');
     return;
@@ -744,11 +809,13 @@ export async function handleCreateMessage(
     // serialize the failure through `sendAnthropicInternalError` here. Mirrors
     // the `mapAnthropicRequest` try/catch above.
     try {
+      const resolveStartedAt = Date.now();
       if (idleSweeper) {
         await idleSweeper.withSuspendedDrains(() => resolveModel(body.model));
       } else {
         await resolveModel(body.model);
       }
+      serverModelResolveMs = Date.now() - resolveStartedAt;
     } catch (err) {
       sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to resolve model');
       return;
@@ -889,7 +956,13 @@ export async function handleCreateMessage(
     idleListenersAttached = true;
 
     try {
+      const mutexQueuedAt = Date.now();
       await sessionReg.withExclusive(async () => {
+        const serverTiming: ServerTimingForUsage = {
+          server_model_resolve_ms: serverModelResolveMs,
+          server_queue_ms: Date.now() - mutexQueuedAt,
+          server_pre_inference_ms: Date.now() - handlerStartedAt,
+        };
         // Hot-swap race guard. `ModelRegistry.register()` is not coordinated with
         // `withExclusive`, so a concurrent re-register of the same friendly name
         // could silently dispatch this request through a stale model. Any drift
@@ -1029,14 +1102,15 @@ export async function handleCreateMessage(
         try {
           if (body.stream === true) {
             // On the paged path the underlying native cache is the
-            // sole reuse mechanism, so pass `isFreshSession = true`
-            // unconditionally — the dual-branch reset in
-            // `runSessionStreaming` collapses to the full
-            // `session.reset()` arm. Non-paged keeps the original
-            // `!lookup.hit` semantics so warm-slot hits route through
-            // `resetPreservingNativeCacheForWarmReuse`.
-            const isFreshSession = pagedActive ? true : !lookup.hit;
-            const outcome = await runSessionStreaming(session, messages, config, streamSignal, isFreshSession);
+            // sole reuse mechanism, so preserve it even though the JS
+            // `ChatSession` is freshly allocated. The native paged
+            // adapter validates reuse by token/hash before any cached
+            // prefix is trusted, and the MoE GDN checkpoint layer now
+            // follows the same content-checked policy. Non-paged keeps
+            // the original `!lookup.hit` semantics so only warm-slot
+            // hits preserve native cache.
+            const resetNativeCache = pagedActive ? false : !lookup.hit;
+            const outcome = await runSessionStreaming(session, messages, config, streamSignal, resetNativeCache);
             const streamResult = await handleStreamingNative(
               res,
               outcome.stream,
@@ -1044,6 +1118,7 @@ export async function handleCreateMessage(
               outcome.wasCommitted,
               httpReq,
               visibility,
+              serverTiming,
             );
             // Warm-slot adopt/drop only applies to the non-paged
             // path. On the paged path the JS-side warm slot plays no
@@ -1075,7 +1150,7 @@ export async function handleCreateMessage(
             // and a clean handler-side terminal must both hold before
             // the session is reachable from a subsequent request.
             if (!pagedActive) {
-              if (streamResult.ok && outcome.wasCommitted()) {
+              if (streamResult.ok && outcome.wasCommitted() && !streamResult.suppressedToolCalls) {
                 sessionReg.adopt(MESSAGES_WARM_SLOT_ID, session, requestedSystem, null);
               } else {
                 sessionReg.drop(MESSAGES_WARM_SLOT_ID);
@@ -1083,11 +1158,11 @@ export async function handleCreateMessage(
             }
           } else {
             // See the streaming branch above for the rationale on
-            // collapsing `isFreshSession` to `true` on the paged path.
-            const isFreshSession = pagedActive ? true : !lookup.hit;
+            // preserving native cache on the paged path.
+            const resetNativeCache = pagedActive ? false : !lookup.hit;
             // Native `chatSessionStart` has no AbortSignal yet — disconnect handling
             // lives inside `handleNonStreaming` / `endJson`.
-            const outcome = await runSessionNonStreaming(session, messages, config, isFreshSession);
+            const outcome = await runSessionNonStreaming(session, messages, config, resetNativeCache);
             const result = outcome.result;
             // Re-classify the `X-Session-Cache` header.
             //
@@ -1118,7 +1193,7 @@ export async function handleCreateMessage(
             if (result.cachedTokens > 0) {
               res.setHeader('X-Cached-Tokens', String(result.cachedTokens));
             }
-            await handleNonStreaming(res, result, body, visibility);
+            await handleNonStreaming(res, result, body, visibility, serverTiming);
             // Non-paged success: adopt the warm slot only when the
             // dispatch actually committed. Mirrors the streaming-side
             // dual-gate at `streamResult.ok && outcome.wasCommitted()`
@@ -1140,7 +1215,7 @@ export async function handleCreateMessage(
             // re-introduce the cross-endpoint warm-slot eviction
             // that paged is supposed to eliminate.
             if (!pagedActive) {
-              if (outcome.committed) {
+              if (outcome.committed && !hasSuppressedToolCalls(result, body)) {
                 sessionReg.adopt(MESSAGES_WARM_SLOT_ID, session, requestedSystem, null);
               } else {
                 sessionReg.drop(MESSAGES_WARM_SLOT_ID);

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -86,7 +86,7 @@ import type { ModelRegistry } from '../registry.js';
 import { QueueFullError, type SessionRegistry } from '../session-registry.js';
 import { beginSSE, endSSE, writeSSEEvent } from '../streaming.js';
 import { longestSuffixPrefixOverlap } from '../text-recovery.js';
-import type { ServerTimingForUsage } from '../timing.js';
+import { resolveServerTuningForUsage, type ServerTimingForUsage } from '../timing.js';
 import { ToolCallTagBuffer } from '../tool-call-buffer.js';
 import {
   createVisibility,
@@ -962,6 +962,7 @@ export async function handleCreateMessage(
           server_model_resolve_ms: serverModelResolveMs,
           server_queue_ms: Date.now() - mutexQueuedAt,
           server_pre_inference_ms: Date.now() - handlerStartedAt,
+          ...resolveServerTuningForUsage(),
         };
         // Hot-swap race guard. `ModelRegistry.register()` is not coordinated with
         // `withExclusive`, so a concurrent re-register of the same friendly name

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -79,6 +79,8 @@ import {
   buildMessageDelta,
   buildMessageStartEvent,
   buildMessageStop,
+  containsToolCallMarkup,
+  recoverSuppressedToolCallText,
   mapStopReason,
 } from '../mappers/anthropic-response.js';
 import { genId } from '../mappers/response.js';
@@ -323,8 +325,11 @@ async function handleStreamingNative(
           suppressedToolCalls = true;
         }
         const finalText =
-          !allowToolUse && event.text.length === 0 && parsedToolCalls.length > 0 && event.rawText.includes('<tool_call')
-            ? event.rawText
+          !allowToolUse &&
+          event.text.length === 0 &&
+          parsedToolCalls.length > 0 &&
+          containsToolCallMarkup(event.rawText)
+            ? recoverSuppressedToolCallText(event.rawText)
             : event.text;
         const okToolCalls = allowToolUse ? parsedToolCalls : [];
         const hasToolCalls = okToolCalls.length > 0;

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -115,6 +115,14 @@ import { validateAndCanonicalizeHistoryToolOrder } from './responses.js';
 const MESSAGES_WARM_SLOT_ID = '__msg_warm__';
 const CLAUDE_CODE_TITLE_MAX_TOKENS = 128;
 
+function withAdmissionControlledInference<T>(
+  sessionReg: SessionRegistry,
+  modelWorkCoordinator: ModelWorkCoordinator | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return sessionReg.withExclusive(() => (modelWorkCoordinator ? modelWorkCoordinator.withInference(fn) : fn()));
+}
+
 function requestAllowsToolUse(body: AnthropicMessagesRequest): boolean {
   return Array.isArray(body.tools) && body.tools.length > 0;
 }
@@ -1060,7 +1068,7 @@ export async function handleCreateMessage(
     try {
       const mutexQueuedAt = Date.now();
       const runInference = () =>
-        sessionReg.withExclusive(async () => {
+        withAdmissionControlledInference(sessionReg, modelWorkCoordinator, async () => {
           const serverTiming: ServerTimingForUsage = {
             server_model_resolve_ms: serverModelResolveMs,
             server_queue_ms: Date.now() - mutexQueuedAt,
@@ -1365,8 +1373,7 @@ export async function handleCreateMessage(
             }
           }
         });
-      if (modelWorkCoordinator) await modelWorkCoordinator.withInference(runInference);
-      else await runInference();
+      await runInference();
     } catch (err) {
       // Admission-control rejection from the per-model queue cap
       // (`SessionRegistry.withExclusive` threw before chaining into

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -84,6 +84,7 @@ import {
   mapStopReason,
 } from '../mappers/anthropic-response.js';
 import { genId } from '../mappers/response.js';
+import type { ModelWorkCoordinator } from '../model-work-coordinator.js';
 import type { ModelRegistry } from '../registry.js';
 import { QueueFullError, type SessionRegistry } from '../session-registry.js';
 import { beginSSE, endSSE, writeSSEEvent } from '../streaming.js';
@@ -522,38 +523,9 @@ async function handleStreamingNative(
           }),
         );
       } else {
-        // Text delta with `<tool_call>` buffering. Requests that did not
-        // advertise tools must treat model-emitted markup as literal text.
-        if (!allowToolUse) {
-          if (event.text) {
-            if (!hasEmittedText) {
-              if (hasEmittedThinking) {
-                writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
-              }
-              hasEmittedText = true;
-              writeSSEEvent(
-                res,
-                'content_block_start',
-                buildContentBlockStart(contentBlockIndex, {
-                  type: 'text',
-                  text: '',
-                }),
-              );
-            }
-            emittedText += event.text;
-            emittedTextLength += event.text.length;
-            writeSSEEvent(
-              res,
-              'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, {
-                type: 'text_delta',
-                text: event.text,
-              }),
-            );
-          }
-          continue;
-        }
-
+        // Text delta with structural-marker buffering. Even when the
+        // request did not advertise tools, model-side tool/channel/turn
+        // markers are transport structure, not user-visible text.
         const { safeText, tagFound, cleanPrefix } = tagBuffer.push(event.text);
         if (tagFound) {
           if (cleanPrefix.trim()) {
@@ -809,6 +781,7 @@ export async function handleCreateMessage(
   httpReq?: IncomingMessage,
   idleSweeper?: IdleSweeper | null,
   resolveModel?: (name: string) => Promise<void>,
+  modelWorkCoordinator?: ModelWorkCoordinator,
 ): Promise<void> {
   const handlerStartedAt = Date.now();
   let serverModelResolveMs: number | undefined;
@@ -881,11 +854,10 @@ export async function handleCreateMessage(
     // the `mapAnthropicRequest` try/catch above.
     try {
       const resolveStartedAt = Date.now();
-      if (idleSweeper) {
-        await idleSweeper.withSuspendedDrains(() => resolveModel(body.model));
-      } else {
-        await resolveModel(body.model);
-      }
+      const runResolve = () =>
+        idleSweeper ? idleSweeper.withSuspendedDrains(() => resolveModel(body.model)) : resolveModel(body.model);
+      if (modelWorkCoordinator) await modelWorkCoordinator.withModelLoad(runResolve);
+      else await runResolve();
       serverModelResolveMs = Date.now() - resolveStartedAt;
     } catch (err) {
       sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to resolve model');
@@ -1029,310 +1001,313 @@ export async function handleCreateMessage(
 
     try {
       const mutexQueuedAt = Date.now();
-      await sessionReg.withExclusive(async () => {
-        const serverTiming: ServerTimingForUsage = {
-          server_model_resolve_ms: serverModelResolveMs,
-          server_queue_ms: Date.now() - mutexQueuedAt,
-          server_pre_inference_ms: Date.now() - handlerStartedAt,
-          ...resolveServerTuningForUsage(),
-        };
-        // Hot-swap race guard. `ModelRegistry.register()` is not coordinated with
-        // `withExclusive`, so a concurrent re-register of the same friendly name
-        // could silently dispatch this request through a stale model. Any drift
-        // from the pre-lock snapshot is fatal.
-        const lockedSessionReg = registry.getSessionRegistry(body.model);
-        const lockedInstanceId = registry.getInstanceId(body.model);
-        if (
-          lockedSessionReg === undefined ||
-          lockedInstanceId === undefined ||
-          lockedSessionReg !== sessionReg ||
-          lockedInstanceId !== preLockInstanceId
-        ) {
-          sendAnthropicBadRequest(
-            res,
-            `Model "${body.model}" binding changed while the request was queued behind the per-model ` +
-              `execution mutex. A concurrent register() re-pointed the name at a different model instance ` +
-              `(or released it entirely) while this waiter was parked, so the session registry and instance ` +
-              `id captured before the mutex wait no longer match the live binding. Dispatching anyway would ` +
-              `service this request through a stale model object — a silent cross-model handoff. Retry the ` +
-              `request — if the swap was intentional, the new binding will service the retry cleanly.`,
-          );
-          return;
-        }
-
-        // Per-model session selection for `/v1/messages` reuse.
-        //
-        // Two paths, gated on whether the underlying native model has
-        // the block-paged KV cache adapter active
-        // (`hasBlockPagedCache()` — captured at load time from
-        // `<Inner>::paged_adapter.is_some()` and surfaced by the
-        // `SessionCapableModel` structural interface):
-        //
-        //   * **Paged-active** (Qwen3 + LFM2 + Gemma4 today; Qwen3.5
-        //     dense + Qwen3.5 MoE once their perf trade-off is
-        //     decided). Allocate a fresh `ChatSession` per request via
-        //     `createFreshSession()`, do NOT touch the warm slot.
-        //     Cross-turn / cross-conversation prefix reuse is handled
-        //     entirely by the native `BlockAllocator`'s prefix-hash
-        //     table: SYS blocks shared across requests are refcounted
-        //     transparently, so two parallel `/v1/messages` requests
-        //     sharing a system prompt both run on distinct
-        //     `ChatSession` objects but reference the SAME physical
-        //     KV blocks. The JS-side warm slot would only serialize
-        //     them and force one into cold replay.
-        //
-        //   * **Non-paged** (Qwen3.5 dense + MoE — default-OFF pending
-        //     a perf decision against the compiled C++ flat path;
-        //     the Qianfan-OCR VLM — no adapter wired). Fall through to
-        //     `getOrCreateWarmAny`, which is the ONLY cross-conversation
-        //     reuse mechanism these models have. The Anthropic Messages
-        //     API is stateless on the wire (no `previous_response_id`,
-        //     clients don't propagate `prompt_cache_key`), so without
-        //     the warm slot every turn is a full cold start.
-        //
-        // The `hasBlockPagedCache?()` getter is optional on the
-        // structural interface so the `QianfanOCRModel` VLM (which
-        // has no paged-adapter wiring) still satisfies the type
-        // contract — a missing getter falls into the non-paged branch
-        // here.
-        //
-        // Adoption stays keyed by the literal sentinel
-        // `MESSAGES_WARM_SLOT_ID = '__msg_warm__'`. The Anthropic
-        // Messages API never produces a `previous_response_id` clients
-        // could echo back (and the OpenAI side mints `resp_*` ids),
-        // so cross-endpoint capture via tier-1 is impossible by
-        // construction — no `/v1/responses` request can collide with
-        // the sentinel through the tier-1 path.
-        //
-        // The two endpoints DO share the single warm slot under the
-        // registry's single-warm invariant on the non-paged path: a
-        // `/v1/messages` turn following a `/v1/responses` turn can
-        // evict (and vice versa). On the paged path neither side
-        // touches the warm slot, so cross-endpoint contention
-        // disappears.
-        //
-        // The `prompt_cache_key` request field is still NOT exposed
-        // on this endpoint. Cross-conversation block-level cache
-        // reuse on paged-active models is now driven by native
-        // content-addressing instead of the JS warm slot, so adding
-        // the field is no longer a prerequisite for that use case.
-        const pagedActive = leaseModel.hasBlockPagedCache?.() === true;
-        const lookup = pagedActive ? sessionReg.createFreshSession() : sessionReg.getOrCreateWarmAny(requestedSystem);
-        const session = lookup.session;
-        // `X-Session-Cache` observability header.
-        //
-        // Non-paged path:
-        //   * Non-streaming: set the optimistic `prefix_hit` value
-        //     BEFORE dispatch on `lookup.hit` (so the header is on the
-        //     wire even if the dispatch throws) and demote
-        //     post-dispatch to `fresh` when the warm slot was leased
-        //     but native prefix reuse did not actually happen
-        //     (`result.cachedTokens === 0`). `res.end` has not fired
-        //     yet, so the overwrite still lands on the wire.
-        //   * Streaming: emits `streaming` to signal the authoritative
-        //     post-dispatch value rides on the SSE stream
-        //     (`message_delta.usage.cache_read_input_tokens` and the
-        //     `X-Cached-Tokens` HTTP trailer, set below in
-        //     `handleStreamingNative` once `terminalCachedTokens` is
-        //     known). Reporting `fresh` here would be a lie — the
-        //     paged engine routinely returns `cachedTokens > 0` on
-        //     turn-2+ and the prior `'fresh'` default falsely advertised
-        //     a cache miss. The previous comment documented this as
-        //     intentional but it was a logging bug.
-        //
-        // Paged path:
-        //   * Non-streaming: `lookup.hit` is always `false` (we
-        //     `createFreshSession`); the post-dispatch promotion
-        //     branch flips `prefix_hit` when the native engine
-        //     reports `cachedTokens > 0`, which is the authoritative
-        //     signal that the block allocator's content-addressed
-        //     reuse picked up shared SYS blocks on this turn.
-        //   * Streaming: same `streaming` value as non-paged; the SSE
-        //     `usage.cache_read_input_tokens` field carries the
-        //     authoritative value.
-        //
-        // Header values: `'fresh' | 'prefix_hit' | 'streaming'`. The
-        // `'streaming'` value tells operators to read the SSE
-        // `message_delta.usage.cache_read_input_tokens` for the
-        // resolved cache-hit count (or `X-Cached-Tokens` trailer if
-        // the client supports HTTP trailers).
-        let sessionCacheStatus: 'fresh' | 'prefix_hit' | 'streaming' =
-          body.stream === true ? 'streaming' : lookup.hit ? 'prefix_hit' : 'fresh';
-        res.setHeader('X-Session-Cache', sessionCacheStatus);
-        // HTTP/1.1 chunked-encoding trailer announcement for streaming.
-        // The actual value is filled in by `handleStreamingNative`
-        // once it has captured `terminalCachedTokens` from the final
-        // SSE chunk.
-        if (body.stream === true) {
-          res.setHeader('Trailer', 'X-Cached-Tokens');
-        }
-
-        // Outer catch branches on `responseMode` (not `res.headersSent`, which
-        // flips in `writeHead` before the body lands) so a crash after
-        // `writeHead(application/json)` cannot leak SSE frames into a JSON body.
-        const visibility = createVisibility();
-
-        try {
-          if (body.stream === true) {
-            // On the paged path the underlying native cache is the
-            // sole reuse mechanism, so preserve it even though the JS
-            // `ChatSession` is freshly allocated. The native paged
-            // adapter validates reuse by token/hash before any cached
-            // prefix is trusted, and the MoE GDN checkpoint layer now
-            // follows the same content-checked policy. Non-paged keeps
-            // the original `!lookup.hit` semantics so only warm-slot
-            // hits preserve native cache.
-            const resetNativeCache = pagedActive ? false : !lookup.hit;
-            const outcome = await runSessionStreaming(session, messages, config, streamSignal, resetNativeCache);
-            const streamResult = await handleStreamingNative(
+      const runInference = () =>
+        sessionReg.withExclusive(async () => {
+          const serverTiming: ServerTimingForUsage = {
+            server_model_resolve_ms: serverModelResolveMs,
+            server_queue_ms: Date.now() - mutexQueuedAt,
+            server_pre_inference_ms: Date.now() - handlerStartedAt,
+            ...resolveServerTuningForUsage(),
+          };
+          // Hot-swap race guard. `ModelRegistry.register()` is not coordinated with
+          // `withExclusive`, so a concurrent re-register of the same friendly name
+          // could silently dispatch this request through a stale model. Any drift
+          // from the pre-lock snapshot is fatal.
+          const lockedSessionReg = registry.getSessionRegistry(body.model);
+          const lockedInstanceId = registry.getInstanceId(body.model);
+          if (
+            lockedSessionReg === undefined ||
+            lockedInstanceId === undefined ||
+            lockedSessionReg !== sessionReg ||
+            lockedInstanceId !== preLockInstanceId
+          ) {
+            sendAnthropicBadRequest(
               res,
-              outcome.stream,
-              body,
-              outcome.wasCommitted,
-              httpReq,
-              visibility,
-              serverTiming,
+              `Model "${body.model}" binding changed while the request was queued behind the per-model ` +
+                `execution mutex. A concurrent register() re-pointed the name at a different model instance ` +
+                `(or released it entirely) while this waiter was parked, so the session registry and instance ` +
+                `id captured before the mutex wait no longer match the live binding. Dispatching anyway would ` +
+                `service this request through a stale model object — a silent cross-model handoff. Retry the ` +
+                `request — if the swap was intentional, the new binding will service the retry cleanly.`,
             );
-            // Warm-slot adopt/drop only applies to the non-paged
-            // path. On the paged path the JS-side warm slot plays no
-            // role (block reuse is content-addressed in native), so
-            // we never touch it — the fresh `ChatSession` allocated
-            // for this request is dropped on the floor and GC'd once
-            // the handler scope exits.
-            //
-            // Non-paged dual-gate adopt: BOTH the producer-side commit
-            // signal (`outcome.wasCommitted()`, which reads
-            // `session.turns` bumped in `startFromHistoryStream`'s
-            // `finally`) AND the handler-side success signal
-            // (`streamResult.ok`, true only when we reached the clean
-            // `message_stop` terminal) must be true to adopt. The
-            // producer's `finally` runs on every break — including
-            // client abort, mid-decode throw, and
-            // `finishReason=error` — so `wasCommitted()` alone is NOT
-            // sufficient: it can return `true` after the SSE side
-            // emitted an `error` terminal (not re-thrown by
-            // `handleStreamingNative`), leaving a session whose
-            // observable wire state is failure but whose `turns`
-            // counter advanced. Adopting in that window would seed the
-            // warm slot with a session the next request can lease but
-            // whose history does not match what the client received.
-            //
-            // Mirrors `responses.ts` (around line 3277) where the
-            // analogous gate combines `committed`, `handlerError`, and
-            // `streamFailureMode === null` — the producer-side commit
-            // and a clean handler-side terminal must both hold before
-            // the session is reachable from a subsequent request.
-            if (!pagedActive) {
-              if (streamResult.ok && outcome.wasCommitted() && !streamResult.suppressedToolCalls) {
-                sessionReg.adopt(MESSAGES_WARM_SLOT_ID, session, requestedSystem, null);
-              } else {
-                sessionReg.drop(MESSAGES_WARM_SLOT_ID);
+            return;
+          }
+
+          // Per-model session selection for `/v1/messages` reuse.
+          //
+          // Two paths, gated on whether the underlying native model has
+          // the block-paged KV cache adapter active
+          // (`hasBlockPagedCache()` — captured at load time from
+          // `<Inner>::paged_adapter.is_some()` and surfaced by the
+          // `SessionCapableModel` structural interface):
+          //
+          //   * **Paged-active** (Qwen3 + LFM2 + Gemma4 today; Qwen3.5
+          //     dense + Qwen3.5 MoE once their perf trade-off is
+          //     decided). Allocate a fresh `ChatSession` per request via
+          //     `createFreshSession()`, do NOT touch the warm slot.
+          //     Cross-turn / cross-conversation prefix reuse is handled
+          //     entirely by the native `BlockAllocator`'s prefix-hash
+          //     table: SYS blocks shared across requests are refcounted
+          //     transparently, so two parallel `/v1/messages` requests
+          //     sharing a system prompt both run on distinct
+          //     `ChatSession` objects but reference the SAME physical
+          //     KV blocks. The JS-side warm slot would only serialize
+          //     them and force one into cold replay.
+          //
+          //   * **Non-paged** (Qwen3.5 dense + MoE — default-OFF pending
+          //     a perf decision against the compiled C++ flat path;
+          //     the Qianfan-OCR VLM — no adapter wired). Fall through to
+          //     `getOrCreateWarmAny`, which is the ONLY cross-conversation
+          //     reuse mechanism these models have. The Anthropic Messages
+          //     API is stateless on the wire (no `previous_response_id`,
+          //     clients don't propagate `prompt_cache_key`), so without
+          //     the warm slot every turn is a full cold start.
+          //
+          // The `hasBlockPagedCache?()` getter is optional on the
+          // structural interface so the `QianfanOCRModel` VLM (which
+          // has no paged-adapter wiring) still satisfies the type
+          // contract — a missing getter falls into the non-paged branch
+          // here.
+          //
+          // Adoption stays keyed by the literal sentinel
+          // `MESSAGES_WARM_SLOT_ID = '__msg_warm__'`. The Anthropic
+          // Messages API never produces a `previous_response_id` clients
+          // could echo back (and the OpenAI side mints `resp_*` ids),
+          // so cross-endpoint capture via tier-1 is impossible by
+          // construction — no `/v1/responses` request can collide with
+          // the sentinel through the tier-1 path.
+          //
+          // The two endpoints DO share the single warm slot under the
+          // registry's single-warm invariant on the non-paged path: a
+          // `/v1/messages` turn following a `/v1/responses` turn can
+          // evict (and vice versa). On the paged path neither side
+          // touches the warm slot, so cross-endpoint contention
+          // disappears.
+          //
+          // The `prompt_cache_key` request field is still NOT exposed
+          // on this endpoint. Cross-conversation block-level cache
+          // reuse on paged-active models is now driven by native
+          // content-addressing instead of the JS warm slot, so adding
+          // the field is no longer a prerequisite for that use case.
+          const pagedActive = leaseModel.hasBlockPagedCache?.() === true;
+          const lookup = pagedActive ? sessionReg.createFreshSession() : sessionReg.getOrCreateWarmAny(requestedSystem);
+          const session = lookup.session;
+          // `X-Session-Cache` observability header.
+          //
+          // Non-paged path:
+          //   * Non-streaming: set the optimistic `prefix_hit` value
+          //     BEFORE dispatch on `lookup.hit` (so the header is on the
+          //     wire even if the dispatch throws) and demote
+          //     post-dispatch to `fresh` when the warm slot was leased
+          //     but native prefix reuse did not actually happen
+          //     (`result.cachedTokens === 0`). `res.end` has not fired
+          //     yet, so the overwrite still lands on the wire.
+          //   * Streaming: emits `streaming` to signal the authoritative
+          //     post-dispatch value rides on the SSE stream
+          //     (`message_delta.usage.cache_read_input_tokens` and the
+          //     `X-Cached-Tokens` HTTP trailer, set below in
+          //     `handleStreamingNative` once `terminalCachedTokens` is
+          //     known). Reporting `fresh` here would be a lie — the
+          //     paged engine routinely returns `cachedTokens > 0` on
+          //     turn-2+ and the prior `'fresh'` default falsely advertised
+          //     a cache miss. The previous comment documented this as
+          //     intentional but it was a logging bug.
+          //
+          // Paged path:
+          //   * Non-streaming: `lookup.hit` is always `false` (we
+          //     `createFreshSession`); the post-dispatch promotion
+          //     branch flips `prefix_hit` when the native engine
+          //     reports `cachedTokens > 0`, which is the authoritative
+          //     signal that the block allocator's content-addressed
+          //     reuse picked up shared SYS blocks on this turn.
+          //   * Streaming: same `streaming` value as non-paged; the SSE
+          //     `usage.cache_read_input_tokens` field carries the
+          //     authoritative value.
+          //
+          // Header values: `'fresh' | 'prefix_hit' | 'streaming'`. The
+          // `'streaming'` value tells operators to read the SSE
+          // `message_delta.usage.cache_read_input_tokens` for the
+          // resolved cache-hit count (or `X-Cached-Tokens` trailer if
+          // the client supports HTTP trailers).
+          let sessionCacheStatus: 'fresh' | 'prefix_hit' | 'streaming' =
+            body.stream === true ? 'streaming' : lookup.hit ? 'prefix_hit' : 'fresh';
+          res.setHeader('X-Session-Cache', sessionCacheStatus);
+          // HTTP/1.1 chunked-encoding trailer announcement for streaming.
+          // The actual value is filled in by `handleStreamingNative`
+          // once it has captured `terminalCachedTokens` from the final
+          // SSE chunk.
+          if (body.stream === true) {
+            res.setHeader('Trailer', 'X-Cached-Tokens');
+          }
+
+          // Outer catch branches on `responseMode` (not `res.headersSent`, which
+          // flips in `writeHead` before the body lands) so a crash after
+          // `writeHead(application/json)` cannot leak SSE frames into a JSON body.
+          const visibility = createVisibility();
+
+          try {
+            if (body.stream === true) {
+              // On the paged path the underlying native cache is the
+              // sole reuse mechanism, so preserve it even though the JS
+              // `ChatSession` is freshly allocated. The native paged
+              // adapter validates reuse by token/hash before any cached
+              // prefix is trusted, and the MoE GDN checkpoint layer now
+              // follows the same content-checked policy. Non-paged keeps
+              // the original `!lookup.hit` semantics so only warm-slot
+              // hits preserve native cache.
+              const resetNativeCache = pagedActive ? false : !lookup.hit;
+              const outcome = await runSessionStreaming(session, messages, config, streamSignal, resetNativeCache);
+              const streamResult = await handleStreamingNative(
+                res,
+                outcome.stream,
+                body,
+                outcome.wasCommitted,
+                httpReq,
+                visibility,
+                serverTiming,
+              );
+              // Warm-slot adopt/drop only applies to the non-paged
+              // path. On the paged path the JS-side warm slot plays no
+              // role (block reuse is content-addressed in native), so
+              // we never touch it — the fresh `ChatSession` allocated
+              // for this request is dropped on the floor and GC'd once
+              // the handler scope exits.
+              //
+              // Non-paged dual-gate adopt: BOTH the producer-side commit
+              // signal (`outcome.wasCommitted()`, which reads
+              // `session.turns` bumped in `startFromHistoryStream`'s
+              // `finally`) AND the handler-side success signal
+              // (`streamResult.ok`, true only when we reached the clean
+              // `message_stop` terminal) must be true to adopt. The
+              // producer's `finally` runs on every break — including
+              // client abort, mid-decode throw, and
+              // `finishReason=error` — so `wasCommitted()` alone is NOT
+              // sufficient: it can return `true` after the SSE side
+              // emitted an `error` terminal (not re-thrown by
+              // `handleStreamingNative`), leaving a session whose
+              // observable wire state is failure but whose `turns`
+              // counter advanced. Adopting in that window would seed the
+              // warm slot with a session the next request can lease but
+              // whose history does not match what the client received.
+              //
+              // Mirrors `responses.ts` (around line 3277) where the
+              // analogous gate combines `committed`, `handlerError`, and
+              // `streamFailureMode === null` — the producer-side commit
+              // and a clean handler-side terminal must both hold before
+              // the session is reachable from a subsequent request.
+              if (!pagedActive) {
+                if (streamResult.ok && outcome.wasCommitted() && !streamResult.suppressedToolCalls) {
+                  sessionReg.adopt(MESSAGES_WARM_SLOT_ID, session, requestedSystem, null);
+                } else {
+                  sessionReg.drop(MESSAGES_WARM_SLOT_ID);
+                }
+              }
+            } else {
+              // See the streaming branch above for the rationale on
+              // preserving native cache on the paged path.
+              const resetNativeCache = pagedActive ? false : !lookup.hit;
+              // Native `chatSessionStart` has no AbortSignal yet — disconnect handling
+              // lives inside `handleNonStreaming` / `endJson`.
+              const outcome = await runSessionNonStreaming(session, messages, config, resetNativeCache);
+              const result = outcome.result;
+              // Re-classify the `X-Session-Cache` header.
+              //
+              // Non-paged: a warm-slot hit that did NOT actually produce
+              // native prefix reuse (`cachedTokens === 0` — e.g.
+              // tokenizer change, system prompt drift squeaking past
+              // the byte-equal compare via some upstream rewrite) gets
+              // demoted from `prefix_hit` back to `fresh`.
+              //
+              // Paged: `lookup.hit` is always `false` so we entered
+              // with `sessionCacheStatus = 'fresh'`. Promote to
+              // `prefix_hit` when the native engine reports
+              // `cachedTokens > 0` — that's the authoritative signal
+              // that `BlockAllocator`'s content-addressed prefix lookup
+              // recovered shared SYS blocks on this turn. `res.end` has
+              // not fired yet (`handleNonStreaming` is what flushes via
+              // `endJson`), so the overwrite still lands on the wire.
+              if (lookup.hit && result.cachedTokens === 0) {
+                sessionCacheStatus = 'fresh';
+                res.setHeader('X-Session-Cache', sessionCacheStatus);
+              } else if (pagedActive && result.cachedTokens > 0) {
+                sessionCacheStatus = 'prefix_hit';
+                res.setHeader('X-Session-Cache', sessionCacheStatus);
+              }
+              // Companion `X-Cached-Tokens` header: emitted only when
+              // reuse genuinely happened, so operators can spot a stale
+              // `prefix_hit` claim from telemetry alone.
+              if (result.cachedTokens > 0) {
+                res.setHeader('X-Cached-Tokens', String(result.cachedTokens));
+              }
+              await handleNonStreaming(res, result, body, visibility, serverTiming);
+              // Non-paged success: adopt the warm slot only when the
+              // dispatch actually committed. Mirrors the streaming-side
+              // dual-gate at `streamResult.ok && outcome.wasCommitted()`
+              // above and the sibling `/v1/responses` adopt gate, so the
+              // local invariant — "never adopt an uncommitted session"
+              // — is enforced by the same check on both wire formats and
+              // both endpoints. Today every native failure throws (and
+              // routes through the inner catch below), so the gate is
+              // dead code on the current Rust paths; it defends the
+              // invariant LOCALLY so a future native change that
+              // resolves `chat_session_start_sync` with
+              // `Ok(finish_reason="error")` cannot silently poison the
+              // warm slot. Drop on the uncommitted branch matches the
+              // streaming-side `else { drop(...) }` so the sentinel does
+              // not accumulate stale entries from earlier turns.
+              //
+              // Paged success: never adopt — block-level reuse is
+              // already in the native cache, and adopting would
+              // re-introduce the cross-endpoint warm-slot eviction
+              // that paged is supposed to eliminate.
+              if (!pagedActive) {
+                if (outcome.committed && !hasSuppressedToolCalls(result, body)) {
+                  sessionReg.adopt(MESSAGES_WARM_SLOT_ID, session, requestedSystem, null);
+                } else {
+                  sessionReg.drop(MESSAGES_WARM_SLOT_ID);
+                }
               }
             }
-          } else {
-            // See the streaming branch above for the rationale on
-            // preserving native cache on the paged path.
-            const resetNativeCache = pagedActive ? false : !lookup.hit;
-            // Native `chatSessionStart` has no AbortSignal yet — disconnect handling
-            // lives inside `handleNonStreaming` / `endJson`.
-            const outcome = await runSessionNonStreaming(session, messages, config, resetNativeCache);
-            const result = outcome.result;
-            // Re-classify the `X-Session-Cache` header.
-            //
-            // Non-paged: a warm-slot hit that did NOT actually produce
-            // native prefix reuse (`cachedTokens === 0` — e.g.
-            // tokenizer change, system prompt drift squeaking past
-            // the byte-equal compare via some upstream rewrite) gets
-            // demoted from `prefix_hit` back to `fresh`.
-            //
-            // Paged: `lookup.hit` is always `false` so we entered
-            // with `sessionCacheStatus = 'fresh'`. Promote to
-            // `prefix_hit` when the native engine reports
-            // `cachedTokens > 0` — that's the authoritative signal
-            // that `BlockAllocator`'s content-addressed prefix lookup
-            // recovered shared SYS blocks on this turn. `res.end` has
-            // not fired yet (`handleNonStreaming` is what flushes via
-            // `endJson`), so the overwrite still lands on the wire.
-            if (lookup.hit && result.cachedTokens === 0) {
-              sessionCacheStatus = 'fresh';
-              res.setHeader('X-Session-Cache', sessionCacheStatus);
-            } else if (pagedActive && result.cachedTokens > 0) {
-              sessionCacheStatus = 'prefix_hit';
-              res.setHeader('X-Session-Cache', sessionCacheStatus);
-            }
-            // Companion `X-Cached-Tokens` header: emitted only when
-            // reuse genuinely happened, so operators can spot a stale
-            // `prefix_hit` claim from telemetry alone.
-            if (result.cachedTokens > 0) {
-              res.setHeader('X-Cached-Tokens', String(result.cachedTokens));
-            }
-            await handleNonStreaming(res, result, body, visibility, serverTiming);
-            // Non-paged success: adopt the warm slot only when the
-            // dispatch actually committed. Mirrors the streaming-side
-            // dual-gate at `streamResult.ok && outcome.wasCommitted()`
-            // above and the sibling `/v1/responses` adopt gate, so the
-            // local invariant — "never adopt an uncommitted session"
-            // — is enforced by the same check on both wire formats and
-            // both endpoints. Today every native failure throws (and
-            // routes through the inner catch below), so the gate is
-            // dead code on the current Rust paths; it defends the
-            // invariant LOCALLY so a future native change that
-            // resolves `chat_session_start_sync` with
-            // `Ok(finish_reason="error")` cannot silently poison the
-            // warm slot. Drop on the uncommitted branch matches the
-            // streaming-side `else { drop(...) }` so the sentinel does
-            // not accumulate stale entries from earlier turns.
-            //
-            // Paged success: never adopt — block-level reuse is
-            // already in the native cache, and adopting would
-            // re-introduce the cross-endpoint warm-slot eviction
-            // that paged is supposed to eliminate.
-            if (!pagedActive) {
-              if (outcome.committed && !hasSuppressedToolCalls(result, body)) {
-                sessionReg.adopt(MESSAGES_WARM_SLOT_ID, session, requestedSystem, null);
-              } else {
-                sessionReg.drop(MESSAGES_WARM_SLOT_ID);
+          } catch (err) {
+            // A failed turn on the non-paged path must not leave a
+            // poisoned warm slot for the next request to lease — drop
+            // the sentinel before emitting the error response.
+            // Streaming half-failures are already covered by the
+            // `wasCommitted()` gate above; this catch handles
+            // non-streaming throws and any pre-handler failures from
+            // the streaming path. The paged path never adopts, so the
+            // drop is a no-op there but kept unconditional for
+            // simplicity (the registry treats `drop` of an absent key
+            // as a no-op).
+            sessionReg.drop(MESSAGES_WARM_SLOT_ID);
+            const message = err instanceof Error ? err.message : 'Unknown error during inference';
+            if (visibility.responseMode === null) {
+              sendAnthropicInternalError(res, message);
+            } else if (visibility.responseMode === 'json') {
+              // Already committed to JSON — destroy the socket rather than corrupt the body.
+              try {
+                res.destroy(err instanceof Error ? err : new Error(message));
+              } catch {
+                // Socket may already be gone.
+              }
+            } else {
+              // SSE: best-effort streaming `error`, but only if no terminal landed
+              // (a double terminal would confuse the client state machine).
+              if (!visibility.terminalEmitted) {
+                writeFallbackErrorSSE(res, 'error', {
+                  error: { type: 'api_error', message },
+                });
+              }
+              try {
+                endSSE(res);
+              } catch {
+                // Already closed.
               }
             }
           }
-        } catch (err) {
-          // A failed turn on the non-paged path must not leave a
-          // poisoned warm slot for the next request to lease — drop
-          // the sentinel before emitting the error response.
-          // Streaming half-failures are already covered by the
-          // `wasCommitted()` gate above; this catch handles
-          // non-streaming throws and any pre-handler failures from
-          // the streaming path. The paged path never adopts, so the
-          // drop is a no-op there but kept unconditional for
-          // simplicity (the registry treats `drop` of an absent key
-          // as a no-op).
-          sessionReg.drop(MESSAGES_WARM_SLOT_ID);
-          const message = err instanceof Error ? err.message : 'Unknown error during inference';
-          if (visibility.responseMode === null) {
-            sendAnthropicInternalError(res, message);
-          } else if (visibility.responseMode === 'json') {
-            // Already committed to JSON — destroy the socket rather than corrupt the body.
-            try {
-              res.destroy(err instanceof Error ? err : new Error(message));
-            } catch {
-              // Socket may already be gone.
-            }
-          } else {
-            // SSE: best-effort streaming `error`, but only if no terminal landed
-            // (a double terminal would confuse the client state machine).
-            if (!visibility.terminalEmitted) {
-              writeFallbackErrorSSE(res, 'error', {
-                error: { type: 'api_error', message },
-              });
-            }
-            try {
-              endSSE(res);
-            } catch {
-              // Already closed.
-            }
-          }
-        }
-      });
+        });
+      if (modelWorkCoordinator) await modelWorkCoordinator.withInference(runInference);
+      else await runInference();
     } catch (err) {
       // Admission-control rejection from the per-model queue cap
       // (`SessionRegistry.withExclusive` threw before chaining into

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -113,6 +113,7 @@ import { validateAndCanonicalizeHistoryToolOrder } from './responses.js';
  * non-streaming) in lockstep.
  */
 const MESSAGES_WARM_SLOT_ID = '__msg_warm__';
+const CLAUDE_CODE_TITLE_MAX_TOKENS = 128;
 
 function requestAllowsToolUse(body: AnthropicMessagesRequest): boolean {
   return Array.isArray(body.tools) && body.tools.length > 0;
@@ -133,6 +134,60 @@ function applyOutputTokenLimit(config: ChatConfig, limit: number | undefined): C
     return config;
   }
   return { ...config, maxNewTokens: Math.floor(limit) };
+}
+
+function systemText(system: AnthropicMessagesRequest['system']): string {
+  if (system == null) return '';
+  if (typeof system === 'string') return system;
+  return system
+    .filter((block): block is Extract<(typeof system)[number], { type: 'text' }> => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+}
+
+function hasTitleJsonSchema(schema: unknown): boolean {
+  if (schema == null || typeof schema !== 'object') return false;
+  const obj = schema as {
+    type?: unknown;
+    properties?: unknown;
+    required?: unknown;
+  };
+  if (obj.type !== 'object') return false;
+  if (obj.properties == null || typeof obj.properties !== 'object') return false;
+  const properties = obj.properties as Record<string, unknown>;
+  const title = properties['title'];
+  if (title == null || typeof title !== 'object') return false;
+  if ((title as { type?: unknown }).type !== 'string') return false;
+  return Array.isArray(obj.required) && obj.required.includes('title');
+}
+
+function isClaudeCodeTitleGenerationRequest(body: AnthropicMessagesRequest): boolean {
+  if (requestAllowsToolUse(body)) return false;
+  const format = body.output_config?.format;
+  if (format?.type !== 'json_schema' || !hasTitleJsonSchema(format.schema)) return false;
+
+  const prompt = systemText(body.system).toLowerCase();
+  return (
+    prompt.includes('generate a concise') &&
+    prompt.includes('title') &&
+    prompt.includes('return json') &&
+    prompt.includes('"title"')
+  );
+}
+
+function applyClaudeCodeTitleFastPath(config: ChatConfig, body: AnthropicMessagesRequest): ChatConfig {
+  if (!isClaudeCodeTitleGenerationRequest(body)) return config;
+  const cappedMax =
+    config.maxNewTokens == null
+      ? CLAUDE_CODE_TITLE_MAX_TOKENS
+      : Math.min(config.maxNewTokens, CLAUDE_CODE_TITLE_MAX_TOKENS);
+  return {
+    ...config,
+    maxNewTokens: cappedMax,
+    reasoningEffort: 'none',
+    thinkingTokenBudget: 0,
+    includeReasoning: false,
+  };
 }
 
 // Non-streaming path
@@ -191,6 +246,7 @@ async function handleStreamingNative(
   wasCommitted: () => boolean,
   httpReq: IncomingMessage | undefined,
   visibility: TransportVisibility,
+  emitReasoning: boolean,
   serverTiming?: ServerTimingForUsage,
 ): Promise<MessagesStreamingHandlerResult> {
   const messageId = genId('msg_');
@@ -499,6 +555,7 @@ async function handleStreamingNative(
 
       // Delta event
       if (event.isReasoning) {
+        if (!emitReasoning) continue;
         const deltaText = event.text.replace(/<\/think>/g, '');
         if (!deltaText) continue;
 
@@ -925,6 +982,7 @@ export async function handleCreateMessage(
   try {
     const sessionReg: SessionRegistry = lease.registry;
     mappedConfig = applyOutputTokenLimit(mappedConfig, sessionReg.outputTokenLimit);
+    mappedConfig = applyClaudeCodeTitleFastPath(mappedConfig, body);
     // Snapshot the monotonic instance id so the in-mutex re-read can detect a
     // hot-swap that lands between lease acquisition and mutex entry. Unlike
     // `/v1/responses`, the Anthropic handler has no stored-identity check
@@ -1164,6 +1222,7 @@ export async function handleCreateMessage(
                 outcome.wasCommitted,
                 httpReq,
                 visibility,
+                config.includeReasoning !== false,
                 serverTiming,
               );
               // Warm-slot adopt/drop only applies to the non-paged

--- a/packages/server/src/endpoints/responses.ts
+++ b/packages/server/src/endpoints/responses.ts
@@ -25,6 +25,7 @@ import {
   genId,
   mapFinishReasonToStatus,
 } from '../mappers/response.js';
+import type { ModelWorkCoordinator } from '../model-work-coordinator.js';
 import { getPendingWritesFor } from '../pending-writes.js';
 import type { ModelRegistry } from '../registry.js';
 import { maybeWarnPromptCacheKeyIneligible, QueueFullError, type SessionRegistry } from '../session-registry.js';
@@ -1632,6 +1633,7 @@ export async function handleCreateResponse(
   httpReq?: IncomingMessage,
   responseRetentionSec?: number,
   idleSweeper?: IdleSweeper | null,
+  modelWorkCoordinator?: ModelWorkCoordinator,
 ): Promise<void> {
   const handlerStartedAt = Date.now();
 
@@ -2345,1084 +2347,1088 @@ export async function handleCreateResponse(
 
     try {
       const mutexQueuedAt = Date.now();
-      await sessionReg.withExclusive(async () => {
-        const serverTiming: ServerTimingForUsage = {
-          server_queue_ms: Date.now() - mutexQueuedAt,
-          server_pre_inference_ms: Date.now() - handlerStartedAt,
-          ...resolveServerTuningForUsage(),
-        };
+      const runInference = () =>
+        sessionReg.withExclusive(async () => {
+          const serverTiming: ServerTimingForUsage = {
+            server_queue_ms: Date.now() - mutexQueuedAt,
+            server_pre_inference_ms: Date.now() - handlerStartedAt,
+            ...resolveServerTuningForUsage(),
+          };
 
-        // Hot-swap race guard inside the mutex.
-        //
-        // `withExclusive` can park this waiter behind a long-running
-        // dispatch on the same model, and `ModelRegistry.register()` is
-        // NOT coordinated with that lock — a concurrent
-        // `registry.register(body.model, newModel)` can re-point the
-        // friendly name while we are parked. Without this in-lock re-read
-        // the closure would still lease a session out of the already-
-        // captured `preLockSessionReg`, adopt under the dead
-        // `preLockInstanceId`, and persist the new chain under a binding
-        // that `body.model` no longer resolves to. The pre-lock
-        // re-read only covered the `store.getChain()` await window; the
-        // mutex-wait window is strictly later and equally unsafe.
-        //
-        // Compare the live binding to the pre-lock snapshot (captured
-        // just before entering the mutex — already refreshed on the
-        // continuation path, identical to the handler-top snapshot
-        // on the stateless path). Any drift — nullable or value — is
-        // fatal and rejected with the same 400 envelope the pre-lock
-        // guard uses, so clients see a consistent "binding changed"
-        // error regardless of which await window caught the race.
-        const lockedSessionReg = registry.getSessionRegistry(body.model);
-        const lockedInstanceId = registry.getInstanceId(body.model);
-        if (
-          lockedSessionReg === undefined ||
-          lockedInstanceId === undefined ||
-          lockedSessionReg !== preLockSessionReg ||
-          lockedInstanceId !== preLockInstanceId
-        ) {
-          sendBadRequest(
-            res,
-            `Model "${body.model}" binding changed while the request was queued behind the per-model ` +
-              `execution mutex. A concurrent register() re-pointed the name at a different model instance ` +
-              `(or released it entirely) while this waiter was parked, so the session registry and instance ` +
-              `id captured before the mutex wait no longer match the live binding. Dispatching anyway would ` +
-              `route the request through the wrong model — priming, decoding, and persisting under a dead ` +
-              `binding. Retry the request — if the swap was intentional, the new binding will service the ` +
-              `retry cleanly.`,
-            'model',
-          );
-          return;
-        }
-
-        // Route the request through a `ChatSession` looked up by the prior
-        // response id. A miss (null id, unknown id, expired entry, or
-        // prefix-state mismatch) returns a fresh session; a hit leases the
-        // cached session out of the registry (single-use — the entry is
-        // removed on hit so overlapping requests against the same prior id
-        // cannot race on the same single-flight ChatSession).
-        //
-        // Hot-path eligibility gate: the chat-session delta API only
-        // serves a SINGLE `user` or `tool` continuation message — the
-        // `send` / `sendToolResult` entry points cover exactly that
-        // shape. A single `assistant` / `system` continuation cannot
-        // be advanced incrementally against the warm KV cache and
-        // must be handled via reset + cold re-prime. That branch is
-        // still VALID — it just routes through `runSession*`'s
-        // `session.turns === 0` fall-through (`primeHistory` +
-        // `startFromHistory*`) instead of the `send` / `sendToolResult`
-        // delta path. Crucially, a tier-1 HIT on this branch is still
-        // useful: `resetPreservingNativeCacheForWarmReuse(session)` keeps
-        // the warm native KV cache, and the subsequent
-        // `chat_session_start_sync` -> `verify_cache_prefix_direct`
-        // recovers the reused prefix even across a full-history
-        // replay. So we must NOT rewrite `previousResponseId` to null
-        // to force a cold-replay lookup — the tier-1 lease is exactly
-        // what makes warm reuse work. (Pre-Round 5 this branch passed
-        // `null` to force a miss, but that was wrong: it threw away a
-        // usable warm lease AND mislabeled the turn as `cold_replay`
-        // when the native prefix verifier was about to reuse the
-        // entire previous-turn prefix.) The hot-path-ineligibility
-        // condition (single non-user/non-tool continuation) is no
-        // longer consulted at lookup time — it's just the natural
-        // fall-through to the `session.turns === 0 || multi-message`
-        // cold-re-prime branch in `runSession*`, which correctly
-        // preserves the warm native cache on HIT via
-        // `resetPreservingNativeCacheForWarmReuse(session)`.
-        // Normalize the caller-supplied `prompt_cache_key` into the
-        // `string | null` shape the registry expects. `undefined` and
-        // missing both map to `null`; an explicit empty string is
-        // preserved distinct from `null` so the registry's tier-2
-        // scan treats "no key" and "empty key" as different tenants
-        // (prevents an unkeyed client from accidentally colliding
-        // with one that explicitly empty-keyed).
-        const promptCacheKey: string | null = typeof body.prompt_cache_key === 'string' ? body.prompt_cache_key : null;
-        // Precedence gate: when `previous_response_id` is present, tier-2
-        // (prompt-cache-key) lookup is DISABLED — even if the request is
-        // hot-path ineligible (single `assistant` / `system` continuation).
-        // The documented precedence is "prev-id wins; tier-1 miss falls
-        // through to FRESH, not tier-2", and that rule has to hold whether
-        // we take the hot path or the ineligible cold-replay branch. If we
-        // let the ineligible branch fall through to tier-2, a mis-routed
-        // prev-id request could lease an UNRELATED warm session that
-        // happens to share `prompt_cache_key`, then cold-replay on top of
-        // it — which `session.reset()` + `primeHistory()` would destroy,
-        // corrupting an unrelated chain. Force `null` for the cache key on
-        // both branches whenever a prev-id is set; tier-2 only runs for
-        // requests with no prev-id at all.
-        const effectivePromptCacheKey = previousResponseId != null ? null : promptCacheKey;
-        // Integrator nudge: if the caller supplied a non-empty
-        // `prompt_cache_key` but tier-2 prerequisites are missing
-        // (env gate off or key below the min-length floor) the turn
-        // silently cold-starts. Emit a once-per-distinct-raw-key
-        // stderr warning so `X-Session-Cache: fresh` on every request
-        // can be diagnosed without reading source. Gated on
-        // `effectivePromptCacheKey` (not raw `promptCacheKey`) so a
-        // request that suppresses the key via `previous_response_id`
-        // precedence does not also log a misleading "key ignored"
-        // message — that case is documented precedence, not a
-        // misconfiguration.
-        if (effectivePromptCacheKey !== null) {
-          maybeWarnPromptCacheKeyIneligible(effectivePromptCacheKey);
-        }
-        const lookup = sessionReg.getOrCreate(
-          previousResponseId ?? null,
-          requestedInstructions,
-          effectivePromptCacheKey,
-        );
-        const session = lookup.session;
-        // `X-Session-Cache` observability header: classify this turn as
-        // `fresh` (no `previous_response_id` on the request and tier-2
-        // prompt-cache-key did not hit), `hit` (prev-id warm-cache
-        // lease consumed on tier 1), `prefix_hit` (tier-2 warm-cache
-        // lease consumed — only promoted from `fresh` later once the
-        // native `cachedTokens > 0` confirms real prefix reuse), or
-        // `cold_replay` (request carried `previous_response_id` but
-        // the warm entry was missing / expired / instructions-
-        // mismatched / already leased, OR the request shape is
-        // ineligible for the hot path — the endpoint will rebuild the
-        // session from the `ResponseStore` below). Set before any
-        // `writeHead` / SSE `beginSSE` so both JSON and SSE responses
-        // carry it. See `endpoints/messages.ts` for the matching
-        // emission on `/v1/messages`.
-        //
-        // The `prefix_hit` promotion and the companion
-        // `X-Cached-Tokens: N` header both depend on the native
-        // ChatResult's `cachedTokens` field, which is only authoritative
-        // AFTER the native dispatch completes. We therefore emit the
-        // initial `fresh` / `hit` / `cold_replay` value here and let
-        // the post-dispatch branch below promote a `fresh`+tier2-hit
-        // classification to `prefix_hit` once the cached-tokens count
-        // is known.
-        const tier2Hit = previousResponseId == null && lookup.hit;
-        // Optimistic pre-dispatch classification. SSE flushes headers on
-        // `beginSSE` inside `handleStreamingNative`, so the streaming
-        // path has exactly one shot to commit the header value — before
-        // the dispatch runs, i.e. BEFORE the native prefix verifier has
-        // reported whether any tokens were actually reused.
-        //
-        // For non-streaming we still commit optimistically to
-        // `prefix_hit` on tier-2 hit and demote to `fresh` post-dispatch
-        // if `cachedTokens === 0` (template drift, tokenizer change,
-        // image-set change, etc.) — `res.end` has not fired yet so the
-        // header is still settable.
-        //
-        // For streaming we deliberately do NOT promote to `prefix_hit`
-        // on tier-2 hit. Once SSE headers flush they cannot be
-        // corrected, and a false-positive `prefix_hit` would contradict
-        // consumers that read `cachedTokens` from the terminal event.
-        // Approach B (this path): emit `fresh` on streaming even when
-        // tier-2 found a warm session — the cache reuse still happens,
-        // only the observability header is conservative. A future
-        // refactor can thread `cached_tokens` through the native
-        // streaming `start` chunk so the server knows authoritatively
-        // before `beginSSE()` flushes, at which point streaming can
-        // commit `prefix_hit` too (Approach A). Until then,
-        // `prefix_hit` is a non-streaming-only signal.
-        const isStreaming = mappedBody.stream === true;
-        // Prev-id branch classification. A tier-1 HIT is labeled `hit`
-        // regardless of whether the request is hot-path-eligible: the
-        // warm native KV cache is reused in both paths (the cheap
-        // `send` / `sendToolResult` delta on the eligible branch; the
-        // full-history `primeHistory` + `startFromHistory*` replay on
-        // the ineligible branch, where `resetPreservingNativeCacheForWarmReuse`
-        // keeps the cache alive for `verify_cache_prefix_direct` to
-        // recover). Only a registry MISS on the prev-id branch
-        // downgrades to `cold_replay` (no warm cache to reuse, the
-        // request must rebuild from `ResponseStore`).
-        let sessionCacheStatus: SessionCacheStatus =
-          previousResponseId == null
-            ? tier2Hit && !isStreaming
-              ? 'prefix_hit'
-              : 'fresh'
-            : lookup.hit
-              ? 'hit'
-              : 'cold_replay';
-        res.setHeader('X-Session-Cache', sessionCacheStatus);
-
-        // Multi-tool-call fan-out gate.
-        //
-        // The chat-session API cannot interleave tool results for a
-        // multi-call fan-out turn (each `sendToolResult` dispatch re-opens
-        // the assistant turn, so responding to the siblings would weave new
-        // assistant replies between the results — see
-        // `ChatSession.pendingUnresolvedToolCallCount`). The only valid forward
-        // progress from such a turn is an atomic replay that resolves every
-        // sibling call in one cold-restart, so we reject any continuation
-        // whose submitted `function_call_output` set does not exactly match
-        // the outstanding call ids.
-        //
-        // The gate only runs for `previous_response_id` continuations, where
-        // the STORED prior chain (`priorMessages`, reconstructed via
-        // `reconstructMessagesFromChain`) is the authoritative view of the
-        // trailing assistant turn and `newInputMessages` contains only the
-        // caller's continuation delta. Stateless requests (no
-        // `previous_response_id`) carry a full self-contained history in
-        // `input`, and historical tool outputs for prior resolved turns
-        // would otherwise be misclassified against the latest assistant's
-        // outstanding id set — leave cold-start histories to the jinja
-        // template / chat-session prefill to handle as-is.
-        const expectedOutstandingIds = priorMessages ? extractOutstandingToolCallIds(priorMessages) : null;
-
-        // Forged-tool-output guard. A `previous_response_id` continuation that
-        // submits any `function_call_output` when the stored prior chain has
-        // ZERO outstanding tool calls is structurally invalid: there is no
-        // assistant tool call for the result to resolve, so dispatching it
-        // would inject a synthetic `<tool_response>` delta into a thread the
-        // model never asked to call. Native backends do not authenticate
-        // `tool_call_id` against prior state — several just append the
-        // delta verbatim — so the gate must live here. Stateless requests
-        // (no `previous_response_id`) carry a full self-contained history
-        // and are left to the jinja template / chat-session prefill.
-        if (previousResponseId && expectedOutstandingIds === null) {
-          for (const m of newInputMessages) {
-            if (m.role === 'tool') {
-              sendBadRequest(
-                res,
-                `function_call_output submitted against a thread with no outstanding tool call. ` +
-                  `The prior assistant turn either never emitted a tool call or every sibling call has ` +
-                  `already been resolved, so there is nothing for this function_call_output to answer. ` +
-                  `Dispatching it anyway would synthesize a tool-response delta for a call the model ` +
-                  `never made and corrupt the conversation structure. Drop the function_call_output, ` +
-                  `or start a new chain without previous_response_id.`,
-                'input',
-              );
-              return;
-            }
+          // Hot-swap race guard inside the mutex.
+          //
+          // `withExclusive` can park this waiter behind a long-running
+          // dispatch on the same model, and `ModelRegistry.register()` is
+          // NOT coordinated with that lock — a concurrent
+          // `registry.register(body.model, newModel)` can re-point the
+          // friendly name while we are parked. Without this in-lock re-read
+          // the closure would still lease a session out of the already-
+          // captured `preLockSessionReg`, adopt under the dead
+          // `preLockInstanceId`, and persist the new chain under a binding
+          // that `body.model` no longer resolves to. The pre-lock
+          // re-read only covered the `store.getChain()` await window; the
+          // mutex-wait window is strictly later and equally unsafe.
+          //
+          // Compare the live binding to the pre-lock snapshot (captured
+          // just before entering the mutex — already refreshed on the
+          // continuation path, identical to the handler-top snapshot
+          // on the stateless path). Any drift — nullable or value — is
+          // fatal and rejected with the same 400 envelope the pre-lock
+          // guard uses, so clients see a consistent "binding changed"
+          // error regardless of which await window caught the race.
+          const lockedSessionReg = registry.getSessionRegistry(body.model);
+          const lockedInstanceId = registry.getInstanceId(body.model);
+          if (
+            lockedSessionReg === undefined ||
+            lockedInstanceId === undefined ||
+            lockedSessionReg !== preLockSessionReg ||
+            lockedInstanceId !== preLockInstanceId
+          ) {
+            sendBadRequest(
+              res,
+              `Model "${body.model}" binding changed while the request was queued behind the per-model ` +
+                `execution mutex. A concurrent register() re-pointed the name at a different model instance ` +
+                `(or released it entirely) while this waiter was parked, so the session registry and instance ` +
+                `id captured before the mutex wait no longer match the live binding. Dispatching anyway would ` +
+                `route the request through the wrong model — priming, decoding, and persisting under a dead ` +
+                `binding. Retry the request — if the swap was intentional, the new binding will service the ` +
+                `retry cleanly.`,
+              'model',
+            );
+            return;
           }
-        }
 
-        if (expectedOutstandingIds !== null) {
-          // Contiguous-prefix guard: function_call_output items must appear
-          // as an unbroken prefix of the continuation delta, before any
-          // user/assistant/system message. A shape like
-          // `[tool(call_a), user(hi), tool(call_b)]` would otherwise pass
-          // every id-set check below (both outstanding ids present, no
-          // duplicates, no stale ids) while still orphaning the fan-out,
-          // because the interleaved user turn re-opens the assistant turn
-          // between the two tool results. Reject early so the caller cannot
-          // smuggle a user turn into the middle of a resolved fan-out.
-          let seenNonTool = false;
-          for (const m of newInputMessages) {
-            if (m.role === 'tool') {
-              if (seenNonTool) {
+          // Route the request through a `ChatSession` looked up by the prior
+          // response id. A miss (null id, unknown id, expired entry, or
+          // prefix-state mismatch) returns a fresh session; a hit leases the
+          // cached session out of the registry (single-use — the entry is
+          // removed on hit so overlapping requests against the same prior id
+          // cannot race on the same single-flight ChatSession).
+          //
+          // Hot-path eligibility gate: the chat-session delta API only
+          // serves a SINGLE `user` or `tool` continuation message — the
+          // `send` / `sendToolResult` entry points cover exactly that
+          // shape. A single `assistant` / `system` continuation cannot
+          // be advanced incrementally against the warm KV cache and
+          // must be handled via reset + cold re-prime. That branch is
+          // still VALID — it just routes through `runSession*`'s
+          // `session.turns === 0` fall-through (`primeHistory` +
+          // `startFromHistory*`) instead of the `send` / `sendToolResult`
+          // delta path. Crucially, a tier-1 HIT on this branch is still
+          // useful: `resetPreservingNativeCacheForWarmReuse(session)` keeps
+          // the warm native KV cache, and the subsequent
+          // `chat_session_start_sync` -> `verify_cache_prefix_direct`
+          // recovers the reused prefix even across a full-history
+          // replay. So we must NOT rewrite `previousResponseId` to null
+          // to force a cold-replay lookup — the tier-1 lease is exactly
+          // what makes warm reuse work. (Pre-Round 5 this branch passed
+          // `null` to force a miss, but that was wrong: it threw away a
+          // usable warm lease AND mislabeled the turn as `cold_replay`
+          // when the native prefix verifier was about to reuse the
+          // entire previous-turn prefix.) The hot-path-ineligibility
+          // condition (single non-user/non-tool continuation) is no
+          // longer consulted at lookup time — it's just the natural
+          // fall-through to the `session.turns === 0 || multi-message`
+          // cold-re-prime branch in `runSession*`, which correctly
+          // preserves the warm native cache on HIT via
+          // `resetPreservingNativeCacheForWarmReuse(session)`.
+          // Normalize the caller-supplied `prompt_cache_key` into the
+          // `string | null` shape the registry expects. `undefined` and
+          // missing both map to `null`; an explicit empty string is
+          // preserved distinct from `null` so the registry's tier-2
+          // scan treats "no key" and "empty key" as different tenants
+          // (prevents an unkeyed client from accidentally colliding
+          // with one that explicitly empty-keyed).
+          const promptCacheKey: string | null =
+            typeof body.prompt_cache_key === 'string' ? body.prompt_cache_key : null;
+          // Precedence gate: when `previous_response_id` is present, tier-2
+          // (prompt-cache-key) lookup is DISABLED — even if the request is
+          // hot-path ineligible (single `assistant` / `system` continuation).
+          // The documented precedence is "prev-id wins; tier-1 miss falls
+          // through to FRESH, not tier-2", and that rule has to hold whether
+          // we take the hot path or the ineligible cold-replay branch. If we
+          // let the ineligible branch fall through to tier-2, a mis-routed
+          // prev-id request could lease an UNRELATED warm session that
+          // happens to share `prompt_cache_key`, then cold-replay on top of
+          // it — which `session.reset()` + `primeHistory()` would destroy,
+          // corrupting an unrelated chain. Force `null` for the cache key on
+          // both branches whenever a prev-id is set; tier-2 only runs for
+          // requests with no prev-id at all.
+          const effectivePromptCacheKey = previousResponseId != null ? null : promptCacheKey;
+          // Integrator nudge: if the caller supplied a non-empty
+          // `prompt_cache_key` but tier-2 prerequisites are missing
+          // (env gate off or key below the min-length floor) the turn
+          // silently cold-starts. Emit a once-per-distinct-raw-key
+          // stderr warning so `X-Session-Cache: fresh` on every request
+          // can be diagnosed without reading source. Gated on
+          // `effectivePromptCacheKey` (not raw `promptCacheKey`) so a
+          // request that suppresses the key via `previous_response_id`
+          // precedence does not also log a misleading "key ignored"
+          // message — that case is documented precedence, not a
+          // misconfiguration.
+          if (effectivePromptCacheKey !== null) {
+            maybeWarnPromptCacheKeyIneligible(effectivePromptCacheKey);
+          }
+          const lookup = sessionReg.getOrCreate(
+            previousResponseId ?? null,
+            requestedInstructions,
+            effectivePromptCacheKey,
+          );
+          const session = lookup.session;
+          // `X-Session-Cache` observability header: classify this turn as
+          // `fresh` (no `previous_response_id` on the request and tier-2
+          // prompt-cache-key did not hit), `hit` (prev-id warm-cache
+          // lease consumed on tier 1), `prefix_hit` (tier-2 warm-cache
+          // lease consumed — only promoted from `fresh` later once the
+          // native `cachedTokens > 0` confirms real prefix reuse), or
+          // `cold_replay` (request carried `previous_response_id` but
+          // the warm entry was missing / expired / instructions-
+          // mismatched / already leased, OR the request shape is
+          // ineligible for the hot path — the endpoint will rebuild the
+          // session from the `ResponseStore` below). Set before any
+          // `writeHead` / SSE `beginSSE` so both JSON and SSE responses
+          // carry it. See `endpoints/messages.ts` for the matching
+          // emission on `/v1/messages`.
+          //
+          // The `prefix_hit` promotion and the companion
+          // `X-Cached-Tokens: N` header both depend on the native
+          // ChatResult's `cachedTokens` field, which is only authoritative
+          // AFTER the native dispatch completes. We therefore emit the
+          // initial `fresh` / `hit` / `cold_replay` value here and let
+          // the post-dispatch branch below promote a `fresh`+tier2-hit
+          // classification to `prefix_hit` once the cached-tokens count
+          // is known.
+          const tier2Hit = previousResponseId == null && lookup.hit;
+          // Optimistic pre-dispatch classification. SSE flushes headers on
+          // `beginSSE` inside `handleStreamingNative`, so the streaming
+          // path has exactly one shot to commit the header value — before
+          // the dispatch runs, i.e. BEFORE the native prefix verifier has
+          // reported whether any tokens were actually reused.
+          //
+          // For non-streaming we still commit optimistically to
+          // `prefix_hit` on tier-2 hit and demote to `fresh` post-dispatch
+          // if `cachedTokens === 0` (template drift, tokenizer change,
+          // image-set change, etc.) — `res.end` has not fired yet so the
+          // header is still settable.
+          //
+          // For streaming we deliberately do NOT promote to `prefix_hit`
+          // on tier-2 hit. Once SSE headers flush they cannot be
+          // corrected, and a false-positive `prefix_hit` would contradict
+          // consumers that read `cachedTokens` from the terminal event.
+          // Approach B (this path): emit `fresh` on streaming even when
+          // tier-2 found a warm session — the cache reuse still happens,
+          // only the observability header is conservative. A future
+          // refactor can thread `cached_tokens` through the native
+          // streaming `start` chunk so the server knows authoritatively
+          // before `beginSSE()` flushes, at which point streaming can
+          // commit `prefix_hit` too (Approach A). Until then,
+          // `prefix_hit` is a non-streaming-only signal.
+          const isStreaming = mappedBody.stream === true;
+          // Prev-id branch classification. A tier-1 HIT is labeled `hit`
+          // regardless of whether the request is hot-path-eligible: the
+          // warm native KV cache is reused in both paths (the cheap
+          // `send` / `sendToolResult` delta on the eligible branch; the
+          // full-history `primeHistory` + `startFromHistory*` replay on
+          // the ineligible branch, where `resetPreservingNativeCacheForWarmReuse`
+          // keeps the cache alive for `verify_cache_prefix_direct` to
+          // recover). Only a registry MISS on the prev-id branch
+          // downgrades to `cold_replay` (no warm cache to reuse, the
+          // request must rebuild from `ResponseStore`).
+          let sessionCacheStatus: SessionCacheStatus =
+            previousResponseId == null
+              ? tier2Hit && !isStreaming
+                ? 'prefix_hit'
+                : 'fresh'
+              : lookup.hit
+                ? 'hit'
+                : 'cold_replay';
+          res.setHeader('X-Session-Cache', sessionCacheStatus);
+
+          // Multi-tool-call fan-out gate.
+          //
+          // The chat-session API cannot interleave tool results for a
+          // multi-call fan-out turn (each `sendToolResult` dispatch re-opens
+          // the assistant turn, so responding to the siblings would weave new
+          // assistant replies between the results — see
+          // `ChatSession.pendingUnresolvedToolCallCount`). The only valid forward
+          // progress from such a turn is an atomic replay that resolves every
+          // sibling call in one cold-restart, so we reject any continuation
+          // whose submitted `function_call_output` set does not exactly match
+          // the outstanding call ids.
+          //
+          // The gate only runs for `previous_response_id` continuations, where
+          // the STORED prior chain (`priorMessages`, reconstructed via
+          // `reconstructMessagesFromChain`) is the authoritative view of the
+          // trailing assistant turn and `newInputMessages` contains only the
+          // caller's continuation delta. Stateless requests (no
+          // `previous_response_id`) carry a full self-contained history in
+          // `input`, and historical tool outputs for prior resolved turns
+          // would otherwise be misclassified against the latest assistant's
+          // outstanding id set — leave cold-start histories to the jinja
+          // template / chat-session prefill to handle as-is.
+          const expectedOutstandingIds = priorMessages ? extractOutstandingToolCallIds(priorMessages) : null;
+
+          // Forged-tool-output guard. A `previous_response_id` continuation that
+          // submits any `function_call_output` when the stored prior chain has
+          // ZERO outstanding tool calls is structurally invalid: there is no
+          // assistant tool call for the result to resolve, so dispatching it
+          // would inject a synthetic `<tool_response>` delta into a thread the
+          // model never asked to call. Native backends do not authenticate
+          // `tool_call_id` against prior state — several just append the
+          // delta verbatim — so the gate must live here. Stateless requests
+          // (no `previous_response_id`) carry a full self-contained history
+          // and are left to the jinja template / chat-session prefill.
+          if (previousResponseId && expectedOutstandingIds === null) {
+            for (const m of newInputMessages) {
+              if (m.role === 'tool') {
                 sendBadRequest(
                   res,
-                  `function_call_output items must appear as a contiguous prefix of the continuation ` +
-                    `before any user, assistant, or system message. Interleaving a non-tool message ` +
-                    `between sibling function_call_output items orphans the fan-out by weaving a new ` +
-                    `assistant turn between the tool results. Reorder the submission so every ` +
-                    `function_call_output precedes any subsequent message, or start a new chain ` +
-                    `without previous_response_id.`,
+                  `function_call_output submitted against a thread with no outstanding tool call. ` +
+                    `The prior assistant turn either never emitted a tool call or every sibling call has ` +
+                    `already been resolved, so there is nothing for this function_call_output to answer. ` +
+                    `Dispatching it anyway would synthesize a tool-response delta for a call the model ` +
+                    `never made and corrupt the conversation structure. Drop the function_call_output, ` +
+                    `or start a new chain without previous_response_id.`,
                   'input',
                 );
                 return;
               }
-            } else {
-              seenNonTool = true;
             }
           }
 
-          const submittedIds: string[] = [];
-          for (const m of newInputMessages) {
-            if (m.role === 'tool' && typeof m.toolCallId === 'string' && m.toolCallId.length > 0) {
-              submittedIds.push(m.toolCallId);
+          if (expectedOutstandingIds !== null) {
+            // Contiguous-prefix guard: function_call_output items must appear
+            // as an unbroken prefix of the continuation delta, before any
+            // user/assistant/system message. A shape like
+            // `[tool(call_a), user(hi), tool(call_b)]` would otherwise pass
+            // every id-set check below (both outstanding ids present, no
+            // duplicates, no stale ids) while still orphaning the fan-out,
+            // because the interleaved user turn re-opens the assistant turn
+            // between the two tool results. Reject early so the caller cannot
+            // smuggle a user turn into the middle of a resolved fan-out.
+            let seenNonTool = false;
+            for (const m of newInputMessages) {
+              if (m.role === 'tool') {
+                if (seenNonTool) {
+                  sendBadRequest(
+                    res,
+                    `function_call_output items must appear as a contiguous prefix of the continuation ` +
+                      `before any user, assistant, or system message. Interleaving a non-tool message ` +
+                      `between sibling function_call_output items orphans the fan-out by weaving a new ` +
+                      `assistant turn between the tool results. Reorder the submission so every ` +
+                      `function_call_output precedes any subsequent message, or start a new chain ` +
+                      `without previous_response_id.`,
+                    'input',
+                  );
+                  return;
+                }
+              } else {
+                seenNonTool = true;
+              }
             }
-          }
 
-          // Short-circuit: a plain user continuation (zero tool results)
-          // would orphan the outstanding call(s) just as surely as a
-          // partial tool-result submission. Reject both paths with the
-          // same 400.
-          const plural = expectedOutstandingIds.length > 1;
-          if (submittedIds.length === 0) {
-            sendBadRequest(
-              res,
-              `Previous assistant turn has ${expectedOutstandingIds.length} unresolved tool call${plural ? 's' : ''} ` +
-                `(${expectedOutstandingIds.join(', ')}); the chat-session API requires every outstanding ` +
-                `function_call_output to be submitted before the thread can advance. A plain user turn ` +
-                `would orphan the unresolved call${plural ? 's' : ''}. Submit function_call_output items for ` +
-                `every outstanding id, or start a new chain without previous_response_id.`,
-              'input',
-            );
-            return;
-          }
+            const submittedIds: string[] = [];
+            for (const m of newInputMessages) {
+              if (m.role === 'tool' && typeof m.toolCallId === 'string' && m.toolCallId.length > 0) {
+                submittedIds.push(m.toolCallId);
+              }
+            }
 
-          const expectedSet = new Set(expectedOutstandingIds);
-          const seen = new Set<string>();
-          for (const id of submittedIds) {
-            if (seen.has(id)) {
+            // Short-circuit: a plain user continuation (zero tool results)
+            // would orphan the outstanding call(s) just as surely as a
+            // partial tool-result submission. Reject both paths with the
+            // same 400.
+            const plural = expectedOutstandingIds.length > 1;
+            if (submittedIds.length === 0) {
               sendBadRequest(
                 res,
-                `Duplicate function_call_output call_id "${id}" — each outstanding tool call must be answered exactly once.`,
+                `Previous assistant turn has ${expectedOutstandingIds.length} unresolved tool call${plural ? 's' : ''} ` +
+                  `(${expectedOutstandingIds.join(', ')}); the chat-session API requires every outstanding ` +
+                  `function_call_output to be submitted before the thread can advance. A plain user turn ` +
+                  `would orphan the unresolved call${plural ? 's' : ''}. Submit function_call_output items for ` +
+                  `every outstanding id, or start a new chain without previous_response_id.`,
                 'input',
               );
               return;
             }
-            seen.add(id);
-            if (!expectedSet.has(id)) {
+
+            const expectedSet = new Set(expectedOutstandingIds);
+            const seen = new Set<string>();
+            for (const id of submittedIds) {
+              if (seen.has(id)) {
+                sendBadRequest(
+                  res,
+                  `Duplicate function_call_output call_id "${id}" — each outstanding tool call must be answered exactly once.`,
+                  'input',
+                );
+                return;
+              }
+              seen.add(id);
+              if (!expectedSet.has(id)) {
+                sendBadRequest(
+                  res,
+                  `Unexpected function_call_output call_id "${id}"; the outstanding multi-tool-call set is ` +
+                    `${expectedOutstandingIds.join(', ')}. Submitting an unrelated or stale call_id would advance ` +
+                    `the chain past an unresolved turn.`,
+                  'input',
+                );
+                return;
+              }
+            }
+            if (seen.size !== expectedSet.size) {
+              const missing: string[] = [];
+              for (const id of expectedOutstandingIds) {
+                if (!seen.has(id)) missing.push(id);
+              }
               sendBadRequest(
                 res,
-                `Unexpected function_call_output call_id "${id}"; the outstanding multi-tool-call set is ` +
-                  `${expectedOutstandingIds.join(', ')}. Submitting an unrelated or stale call_id would advance ` +
-                  `the chain past an unresolved turn.`,
+                `Missing function_call_output items for outstanding tool calls: ${missing.join(', ')}. ` +
+                  `Partial submissions would orphan the sibling tool calls and advance the chain past an ` +
+                  `unresolved turn. Resubmit with every sibling output, or start a new chain without ` +
+                  `previous_response_id.`,
                 'input',
               );
               return;
             }
-          }
-          if (seen.size !== expectedSet.size) {
-            const missing: string[] = [];
-            for (const id of expectedOutstandingIds) {
-              if (!seen.has(id)) missing.push(id);
+
+            // All outstanding ids are accounted for. Canonicalize the submitted
+            // tool-message order to the stored sibling order before the replay
+            // runs — both `messages` (primed into the fresh session on the cold
+            // path) and `newInputMessages` (persisted verbatim into the store
+            // for future chain reconstruction) must reflect the canonical
+            // order, otherwise a caller can swap outputs and silently poison
+            // replay even after the id-set gate passes.
+            //
+            // Compute the tool block's end as the contiguous-prefix run of
+            // `role === 'tool'` messages starting at `priorOffset`. The
+            // contiguous-prefix guard above already rejected any shape that
+            // interleaves a non-tool message inside the delta's tool block,
+            // so this simple forward scan matches the exact block the gate
+            // just authenticated. Passing an explicit `blockEnd` keeps the
+            // helper from accidentally walking into any later turn that
+            // `mapRequest` may have appended to `messages`.
+            let deltaBlockEnd = priorOffset;
+            while (deltaBlockEnd < messages.length && messages[deltaBlockEnd]!.role === 'tool') {
+              deltaBlockEnd++;
             }
-            sendBadRequest(
-              res,
-              `Missing function_call_output items for outstanding tool calls: ${missing.join(', ')}. ` +
-                `Partial submissions would orphan the sibling tool calls and advance the chain past an ` +
-                `unresolved turn. Resubmit with every sibling output, or start a new chain without ` +
-                `previous_response_id.`,
-              'input',
-            );
-            return;
+            canonicalizeToolMessageOrder(messages, priorOffset, deltaBlockEnd, expectedOutstandingIds);
+            newInputMessages = messages.slice(priorOffset);
           }
 
-          // All outstanding ids are accounted for. Canonicalize the submitted
-          // tool-message order to the stored sibling order before the replay
-          // runs — both `messages` (primed into the fresh session on the cold
-          // path) and `newInputMessages` (persisted verbatim into the store
-          // for future chain reconstruction) must reflect the canonical
-          // order, otherwise a caller can swap outputs and silently poison
-          // replay even after the id-set gate passes.
+          // Walk the full merged history and canonicalize every assistant
+          // fan-out's trailing tool block against its declared sibling order.
           //
-          // Compute the tool block's end as the contiguous-prefix run of
-          // `role === 'tool'` messages starting at `priorOffset`. The
-          // contiguous-prefix guard above already rejected any shape that
-          // interleaves a non-tool message inside the delta's tool block,
-          // so this simple forward scan matches the exact block the gate
-          // just authenticated. Passing an explicit `blockEnd` keeps the
-          // helper from accidentally walking into any later turn that
-          // `mapRequest` may have appended to `messages`.
-          let deltaBlockEnd = priorOffset;
-          while (deltaBlockEnd < messages.length && messages[deltaBlockEnd]!.role === 'tool') {
-            deltaBlockEnd++;
+          // The multi-tool-call gate above only fires on `previous_response_id`
+          // continuations, and even there it only handles the caller's delta
+          // block against the STORED prior chain's trailing assistant. That
+          // leaves two cases uncovered:
+          //
+          //   1. Stateless cold-start histories (no `previous_response_id`).
+          //      The caller ships a full self-contained conversation through
+          //      `input`; the gate is skipped entirely and the caller-supplied
+          //      tool-message order flows straight into `primeHistory()`. A
+          //      caller can reverse two sibling tool outputs, and since
+          //      several native session backends pair tool results to
+          //      fan-out calls POSITIONALLY (not by id), each result binds
+          //      to the wrong sibling call.
+          //   2. Earlier fan-outs embedded inside the stored prior history
+          //      on a continuation. Those came from the server's own store
+          //      so they should already be canonical, but defense in depth
+          //      is cheap — a single full-history walk covers every shape.
+          //
+          // Malformed histories (missing/duplicate/unknown ids, orphan tool
+          // messages, unresolved trailing fan-out in a stateless request)
+          // are rejected with a clear 400 instead of silently rewritten.
+          const historyError = validateAndCanonicalizeHistoryToolOrder(messages);
+          if (historyError !== null) {
+            sendBadRequest(res, historyError, 'input');
+            return;
           }
-          canonicalizeToolMessageOrder(messages, priorOffset, deltaBlockEnd, expectedOutstandingIds);
+          // Canonicalization may have reordered tool messages inside the
+          // continuation delta (on the stateless-history walk over the
+          // post-priorOffset portion), so recompute `newInputMessages` from
+          // the now-canonical `messages`.
           newInputMessages = messages.slice(priorOffset);
-        }
 
-        // Walk the full merged history and canonicalize every assistant
-        // fan-out's trailing tool block against its declared sibling order.
-        //
-        // The multi-tool-call gate above only fires on `previous_response_id`
-        // continuations, and even there it only handles the caller's delta
-        // block against the STORED prior chain's trailing assistant. That
-        // leaves two cases uncovered:
-        //
-        //   1. Stateless cold-start histories (no `previous_response_id`).
-        //      The caller ships a full self-contained conversation through
-        //      `input`; the gate is skipped entirely and the caller-supplied
-        //      tool-message order flows straight into `primeHistory()`. A
-        //      caller can reverse two sibling tool outputs, and since
-        //      several native session backends pair tool results to
-        //      fan-out calls POSITIONALLY (not by id), each result binds
-        //      to the wrong sibling call.
-        //   2. Earlier fan-outs embedded inside the stored prior history
-        //      on a continuation. Those came from the server's own store
-        //      so they should already be canonical, but defense in depth
-        //      is cheap — a single full-history walk covers every shape.
-        //
-        // Malformed histories (missing/duplicate/unknown ids, orphan tool
-        // messages, unresolved trailing fan-out in a stateless request)
-        // are rejected with a clear 400 instead of silently rewritten.
-        const historyError = validateAndCanonicalizeHistoryToolOrder(messages);
-        if (historyError !== null) {
-          sendBadRequest(res, historyError, 'input');
-          return;
-        }
-        // Canonicalization may have reordered tool messages inside the
-        // continuation delta (on the stateless-history walk over the
-        // post-priorOffset portion), so recompute `newInputMessages` from
-        // the now-canonical `messages`.
-        newInputMessages = messages.slice(priorOffset);
+          // Visibility / wire-format tracker shared between the handler
+          // body and the outer catch. Declared outside the `try` so the
+          // catch can branch on `responseMode` (JSON vs SSE) and know
+          // whether a terminal artefact already landed — both signals
+          // are authoritative, unlike `res.headersSent`.
+          const visibility = createVisibility();
 
-        // Visibility / wire-format tracker shared between the handler
-        // body and the outer catch. Declared outside the `try` so the
-        // catch can branch on `responseMode` (JSON vs SSE) and know
-        // whether a terminal artefact already landed — both signals
-        // are authoritative, unlike `res.headersSent`.
-        const visibility = createVisibility();
+          try {
+            // `runSession*` plumbs an honest commit signal out of the helper:
+            // `ChatSession` only advances `turns` on a successful non-error
+            // final chunk (streaming) or a resolved native promise
+            // (non-streaming). The streaming safety-net path (generator
+            // exhausts without a `done` event, see `handleStreamingNative`
+            // fallback) and the `finishReason === 'error'` final chunk both
+            // leave `turns` unchanged. The helper captures its baseline
+            // AFTER any internal `session.reset()` on the multi-message
+            // reset-and-cold-restart branch, so the signal is honest there
+            // too — a pre-helper snapshot would be stale.
+            let committed: boolean;
+            // Pass `mappedBody` (not the raw `body`) so the response
+            // object and the persisted record carry the EFFECTIVE
+            // instructions, including any value inherited from the
+            // trailing stored record via instruction inheritance.
+            // Using `body` here
+            // would re-drop the inherited value on the wire — the
+            // client's response would report `instructions: null` even
+            // though the turn was run against the inherited system
+            // context, and the next cold replay would have nothing to
+            // re-inherit from.
+            // Wrap the handler call in its own try/catch so that a
+            // post-commit persistence failure does not prevent adopt.
+            // Post-commit store failures are caught inside the handlers
+            // themselves (handleNonStreaming / handleStreamingNative) and
+            // demoted to log-only. A handlerError at this level therefore
+            // comes from non-persistence failures (response construction,
+            // SSE write, res.writeHead/end crash).
+            //
+            // `res.headersSent` is NOT a reliable proxy for "the client
+            // received the response": Node's `writeHead` flips
+            // `headersSent = true` synchronously before any body bytes
+            // leave the buffer, and the sync return of `res.end()` /
+            // `writeSSEEvent` only proves the bytes were queued — an
+            // async socket failure after the queue could still leave
+            // the client with no terminal. Picking JSON-vs-SSE fallback
+            // from `res.headersSent` is also unsafe because a
+            // `writeHead(200, 'application/json')` → `res.end()` crash
+            // would otherwise emit SSE frames into a JSON-declared
+            // response.
+            //
+            // The `TransportVisibility` record instead tracks both the
+            // wire format the handler committed to (`responseMode`)
+            // AND whether the client observed a terminal artefact
+            // (`responseBodyWritten` / `terminalEmitted`). Both flags
+            // are flipped only from the kernel-ack callback of the
+            // underlying `res.end` / `res.write` — synchronous return
+            // is NOT treated as proof of visibility. The outer catch
+            // branches on `responseMode` to choose the clean-up shape
+            // (JSON error, SSE `error` frame, or socket destroy).
+            let handlerError: Error | null = null;
 
-        try {
-          // `runSession*` plumbs an honest commit signal out of the helper:
-          // `ChatSession` only advances `turns` on a successful non-error
-          // final chunk (streaming) or a resolved native promise
-          // (non-streaming). The streaming safety-net path (generator
-          // exhausts without a `done` event, see `handleStreamingNative`
-          // fallback) and the `finishReason === 'error'` final chunk both
-          // leave `turns` unchanged. The helper captures its baseline
-          // AFTER any internal `session.reset()` on the multi-message
-          // reset-and-cold-restart branch, so the signal is honest there
-          // too — a pre-helper snapshot would be stale.
-          let committed: boolean;
-          // Pass `mappedBody` (not the raw `body`) so the response
-          // object and the persisted record carry the EFFECTIVE
-          // instructions, including any value inherited from the
-          // trailing stored record via instruction inheritance.
-          // Using `body` here
-          // would re-drop the inherited value on the wire — the
-          // client's response would report `instructions: null` even
-          // though the turn was run against the inherited system
-          // context, and the next cold replay would have nothing to
-          // re-inherit from.
-          // Wrap the handler call in its own try/catch so that a
-          // post-commit persistence failure does not prevent adopt.
-          // Post-commit store failures are caught inside the handlers
-          // themselves (handleNonStreaming / handleStreamingNative) and
-          // demoted to log-only. A handlerError at this level therefore
-          // comes from non-persistence failures (response construction,
-          // SSE write, res.writeHead/end crash).
-          //
-          // `res.headersSent` is NOT a reliable proxy for "the client
-          // received the response": Node's `writeHead` flips
-          // `headersSent = true` synchronously before any body bytes
-          // leave the buffer, and the sync return of `res.end()` /
-          // `writeSSEEvent` only proves the bytes were queued — an
-          // async socket failure after the queue could still leave
-          // the client with no terminal. Picking JSON-vs-SSE fallback
-          // from `res.headersSent` is also unsafe because a
-          // `writeHead(200, 'application/json')` → `res.end()` crash
-          // would otherwise emit SSE frames into a JSON-declared
-          // response.
-          //
-          // The `TransportVisibility` record instead tracks both the
-          // wire format the handler committed to (`responseMode`)
-          // AND whether the client observed a terminal artefact
-          // (`responseBodyWritten` / `terminalEmitted`). Both flags
-          // are flipped only from the kernel-ack callback of the
-          // underlying `res.end` / `res.write` — synchronous return
-          // is NOT treated as proof of visibility. The outer catch
-          // branches on `responseMode` to choose the clean-up shape
-          // (JSON error, SSE `error` frame, or socket destroy).
-          let handlerError: Error | null = null;
-
-          if (mappedBody.stream) {
-            const outcome = await runSessionStreaming(
-              session,
-              messages,
-              newInputMessages,
-              config,
-              streamSignal,
-              !lookup.hit,
-            );
-            const streamingWasCommitted = () => outcome.wasCommitted();
-            try {
-              const handlerOutcome = await handleStreamingNative(
-                res,
-                outcome.stream,
-                mappedBody,
-                responseId,
-                previousResponseId,
-                streamingWasCommitted,
-                httpReq,
-                visibility,
-                serverTiming,
+            if (mappedBody.stream) {
+              const outcome = await runSessionStreaming(
+                session,
+                messages,
+                newInputMessages,
+                config,
+                streamSignal,
+                !lookup.hit,
               );
-              streamFailureMode = handlerOutcome.failureMode;
-              if (handlerOutcome.terminalToPersist != null && store && body.store !== false) {
-                // Initiate the write SYNCHRONOUSLY inside the mutex so
-                // the pending-write tracker observes it before the
-                // mutex releases. The promise is awaited off-lock in
-                // the outer finally block.
-                const record = buildResponseRecord(
-                  handlerOutcome.terminalToPersist,
-                  newInputMessages,
+              const streamingWasCommitted = () => outcome.wasCommitted();
+              try {
+                const handlerOutcome = await handleStreamingNative(
+                  res,
+                  outcome.stream,
+                  mappedBody,
+                  responseId,
                   previousResponseId,
-                  currentInstanceId,
-                  effectiveRetentionSec,
+                  streamingWasCommitted,
+                  httpReq,
+                  visibility,
+                  serverTiming,
                 );
-                // Pair a `retainBinding` against the persist promise
-                // so the binding's `modelInstanceId` survives a
-                // concurrent same-model unregister + re-register that
-                // races the post-commit write. `releaseBinding` runs
-                // in the persist's `.finally(...)` regardless of
-                // outcome, so the retention counter stays balanced
-                // whether the write fulfils or rejects.
-                //
-                // Leaving the retain pinned forever on a wedged write
-                // would make the binding unreclaimable until process
-                // restart, so an INDEPENDENT hard-timeout timer is
-                // armed alongside the persist (see
-                // `getPostCommitPersistHardTimeoutMs` for the default).
-                // If the persist settles naturally the timer is
-                // cancelled via `clearTimeout` inside the same
-                // `.finally(...)` — slow-but-eventual writes are
-                // unaffected. If the persist is still wedged past the
-                // hard bound, the timer fires and force-releases the
-                // retain via the idempotent `persistRetainBox`. The
-                // hard timer is armed off the handler's await path, so
-                // the response is never delayed by it.
-                //
-                // Before the hard timeout force-releases the retain
-                // (which unblocks binding teardown), it calls
-                // `registry.retireInstanceIdForForceRelease(leaseModel)`
-                // to tombstone the binding's current instance id on
-                // the model object. A subsequent `register()` of the
-                // SAME model object inherits that retired id rather
-                // than minting fresh — so the late-landing persist's
-                // record (stamped with the retired id) still matches
-                // the live binding and stays chainable through
-                // `previous_response_id`. Only a true hot-swap
-                // (re-register with a DIFFERENT model object) mints a
-                // fresh id, and the 400 instance-mismatch that results
-                // is the correct semantic outcome because the new
-                // model is semantically different from the one that
-                // produced the stored record. Retirement MUST happen
-                // BEFORE release so `instanceIds.get(model)` still
-                // returns the live id the record carries.
-                //
-                // The tombstone's lifetime is scoped to the pending
-                // persists that installed it — the `.finally(...)`
-                // calls `registry.releaseTombstone(leaseModel)` so
-                // that when the late write eventually settles
-                // (fulfills or rejects), the shared refcount drops
-                // and, once every outstanding persist has released,
-                // any subsequent re-registration correctly mints a
-                // fresh id. Without this scoping, a past hard-timeout
-                // event would permanently re-enable id inheritance
-                // across unrelated later lifecycles — reopening
-                // stale-chain replay across what should be logically
-                // dead bindings. The refcounted single-entry layout
-                // handles OVERLAPPING hard-timeouts on the same live
-                // instance id in bounded space: every breaker targets
-                // the SAME retired id (the register-inherit path
-                // keeps using it while the tombstone is alive) so one
-                // shared refcount safely collapses every in-flight
-                // retire, and memory stays O(1) per model even under
-                // a truly wedged store that never settles.
-                registry.retainBinding(leaseModel);
-                let persistRetainReleased = false;
-                persistRetainBox.release = () => {
-                  if (persistRetainReleased) return;
-                  persistRetainReleased = true;
-                  registry.releaseBinding(leaseModel);
-                };
-                const streamingPersistMode = 'streaming' as const;
-                const streamingHardTimeoutMs = getPostCommitPersistHardTimeoutMs();
-                let retiredTombstone: { instanceId: number } | undefined;
-                // Compute the scalar `absoluteExpiresAtMs` ONCE up
-                // front — the MINIMUM of the newly produced record's
-                // own row expiry and the earliest expiry across any
-                // resolved ancestor chain. This value is threaded
-                // into both the pending-write tracker at
-                // `initiatePersist()` time (so the pre-breaker
-                // `awaitPending` path can short-circuit to 404 once
-                // the bound is crossed) AND the hard-timeout marker
-                // at breaker-fire time (absolute cap). The
-                // hard-timeout closure captures ONLY this scalar —
-                // NOT the full resolved chain — so the closure's
-                // retained heap stays O(1) under sustained pending
-                // continuations against a degraded backend.
-                //
-                // `record.expiresAt` is epoch-seconds (see
-                // `buildResponseRecord` — it adds
-                // `RESPONSE_TTL_SECONDS` to `Math.floor(Date.now() /
-                // 1000)`); convert to ms at this boundary. If both
-                // the record and the chain lack a finite expiry
-                // (legacy rows), fall back to
-                // `Number.POSITIVE_INFINITY` at the marker call site
-                // so TTL-only bounding still holds.
-                const recordExpiresAtMs =
-                  record.expiresAt != null && Number.isFinite(record.expiresAt) ? record.expiresAt * 1000 : undefined;
-                const absoluteExpiresAtMs =
-                  recordExpiresAtMs !== undefined && chainEarliestExpiresAtMs !== undefined
-                    ? Math.min(recordExpiresAtMs, chainEarliestExpiresAtMs)
-                    : (recordExpiresAtMs ?? chainEarliestExpiresAtMs);
-                const streamingHardTimeoutHandle: ReturnType<typeof setTimeout> | null =
-                  streamingHardTimeoutMs > 0
-                    ? setTimeout(() => {
-                        if (persistRetainReleased) return;
-                        console.error(
-                          `[responses] post-commit persist HARD timeout (${streamingHardTimeoutMs}ms, ` +
-                            `${streamingPersistMode}): underlying store.store(...) has not settled; assuming ` +
-                            `wedged backend, force-releasing the binding retain so the binding can be torn ` +
-                            `down. Retiring the current instance id via tombstone so a same-object ` +
-                            `re-registration inherits it and a late-landing persist remains chainable; a ` +
-                            `hot-swap to a DIFFERENT model object will mint a fresh id and the stale chain ` +
-                            `will correctly fail with 400 instance-mismatch.`,
-                        );
-                        // Move the pending-write tracker entry into
-                        // the hard-timed-out marker state for this
-                        // response id. The pending entry is dropped
-                        // so a wedged store.store(...) does not pin
-                        // one promise closure + tracker entry per
-                        // hard-timed-out request, AND the id is added
-                        // to the `hardTimedOut` marker so a concurrent
-                        // `previous_response_id` continuation can
-                        // tell the difference between a permanent
-                        // 404 and a slow-but-eventual persist that
-                        // crossed the hard timeout. The continuation
-                        // path consults `isHardTimedOut(id)` before
-                        // falling through to `sendNotFound(...)` and
-                        // returns retryable 503 `storage_timeout`
-                        // instead, so clients keep retrying rather
-                        // than discarding the chain. The marker has
-                        // two cleanup paths: (1) fast — the underlying
-                        // store promise's `.finally(...)` inside
-                        // `track()` fires when the wedged store
-                        // unwedges; (2) slow — an independent TTL
-                        // (`MLX_HARD_TIMEOUT_MARKER_TTL_MS`, default
-                        // 300s) bounds memory at O(requestRate × TTL)
-                        // even against a truly wedged store that
-                        // NEVER settles. Marker lifetime =
-                        // min(settlement, TTL expiry).
-                        //
-                        // Pass the record's absolute row expiry as a
-                        // hard cap on the marker. The record's
-                        // `expiresAt` field is epoch-seconds (see
-                        // `buildResponseRecord` — it adds
-                        // `RESPONSE_TTL_SECONDS` to `Math.floor(Date.now()
-                        // / 1000)`), so convert to ms for the marker
-                        // map. Once the absolute bound passes,
-                        // `ResponseStore.getChain()` hides the row and
-                        // the retryable-503 classification is factually
-                        // wrong — the marker must flip to 404 regardless
-                        // of ongoing client retries.
-                        //
-                        // Capture ONLY the precomputed scalar
-                        // `absoluteExpiresAtMs` in this closure — NOT
-                        // the full resolved chain. The scalar is
-                        // `min(record.expiresAt * 1000,
-                        // chainEarliestExpiresAtMs)`, computed once
-                        // when the hard-timeout handle was armed
-                        // above. `ResponseStore.getChain()` walks
-                        // ancestors and aborts on the first expired
-                        // link (see
-                        // `crates/mlx-db/src/response_store/reader.rs:44-59`),
-                        // so clamping the marker at whichever link
-                        // would disappear from `getChain()` first is
-                        // the authoritative bound. Capturing only
-                        // the scalar means background pending
-                        // continuations under a degraded store do
-                        // not retain ancestor transcripts —
-                        // heap growth stays O(1) per hard-timed-out
-                        // persist regardless of chain length.
-                        getPendingWritesFor(store).markHardTimedOut(
-                          record.id,
-                          getHardTimedOutMarkerTtlMs(),
-                          absoluteExpiresAtMs ?? Number.POSITIVE_INFINITY,
-                        );
-                        // Retire the id FIRST (binding is still alive
-                        // here — retirement reads the live id) then
-                        // drop the retain, which may trigger the
-                        // deferred teardown. Capture the retired id so
-                        // the persist's `.finally(...)` can release
-                        // the tombstone once the late write eventually
-                        // settles. The registry stores one refcounted
-                        // tombstone per model regardless of how many
-                        // hard-timeouts overlap — each retire
-                        // increments the shared counter and each
-                        // release decrements it — so the returned
-                        // `{ instanceId }` is captured as a presence
-                        // flag and `releaseTombstone(leaseModel)` is
-                        // called in the persist's `.finally(...)`.
-                        retiredTombstone = registry.retireInstanceIdForForceRelease(leaseModel);
-                        persistRetainBox.release?.();
-                      }, streamingHardTimeoutMs)
-                    : null;
-                pendingPersistOuter = initiatePersist(store, record, absoluteExpiresAtMs).finally(() => {
-                  if (streamingHardTimeoutHandle !== null) {
-                    clearTimeout(streamingHardTimeoutHandle);
-                  }
-                  // If the hard-timeout breaker fired and installed a
-                  // tombstone on `leaseModel`, decrement the shared
-                  // refcount now that this persist has settled. The
-                  // single-entry refcount layout means overlapping
-                  // breakers share one slot — releasing one balances
-                  // one retire, and the entry survives until the
-                  // last outstanding persist releases.
-                  if (retiredTombstone !== undefined) {
-                    registry.releaseTombstone(leaseModel);
-                  }
-                  persistRetainBox.release?.();
-                });
-                persistMode = streamingPersistMode;
+                streamFailureMode = handlerOutcome.failureMode;
+                if (handlerOutcome.terminalToPersist != null && store && body.store !== false) {
+                  // Initiate the write SYNCHRONOUSLY inside the mutex so
+                  // the pending-write tracker observes it before the
+                  // mutex releases. The promise is awaited off-lock in
+                  // the outer finally block.
+                  const record = buildResponseRecord(
+                    handlerOutcome.terminalToPersist,
+                    newInputMessages,
+                    previousResponseId,
+                    currentInstanceId,
+                    effectiveRetentionSec,
+                  );
+                  // Pair a `retainBinding` against the persist promise
+                  // so the binding's `modelInstanceId` survives a
+                  // concurrent same-model unregister + re-register that
+                  // races the post-commit write. `releaseBinding` runs
+                  // in the persist's `.finally(...)` regardless of
+                  // outcome, so the retention counter stays balanced
+                  // whether the write fulfils or rejects.
+                  //
+                  // Leaving the retain pinned forever on a wedged write
+                  // would make the binding unreclaimable until process
+                  // restart, so an INDEPENDENT hard-timeout timer is
+                  // armed alongside the persist (see
+                  // `getPostCommitPersistHardTimeoutMs` for the default).
+                  // If the persist settles naturally the timer is
+                  // cancelled via `clearTimeout` inside the same
+                  // `.finally(...)` — slow-but-eventual writes are
+                  // unaffected. If the persist is still wedged past the
+                  // hard bound, the timer fires and force-releases the
+                  // retain via the idempotent `persistRetainBox`. The
+                  // hard timer is armed off the handler's await path, so
+                  // the response is never delayed by it.
+                  //
+                  // Before the hard timeout force-releases the retain
+                  // (which unblocks binding teardown), it calls
+                  // `registry.retireInstanceIdForForceRelease(leaseModel)`
+                  // to tombstone the binding's current instance id on
+                  // the model object. A subsequent `register()` of the
+                  // SAME model object inherits that retired id rather
+                  // than minting fresh — so the late-landing persist's
+                  // record (stamped with the retired id) still matches
+                  // the live binding and stays chainable through
+                  // `previous_response_id`. Only a true hot-swap
+                  // (re-register with a DIFFERENT model object) mints a
+                  // fresh id, and the 400 instance-mismatch that results
+                  // is the correct semantic outcome because the new
+                  // model is semantically different from the one that
+                  // produced the stored record. Retirement MUST happen
+                  // BEFORE release so `instanceIds.get(model)` still
+                  // returns the live id the record carries.
+                  //
+                  // The tombstone's lifetime is scoped to the pending
+                  // persists that installed it — the `.finally(...)`
+                  // calls `registry.releaseTombstone(leaseModel)` so
+                  // that when the late write eventually settles
+                  // (fulfills or rejects), the shared refcount drops
+                  // and, once every outstanding persist has released,
+                  // any subsequent re-registration correctly mints a
+                  // fresh id. Without this scoping, a past hard-timeout
+                  // event would permanently re-enable id inheritance
+                  // across unrelated later lifecycles — reopening
+                  // stale-chain replay across what should be logically
+                  // dead bindings. The refcounted single-entry layout
+                  // handles OVERLAPPING hard-timeouts on the same live
+                  // instance id in bounded space: every breaker targets
+                  // the SAME retired id (the register-inherit path
+                  // keeps using it while the tombstone is alive) so one
+                  // shared refcount safely collapses every in-flight
+                  // retire, and memory stays O(1) per model even under
+                  // a truly wedged store that never settles.
+                  registry.retainBinding(leaseModel);
+                  let persistRetainReleased = false;
+                  persistRetainBox.release = () => {
+                    if (persistRetainReleased) return;
+                    persistRetainReleased = true;
+                    registry.releaseBinding(leaseModel);
+                  };
+                  const streamingPersistMode = 'streaming' as const;
+                  const streamingHardTimeoutMs = getPostCommitPersistHardTimeoutMs();
+                  let retiredTombstone: { instanceId: number } | undefined;
+                  // Compute the scalar `absoluteExpiresAtMs` ONCE up
+                  // front — the MINIMUM of the newly produced record's
+                  // own row expiry and the earliest expiry across any
+                  // resolved ancestor chain. This value is threaded
+                  // into both the pending-write tracker at
+                  // `initiatePersist()` time (so the pre-breaker
+                  // `awaitPending` path can short-circuit to 404 once
+                  // the bound is crossed) AND the hard-timeout marker
+                  // at breaker-fire time (absolute cap). The
+                  // hard-timeout closure captures ONLY this scalar —
+                  // NOT the full resolved chain — so the closure's
+                  // retained heap stays O(1) under sustained pending
+                  // continuations against a degraded backend.
+                  //
+                  // `record.expiresAt` is epoch-seconds (see
+                  // `buildResponseRecord` — it adds
+                  // `RESPONSE_TTL_SECONDS` to `Math.floor(Date.now() /
+                  // 1000)`); convert to ms at this boundary. If both
+                  // the record and the chain lack a finite expiry
+                  // (legacy rows), fall back to
+                  // `Number.POSITIVE_INFINITY` at the marker call site
+                  // so TTL-only bounding still holds.
+                  const recordExpiresAtMs =
+                    record.expiresAt != null && Number.isFinite(record.expiresAt) ? record.expiresAt * 1000 : undefined;
+                  const absoluteExpiresAtMs =
+                    recordExpiresAtMs !== undefined && chainEarliestExpiresAtMs !== undefined
+                      ? Math.min(recordExpiresAtMs, chainEarliestExpiresAtMs)
+                      : (recordExpiresAtMs ?? chainEarliestExpiresAtMs);
+                  const streamingHardTimeoutHandle: ReturnType<typeof setTimeout> | null =
+                    streamingHardTimeoutMs > 0
+                      ? setTimeout(() => {
+                          if (persistRetainReleased) return;
+                          console.error(
+                            `[responses] post-commit persist HARD timeout (${streamingHardTimeoutMs}ms, ` +
+                              `${streamingPersistMode}): underlying store.store(...) has not settled; assuming ` +
+                              `wedged backend, force-releasing the binding retain so the binding can be torn ` +
+                              `down. Retiring the current instance id via tombstone so a same-object ` +
+                              `re-registration inherits it and a late-landing persist remains chainable; a ` +
+                              `hot-swap to a DIFFERENT model object will mint a fresh id and the stale chain ` +
+                              `will correctly fail with 400 instance-mismatch.`,
+                          );
+                          // Move the pending-write tracker entry into
+                          // the hard-timed-out marker state for this
+                          // response id. The pending entry is dropped
+                          // so a wedged store.store(...) does not pin
+                          // one promise closure + tracker entry per
+                          // hard-timed-out request, AND the id is added
+                          // to the `hardTimedOut` marker so a concurrent
+                          // `previous_response_id` continuation can
+                          // tell the difference between a permanent
+                          // 404 and a slow-but-eventual persist that
+                          // crossed the hard timeout. The continuation
+                          // path consults `isHardTimedOut(id)` before
+                          // falling through to `sendNotFound(...)` and
+                          // returns retryable 503 `storage_timeout`
+                          // instead, so clients keep retrying rather
+                          // than discarding the chain. The marker has
+                          // two cleanup paths: (1) fast — the underlying
+                          // store promise's `.finally(...)` inside
+                          // `track()` fires when the wedged store
+                          // unwedges; (2) slow — an independent TTL
+                          // (`MLX_HARD_TIMEOUT_MARKER_TTL_MS`, default
+                          // 300s) bounds memory at O(requestRate × TTL)
+                          // even against a truly wedged store that
+                          // NEVER settles. Marker lifetime =
+                          // min(settlement, TTL expiry).
+                          //
+                          // Pass the record's absolute row expiry as a
+                          // hard cap on the marker. The record's
+                          // `expiresAt` field is epoch-seconds (see
+                          // `buildResponseRecord` — it adds
+                          // `RESPONSE_TTL_SECONDS` to `Math.floor(Date.now()
+                          // / 1000)`), so convert to ms for the marker
+                          // map. Once the absolute bound passes,
+                          // `ResponseStore.getChain()` hides the row and
+                          // the retryable-503 classification is factually
+                          // wrong — the marker must flip to 404 regardless
+                          // of ongoing client retries.
+                          //
+                          // Capture ONLY the precomputed scalar
+                          // `absoluteExpiresAtMs` in this closure — NOT
+                          // the full resolved chain. The scalar is
+                          // `min(record.expiresAt * 1000,
+                          // chainEarliestExpiresAtMs)`, computed once
+                          // when the hard-timeout handle was armed
+                          // above. `ResponseStore.getChain()` walks
+                          // ancestors and aborts on the first expired
+                          // link (see
+                          // `crates/mlx-db/src/response_store/reader.rs:44-59`),
+                          // so clamping the marker at whichever link
+                          // would disappear from `getChain()` first is
+                          // the authoritative bound. Capturing only
+                          // the scalar means background pending
+                          // continuations under a degraded store do
+                          // not retain ancestor transcripts —
+                          // heap growth stays O(1) per hard-timed-out
+                          // persist regardless of chain length.
+                          getPendingWritesFor(store).markHardTimedOut(
+                            record.id,
+                            getHardTimedOutMarkerTtlMs(),
+                            absoluteExpiresAtMs ?? Number.POSITIVE_INFINITY,
+                          );
+                          // Retire the id FIRST (binding is still alive
+                          // here — retirement reads the live id) then
+                          // drop the retain, which may trigger the
+                          // deferred teardown. Capture the retired id so
+                          // the persist's `.finally(...)` can release
+                          // the tombstone once the late write eventually
+                          // settles. The registry stores one refcounted
+                          // tombstone per model regardless of how many
+                          // hard-timeouts overlap — each retire
+                          // increments the shared counter and each
+                          // release decrements it — so the returned
+                          // `{ instanceId }` is captured as a presence
+                          // flag and `releaseTombstone(leaseModel)` is
+                          // called in the persist's `.finally(...)`.
+                          retiredTombstone = registry.retireInstanceIdForForceRelease(leaseModel);
+                          persistRetainBox.release?.();
+                        }, streamingHardTimeoutMs)
+                      : null;
+                  pendingPersistOuter = initiatePersist(store, record, absoluteExpiresAtMs).finally(() => {
+                    if (streamingHardTimeoutHandle !== null) {
+                      clearTimeout(streamingHardTimeoutHandle);
+                    }
+                    // If the hard-timeout breaker fired and installed a
+                    // tombstone on `leaseModel`, decrement the shared
+                    // refcount now that this persist has settled. The
+                    // single-entry refcount layout means overlapping
+                    // breakers share one slot — releasing one balances
+                    // one retire, and the entry survives until the
+                    // last outstanding persist releases.
+                    if (retiredTombstone !== undefined) {
+                      registry.releaseTombstone(leaseModel);
+                    }
+                    persistRetainBox.release?.();
+                  });
+                  persistMode = streamingPersistMode;
+                }
+              } catch (err) {
+                handlerError = err instanceof Error ? err : new Error(String(err));
               }
-            } catch (err) {
-              handlerError = err instanceof Error ? err : new Error(String(err));
-            }
-            committed = streamingWasCommitted();
-          } else {
-            // The non-streaming native path has NO AbortSignal surface
-            // (plain `chatSession*` returns a Promise, no cancel), so a
-            // client that disconnects mid-generation still burns the
-            // full decode budget under this mutex. TODO: native
-            // cancellation for `chatSession*` — until then the best we
-            // can do is the disconnect-aware skip inside
-            // `handleNonStreaming` (short-circuits `endJson` and
-            // signals the outer persist gate) plus this documented
-            // limitation.
-            const outcome = await runSessionNonStreaming(session, messages, newInputMessages, config, !lookup.hit);
-            // Prefix-cache observability headers for the non-streaming
-            // path. `res.end` has not fired yet (the handler's
-            // `endJson` call below is what flushes), so `setHeader`
-            // still lands on the wire. We re-classify the
-            // `X-Session-Cache` header here so a tier-2 lookup that
-            // did NOT actually produce native prefix reuse
-            // (`cachedTokens === 0`) gets demoted from the optimistic
-            // `prefix_hit` back to `fresh` — matching the plan's
-            // contract that `prefix_hit` only fires when the registry
-            // served a match via `promptCacheKey` AND the ChatResult
-            // reports `cachedTokens > 0`. The companion
-            // `X-Cached-Tokens: N` header reports the exact count for
-            // operators and downstream telemetry whenever reuse
-            // happened.
-            if (tier2Hit && outcome.result.cachedTokens === 0) {
-              sessionCacheStatus = 'fresh';
-              res.setHeader('X-Session-Cache', sessionCacheStatus);
-            }
-            if (outcome.result.cachedTokens > 0) {
-              res.setHeader('X-Cached-Tokens', String(outcome.result.cachedTokens));
-            }
-            try {
-              const handlerOutcome = await handleNonStreaming(
-                res,
-                outcome.result,
-                mappedBody,
-                responseId,
-                previousResponseId,
-                visibility,
-                serverTiming,
-              );
-              if (store && body.store !== false) {
-                // Same in-lock-initiate / off-lock-await split as the
-                // streaming branch. The non-streaming handler only
-                // returns when the JSON body's `res.end()` callback
-                // has fired, so reaching this point means the client
-                // observed the turn — the pending-write tracker
-                // protects a back-to-back continuation from a
-                // transient 404.
-                const record = buildResponseRecord(
-                  handlerOutcome.response,
-                  newInputMessages,
+              committed = streamingWasCommitted();
+            } else {
+              // The non-streaming native path has NO AbortSignal surface
+              // (plain `chatSession*` returns a Promise, no cancel), so a
+              // client that disconnects mid-generation still burns the
+              // full decode budget under this mutex. TODO: native
+              // cancellation for `chatSession*` — until then the best we
+              // can do is the disconnect-aware skip inside
+              // `handleNonStreaming` (short-circuits `endJson` and
+              // signals the outer persist gate) plus this documented
+              // limitation.
+              const outcome = await runSessionNonStreaming(session, messages, newInputMessages, config, !lookup.hit);
+              // Prefix-cache observability headers for the non-streaming
+              // path. `res.end` has not fired yet (the handler's
+              // `endJson` call below is what flushes), so `setHeader`
+              // still lands on the wire. We re-classify the
+              // `X-Session-Cache` header here so a tier-2 lookup that
+              // did NOT actually produce native prefix reuse
+              // (`cachedTokens === 0`) gets demoted from the optimistic
+              // `prefix_hit` back to `fresh` — matching the plan's
+              // contract that `prefix_hit` only fires when the registry
+              // served a match via `promptCacheKey` AND the ChatResult
+              // reports `cachedTokens > 0`. The companion
+              // `X-Cached-Tokens: N` header reports the exact count for
+              // operators and downstream telemetry whenever reuse
+              // happened.
+              if (tier2Hit && outcome.result.cachedTokens === 0) {
+                sessionCacheStatus = 'fresh';
+                res.setHeader('X-Session-Cache', sessionCacheStatus);
+              }
+              if (outcome.result.cachedTokens > 0) {
+                res.setHeader('X-Cached-Tokens', String(outcome.result.cachedTokens));
+              }
+              try {
+                const handlerOutcome = await handleNonStreaming(
+                  res,
+                  outcome.result,
+                  mappedBody,
+                  responseId,
                   previousResponseId,
-                  currentInstanceId,
-                  effectiveRetentionSec,
+                  visibility,
+                  serverTiming,
                 );
-                // See the streaming branch for the retain/release
-                // rationale — a same-model unregister + re-register
-                // during the slow persist must not mint a fresh
-                // `modelInstanceId` that invalidates the row this
-                // write is about to land. The idempotent-release
-                // scaffolding is a structural hook for a future split
-                // teardown; the post-commit SOFT timeout arm does not
-                // force-fire it.
-                //
-                // A wedged persist would otherwise leak the binding
-                // retain for the lifetime of the process, so the
-                // hard-timeout timer is armed here in the same shape
-                // as the streaming branch, cancelled from the
-                // persist's own `.finally(...)` when the write settles
-                // naturally, and fires a force-release through the
-                // idempotent `persistRetainBox` otherwise. Default
-                // 60s, override via
-                // `MLX_POST_COMMIT_PERSIST_HARD_TIMEOUT_MS`, `'0'`
-                // disables. Empty string is treated as unset (falls
-                // back to the 60000ms default) so a config-templating
-                // typo cannot silently disable the breaker.
-                //
-                // The force-release path also calls
-                // `registry.retireInstanceIdForForceRelease(leaseModel)`
-                // BEFORE releasing the retain so a same-object
-                // re-registration AFTER teardown inherits the retired
-                // instance id from the tombstone — a late-landing
-                // persist against the retired id stays chainable. A
-                // hot-swap to a DIFFERENT model object mints a fresh
-                // id and the 400 instance-mismatch is correct.
-                //
-                // The tombstone's lifetime is scoped to the pending
-                // persists that installed it — the `.finally(...)`
-                // calls `registry.releaseTombstone(leaseModel)` so
-                // that when the late write eventually settles, the
-                // shared refcount drops and, once every outstanding
-                // persist has released, any subsequent
-                // re-registration correctly mints a fresh id. Without
-                // this scoping, a past hard-timeout event would
-                // permanently re-enable id inheritance across
-                // unrelated later lifecycles — reopening stale-chain
-                // replay across what should be logically dead
-                // bindings. The refcounted single-entry layout
-                // handles OVERLAPPING hard-timeouts on the same live
-                // instance id in bounded space: every breaker targets
-                // the SAME retired id (the register-inherit path
-                // keeps using it while the tombstone is alive) so one
-                // shared refcount safely collapses every in-flight
-                // retire, and memory stays O(1) per model even under
-                // a truly wedged store that never settles.
-                registry.retainBinding(leaseModel);
-                let persistRetainReleased = false;
-                persistRetainBox.release = () => {
-                  if (persistRetainReleased) return;
-                  persistRetainReleased = true;
-                  registry.releaseBinding(leaseModel);
-                };
-                const nonStreamingPersistMode = 'non-streaming' as const;
-                const nonStreamingHardTimeoutMs = getPostCommitPersistHardTimeoutMs();
-                let retiredTombstone: { instanceId: number } | undefined;
-                // See the matching streaming-path comment above —
-                // precompute the scalar `absoluteExpiresAtMs`
-                // (`min(record.expiresAt * 1000,
-                // chainEarliestExpiresAtMs)`) ONCE, thread it into
-                // the tracker at `initiatePersist()` time, and capture
-                // ONLY this scalar in the hard-timeout closure.
-                const recordExpiresAtMs =
-                  record.expiresAt != null && Number.isFinite(record.expiresAt) ? record.expiresAt * 1000 : undefined;
-                const absoluteExpiresAtMs =
-                  recordExpiresAtMs !== undefined && chainEarliestExpiresAtMs !== undefined
-                    ? Math.min(recordExpiresAtMs, chainEarliestExpiresAtMs)
-                    : (recordExpiresAtMs ?? chainEarliestExpiresAtMs);
-                const nonStreamingHardTimeoutHandle: ReturnType<typeof setTimeout> | null =
-                  nonStreamingHardTimeoutMs > 0
-                    ? setTimeout(() => {
-                        if (persistRetainReleased) return;
-                        console.error(
-                          `[responses] post-commit persist HARD timeout (${nonStreamingHardTimeoutMs}ms, ` +
-                            `${nonStreamingPersistMode}): underlying store.store(...) has not settled; ` +
-                            `assuming wedged backend, force-releasing the binding retain so the binding can ` +
-                            `be torn down. Retiring the current instance id via tombstone so a same-object ` +
-                            `re-registration inherits it and a late-landing persist remains chainable; a ` +
-                            `hot-swap to a DIFFERENT model object will mint a fresh id and the stale chain ` +
-                            `will correctly fail with 400 instance-mismatch.`,
-                        );
-                        // Move the pending-write tracker entry into
-                        // the hard-timed-out marker state for this
-                        // response id. The pending entry is dropped
-                        // so a wedged store.store(...) does not pin
-                        // one promise closure + tracker entry per
-                        // hard-timed-out request, AND the id is added
-                        // to the `hardTimedOut` marker so a concurrent
-                        // `previous_response_id` continuation can
-                        // tell the difference between a permanent
-                        // 404 and a slow-but-eventual persist that
-                        // crossed the hard timeout. The continuation
-                        // path consults `isHardTimedOut(id)` before
-                        // falling through to `sendNotFound(...)` and
-                        // returns retryable 503 `storage_timeout`
-                        // instead, so clients keep retrying rather
-                        // than discarding the chain. The marker has
-                        // two cleanup paths: (1) fast — the
-                        // underlying store promise's `.finally(...)`
-                        // inside `track()` fires when the wedged
-                        // store unwedges; (2) slow — an independent
-                        // TTL (`MLX_HARD_TIMEOUT_MARKER_TTL_MS`,
-                        // default 300s) bounds memory at
-                        // O(requestRate × TTL) even against a truly
-                        // wedged store that NEVER settles. Marker
-                        // lifetime = min(settlement, TTL expiry).
-                        //
-                        // Pass the record's absolute row expiry as a
-                        // hard cap on the marker. The record's
-                        // `expiresAt` field is epoch-seconds (see
-                        // `buildResponseRecord` — it adds
-                        // `RESPONSE_TTL_SECONDS` to `Math.floor(Date.now()
-                        // / 1000)`), so convert to ms for the marker
-                        // map. Once the absolute bound passes,
-                        // `ResponseStore.getChain()` hides the row and
-                        // the retryable-503 classification is factually
-                        // wrong — the marker must flip to 404 regardless
-                        // of ongoing client retries.
-                        //
-                        // Capture ONLY the precomputed scalar
-                        // `absoluteExpiresAtMs` in this closure — see
-                        // the matching streaming-path comment for the
-                        // full rationale. The scalar was computed
-                        // above when the hard-timeout handle was
-                        // armed.
-                        getPendingWritesFor(store).markHardTimedOut(
-                          record.id,
-                          getHardTimedOutMarkerTtlMs(),
-                          absoluteExpiresAtMs ?? Number.POSITIVE_INFINITY,
-                        );
-                        // Retire the id FIRST (binding is still alive
-                        // here — retirement reads the live id) then
-                        // drop the retain, which may trigger the
-                        // deferred teardown. Capture the retired id so
-                        // the persist's `.finally(...)` can release
-                        // the tombstone once the late write eventually
-                        // settles. The registry stores one refcounted
-                        // tombstone per model regardless of how many
-                        // hard-timeouts overlap — each retire
-                        // increments the shared counter and each
-                        // release decrements it — so the returned
-                        // `{ instanceId }` is captured as a presence
-                        // flag and `releaseTombstone(leaseModel)` is
-                        // called in the persist's `.finally(...)`.
-                        retiredTombstone = registry.retireInstanceIdForForceRelease(leaseModel);
-                        persistRetainBox.release?.();
-                      }, nonStreamingHardTimeoutMs)
-                    : null;
-                pendingPersistOuter = initiatePersist(store, record, absoluteExpiresAtMs).finally(() => {
-                  if (nonStreamingHardTimeoutHandle !== null) {
-                    clearTimeout(nonStreamingHardTimeoutHandle);
-                  }
-                  // If the hard-timeout breaker fired and installed a
-                  // tombstone on `leaseModel`, decrement the shared
-                  // refcount now that this persist has settled. The
-                  // single-entry refcount layout means overlapping
-                  // breakers share one slot — releasing one balances
-                  // one retire, and the entry survives until the
-                  // last outstanding persist releases.
-                  if (retiredTombstone !== undefined) {
-                    registry.releaseTombstone(leaseModel);
-                  }
-                  persistRetainBox.release?.();
-                });
-                persistMode = nonStreamingPersistMode;
+                if (store && body.store !== false) {
+                  // Same in-lock-initiate / off-lock-await split as the
+                  // streaming branch. The non-streaming handler only
+                  // returns when the JSON body's `res.end()` callback
+                  // has fired, so reaching this point means the client
+                  // observed the turn — the pending-write tracker
+                  // protects a back-to-back continuation from a
+                  // transient 404.
+                  const record = buildResponseRecord(
+                    handlerOutcome.response,
+                    newInputMessages,
+                    previousResponseId,
+                    currentInstanceId,
+                    effectiveRetentionSec,
+                  );
+                  // See the streaming branch for the retain/release
+                  // rationale — a same-model unregister + re-register
+                  // during the slow persist must not mint a fresh
+                  // `modelInstanceId` that invalidates the row this
+                  // write is about to land. The idempotent-release
+                  // scaffolding is a structural hook for a future split
+                  // teardown; the post-commit SOFT timeout arm does not
+                  // force-fire it.
+                  //
+                  // A wedged persist would otherwise leak the binding
+                  // retain for the lifetime of the process, so the
+                  // hard-timeout timer is armed here in the same shape
+                  // as the streaming branch, cancelled from the
+                  // persist's own `.finally(...)` when the write settles
+                  // naturally, and fires a force-release through the
+                  // idempotent `persistRetainBox` otherwise. Default
+                  // 60s, override via
+                  // `MLX_POST_COMMIT_PERSIST_HARD_TIMEOUT_MS`, `'0'`
+                  // disables. Empty string is treated as unset (falls
+                  // back to the 60000ms default) so a config-templating
+                  // typo cannot silently disable the breaker.
+                  //
+                  // The force-release path also calls
+                  // `registry.retireInstanceIdForForceRelease(leaseModel)`
+                  // BEFORE releasing the retain so a same-object
+                  // re-registration AFTER teardown inherits the retired
+                  // instance id from the tombstone — a late-landing
+                  // persist against the retired id stays chainable. A
+                  // hot-swap to a DIFFERENT model object mints a fresh
+                  // id and the 400 instance-mismatch is correct.
+                  //
+                  // The tombstone's lifetime is scoped to the pending
+                  // persists that installed it — the `.finally(...)`
+                  // calls `registry.releaseTombstone(leaseModel)` so
+                  // that when the late write eventually settles, the
+                  // shared refcount drops and, once every outstanding
+                  // persist has released, any subsequent
+                  // re-registration correctly mints a fresh id. Without
+                  // this scoping, a past hard-timeout event would
+                  // permanently re-enable id inheritance across
+                  // unrelated later lifecycles — reopening stale-chain
+                  // replay across what should be logically dead
+                  // bindings. The refcounted single-entry layout
+                  // handles OVERLAPPING hard-timeouts on the same live
+                  // instance id in bounded space: every breaker targets
+                  // the SAME retired id (the register-inherit path
+                  // keeps using it while the tombstone is alive) so one
+                  // shared refcount safely collapses every in-flight
+                  // retire, and memory stays O(1) per model even under
+                  // a truly wedged store that never settles.
+                  registry.retainBinding(leaseModel);
+                  let persistRetainReleased = false;
+                  persistRetainBox.release = () => {
+                    if (persistRetainReleased) return;
+                    persistRetainReleased = true;
+                    registry.releaseBinding(leaseModel);
+                  };
+                  const nonStreamingPersistMode = 'non-streaming' as const;
+                  const nonStreamingHardTimeoutMs = getPostCommitPersistHardTimeoutMs();
+                  let retiredTombstone: { instanceId: number } | undefined;
+                  // See the matching streaming-path comment above —
+                  // precompute the scalar `absoluteExpiresAtMs`
+                  // (`min(record.expiresAt * 1000,
+                  // chainEarliestExpiresAtMs)`) ONCE, thread it into
+                  // the tracker at `initiatePersist()` time, and capture
+                  // ONLY this scalar in the hard-timeout closure.
+                  const recordExpiresAtMs =
+                    record.expiresAt != null && Number.isFinite(record.expiresAt) ? record.expiresAt * 1000 : undefined;
+                  const absoluteExpiresAtMs =
+                    recordExpiresAtMs !== undefined && chainEarliestExpiresAtMs !== undefined
+                      ? Math.min(recordExpiresAtMs, chainEarliestExpiresAtMs)
+                      : (recordExpiresAtMs ?? chainEarliestExpiresAtMs);
+                  const nonStreamingHardTimeoutHandle: ReturnType<typeof setTimeout> | null =
+                    nonStreamingHardTimeoutMs > 0
+                      ? setTimeout(() => {
+                          if (persistRetainReleased) return;
+                          console.error(
+                            `[responses] post-commit persist HARD timeout (${nonStreamingHardTimeoutMs}ms, ` +
+                              `${nonStreamingPersistMode}): underlying store.store(...) has not settled; ` +
+                              `assuming wedged backend, force-releasing the binding retain so the binding can ` +
+                              `be torn down. Retiring the current instance id via tombstone so a same-object ` +
+                              `re-registration inherits it and a late-landing persist remains chainable; a ` +
+                              `hot-swap to a DIFFERENT model object will mint a fresh id and the stale chain ` +
+                              `will correctly fail with 400 instance-mismatch.`,
+                          );
+                          // Move the pending-write tracker entry into
+                          // the hard-timed-out marker state for this
+                          // response id. The pending entry is dropped
+                          // so a wedged store.store(...) does not pin
+                          // one promise closure + tracker entry per
+                          // hard-timed-out request, AND the id is added
+                          // to the `hardTimedOut` marker so a concurrent
+                          // `previous_response_id` continuation can
+                          // tell the difference between a permanent
+                          // 404 and a slow-but-eventual persist that
+                          // crossed the hard timeout. The continuation
+                          // path consults `isHardTimedOut(id)` before
+                          // falling through to `sendNotFound(...)` and
+                          // returns retryable 503 `storage_timeout`
+                          // instead, so clients keep retrying rather
+                          // than discarding the chain. The marker has
+                          // two cleanup paths: (1) fast — the
+                          // underlying store promise's `.finally(...)`
+                          // inside `track()` fires when the wedged
+                          // store unwedges; (2) slow — an independent
+                          // TTL (`MLX_HARD_TIMEOUT_MARKER_TTL_MS`,
+                          // default 300s) bounds memory at
+                          // O(requestRate × TTL) even against a truly
+                          // wedged store that NEVER settles. Marker
+                          // lifetime = min(settlement, TTL expiry).
+                          //
+                          // Pass the record's absolute row expiry as a
+                          // hard cap on the marker. The record's
+                          // `expiresAt` field is epoch-seconds (see
+                          // `buildResponseRecord` — it adds
+                          // `RESPONSE_TTL_SECONDS` to `Math.floor(Date.now()
+                          // / 1000)`), so convert to ms for the marker
+                          // map. Once the absolute bound passes,
+                          // `ResponseStore.getChain()` hides the row and
+                          // the retryable-503 classification is factually
+                          // wrong — the marker must flip to 404 regardless
+                          // of ongoing client retries.
+                          //
+                          // Capture ONLY the precomputed scalar
+                          // `absoluteExpiresAtMs` in this closure — see
+                          // the matching streaming-path comment for the
+                          // full rationale. The scalar was computed
+                          // above when the hard-timeout handle was
+                          // armed.
+                          getPendingWritesFor(store).markHardTimedOut(
+                            record.id,
+                            getHardTimedOutMarkerTtlMs(),
+                            absoluteExpiresAtMs ?? Number.POSITIVE_INFINITY,
+                          );
+                          // Retire the id FIRST (binding is still alive
+                          // here — retirement reads the live id) then
+                          // drop the retain, which may trigger the
+                          // deferred teardown. Capture the retired id so
+                          // the persist's `.finally(...)` can release
+                          // the tombstone once the late write eventually
+                          // settles. The registry stores one refcounted
+                          // tombstone per model regardless of how many
+                          // hard-timeouts overlap — each retire
+                          // increments the shared counter and each
+                          // release decrements it — so the returned
+                          // `{ instanceId }` is captured as a presence
+                          // flag and `releaseTombstone(leaseModel)` is
+                          // called in the persist's `.finally(...)`.
+                          retiredTombstone = registry.retireInstanceIdForForceRelease(leaseModel);
+                          persistRetainBox.release?.();
+                        }, nonStreamingHardTimeoutMs)
+                      : null;
+                  pendingPersistOuter = initiatePersist(store, record, absoluteExpiresAtMs).finally(() => {
+                    if (nonStreamingHardTimeoutHandle !== null) {
+                      clearTimeout(nonStreamingHardTimeoutHandle);
+                    }
+                    // If the hard-timeout breaker fired and installed a
+                    // tombstone on `leaseModel`, decrement the shared
+                    // refcount now that this persist has settled. The
+                    // single-entry refcount layout means overlapping
+                    // breakers share one slot — releasing one balances
+                    // one retire, and the entry survives until the
+                    // last outstanding persist releases.
+                    if (retiredTombstone !== undefined) {
+                      registry.releaseTombstone(leaseModel);
+                    }
+                    persistRetainBox.release?.();
+                  });
+                  persistMode = nonStreamingPersistMode;
+                }
+              } catch (err) {
+                handlerError = err instanceof Error ? err : new Error(String(err));
               }
-            } catch (err) {
-              handlerError = err instanceof Error ? err : new Error(String(err));
+              committed = outcome.committed;
             }
-            committed = outcome.committed;
-          }
 
-          // "Safe to suppress" collapses to: did the client observe a
-          // terminal artefact for this responseId? On the non-
-          // streaming path that is the JSON body landing cleanly on
-          // the wire; on the streaming path it is a terminal SSE
-          // event (`response.completed` or `response.failed`) landing
-          // cleanly on the wire. In either case the client can see
-          // the responseId and knows the turn is over, so adopting
-          // the committed session under that id is safe and
-          // swallowing the (already-surfaced-via-failed-event)
-          // handler error is the only option that does not produce a
-          // malformed double-response.
-          const safeToSuppress = visibility.responseBodyWritten || visibility.terminalEmitted;
+            // "Safe to suppress" collapses to: did the client observe a
+            // terminal artefact for this responseId? On the non-
+            // streaming path that is the JSON body landing cleanly on
+            // the wire; on the streaming path it is a terminal SSE
+            // event (`response.completed` or `response.failed`) landing
+            // cleanly on the wire. In either case the client can see
+            // the responseId and knows the turn is over, so adopting
+            // the committed session under that id is safe and
+            // swallowing the (already-surfaced-via-failed-event)
+            // handler error is the only option that does not produce a
+            // malformed double-response.
+            const safeToSuppress = visibility.responseBodyWritten || visibility.terminalEmitted;
 
-          if (previousResponseId) {
-            sessionReg.drop(previousResponseId);
-          }
-          // Only adopt if the turn committed AND either the handler
-          // succeeded or a terminal artefact is already on the wire.
-          // A committed turn whose handler threw before the client
-          // saw anything it can chain off of must NOT be adopted —
-          // the responseId is unreachable from the client, so caching
-          // the session under it creates a permanently dangling warm
-          // session.
-          //
-          // Refuse to adopt whenever the streaming handler took ANY
-          // failure epilogue, not just `client_abort`. The streaming
-          // handler writes `failureMode` for every path that does
-          // not produce a clean `response.completed`:
-          //
-          //   * `'client_abort'`  — client dropped the socket after
-          //     the decode loop committed but before the success
-          //     terminal was flushed; `response.failed` goes on the
-          //     wire under a responseId the client has abandoned.
-          //
-          //   * `'error'`         — post-final teardown threw in
-          //     the stream adapter's `finally` after the decode
-          //     loop had already committed; `terminalToPersist` is
-          //     null and the client saw `response.failed`, so the
-          //     responseId is not a chainable artefact from the
-          //     client's perspective.
-          //
-          //   * `'finish_reason_error'` / `'stream_exhausted'` —
-          //     terminal derived from a non-clean end of stream.
-          //     Same reasoning: `response.failed` on the wire, no
-          //     chainable success terminal.
-          //
-          // In every non-null `failureMode` case the session
-          // committed at the native level but the observable wire
-          // state is a failure, so adopting the session under the
-          // responseId would evict the last good hot session for
-          // this model under the single-warm invariant even
-          // though the adopted slot is unreachable.
-          //
-          // `failureMode === null` is the sole signal that the
-          // stream path completed cleanly and the adopted session
-          // is genuinely reachable via the responseId.
-          if (committed && (handlerError == null || safeToSuppress) && streamFailureMode === null) {
-            // Adopt under the SAME `effectivePromptCacheKey` that was
-            // used for `getOrCreate` above — not the raw
-            // `promptCacheKey` from the request body. When a request
-            // carries `previous_response_id` (tier-1 path), tier-2 is
-            // deliberately disabled on the lookup side by forcing
-            // `effectivePromptCacheKey = null`; the adopt side must
-            // follow the same rule or a mixed-mode request
-            // (`previous_response_id=rA + prompt_cache_key=K`) would
-            // store the adopted session under `K` even though the
-            // lookup was resolved via `rA`. A subsequent keyless/
-            // prev-idless request with `prompt_cache_key=K` would then
-            // tier-2 hit and lease rA's chain session — a cross-chain
-            // corruption the precedence rule was explicitly designed
-            // to prevent. Keep adopt's key aligned with lookup's key.
-            sessionReg.adopt(responseId, session, requestedInstructions, effectivePromptCacheKey);
-          }
+            if (previousResponseId) {
+              sessionReg.drop(previousResponseId);
+            }
+            // Only adopt if the turn committed AND either the handler
+            // succeeded or a terminal artefact is already on the wire.
+            // A committed turn whose handler threw before the client
+            // saw anything it can chain off of must NOT be adopted —
+            // the responseId is unreachable from the client, so caching
+            // the session under it creates a permanently dangling warm
+            // session.
+            //
+            // Refuse to adopt whenever the streaming handler took ANY
+            // failure epilogue, not just `client_abort`. The streaming
+            // handler writes `failureMode` for every path that does
+            // not produce a clean `response.completed`:
+            //
+            //   * `'client_abort'`  — client dropped the socket after
+            //     the decode loop committed but before the success
+            //     terminal was flushed; `response.failed` goes on the
+            //     wire under a responseId the client has abandoned.
+            //
+            //   * `'error'`         — post-final teardown threw in
+            //     the stream adapter's `finally` after the decode
+            //     loop had already committed; `terminalToPersist` is
+            //     null and the client saw `response.failed`, so the
+            //     responseId is not a chainable artefact from the
+            //     client's perspective.
+            //
+            //   * `'finish_reason_error'` / `'stream_exhausted'` —
+            //     terminal derived from a non-clean end of stream.
+            //     Same reasoning: `response.failed` on the wire, no
+            //     chainable success terminal.
+            //
+            // In every non-null `failureMode` case the session
+            // committed at the native level but the observable wire
+            // state is a failure, so adopting the session under the
+            // responseId would evict the last good hot session for
+            // this model under the single-warm invariant even
+            // though the adopted slot is unreachable.
+            //
+            // `failureMode === null` is the sole signal that the
+            // stream path completed cleanly and the adopted session
+            // is genuinely reachable via the responseId.
+            if (committed && (handlerError == null || safeToSuppress) && streamFailureMode === null) {
+              // Adopt under the SAME `effectivePromptCacheKey` that was
+              // used for `getOrCreate` above — not the raw
+              // `promptCacheKey` from the request body. When a request
+              // carries `previous_response_id` (tier-1 path), tier-2 is
+              // deliberately disabled on the lookup side by forcing
+              // `effectivePromptCacheKey = null`; the adopt side must
+              // follow the same rule or a mixed-mode request
+              // (`previous_response_id=rA + prompt_cache_key=K`) would
+              // store the adopted session under `K` even though the
+              // lookup was resolved via `rA`. A subsequent keyless/
+              // prev-idless request with `prompt_cache_key=K` would then
+              // tier-2 hit and lease rA's chain session — a cross-chain
+              // corruption the precedence rule was explicitly designed
+              // to prevent. Keep adopt's key aligned with lookup's key.
+              sessionReg.adopt(responseId, session, requestedInstructions, effectivePromptCacheKey);
+            }
 
-          // Rethrow handler errors when the client hasn't seen a
-          // terminal yet, regardless of commit state. The outer
-          // catch will send a proper 500 (non-streaming) or a last-
-          // ditch SSE `error` event (streaming, after `beginSSE` but
-          // before any terminal). Without this the request would
-          // hang from the client's perspective.
-          if (handlerError && !safeToSuppress) {
-            throw handlerError;
-          }
-          // If a terminal is on the wire but the handler still
-          // threw: log only. Rethrowing would produce a malformed
-          // double-response; the client already has a terminal event
-          // it can parse.
-          if (handlerError) {
-            console.error('[responses] handler error after terminal response already delivered:', handlerError);
-          }
-        } catch (err) {
-          const message = err instanceof Error ? err.message : 'Unknown error during inference';
-          // Branch on `responseMode` (the wire format the handler
-          // committed to), NOT `res.headersSent`
-          // (which flips synchronously in `writeHead` and lies about
-          // which format the client is consuming). Each branch
-          // produces output that matches the Content-Type the client
-          // already received — or no output at all if the terminal
-          // already landed.
-          if (visibility.responseMode === null) {
-            // Headers never went out. Safe to emit a clean 500 JSON
-            // error.
-            sendInternalError(res, message);
-          } else if (visibility.responseMode === 'json') {
-            // We already wrote `Content-Type: application/json` and
-            // possibly some body bytes; emitting an SSE frame here
-            // would corrupt the response. Best we can do is destroy
-            // the socket so the client sees a truncated JSON
-            // response instead of a malformed document with an
-            // unexpected MIME type. If the body was fully written
-            // (`responseBodyWritten === true`) the outcome gate
-            // above already returned without rethrowing, so reaching
-            // this branch means the JSON never fully landed.
-            try {
-              res.destroy(err instanceof Error ? err : new Error(message));
-            } catch {
-              // Socket may already be gone; nothing more we can do.
+            // Rethrow handler errors when the client hasn't seen a
+            // terminal yet, regardless of commit state. The outer
+            // catch will send a proper 500 (non-streaming) or a last-
+            // ditch SSE `error` event (streaming, after `beginSSE` but
+            // before any terminal). Without this the request would
+            // hang from the client's perspective.
+            if (handlerError && !safeToSuppress) {
+              throw handlerError;
             }
-          } else {
-            // `responseMode === 'sse'`: headers advertise SSE and
-            // some (or all) of the stream already went out. If a
-            // terminal event already landed, emitting another frame
-            // is a no-op from the client's perspective but we still
-            // close the stream cleanly. If no terminal landed (early
-            // `writeSSEEvent` crash before `response.created`), emit
-            // a best-effort streaming `error` frame so the client
-            // sees SOMETHING it can parse.
-            if (!visibility.terminalEmitted) {
-              writeFallbackErrorSSE(res, 'error', { error_type: 'server_error', message });
+            // If a terminal is on the wire but the handler still
+            // threw: log only. Rethrowing would produce a malformed
+            // double-response; the client already has a terminal event
+            // it can parse.
+            if (handlerError) {
+              console.error('[responses] handler error after terminal response already delivered:', handlerError);
             }
-            try {
-              endSSE(res);
-            } catch {
-              // Already closed / destroyed.
+          } catch (err) {
+            const message = err instanceof Error ? err.message : 'Unknown error during inference';
+            // Branch on `responseMode` (the wire format the handler
+            // committed to), NOT `res.headersSent`
+            // (which flips synchronously in `writeHead` and lies about
+            // which format the client is consuming). Each branch
+            // produces output that matches the Content-Type the client
+            // already received — or no output at all if the terminal
+            // already landed.
+            if (visibility.responseMode === null) {
+              // Headers never went out. Safe to emit a clean 500 JSON
+              // error.
+              sendInternalError(res, message);
+            } else if (visibility.responseMode === 'json') {
+              // We already wrote `Content-Type: application/json` and
+              // possibly some body bytes; emitting an SSE frame here
+              // would corrupt the response. Best we can do is destroy
+              // the socket so the client sees a truncated JSON
+              // response instead of a malformed document with an
+              // unexpected MIME type. If the body was fully written
+              // (`responseBodyWritten === true`) the outcome gate
+              // above already returned without rethrowing, so reaching
+              // this branch means the JSON never fully landed.
+              try {
+                res.destroy(err instanceof Error ? err : new Error(message));
+              } catch {
+                // Socket may already be gone; nothing more we can do.
+              }
+            } else {
+              // `responseMode === 'sse'`: headers advertise SSE and
+              // some (or all) of the stream already went out. If a
+              // terminal event already landed, emitting another frame
+              // is a no-op from the client's perspective but we still
+              // close the stream cleanly. If no terminal landed (early
+              // `writeSSEEvent` crash before `response.created`), emit
+              // a best-effort streaming `error` frame so the client
+              // sees SOMETHING it can parse.
+              if (!visibility.terminalEmitted) {
+                writeFallbackErrorSSE(res, 'error', { error_type: 'server_error', message });
+              }
+              try {
+                endSSE(res);
+              } catch {
+                // Already closed / destroyed.
+              }
             }
           }
-        }
-      });
+        });
+      if (modelWorkCoordinator) await modelWorkCoordinator.withInference(runInference);
+      else await runInference();
     } catch (err) {
       // Admission-control rejection from the per-model queue cap
       // (`SessionRegistry.withExclusive` threw before chaining into

--- a/packages/server/src/endpoints/responses.ts
+++ b/packages/server/src/endpoints/responses.ts
@@ -58,6 +58,14 @@ import type {
  */
 const RESPONSE_TTL_SECONDS = 1800;
 
+function withAdmissionControlledInference<T>(
+  sessionReg: SessionRegistry,
+  modelWorkCoordinator: ModelWorkCoordinator | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return sessionReg.withExclusive(() => (modelWorkCoordinator ? modelWorkCoordinator.withInference(fn) : fn()));
+}
+
 /**
  * Value of the `X-Session-Cache` response header emitted on every
  * `/v1/responses` and `/v1/messages` response. Advertises whether the
@@ -2348,7 +2356,7 @@ export async function handleCreateResponse(
     try {
       const mutexQueuedAt = Date.now();
       const runInference = () =>
-        sessionReg.withExclusive(async () => {
+        withAdmissionControlledInference(sessionReg, modelWorkCoordinator, async () => {
           const serverTiming: ServerTimingForUsage = {
             server_queue_ms: Date.now() - mutexQueuedAt,
             server_pre_inference_ms: Date.now() - handlerStartedAt,
@@ -3427,8 +3435,7 @@ export async function handleCreateResponse(
             }
           }
         });
-      if (modelWorkCoordinator) await modelWorkCoordinator.withInference(runInference);
-      else await runInference();
+      await runInference();
     } catch (err) {
       // Admission-control rejection from the per-model queue cap
       // (`SessionRegistry.withExclusive` threw before chaining into

--- a/packages/server/src/endpoints/responses.ts
+++ b/packages/server/src/endpoints/responses.ts
@@ -30,6 +30,8 @@ import type { ModelRegistry } from '../registry.js';
 import { maybeWarnPromptCacheKeyIneligible, QueueFullError, type SessionRegistry } from '../session-registry.js';
 import { beginSSE, endSSE, writeSSEEvent } from '../streaming.js';
 import { longestSuffixPrefixOverlap } from '../text-recovery.js';
+import type { ServerTimingForUsage } from '../timing.js';
+import { mergeTimingUsageExtensions } from '../timing.js';
 import { ToolCallTagBuffer } from '../tool-call-buffer.js';
 import {
   createVisibility,
@@ -202,8 +204,17 @@ async function handleNonStreaming(
   responseId: string,
   previousResponseId: string | undefined,
   visibility: TransportVisibility,
+  serverTiming?: ServerTimingForUsage,
 ): Promise<NonStreamingHandlerOutcome> {
   const response = buildResponseObject(result, req, responseId, previousResponseId);
+  mergeTimingUsageExtensions(
+    response.usage,
+    result.performance,
+    result.promptTokens,
+    result.numTokens,
+    result.cachedTokens,
+    serverTiming,
+  );
 
   // `chatSession*` has no AbortSignal surface yet, so a mid-decode
   // client disconnect still burns the full decode budget — peer loss
@@ -308,6 +319,7 @@ async function handleStreamingNative(
   wasCommitted: () => boolean,
   httpReq: IncomingMessage | undefined,
   visibility: TransportVisibility,
+  serverTiming?: ServerTimingForUsage,
 ): Promise<StreamingHandlerOutcome> {
   beginSSE(res);
   // Commit to SSE wire format synchronously so the outer catch
@@ -715,6 +727,7 @@ async function handleStreamingNative(
         if (cachedTokens != null && cachedTokens > 0) {
           usage.input_tokens_details = { cached_tokens: cachedTokens };
         }
+        mergeTimingUsageExtensions(usage, event.performance, promptTokens, event.numTokens, cachedTokens, serverTiming);
 
         const finalOutput = outputItems.filter((_, idx) => idx !== suppressedMessageIndex);
         completedResponse = {
@@ -1621,6 +1634,8 @@ export async function handleCreateResponse(
   responseRetentionSec?: number,
   idleSweeper?: IdleSweeper | null,
 ): Promise<void> {
+  const handlerStartedAt = Date.now();
+
   // Validate required fields
   if (body == null || typeof body !== 'object') {
     sendBadRequest(res, 'Request body must be a JSON object', 'body');
@@ -2330,7 +2345,13 @@ export async function handleCreateResponse(
     idleListenersAttached = true;
 
     try {
+      const mutexQueuedAt = Date.now();
       await sessionReg.withExclusive(async () => {
+        const serverTiming: ServerTimingForUsage = {
+          server_queue_ms: Date.now() - mutexQueuedAt,
+          server_pre_inference_ms: Date.now() - handlerStartedAt,
+        };
+
         // Hot-swap race guard inside the mutex.
         //
         // `withExclusive` can park this waiter behind a long-running
@@ -2805,6 +2826,7 @@ export async function handleCreateResponse(
                 streamingWasCommitted,
                 httpReq,
                 visibility,
+                serverTiming,
               );
               streamFailureMode = handlerOutcome.failureMode;
               if (handlerOutcome.terminalToPersist != null && store && body.store !== false) {
@@ -3070,6 +3092,7 @@ export async function handleCreateResponse(
                 responseId,
                 previousResponseId,
                 visibility,
+                serverTiming,
               );
               if (store && body.store !== false) {
                 // Same in-lock-initiate / off-lock-await split as the

--- a/packages/server/src/endpoints/responses.ts
+++ b/packages/server/src/endpoints/responses.ts
@@ -30,8 +30,7 @@ import type { ModelRegistry } from '../registry.js';
 import { maybeWarnPromptCacheKeyIneligible, QueueFullError, type SessionRegistry } from '../session-registry.js';
 import { beginSSE, endSSE, writeSSEEvent } from '../streaming.js';
 import { longestSuffixPrefixOverlap } from '../text-recovery.js';
-import type { ServerTimingForUsage } from '../timing.js';
-import { mergeTimingUsageExtensions } from '../timing.js';
+import { mergeTimingUsageExtensions, resolveServerTuningForUsage, type ServerTimingForUsage } from '../timing.js';
 import { ToolCallTagBuffer } from '../tool-call-buffer.js';
 import {
   createVisibility,
@@ -2350,6 +2349,7 @@ export async function handleCreateResponse(
         const serverTiming: ServerTimingForUsage = {
           server_queue_ms: Date.now() - mutexQueuedAt,
           server_pre_inference_ms: Date.now() - handlerStartedAt,
+          ...resolveServerTuningForUsage(),
         };
 
         // Hot-swap race guard inside the mutex.

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -99,6 +99,10 @@ export function sendAnthropicInternalError(res: ServerResponse, message: string)
   sendAnthropicError(res, 500, 'api_error', message);
 }
 
+export function sendAnthropicNotImplemented(res: ServerResponse, message: string): void {
+  sendAnthropicError(res, 501, 'not_supported_error', message);
+}
+
 export function sendAnthropicMethodNotAllowed(res: ServerResponse, allowed: string): void {
   res.writeHead(405, { Allow: allowed, 'Content-Type': 'application/json' });
   res.end(JSON.stringify({ type: 'error', error: { type: 'invalid_request_error', message: 'Method not allowed' } }));

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -6,6 +6,7 @@ import type { ResponseStore } from '@mlx-node/core';
 
 import { sendInternalError } from './errors.js';
 import type { IdleSweeper } from './idle-sweeper.js';
+import { ModelWorkCoordinator } from './model-work-coordinator.js';
 import type { ModelRegistry } from './registry.js';
 import { routeRequest } from './router.js';
 
@@ -52,6 +53,11 @@ export interface HandlerOptions {
    */
   resolveModel?: (name: string) => Promise<void>;
   /**
+   * Coordinates process-wide MLX work so lazy model loads / warmups do not
+   * overlap live inference on another model.
+   */
+  modelWorkCoordinator?: ModelWorkCoordinator;
+  /**
    * Optional override for `GET /v1/models`. When provided, that endpoint
    * returns this list instead of `registry.list()`.
    */
@@ -67,6 +73,7 @@ export function createHandler(
   const responseRetentionSec = options?.responseRetentionSec;
   const idleSweeper = options?.idleSweeper ?? null;
   const resolveModel = options?.resolveModel;
+  const modelWorkCoordinator = options?.modelWorkCoordinator ?? (resolveModel ? new ModelWorkCoordinator() : undefined);
   const listModels = options?.listModels;
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
@@ -86,7 +93,17 @@ export function createHandler(
     // post-`res.end()` bookkeeping (e.g. `SessionRegistry.adopt`). `http.createServer`
     // ignores the return value, so this is transparent to production callers.
     try {
-      await routeRequest(req, res, registry, store, responseRetentionSec, idleSweeper, resolveModel, listModels);
+      await routeRequest(
+        req,
+        res,
+        registry,
+        store,
+        responseRetentionSec,
+        idleSweeper,
+        resolveModel,
+        listModels,
+        modelWorkCoordinator,
+      );
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Internal server error';
       if (!res.headersSent) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -28,6 +28,7 @@ export type { ServableModel, ModelEntry, ModelRegistryOptions, RegisterOptions }
 
 export { QueueFullError, SessionRegistry } from './session-registry.js';
 export type { SessionLookupResult, SessionRegistryOptions } from './session-registry.js';
+export { resolveServerTuningForUsage } from './timing.js';
 // NOTE: `__resetPromptCacheKeyNonceForTests` is intentionally NOT
 // re-exported here. It is a test-only helper that nukes the module-
 // scoped HMAC nonce (and the once-per-process single-tenant warning

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -62,6 +62,8 @@ export type {
 } from './types.js';
 
 export type {
+  AnthropicCountTokensRequest,
+  AnthropicCountTokensResponse,
   AnthropicMessagesRequest,
   AnthropicMessagesResponse,
   AnthropicMessage,

--- a/packages/server/src/mappers/anthropic-request.ts
+++ b/packages/server/src/mappers/anthropic-request.ts
@@ -4,6 +4,7 @@ import type { ChatConfig, ChatMessage, ToolDefinition } from '@mlx-node/core';
 
 import type {
   AnthropicContentBlock,
+  AnthropicCountTokensRequest,
   AnthropicImageContentBlock,
   AnthropicMessagesRequest,
   AnthropicTextContentBlock,
@@ -116,7 +117,9 @@ function mapTool(tool: AnthropicToolDefinition): ToolDefinition {
   };
 }
 
-export function mapAnthropicRequest(req: AnthropicMessagesRequest): MappedAnthropicRequest {
+export function mapAnthropicRequest(
+  req: AnthropicMessagesRequest | AnthropicCountTokensRequest,
+): MappedAnthropicRequest {
   const messages: ChatMessage[] = [];
 
   if (req.system != null) {

--- a/packages/server/src/mappers/anthropic-response.ts
+++ b/packages/server/src/mappers/anthropic-response.ts
@@ -34,6 +34,23 @@ export function mapStopReason(finishReason: string, hasToolCalls: boolean): 'end
   return 'end_turn';
 }
 
+export function containsToolCallMarkup(rawText: string): boolean {
+  return (
+    rawText.includes('<tool_call') ||
+    rawText.includes('</tool_call') ||
+    rawText.includes('<|tool_call') ||
+    rawText.includes('<tool_call|>')
+  );
+}
+
+export function recoverSuppressedToolCallText(rawText: string): string {
+  return rawText
+    .replace(/<\|channel>[\s\S]*?(?:<channel\|>|$)/g, '')
+    .replace(/<channel\|>/g, '')
+    .replace(/<\|turn>[^\n]*(?:\n|$)/g, '')
+    .replace(/<turn\|>/g, '');
+}
+
 export function buildAnthropicContent(result: ChatResult, allowToolUse = true): AnthropicResponseContent[] {
   const content: AnthropicResponseContent[] = [];
 
@@ -44,8 +61,8 @@ export function buildAnthropicContent(result: ChatResult, allowToolUse = true): 
   const parsedToolCalls = result.toolCalls.filter((t) => t.status === 'ok');
   const okToolCalls = allowToolUse ? parsedToolCalls : [];
   const text =
-    !allowToolUse && result.text.length === 0 && parsedToolCalls.length > 0 && result.rawText.includes('<tool_call')
-      ? result.rawText
+    !allowToolUse && result.text.length === 0 && parsedToolCalls.length > 0 && containsToolCallMarkup(result.rawText)
+      ? recoverSuppressedToolCallText(result.rawText)
       : result.text;
 
   // Emit a text block unless tool calls exist and there is no text.
@@ -194,7 +211,9 @@ export function buildMessageDelta(
   // omitted by an in-process driver / mock) the cache fields stay
   // off the wire. See the matching block on `buildAnthropicResponse`
   // and the field-level docstrings on `AnthropicUsage`.
-  const usage: AnthropicMessageDeltaEvent['usage'] = { output_tokens: outputTokens };
+  const usage: AnthropicMessageDeltaEvent['usage'] = {
+    output_tokens: outputTokens,
+  };
   if (cachedTokens != null && cachedTokens > 0) {
     if (inputTokens != null) {
       usage.input_tokens = inputTokens - cachedTokens;

--- a/packages/server/src/mappers/anthropic-response.ts
+++ b/packages/server/src/mappers/anthropic-response.ts
@@ -47,6 +47,10 @@ export function recoverSuppressedToolCallText(rawText: string): string {
   return rawText
     .replace(/<\|channel>[\s\S]*?(?:<channel\|>|$)/g, '')
     .replace(/<channel\|>/g, '')
+    .replace(/<\|tool_call>[\s\S]*?(?:<tool_call\|>|$)/g, '')
+    .replace(/<tool_call>[\s\S]*?(?:<\/tool_call>|$)/g, '')
+    .replace(/<\|tool_response>[\s\S]*?(?:<tool_response\|>|$)/g, '')
+    .replace(/<\|tool>[\s\S]*?(?:<tool\|>|$)/g, '')
     .replace(/<\|turn>[^\n]*(?:\n|$)/g, '')
     .replace(/<turn\|>/g, '');
 }

--- a/packages/server/src/mappers/anthropic-response.ts
+++ b/packages/server/src/mappers/anthropic-response.ts
@@ -2,6 +2,7 @@
 
 import type { ChatResult } from '@mlx-node/core';
 
+import { mergeTimingUsageExtensions, type PerformanceMetricsForUsage, type ServerTimingForUsage } from '../timing.js';
 import type {
   AnthropicContentBlockDeltaEvent,
   AnthropicContentBlockStartEvent,
@@ -15,49 +16,6 @@ import type {
   AnthropicResponseContent,
 } from '../types-anthropic.js';
 import { genId } from './response.js';
-
-/**
- * Subset of `@mlx-node/core`'s `PerformanceMetrics` consumed by the
- * Anthropic mapper. Defined locally to keep the mapper independent of
- * the native package's exported shape — only the three fields we
- * forward onto the wire are required, and each one is gated through
- * `Number.isFinite(...) && > 0` before emission so a partially-plumbed
- * driver (or a future shape that adds fields) cannot leak invalid
- * values through.
- */
-export interface PerformanceMetricsForUsage {
-  ttftMs?: number;
-  prefillTokensPerSecond?: number;
-  decodeTokensPerSecond?: number;
-}
-
-/**
- * Mirror the cache-field gating pattern: emit `key` on `usage` only
- * when `value` is a finite, strictly-positive number. Missing,
- * non-finite, zero, or negative metrics are elided (the launcher's
- * verbose log treats absence as "unknown / not plumbed", which is
- * the correct read for a turn whose native dispatch did not produce
- * the metric).
- */
-function assignFinitePositive<T extends Record<string, number | undefined>>(
-  usage: T,
-  key: keyof T & string,
-  value: number | undefined,
-): void {
-  if (value != null && Number.isFinite(value) && value > 0) {
-    (usage as Record<string, number | undefined>)[key] = value;
-  }
-}
-
-function mergePerformanceIntoUsage(
-  usage: { time_to_first_token_ms?: number; prefill_tokens_per_second?: number; decode_tokens_per_second?: number },
-  performance: PerformanceMetricsForUsage | undefined,
-): void {
-  if (performance == null) return;
-  assignFinitePositive(usage, 'time_to_first_token_ms', performance.ttftMs);
-  assignFinitePositive(usage, 'prefill_tokens_per_second', performance.prefillTokensPerSecond);
-  assignFinitePositive(usage, 'decode_tokens_per_second', performance.decodeTokensPerSecond);
-}
 
 function parseArguments(args: Record<string, unknown> | string): Record<string, unknown> {
   if (typeof args === 'string') {
@@ -76,18 +34,23 @@ export function mapStopReason(finishReason: string, hasToolCalls: boolean): 'end
   return 'end_turn';
 }
 
-export function buildAnthropicContent(result: ChatResult): AnthropicResponseContent[] {
+export function buildAnthropicContent(result: ChatResult, allowToolUse = true): AnthropicResponseContent[] {
   const content: AnthropicResponseContent[] = [];
 
   if (result.thinking) {
     content.push({ type: 'thinking', thinking: result.thinking });
   }
 
-  const okToolCalls = result.toolCalls.filter((t) => t.status === 'ok');
+  const parsedToolCalls = result.toolCalls.filter((t) => t.status === 'ok');
+  const okToolCalls = allowToolUse ? parsedToolCalls : [];
+  const text =
+    !allowToolUse && result.text.length === 0 && parsedToolCalls.length > 0 && result.rawText.includes('<tool_call')
+      ? result.rawText
+      : result.text;
 
   // Emit a text block unless tool calls exist and there is no text.
-  if (result.text || okToolCalls.length === 0) {
-    content.push({ type: 'text', text: result.text });
+  if (text || okToolCalls.length === 0) {
+    content.push({ type: 'text', text });
   }
 
   for (const tc of okToolCalls) {
@@ -107,8 +70,10 @@ export function buildAnthropicResponse(
   req: AnthropicMessagesRequest,
   messageId: string,
   performance?: PerformanceMetricsForUsage,
+  allowToolUse = true,
+  serverTiming?: ServerTimingForUsage,
 ): AnthropicMessagesResponse {
-  const okToolCalls = result.toolCalls.filter((t) => t.status === 'ok');
+  const okToolCalls = allowToolUse ? result.toolCalls.filter((t) => t.status === 'ok') : [];
   const hasToolCalls = okToolCalls.length > 0;
 
   // Cache accounting (Anthropic Messages API spec):
@@ -145,15 +110,17 @@ export function buildAnthropicResponse(
   // dispatch produced a finite, positive value — `undefined` /
   // `NaN` / `0` is elided so the launcher's verbose log can read
   // absence as "not plumbed" instead of treating zero as a real
-  // measurement.
-  mergePerformanceIntoUsage(usage, performance);
+  // measurement. Cache-context fields make the prefill rate explicit:
+  // on cached-prefix turns the denominator is the uncached suffix, not
+  // the full logical prompt.
+  mergeTimingUsageExtensions(usage, performance, result.promptTokens, result.numTokens, cachedTokens, serverTiming);
 
   return {
     id: messageId,
     type: 'message',
     role: 'assistant',
     model: req.model,
-    content: buildAnthropicContent(result),
+    content: buildAnthropicContent(result, allowToolUse),
     stop_reason: mapStopReason(result.finishReason, hasToolCalls),
     stop_sequence: null,
     usage,
@@ -218,6 +185,7 @@ export function buildMessageDelta(
   inputTokens?: number,
   cachedTokens?: number,
   performance?: PerformanceMetricsForUsage,
+  serverTiming?: ServerTimingForUsage,
 ): AnthropicMessageDeltaEvent {
   // Streaming `message_delta` mirrors the non-streaming response's
   // cache accounting: when `cachedTokens > 0` we emit
@@ -239,7 +207,7 @@ export function buildMessageDelta(
   // cache-field block above. See `buildAnthropicResponse` for the
   // matching non-streaming branch and the docstring on
   // `AnthropicUsage` for the wire-format rationale.
-  mergePerformanceIntoUsage(usage, performance);
+  mergeTimingUsageExtensions(usage, performance, inputTokens, outputTokens, cachedTokens, serverTiming);
   return {
     type: 'message_delta',
     delta: {

--- a/packages/server/src/mappers/response.ts
+++ b/packages/server/src/mappers/response.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto';
 
 import type { ChatResult } from '@mlx-node/core';
 
+import { mergeTimingUsageExtensions } from '../timing.js';
 import type {
   FunctionCallOutputItem,
   MessageOutputItem,
@@ -85,6 +86,7 @@ export function buildUsage(result: ChatResult): ResponseUsage {
   if (result.cachedTokens > 0) {
     usage.input_tokens_details = { cached_tokens: result.cachedTokens };
   }
+  mergeTimingUsageExtensions(usage, result.performance, result.promptTokens, result.numTokens, result.cachedTokens);
   return usage;
 }
 

--- a/packages/server/src/model-work-coordinator.ts
+++ b/packages/server/src/model-work-coordinator.ts
@@ -1,0 +1,86 @@
+/**
+ * Process-local gate for native MLX work.
+ *
+ * Individual model instances already have a per-model execution mutex, but a
+ * lazy `loadModel()` can still run load-time materialization / warmup Metal
+ * work while another model is decoding. MLX's allocator and command queues are
+ * process-wide, so model load/swap takes an exclusive writer slot; inference
+ * takes shared reader slots.
+ */
+export class ModelWorkCoordinator {
+  private activeReaders = 0;
+  private writerActive = false;
+  private waitingWriters = 0;
+  private readonly readerWaiters: Array<() => void> = [];
+  private readonly writerWaiters: Array<() => void> = [];
+
+  async withModelLoad<T>(fn: () => Promise<T> | T): Promise<T> {
+    await this.acquireWrite();
+    try {
+      return await fn();
+    } finally {
+      this.releaseWrite();
+    }
+  }
+
+  async withInference<T>(fn: () => Promise<T> | T): Promise<T> {
+    await this.acquireRead();
+    try {
+      return await fn();
+    } finally {
+      this.releaseRead();
+    }
+  }
+
+  private acquireRead(): Promise<void> {
+    if (!this.writerActive && this.waitingWriters === 0) {
+      this.activeReaders += 1;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.readerWaiters.push(() => {
+        this.activeReaders += 1;
+        resolve();
+      });
+    });
+  }
+
+  private acquireWrite(): Promise<void> {
+    this.waitingWriters += 1;
+    if (!this.writerActive && this.activeReaders === 0) {
+      this.waitingWriters -= 1;
+      this.writerActive = true;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.writerWaiters.push(() => {
+        this.waitingWriters -= 1;
+        this.writerActive = true;
+        resolve();
+      });
+    });
+  }
+
+  private releaseRead(): void {
+    this.activeReaders -= 1;
+    if (this.activeReaders < 0) this.activeReaders = 0;
+    if (this.activeReaders === 0) this.drain();
+  }
+
+  private releaseWrite(): void {
+    this.writerActive = false;
+    this.drain();
+  }
+
+  private drain(): void {
+    if (this.writerActive) return;
+    if (this.activeReaders === 0 && this.writerWaiters.length > 0) {
+      this.writerWaiters.shift()?.();
+      return;
+    }
+    if (this.waitingWriters === 0 && this.readerWaiters.length > 0) {
+      const readers = this.readerWaiters.splice(0);
+      for (const resolve of readers) resolve();
+    }
+  }
+}

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -128,6 +128,13 @@ export interface RegisterOptions {
    * per-binding state.
    */
   samplingDefaults?: ChatConfig;
+  /**
+   * Optional per-model upper bound for generated output tokens. This is
+   * intentionally separate from `samplingDefaults.maxNewTokens`: client
+   * requests still provide the desired length, while endpoint handlers can
+   * clamp pathological values before dispatch.
+   */
+  maxOutputTokens?: number;
 }
 
 export class ModelRegistry {
@@ -212,6 +219,7 @@ export class ModelRegistry {
    */
   register(name: string, model: ServableModel, opts?: RegisterOptions): void {
     const samplingDefaults = opts?.samplingDefaults;
+    const maxOutputTokens = opts?.maxOutputTokens;
     const existing = this.models.get(name);
     if (existing && existing.model === model) {
       // Same name + same model object: leave the binding and refcount
@@ -222,6 +230,9 @@ export class ModelRegistry {
       existing.createdAt = Math.floor(Date.now() / 1000);
       if (opts && 'samplingDefaults' in opts) {
         existing.sessionRegistry.setSamplingDefaults(samplingDefaults);
+      }
+      if (opts && 'maxOutputTokens' in opts) {
+        existing.sessionRegistry.setMaxOutputTokens(maxOutputTokens);
       }
       return;
     }
@@ -240,7 +251,12 @@ export class ModelRegistry {
     let binding = this.sessionRegistriesByModel.get(model);
     if (!binding) {
       binding = {
-        registry: new SessionRegistry({ model, maxQueueDepth: this.maxQueueDepth, samplingDefaults }),
+        registry: new SessionRegistry({
+          model,
+          maxQueueDepth: this.maxQueueDepth,
+          samplingDefaults,
+          maxOutputTokens,
+        }),
         refCount: 0,
         inFlight: 0,
         pendingPersists: 0,
@@ -258,6 +274,9 @@ export class ModelRegistry {
       // intact.
       if (opts && 'samplingDefaults' in opts) {
         binding.registry.setSamplingDefaults(samplingDefaults);
+      }
+      if (opts && 'maxOutputTokens' in opts) {
+        binding.registry.setMaxOutputTokens(maxOutputTokens);
       }
     }
     binding.refCount += 1;
@@ -583,7 +602,12 @@ export class ModelRegistry {
    * List all registered models in the OpenAI /v1/models format.
    */
   list(): { id: string; object: string; created: number; owned_by: string }[] {
-    const result: { id: string; object: string; created: number; owned_by: string }[] = [];
+    const result: {
+      id: string;
+      object: string;
+      created: number;
+      owned_by: string;
+    }[] = [];
     for (const entry of this.models.values()) {
       result.push({
         id: entry.id,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -4,6 +4,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import type { ResponseStore } from '@mlx-node/core';
 
+import { handleCountMessageTokens } from './endpoints/messages-count-tokens.js';
 import { handleCreateMessage } from './endpoints/messages.js';
 import { handleListModels } from './endpoints/models.js';
 import { handleCreateResponse } from './endpoints/responses.js';
@@ -17,7 +18,7 @@ import {
 import type { PublicModelEntry } from './handler.js';
 import type { IdleSweeper } from './idle-sweeper.js';
 import type { ModelRegistry } from './registry.js';
-import type { AnthropicMessagesRequest } from './types-anthropic.js';
+import type { AnthropicCountTokensRequest, AnthropicMessagesRequest } from './types-anthropic.js';
 import type { ResponsesAPIRequest } from './types.js';
 
 /** Max request body size (10 MB). */
@@ -81,6 +82,27 @@ export async function routeRequest(
     }
 
     await handleCreateResponse(res, body, registry, store, req, responseRetentionSec, idleSweeper);
+    return;
+  }
+
+  if (path === '/v1/messages/count_tokens') {
+    if (req.method !== 'POST') {
+      sendAnthropicMethodNotAllowed(res, 'POST');
+      return;
+    }
+
+    let body: AnthropicCountTokensRequest;
+    try {
+      const raw = await readBody(req);
+      body = JSON.parse(raw) as AnthropicCountTokensRequest;
+    } catch (err) {
+      const msg =
+        err instanceof Error && err.message === 'Request body too large' ? err.message : 'Invalid JSON in request body';
+      sendAnthropicBadRequest(res, msg);
+      return;
+    }
+
+    await handleCountMessageTokens(res, body, registry, idleSweeper, resolveModel);
     return;
   }
 

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -17,6 +17,7 @@ import {
 } from './errors.js';
 import type { PublicModelEntry } from './handler.js';
 import type { IdleSweeper } from './idle-sweeper.js';
+import type { ModelWorkCoordinator } from './model-work-coordinator.js';
 import type { ModelRegistry } from './registry.js';
 import type { AnthropicCountTokensRequest, AnthropicMessagesRequest } from './types-anthropic.js';
 import type { ResponsesAPIRequest } from './types.js';
@@ -51,6 +52,7 @@ export async function routeRequest(
   idleSweeper?: IdleSweeper | null,
   resolveModel?: (name: string) => Promise<void>,
   listModels?: () => PublicModelEntry[],
+  modelWorkCoordinator?: ModelWorkCoordinator,
 ): Promise<void> {
   const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
   const path = url.pathname;
@@ -81,7 +83,16 @@ export async function routeRequest(
       return;
     }
 
-    await handleCreateResponse(res, body, registry, store, req, responseRetentionSec, idleSweeper);
+    await handleCreateResponse(
+      res,
+      body,
+      registry,
+      store,
+      req,
+      responseRetentionSec,
+      idleSweeper,
+      modelWorkCoordinator,
+    );
     return;
   }
 
@@ -102,7 +113,7 @@ export async function routeRequest(
       return;
     }
 
-    await handleCountMessageTokens(res, body, registry, idleSweeper, resolveModel);
+    await handleCountMessageTokens(res, body, registry, idleSweeper, resolveModel, modelWorkCoordinator);
     return;
   }
 
@@ -123,7 +134,7 @@ export async function routeRequest(
       return;
     }
 
-    await handleCreateMessage(res, body, registry, req, idleSweeper, resolveModel);
+    await handleCreateMessage(res, body, registry, req, idleSweeper, resolveModel, modelWorkCoordinator);
     return;
   }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -11,6 +11,7 @@ import { ResponseStore } from '@mlx-node/core';
 import type { PublicModelEntry } from './handler.js';
 import { createHandler } from './handler.js';
 import { createIdleSweeper, DEFAULT_IDLE_CLEAR_CACHE_MS, parseIdleClearCacheEnv } from './idle-sweeper.js';
+import { ModelWorkCoordinator } from './model-work-coordinator.js';
 import { ModelRegistry } from './registry.js';
 
 /** Cleanup interval for expired responses (ms). */
@@ -244,6 +245,7 @@ export async function createServer(config?: ServerConfig): Promise<ServerInstanc
   // request will not fire `clearCache()`. See the `idle-sweeper.ts`
   // module doc (section "Drain is post-request only") for rationale.
   const registry = new ModelRegistry({ maxQueueDepth: maxQueueDepthPerModel });
+  const modelWorkCoordinator = new ModelWorkCoordinator();
 
   let store: ResponseStore | null = null;
   if (!disableStore) {
@@ -270,6 +272,7 @@ export async function createServer(config?: ServerConfig): Promise<ServerInstanc
     responseRetentionSec,
     idleSweeper,
     resolveModel: config?.resolveModel,
+    modelWorkCoordinator,
     listModels: config?.listModels,
   });
   const server = httpCreateServer(handler);

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -334,6 +334,11 @@ export interface SessionRegistryOptions {
    * (each `new ChatSession(model)` uses an empty `defaultConfig`).
    */
   samplingDefaults?: ChatConfig;
+  /**
+   * Optional per-model cap for generated output tokens. Endpoint handlers
+   * apply it after request mapping, before dispatching into native decode.
+   */
+  maxOutputTokens?: number;
 }
 
 /**
@@ -413,6 +418,7 @@ export class SessionRegistry {
    * {@link SessionRegistryOptions.samplingDefaults}.
    */
   private samplingDefaults: ChatConfig | undefined;
+  private maxOutputTokens: number | undefined;
   /**
    * Number of callers that are currently WAITING for the per-model
    * execution mutex — i.e. have entered `withExclusive` but have not
@@ -473,6 +479,7 @@ export class SessionRegistry {
     this.ttlSec = opts.ttlSec ?? 1800;
     this.maxQueueDepth = opts.maxQueueDepth;
     this.samplingDefaults = opts.samplingDefaults;
+    this.maxOutputTokens = opts.maxOutputTokens;
   }
 
   /**
@@ -487,7 +494,9 @@ export class SessionRegistry {
     if (this.samplingDefaults === undefined) {
       return new ChatSession(this.model);
     }
-    return new ChatSession(this.model, { defaultConfig: this.samplingDefaults });
+    return new ChatSession(this.model, {
+      defaultConfig: this.samplingDefaults,
+    });
   }
 
   /**
@@ -507,6 +516,10 @@ export class SessionRegistry {
     return this.samplingDefaults;
   }
 
+  get outputTokenLimit(): number | undefined {
+    return this.maxOutputTokens;
+  }
+
   /**
    * Replace the sampling defaults forwarded into every future
    * `ChatSession` this registry allocates. Called by `ModelRegistry`
@@ -518,6 +531,10 @@ export class SessionRegistry {
    */
   setSamplingDefaults(defaults: ChatConfig | undefined): void {
     this.samplingDefaults = defaults;
+  }
+
+  setMaxOutputTokens(limit: number | undefined): void {
+    this.maxOutputTokens = limit;
   }
 
   /** Number of sessions currently cached. Primarily for tests and diagnostics. Always 0 or 1. */

--- a/packages/server/src/timing.ts
+++ b/packages/server/src/timing.ts
@@ -31,6 +31,12 @@ export interface TimingUsageExtensions {
   server_queue_ms?: number;
   /** Server-extension: handler time before native inference begins, including resolve and queue wait. */
   server_pre_inference_ms?: number;
+  /** Server-extension: effective process-level paged-prefill chunk size. */
+  server_paged_prefill_chunk_size?: number;
+  /** Server-extension: effective process-level paged-prefill eval/clear cadence. */
+  server_paged_prefill_eval_interval?: number;
+  /** Server-extension: effective process-level paged-decode cache-clear cadence. */
+  server_paged_decode_cache_clear_interval?: number;
 }
 
 function finitePositive(value: number | undefined): number | undefined {
@@ -49,6 +55,42 @@ export interface ServerTimingForUsage {
   server_model_resolve_ms?: number;
   server_queue_ms?: number;
   server_pre_inference_ms?: number;
+  server_paged_prefill_chunk_size?: number;
+  server_paged_prefill_eval_interval?: number;
+  server_paged_decode_cache_clear_interval?: number;
+}
+
+const I32_MAX = 0x7fff_ffff;
+
+function parseI32(value: string | undefined): number | undefined {
+  if (value == null) return undefined;
+  const trimmed = value.trim();
+  if (!/^[+-]?\d+$/.test(trimmed)) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) && parsed >= -0x8000_0000 && parsed <= I32_MAX ? parsed : undefined;
+}
+
+function parseNonNegativeI32(value: string | undefined, fallback: number): number {
+  const parsed = parseI32(value);
+  return parsed != null && parsed >= 0 ? parsed : fallback;
+}
+
+function parsePositiveI32(value: string | undefined, fallback: number): number {
+  const parsed = parseI32(value);
+  return parsed != null && parsed > 0 ? parsed : fallback;
+}
+
+export function resolveServerTuningForUsage(
+  env: Record<string, string | undefined> = process.env,
+): Pick<
+  ServerTimingForUsage,
+  'server_paged_prefill_chunk_size' | 'server_paged_prefill_eval_interval' | 'server_paged_decode_cache_clear_interval'
+> {
+  return {
+    server_paged_prefill_chunk_size: parseNonNegativeI32(env.MLX_PAGED_PREFILL_CHUNK_SIZE, 0),
+    server_paged_prefill_eval_interval: parsePositiveI32(env.MLX_PAGED_PREFILL_EVAL_INTERVAL, 8),
+    server_paged_decode_cache_clear_interval: parsePositiveI32(env.MLX_PAGED_DECODE_CACHE_CLEAR_INTERVAL, 64),
+  };
 }
 
 function computeServerInferenceElapsedMs(
@@ -123,6 +165,20 @@ export function buildTimingUsageExtensions(
   const preInferenceMs = finiteNonNegative(serverTiming?.server_pre_inference_ms);
   if (preInferenceMs != null) {
     extensions.server_pre_inference_ms = preInferenceMs;
+  }
+  const pagedPrefillChunkSize = finiteNonNegativeInteger(serverTiming?.server_paged_prefill_chunk_size);
+  if (pagedPrefillChunkSize != null) {
+    extensions.server_paged_prefill_chunk_size = pagedPrefillChunkSize;
+  }
+  const pagedPrefillEvalInterval = finiteNonNegativeInteger(serverTiming?.server_paged_prefill_eval_interval);
+  if (pagedPrefillEvalInterval != null) {
+    extensions.server_paged_prefill_eval_interval = pagedPrefillEvalInterval;
+  }
+  const pagedDecodeCacheClearInterval = finiteNonNegativeInteger(
+    serverTiming?.server_paged_decode_cache_clear_interval,
+  );
+  if (pagedDecodeCacheClearInterval != null) {
+    extensions.server_paged_decode_cache_clear_interval = pagedDecodeCacheClearInterval;
   }
 
   return extensions;

--- a/packages/server/src/timing.ts
+++ b/packages/server/src/timing.ts
@@ -17,6 +17,8 @@ export interface TimingUsageExtensions {
   server_inference_elapsed_ms?: number;
   /** Server-extension alias for disambiguating native TTFT from request/HTTP elapsed time. */
   server_time_to_first_token_ms?: number;
+  /** Server-extension: handler-start to first native token, including model resolve/load and queue wait. */
+  server_total_time_to_first_token_ms?: number;
   /** Server-extension alias for native prefill throughput. */
   server_prefill_tokens_per_second?: number;
   /** Server-extension alias for native decode throughput. */
@@ -124,11 +126,15 @@ export function buildTimingUsageExtensions(
   const prefillTokensPerSecond = finitePositive(performance?.prefillTokensPerSecond);
   const decodeTokensPerSecond = finitePositive(performance?.decodeTokensPerSecond);
   const serverInferenceElapsedMs = computeServerInferenceElapsedMs(ttftMs, decodeTokensPerSecond, outputTokens);
+  const preInferenceMs = finiteNonNegative(serverTiming?.server_pre_inference_ms);
 
   const extensions: TimingUsageExtensions = {};
   if (ttftMs != null) {
     extensions.time_to_first_token_ms = ttftMs;
     extensions.server_time_to_first_token_ms = ttftMs;
+    if (preInferenceMs != null) {
+      extensions.server_total_time_to_first_token_ms = preInferenceMs + ttftMs;
+    }
   }
   if (prefillTokensPerSecond != null) {
     extensions.prefill_tokens_per_second = prefillTokensPerSecond;
@@ -162,7 +168,6 @@ export function buildTimingUsageExtensions(
   if (queueMs != null) {
     extensions.server_queue_ms = queueMs;
   }
-  const preInferenceMs = finiteNonNegative(serverTiming?.server_pre_inference_ms);
   if (preInferenceMs != null) {
     extensions.server_pre_inference_ms = preInferenceMs;
   }

--- a/packages/server/src/timing.ts
+++ b/packages/server/src/timing.ts
@@ -1,0 +1,140 @@
+/** Wire-safe server timing extensions derived from native performance metrics. */
+
+export interface PerformanceMetricsForUsage {
+  ttftMs?: number;
+  prefillTokensPerSecond?: number;
+  decodeTokensPerSecond?: number;
+}
+
+export interface TimingUsageExtensions {
+  /** Server-extension: native time-to-first-token in milliseconds. */
+  time_to_first_token_ms?: number;
+  /** Server-extension: prompt-token throughput for the tokens actually prefetched this turn. */
+  prefill_tokens_per_second?: number;
+  /** Server-extension: generated-token throughput during decode. */
+  decode_tokens_per_second?: number;
+  /** Server-extension: native/server inference elapsed, excluding HTTP transport and logging overhead. */
+  server_inference_elapsed_ms?: number;
+  /** Server-extension alias for disambiguating native TTFT from request/HTTP elapsed time. */
+  server_time_to_first_token_ms?: number;
+  /** Server-extension alias for native prefill throughput. */
+  server_prefill_tokens_per_second?: number;
+  /** Server-extension alias for native decode throughput. */
+  server_decode_tokens_per_second?: number;
+  /** Server-extension: prompt tokens actually prefetched this turn after cached-prefix reuse. */
+  prefill_input_tokens?: number;
+  /** Server-extension: prompt tokens skipped because a cached prefix was reused. */
+  cached_prefix_tokens?: number;
+  /** Server-extension: time spent resolving/loading/aliasing the requested model before registry lookup. */
+  server_model_resolve_ms?: number;
+  /** Server-extension: time spent waiting behind the per-model execution mutex. */
+  server_queue_ms?: number;
+  /** Server-extension: handler time before native inference begins, including resolve and queue wait. */
+  server_pre_inference_ms?: number;
+}
+
+function finitePositive(value: number | undefined): number | undefined {
+  return value != null && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function finiteNonNegativeInteger(value: number | undefined): number | undefined {
+  return value != null && Number.isFinite(value) && value >= 0 ? Math.max(0, Math.floor(value)) : undefined;
+}
+
+function finiteNonNegative(value: number | undefined): number | undefined {
+  return value != null && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+export interface ServerTimingForUsage {
+  server_model_resolve_ms?: number;
+  server_queue_ms?: number;
+  server_pre_inference_ms?: number;
+}
+
+function computeServerInferenceElapsedMs(
+  ttftMs: number | undefined,
+  decodeTokensPerSecond: number | undefined,
+  outputTokens: number | undefined,
+): number | undefined {
+  if (ttftMs == null) return undefined;
+
+  const generatedTokens = finiteNonNegativeInteger(outputTokens);
+  if (generatedTokens == null) {
+    return ttftMs;
+  }
+  if (generatedTokens <= 1) {
+    return ttftMs;
+  }
+  if (decodeTokensPerSecond == null) {
+    return undefined;
+  }
+  return ttftMs + ((generatedTokens - 1) / decodeTokensPerSecond) * 1000;
+}
+
+export function buildTimingUsageExtensions(
+  performance: PerformanceMetricsForUsage | undefined,
+  promptTokens: number | undefined,
+  outputTokens: number | undefined,
+  cachedTokens: number | undefined,
+  serverTiming?: ServerTimingForUsage,
+): TimingUsageExtensions {
+  const ttftMs = finitePositive(performance?.ttftMs);
+  const prefillTokensPerSecond = finitePositive(performance?.prefillTokensPerSecond);
+  const decodeTokensPerSecond = finitePositive(performance?.decodeTokensPerSecond);
+  const serverInferenceElapsedMs = computeServerInferenceElapsedMs(ttftMs, decodeTokensPerSecond, outputTokens);
+
+  const extensions: TimingUsageExtensions = {};
+  if (ttftMs != null) {
+    extensions.time_to_first_token_ms = ttftMs;
+    extensions.server_time_to_first_token_ms = ttftMs;
+  }
+  if (prefillTokensPerSecond != null) {
+    extensions.prefill_tokens_per_second = prefillTokensPerSecond;
+    extensions.server_prefill_tokens_per_second = prefillTokensPerSecond;
+  }
+  if (decodeTokensPerSecond != null) {
+    extensions.decode_tokens_per_second = decodeTokensPerSecond;
+    extensions.server_decode_tokens_per_second = decodeTokensPerSecond;
+  }
+  if (serverInferenceElapsedMs != null && Number.isFinite(serverInferenceElapsedMs) && serverInferenceElapsedMs > 0) {
+    extensions.server_inference_elapsed_ms = serverInferenceElapsedMs;
+  }
+
+  if (performance != null) {
+    const prompt = finiteNonNegativeInteger(promptTokens);
+    const cached = finiteNonNegativeInteger(cachedTokens);
+    if (prompt != null) {
+      const cachedPrefix = cached == null ? 0 : Math.min(cached, prompt);
+      extensions.prefill_input_tokens = prompt - cachedPrefix;
+      if (cachedPrefix > 0) {
+        extensions.cached_prefix_tokens = cachedPrefix;
+      }
+    }
+  }
+
+  const modelResolveMs = finiteNonNegative(serverTiming?.server_model_resolve_ms);
+  if (modelResolveMs != null) {
+    extensions.server_model_resolve_ms = modelResolveMs;
+  }
+  const queueMs = finiteNonNegative(serverTiming?.server_queue_ms);
+  if (queueMs != null) {
+    extensions.server_queue_ms = queueMs;
+  }
+  const preInferenceMs = finiteNonNegative(serverTiming?.server_pre_inference_ms);
+  if (preInferenceMs != null) {
+    extensions.server_pre_inference_ms = preInferenceMs;
+  }
+
+  return extensions;
+}
+
+export function mergeTimingUsageExtensions<T extends TimingUsageExtensions>(
+  usage: T,
+  performance: PerformanceMetricsForUsage | undefined,
+  promptTokens: number | undefined,
+  outputTokens: number | undefined,
+  cachedTokens: number | undefined,
+  serverTiming?: ServerTimingForUsage,
+): void {
+  Object.assign(usage, buildTimingUsageExtensions(performance, promptTokens, outputTokens, cachedTokens, serverTiming));
+}

--- a/packages/server/src/tool-call-buffer.ts
+++ b/packages/server/src/tool-call-buffer.ts
@@ -1,11 +1,24 @@
 /**
- * Buffers streaming text to detect and suppress `<tool_call>` tags. Text
+ * Buffers streaming text to detect and suppress model structural tags. Text
  * that cannot be part of a partial tag is released immediately; once a
- * full tag is seen, everything after it is suppressed until the stream
- * ends.
+ * full structural tag is seen, everything after it is suppressed until
+ * the stream ends.
  */
 export class ToolCallTagBuffer {
-  private static readonly TAG = '<tool_call>';
+  private static readonly TAGS = [
+    '<tool_call>',
+    '</tool_call>',
+    '<|tool_call>',
+    '<tool_call|>',
+    '<|tool_response>',
+    '<tool_response|>',
+    '<|tool>',
+    '<tool|>',
+    '<|channel>',
+    '<channel|>',
+    '<|turn>',
+    '<turn|>',
+  ] as const;
   private pendingText = '';
   private _suppressed = false;
 
@@ -15,7 +28,7 @@ export class ToolCallTagBuffer {
 
   /**
    * Feed text in. Returns `safeText` (emit as delta), `tagFound` (a full
-   * `<tool_call>` was just seen), and `cleanPrefix` (text before the tag
+   * structural tag was just seen), and `cleanPrefix` (text before the tag
    * when `tagFound` — may contain whitespace; use `.trim()` only for
    * emptiness checks, never for emission).
    */
@@ -26,7 +39,13 @@ export class ToolCallTagBuffer {
 
     this.pendingText += text;
 
-    const tagIdx = this.pendingText.indexOf(ToolCallTagBuffer.TAG);
+    let tagIdx = -1;
+    for (const tag of ToolCallTagBuffer.TAGS) {
+      const idx = this.pendingText.indexOf(tag);
+      if (idx >= 0 && (tagIdx < 0 || idx < tagIdx)) {
+        tagIdx = idx;
+      }
+    }
     if (tagIdx >= 0) {
       const cleanPrefix = this.pendingText.slice(0, tagIdx);
       this._suppressed = true;
@@ -36,9 +55,10 @@ export class ToolCallTagBuffer {
 
     // Hold back any suffix that could be the start of the tag.
     let safeLen = this.pendingText.length;
-    for (let i = 1; i <= Math.min(this.pendingText.length, ToolCallTagBuffer.TAG.length - 1); i++) {
+    const maxTagLength = Math.max(...ToolCallTagBuffer.TAGS.map((tag) => tag.length));
+    for (let i = 1; i <= Math.min(this.pendingText.length, maxTagLength - 1); i++) {
       const suffix = this.pendingText.slice(-i);
-      if (ToolCallTagBuffer.TAG.startsWith(suffix)) {
+      if (ToolCallTagBuffer.TAGS.some((tag) => tag.startsWith(suffix))) {
         safeLen = this.pendingText.length - i;
         break;
       }

--- a/packages/server/src/types-anthropic.ts
+++ b/packages/server/src/types-anthropic.ts
@@ -93,6 +93,12 @@ export interface AnthropicMessagesRequest {
   stream?: boolean;
   stop_sequences?: string[];
   metadata?: { user_id?: string };
+  output_config?: {
+    format?: {
+      type?: string;
+      schema?: unknown;
+    };
+  };
   // NOTE: `prompt_cache_key` is intentionally NOT advertised on this
   // endpoint. KV-cache reuse on `/v1/messages` is delivered via the
   // server-side `getOrCreateWarmAny` warm-slot mechanism keyed on the

--- a/packages/server/src/types-anthropic.ts
+++ b/packages/server/src/types-anthropic.ts
@@ -210,6 +210,12 @@ export interface AnthropicUsage {
   server_queue_ms?: number;
   /** Server-extension: handler time before native inference begins, including resolve and queue wait. */
   server_pre_inference_ms?: number;
+  /** Server-extension: effective process-level paged-prefill chunk size. */
+  server_paged_prefill_chunk_size?: number;
+  /** Server-extension: effective process-level paged-prefill eval/clear cadence. */
+  server_paged_prefill_eval_interval?: number;
+  /** Server-extension: effective process-level paged-decode cache-clear cadence. */
+  server_paged_decode_cache_clear_interval?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -321,6 +327,12 @@ export interface AnthropicMessageDeltaEvent {
     server_queue_ms?: number;
     /** Server-extension: handler time before native inference begins, including resolve and queue wait. */
     server_pre_inference_ms?: number;
+    /** Server-extension: effective process-level paged-prefill chunk size. */
+    server_paged_prefill_chunk_size?: number;
+    /** Server-extension: effective process-level paged-prefill eval/clear cadence. */
+    server_paged_prefill_eval_interval?: number;
+    /** Server-extension: effective process-level paged-decode cache-clear cadence. */
+    server_paged_decode_cache_clear_interval?: number;
   };
 }
 

--- a/packages/server/src/types-anthropic.ts
+++ b/packages/server/src/types-anthropic.ts
@@ -196,6 +196,8 @@ export interface AnthropicUsage {
   server_inference_elapsed_ms?: number;
   /** Server-extension alias for disambiguating native TTFT from request/HTTP elapsed time. */
   server_time_to_first_token_ms?: number;
+  /** Server-extension: handler-start to first native token, including model resolve/load and queue wait. */
+  server_total_time_to_first_token_ms?: number;
   /** Server-extension alias for native prefill throughput. */
   server_prefill_tokens_per_second?: number;
   /** Server-extension alias for native decode throughput. */
@@ -313,6 +315,8 @@ export interface AnthropicMessageDeltaEvent {
     server_inference_elapsed_ms?: number;
     /** Server-extension alias for disambiguating native TTFT from request/HTTP elapsed time. */
     server_time_to_first_token_ms?: number;
+    /** Server-extension: handler-start to first native token, including model resolve/load and queue wait. */
+    server_total_time_to_first_token_ms?: number;
     /** Server-extension alias for native prefill throughput. */
     server_prefill_tokens_per_second?: number;
     /** Server-extension alias for native decode throughput. */

--- a/packages/server/src/types-anthropic.ts
+++ b/packages/server/src/types-anthropic.ts
@@ -105,6 +105,14 @@ export interface AnthropicMessagesRequest {
   // tier-2 lookup.
 }
 
+export type AnthropicCountTokensRequest = Omit<AnthropicMessagesRequest, 'max_tokens'> & {
+  max_tokens?: number;
+};
+
+export interface AnthropicCountTokensResponse {
+  input_tokens: number;
+}
+
 // ---------------------------------------------------------------------------
 // Response content blocks
 // ---------------------------------------------------------------------------
@@ -157,17 +165,21 @@ export type AnthropicResponseContent =
  *     that did not request explicit caching should never see a
  *     non-zero creation count.
  *
- * The `time_to_first_token_ms`, `prefill_tokens_per_second`, and
- * `decode_tokens_per_second` fields are NON-Anthropic extension
- * fields surfaced for the launcher's verbose log
- * (`requests.ndjson`) so per-turn decode-rate / TTFT / prefill-rate
- * telemetry rides the same response envelope. They are emitted only
- * when the underlying native dispatch produced a finite, positive
- * value — missing or non-finite metrics are elided rather than
- * surfaced as zero / null. Anthropic-compatible clients (Claude
- * Code, official Anthropic SDKs) ignore unknown fields, so the
- * extension is wire-safe — it parallels how `cache_read_input_tokens`
- * is treated above.
+ * The timing fields below are NON-Anthropic extension fields surfaced
+ * for the launcher's verbose log (`requests.ndjson`) so per-turn
+ * decode-rate / TTFT / prefill-rate telemetry rides the same response
+ * envelope. They describe native/server inference timing, not the
+ * HTTP logger's outer `elapsedMs` envelope. They are emitted only when
+ * the underlying native dispatch produced a finite, positive value —
+ * missing or non-finite metrics are elided rather than surfaced as
+ * zero / null. Anthropic-compatible clients (Claude Code, official
+ * Anthropic SDKs) ignore unknown fields, so the extension is wire-safe
+ * — it parallels how `cache_read_input_tokens` is treated above.
+ *
+ * `prefill_input_tokens` and `cached_prefix_tokens` provide the
+ * denominator/context for `prefill_tokens_per_second`: on cached-prefix
+ * turns the prefill rate is for the uncached suffix, not the full
+ * logical prompt.
  */
 export interface AnthropicUsage {
   input_tokens: number;
@@ -180,6 +192,24 @@ export interface AnthropicUsage {
   prefill_tokens_per_second?: number;
   /** Server-extension: generated-token throughput during decode. */
   decode_tokens_per_second?: number;
+  /** Server-extension: native/server inference elapsed, excluding HTTP transport and logging overhead. */
+  server_inference_elapsed_ms?: number;
+  /** Server-extension alias for disambiguating native TTFT from request/HTTP elapsed time. */
+  server_time_to_first_token_ms?: number;
+  /** Server-extension alias for native prefill throughput. */
+  server_prefill_tokens_per_second?: number;
+  /** Server-extension alias for native decode throughput. */
+  server_decode_tokens_per_second?: number;
+  /** Server-extension: prompt tokens actually prefetched this turn after cached-prefix reuse. */
+  prefill_input_tokens?: number;
+  /** Server-extension: prompt tokens skipped because a cached prefix was reused. */
+  cached_prefix_tokens?: number;
+  /** Server-extension: time spent resolving/loading/aliasing the requested model before registry lookup. */
+  server_model_resolve_ms?: number;
+  /** Server-extension: time spent waiting behind the per-model execution mutex. */
+  server_queue_ms?: number;
+  /** Server-extension: handler time before native inference begins, including resolve and queue wait. */
+  server_pre_inference_ms?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -257,8 +287,7 @@ export interface AnthropicMessageDeltaEvent {
    * prefix, and `cache_read_input_tokens` is emitted only on a true
    * reuse turn.
    *
-   * `time_to_first_token_ms`, `prefill_tokens_per_second`, and
-   * `decode_tokens_per_second` are server-extension fields (not in
+   * Timing/accounting fields are server extensions (not in
    * Anthropic's spec) surfaced for the launcher's verbose log; see
    * the docstring on `AnthropicUsage`. Clients that do not recognize
    * them ignore them.
@@ -274,6 +303,24 @@ export interface AnthropicMessageDeltaEvent {
     prefill_tokens_per_second?: number;
     /** Server-extension: generated-token throughput during decode. */
     decode_tokens_per_second?: number;
+    /** Server-extension: native/server inference elapsed, excluding HTTP transport and logging overhead. */
+    server_inference_elapsed_ms?: number;
+    /** Server-extension alias for disambiguating native TTFT from request/HTTP elapsed time. */
+    server_time_to_first_token_ms?: number;
+    /** Server-extension alias for native prefill throughput. */
+    server_prefill_tokens_per_second?: number;
+    /** Server-extension alias for native decode throughput. */
+    server_decode_tokens_per_second?: number;
+    /** Server-extension: prompt tokens actually prefetched this turn after cached-prefix reuse. */
+    prefill_input_tokens?: number;
+    /** Server-extension: prompt tokens skipped because a cached prefix was reused. */
+    cached_prefix_tokens?: number;
+    /** Server-extension: time spent resolving/loading/aliasing the requested model before registry lookup. */
+    server_model_resolve_ms?: number;
+    /** Server-extension: time spent waiting behind the per-model execution mutex. */
+    server_queue_ms?: number;
+    /** Server-extension: handler time before native inference begins, including resolve and queue wait. */
+    server_pre_inference_ms?: number;
   };
 }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -266,6 +266,9 @@ export interface ResponseUsage {
   server_model_resolve_ms?: number;
   server_queue_ms?: number;
   server_pre_inference_ms?: number;
+  server_paged_prefill_chunk_size?: number;
+  server_paged_prefill_eval_interval?: number;
+  server_paged_decode_cache_clear_interval?: number;
   /**
    * Server-extension cache context for `prefill_tokens_per_second`.
    * On cached-prefix turns, `prefill_input_tokens` is the uncached

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -261,6 +261,7 @@ export interface ResponseUsage {
   decode_tokens_per_second?: number;
   server_inference_elapsed_ms?: number;
   server_time_to_first_token_ms?: number;
+  server_total_time_to_first_token_ms?: number;
   server_prefill_tokens_per_second?: number;
   server_decode_tokens_per_second?: number;
   server_model_resolve_ms?: number;

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -250,6 +250,31 @@ export interface ResponseUsage {
    * in-band number is the authoritative signal).
    */
   input_tokens_details?: { cached_tokens: number };
+  /**
+   * Server-extension timing fields surfaced for verbose logs. These
+   * are native/server inference measurements, distinct from the HTTP
+   * logger's outer `elapsedMs` envelope. Unknown fields are ignored by
+   * OpenAI-compatible clients.
+   */
+  time_to_first_token_ms?: number;
+  prefill_tokens_per_second?: number;
+  decode_tokens_per_second?: number;
+  server_inference_elapsed_ms?: number;
+  server_time_to_first_token_ms?: number;
+  server_prefill_tokens_per_second?: number;
+  server_decode_tokens_per_second?: number;
+  server_model_resolve_ms?: number;
+  server_queue_ms?: number;
+  server_pre_inference_ms?: number;
+  /**
+   * Server-extension cache context for `prefill_tokens_per_second`.
+   * On cached-prefix turns, `prefill_input_tokens` is the uncached
+   * suffix that was actually prefetched and `cached_prefix_tokens`
+   * is the skipped prefix, so verbose logs do not mistake suffix-only
+   * prefill throughput for full-prompt throughput.
+   */
+  prefill_input_tokens?: number;
+  cached_prefix_tokens?: number;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches core inference and cache/attention paths (Gemma4 paged attention + MLX eval/materialization) and server request dispatch limits, so regressions could impact correctness, latency, or stability under load.
> 
> **Overview**
> Improves server-side observability and request shaping by **adding a `/v1/messages/count_tokens` endpoint** (non-generating chat-template tokenization with race-guards against model re-registration), enforcing a **per-model queue cap** (429 + `Retry-After`) and introducing a process-wide `ModelWorkCoordinator` to prioritize model loads over new inference.
> 
> Extends wire/CLI logging with richer **timing + cache context** (server vs native TTFT/TTFB, cached-prefix accounting, paged tuning metadata), clamps `max_tokens` to per-model output caps, adds a Claude Code title-generation fast path (disable thinking + cap tokens), and tightens tool-call suppression so parsed tool-call markup isn’t emitted when tools are absent.
> 
> On the native side, adds `MLX_INFERENCE_TRACE` logging, makes MLX `eval`/weight materialization failures surfaced as errors (with chunked, auto-budgeted materialization), and updates Gemma4 paged attention to prefer graph-native paged gather paths with fallbacks plus stricter mask validation (with new correctness tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b915cebe4fc91416f44eaadbcb4dcd170083e3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->