### PR TITLE
fix: anthropic /v1/messages parsing, observability, and is_error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+        with:
+          # Don't cache ~/.cargo/bin — restoring it overwrites the
+          # rustup proxy installed by setup-rust-toolchain and leaves
+          # cargo resolving to rustup-init's usage screen.
+          cache-bin: false
+          # Bumped after switching toolchain action; forces fresh
+          # caches and orphans the poisoned v0-rust archives.
+          prefix-key: v1-rust
 
       - name: Configure GitHub token for CMake downloads
         run: |
@@ -98,6 +106,14 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+        with:
+          # Don't cache ~/.cargo/bin — restoring it overwrites the
+          # rustup proxy installed by setup-rust-toolchain and leaves
+          # cargo resolving to rustup-init's usage screen.
+          cache-bin: false
+          # Bumped after switching toolchain action; forces fresh
+          # caches and orphans the poisoned v0-rust archives.
+          prefix-key: v1-rust
 
       - name: Configure GitHub token for CMake downloads
         run: |
@@ -152,6 +168,14 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+        with:
+          # Don't cache ~/.cargo/bin — restoring it overwrites the
+          # rustup proxy installed by setup-rust-toolchain and leaves
+          # cargo resolving to rustup-init's usage screen.
+          cache-bin: false
+          # Bumped after switching toolchain action; forces fresh
+          # caches and orphans the poisoned v0-rust archives.
+          prefix-key: v1-rust
 
       - name: Configure GitHub token for CMake downloads
         run: |

--- a/__test__/cli/launch-claude/logger.test.ts
+++ b/__test__/cli/launch-claude/logger.test.ts
@@ -178,4 +178,42 @@ describe('attachLogger', () => {
     expect(pretty).toContain('perf(ttfb=312ms ttft=250ms prefill=20.00/s decode=40.00/s infer=350ms)');
     expect(pretty).toContain('server(resolve=57ms queue=5ms pre=62ms)');
   });
+
+  it('surfaces load_wait and load_owner in the server(...) summary when present', async () => {
+    // Observability split: a follower request that arrives during a peer's
+    // cold load gets `load_wait_ms` ≈ cold load latency and
+    // `load_owner=false`. Without surfacing the split, the follower's
+    // `resolve_ms` would be indistinguishable from a request that drove
+    // the load itself.
+    const logDir = makeTmpDir();
+    const port = await pickFreePort();
+
+    const srv = createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          model: 'gemma-test',
+          stop_reason: 'end_turn',
+          usage: {
+            input_tokens: 20,
+            output_tokens: 5,
+            server_model_resolve_ms: 60_300,
+            server_load_wait_ms: 60_290,
+            server_load_owner: false,
+            server_queue_ms: 1,
+            server_pre_inference_ms: 60_302,
+          },
+        }),
+      );
+    });
+    const logger = attachLogger(srv, logDir);
+    await new Promise<void>((resolve) => srv.listen(port, '127.0.0.1', resolve));
+
+    await postJson(port, { model: 'gemma-test' });
+    await logger.close();
+    await closeServer(srv);
+
+    const pretty = readFileSync(join(logDir, 'session.log'), 'utf-8');
+    expect(pretty).toContain('server(resolve=60300ms load_wait=60290ms load_owner=false queue=1ms pre=60302ms)');
+  });
 });

--- a/__test__/models/chat-session.test.ts
+++ b/__test__/models/chat-session.test.ts
@@ -98,8 +98,8 @@ function makeMockModel() {
     async (
       _toolCallId: string,
       _content: string,
-      _isError?: boolean | null,
       _config?: ChatConfig | null,
+      _isError?: boolean | null,
     ): Promise<ChatResult> => makeChatResult('tool-reply'),
   );
   const chatStreamSessionStart = vi.fn(async function* (
@@ -121,8 +121,8 @@ function makeMockModel() {
   const chatStreamSessionContinueTool = vi.fn(async function* (
     _toolCallId: string,
     _content: string,
-    _isError?: boolean | null,
     _config?: ChatConfig | null,
+    _isError?: boolean | null,
   ): AsyncGenerator<ChatStreamEvent> {
     yield { text: 'tool', done: false };
     yield finalChunk('tool-reply');
@@ -681,12 +681,15 @@ describe('ChatSession', () => {
       expect(chatSessionContinueTool).toHaveBeenCalledTimes(1);
       expect(chatSessionContinueTool.mock.calls[0][0]).toBe('call-42');
       expect(chatSessionContinueTool.mock.calls[0][1]).toBe('{"status":"ok"}');
-      // The third arg is the structured `isError` signal — defaults to
+      // The third native arg is the merged `config` (config precedes
+      // `isError` at the NAPI boundary so the trailing-optional shape
+      // accepts pre-feature 3-arg callers without InvalidArg).
+      expect(chatSessionContinueTool.mock.calls[0][2]?.reuseCache).toBe(true);
+      // The fourth arg is the structured `isError` signal — defaults to
       // `null` when the caller omits it (we coerce `undefined` to `null`
       // at the wrapper boundary so the NAPI binding sees a stable
       // shape).
-      expect(chatSessionContinueTool.mock.calls[0][2]).toBeNull();
-      expect(chatSessionContinueTool.mock.calls[0][3]?.reuseCache).toBe(true);
+      expect(chatSessionContinueTool.mock.calls[0][3]).toBeNull();
       expect(session.turns).toBe(2);
       // Tool-reply has no further outstanding calls.
       expect(session.pendingUnresolvedToolCallCount).toBeNull();
@@ -694,7 +697,7 @@ describe('ChatSession', () => {
 
     it('forwards isError=true through to the native binding', async () => {
       // Pin the structured tool-error plumbing: when the caller passes
-      // `isError: true`, the wrapper MUST forward it as the third
+      // `isError: true`, the wrapper MUST forward it as the fourth
       // positional argument to the native `chatSessionContinueTool`
       // call so the renderer can inject the wire-format
       // `[tool error]` marker. The history entry MUST also carry the
@@ -715,17 +718,19 @@ describe('ChatSession', () => {
       expect(chatSessionContinueTool).toHaveBeenCalledTimes(1);
       expect(chatSessionContinueTool.mock.calls[0][0]).toBe('call-err');
       expect(chatSessionContinueTool.mock.calls[0][1]).toBe('{"error":"boom"}');
-      // The third native arg is the structured `isError` signal — `true` must
-      // pass through verbatim (not coerced to `null` like the omit case).
-      expect(chatSessionContinueTool.mock.calls[0][2]).toBe(true);
+      // The fourth native arg is the structured `isError` signal — `true`
+      // must pass through verbatim (not coerced to `null` like the omit
+      // case). `config` precedes it at index [2].
+      expect(chatSessionContinueTool.mock.calls[0][3]).toBe(true);
     });
 
     it('forwards isError=true through to the streaming native binding', async () => {
       // Streaming counterpart to the non-streaming `isError=true`
-      // assertion above. Mirrors the wire-format invariant: the third
+      // assertion above. Mirrors the wire-format invariant: the fourth
       // positional arg of `chatStreamSessionContinueTool` must carry
       // the structured flag so the streaming renderer injects the
-      // same `[tool error]` marker as the non-streaming path.
+      // same `[tool error]` marker as the non-streaming path. `config`
+      // precedes it at index [2].
       const { model, chatSessionStart, chatStreamSessionContinueTool } = makeMockModel();
       chatSessionStart.mockResolvedValueOnce(makeChatResultWithSingleToolCall('first-call', 'call-err'));
       const session = new ChatSession(model);
@@ -740,7 +745,7 @@ describe('ChatSession', () => {
       expect(chatStreamSessionContinueTool).toHaveBeenCalledTimes(1);
       expect(chatStreamSessionContinueTool.mock.calls[0][0]).toBe('call-err');
       expect(chatStreamSessionContinueTool.mock.calls[0][1]).toBe('{"error":"boom"}');
-      expect(chatStreamSessionContinueTool.mock.calls[0][2]).toBe(true);
+      expect(chatStreamSessionContinueTool.mock.calls[0][3]).toBe(true);
       // The stream still terminates normally on the mock — confirms the
       // history-append commit branch ran (sawFinal === true).
       expect(events.at(-1)?.done).toBe(true);
@@ -757,8 +762,8 @@ describe('ChatSession', () => {
 
       await session.send('fire the tool call');
       await session.sendToolResult('call-ok', '{"status":"ok"}');
-      // No third arg → coerced to `null`, not `undefined`.
-      expect(chatSessionContinueTool.mock.calls[0][2]).toBeNull();
+      // `isError` omitted → coerced to `null` at index [3], not `undefined`.
+      expect(chatSessionContinueTool.mock.calls[0][3]).toBeNull();
     });
 
     it('forwards isError=false unchanged (still no marker, but explicit)', async () => {
@@ -773,7 +778,7 @@ describe('ChatSession', () => {
 
       await session.send('fire the tool call');
       await session.sendToolResult('call-ok', '{"status":"ok"}', { isError: false });
-      expect(chatSessionContinueTool.mock.calls[0][2]).toBe(false);
+      expect(chatSessionContinueTool.mock.calls[0][3]).toBe(false);
     });
 
     it('accepts the opts-bag without isError (backward compat with { config } only)', async () => {
@@ -792,10 +797,11 @@ describe('ChatSession', () => {
       await session.send('fire');
       await session.sendToolResult('c1', 'out', { config: { reuseCache: false } });
       expect(chatSessionContinueTool).toHaveBeenCalledTimes(1);
-      // `isError` was omitted → coerced to `null` at the NAPI boundary.
-      expect(chatSessionContinueTool.mock.calls[0][2]).toBeNull();
-      // The merged config still forces reuseCache: true.
-      expect(chatSessionContinueTool.mock.calls[0][3]?.reuseCache).toBe(true);
+      // The merged config sits at index [2] and still forces reuseCache: true.
+      expect(chatSessionContinueTool.mock.calls[0][2]?.reuseCache).toBe(true);
+      // `isError` was omitted → coerced to `null` at the NAPI boundary,
+      // landing in the trailing-optional [3] slot.
+      expect(chatSessionContinueTool.mock.calls[0][3]).toBeNull();
     });
 
     it('rejects sendToolResult when no outstanding tool call exists', async () => {
@@ -847,11 +853,11 @@ describe('ChatSession', () => {
 
       await session.send('fire'); // establishes outstanding call 'c1'
       await session.sendToolResult('c1', 'out', { config: { reuseCache: false } });
-      // The fourth positional native arg is the merged `ChatConfig` —
+      // The third positional native arg is the merged `ChatConfig` —
       // `mergeConfig` always forces `reuseCache: true` regardless of the
       // caller-supplied value (the session path is a cache-reuse op by
       // construction).
-      expect(chatSessionContinueTool.mock.calls[0][3]?.reuseCache).toBe(true);
+      expect(chatSessionContinueTool.mock.calls[0][2]?.reuseCache).toBe(true);
     });
 
     it('clears inFlight on exception', async () => {

--- a/__test__/models/chat-session.test.ts
+++ b/__test__/models/chat-session.test.ts
@@ -122,6 +122,7 @@ function makeMockModel() {
     _toolCallId: string,
     _content: string,
     _config?: ChatConfig | null,
+    _signal?: AbortSignal,
     _isError?: boolean | null,
   ): AsyncGenerator<ChatStreamEvent> {
     yield { text: 'tool', done: false };
@@ -726,11 +727,12 @@ describe('ChatSession', () => {
 
     it('forwards isError=true through to the streaming native binding', async () => {
       // Streaming counterpart to the non-streaming `isError=true`
-      // assertion above. Mirrors the wire-format invariant: the fourth
+      // assertion above. Mirrors the wire-format invariant: the fifth
       // positional arg of `chatStreamSessionContinueTool` must carry
       // the structured flag so the streaming renderer injects the
       // same `[tool error]` marker as the non-streaming path. `config`
-      // precedes it at index [2].
+      // sits at index [2] and `signal` at [3]; `isError` is the
+      // trailing-optional fifth arg.
       const { model, chatSessionStart, chatStreamSessionContinueTool } = makeMockModel();
       chatSessionStart.mockResolvedValueOnce(makeChatResultWithSingleToolCall('first-call', 'call-err'));
       const session = new ChatSession(model);
@@ -745,7 +747,11 @@ describe('ChatSession', () => {
       expect(chatStreamSessionContinueTool).toHaveBeenCalledTimes(1);
       expect(chatStreamSessionContinueTool.mock.calls[0][0]).toBe('call-err');
       expect(chatStreamSessionContinueTool.mock.calls[0][1]).toBe('{"error":"boom"}');
-      expect(chatStreamSessionContinueTool.mock.calls[0][3]).toBe(true);
+      // `signal` (index [3]) precedes `isError` (index [4]) at the
+      // wrapper boundary — mirrors the native NAPI ordering where
+      // the trailing-optional `isError` follows the required callback
+      // so pre-feature 4-arg callers still type-check.
+      expect(chatStreamSessionContinueTool.mock.calls[0][4]).toBe(true);
       // The stream still terminates normally on the mock — confirms the
       // history-append commit branch ran (sawFinal === true).
       expect(events.at(-1)?.done).toBe(true);

--- a/__test__/models/chat-session.test.ts
+++ b/__test__/models/chat-session.test.ts
@@ -95,8 +95,12 @@ function makeMockModel() {
       makeChatResult('continue-reply'),
   );
   const chatSessionContinueTool = vi.fn(
-    async (_toolCallId: string, _content: string, _config?: ChatConfig | null): Promise<ChatResult> =>
-      makeChatResult('tool-reply'),
+    async (
+      _toolCallId: string,
+      _content: string,
+      _isError?: boolean | null,
+      _config?: ChatConfig | null,
+    ): Promise<ChatResult> => makeChatResult('tool-reply'),
   );
   const chatStreamSessionStart = vi.fn(async function* (
     _messages: ChatMessage[],
@@ -117,6 +121,7 @@ function makeMockModel() {
   const chatStreamSessionContinueTool = vi.fn(async function* (
     _toolCallId: string,
     _content: string,
+    _isError?: boolean | null,
     _config?: ChatConfig | null,
   ): AsyncGenerator<ChatStreamEvent> {
     yield { text: 'tool', done: false };
@@ -676,10 +681,99 @@ describe('ChatSession', () => {
       expect(chatSessionContinueTool).toHaveBeenCalledTimes(1);
       expect(chatSessionContinueTool.mock.calls[0][0]).toBe('call-42');
       expect(chatSessionContinueTool.mock.calls[0][1]).toBe('{"status":"ok"}');
-      expect(chatSessionContinueTool.mock.calls[0][2]?.reuseCache).toBe(true);
+      // The third arg is the structured `isError` signal — defaults to
+      // `null` when the caller omits it (we coerce `undefined` to `null`
+      // at the wrapper boundary so the NAPI binding sees a stable
+      // shape).
+      expect(chatSessionContinueTool.mock.calls[0][2]).toBeNull();
+      expect(chatSessionContinueTool.mock.calls[0][3]?.reuseCache).toBe(true);
       expect(session.turns).toBe(2);
       // Tool-reply has no further outstanding calls.
       expect(session.pendingUnresolvedToolCallCount).toBeNull();
+    });
+
+    it('forwards isError=true through to the native binding', async () => {
+      // Pin the structured tool-error plumbing: when the caller passes
+      // `isError: true`, the wrapper MUST forward it as the third
+      // positional argument to the native `chatSessionContinueTool`
+      // call so the renderer can inject the wire-format
+      // `[tool error]` marker. The history entry MUST also carry the
+      // structured flag so cold-replay (image-change restart,
+      // `startFromHistory*`, server-side `SessionRegistry`
+      // cache-miss rebuild) re-renders the marker consistently. The
+      // assertion is at the native binding boundary so the test
+      // covers BOTH the JS-side argument plumbing and the
+      // history-append shape without needing a loaded model.
+      const { model, chatSessionStart, chatSessionContinueTool } = makeMockModel();
+      chatSessionStart.mockResolvedValueOnce(makeChatResultWithSingleToolCall('first-call', 'call-err'));
+      const session = new ChatSession(model);
+
+      await session.send('fire the tool call');
+      expect(session.pendingUnresolvedToolCallCount).toBe(1);
+
+      await session.sendToolResult('call-err', '{"error":"boom"}', true);
+      expect(chatSessionContinueTool).toHaveBeenCalledTimes(1);
+      expect(chatSessionContinueTool.mock.calls[0][0]).toBe('call-err');
+      expect(chatSessionContinueTool.mock.calls[0][1]).toBe('{"error":"boom"}');
+      // The third native arg is the structured `isError` signal — `true` must
+      // pass through verbatim (not coerced to `null` like the omit case).
+      expect(chatSessionContinueTool.mock.calls[0][2]).toBe(true);
+    });
+
+    it('forwards isError=true through to the streaming native binding', async () => {
+      // Streaming counterpart to the non-streaming `isError=true`
+      // assertion above. Mirrors the wire-format invariant: the third
+      // positional arg of `chatStreamSessionContinueTool` must carry
+      // the structured flag so the streaming renderer injects the
+      // same `[tool error]` marker as the non-streaming path.
+      const { model, chatSessionStart, chatStreamSessionContinueTool } = makeMockModel();
+      chatSessionStart.mockResolvedValueOnce(makeChatResultWithSingleToolCall('first-call', 'call-err'));
+      const session = new ChatSession(model);
+
+      await session.send('fire the tool call');
+      expect(session.pendingUnresolvedToolCallCount).toBe(1);
+
+      const events: ChatStreamEvent[] = [];
+      for await (const ev of session.sendToolResultStream('call-err', '{"error":"boom"}', true)) {
+        events.push(ev);
+      }
+      expect(chatStreamSessionContinueTool).toHaveBeenCalledTimes(1);
+      expect(chatStreamSessionContinueTool.mock.calls[0][0]).toBe('call-err');
+      expect(chatStreamSessionContinueTool.mock.calls[0][1]).toBe('{"error":"boom"}');
+      expect(chatStreamSessionContinueTool.mock.calls[0][2]).toBe(true);
+      // The stream still terminates normally on the mock — confirms the
+      // history-append commit branch ran (sawFinal === true).
+      expect(events.at(-1)?.done).toBe(true);
+    });
+
+    it('defaults isError to null when the caller omits it', async () => {
+      // Default semantics: `isError` is optional and the wrapper
+      // coerces `undefined` to `null` at the NAPI boundary so the
+      // binding sees a stable shape. This pins the "no marker"
+      // pre-feature behavior against accidental flag-inference drift.
+      const { model, chatSessionStart, chatSessionContinueTool } = makeMockModel();
+      chatSessionStart.mockResolvedValueOnce(makeChatResultWithSingleToolCall('first-call', 'call-ok'));
+      const session = new ChatSession(model);
+
+      await session.send('fire the tool call');
+      await session.sendToolResult('call-ok', '{"status":"ok"}');
+      // No third arg → coerced to `null`, not `undefined`.
+      expect(chatSessionContinueTool.mock.calls[0][2]).toBeNull();
+    });
+
+    it('forwards isError=false unchanged (still no marker, but explicit)', async () => {
+      // `Some(false)` is the same wire output as `None` per the
+      // renderer's contract — but the wrapper must NOT silently fold
+      // `false` into `null` because the structured channel is the
+      // authoritative source-of-truth and callers may legitimately
+      // pass an explicit `false` to disambiguate from "not set".
+      const { model, chatSessionStart, chatSessionContinueTool } = makeMockModel();
+      chatSessionStart.mockResolvedValueOnce(makeChatResultWithSingleToolCall('first-call', 'call-ok'));
+      const session = new ChatSession(model);
+
+      await session.send('fire the tool call');
+      await session.sendToolResult('call-ok', '{"status":"ok"}', false);
+      expect(chatSessionContinueTool.mock.calls[0][2]).toBe(false);
     });
 
     it('rejects sendToolResult when no outstanding tool call exists', async () => {
@@ -730,8 +824,12 @@ describe('ChatSession', () => {
       const session = new ChatSession(model);
 
       await session.send('fire'); // establishes outstanding call 'c1'
-      await session.sendToolResult('c1', 'out', { config: { reuseCache: false } });
-      expect(chatSessionContinueTool.mock.calls[0][2]?.reuseCache).toBe(true);
+      await session.sendToolResult('c1', 'out', undefined, { config: { reuseCache: false } });
+      // The fourth positional native arg is the merged `ChatConfig` —
+      // `mergeConfig` always forces `reuseCache: true` regardless of the
+      // caller-supplied value (the session path is a cache-reuse op by
+      // construction).
+      expect(chatSessionContinueTool.mock.calls[0][3]?.reuseCache).toBe(true);
     });
 
     it('clears inFlight on exception', async () => {

--- a/__test__/models/chat-session.test.ts
+++ b/__test__/models/chat-session.test.ts
@@ -711,7 +711,7 @@ describe('ChatSession', () => {
       await session.send('fire the tool call');
       expect(session.pendingUnresolvedToolCallCount).toBe(1);
 
-      await session.sendToolResult('call-err', '{"error":"boom"}', true);
+      await session.sendToolResult('call-err', '{"error":"boom"}', { isError: true });
       expect(chatSessionContinueTool).toHaveBeenCalledTimes(1);
       expect(chatSessionContinueTool.mock.calls[0][0]).toBe('call-err');
       expect(chatSessionContinueTool.mock.calls[0][1]).toBe('{"error":"boom"}');
@@ -734,7 +734,7 @@ describe('ChatSession', () => {
       expect(session.pendingUnresolvedToolCallCount).toBe(1);
 
       const events: ChatStreamEvent[] = [];
-      for await (const ev of session.sendToolResultStream('call-err', '{"error":"boom"}', true)) {
+      for await (const ev of session.sendToolResultStream('call-err', '{"error":"boom"}', { isError: true })) {
         events.push(ev);
       }
       expect(chatStreamSessionContinueTool).toHaveBeenCalledTimes(1);
@@ -772,8 +772,30 @@ describe('ChatSession', () => {
       const session = new ChatSession(model);
 
       await session.send('fire the tool call');
-      await session.sendToolResult('call-ok', '{"status":"ok"}', false);
+      await session.sendToolResult('call-ok', '{"status":"ok"}', { isError: false });
       expect(chatSessionContinueTool.mock.calls[0][2]).toBe(false);
+    });
+
+    it('accepts the opts-bag without isError (backward compat with { config } only)', async () => {
+      // Regression: the additive opts-bag signature must accept callers
+      // that pass only `{ config }` without `isError`. The pre-fix
+      // signature interleaved `isError` as a positional third argument
+      // so any caller using `sendToolResult(id, content, { config })`
+      // landed `{ config }` in the `isError` slot and crashed at the
+      // native NAPI boundary (Option<bool>). This pins the opts-bag
+      // contract: `{ config }` alone is a valid call shape and
+      // `isError` defaults to `null` at the native boundary.
+      const { model, chatSessionStart, chatSessionContinueTool } = makeMockModel();
+      chatSessionStart.mockResolvedValueOnce(makeChatResultWithSingleToolCall('first-call', 'c1'));
+      const session = new ChatSession(model);
+
+      await session.send('fire');
+      await session.sendToolResult('c1', 'out', { config: { reuseCache: false } });
+      expect(chatSessionContinueTool).toHaveBeenCalledTimes(1);
+      // `isError` was omitted → coerced to `null` at the NAPI boundary.
+      expect(chatSessionContinueTool.mock.calls[0][2]).toBeNull();
+      // The merged config still forces reuseCache: true.
+      expect(chatSessionContinueTool.mock.calls[0][3]?.reuseCache).toBe(true);
     });
 
     it('rejects sendToolResult when no outstanding tool call exists', async () => {
@@ -824,7 +846,7 @@ describe('ChatSession', () => {
       const session = new ChatSession(model);
 
       await session.send('fire'); // establishes outstanding call 'c1'
-      await session.sendToolResult('c1', 'out', undefined, { config: { reuseCache: false } });
+      await session.sendToolResult('c1', 'out', { config: { reuseCache: false } });
       // The fourth positional native arg is the merged `ChatConfig` —
       // `mergeConfig` always forces `reuseCache: true` regardless of the
       // caller-supplied value (the session path is a cache-reuse op by

--- a/__test__/models/model-loader-gemma4.test.ts
+++ b/__test__/models/model-loader-gemma4.test.ts
@@ -158,7 +158,7 @@ describe('Gemma4Model(config) stub (round-5 Finding B)', () => {
 
   it('rejects chatStreamSessionContinueTool with a "not initialized" error', async () => {
     const stub = new Gemma4ModelNative(stubConfig());
-    await expect(stub.chatStreamSessionContinueTool('tool_123', '{"ok":true}', null, () => {})).rejects.toThrow(
+    await expect(stub.chatStreamSessionContinueTool('tool_123', '{"ok":true}', null, null, () => {})).rejects.toThrow(
       /not initialized/i,
     );
   });

--- a/__test__/models/model-loader-gemma4.test.ts
+++ b/__test__/models/model-loader-gemma4.test.ts
@@ -158,7 +158,7 @@ describe('Gemma4Model(config) stub (round-5 Finding B)', () => {
 
   it('rejects chatStreamSessionContinueTool with a "not initialized" error', async () => {
     const stub = new Gemma4ModelNative(stubConfig());
-    await expect(stub.chatStreamSessionContinueTool('tool_123', '{"ok":true}', null, null, () => {})).rejects.toThrow(
+    await expect(stub.chatStreamSessionContinueTool('tool_123', '{"ok":true}', null, () => {}, null)).rejects.toThrow(
       /not initialized/i,
     );
   });

--- a/__test__/models/qwen3-chat.test.ts
+++ b/__test__/models/qwen3-chat.test.ts
@@ -285,7 +285,7 @@ describe.sequential('Qwen3 Chat Session API', () => {
       // Round-trip a tool-result delta. The content does not need to match
       // a real tool schema — we only care that the cache hoist-and-save-back
       // path completes cleanly.
-      const r2 = await model.chatSessionContinueTool('call_test_123', '{"result": 42}', {
+      const r2 = await model.chatSessionContinueTool('call_test_123', '{"result": 42}', null, {
         maxNewTokens: 16,
         temperature: 0,
       });

--- a/__test__/models/qwen3-chat.test.ts
+++ b/__test__/models/qwen3-chat.test.ts
@@ -285,10 +285,12 @@ describe.sequential('Qwen3 Chat Session API', () => {
       // Round-trip a tool-result delta. The content does not need to match
       // a real tool schema — we only care that the cache hoist-and-save-back
       // path completes cleanly.
-      const r2 = await model.chatSessionContinueTool('call_test_123', '{"result": 42}', null, {
-        maxNewTokens: 16,
-        temperature: 0,
-      });
+      const r2 = await model.chatSessionContinueTool(
+        'call_test_123',
+        '{"result": 42}',
+        { maxNewTokens: 16, temperature: 0 },
+        null,
+      );
       expect(r2).toBeDefined();
       expect(r2.numTokens).toBeGreaterThan(0);
       expect(typeof r2.rawText).toBe('string');

--- a/__test__/server/anthropic-request-mapper.test.ts
+++ b/__test__/server/anthropic-request-mapper.test.ts
@@ -557,11 +557,79 @@ describe('mapAnthropicRequest', () => {
     expect(messages[0].images).toHaveLength(1);
   });
 
-  it('wraps tool_result.is_error=true content in a JSON envelope', () => {
-    // `ChatMessage.content` is a string with no `isError` field, so errored
-    // tool_result content is wrapped as `{"is_error":true,"content":<original>}` —
-    // an unambiguous, lossless, non-colliding encoding that preserves the raw
-    // payload verbatim. Successful tool_result is passed through untouched.
+  it('rewrites incoming toolu_<uuid> ids back to internal call_<uuid> on tool_result blocks', () => {
+    // Anthropic-spec clients echo back the same `toolu_<uuid>` we emitted
+    // on the prior assistant turn. The internal session store and the
+    // native session continue paths see `call_<uuid>` ids, so the
+    // mapper must translate inbound `toolu_*` back to `call_*` to keep
+    // historical tool_call_id lookups matching.
+    const { messages } = mapAnthropicRequest({
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_abc123', content: 'sunny' }],
+        },
+      ],
+    });
+    expect(messages).toEqual([{ role: 'tool', content: 'sunny', toolCallId: 'call_abc123' }]);
+  });
+
+  it('rewrites incoming toolu_<uuid> ids on assistant.tool_use blocks too', () => {
+    // Assistant turns the client echoes back carry the `toolu_*` ids
+    // we previously emitted. The mapper must translate them back so
+    // the internal `ChatMessage.toolCalls[].id` stays in the `call_*`
+    // family the native paths expect.
+    const { messages } = mapAnthropicRequest({
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'toolu_xyz789', name: 'get_weather', input: { city: 'SF' } }],
+        },
+      ],
+    });
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [{ id: 'call_xyz789', name: 'get_weather', arguments: '{"city":"SF"}' }],
+      },
+    ]);
+  });
+
+  it('passes through tool_use_id values that do not have the toolu_ prefix', () => {
+    // Defensive: legacy callers that already speak the internal `call_*`
+    // shape (or any other unrecognised id family) must round-trip
+    // unchanged.
+    const { messages } = mapAnthropicRequest({
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call_already', content: 'ok' }],
+        },
+      ],
+    });
+    expect(messages).toEqual([{ role: 'tool', content: 'ok', toolCallId: 'call_already' }]);
+  });
+
+  it('encodes tool_result.is_error=true via the structured isError field, leaving content verbatim', () => {
+    // Earlier revisions used an in-band `[error] ` content prefix to
+    // surface tool-call failure. Codex review flagged the in-band marker
+    // as theoretically collision-prone — a successful tool_result whose
+    // literal content begins with the same prefix would be
+    // indistinguishable from an errored one on later read-back. The fix
+    // is the structured `isError` field on `ChatMessage` (mirroring
+    // `toolCallId`): the mapper passes content through unchanged and
+    // surfaces the error condition on a dedicated field, eliminating
+    // the read-back ambiguity. The wire-format renderers on the Rust
+    // side still inject a `[tool error]` cue into the model prompt at
+    // serialization time, but the structured field stays the source of
+    // truth and the original payload is preserved byte-for-byte.
     const { messages } = mapAnthropicRequest({
       model: 'claude-3-5-sonnet-20241022',
       max_tokens: 1024,
@@ -583,16 +651,18 @@ describe('mapAnthropicRequest', () => {
     expect(messages).toEqual([
       {
         role: 'tool',
-        content: JSON.stringify({ is_error: true, content: 'boom: connection refused' }),
+        content: 'boom: connection refused',
         toolCallId: 'call_fail',
+        isError: true,
       },
     ]);
   });
 
-  it('preserves a JSON tool_result payload losslessly inside the is_error envelope', () => {
-    // The envelope preserves the raw payload verbatim as the `content` field, so a
-    // downstream reader can either pass the whole envelope through or `JSON.parse`
-    // it and recover both the flag and the original JSON text.
+  it('preserves a JSON tool_result payload verbatim under isError=true', () => {
+    // The structured `isError` field is the failure signal; `content`
+    // stays byte-for-byte equal to the original payload so downstream
+    // consumers (replay logic, audit logs, the model's own template
+    // rendering) get the unmodified bytes back.
     const jsonPayload = '{"error_code":500,"message":"upstream unavailable"}';
     const { messages } = mapAnthropicRequest({
       model: 'claude-3-5-sonnet-20241022',
@@ -616,16 +686,17 @@ describe('mapAnthropicRequest', () => {
     const toolMsg = messages[0]!;
     expect(toolMsg.role).toBe('tool');
     expect(toolMsg.toolCallId).toBe('call_json_fail');
-    // Encoded content is itself valid JSON and `content` inside equals the original.
-    const parsed = JSON.parse(toolMsg.content) as { is_error: boolean; content: string };
-    expect(parsed).toEqual({ is_error: true, content: jsonPayload });
+    expect(toolMsg.content).toBe(jsonPayload);
+    expect(toolMsg.isError).toBe(true);
   });
 
-  it('does not wrap successful tool_result content that looks like a JSON envelope', () => {
-    // A successful tool_result whose content happens to be a JSON object — even one
-    // structurally resembling `{"is_error":true,"content":...}` — MUST NOT be
-    // rewrapped. The envelope shape is reserved exclusively for `is_error === true`.
-    const suspicious = '{"is_error":true,"content":"this was supplied by a tool that returned success"}';
+  it('does not set isError on successful tool_result content even when it resembles a legacy error marker', () => {
+    // A successful tool_result whose content happens to start with the
+    // legacy `[error]` text MUST NOT be re-marked. With the structured
+    // field, this case can no longer be confused with an errored result —
+    // `isError` is undefined (or false) on success regardless of what the
+    // content text looks like. Guard the round-trip explicitly.
+    const suspicious = '[error] this was supplied by a tool that returned success';
     const { messages } = mapAnthropicRequest({
       model: 'claude-3-5-sonnet-20241022',
       max_tokens: 1024,
@@ -638,11 +709,14 @@ describe('mapAnthropicRequest', () => {
     });
 
     expect(messages).toEqual([{ role: 'tool', content: suspicious, toolCallId: 'call_ok' }]);
+    expect(messages[0]!.isError).toBeUndefined();
   });
 
-  it('leaves tool_result content untouched when is_error is absent or false', () => {
-    // The envelope MUST NOT leak into successful tool_result content — including
-    // content that literally starts with `[tool error] `.
+  it('leaves tool_result content untouched and isError unset when is_error is absent or false', () => {
+    // Successful tool_result entries — including ones whose content text
+    // happens to begin with `[error] ` or the new model-facing
+    // `[tool error] ` cue — must survive verbatim and MUST NOT carry an
+    // `isError` flag.
     const { messages } = mapAnthropicRequest({
       model: 'claude-3-5-sonnet-20241022',
       max_tokens: 1024,
@@ -652,7 +726,8 @@ describe('mapAnthropicRequest', () => {
           content: [
             { type: 'tool_result', tool_use_id: 'call_ok_1', content: '72F and sunny', is_error: false },
             { type: 'tool_result', tool_use_id: 'call_ok_2', content: '68F and cloudy' },
-            { type: 'tool_result', tool_use_id: 'call_ok_3', content: '[tool error] this is a legitimate payload' },
+            { type: 'tool_result', tool_use_id: 'call_ok_3', content: '[error] this is a legitimate payload' },
+            { type: 'tool_result', tool_use_id: 'call_ok_4', content: '[tool error] also legitimate' },
           ],
         },
       ],
@@ -661,8 +736,12 @@ describe('mapAnthropicRequest', () => {
     expect(messages).toEqual([
       { role: 'tool', content: '72F and sunny', toolCallId: 'call_ok_1' },
       { role: 'tool', content: '68F and cloudy', toolCallId: 'call_ok_2' },
-      { role: 'tool', content: '[tool error] this is a legitimate payload', toolCallId: 'call_ok_3' },
+      { role: 'tool', content: '[error] this is a legitimate payload', toolCallId: 'call_ok_3' },
+      { role: 'tool', content: '[tool error] also legitimate', toolCallId: 'call_ok_4' },
     ]);
+    for (const m of messages) {
+      expect(m.isError).toBeUndefined();
+    }
   });
 
   it('maps assistant message with tool_use to assistant with toolCalls', () => {

--- a/__test__/server/anthropic-response-mapper.test.ts
+++ b/__test__/server/anthropic-response-mapper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 
 import {
+  anthropicToolUseIdToInternal,
   buildAnthropicResponse,
   buildContentBlockDelta,
   buildContentBlockStart,
@@ -8,6 +9,7 @@ import {
   buildMessageDelta,
   buildMessageStartEvent,
   buildMessageStop,
+  internalToolCallIdToAnthropic,
   mapStopReason,
 } from '../../packages/server/src/mappers/anthropic-response.js';
 
@@ -369,6 +371,53 @@ describe('buildAnthropicResponse', () => {
     expect(response.content[0].type).toBe('text');
   });
 
+  it('translates native call_<uuid> ids to Anthropic toolu_<uuid> on the wire', () => {
+    // The native parser mints `call_<uuid>` (the OpenAI Responses
+    // convention, kept stable on the OpenAI endpoint). The Anthropic
+    // wire spec uses `toolu_<uuid>`. Translation happens at the wire
+    // boundary only — the uuid body is preserved verbatim so a client
+    // that echoes the id back via `tool_result.tool_use_id` round-trips
+    // losslessly through `anthropicToolUseIdToInternal`.
+    const result = makeChatResult({
+      text: '',
+      toolCalls: [
+        {
+          id: 'call_abc123def456',
+          name: 'get_weather',
+          arguments: '{"city":"SF"}',
+          status: 'ok',
+          rawContent: '',
+        },
+      ],
+    });
+    const response = buildAnthropicResponse(result, baseReq, 'msg_translate');
+
+    const toolBlock = response.content[0] as { type: 'tool_use'; id: string };
+    expect(toolBlock.id).toBe('toolu_abc123def456');
+  });
+
+  it('passes through tool_use ids without the call_ prefix unchanged', () => {
+    // Defensive: an in-process driver or legacy bridge that already
+    // emits a non-`call_*` id must not have it mangled. The translator
+    // is a no-op on any id that does not match the expected prefix.
+    const result = makeChatResult({
+      text: '',
+      toolCalls: [
+        {
+          id: 'custom_xyz',
+          name: 'fn',
+          arguments: '{}',
+          status: 'ok',
+          rawContent: '',
+        },
+      ],
+    });
+    const response = buildAnthropicResponse(result, baseReq, 'msg_passthrough');
+
+    const toolBlock = response.content[0] as { type: 'tool_use'; id: string };
+    expect(toolBlock.id).toBe('custom_xyz');
+  });
+
   it('generates a toolu_ prefixed id when tool call id is missing', () => {
     const result = makeChatResult({
       text: '',
@@ -386,6 +435,34 @@ describe('buildAnthropicResponse', () => {
 
     const toolBlock = response.content[0] as { type: 'tool_use'; id: string };
     expect(toolBlock.id).toMatch(/^toolu_/);
+  });
+});
+
+describe('tool-call id translation helpers', () => {
+  it('rewrites internal call_<uuid> ids to Anthropic toolu_<uuid>', () => {
+    expect(internalToolCallIdToAnthropic('call_abc123')).toBe('toolu_abc123');
+  });
+
+  it('rewrites Anthropic toolu_<uuid> ids back to internal call_<uuid>', () => {
+    expect(anthropicToolUseIdToInternal('toolu_abc123')).toBe('call_abc123');
+  });
+
+  it('round-trips losslessly across the wire boundary', () => {
+    const internal = 'call_0123456789abcdef';
+    expect(anthropicToolUseIdToInternal(internalToolCallIdToAnthropic(internal))).toBe(internal);
+  });
+
+  it('passes unrecognised ids through unchanged in both directions', () => {
+    // A legacy caller that ships raw `call_*` over the Anthropic wire,
+    // or any in-process driver constructing its own id, must not have
+    // the value mangled. Both translators are no-ops outside the
+    // expected prefix.
+    expect(internalToolCallIdToAnthropic('legacy_xyz')).toBe('legacy_xyz');
+    expect(anthropicToolUseIdToInternal('legacy_xyz')).toBe('legacy_xyz');
+    expect(internalToolCallIdToAnthropic('toolu_already')).toBe('toolu_already');
+    expect(anthropicToolUseIdToInternal('call_already')).toBe('call_already');
+    expect(internalToolCallIdToAnthropic('')).toBe('');
+    expect(anthropicToolUseIdToInternal('')).toBe('');
   });
 });
 

--- a/__test__/server/handler.test.ts
+++ b/__test__/server/handler.test.ts
@@ -9445,6 +9445,45 @@ describe('createHandler', () => {
     });
   });
 
+  describe('root liveness probe', () => {
+    it('returns 200 for HEAD /', async () => {
+      const registry = new ModelRegistry();
+      const handler = createHandler(registry);
+      const req = createMockReq('HEAD', '/');
+      const { res, getStatus, waitForEnd } = createMockRes();
+
+      await handler(req, res);
+      await waitForEnd();
+
+      expect(getStatus()).toBe(200);
+    });
+
+    it('returns 200 JSON for GET /', async () => {
+      const registry = new ModelRegistry();
+      const handler = createHandler(registry);
+      const req = createMockReq('GET', '/');
+      const { res, getStatus, getBody, waitForEnd } = createMockRes();
+
+      await handler(req, res);
+      await waitForEnd();
+
+      expect(getStatus()).toBe(200);
+      expect(JSON.parse(getBody())).toEqual({ service: 'mlx-node' });
+    });
+
+    it('returns 405 for POST /', async () => {
+      const registry = new ModelRegistry();
+      const handler = createHandler(registry);
+      const req = createMockReq('POST', '/');
+      const { res, getStatus, waitForEnd } = createMockRes();
+
+      await handler(req, res);
+      await waitForEnd();
+
+      expect(getStatus()).toBe(405);
+    });
+  });
+
   describe('streaming with tool calls', () => {
     it('does not leak <tool_call> markup in text deltas', async () => {
       // Simulate a model that streams normal text, then tool-call markup, then final event

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -1865,6 +1865,128 @@ describe('handleCreateMessage', () => {
       const combined = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
       expect(combined).toBe('\n\nhello');
     });
+
+    it('preserves buffered leading whitespace when tool_call is preceded by visible text in the same chunk', async () => {
+      // Regression: when the stream is `["\n\n", "Let me check.<tool_call>..."]`,
+      // the buffered `\n\n` (held back because the first delta is whitespace-only)
+      // semantically belongs to the visible `Let me check.` prefix that arrives
+      // in the same chunk as the `<tool_call>` tag. The previous implementation
+      // unconditionally cleared `pendingLeadingWhitespace` in the `tagFound`
+      // branch before deciding whether to emit `cleanPrefix`, so the wire
+      // received `"Let me check."` instead of `"\n\nLet me check."` and the
+      // leading whitespace was silently dropped (or duplicated downstream
+      // depending on `</think>` trimming).
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: '\n\n', done: false, isReasoning: false },
+        {
+          text: 'Let me check.<tool_call>{"name":"get_weather","arguments":{"city":"SF"}}</tool_call>',
+          done: false,
+          isReasoning: false,
+        },
+        {
+          text: '\n\nLet me check.',
+          done: true,
+          finishReason: 'tool_calls',
+          toolCalls: [
+            {
+              status: 'ok',
+              id: 'call_weather',
+              name: 'get_weather',
+              arguments: '{"city":"SF"}',
+            } as ToolCallResult,
+          ],
+          thinking: null,
+          numTokens: 12,
+          promptTokens: 5,
+          reasoningTokens: 0,
+          rawText: '\n\nLet me check.<tool_call>{"name":"get_weather","arguments":{"city":"SF"}}</tool_call>',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'weather?' }],
+          max_tokens: 100,
+          stream: true,
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+
+      // The text block opens BEFORE the tool_use frame and its deltas join to
+      // `"\n\nLet me check."` — the leading `\n\n` survives the tag transition.
+      const textStarts = events.filter(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'text',
+      );
+      expect(textStarts).toHaveLength(1);
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const combined = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(combined).toBe('\n\nLet me check.');
+
+      // The tool_use frame still follows and carries the parsed call.
+      const toolStarts = events.filter(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'tool_use',
+      );
+      expect(toolStarts).toHaveLength(1);
+    });
+
+    it('does not double leading whitespace when only whitespace deltas precede the done event', async () => {
+      // Regression: `finalText` on the terminal done chunk is the FULL
+      // accumulated text from the native side, not a delta. When the only
+      // intermediate delta is whitespace (`"\n\n"`) and gets buffered into
+      // `pendingLeadingWhitespace`, the same whitespace is already part of
+      // `finalText`. The previous implementation prepended the buffer onto
+      // `finalText` and emitted `"\n\n\n\nhello"` (4 newlines) instead of
+      // `"\n\nhello"` (2 newlines, the byte-accurate model output).
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: '\n\n', done: false, isReasoning: false },
+        {
+          text: '\n\nhello',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 3,
+          promptTokens: 5,
+          reasoningTokens: 0,
+          rawText: '\n\nhello',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 100,
+          stream: true,
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textStarts = events.filter(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'text',
+      );
+      expect(textStarts).toHaveLength(1);
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const combined = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(combined).toBe('\n\nhello');
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -1747,6 +1747,124 @@ describe('handleCreateMessage', () => {
       const combined = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
       expect(combined).toBe('<tool_call>just text');
     });
+
+    it('drops whitespace-only text emitted right before a tool_call tag (no stray text block)', async () => {
+      // Symptom from the production log: when the model emits `</think>\n\n<tool_call>...`,
+      // the streaming buffer flushed the `\n\n` as `safeText` BEFORE the
+      // `<tool_call>` tag opened, ratifying a content_block_start(text) /
+      // content_block_delta(\n\n) / content_block_stop triple right before
+      // the tool_use frame — which clients render as visible whitespace.
+      // The fix holds back leading whitespace-only text until either real
+      // content arrives (flushed together) or a non-text block opens
+      // (dropped silently).
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: '\n\n', done: false, isReasoning: false },
+        {
+          text: '',
+          done: true,
+          finishReason: 'tool_calls',
+          toolCalls: [
+            {
+              status: 'ok',
+              id: 'call_weather',
+              name: 'get_weather',
+              arguments: '{"city":"SF"}',
+            } as ToolCallResult,
+          ],
+          thinking: null,
+          numTokens: 8,
+          promptTokens: 5,
+          reasoningTokens: 0,
+          rawText: '\n\n',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'weather?' }],
+          max_tokens: 100,
+          stream: true,
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+
+      // No text content_block_start at all — the leading `\n\n` was held
+      // back and dropped when the tool_use opened.
+      const textStarts = events.filter(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'text',
+      );
+      expect(textStarts).toHaveLength(0);
+
+      // The tool_use frame opens at index 0 (no text block was emitted
+      // ahead of it). Its id is rewritten to the Anthropic `toolu_*` shape.
+      const toolStarts = events.filter(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'tool_use',
+      );
+      expect(toolStarts).toHaveLength(1);
+      expect((toolStarts[0].data['content_block'] as any).id).toBe('toolu_weather');
+
+      // No stray whitespace text_delta on the wire.
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      expect(textDeltas).toHaveLength(0);
+    });
+
+    it('flushes buffered leading whitespace alongside the first real text delta', async () => {
+      // The opposite end of the spectrum: when whitespace IS followed by
+      // real content, the buffered prefix must be flushed as part of the
+      // first text block so the wire-content matches what the model
+      // produced. Exactly one text block opens, with combined `"\n\nhello"`.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: '\n\n', done: false, isReasoning: false },
+        { text: 'hello', done: false, isReasoning: false },
+        {
+          text: '\n\nhello',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 3,
+          promptTokens: 5,
+          reasoningTokens: 0,
+          rawText: '\n\nhello',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 100,
+          stream: true,
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textStarts = events.filter(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'text',
+      );
+      expect(textStarts).toHaveLength(1);
+
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const combined = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(combined).toBe('\n\nhello');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -2833,10 +2951,16 @@ describe('handleCreateMessage', () => {
       expect(afterTool.content).toContain('here are outputs');
     });
 
-    it('primes tool_result.is_error=true content with a JSON envelope through the full /v1/messages dispatch', async () => {
-      // End-to-end smoke test: the Anthropic mapper wraps `tool_result.is_error ===
-      // true` content as `{"is_error":true,"content":<original>}`, and the primed
-      // history passed to `chatSessionStart` carries exactly that envelope.
+    it('primes tool_result.is_error=true via the structured isError field through the full /v1/messages dispatch', async () => {
+      // End-to-end smoke test: the Anthropic mapper translates
+      // `tool_result.is_error === true` into the structured `isError`
+      // field on the internal `ChatMessage` (mirroring `toolCallId`) and
+      // leaves `content` byte-for-byte equal to the original payload.
+      // The Rust-side wire renderer injects the model-facing
+      // `[tool error]` cue at serialization time, but the primed history
+      // visible to the test never contains an in-band marker — replay
+      // and audit paths see the unmodified bytes plus the structured
+      // failure signal.
       const registry = new ModelRegistry();
       const mockModel = createMockModel(makeChatResult({ text: 'ack' }));
       registry.register('test-model', mockModel);
@@ -2882,18 +3006,13 @@ describe('handleCreateMessage', () => {
       const startSpy = mockModel.chatSessionStart as unknown as ReturnType<typeof vi.fn>;
       expect(startSpy).toHaveBeenCalledTimes(1);
       const [primedMessages] = startSpy.mock.calls[0] as [
-        Array<{ role: string; content: string; toolCallId?: string }>,
+        Array<{ role: string; content: string; toolCallId?: string; isError?: boolean }>,
       ];
       const toolMsg = primedMessages.find((m) => m.role === 'tool' && m.toolCallId === 'call_fail');
       expect(toolMsg).toBeDefined();
-      expect(toolMsg!.content).toBe(JSON.stringify({ is_error: true, content: 'boom: connection refused' }));
-      // Envelope content is valid JSON and round-trips cleanly.
-      const parsed = JSON.parse(toolMsg!.content) as {
-        is_error: boolean;
-        content: string;
-      };
-      expect(parsed.is_error).toBe(true);
-      expect(parsed.content).toBe('boom: connection refused');
+      // Structured field carries the failure signal; content is verbatim.
+      expect(toolMsg!.isError).toBe(true);
+      expect(toolMsg!.content).toBe('boom: connection refused');
     });
   });
 

--- a/__test__/server/model-work-coordinator.test.ts
+++ b/__test__/server/model-work-coordinator.test.ts
@@ -37,6 +37,89 @@ describe('ModelWorkCoordinator', () => {
     expect(events).toEqual(['a:start', 'b:start', 'a:end', 'b:end']);
   });
 
+  it('flags the first writer as load_owner=true and a follower as load_owner=false', async () => {
+    // Observability split: request A drives a cold load while request B
+    // arrives microseconds later. Without the split, B's `resolve_ms`
+    // looks like the full load latency even though A actually paid the
+    // cost. `withModelLoadInstrumented` returns `owner=true` only when
+    // the lock was free at sync-time; the follower observes `owner=false`
+    // because A's `acquireWrite` already incremented `waitingWriters`.
+    const coordinator = new ModelWorkCoordinator();
+    const releaseA = deferred();
+    const order: string[] = [];
+
+    const aPromise = coordinator.withModelLoadInstrumented(async () => {
+      order.push('a:start');
+      await releaseA.promise;
+      order.push('a:end');
+      return 'A';
+    });
+
+    // Let A acquire the writer slot before B arrives. After this tick,
+    // A is parked inside `fn` (awaiting `releaseA.promise`); the writer
+    // lock is held synchronously so B will observe contention.
+    await tick();
+
+    const bPromise = coordinator.withModelLoadInstrumented(async () => {
+      order.push('b:start');
+      return 'B';
+    });
+
+    await tick();
+    expect(order).toEqual(['a:start']);
+
+    releaseA.resolve();
+    const [a, b] = await Promise.all([aPromise, bPromise]);
+
+    expect(a.owner).toBe(true);
+    expect(a.result).toBe('A');
+    expect(b.owner).toBe(false);
+    expect(b.result).toBe('B');
+    expect(order).toEqual(['a:start', 'a:end', 'b:start']);
+  });
+
+  it('partitions wait vs own-execution time in the instrumented outcome', async () => {
+    // Regression: `serverLoadWaitMs` and `serverModelResolveMs` used to
+    // both subtract from the same end timestamp, so a follower request
+    // saw both fields report the full cold-load duration. The
+    // coordinator now measures the two phases internally and exposes
+    // them as `waitMs` (time blocked in `acquireWrite`) and `ownMs`
+    // (time inside `fn` with the writer lock held). Together they
+    // partition the call without overlap.
+    const coordinator = new ModelWorkCoordinator();
+    const aStarted = deferred();
+    const releaseA = deferred();
+    const OWN_DURATION_MS = 50;
+
+    const aPromise = coordinator.withModelLoadInstrumented(async () => {
+      aStarted.resolve();
+      // Sleep inside the writer-held region so A's `ownMs` measures
+      // the load-like work and B's `waitMs` measures the same span
+      // from the other side of the lock.
+      await new Promise<void>((resolve) => setTimeout(resolve, OWN_DURATION_MS));
+      await releaseA.promise;
+      return 'A';
+    });
+
+    // Wait until A has the writer slot and is parked inside `fn`.
+    // Otherwise B might arrive before A's synchronous `acquireWrite`
+    // increments `waitingWriters`, and the owner check would mis-fire.
+    await aStarted.promise;
+
+    const bPromise = coordinator.withModelLoadInstrumented(async () => 'B');
+
+    releaseA.resolve();
+    const [a, b] = await Promise.all([aPromise, bPromise]);
+
+    expect(a.owner).toBe(true);
+    expect(a.waitMs).toBeLessThan(20);
+    expect(a.ownMs).toBeGreaterThanOrEqual(OWN_DURATION_MS - 5);
+
+    expect(b.owner).toBe(false);
+    expect(b.waitMs).toBeGreaterThanOrEqual(OWN_DURATION_MS - 5);
+    expect(b.ownMs).toBeLessThan(20);
+  });
+
   it('gives pending model loads priority over new inference readers', async () => {
     const coordinator = new ModelWorkCoordinator();
     const releaseRead = deferred();

--- a/__test__/server/model-work-coordinator.test.ts
+++ b/__test__/server/model-work-coordinator.test.ts
@@ -120,6 +120,43 @@ describe('ModelWorkCoordinator', () => {
     expect(b.ownMs).toBeLessThan(20);
   });
 
+  it('flags load_owner=true when a writer arrives during active inference reads', async () => {
+    // Regression: the owner-decision predicate used to AND in
+    // `activeReaders === 0`, so a writer that arrived during a live
+    // inference read was mislabeled as `owner=false` and its
+    // own load latency landed in `load_wait_ms` instead of
+    // `resolve_ms`. The contract per `ModelLoadOutcome` and the
+    // surrounding doc-comment is: a caller owns the load iff no
+    // other writer is active and no writer is queued ahead — active
+    // readers MUST NOT demote the arriving writer because, once
+    // those reads drain, this writer is the one that performs the
+    // load.
+    const coordinator = new ModelWorkCoordinator();
+    const readerRelease = deferred();
+    const READER_HOLD_MS = 40;
+
+    const readerPromise = coordinator.withInference(async () => {
+      // Hold the reader long enough that B observes a measurable
+      // `waitMs` after the reads drain.
+      await new Promise<void>((resolve) => setTimeout(resolve, READER_HOLD_MS));
+      await readerRelease.promise;
+    });
+
+    // Let the reader synchronously increment `activeReaders` before
+    // the writer arrives, so the bug branch (the `activeReaders === 0`
+    // term) would fire if reintroduced.
+    await tick();
+
+    const writerPromise = coordinator.withModelLoadInstrumented(async () => 'W');
+
+    readerRelease.resolve();
+    const [, w] = await Promise.all([readerPromise, writerPromise]);
+
+    expect(w.owner).toBe(true);
+    expect(w.result).toBe('W');
+    expect(w.waitMs).toBeGreaterThanOrEqual(READER_HOLD_MS - 5);
+  });
+
   it('gives pending model loads priority over new inference readers', async () => {
     const coordinator = new ModelWorkCoordinator();
     const releaseRead = deferred();

--- a/crates/mlx-core/src/grpo/engine.rs
+++ b/crates/mlx-core/src/grpo/engine.rs
@@ -1540,7 +1540,7 @@ impl GRPOTrainingEngine {
                         content: m.content.clone(),
                         tool_calls: m.tool_calls.clone(),
                         tool_call_id: m.tool_call_id.clone(),
-                        is_error: None,
+                        is_error: m.is_error,
                         reasoning_content: m.reasoning_content.clone(),
                         images: None, // Images not used in training
                     })

--- a/crates/mlx-core/src/grpo/engine.rs
+++ b/crates/mlx-core/src/grpo/engine.rs
@@ -1540,6 +1540,7 @@ impl GRPOTrainingEngine {
                         content: m.content.clone(),
                         tool_calls: m.tool_calls.clone(),
                         tool_call_id: m.tool_call_id.clone(),
+                        is_error: None,
                         reasoning_content: m.reasoning_content.clone(),
                         images: None, // Images not used in training
                     })

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -5990,15 +5990,15 @@ impl Gemma4Model {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<|turn>tool` block.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null | undefined, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void, isError?: boolean | null | undefined"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
         config: Option<ChatConfig>,
-        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
+        is_error: Option<bool>,
     ) -> Result<ChatStreamHandle> {
         let thread = self.thread.as_ref().ok_or_else(|| {
             Error::from_reason("Model not initialized. Call Gemma4Model.load() first.")

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -5878,8 +5878,8 @@ impl Gemma4Model {
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
     ) -> Result<ChatResult> {
         let thread = self.thread.as_ref().ok_or_else(|| {
             Error::from_reason("Model not initialized. Call Gemma4Model.load() first.")
@@ -5990,14 +5990,14 @@ impl Gemma4Model {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<|turn>tool` block.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null | undefined, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
         let thread = self.thread.as_ref().ok_or_else(|| {

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -329,9 +329,16 @@ pub(crate) enum Gemma4Cmd {
     /// [`Gemma4Inner::chat_session_continue_tool_sync`] — builds a
     /// Gemma4-format tool delta (`\n<|turn>tool\n{content}<turn|>\n<|turn>model\n`)
     /// and prefills on top of the live caches.
+    ///
+    /// `is_error` is the structured tool-error signal threaded through
+    /// from the NAPI surface. When `Some(true)`, the renderer prepends
+    /// the shared [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<|turn>tool` block. `None` / `Some(false)` produce the
+    /// pre-feature byte-equal output.
     ChatSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         reply: ResponseTx<ChatResult>,
     },
@@ -357,10 +364,12 @@ pub(crate) enum Gemma4Cmd {
     },
     /// Streaming tool-result continuation: same semantics as
     /// [`ChatSessionContinueTool`](Self::ChatSessionContinueTool) but
-    /// streams token deltas through `stream_tx`.
+    /// streams token deltas through `stream_tx`. Carries the same
+    /// structured `is_error` signal.
     ChatStreamSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -4762,10 +4771,17 @@ impl Gemma4Inner {
     /// Qwen3.5-specific). The `tool_call_id` is intentionally dropped
     /// from the wire format — Gemma4's template identifies tool
     /// responses positionally, not via an explicit id.
+    ///
+    /// `is_error` is forwarded to [`build_gemma4_tool_delta_text`]:
+    /// `Some(true)` injects the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<|turn>tool` block; `None` / `Some(false)` keep the
+    /// pre-feature byte-equal output.
     pub(crate) fn chat_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
     ) -> Result<ChatResult> {
         let tokenizer = self
@@ -4775,7 +4791,8 @@ impl Gemma4Inner {
             .clone();
 
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
-        let delta_text = build_gemma4_tool_delta_text(&tool_call_id, &content, enable_thinking);
+        let delta_text =
+            build_gemma4_tool_delta_text(&tool_call_id, &content, enable_thinking, is_error);
         let delta_tokens = tokenizer.encode_sync(&delta_text, Some(false))?;
 
         self.chat_tokens_delta_sync(delta_tokens, config)
@@ -5149,10 +5166,13 @@ impl Gemma4Inner {
     }
 
     /// Streaming variant of [`Self::chat_session_continue_tool_sync`].
+    /// `is_error` is forwarded verbatim to the wire-format renderer;
+    /// see the non-streaming entry point for the marker semantics.
     pub(crate) fn chat_stream_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -5174,7 +5194,8 @@ impl Gemma4Inner {
         };
 
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
-        let delta_text = build_gemma4_tool_delta_text(&tool_call_id, &content, enable_thinking);
+        let delta_text =
+            build_gemma4_tool_delta_text(&tool_call_id, &content, enable_thinking, is_error);
 
         let delta_tokens = match tokenizer.encode_sync(&delta_text, Some(false)) {
             Ok(t) => t,
@@ -5552,17 +5573,23 @@ fn build_gemma4_continue_delta_text(sanitized_user: &str, enable_thinking: Optio
 ///
 /// Tool content is passed through [`escape_gemma4_content`] so
 /// malicious tool output containing Gemma4 delimiter tokens can't
-/// escape the tool turn and inject synthetic structure.
+/// escape the tool turn and inject synthetic structure. The shared
+/// [`crate::tokenizer::TOOL_ERROR_MARKER`] (when `is_error == Some(true)`)
+/// is prepended BEFORE escaping so the marker text — which contains
+/// no Gemma4 delimiter tokens — passes through verbatim and the
+/// downstream escaping still protects any user content that follows.
 fn build_gemma4_tool_delta_text(
     _tool_call_id: &str,
     content: &str,
     enable_thinking: Option<bool>,
+    is_error: Option<bool>,
 ) -> String {
     // `enable_thinking` intentionally unused: see
     // `build_gemma4_continue_delta_text` for why the raw delta path
     // ignores reasoning mode.
     let _ = enable_thinking;
-    let escaped = escape_gemma4_content(content);
+    let rendered_content = crate::tokenizer::apply_tool_error_marker(content, is_error);
+    let escaped = escape_gemma4_content(&rendered_content);
     format!("\n<|turn>tool\n{escaped}<turn|>\n<|turn>model\n")
 }
 
@@ -5592,11 +5619,16 @@ pub(crate) fn handle_gemma4_cmd(inner: &mut Gemma4Inner, cmd: Gemma4Cmd) {
         Gemma4Cmd::ChatSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             reply,
         } => {
-            let _ =
-                reply.send(inner.chat_session_continue_tool_sync(tool_call_id, content, config));
+            let _ = reply.send(inner.chat_session_continue_tool_sync(
+                tool_call_id,
+                content,
+                is_error,
+                config,
+            ));
         }
         Gemma4Cmd::ChatStreamSessionStart {
             messages,
@@ -5624,6 +5656,7 @@ pub(crate) fn handle_gemma4_cmd(inner: &mut Gemma4Inner, cmd: Gemma4Cmd) {
         Gemma4Cmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled,
@@ -5631,6 +5664,7 @@ pub(crate) fn handle_gemma4_cmd(inner: &mut Gemma4Inner, cmd: Gemma4Cmd) {
             inner.chat_stream_session_continue_tool_sync(
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 stream_tx,
                 cancelled,
@@ -5831,12 +5865,20 @@ impl Gemma4Model {
     /// not via an explicit id. Callers may still log it for their own
     /// bookkeeping.
     ///
+    /// `is_error` is the structured tool-error signal. When `Some(true)`,
+    /// the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<|turn>tool` block so the model receives a clear text-level
+    /// cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+    /// pre-feature output.
+    ///
     /// Requires a live session started via `chatSessionStart`.
     #[napi]
     pub async fn chat_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
     ) -> Result<ChatResult> {
         let thread = self.thread.as_ref().ok_or_else(|| {
@@ -5847,6 +5889,7 @@ impl Gemma4Model {
         crate::model_thread::send_and_await(thread, |reply| Gemma4Cmd::ChatSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             reply,
         })
@@ -5941,13 +5984,19 @@ impl Gemma4Model {
     }
 
     /// Streaming variant of `chatSessionContinueTool`.
+    ///
+    /// `is_error` mirrors the non-streaming entry point — when
+    /// `Some(true)`, the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<|turn>tool` block.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
@@ -5964,6 +6013,7 @@ impl Gemma4Model {
         thread.send(Gemma4Cmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled: cancelled_inner,
@@ -9224,6 +9274,80 @@ mod prefix_cache_decision_tests {
             classify_prefix_cache_decision(10, 5),
             PrefixCacheDecision::Miss,
             "cached_prefix_len > tokens_len must be Miss (defensive fallthrough)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tool_delta_marker_tests {
+    //! Guard the structured `is_error` channel on Gemma4's tool-result
+    //! wire format. The shared
+    //! [`crate::tokenizer::TOOL_ERROR_MARKER`] must be injected inside
+    //! the `<|turn>tool` block only when the caller passes
+    //! `Some(true)`. `None` and `Some(false)` keep the output
+    //! byte-equal to the pre-feature behavior — guarding both the hot
+    //! (successful) path and the explicit-false path against
+    //! accidental drift. The marker text contains no Gemma4 delimiter
+    //! tokens so the downstream `escape_gemma4_content` step is a
+    //! no-op on it.
+
+    use super::build_gemma4_tool_delta_text;
+    use crate::tokenizer::TOOL_ERROR_MARKER;
+
+    #[test]
+    fn injects_marker_when_is_error_true() {
+        let payload = "boom: connection refused";
+        let rendered = build_gemma4_tool_delta_text("call_fail", payload, None, Some(true));
+        let expected_inner = format!("{TOOL_ERROR_MARKER}{payload}");
+        assert!(
+            rendered.contains(&expected_inner),
+            "expected error marker inside <|turn>tool block; got:\n{rendered}",
+        );
+        // Wrapper integrity stays correct on the marked path.
+        assert!(
+            rendered.contains("<|turn>tool\n"),
+            "tool block opener missing"
+        );
+        assert!(rendered.contains("<turn|>"), "turn closer missing");
+        assert!(rendered.contains("<|turn>model\n"), "model opener missing");
+    }
+
+    #[test]
+    fn skips_marker_when_is_error_none() {
+        let payload = "{\"temperature\": 72}";
+        let rendered = build_gemma4_tool_delta_text("call_ok", payload, None, None);
+        assert!(
+            !rendered.contains(TOOL_ERROR_MARKER),
+            "marker leaked into unflagged delta:\n{rendered}",
+        );
+        assert!(
+            rendered.contains(payload),
+            "original content missing from delta:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn skips_marker_when_is_error_some_false() {
+        let payload = "ok";
+        let rendered = build_gemma4_tool_delta_text("call_ok", payload, None, Some(false));
+        assert!(
+            !rendered.contains(TOOL_ERROR_MARKER),
+            "marker leaked into Some(false) delta:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn does_not_remark_content_that_resembles_marker() {
+        // The structured channel removes the collision concern: a
+        // successful tool result whose literal content begins with the
+        // marker text must NOT double-prefix the marker on its way
+        // through the renderer.
+        let suspicious = format!("{TOOL_ERROR_MARKER}this is a successful payload");
+        let rendered = build_gemma4_tool_delta_text("call_ok", &suspicious, None, None);
+        let occurrences = rendered.matches(TOOL_ERROR_MARKER).count();
+        assert_eq!(
+            occurrences, 1,
+            "marker count should be 1 (the original literal); got {occurrences} in:\n{rendered}",
         );
     }
 }

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -3289,15 +3289,15 @@ impl Lfm2Model {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<|im_start|>tool` block.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void, isError?: boolean | null | undefined"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
         config: Option<ChatConfig>,
-        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
+        is_error: Option<bool>,
     ) -> Result<ChatStreamHandle> {
         let config = config.unwrap_or_default();
 

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -90,9 +90,16 @@ pub(crate) enum Lfm2Cmd {
     /// `<|im_start|>tool\n{content}<|im_end|>` delta (matching LFM2's
     /// template which does NOT use Qwen3.5's `<tool_response>` wrapping)
     /// and prefills on top of the live caches.
+    ///
+    /// `is_error` is the structured tool-error signal threaded through
+    /// from the NAPI surface. When `Some(true)`, the renderer prepends
+    /// the shared [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<|im_start|>tool` block. `None` / `Some(false)` produce the
+    /// pre-feature byte-equal output.
     ChatSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         reply: ResponseTx<ChatResult>,
     },
@@ -118,10 +125,12 @@ pub(crate) enum Lfm2Cmd {
     },
     /// Streaming tool-result continuation: same semantics as
     /// [`ChatSessionContinueTool`](Self::ChatSessionContinueTool) but
-    /// streams token deltas through `stream_tx`.
+    /// streams token deltas through `stream_tx`. Carries the same
+    /// structured `is_error` signal.
     ChatStreamSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -195,6 +204,31 @@ pub(crate) fn classify_prefix_cache_decision(
     } else {
         PrefixCacheDecision::Miss
     }
+}
+
+/// Build the LFM2 wire-format delta text for a tool-result turn.
+///
+/// LFM2's chat template renders tool-role messages as plain
+/// `<|im_start|>tool\n{content}<|im_end|>` blocks — no
+/// `<tool_response>` wrapping (unlike Qwen3.5). Leading `\n` closes
+/// the cached `<|im_end|>` line, then we open the `tool` turn, close
+/// it, and open an assistant turn ready for generation. No
+/// `<think>\n` prefix because LFM2's template never injects one.
+///
+/// `is_error` is the structured tool-error signal. When `Some(true)`,
+/// the shared [`crate::tokenizer::TOOL_ERROR_MARKER`] is prepended to
+/// `content` via [`crate::tokenizer::apply_tool_error_marker`]; `None`
+/// / `Some(false)` keep the wire bytes byte-equal to the pre-feature
+/// output.
+///
+/// Extracted from
+/// [`Lfm2Inner::chat_session_continue_tool_sync`] /
+/// [`Lfm2Inner::chat_stream_session_continue_tool_sync`] so the
+/// wire-format choice can be pinned by pure-string unit tests that
+/// don't need a loaded LFM2 model.
+pub(crate) fn build_lfm2_tool_delta_text(content: &str, is_error: Option<bool>) -> String {
+    let rendered_content = crate::tokenizer::apply_tool_error_marker(content, is_error);
+    format!("\n<|im_start|>tool\n{rendered_content}<|im_end|>\n<|im_start|>assistant\n")
 }
 
 impl Lfm2Inner {
@@ -2381,10 +2415,18 @@ impl Lfm2Inner {
     /// Delegates to [`Self::chat_tokens_delta_sync`] which inherits the
     /// same text-only-delta invariant (errors if the session currently
     /// holds image state).
+    ///
+    /// `is_error` is the structured tool-error signal. When `Some(true)`,
+    /// the shared [`crate::tokenizer::TOOL_ERROR_MARKER`] is prepended
+    /// to `content` inside the `<|im_start|>tool` block via
+    /// [`crate::tokenizer::apply_tool_error_marker`]. `None` /
+    /// `Some(false)` keep the wire bytes byte-equal to the pre-feature
+    /// output.
     pub(crate) fn chat_session_continue_tool_sync(
         &mut self,
         _tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
     ) -> Result<ChatResult> {
         let tokenizer = self
@@ -2393,14 +2435,7 @@ impl Lfm2Inner {
             .ok_or_else(|| Error::from_reason("Tokenizer not loaded"))?
             .clone();
 
-        // Build the LFM2-specific tool delta inline. Leading `\n`
-        // closes the cached `<|im_end|>` line, then we open a `tool`
-        // role turn, close it, and open an assistant turn ready for
-        // generation. No `<think>\n` prefix because LFM2's template
-        // does not inject one.
-        let delta_text =
-            format!("\n<|im_start|>tool\n{content}<|im_end|>\n<|im_start|>assistant\n");
-
+        let delta_text = build_lfm2_tool_delta_text(&content, is_error);
         let delta_tokens = tokenizer.encode_sync(&delta_text, Some(false))?;
 
         self.chat_tokens_delta_sync(delta_tokens, config)
@@ -2512,10 +2547,13 @@ impl Lfm2Inner {
     }
 
     /// Streaming analog of [`Self::chat_session_continue_tool_sync`].
+    /// `is_error` is forwarded verbatim to the wire-format renderer;
+    /// see the non-streaming entry point for the marker semantics.
     pub(crate) fn chat_stream_session_continue_tool_sync(
         &mut self,
         _tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -2539,8 +2577,7 @@ impl Lfm2Inner {
         // LFM2-specific plain tool delta (no `<tool_response>`
         // wrapper). See `chat_session_continue_tool_sync` for the
         // rationale.
-        let delta_text =
-            format!("\n<|im_start|>tool\n{content}<|im_end|>\n<|im_start|>assistant\n");
+        let delta_text = build_lfm2_tool_delta_text(&content, is_error);
 
         let delta_tokens = match tokenizer.encode_sync(&delta_text, Some(false)) {
             Ok(t) => t,
@@ -2906,11 +2943,16 @@ pub(crate) fn handle_lfm2_cmd(inner: &mut Lfm2Inner, cmd: Lfm2Cmd) {
         Lfm2Cmd::ChatSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             reply,
         } => {
-            let _ =
-                reply.send(inner.chat_session_continue_tool_sync(tool_call_id, content, config));
+            let _ = reply.send(inner.chat_session_continue_tool_sync(
+                tool_call_id,
+                content,
+                is_error,
+                config,
+            ));
         }
         Lfm2Cmd::ChatStreamSessionStart {
             messages,
@@ -2938,6 +2980,7 @@ pub(crate) fn handle_lfm2_cmd(inner: &mut Lfm2Inner, cmd: Lfm2Cmd) {
         Lfm2Cmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled,
@@ -2945,6 +2988,7 @@ pub(crate) fn handle_lfm2_cmd(inner: &mut Lfm2Inner, cmd: Lfm2Cmd) {
             inner.chat_stream_session_continue_tool_sync(
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 stream_tx,
                 cancelled,
@@ -3129,12 +3173,20 @@ impl Lfm2Model {
     /// not via an explicit id. Callers may still log it for their own
     /// bookkeeping.
     ///
+    /// `is_error` is the structured tool-error signal. When `Some(true)`,
+    /// the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<|im_start|>tool` block so the model receives a clear text-level
+    /// cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+    /// pre-feature output.
+    ///
     /// Requires a live session started via `chatSessionStart`.
     #[napi]
     pub async fn chat_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
     ) -> Result<ChatResult> {
         let config = config.unwrap_or_default();
@@ -3143,6 +3195,7 @@ impl Lfm2Model {
             Lfm2Cmd::ChatSessionContinueTool {
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 reply,
             }
@@ -3230,13 +3283,19 @@ impl Lfm2Model {
     }
 
     /// Streaming variant of `chatSessionContinueTool`.
+    ///
+    /// `is_error` mirrors the non-streaming entry point — when
+    /// `Some(true)`, the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<|im_start|>tool` block.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
@@ -3250,6 +3309,7 @@ impl Lfm2Model {
         self.thread.send(Lfm2Cmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled: cancelled_inner,
@@ -3494,6 +3554,83 @@ mod prefix_cache_decision_tests {
             classify_prefix_cache_decision(10, 5),
             PrefixCacheDecision::Miss,
             "cached_prefix_len > tokens_len must be Miss (defensive fallthrough)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tool_delta_marker_tests {
+    //! Guard the structured `is_error` channel on LFM2's tool-result
+    //! wire format. The shared
+    //! [`crate::tokenizer::TOOL_ERROR_MARKER`] must be injected inside
+    //! the `<|im_start|>tool` block only when the caller passes
+    //! `Some(true)`. `None` and `Some(false)` keep the output
+    //! byte-equal to the pre-feature behavior — guarding both the hot
+    //! (successful) path and the explicit-false path against
+    //! accidental drift.
+
+    use super::build_lfm2_tool_delta_text;
+    use crate::tokenizer::TOOL_ERROR_MARKER;
+
+    #[test]
+    fn injects_marker_when_is_error_true() {
+        let payload = "boom: connection refused";
+        let rendered = build_lfm2_tool_delta_text(payload, Some(true));
+        let expected_inner = format!("{TOOL_ERROR_MARKER}{payload}");
+        assert!(
+            rendered.contains(&expected_inner),
+            "expected error marker inside <|im_start|>tool block; got:\n{rendered}",
+        );
+        // Wrapper integrity stays correct on the marked path so we
+        // don't ship a malformed delta that only the unflagged path
+        // renders right.
+        assert!(
+            rendered.contains("<|im_start|>tool\n"),
+            "tool block opener missing"
+        );
+        assert!(rendered.contains("<|im_end|>"), "im_end closer missing");
+        assert!(
+            rendered.contains("<|im_start|>assistant\n"),
+            "assistant opener missing"
+        );
+    }
+
+    #[test]
+    fn skips_marker_when_is_error_none() {
+        let payload = "{\"temperature\": 72}";
+        let rendered = build_lfm2_tool_delta_text(payload, None);
+        assert!(
+            !rendered.contains(TOOL_ERROR_MARKER),
+            "marker leaked into unflagged delta:\n{rendered}",
+        );
+        assert!(
+            rendered.contains(payload),
+            "original content missing from delta:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn skips_marker_when_is_error_some_false() {
+        let payload = "ok";
+        let rendered = build_lfm2_tool_delta_text(payload, Some(false));
+        assert!(
+            !rendered.contains(TOOL_ERROR_MARKER),
+            "marker leaked into Some(false) delta:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn does_not_remark_content_that_resembles_marker() {
+        // The structured channel removes the collision concern: a
+        // successful tool result whose literal content begins with the
+        // marker text must NOT double-prefix the marker on its way
+        // through the renderer.
+        let suspicious = format!("{TOOL_ERROR_MARKER}this is a successful payload");
+        let rendered = build_lfm2_tool_delta_text(&suspicious, None);
+        let occurrences = rendered.matches(TOOL_ERROR_MARKER).count();
+        assert_eq!(
+            occurrences, 1,
+            "marker count should be 1 (the original literal); got {occurrences} in:\n{rendered}",
         );
     }
 }

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -3186,8 +3186,8 @@ impl Lfm2Model {
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
     ) -> Result<ChatResult> {
         let config = config.unwrap_or_default();
 
@@ -3289,14 +3289,14 @@ impl Lfm2Model {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<|im_start|>tool` block.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
         let config = config.unwrap_or_default();

--- a/crates/mlx-core/src/models/qianfan_ocr/chat.rs
+++ b/crates/mlx-core/src/models/qianfan_ocr/chat.rs
@@ -421,6 +421,7 @@ mod tests {
             content: content.to_string(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: None,
             images: None,
         }
@@ -433,6 +434,7 @@ mod tests {
             content: content.to_string(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: None,
             images: Some(images),
         }
@@ -448,6 +450,7 @@ mod tests {
             content: content.to_string(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: Some(reasoning.to_string()),
             images: None,
         }
@@ -469,6 +472,7 @@ mod tests {
                     .collect(),
             ),
             tool_call_id: None,
+            is_error: None,
             reasoning_content: None,
             images: None,
         }
@@ -480,6 +484,7 @@ mod tests {
             content: content.to_string(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: None,
             images: None,
         }

--- a/crates/mlx-core/src/models/qianfan_ocr/model.rs
+++ b/crates/mlx-core/src/models/qianfan_ocr/model.rs
@@ -128,9 +128,16 @@ pub(crate) enum QianfanOCRCmd {
     /// [`QianfanOCRInner::chat_session_continue_tool_sync`] — builds a
     /// ChatML `<tool_response>` delta and prefills on top of the live
     /// caches.
+    ///
+    /// `is_error` is the structured tool-error signal threaded through
+    /// from the NAPI surface. When `Some(true)`, the renderer prepends
+    /// the shared [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper. `None` / `Some(false)` produce the
+    /// pre-feature byte-equal output.
     ChatSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         reply: ResponseTx<ChatResult>,
     },
@@ -156,10 +163,12 @@ pub(crate) enum QianfanOCRCmd {
     },
     /// Streaming tool-result continuation: same semantics as
     /// [`ChatSessionContinueTool`](Self::ChatSessionContinueTool) but
-    /// streams token deltas through `stream_tx`.
+    /// streams token deltas through `stream_tx`. Carries the same
+    /// structured `is_error` signal.
     ChatStreamSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -205,11 +214,16 @@ pub(crate) fn handle_qianfan_ocr_cmd(inner: &mut QianfanOCRInner, cmd: QianfanOC
         QianfanOCRCmd::ChatSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             reply,
         } => {
-            let _ =
-                reply.send(inner.chat_session_continue_tool_sync(tool_call_id, content, config));
+            let _ = reply.send(inner.chat_session_continue_tool_sync(
+                tool_call_id,
+                content,
+                is_error,
+                config,
+            ));
         }
         QianfanOCRCmd::ChatStreamSessionStart {
             messages,
@@ -237,6 +251,7 @@ pub(crate) fn handle_qianfan_ocr_cmd(inner: &mut QianfanOCRInner, cmd: QianfanOC
         QianfanOCRCmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled,
@@ -244,6 +259,7 @@ pub(crate) fn handle_qianfan_ocr_cmd(inner: &mut QianfanOCRInner, cmd: QianfanOC
             inner.chat_stream_session_continue_tool_sync(
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 stream_tx,
                 cancelled,
@@ -1240,10 +1256,18 @@ impl QianfanOCRInner {
     /// Text-only; delegates to [`Self::chat_tokens_delta_sync`] which
     /// inherits the same text-only-delta invariant (errors if the
     /// session currently holds image state).
+    ///
+    /// `is_error` is forwarded verbatim to
+    /// [`crate::models::qwen3_5::chat_common::build_chatml_tool_delta_text`]:
+    /// `Some(true)` injects the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper; `None` / `Some(false)` keep the
+    /// pre-feature byte-equal output.
     pub(crate) fn chat_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
     ) -> Result<ChatResult> {
         let tokenizer = self.tokenizer.clone();
@@ -1253,6 +1277,7 @@ impl QianfanOCRInner {
             &tool_call_id,
             &content,
             enable_thinking,
+            is_error,
         );
         let delta_tokens = tokenizer.encode_sync(&delta_text, Some(false))?;
 
@@ -1653,10 +1678,13 @@ impl QianfanOCRInner {
     }
 
     /// Streaming variant of [`Self::chat_session_continue_tool_sync`].
+    /// `is_error` is forwarded verbatim to the wire-format renderer;
+    /// see the non-streaming entry point for the marker semantics.
     pub(crate) fn chat_stream_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -1676,6 +1704,7 @@ impl QianfanOCRInner {
             &tool_call_id,
             &content,
             enable_thinking,
+            is_error,
         );
 
         let delta_tokens = match tokenizer.encode_sync(&delta_text, Some(false)) {
@@ -2323,12 +2352,20 @@ impl QianfanOCRModel {
     /// decodes the model reply. Stops on `<|im_end|>` so the cache stays
     /// on a clean turn boundary for the next turn.
     ///
+    /// `is_error` is the structured tool-error signal. When `Some(true)`,
+    /// the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper so the model receives a clear text-level
+    /// cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+    /// pre-feature output.
+    ///
     /// Requires a live session started via `chatSessionStart`.
     #[napi]
     pub async fn chat_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
     ) -> Result<ChatResult> {
         let thread = self.thread.as_ref().ok_or_else(|| {
@@ -2341,6 +2378,7 @@ impl QianfanOCRModel {
             QianfanOCRCmd::ChatSessionContinueTool {
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 reply,
             }
@@ -2427,13 +2465,19 @@ impl QianfanOCRModel {
     }
 
     /// Streaming variant of `chatSessionContinueTool`.
+    ///
+    /// `is_error` mirrors the non-streaming entry point — when
+    /// `Some(true)`, the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
@@ -2451,6 +2495,7 @@ impl QianfanOCRModel {
         thread.send(QianfanOCRCmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled: cancelled_inner,

--- a/crates/mlx-core/src/models/qianfan_ocr/model.rs
+++ b/crates/mlx-core/src/models/qianfan_ocr/model.rs
@@ -2365,8 +2365,8 @@ impl QianfanOCRModel {
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
     ) -> Result<ChatResult> {
         let thread = self.thread.as_ref().ok_or_else(|| {
             Error::from_reason("Model not initialized. Call QianfanOCRModel.load() first.")
@@ -2471,14 +2471,14 @@ impl QianfanOCRModel {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null | undefined, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
         let thread = self.thread.as_ref().ok_or_else(|| {

--- a/crates/mlx-core/src/models/qianfan_ocr/model.rs
+++ b/crates/mlx-core/src/models/qianfan_ocr/model.rs
@@ -2471,15 +2471,15 @@ impl QianfanOCRModel {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null | undefined, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void, isError?: boolean | null | undefined"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
         config: Option<ChatConfig>,
-        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
+        is_error: Option<bool>,
     ) -> Result<ChatStreamHandle> {
         let thread = self.thread.as_ref().ok_or_else(|| {
             Error::from_reason("Model not initialized. Call QianfanOCRModel.load() first.")

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -4270,7 +4270,7 @@ impl Qwen3Inner {
                         content: m.content.clone(),
                         tool_calls: m.tool_calls.clone(),
                         tool_call_id: m.tool_call_id.clone(),
-                        is_error: None,
+                        is_error: m.is_error,
                         reasoning_content: m.reasoning_content.clone(),
                         images: None,
                     })
@@ -4297,7 +4297,7 @@ impl Qwen3Inner {
                         content: m.content.clone(),
                         tool_calls: m.tool_calls.clone(),
                         tool_call_id: m.tool_call_id.clone(),
-                        is_error: None,
+                        is_error: m.is_error,
                         reasoning_content: m.reasoning_content.clone(),
                         images: None,
                     })
@@ -6083,8 +6083,8 @@ impl Qwen3Model {
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
     ) -> Result<ChatResult> {
         let config = config.unwrap_or_default();
         send_and_await(&self.thread, |reply| Qwen3Cmd::ChatSessionContinueTool {
@@ -6173,14 +6173,14 @@ impl Qwen3Model {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
         let config = config.unwrap_or_default();

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -6173,15 +6173,15 @@ impl Qwen3Model {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void, isError?: boolean | null | undefined"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
         config: Option<ChatConfig>,
-        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
+        is_error: Option<bool>,
     ) -> Result<ChatStreamHandle> {
         let config = config.unwrap_or_default();
 

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -127,9 +127,17 @@ pub(crate) enum Qwen3Cmd {
     /// Qwen3-style `<tool_response>`-wrapped user-role delta (matching
     /// Qwen3.5's template), tokenizes it, and prefills on top of the live
     /// caches.
+    ///
+    /// `is_error` is the structured tool-error signal threaded through
+    /// from the NAPI surface (`chatSessionContinueTool(..., isError)`).
+    /// When `Some(true)`, the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] to the wire content so
+    /// the model receives a clear text-level cue. `None` / `Some(false)`
+    /// keep the wire bytes byte-equal to the pre-feature output.
     ChatSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         reply: ResponseTx<ChatResult>,
     },
@@ -153,10 +161,12 @@ pub(crate) enum Qwen3Cmd {
     },
     /// Streaming tool-result continuation: same semantics as
     /// [`Self::ChatSessionContinueTool`] but streams token deltas through
-    /// `stream_tx`.
+    /// `stream_tx`. Carries the same structured `is_error` signal so the
+    /// streaming wire content matches the non-streaming output.
     ChatStreamSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -266,11 +276,16 @@ pub(crate) fn handle_qwen3_cmd(inner: &mut Qwen3Inner, cmd: Qwen3Cmd) {
         Qwen3Cmd::ChatSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             reply,
         } => {
-            let _ =
-                reply.send(inner.chat_session_continue_tool_sync(tool_call_id, content, config));
+            let _ = reply.send(inner.chat_session_continue_tool_sync(
+                tool_call_id,
+                content,
+                is_error,
+                config,
+            ));
         }
         Qwen3Cmd::ChatStreamSessionStart {
             messages,
@@ -298,6 +313,7 @@ pub(crate) fn handle_qwen3_cmd(inner: &mut Qwen3Inner, cmd: Qwen3Cmd) {
         Qwen3Cmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled,
@@ -305,6 +321,7 @@ pub(crate) fn handle_qwen3_cmd(inner: &mut Qwen3Inner, cmd: Qwen3Cmd) {
             inner.chat_stream_session_continue_tool_sync(
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 stream_tx,
                 cancelled,
@@ -3351,10 +3368,17 @@ impl Qwen3Inner {
     ///
     /// Delegates to [`Self::chat_tokens_delta_sync`] which inherits the
     /// same text-only-delta invariant.
+    ///
+    /// `is_error` is forwarded verbatim to
+    /// [`chat_common::build_chatml_tool_delta_text`]: `Some(true)` injects
+    /// the shared [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper; `None` / `Some(false)` keep the
+    /// pre-feature byte-equal output.
     pub(crate) fn chat_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
     ) -> Result<ChatResult> {
         let tokenizer = self
@@ -3364,7 +3388,8 @@ impl Qwen3Inner {
             .clone();
 
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
-        let delta_text = build_chatml_tool_delta_text(&tool_call_id, &content, enable_thinking);
+        let delta_text =
+            build_chatml_tool_delta_text(&tool_call_id, &content, enable_thinking, is_error);
 
         let delta_tokens = tokenizer.encode_sync(&delta_text, Some(false))?;
 
@@ -3478,10 +3503,15 @@ impl Qwen3Inner {
     }
 
     /// Streaming analog of [`Self::chat_session_continue_tool_sync`].
+    ///
+    /// `is_error` is the structured tool-error signal forwarded verbatim
+    /// to [`chat_common::build_chatml_tool_delta_text`]; see the
+    /// non-streaming entry point for the wire-format semantics.
     pub(crate) fn chat_stream_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -3503,7 +3533,8 @@ impl Qwen3Inner {
         };
 
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
-        let delta_text = build_chatml_tool_delta_text(&tool_call_id, &content, enable_thinking);
+        let delta_text =
+            build_chatml_tool_delta_text(&tool_call_id, &content, enable_thinking, is_error);
 
         let delta_tokens = match tokenizer.encode_sync(&delta_text, Some(false)) {
             Ok(t) => t,
@@ -4239,6 +4270,7 @@ impl Qwen3Inner {
                         content: m.content.clone(),
                         tool_calls: m.tool_calls.clone(),
                         tool_call_id: m.tool_call_id.clone(),
+                        is_error: None,
                         reasoning_content: m.reasoning_content.clone(),
                         images: None,
                     })
@@ -4265,6 +4297,7 @@ impl Qwen3Inner {
                         content: m.content.clone(),
                         tool_calls: m.tool_calls.clone(),
                         tool_call_id: m.tool_call_id.clone(),
+                        is_error: None,
                         reasoning_content: m.reasoning_content.clone(),
                         images: None,
                     })
@@ -6037,18 +6070,27 @@ impl Qwen3Model {
     /// caches, then decodes the assistant reply. Stops on `<|im_end|>`
     /// so the cache stays on a clean boundary for the next turn.
     ///
+    /// `is_error` is the structured tool-error signal. When `Some(true)`,
+    /// the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper so the model receives a clear text-level
+    /// cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+    /// pre-feature output.
+    ///
     /// Requires a live session started via `chatSessionStart`.
     #[napi]
     pub async fn chat_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
     ) -> Result<ChatResult> {
         let config = config.unwrap_or_default();
         send_and_await(&self.thread, |reply| Qwen3Cmd::ChatSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             reply,
         })
@@ -6125,13 +6167,19 @@ impl Qwen3Model {
     }
 
     /// Streaming variant of `chatSessionContinueTool`.
+    ///
+    /// `is_error` mirrors the non-streaming entry point — when
+    /// `Some(true)`, the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
@@ -6145,6 +6193,7 @@ impl Qwen3Model {
         self.thread.send(Qwen3Cmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled: cancelled_inner,

--- a/crates/mlx-core/src/models/qwen3_5/chat_common.rs
+++ b/crates/mlx-core/src/models/qwen3_5/chat_common.rs
@@ -145,6 +145,7 @@ pub(crate) fn build_synthetic_user_message(user: &str) -> ChatMessage {
         content: user.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }
@@ -210,10 +211,19 @@ pub(crate) fn build_chatml_continue_delta_text(
 /// matching what the Qwen3.5 jinja template does after the assistant
 /// opener. Callers resolve `enable_thinking` from the current
 /// `ChatConfig` via `resolve_enable_thinking` before calling this helper.
+///
+/// `is_error` is the model-facing failure cue: when `Some(true)`, the
+/// shared [`crate::tokenizer::TOOL_ERROR_MARKER`] is prepended to
+/// `content` inside the `<tool_response>` wrapper. The structured
+/// `ChatMessage::is_error` field on the originating message is the
+/// authoritative signal; the marker injection here only affects the
+/// wire bytes the model decodes. `None` / `Some(false)` produce the
+/// unmarked wire format and stay byte-equal to the pre-feature output.
 pub(crate) fn build_chatml_tool_delta_text(
     _tool_call_id: &str,
     content: &str,
     enable_thinking: Option<bool>,
+    is_error: Option<bool>,
 ) -> String {
     let thinking_prefix = match enable_thinking {
         Some(false) => "",
@@ -221,8 +231,9 @@ pub(crate) fn build_chatml_tool_delta_text(
         // Some(true) both take the thinking path.
         _ => "<think>\n",
     };
+    let rendered_content = crate::tokenizer::apply_tool_error_marker(content, is_error);
     format!(
-        "\n<|im_start|>user\n<tool_response>\n{content}\n</tool_response><|im_end|>\n<|im_start|>assistant\n{thinking_prefix}",
+        "\n<|im_start|>user\n<tool_response>\n{rendered_content}\n</tool_response><|im_end|>\n<|im_start|>assistant\n{thinking_prefix}",
     )
 }
 
@@ -978,6 +989,107 @@ mod compiled_paged_fallback_policy_tests {
             "compiled forward failure AFTER a successful compiled step must propagate as fatal: \
              the C++ GDN linear-cache globals advanced but self.caches is stale, so a pure-Rust \
              fallback would silently corrupt the response"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tool_delta_marker_tests {
+    //! Guard the structured `is_error` channel on
+    //! `build_chatml_tool_delta_text`. The renderer injects the
+    //! `TOOL_ERROR_MARKER` cue into the `<tool_response>` wire content
+    //! only when the caller passes `Some(true)`. `None` and
+    //! `Some(false)` keep the output byte-equal to the pre-feature
+    //! behavior — guarding both the hot (successful) path and the
+    //! explicit-false path against accidental drift.
+
+    use super::build_chatml_tool_delta_text;
+    use crate::tokenizer::TOOL_ERROR_MARKER;
+
+    #[test]
+    fn tool_delta_injects_marker_when_is_error_true() {
+        // `Some(true)` must produce the marker prefix inside the
+        // `<tool_response>` wrapper. The marker is the single shared
+        // constant — using it directly here keeps the test in sync
+        // with any future rename.
+        let payload = "boom: connection refused";
+        let rendered = build_chatml_tool_delta_text("call_fail", payload, None, Some(true));
+        let expected_inner = format!("{TOOL_ERROR_MARKER}{payload}");
+        assert!(
+            rendered.contains(&expected_inner),
+            "expected error marker inside <tool_response> wrapper; got:\n{rendered}",
+        );
+        // The wrapper itself must stay correct (we don't want to ship
+        // a malformed delta that only the unflagged path renders right).
+        assert!(
+            rendered.contains("<tool_response>\n"),
+            "wrapper open missing"
+        );
+        assert!(
+            rendered.contains("</tool_response>"),
+            "wrapper close missing"
+        );
+    }
+
+    #[test]
+    fn tool_delta_skips_marker_when_is_error_none() {
+        // None = default; pre-feature output. The marker MUST NOT
+        // appear anywhere in the wire text.
+        let payload = "{\"temperature\": 72}";
+        let rendered = build_chatml_tool_delta_text("call_ok", payload, None, None);
+        assert!(
+            !rendered.contains(TOOL_ERROR_MARKER),
+            "marker leaked into unflagged delta:\n{rendered}",
+        );
+        assert!(
+            rendered.contains(payload),
+            "original content missing from delta:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn tool_delta_skips_marker_when_is_error_some_false() {
+        // Explicit `Some(false)` is the same as `None` — only
+        // `Some(true)` flips the marker on.
+        let payload = "ok";
+        let rendered = build_chatml_tool_delta_text("call_ok", payload, None, Some(false));
+        assert!(
+            !rendered.contains(TOOL_ERROR_MARKER),
+            "marker leaked into Some(false) delta:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn tool_delta_does_not_remark_content_that_resembles_marker() {
+        // The structured channel removes the collision concern: a
+        // successful tool result whose literal content begins with the
+        // marker text must NOT double-prefix the marker on its way
+        // through the renderer.
+        let suspicious = format!("{TOOL_ERROR_MARKER}this is a successful payload");
+        let rendered = build_chatml_tool_delta_text("call_ok", &suspicious, None, None);
+        // Exactly one occurrence — the original payload — no extra
+        // prefix.
+        let occurrences = rendered.matches(TOOL_ERROR_MARKER).count();
+        assert_eq!(
+            occurrences, 1,
+            "marker count should be 1 (the original literal); got {occurrences} in:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn tool_delta_marker_interacts_correctly_with_thinking_prefix() {
+        // The marker and the `<think>\n` prefix occupy different slots
+        // in the delta. Both must render together when both are active:
+        // marker inside `<tool_response>`, `<think>\n` after the
+        // assistant opener.
+        let rendered = build_chatml_tool_delta_text("call_fail", "boom", Some(true), Some(true));
+        assert!(
+            rendered.contains(&format!("{TOOL_ERROR_MARKER}boom")),
+            "marker missing from thinking-enabled delta:\n{rendered}",
+        );
+        assert!(
+            rendered.contains("<|im_start|>assistant\n<think>\n"),
+            "thinking prefix missing from thinking-enabled delta:\n{rendered}",
         );
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -347,9 +347,17 @@ pub(crate) enum Qwen35Cmd {
     /// [`Qwen35Inner::chat_session_continue_tool_sync`] — builds a
     /// ChatML `<tool_response>` delta and prefills on top of the live
     /// caches.
+    ///
+    /// `is_error` is the structured tool-error signal threaded through
+    /// from the NAPI surface (`chatSessionContinueTool(..., isError)`).
+    /// When `Some(true)`, the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper. `None` / `Some(false)` produce the
+    /// pre-feature byte-equal output.
     ChatSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         reply: ResponseTx<ChatResult>,
     },
@@ -375,10 +383,12 @@ pub(crate) enum Qwen35Cmd {
     },
     /// Streaming tool-result continuation: same semantics as
     /// [`ChatSessionContinueTool`](Self::ChatSessionContinueTool) but
-    /// streams token deltas through `stream_tx`.
+    /// streams token deltas through `stream_tx`. Carries the same
+    /// structured `is_error` signal.
     ChatStreamSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -478,11 +488,16 @@ pub(crate) fn handle_qwen35_cmd(inner: &mut Qwen35Inner, cmd: Qwen35Cmd) {
         Qwen35Cmd::ChatSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             reply,
         } => {
-            let _ =
-                reply.send(inner.chat_session_continue_tool_sync(tool_call_id, content, config));
+            let _ = reply.send(inner.chat_session_continue_tool_sync(
+                tool_call_id,
+                content,
+                is_error,
+                config,
+            ));
         }
         Qwen35Cmd::ChatStreamSessionStart {
             messages,
@@ -510,6 +525,7 @@ pub(crate) fn handle_qwen35_cmd(inner: &mut Qwen35Inner, cmd: Qwen35Cmd) {
         Qwen35Cmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             stream_tx,
             config,
             cancelled,
@@ -517,6 +533,7 @@ pub(crate) fn handle_qwen35_cmd(inner: &mut Qwen35Inner, cmd: Qwen35Cmd) {
             inner.chat_stream_session_continue_tool_sync(
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 stream_tx,
                 cancelled,
@@ -2145,10 +2162,17 @@ impl Qwen35Inner {
     /// Text-only; delegates to [`Self::chat_tokens_delta_sync`] which
     /// inherits the same text-only-delta invariant (errors if the
     /// session currently holds image state).
+    ///
+    /// `is_error` is forwarded verbatim to
+    /// [`chat_common::build_chatml_tool_delta_text`]: `Some(true)` injects
+    /// the shared [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper; `None` / `Some(false)` keep the
+    /// pre-feature byte-equal output.
     pub(crate) fn chat_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
     ) -> Result<ChatResult> {
         let tokenizer = self
@@ -2158,8 +2182,12 @@ impl Qwen35Inner {
             .clone();
 
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
-        let delta_text =
-            chat_common::build_chatml_tool_delta_text(&tool_call_id, &content, enable_thinking);
+        let delta_text = chat_common::build_chatml_tool_delta_text(
+            &tool_call_id,
+            &content,
+            enable_thinking,
+            is_error,
+        );
 
         let delta_tokens = tokenizer.encode_sync(&delta_text, Some(false))?;
 
@@ -3992,11 +4020,14 @@ impl Qwen35Inner {
     ///
     /// Builds a ChatML tool-response delta, tokenizes it, and delegates
     /// to [`Self::chat_stream_tokens_delta_sync`]. Inherits the same
-    /// text-only-delta invariant.
+    /// text-only-delta invariant. `is_error` is forwarded verbatim to
+    /// the wire-format renderer; see the non-streaming entry point for
+    /// the marker semantics.
     pub(crate) fn chat_stream_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -4018,8 +4049,12 @@ impl Qwen35Inner {
         };
 
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
-        let delta_text =
-            chat_common::build_chatml_tool_delta_text(&tool_call_id, &content, enable_thinking);
+        let delta_text = chat_common::build_chatml_tool_delta_text(
+            &tool_call_id,
+            &content,
+            enable_thinking,
+            is_error,
+        );
 
         let delta_tokens = match tokenizer.encode_sync(&delta_text, Some(false)) {
             Ok(t) => t,
@@ -6837,12 +6872,20 @@ impl Qwen3_5Model {
     /// wrapper tags, not an explicit id. Callers may still log it for
     /// their own bookkeeping.
     ///
+    /// `is_error` is the structured tool-error signal. When `Some(true)`,
+    /// the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper so the model receives a clear text-level
+    /// cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+    /// pre-feature output.
+    ///
     /// Requires a live session started via `chatSessionStart`.
     #[napi]
     pub async fn chat_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
     ) -> Result<ChatResult> {
         let config = config.unwrap_or(ChatConfig {
@@ -6872,6 +6915,7 @@ impl Qwen3_5Model {
             Qwen35Cmd::ChatSessionContinueTool {
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 reply,
             }
@@ -7017,13 +7061,18 @@ impl Qwen3_5Model {
     /// Builds a ChatML tool-response delta on top of the live session
     /// caches and streams the decoded reply. Requires a live session
     /// started via `chatSessionStart` / `chatStreamSessionStart`.
+    /// `is_error` mirrors the non-streaming entry point — when
+    /// `Some(true)`, the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
@@ -7058,6 +7107,7 @@ impl Qwen3_5Model {
         self.thread.send(Qwen35Cmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled: cancelled_inner,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -7066,15 +7066,15 @@ impl Qwen3_5Model {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void, isError?: boolean | null | undefined"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
         config: Option<ChatConfig>,
-        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
+        is_error: Option<bool>,
     ) -> Result<ChatStreamHandle> {
         let config = config.unwrap_or(ChatConfig {
             max_new_tokens: None,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -6885,8 +6885,8 @@ impl Qwen3_5Model {
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
     ) -> Result<ChatResult> {
         let config = config.unwrap_or(ChatConfig {
             max_new_tokens: None,
@@ -7066,14 +7066,14 @@ impl Qwen3_5Model {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
         let config = config.unwrap_or(ChatConfig {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -6888,8 +6888,8 @@ impl Qwen3_5MoeModel {
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
     ) -> Result<ChatResult> {
         let config = config.unwrap_or(ChatConfig {
             max_new_tokens: None,
@@ -7069,14 +7069,14 @@ impl Qwen3_5MoeModel {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
-        is_error: Option<bool>,
         config: Option<ChatConfig>,
+        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
         let config = config.unwrap_or(ChatConfig {

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -343,9 +343,17 @@ pub(crate) enum Qwen35MoeCmd {
     /// [`Qwen35MoeInner::chat_session_continue_tool_sync`] — builds a
     /// ChatML `<tool_response>` delta and prefills on top of the live
     /// caches.
+    ///
+    /// `is_error` is the structured tool-error signal threaded through
+    /// from the NAPI surface (`chatSessionContinueTool(..., isError)`).
+    /// When `Some(true)`, the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper. `None` / `Some(false)` produce the
+    /// pre-feature byte-equal output.
     ChatSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         reply: ResponseTx<ChatResult>,
     },
@@ -371,10 +379,12 @@ pub(crate) enum Qwen35MoeCmd {
     },
     /// Streaming tool-result continuation: same semantics as
     /// [`ChatSessionContinueTool`](Self::ChatSessionContinueTool) but
-    /// streams token deltas through `stream_tx`.
+    /// streams token deltas through `stream_tx`. Carries the same
+    /// structured `is_error` signal.
     ChatStreamSessionContinueTool {
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -474,11 +484,16 @@ pub(crate) fn handle_qwen35_moe_cmd(inner: &mut Qwen35MoeInner, cmd: Qwen35MoeCm
         Qwen35MoeCmd::ChatSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             reply,
         } => {
-            let _ =
-                reply.send(inner.chat_session_continue_tool_sync(tool_call_id, content, config));
+            let _ = reply.send(inner.chat_session_continue_tool_sync(
+                tool_call_id,
+                content,
+                is_error,
+                config,
+            ));
         }
         Qwen35MoeCmd::ChatStreamSessionStart {
             messages,
@@ -506,6 +521,7 @@ pub(crate) fn handle_qwen35_moe_cmd(inner: &mut Qwen35MoeInner, cmd: Qwen35MoeCm
         Qwen35MoeCmd::ChatStreamSessionContinueTool {
             tool_call_id,
             content,
+            is_error,
             config,
             stream_tx,
             cancelled,
@@ -513,6 +529,7 @@ pub(crate) fn handle_qwen35_moe_cmd(inner: &mut Qwen35MoeInner, cmd: Qwen35MoeCm
             inner.chat_stream_session_continue_tool_sync(
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 stream_tx,
                 cancelled,
@@ -4327,10 +4344,17 @@ impl Qwen35MoeInner {
     /// Text-only; delegates to [`Self::chat_tokens_delta_sync`] which
     /// inherits the same text-only-delta invariant (errors if the session
     /// currently holds image state).
+    ///
+    /// `is_error` is forwarded verbatim to
+    /// [`chat_common::build_chatml_tool_delta_text`]: `Some(true)` injects
+    /// the shared [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper; `None` / `Some(false)` keep the
+    /// pre-feature byte-equal output.
     pub(crate) fn chat_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
     ) -> Result<ChatResult> {
         let tokenizer = self
@@ -4340,8 +4364,12 @@ impl Qwen35MoeInner {
             .clone();
 
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
-        let delta_text =
-            chat_common::build_chatml_tool_delta_text(&tool_call_id, &content, enable_thinking);
+        let delta_text = chat_common::build_chatml_tool_delta_text(
+            &tool_call_id,
+            &content,
+            enable_thinking,
+            is_error,
+        );
 
         let delta_tokens = tokenizer.encode_sync(&delta_text, Some(false))?;
 
@@ -4465,10 +4493,13 @@ impl Qwen35MoeInner {
     }
 
     /// Streaming analog of [`Self::chat_session_continue_tool_sync`].
+    /// `is_error` is forwarded verbatim to the wire-format renderer;
+    /// see the non-streaming entry point for the marker semantics.
     pub(crate) fn chat_stream_session_continue_tool_sync(
         &mut self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: ChatConfig,
         stream_tx: StreamTx<ChatStreamChunk>,
         cancelled: Arc<AtomicBool>,
@@ -4490,8 +4521,12 @@ impl Qwen35MoeInner {
         };
 
         let enable_thinking = chat_common::resolve_enable_thinking(&config);
-        let delta_text =
-            chat_common::build_chatml_tool_delta_text(&tool_call_id, &content, enable_thinking);
+        let delta_text = chat_common::build_chatml_tool_delta_text(
+            &tool_call_id,
+            &content,
+            enable_thinking,
+            is_error,
+        );
 
         let delta_tokens = match tokenizer.encode_sync(&delta_text, Some(false)) {
             Ok(t) => t,
@@ -6840,12 +6875,20 @@ impl Qwen3_5MoeModel {
     /// wrapper tags, not an explicit id. Callers may still log it for
     /// their own bookkeeping.
     ///
+    /// `is_error` is the structured tool-error signal. When `Some(true)`,
+    /// the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper so the model receives a clear text-level
+    /// cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+    /// pre-feature output.
+    ///
     /// Requires a live session started via `chatSessionStart`.
     #[napi]
     pub async fn chat_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
     ) -> Result<ChatResult> {
         let config = config.unwrap_or(ChatConfig {
@@ -6875,6 +6918,7 @@ impl Qwen3_5MoeModel {
             Qwen35MoeCmd::ChatSessionContinueTool {
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 reply,
             }
@@ -7020,13 +7064,18 @@ impl Qwen3_5MoeModel {
     /// Builds a ChatML tool-response delta on top of the live session
     /// caches and streams the decoded reply. Requires a live session
     /// started via `chatSessionStart` / `chatStreamSessionStart`.
+    /// `is_error` mirrors the non-streaming entry point — when
+    /// `Some(true)`, the renderer prepends the shared
+    /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+    /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, isError: boolean | null | undefined, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
+        is_error: Option<bool>,
         config: Option<ChatConfig>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
     ) -> Result<ChatStreamHandle> {
@@ -7062,6 +7111,7 @@ impl Qwen3_5MoeModel {
             .send(Qwen35MoeCmd::ChatStreamSessionContinueTool {
                 tool_call_id,
                 content,
+                is_error,
                 config,
                 stream_tx,
                 cancelled: cancelled_inner,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -7069,15 +7069,15 @@ impl Qwen3_5MoeModel {
     /// [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
     /// `<tool_response>` wrapper.
     #[napi(
-        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, isError: boolean | null | undefined, callback: (err: Error | null, chunk: ChatStreamChunk) => void"
+        ts_args_type = "toolCallId: string, content: string, config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void, isError?: boolean | null | undefined"
     )]
     pub async fn chat_stream_session_continue_tool(
         &self,
         tool_call_id: String,
         content: String,
         config: Option<ChatConfig>,
-        is_error: Option<bool>,
         callback: ThreadsafeFunction<ChatStreamChunk, ()>,
+        is_error: Option<bool>,
     ) -> Result<ChatStreamHandle> {
         let config = config.unwrap_or(ChatConfig {
             max_new_tokens: None,

--- a/crates/mlx-core/src/tokenizer.rs
+++ b/crates/mlx-core/src/tokenizer.rs
@@ -120,6 +120,22 @@ pub struct ChatMessage {
     /// Tool call ID this message is responding to (for tool messages)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,
+    /// Whether this tool-role message represents an errored tool result.
+    ///
+    /// Authoritative, structured signal of tool-call failure. Set to
+    /// `Some(true)` when the caller (e.g. the Anthropic
+    /// `tool_result.is_error === true` translator) wants the model to
+    /// treat the tool output as an error. The renderer prepends a short
+    /// `[tool error]` prefix to `content` when emitting the wire-format
+    /// tool response so the model receives a clear text-level cue, but
+    /// the original `content` stays byte-for-byte intact in the
+    /// structured form — no JSON wrapping, no in-band marker that could
+    /// collide with a successful tool result whose literal content
+    /// happens to start with the same prefix.
+    ///
+    /// `None` / `Some(false)` produce the unmarked wire format.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
     /// Reasoning content for thinking mode (used with <think> tags)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
@@ -136,6 +152,7 @@ impl std::fmt::Debug for ChatMessage {
             .field("content", &self.content)
             .field("tool_calls", &self.tool_calls)
             .field("tool_call_id", &self.tool_call_id)
+            .field("is_error", &self.is_error)
             .field("reasoning_content", &self.reasoning_content)
             .field(
                 "images",
@@ -145,6 +162,38 @@ impl std::fmt::Debug for ChatMessage {
                     .map(|imgs| imgs.iter().map(|i| i.len()).collect::<Vec<_>>()),
             )
             .finish()
+    }
+}
+
+/// Marker prepended to a tool-role message's wire content when
+/// [`ChatMessage::is_error`] is `Some(true)`.
+///
+/// The marker is a **model-facing cue** — a short, conventional prefix
+/// that gives the model a clear text-level signal that the tool result
+/// represents an error. The structured `is_error` field on the message
+/// is the authoritative source of truth; the marker is purely a
+/// presentation choice for what reaches the model's prompt.
+///
+/// This constant is shared by every renderer (the Jinja serializer used
+/// by the cold-start path, the ChatML fallback formatter, and the
+/// per-variant `chat_session_continue_tool` delta builders) so the
+/// marker stays consistent across all entry points.
+pub const TOOL_ERROR_MARKER: &str = "[tool error] ";
+
+/// Apply [`TOOL_ERROR_MARKER`] to `content` when `is_error == Some(true)`.
+///
+/// Used by every wire-format renderer that consumes a tool-role
+/// `ChatMessage`: the Jinja serializer ([`serialize_message_for_jinja`])
+/// for the cold-start replay path, the ChatML fallback formatter, and
+/// each per-variant `chat_session_continue_tool` delta builder.
+///
+/// Returning `Cow<str>` keeps the unmarked path (the overwhelmingly
+/// common case) free of allocations.
+pub fn apply_tool_error_marker(content: &str, is_error: Option<bool>) -> std::borrow::Cow<'_, str> {
+    if is_error == Some(true) {
+        std::borrow::Cow::Owned(format!("{TOOL_ERROR_MARKER}{content}"))
+    } else {
+        std::borrow::Cow::Borrowed(content)
     }
 }
 
@@ -712,6 +761,7 @@ impl Qwen3Tokenizer {
                 content: Self::sanitize_chatml_content(&msg.content),
                 tool_calls: msg.tool_calls.clone(),
                 tool_call_id: msg.tool_call_id.clone(),
+                is_error: msg.is_error,
                 reasoning_content: msg.reasoning_content.clone(),
                 images: msg.images.as_ref().map(|imgs| {
                     imgs.iter()
@@ -736,9 +786,18 @@ impl Qwen3Tokenizer {
         let mut formatted = String::new();
 
         for msg in messages {
+            // For tool-role messages flagged with the structured
+            // `is_error` field, prepend the model-facing error marker
+            // to the wire content. The structured field stays
+            // authoritative; this rendering step is purely a model cue.
+            let content = if msg.role == "tool" {
+                apply_tool_error_marker(&msg.content, msg.is_error)
+            } else {
+                std::borrow::Cow::Borrowed(msg.content.as_str())
+            };
             formatted.push_str(&format!(
                 "<|im_start|>{}\n{}<|im_end|>\n",
-                msg.role, msg.content
+                msg.role, content
             ));
         }
 
@@ -1330,10 +1389,21 @@ pub(crate) fn serialize_message_for_jinja(msg: &ChatMessage) -> serde_json::Valu
 
     let has_images = msg.images.as_ref().is_some_and(|imgs| !imgs.is_empty());
 
+    // For tool-role messages flagged with the structured `is_error`
+    // field, prepend the model-facing error marker to the wire content
+    // before the template sees it. The structured field stays the
+    // source of truth — this only affects what the model reads in its
+    // prompt context.
+    let rendered_content: std::borrow::Cow<'_, str> = if msg.role == "tool" {
+        apply_tool_error_marker(&msg.content, msg.is_error)
+    } else {
+        std::borrow::Cow::Borrowed(msg.content.as_str())
+    };
+
     if has_images && msg.role == "user" {
         let mut parts: Vec<serde_json::Value> = Vec::new();
-        if !msg.content.is_empty() {
-            parts.push(serde_json::json!({ "type": "text", "text": msg.content }));
+        if !rendered_content.is_empty() {
+            parts.push(serde_json::json!({ "type": "text", "text": rendered_content.as_ref() }));
         }
         // SAFETY: `is_some_and` above ensured this is Some and non-empty.
         for _ in msg.images.as_ref().unwrap() {
@@ -1341,7 +1411,10 @@ pub(crate) fn serialize_message_for_jinja(msg: &ChatMessage) -> serde_json::Valu
         }
         obj.insert("content".to_string(), serde_json::Value::Array(parts));
     } else {
-        obj.insert("content".to_string(), serde_json::json!(msg.content));
+        obj.insert(
+            "content".to_string(),
+            serde_json::json!(rendered_content.as_ref()),
+        );
     }
 
     if let Some(tool_calls) = &msg.tool_calls {
@@ -1424,6 +1497,7 @@ mod tests {
             content: content.to_string(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: None,
             images,
         }
@@ -1576,6 +1650,7 @@ mod tests {
                 content: "describe these".to_string(),
                 tool_calls: None,
                 tool_call_id: None,
+                is_error: None,
                 reasoning_content: None,
                 images: Some(vec![
                     Uint8Array::new(vec![0x01, 0x02, 0x03, 0x04]),
@@ -1587,6 +1662,7 @@ mod tests {
                 content: "ok".to_string(),
                 tool_calls: None,
                 tool_call_id: None,
+                is_error: None,
                 reasoning_content: None,
                 images: None,
             },
@@ -1640,6 +1716,7 @@ mod tests {
             content: "What is this?".to_string(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: None,
             images: Some(vec![Uint8Array::new(vec![0; 4])]),
         }];
@@ -1827,6 +1904,7 @@ mod tests {
             content: "hello".to_string(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: None,
             images: None,
         }];
@@ -1885,6 +1963,7 @@ mod tests {
             content: "hello".to_string(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: Some("because".to_string()),
             images: None,
         };
@@ -1927,6 +2006,7 @@ mod tests {
             content: "Making the edit.".to_string(),
             tool_calls: Some(vec![call]),
             tool_call_id: None,
+            is_error: None,
             reasoning_content: Some("think".to_string()),
             images: None,
         };
@@ -2046,6 +2126,7 @@ mod tests {
                     content: "Run ls.".to_string(),
                     tool_calls: None,
                     tool_call_id: None,
+                    is_error: None,
                     reasoning_content: None,
                     images: None,
                 },
@@ -2058,6 +2139,7 @@ mod tests {
                         arguments: r#"{"command":"ls"}"#.to_string(),
                     }]),
                     tool_call_id: None,
+                    is_error: None,
                     reasoning_content: Some(reasoning.to_string()),
                     images: None,
                 },
@@ -2102,5 +2184,176 @@ mod tests {
             !rendered_fix.contains("thought\nthought\n"),
             "fixed shape must NOT double `thought\\n`:\n{rendered_fix}"
         );
+    }
+
+    // ----- Tool-error marker tests -----
+    //
+    // These guard the structured `is_error` channel on `ChatMessage`. The
+    // structured field is the authoritative failure signal; the rendered
+    // wire content carries a `[tool error]` prefix purely as a model cue,
+    // so the `content` field itself stays byte-for-byte intact and
+    // successful tool results whose literal text happens to start with
+    // the marker cannot be confused with errored ones on read-back.
+
+    fn tool_msg_with_error(content: &str, is_error: Option<bool>) -> ChatMessage {
+        ChatMessage {
+            role: "tool".to_string(),
+            content: content.to_string(),
+            tool_calls: None,
+            tool_call_id: Some("call_xyz".to_string()),
+            is_error,
+            reasoning_content: None,
+            images: None,
+        }
+    }
+
+    #[test]
+    fn apply_tool_error_marker_prepends_only_for_some_true() {
+        // Some(true) prepends; None / Some(false) pass through unchanged.
+        // The marker is the single shared constant — keep tests in sync
+        // with the constant so any rename trips the suite, not the
+        // models silently.
+        let payload = "boom: connection refused";
+        let marked = apply_tool_error_marker(payload, Some(true));
+        assert_eq!(marked, format!("{TOOL_ERROR_MARKER}{payload}"));
+        let unmarked_none = apply_tool_error_marker(payload, None);
+        assert_eq!(unmarked_none, payload);
+        let unmarked_false = apply_tool_error_marker(payload, Some(false));
+        assert_eq!(unmarked_false, payload);
+    }
+
+    #[test]
+    fn apply_tool_error_marker_borrows_on_pass_through() {
+        // The unmarked branch returns a `Cow::Borrowed` to keep the hot
+        // (non-error) path free of allocations.
+        let payload = "{\"temperature\": 72}";
+        let cow = apply_tool_error_marker(payload, None);
+        assert!(matches!(cow, std::borrow::Cow::Borrowed(_)));
+        let cow_false = apply_tool_error_marker(payload, Some(false));
+        assert!(matches!(cow_false, std::borrow::Cow::Borrowed(_)));
+        let cow_err = apply_tool_error_marker(payload, Some(true));
+        assert!(matches!(cow_err, std::borrow::Cow::Owned(_)));
+    }
+
+    #[test]
+    fn jinja_serializer_injects_marker_for_errored_tool_message() {
+        // The Jinja serializer is the cold-start path's wire-format
+        // renderer (consumed by `chatSessionStart`). When the structured
+        // `is_error` flag is set, the rendered `content` field that the
+        // template sees must carry the `[tool error]` cue.
+        let msg = tool_msg_with_error("boom", Some(true));
+        let v = serialize_message_for_jinja(&msg);
+        assert_eq!(v["role"], "tool");
+        assert_eq!(
+            v["content"]
+                .as_str()
+                .expect("tool-role content is a flat string"),
+            format!("{TOOL_ERROR_MARKER}boom")
+        );
+    }
+
+    #[test]
+    fn jinja_serializer_skips_marker_when_is_error_is_none() {
+        // No flag → no marker, even if the literal content happens to
+        // begin with the marker text (the collision case Codex flagged).
+        let suspicious = format!("{TOOL_ERROR_MARKER}this is a successful payload");
+        let msg = tool_msg_with_error(&suspicious, None);
+        let v = serialize_message_for_jinja(&msg);
+        assert_eq!(
+            v["content"]
+                .as_str()
+                .expect("tool-role content is a flat string"),
+            suspicious,
+            "successful tool_result whose text resembles the marker must round-trip verbatim",
+        );
+    }
+
+    #[test]
+    fn jinja_serializer_skips_marker_when_is_error_is_some_false() {
+        let msg = tool_msg_with_error("ok", Some(false));
+        let v = serialize_message_for_jinja(&msg);
+        assert_eq!(v["content"].as_str().unwrap(), "ok");
+    }
+
+    #[test]
+    fn jinja_serializer_keeps_tool_call_id_alongside_marker() {
+        // The marker channel must coexist with `tool_call_id` — the
+        // structured field is the parallel addition that motivated this
+        // change.
+        let msg = tool_msg_with_error("boom", Some(true));
+        let v = serialize_message_for_jinja(&msg);
+        assert_eq!(v["tool_call_id"], "call_xyz");
+        assert_eq!(
+            v["content"].as_str().unwrap(),
+            format!("{TOOL_ERROR_MARKER}boom"),
+        );
+    }
+
+    #[test]
+    fn jinja_serializer_does_not_mark_non_tool_roles() {
+        // Defensive: the marker is reserved for `role == "tool"`. A
+        // user / assistant / system message with `is_error: Some(true)`
+        // (an unusual but possible direct construction) must not get
+        // the prefix — the field's contract is "errored tool result",
+        // and applying it to a user message would silently corrupt the
+        // turn the template renders.
+        for role in &["user", "assistant", "system"] {
+            let mut msg = tool_msg_with_error("hello", Some(true));
+            msg.role = (*role).to_string();
+            msg.tool_call_id = None;
+            let v = serialize_message_for_jinja(&msg);
+            assert_eq!(
+                v["content"].as_str().unwrap(),
+                "hello",
+                "role={role} must not receive the tool-error marker",
+            );
+        }
+    }
+
+    #[test]
+    fn format_chatml_presanitized_injects_marker_for_errored_tool_message() {
+        // The fallback ChatML formatter is the no-template path. The
+        // marker must apply equally there.
+        let msgs = vec![tool_msg_with_error("boom", Some(true))];
+        let rendered = Qwen3Tokenizer::format_chatml_presanitized(&msgs, false);
+        assert!(
+            rendered.contains(&format!("{TOOL_ERROR_MARKER}boom")),
+            "ChatML fallback formatter must inject the marker:\n{rendered}",
+        );
+    }
+
+    #[test]
+    fn format_chatml_presanitized_skips_marker_when_unflagged() {
+        // The hot (successful) path must remain byte-equal to the
+        // pre-feature output: same content, no prefix.
+        let msgs = vec![tool_msg_with_error("ok", None)];
+        let rendered = Qwen3Tokenizer::format_chatml_presanitized(&msgs, false);
+        assert!(
+            !rendered.contains(TOOL_ERROR_MARKER),
+            "ChatML fallback must not inject the marker on unflagged messages:\n{rendered}",
+        );
+        assert!(
+            rendered.contains("ok"),
+            "content must still appear:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn sanitize_messages_preserves_is_error() {
+        // The structured field must round-trip through sanitization the
+        // same way `tool_call_id` does — otherwise the marker injection
+        // would never see the flag for any caller that passes messages
+        // through `sanitize_messages_public` first (which is every
+        // production caller).
+        let original = vec![
+            tool_msg_with_error("boom", Some(true)),
+            tool_msg_with_error("ok-explicit", Some(false)),
+            tool_msg_with_error("ok-default", None),
+        ];
+        let sanitized = Qwen3Tokenizer::sanitize_messages_public(&original);
+        assert_eq!(sanitized.len(), 3);
+        assert_eq!(sanitized[0].is_error, Some(true));
+        assert_eq!(sanitized[1].is_error, Some(false));
+        assert_eq!(sanitized[2].is_error, None);
     }
 }

--- a/crates/mlx-core/tests/gemma4_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/gemma4_paged_vs_flat_parity.rs
@@ -138,6 +138,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }

--- a/crates/mlx-core/tests/gemma4_session.rs
+++ b/crates/mlx-core/tests/gemma4_session.rs
@@ -51,6 +51,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }
@@ -106,6 +107,7 @@ async fn gemma4_session_start_prefix_reuse_append_hit() {
             content: r1.text.clone(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: None,
             images: None,
         },

--- a/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
@@ -133,6 +133,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }

--- a/crates/mlx-core/tests/lfm2_session.rs
+++ b/crates/mlx-core/tests/lfm2_session.rs
@@ -531,8 +531,8 @@ async fn lfm2_session_continue_tool_round_trips() {
         .chat_session_continue_tool(
             "dummy_id".to_string(),
             "result content".to_string(),
-            None,
             Some(tool_cfg),
+            None,
         )
         .await
         .expect("chat_session_continue_tool failed");

--- a/crates/mlx-core/tests/lfm2_session.rs
+++ b/crates/mlx-core/tests/lfm2_session.rs
@@ -56,6 +56,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }
@@ -530,6 +531,7 @@ async fn lfm2_session_continue_tool_round_trips() {
         .chat_session_continue_tool(
             "dummy_id".to_string(),
             "result content".to_string(),
+            None,
             Some(tool_cfg),
         )
         .await
@@ -855,6 +857,7 @@ async fn lfm2_session_start_prefix_reuse_append_hit() {
             content: r1.text.clone(),
             tool_calls: None,
             tool_call_id: None,
+            is_error: None,
             reasoning_content: None,
             images: None,
         },

--- a/crates/mlx-core/tests/qwen3_5_delta_chat.rs
+++ b/crates/mlx-core/tests/qwen3_5_delta_chat.rs
@@ -602,8 +602,8 @@ async fn session_continue_tool_round_trips() {
         .chat_session_continue_tool(
             "dummy_id".to_string(),
             "result content".to_string(),
-            None,
             Some(tool_cfg),
+            None,
         )
         .await
         .expect("chat_session_continue_tool failed");

--- a/crates/mlx-core/tests/qwen3_5_delta_chat.rs
+++ b/crates/mlx-core/tests/qwen3_5_delta_chat.rs
@@ -54,6 +54,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }
@@ -601,6 +602,7 @@ async fn session_continue_tool_round_trips() {
         .chat_session_continue_tool(
             "dummy_id".to_string(),
             "result content".to_string(),
+            None,
             Some(tool_cfg),
         )
         .await
@@ -662,6 +664,7 @@ async fn session_start_accepts_images_for_vlm() {
         content: "Describe this image briefly.".to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: Some(vec![image_uint8]),
     };

--- a/crates/mlx-core/tests/qwen3_5_moe_chunked_prefill.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_chunked_prefill.rs
@@ -81,6 +81,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }

--- a/crates/mlx-core/tests/qwen3_5_moe_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_paged_vs_flat_parity.rs
@@ -107,6 +107,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }

--- a/crates/mlx-core/tests/qwen3_5_moe_session.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_session.rs
@@ -56,6 +56,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }
@@ -530,6 +531,7 @@ async fn moe_session_continue_tool_round_trips() {
         .chat_session_continue_tool(
             "dummy_id".to_string(),
             "result content".to_string(),
+            None,
             Some(tool_cfg),
         )
         .await

--- a/crates/mlx-core/tests/qwen3_5_moe_session.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_session.rs
@@ -531,8 +531,8 @@ async fn moe_session_continue_tool_round_trips() {
         .chat_session_continue_tool(
             "dummy_id".to_string(),
             "result content".to_string(),
-            None,
             Some(tool_cfg),
+            None,
         )
         .await
         .expect("chat_session_continue_tool failed");

--- a/crates/mlx-core/tests/qwen3_5_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/qwen3_5_paged_vs_flat_parity.rs
@@ -123,6 +123,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }

--- a/crates/mlx-core/tests/qwen3_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/qwen3_paged_vs_flat_parity.rs
@@ -164,6 +164,7 @@ fn user_message(content: &str) -> ChatMessage {
         content: content.to_string(),
         tool_calls: None,
         tool_call_id: None,
+        is_error: None,
         reasoning_content: None,
         images: None,
     }

--- a/examples/tool-use-example.ts
+++ b/examples/tool-use-example.ts
@@ -137,7 +137,7 @@ async function runToolConversation(session: ChatSession<Qwen35Model>, userPrompt
       console.log(`   [<-] ${displayResult}`);
 
       console.log('\n[->] Generating follow-up response with tool result...');
-      finalResult = await session.sendToolResult(call.id, toolResult, {
+      finalResult = await session.sendToolResult(call.id, toolResult, undefined, {
         config: {
           tools,
           maxNewTokens: 2048,

--- a/examples/tool-use-example.ts
+++ b/examples/tool-use-example.ts
@@ -137,7 +137,7 @@ async function runToolConversation(session: ChatSession<Qwen35Model>, userPrompt
       console.log(`   [<-] ${displayResult}`);
 
       console.log('\n[->] Generating follow-up response with tool result...');
-      finalResult = await session.sendToolResult(call.id, toolResult, undefined, {
+      finalResult = await session.sendToolResult(call.id, toolResult, {
         config: {
           tools,
           maxNewTokens: 2048,

--- a/packages/cli/src/commands/launch-claude/logger.ts
+++ b/packages/cli/src/commands/launch-claude/logger.ts
@@ -36,6 +36,8 @@ interface UsageSummary {
   prefill_input_tokens?: number;
   cached_prefix_tokens?: number;
   server_model_resolve_ms?: number;
+  server_load_wait_ms?: number;
+  server_load_owner?: boolean;
   server_queue_ms?: number;
   server_pre_inference_ms?: number;
   server_paged_prefill_chunk_size?: number;
@@ -153,6 +155,8 @@ function buildTimingSummary(reqBody: string, resBody: string): string {
 
     const serverParts = [
       fmtMs(usage.server_model_resolve_ms) ? `resolve=${fmtMs(usage.server_model_resolve_ms)}` : undefined,
+      fmtMs(usage.server_load_wait_ms) ? `load_wait=${fmtMs(usage.server_load_wait_ms)}` : undefined,
+      typeof usage.server_load_owner === 'boolean' ? `load_owner=${usage.server_load_owner}` : undefined,
       fmtMs(usage.server_queue_ms) ? `queue=${fmtMs(usage.server_queue_ms)}` : undefined,
       fmtMs(usage.server_pre_inference_ms) ? `pre=${fmtMs(usage.server_pre_inference_ms)}` : undefined,
     ].filter((part): part is string => part != null);

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -275,8 +275,8 @@ export declare class Gemma4Model {
     toolCallId: string,
     content: string,
     config: ChatConfig | null | undefined,
-    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+    isError?: boolean | null | undefined,
   ): Promise<ChatStreamHandle>;
 }
 
@@ -647,8 +647,8 @@ export declare class Lfm2Model {
     toolCallId: string,
     content: string,
     config: ChatConfig | null,
-    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+    isError?: boolean | null | undefined,
   ): Promise<ChatStreamHandle>;
   /** Get the model configuration. */
   getConfig(): Lfm2Config;
@@ -1170,8 +1170,8 @@ export declare class QianfanOCRModel {
     toolCallId: string,
     content: string,
     config: ChatConfig | null | undefined,
-    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+    isError?: boolean | null | undefined,
   ): Promise<ChatStreamHandle>;
 }
 
@@ -1334,8 +1334,8 @@ export declare class Qwen35Model {
     toolCallId: string,
     content: string,
     config: ChatConfig | null,
-    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+    isError?: boolean | null | undefined,
   ): Promise<ChatStreamHandle>;
   /**
    * Get the number of parameters in the model.
@@ -1503,8 +1503,8 @@ export declare class Qwen35MoeModel {
     toolCallId: string,
     content: string,
     config: ChatConfig | null,
-    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+    isError?: boolean | null | undefined,
   ): Promise<ChatStreamHandle>;
   /**
    * Get the number of parameters in the model.
@@ -1667,8 +1667,8 @@ export declare class Qwen3Model {
     toolCallId: string,
     content: string,
     config: ChatConfig | null,
-    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+    isError?: boolean | null | undefined,
   ): Promise<ChatStreamHandle>;
   /**
    * Generate multiple completions for multiple prompts in batch

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -247,8 +247,8 @@ export declare class Gemma4Model {
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
+    isError?: boolean | undefined | null,
   ): Promise<ChatResult>;
   /** Streaming variant of `chatSessionStart`. */
   chatStreamSessionStart(
@@ -274,8 +274,8 @@ export declare class Gemma4Model {
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError: boolean | null | undefined,
     config: ChatConfig | null | undefined,
+    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
 }
@@ -619,8 +619,8 @@ export declare class Lfm2Model {
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
+    isError?: boolean | undefined | null,
   ): Promise<ChatResult>;
   /** Streaming variant of `chatSessionStart`. */
   chatStreamSessionStart(
@@ -646,8 +646,8 @@ export declare class Lfm2Model {
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError: boolean | null | undefined,
     config: ChatConfig | null,
+    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
   /** Get the model configuration. */
@@ -1142,8 +1142,8 @@ export declare class QianfanOCRModel {
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
+    isError?: boolean | undefined | null,
   ): Promise<ChatResult>;
   /** Streaming variant of `chatSessionStart`. */
   chatStreamSessionStart(
@@ -1169,8 +1169,8 @@ export declare class QianfanOCRModel {
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError: boolean | null | undefined,
     config: ChatConfig | null | undefined,
+    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
 }
@@ -1278,8 +1278,8 @@ export declare class Qwen35Model {
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
+    isError?: boolean | undefined | null,
   ): Promise<ChatResult>;
   /**
    * Streaming variant of `chatSessionStart`.
@@ -1333,8 +1333,8 @@ export declare class Qwen35Model {
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError: boolean | null | undefined,
     config: ChatConfig | null,
+    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
   /**
@@ -1447,8 +1447,8 @@ export declare class Qwen35MoeModel {
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
+    isError?: boolean | undefined | null,
   ): Promise<ChatResult>;
   /**
    * Streaming variant of `chatSessionStart`.
@@ -1502,8 +1502,8 @@ export declare class Qwen35MoeModel {
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError: boolean | null | undefined,
     config: ChatConfig | null,
+    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
   /**
@@ -1639,8 +1639,8 @@ export declare class Qwen3Model {
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
+    isError?: boolean | undefined | null,
   ): Promise<ChatResult>;
   /** Streaming variant of `chatSessionStart`. */
   chatStreamSessionStart(
@@ -1666,8 +1666,8 @@ export declare class Qwen3Model {
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError: boolean | null | undefined,
     config: ChatConfig | null,
+    isError: boolean | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
   /**

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -235,11 +235,19 @@ export declare class Gemma4Model {
    * not via an explicit id. Callers may still log it for their own
    * bookkeeping.
    *
+   * `is_error` is the structured tool-error signal. When `Some(true)`,
+   * the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<|turn>tool` block so the model receives a clear text-level
+   * cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+   * pre-feature output.
+   *
    * Requires a live session started via `chatSessionStart`.
    */
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
   ): Promise<ChatResult>;
   /** Streaming variant of `chatSessionStart`. */
@@ -255,10 +263,18 @@ export declare class Gemma4Model {
     config: ChatConfig | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
-  /** Streaming variant of `chatSessionContinueTool`. */
+  /**
+   * Streaming variant of `chatSessionContinueTool`.
+   *
+   * `is_error` mirrors the non-streaming entry point — when
+   * `Some(true)`, the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<|turn>tool` block.
+   */
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError: boolean | null | undefined,
     config: ChatConfig | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
@@ -591,11 +607,19 @@ export declare class Lfm2Model {
  * not via an explicit id. Callers may still log it for their own
  * bookkeeping.
  *
+ * `is_error` is the structured tool-error signal. When `Some(true)`,
+ * the renderer prepends the shared
+ * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+ * `<|im_start|>tool` block so the model receives a clear text-level
+ * cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+ * pre-feature output.
+ *
  * Requires a live session started via `chatSessionStart`.
  */
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
   ): Promise<ChatResult>;
   /** Streaming variant of `chatSessionStart`. */
@@ -611,10 +635,18 @@ export declare class Lfm2Model {
     config: ChatConfig | null,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
-  /** Streaming variant of `chatSessionContinueTool`. */
+  /**
+   * Streaming variant of `chatSessionContinueTool`.
+   *
+   * `is_error` mirrors the non-streaming entry point — when
+   * `Some(true)`, the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<|im_start|>tool` block.
+   */
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError: boolean | null | undefined,
     config: ChatConfig | null,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
@@ -1098,11 +1130,19 @@ export declare class QianfanOCRModel {
    * decodes the model reply. Stops on `<|im_end|>` so the cache stays
    * on a clean turn boundary for the next turn.
    *
+   * `is_error` is the structured tool-error signal. When `Some(true)`,
+   * the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<tool_response>` wrapper so the model receives a clear text-level
+   * cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+   * pre-feature output.
+   *
    * Requires a live session started via `chatSessionStart`.
    */
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
   ): Promise<ChatResult>;
   /** Streaming variant of `chatSessionStart`. */
@@ -1118,10 +1158,18 @@ export declare class QianfanOCRModel {
     config: ChatConfig | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
-  /** Streaming variant of `chatSessionContinueTool`. */
+  /**
+   * Streaming variant of `chatSessionContinueTool`.
+   *
+   * `is_error` mirrors the non-streaming entry point — when
+   * `Some(true)`, the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<tool_response>` wrapper.
+   */
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError: boolean | null | undefined,
     config: ChatConfig | null | undefined,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
@@ -1218,11 +1266,19 @@ export declare class Qwen35Model {
    * wrapper tags, not an explicit id. Callers may still log it for
    * their own bookkeeping.
    *
+   * `is_error` is the structured tool-error signal. When `Some(true)`,
+   * the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<tool_response>` wrapper so the model receives a clear text-level
+   * cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+   * pre-feature output.
+   *
    * Requires a live session started via `chatSessionStart`.
    */
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
   ): Promise<ChatResult>;
   /**
@@ -1269,10 +1325,15 @@ export declare class Qwen35Model {
    * Builds a ChatML tool-response delta on top of the live session
    * caches and streams the decoded reply. Requires a live session
    * started via `chatSessionStart` / `chatStreamSessionStart`.
+   * `is_error` mirrors the non-streaming entry point — when
+   * `Some(true)`, the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<tool_response>` wrapper.
    */
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError: boolean | null | undefined,
     config: ChatConfig | null,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
@@ -1374,11 +1435,19 @@ export declare class Qwen35MoeModel {
    * wrapper tags, not an explicit id. Callers may still log it for
    * their own bookkeeping.
    *
+   * `is_error` is the structured tool-error signal. When `Some(true)`,
+   * the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<tool_response>` wrapper so the model receives a clear text-level
+   * cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+   * pre-feature output.
+   *
    * Requires a live session started via `chatSessionStart`.
    */
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
   ): Promise<ChatResult>;
   /**
@@ -1425,10 +1494,15 @@ export declare class Qwen35MoeModel {
    * Builds a ChatML tool-response delta on top of the live session
    * caches and streams the decoded reply. Requires a live session
    * started via `chatSessionStart` / `chatStreamSessionStart`.
+   * `is_error` mirrors the non-streaming entry point — when
+   * `Some(true)`, the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<tool_response>` wrapper.
    */
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError: boolean | null | undefined,
     config: ChatConfig | null,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
@@ -1553,11 +1627,19 @@ export declare class Qwen3Model {
    * caches, then decodes the assistant reply. Stops on `<|im_end|>`
    * so the cache stays on a clean boundary for the next turn.
    *
+   * `is_error` is the structured tool-error signal. When `Some(true)`,
+   * the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<tool_response>` wrapper so the model receives a clear text-level
+   * cue. `None` / `Some(false)` keep the wire bytes byte-equal to the
+   * pre-feature output.
+   *
    * Requires a live session started via `chatSessionStart`.
    */
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | undefined | null,
     config?: ChatConfig | undefined | null,
   ): Promise<ChatResult>;
   /** Streaming variant of `chatSessionStart`. */
@@ -1573,10 +1655,18 @@ export declare class Qwen3Model {
     config: ChatConfig | null,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
-  /** Streaming variant of `chatSessionContinueTool`. */
+  /**
+   * Streaming variant of `chatSessionContinueTool`.
+   *
+   * `is_error` mirrors the non-streaming entry point — when
+   * `Some(true)`, the renderer prepends the shared
+   * [`crate::tokenizer::TOOL_ERROR_MARKER`] inside the
+   * `<tool_response>` wrapper.
+   */
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError: boolean | null | undefined,
     config: ChatConfig | null,
     callback: (err: Error | null, chunk: ChatStreamChunk) => void,
   ): Promise<ChatStreamHandle>;
@@ -2314,6 +2404,23 @@ export interface ChatMessage {
   toolCalls?: Array<ToolCall>;
   /** Tool call ID this message is responding to (for tool messages) */
   toolCallId?: string;
+  /**
+   * Whether this tool-role message represents an errored tool result.
+   *
+   * Authoritative, structured signal of tool-call failure. Set to
+   * `Some(true)` when the caller (e.g. the Anthropic
+   * `tool_result.is_error === true` translator) wants the model to
+   * treat the tool output as an error. The renderer prepends a short
+   * `[tool error]` prefix to `content` when emitting the wire-format
+   * tool response so the model receives a clear text-level cue, but
+   * the original `content` stays byte-for-byte intact in the
+   * structured form — no JSON wrapping, no in-band marker that could
+   * collide with a successful tool result whose literal content
+   * happens to start with the same prefix.
+   *
+   * `None` / `Some(false)` produce the unmarked wire format.
+   */
+  isError?: boolean;
   /** Reasoning content for thinking mode (used with <think> tags) */
   reasoningContent?: string;
   /** Image data for VLM models (encoded image bytes: PNG/JPEG, passed as Uint8Array/Buffer) */

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -228,8 +228,8 @@ export interface SessionCapableModel {
     toolCallId: string,
     content: string,
     config?: ChatConfig | null,
-    isError?: boolean | null,
     signal?: AbortSignal,
+    isError?: boolean | null,
   ): AsyncGenerator<ChatStreamEvent>;
   resetCaches(): void;
   /**
@@ -704,8 +704,8 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
           toolCallId,
           content,
           mergedConfig,
-          isError ?? null,
           signal,
+          isError ?? null,
         )) {
           if (event.done) {
             if (event.finishReason !== 'error') {

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -201,8 +201,8 @@ export interface SessionCapableModel {
   chatSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | null,
     config?: ChatConfig | null,
+    isError?: boolean | null,
   ): Promise<ChatResult>;
   /**
    * The optional `signal` parameter on every streaming entry point is
@@ -227,8 +227,8 @@ export interface SessionCapableModel {
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | null,
     config?: ChatConfig | null,
+    isError?: boolean | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent>;
   resetCaches(): void;
@@ -661,7 +661,7 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
     try {
       const { isError, config } = opts;
       const mergedConfig = this.mergeConfig(config);
-      const result = await this.model.chatSessionContinueTool(toolCallId, content, isError ?? null, mergedConfig);
+      const result = await this.model.chatSessionContinueTool(toolCallId, content, mergedConfig, isError ?? null);
       this.history.push({ role: 'tool', content, toolCallId, isError });
       this.history.push(buildAssistantMessage(result.text, result.toolCalls));
       this.turnCount++;
@@ -703,8 +703,8 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
         for await (const event of this.model.chatStreamSessionContinueTool(
           toolCallId,
           content,
-          isError ?? null,
           mergedConfig,
+          isError ?? null,
           signal,
         )) {
           if (event.done) {

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -198,7 +198,12 @@ export interface SessionCapableModel {
     images: Uint8Array[] | null,
     config?: ChatConfig | null,
   ): Promise<ChatResult>;
-  chatSessionContinueTool(toolCallId: string, content: string, config?: ChatConfig | null): Promise<ChatResult>;
+  chatSessionContinueTool(
+    toolCallId: string,
+    content: string,
+    isError?: boolean | null,
+    config?: ChatConfig | null,
+  ): Promise<ChatResult>;
   /**
    * The optional `signal` parameter on every streaming entry point is
    * plumbed into the `_runChatStream` fast-abort path in the wrapper
@@ -222,6 +227,7 @@ export interface SessionCapableModel {
   chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | null,
     config?: ChatConfig | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent>;
@@ -628,9 +634,26 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
    * hit this must tighten the prompt / tool spec or reset the
    * session.
    *
+   * `isError` is the structured tool-error signal. When `true`, the
+   * native renderer prepends a short, model-facing error marker to
+   * `content` inside the wire-format tool block so the model
+   * receives a clear text-level cue that the tool result represents
+   * a failure. The structured field is stored verbatim on the
+   * appended `{ role: 'tool', ... }` history entry so cold-replay
+   * (image-change restart, `startFromHistory*`, server-side
+   * `SessionRegistry` cache-miss rebuild) re-renders the marker
+   * consistently with the live turn. Defaults to `undefined` (no
+   * marker). Pass through verbatim — we do NOT infer error from
+   * `content`.
+   *
    * Appends a `{ role: 'tool', ... }` message to history on success.
    */
-  async sendToolResult(toolCallId: string, content: string, opts: { config?: ChatConfig } = {}): Promise<ChatResult> {
+  async sendToolResult(
+    toolCallId: string,
+    content: string,
+    isError?: boolean,
+    opts: { config?: ChatConfig } = {},
+  ): Promise<ChatResult> {
     if (this.inFlight) {
       throw new Error('ChatSession: concurrent send() not allowed; await the previous call first');
     }
@@ -638,8 +661,8 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
     this.inFlight = true;
     try {
       const mergedConfig = this.mergeConfig(opts.config);
-      const result = await this.model.chatSessionContinueTool(toolCallId, content, mergedConfig);
-      this.history.push({ role: 'tool', content, toolCallId });
+      const result = await this.model.chatSessionContinueTool(toolCallId, content, isError ?? null, mergedConfig);
+      this.history.push({ role: 'tool', content, toolCallId, isError });
       this.history.push(buildAssistantMessage(result.text, result.toolCalls));
       this.turnCount++;
       this.recordToolCallFanout(result.toolCalls);
@@ -649,10 +672,20 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
     }
   }
 
-  /** Streaming variant of {@link ChatSession#sendToolResult}. */
+  /**
+   * Streaming variant of {@link ChatSession#sendToolResult}.
+   *
+   * `isError` mirrors the non-streaming entry point — when `true`,
+   * the native renderer prepends a short, model-facing error marker
+   * to `content` inside the wire-format tool block. The structured
+   * field is stored verbatim on the appended `{ role: 'tool', ... }`
+   * history entry so cold-replay re-renders the marker consistently
+   * with the live streaming turn.
+   */
   async *sendToolResultStream(
     toolCallId: string,
     content: string,
+    isError?: boolean,
     opts: { config?: ChatConfig; signal?: AbortSignal } = {},
   ): AsyncGenerator<ChatStreamEvent> {
     if (this.inFlight) {
@@ -670,6 +703,7 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
         for await (const event of this.model.chatStreamSessionContinueTool(
           toolCallId,
           content,
+          isError ?? null,
           mergedConfig,
           opts.signal,
         )) {
@@ -690,7 +724,7 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
         // and error-finish chunks alike. Tool turns never touch
         // history until commit, so the rollback branch is a no-op.
         if (sawFinal) {
-          this.history.push({ role: 'tool', content, toolCallId });
+          this.history.push({ role: 'tool', content, toolCallId, isError });
           this.history.push(buildAssistantMessage(finalRaw ?? accumulated, finalToolCalls));
           this.turnCount++;
           this.recordToolCallFanout(finalToolCalls);

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -651,8 +651,7 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
   async sendToolResult(
     toolCallId: string,
     content: string,
-    isError?: boolean,
-    opts: { config?: ChatConfig } = {},
+    opts: { isError?: boolean; config?: ChatConfig } = {},
   ): Promise<ChatResult> {
     if (this.inFlight) {
       throw new Error('ChatSession: concurrent send() not allowed; await the previous call first');
@@ -660,7 +659,8 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
     this.assertCanSendToolResult('sendToolResult');
     this.inFlight = true;
     try {
-      const mergedConfig = this.mergeConfig(opts.config);
+      const { isError, config } = opts;
+      const mergedConfig = this.mergeConfig(config);
       const result = await this.model.chatSessionContinueTool(toolCallId, content, isError ?? null, mergedConfig);
       this.history.push({ role: 'tool', content, toolCallId, isError });
       this.history.push(buildAssistantMessage(result.text, result.toolCalls));
@@ -685,8 +685,7 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
   async *sendToolResultStream(
     toolCallId: string,
     content: string,
-    isError?: boolean,
-    opts: { config?: ChatConfig; signal?: AbortSignal } = {},
+    opts: { isError?: boolean; config?: ChatConfig; signal?: AbortSignal } = {},
   ): AsyncGenerator<ChatStreamEvent> {
     if (this.inFlight) {
       throw new Error('ChatSession: concurrent send() not allowed; await the previous call first');
@@ -694,7 +693,8 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
     this.assertCanSendToolResult('sendToolResultStream');
     this.inFlight = true;
     try {
-      const mergedConfig = this.mergeConfig(opts.config);
+      const { isError, config, signal } = opts;
+      const mergedConfig = this.mergeConfig(config);
       let sawFinal = false;
       let accumulated = '';
       let finalRaw: string | null = null;
@@ -705,7 +705,7 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
           content,
           isError ?? null,
           mergedConfig,
-          opts.signal,
+          signal,
         )) {
           if (event.done) {
             if (event.finishReason !== 'error') {

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -414,8 +414,8 @@ export class Qwen35Model extends Qwen35ModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | null,
     config?: ChatConfig | null,
+    isError?: boolean | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
@@ -424,8 +424,8 @@ export class Qwen35Model extends Qwen35ModelNative {
           this,
           toolCallId,
           content,
-          isError ?? null,
           config ?? null,
+          isError ?? null,
           callback,
         ),
       signal,
@@ -490,8 +490,8 @@ export class Qwen35MoeModel extends Qwen35MoeModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | null,
     config?: ChatConfig | null,
+    isError?: boolean | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
@@ -500,8 +500,8 @@ export class Qwen35MoeModel extends Qwen35MoeModelNative {
           this,
           toolCallId,
           content,
-          isError ?? null,
           config ?? null,
+          isError ?? null,
           callback,
         ),
       signal,
@@ -568,8 +568,8 @@ export class Lfm2Model extends Lfm2ModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | null,
     config?: ChatConfig | null,
+    isError?: boolean | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
@@ -578,8 +578,8 @@ export class Lfm2Model extends Lfm2ModelNative {
           this,
           toolCallId,
           content,
-          isError ?? null,
           config ?? null,
+          isError ?? null,
           callback,
         ),
       signal,
@@ -646,8 +646,8 @@ export class Gemma4Model extends Gemma4ModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | null,
     config?: ChatConfig | null,
+    isError?: boolean | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
@@ -656,8 +656,8 @@ export class Gemma4Model extends Gemma4ModelNative {
           this,
           toolCallId,
           content,
-          isError ?? null,
           config ?? null,
+          isError ?? null,
           callback,
         ),
       signal,
@@ -715,8 +715,8 @@ export class Qwen3Model extends Qwen3ModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | null,
     config?: ChatConfig | null,
+    isError?: boolean | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
@@ -725,8 +725,8 @@ export class Qwen3Model extends Qwen3ModelNative {
           this,
           toolCallId,
           content,
-          isError ?? null,
           config ?? null,
+          isError ?? null,
           callback,
         ),
       signal,

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -415,8 +415,8 @@ export class Qwen35Model extends Qwen35ModelNative {
     toolCallId: string,
     content: string,
     config?: ChatConfig | null,
-    isError?: boolean | null,
     signal?: AbortSignal,
+    isError?: boolean | null,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
       (callback) =>
@@ -425,8 +425,8 @@ export class Qwen35Model extends Qwen35ModelNative {
           toolCallId,
           content,
           config ?? null,
-          isError ?? null,
           callback,
+          isError ?? null,
         ),
       signal,
     );
@@ -491,8 +491,8 @@ export class Qwen35MoeModel extends Qwen35MoeModelNative {
     toolCallId: string,
     content: string,
     config?: ChatConfig | null,
-    isError?: boolean | null,
     signal?: AbortSignal,
+    isError?: boolean | null,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
       (callback) =>
@@ -501,8 +501,8 @@ export class Qwen35MoeModel extends Qwen35MoeModelNative {
           toolCallId,
           content,
           config ?? null,
-          isError ?? null,
           callback,
+          isError ?? null,
         ),
       signal,
     );
@@ -569,8 +569,8 @@ export class Lfm2Model extends Lfm2ModelNative {
     toolCallId: string,
     content: string,
     config?: ChatConfig | null,
-    isError?: boolean | null,
     signal?: AbortSignal,
+    isError?: boolean | null,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
       (callback) =>
@@ -579,8 +579,8 @@ export class Lfm2Model extends Lfm2ModelNative {
           toolCallId,
           content,
           config ?? null,
-          isError ?? null,
           callback,
+          isError ?? null,
         ),
       signal,
     );
@@ -647,8 +647,8 @@ export class Gemma4Model extends Gemma4ModelNative {
     toolCallId: string,
     content: string,
     config?: ChatConfig | null,
-    isError?: boolean | null,
     signal?: AbortSignal,
+    isError?: boolean | null,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
       (callback) =>
@@ -657,8 +657,8 @@ export class Gemma4Model extends Gemma4ModelNative {
           toolCallId,
           content,
           config ?? null,
-          isError ?? null,
           callback,
+          isError ?? null,
         ),
       signal,
     );
@@ -716,8 +716,8 @@ export class Qwen3Model extends Qwen3ModelNative {
     toolCallId: string,
     content: string,
     config?: ChatConfig | null,
-    isError?: boolean | null,
     signal?: AbortSignal,
+    isError?: boolean | null,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
       (callback) =>
@@ -726,8 +726,8 @@ export class Qwen3Model extends Qwen3ModelNative {
           toolCallId,
           content,
           config ?? null,
-          isError ?? null,
           callback,
+          isError ?? null,
         ),
       signal,
     );

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -406,17 +406,28 @@ export class Qwen35Model extends Qwen35ModelNative {
    * Builds a ChatML `<tool_response>` delta on top of the live
    * session caches and streams the decoded assistant reply. Requires
    * a live session started via `chatSessionStart` /
-   * `chatStreamSessionStart`.
+   * `chatStreamSessionStart`. `isError` is forwarded to the native
+   * renderer — see `chatSessionContinueTool` for the wire-format
+   * marker semantics.
    */
   // @ts-expect-error — override callback-based native method with AsyncGenerator
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | null,
     config?: ChatConfig | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
-      (callback) => _nativeDenseChatStreamSessionContinueTool.call(this, toolCallId, content, config ?? null, callback),
+      (callback) =>
+        _nativeDenseChatStreamSessionContinueTool.call(
+          this,
+          toolCallId,
+          content,
+          isError ?? null,
+          config ?? null,
+          callback,
+        ),
       signal,
     );
   }
@@ -479,11 +490,20 @@ export class Qwen35MoeModel extends Qwen35MoeModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | null,
     config?: ChatConfig | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
-      (callback) => _nativeMoeChatStreamSessionContinueTool.call(this, toolCallId, content, config ?? null, callback),
+      (callback) =>
+        _nativeMoeChatStreamSessionContinueTool.call(
+          this,
+          toolCallId,
+          content,
+          isError ?? null,
+          config ?? null,
+          callback,
+        ),
       signal,
     );
   }
@@ -548,11 +568,20 @@ export class Lfm2Model extends Lfm2ModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | null,
     config?: ChatConfig | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
-      (callback) => _nativeLfm2ChatStreamSessionContinueTool.call(this, toolCallId, content, config ?? null, callback),
+      (callback) =>
+        _nativeLfm2ChatStreamSessionContinueTool.call(
+          this,
+          toolCallId,
+          content,
+          isError ?? null,
+          config ?? null,
+          callback,
+        ),
       signal,
     );
   }
@@ -617,12 +646,20 @@ export class Gemma4Model extends Gemma4ModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | null,
     config?: ChatConfig | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
       (callback) =>
-        _nativeGemma4ChatStreamSessionContinueTool.call(this, toolCallId, content, config ?? null, callback),
+        _nativeGemma4ChatStreamSessionContinueTool.call(
+          this,
+          toolCallId,
+          content,
+          isError ?? null,
+          config ?? null,
+          callback,
+        ),
       signal,
     );
   }
@@ -678,11 +715,20 @@ export class Qwen3Model extends Qwen3ModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | null,
     config?: ChatConfig | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
-      (callback) => _nativeQwen3ChatStreamSessionContinueTool.call(this, toolCallId, content, config ?? null, callback),
+      (callback) =>
+        _nativeQwen3ChatStreamSessionContinueTool.call(
+          this,
+          toolCallId,
+          content,
+          isError ?? null,
+          config ?? null,
+          callback,
+        ),
       signal,
     );
   }

--- a/packages/lm/src/tools/index.ts
+++ b/packages/lm/src/tools/index.ts
@@ -45,7 +45,7 @@
  * const call = okCalls[0];
  * if (call) {
  *   const toolOutput = await executeMyTool(call.name, call.arguments);
- *   const followUp = await session.sendToolResult(call.id, JSON.stringify(toolOutput), undefined, {
+ *   const followUp = await session.sendToolResult(call.id, JSON.stringify(toolOutput), {
  *     config: { tools: [weatherTool] },
  *   });
  *   console.log(followUp.text);

--- a/packages/lm/src/tools/index.ts
+++ b/packages/lm/src/tools/index.ts
@@ -45,7 +45,7 @@
  * const call = okCalls[0];
  * if (call) {
  *   const toolOutput = await executeMyTool(call.name, call.arguments);
- *   const followUp = await session.sendToolResult(call.id, JSON.stringify(toolOutput), {
+ *   const followUp = await session.sendToolResult(call.id, JSON.stringify(toolOutput), undefined, {
  *     config: { tools: [weatherTool] },
  *   });
  *   console.log(followUp.text);

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -80,6 +80,7 @@ import {
   buildMessageStartEvent,
   buildMessageStop,
   containsToolCallMarkup,
+  internalToolCallIdToAnthropic,
   recoverSuppressedToolCallText,
   mapStopReason,
 } from '../mappers/anthropic-response.js';
@@ -269,6 +270,16 @@ async function handleStreamingNative(
   let hasEmittedThinking = false;
   let hasEmittedText = false;
   let emittedTextLength = 0;
+  // Whitespace-only text seen before any non-whitespace content is buffered
+  // here so we don't open a text content block that the client would have
+  // to render as a stray `"\n\n"` immediately before a tool_use block.
+  // Flushed lazily when the first non-whitespace text delta arrives;
+  // dropped silently when a non-text block (tool_use) is about to open or
+  // when the stream ends without further text. Once `hasEmittedText` flips
+  // true (a real text block exists) this buffer is no longer consulted —
+  // subsequent whitespace-only deltas pass through to keep streamed text
+  // byte-accurate.
+  let pendingLeadingWhitespace = '';
   // Mirror of the actual streamed text body, used by the malformed-tool-call
   // recovery branches below. `emittedTextLength` counts bytes of streamed text
   // — but `event.text` on the terminal `done` chunk is the post-</think>-trim
@@ -355,30 +366,40 @@ async function handleStreamingNative(
 
         const remainingText = tagBuffer.flush();
         if (!tagBuffer.suppressed && remainingText) {
-          if (!hasEmittedText) {
-            if (hasEmittedThinking) {
-              writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
+          // Flush any pending leading whitespace alongside the residual
+          // text — once a real text block opens, its declared content
+          // must be byte-accurate, so the buffered whitespace is
+          // promoted to the head of that block. If `remainingText`
+          // itself is whitespace-only and there is no buffered
+          // whitespace, `combined.trim()` is empty and we drop both.
+          const combined = pendingLeadingWhitespace + remainingText;
+          pendingLeadingWhitespace = '';
+          if (hasEmittedText || combined.trim().length > 0) {
+            if (!hasEmittedText) {
+              if (hasEmittedThinking) {
+                writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
+              }
+              hasEmittedText = true;
+              writeSSEEvent(
+                res,
+                'content_block_start',
+                buildContentBlockStart(contentBlockIndex, {
+                  type: 'text',
+                  text: '',
+                }),
+              );
             }
-            hasEmittedText = true;
+            emittedText += combined;
+            emittedTextLength += combined.length;
             writeSSEEvent(
               res,
-              'content_block_start',
-              buildContentBlockStart(contentBlockIndex, {
-                type: 'text',
-                text: '',
+              'content_block_delta',
+              buildContentBlockDelta(contentBlockIndex, {
+                type: 'text_delta',
+                text: combined,
               }),
             );
           }
-          emittedText += remainingText;
-          emittedTextLength += remainingText.length;
-          writeSSEEvent(
-            res,
-            'content_block_delta',
-            buildContentBlockDelta(contentBlockIndex, {
-              type: 'text_delta',
-              text: remainingText,
-            }),
-          );
         }
 
         if (hasEmittedThinking && !hasEmittedText) {
@@ -495,10 +516,17 @@ async function handleStreamingNative(
         if (hasEmittedText) {
           writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
           contentBlockIndex++;
+          pendingLeadingWhitespace = '';
         } else if (!finalText && hasToolCalls) {
-          // Pure tool-call turn — no text block.
+          // Pure tool-call turn — no text block. Drop any leading
+          // whitespace we had buffered before the `<tool_call>` tag.
+          pendingLeadingWhitespace = '';
         } else if (finalText) {
-          // All text arrived in the final event; emit it as a single block.
+          // All text arrived in the final event; emit it as a single
+          // block. Prepend any pending leading whitespace so the block's
+          // byte-content matches what the model actually produced.
+          const combined = pendingLeadingWhitespace + finalText;
+          pendingLeadingWhitespace = '';
           writeSSEEvent(
             res,
             'content_block_start',
@@ -507,22 +535,31 @@ async function handleStreamingNative(
               text: '',
             }),
           );
-          emittedText += finalText;
-          emittedTextLength += finalText.length;
+          emittedText += combined;
+          emittedTextLength += combined.length;
           writeSSEEvent(
             res,
             'content_block_delta',
             buildContentBlockDelta(contentBlockIndex, {
               type: 'text_delta',
-              text: finalText,
+              text: combined,
             }),
           );
           writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
           contentBlockIndex++;
+        } else {
+          // No text emission at all this turn — drop the buffer.
+          pendingLeadingWhitespace = '';
         }
 
         for (const tc of okToolCalls) {
-          const toolId = tc.id ?? genId('toolu_');
+          // Translate native `call_<uuid>` ids (minted by the Rust parser,
+          // which keeps the OpenAI Responses convention) into the
+          // Anthropic-spec `toolu_<uuid>` shape at the wire boundary.
+          // The `genId('toolu_')` fallback covers the case where the
+          // native side did not populate an id (an in-process driver or
+          // a legacy bridge).
+          const toolId = tc.id != null ? internalToolCallIdToAnthropic(tc.id) : genId('toolu_');
           const parsedInput =
             typeof tc.arguments === 'string'
               ? (JSON.parse(tc.arguments) as Record<string, unknown>)
@@ -593,6 +630,13 @@ async function handleStreamingNative(
         // markers are transport structure, not user-visible text.
         const { safeText, tagFound, cleanPrefix } = tagBuffer.push(event.text);
         if (tagFound) {
+          // A structural tag (`<tool_call>` etc.) follows. Any pending
+          // leading whitespace we were holding back semantically belongs
+          // to the tool-call transition, not to a user-visible text
+          // block — drop it so the SSE wire never carries a stray
+          // whitespace-only `content_block_start`/`_stop` pair before
+          // the tool_use frame.
+          pendingLeadingWhitespace = '';
           if (cleanPrefix.trim()) {
             if (!hasEmittedText) {
               if (hasEmittedThinking) {
@@ -621,29 +665,55 @@ async function handleStreamingNative(
           }
         } else if (safeText) {
           if (!hasEmittedText) {
-            if (hasEmittedThinking) {
-              writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
+            // Hold back leading whitespace-only text so a `\n\n` emitted
+            // right before a `<tool_call>` tag never gets ratified into a
+            // standalone text content block. We can't open the block now
+            // because we don't yet know whether the next event is a real
+            // text delta (in which case the buffered prefix is flushed
+            // together with it) or a structural tag (in which case the
+            // buffer is dropped silently at tag-found / done time). When
+            // any non-whitespace arrives we ratify the block exactly
+            // once with `pendingLeadingWhitespace + safeText`.
+            const combined = pendingLeadingWhitespace + safeText;
+            if (combined.trim().length === 0) {
+              pendingLeadingWhitespace = combined;
+            } else {
+              if (hasEmittedThinking) {
+                writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
+              }
+              hasEmittedText = true;
+              writeSSEEvent(
+                res,
+                'content_block_start',
+                buildContentBlockStart(contentBlockIndex, {
+                  type: 'text',
+                  text: '',
+                }),
+              );
+              pendingLeadingWhitespace = '';
+              emittedText += combined;
+              emittedTextLength += combined.length;
+              writeSSEEvent(
+                res,
+                'content_block_delta',
+                buildContentBlockDelta(contentBlockIndex, {
+                  type: 'text_delta',
+                  text: combined,
+                }),
+              );
             }
-            hasEmittedText = true;
+          } else {
+            emittedText += safeText;
+            emittedTextLength += safeText.length;
             writeSSEEvent(
               res,
-              'content_block_start',
-              buildContentBlockStart(contentBlockIndex, {
-                type: 'text',
-                text: '',
+              'content_block_delta',
+              buildContentBlockDelta(contentBlockIndex, {
+                type: 'text_delta',
+                text: safeText,
               }),
             );
           }
-          emittedText += safeText;
-          emittedTextLength += safeText.length;
-          writeSSEEvent(
-            res,
-            'content_block_delta',
-            buildContentBlockDelta(contentBlockIndex, {
-              type: 'text_delta',
-              text: safeText,
-            }),
-          );
         }
       }
     }
@@ -850,6 +920,14 @@ export async function handleCreateMessage(
 ): Promise<void> {
   const handlerStartedAt = Date.now();
   let serverModelResolveMs: number | undefined;
+  // Split observability for the resolve path: a request that arrives
+  // milliseconds after a peer's cold-load should not be billed the full
+  // load latency as if it drove the load itself. `serverLoadWaitMs`
+  // captures wall-clock spent blocked on the writer lock (whether
+  // waiting on a peer or self-loading); `serverLoadOwner` is true only
+  // when this request acquired the lock without contention.
+  let serverLoadWaitMs: number | undefined;
+  let serverLoadOwner: boolean | undefined;
 
   if (body == null || typeof body !== 'object') {
     sendAnthropicBadRequest(res, 'Request body must be a JSON object');
@@ -921,9 +999,32 @@ export async function handleCreateMessage(
       const resolveStartedAt = Date.now();
       const runResolve = () =>
         idleSweeper ? idleSweeper.withSuspendedDrains(() => resolveModel(body.model)) : resolveModel(body.model);
-      if (modelWorkCoordinator) await modelWorkCoordinator.withModelLoad(runResolve);
-      else await runResolve();
-      serverModelResolveMs = Date.now() - resolveStartedAt;
+      if (modelWorkCoordinator) {
+        // Use the instrumented variant so we can tell whether this
+        // request actually drove the load (owner) or merely parked
+        // behind a peer's in-flight load. Without the split, two
+        // requests racing into a 60s cold-load both report
+        // `resolve_ms=60000` and observers can't tell which one paid
+        // the cost vs. inherited the wait.
+        //
+        // The coordinator internally partitions the call into a wait
+        // phase (`acquireWrite()`) and an own-execution phase (`fn`)
+        // so `waitMs + ownMs` covers the total elapsed time without
+        // overlap. We plumb them straight through into the matching
+        // observability fields:
+        //  - owner driving a cold load → waitMs ≈ 0, ownMs ≈ load duration
+        //  - follower parked behind peer → waitMs ≈ peer load, ownMs ≈ 0
+        //  - already-loaded fast path  → waitMs ≈ 0, ownMs ≈ 0
+        // This matches the documented contract in `timing.ts` where
+        // `server_model_resolve_ms` excludes peer-wait time.
+        const outcome = await modelWorkCoordinator.withModelLoadInstrumented(runResolve);
+        serverLoadOwner = outcome.owner;
+        serverLoadWaitMs = outcome.waitMs;
+        serverModelResolveMs = outcome.ownMs;
+      } else {
+        await runResolve();
+        serverModelResolveMs = Date.now() - resolveStartedAt;
+      }
     } catch (err) {
       sendAnthropicInternalError(res, err instanceof Error ? err.message : 'Failed to resolve model');
       return;
@@ -1071,6 +1172,8 @@ export async function handleCreateMessage(
         withAdmissionControlledInference(sessionReg, modelWorkCoordinator, async () => {
           const serverTiming: ServerTimingForUsage = {
             server_model_resolve_ms: serverModelResolveMs,
+            server_load_wait_ms: serverLoadWaitMs,
+            server_load_owner: serverLoadOwner,
             server_queue_ms: Date.now() - mutexQueuedAt,
             server_pre_inference_ms: Date.now() - handlerStartedAt,
             ...resolveServerTuningForUsage(),

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -523,9 +523,12 @@ async function handleStreamingNative(
           pendingLeadingWhitespace = '';
         } else if (finalText) {
           // All text arrived in the final event; emit it as a single
-          // block. Prepend any pending leading whitespace so the block's
-          // byte-content matches what the model actually produced.
-          const combined = pendingLeadingWhitespace + finalText;
+          // block. `finalText` is the FULL accumulated text from the
+          // native side, NOT a delta — any whitespace we buffered in
+          // `pendingLeadingWhitespace` from intermediate whitespace-only
+          // deltas is already part of `finalText`, so prepending the
+          // buffer here would double-emit those bytes. Drop the buffer
+          // and emit `finalText` verbatim.
           pendingLeadingWhitespace = '';
           writeSSEEvent(
             res,
@@ -535,14 +538,14 @@ async function handleStreamingNative(
               text: '',
             }),
           );
-          emittedText += combined;
-          emittedTextLength += combined.length;
+          emittedText += finalText;
+          emittedTextLength += finalText.length;
           writeSSEEvent(
             res,
             'content_block_delta',
             buildContentBlockDelta(contentBlockIndex, {
               type: 'text_delta',
-              text: combined,
+              text: finalText,
             }),
           );
           writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
@@ -630,14 +633,20 @@ async function handleStreamingNative(
         // markers are transport structure, not user-visible text.
         const { safeText, tagFound, cleanPrefix } = tagBuffer.push(event.text);
         if (tagFound) {
-          // A structural tag (`<tool_call>` etc.) follows. Any pending
-          // leading whitespace we were holding back semantically belongs
-          // to the tool-call transition, not to a user-visible text
-          // block — drop it so the SSE wire never carries a stray
+          // A structural tag (`<tool_call>` etc.) follows. When the
+          // chunk has visible text BEFORE the tag (`cleanPrefix.trim()`
+          // non-empty), the buffered leading whitespace semantically
+          // belongs to that visible text — they were one logical text
+          // run that just happened to land split across deltas. Combine
+          // them and emit as a single text_delta so the wire preserves
+          // exactly what the model produced. When the chunk is a pure
+          // tag transition (no visible prefix), the buffered whitespace
+          // is dropped so the wire never carries a stray
           // whitespace-only `content_block_start`/`_stop` pair before
           // the tool_use frame.
-          pendingLeadingWhitespace = '';
           if (cleanPrefix.trim()) {
+            const combined = pendingLeadingWhitespace + cleanPrefix;
+            pendingLeadingWhitespace = '';
             if (!hasEmittedText) {
               if (hasEmittedThinking) {
                 writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
@@ -652,16 +661,18 @@ async function handleStreamingNative(
                 }),
               );
             }
-            emittedText += cleanPrefix;
-            emittedTextLength += cleanPrefix.length;
+            emittedText += combined;
+            emittedTextLength += combined.length;
             writeSSEEvent(
               res,
               'content_block_delta',
               buildContentBlockDelta(contentBlockIndex, {
                 type: 'text_delta',
-                text: cleanPrefix,
+                text: combined,
               }),
             );
+          } else {
+            pendingLeadingWhitespace = '';
           }
         } else if (safeText) {
           if (!hasEmittedText) {

--- a/packages/server/src/endpoints/responses.ts
+++ b/packages/server/src/endpoints/responses.ts
@@ -1411,7 +1411,7 @@ async function runSessionNonStreaming(
       // with the Anthropic `tool_result.is_error === true` source field
       // (the structured channel is the authoritative signal — see
       // `ChatMessage.isError` rustdoc).
-      const result = await session.sendToolResult(last.toolCallId, last.content, last.isError, { config });
+      const result = await session.sendToolResult(last.toolCallId, last.content, { config, isError: last.isError });
       return { result, committed: session.turns > initialTurns };
     }
     // Non-user / non-tool single-message continuation (assistant /
@@ -1497,7 +1497,7 @@ async function runSessionStreaming(
         // renderer so the streaming wire-format `[tool error]` marker
         // stays in sync with the Anthropic `tool_result.is_error === true`
         // source field — same contract as the non-streaming path above.
-        stream: session.sendToolResultStream(last.toolCallId, last.content, last.isError, { config, signal }),
+        stream: session.sendToolResultStream(last.toolCallId, last.content, { config, signal, isError: last.isError }),
         wasCommitted: () => session.turns > initialTurns,
       };
     }

--- a/packages/server/src/endpoints/responses.ts
+++ b/packages/server/src/endpoints/responses.ts
@@ -1406,7 +1406,12 @@ async function runSessionNonStreaming(
         throw new Error('tool message missing toolCallId');
       }
       const initialTurns = session.turns;
-      const result = await session.sendToolResult(last.toolCallId, last.content, { config });
+      // Forward the structured `isError` field through to the native
+      // renderer so the wire-format `[tool error]` marker stays in sync
+      // with the Anthropic `tool_result.is_error === true` source field
+      // (the structured channel is the authoritative signal — see
+      // `ChatMessage.isError` rustdoc).
+      const result = await session.sendToolResult(last.toolCallId, last.content, last.isError, { config });
       return { result, committed: session.turns > initialTurns };
     }
     // Non-user / non-tool single-message continuation (assistant /
@@ -1488,7 +1493,11 @@ async function runSessionStreaming(
       }
       const initialTurns = session.turns;
       return {
-        stream: session.sendToolResultStream(last.toolCallId, last.content, { config, signal }),
+        // Forward the structured `isError` field through to the native
+        // renderer so the streaming wire-format `[tool error]` marker
+        // stays in sync with the Anthropic `tool_result.is_error === true`
+        // source field — same contract as the non-streaming path above.
+        stream: session.sendToolResultStream(last.toolCallId, last.content, last.isError, { config, signal }),
         wasCommitted: () => session.turns > initialTurns,
       };
     }

--- a/packages/server/src/mappers/anthropic-request.ts
+++ b/packages/server/src/mappers/anthropic-request.ts
@@ -11,6 +11,7 @@ import type {
   AnthropicToolDefinition,
   SystemBlock,
 } from '../types-anthropic.js';
+import { anthropicToolUseIdToInternal } from './anthropic-response.js';
 
 export interface MappedAnthropicRequest {
   messages: ChatMessage[];
@@ -200,8 +201,15 @@ export function mapAnthropicRequest(
             }
             seenToolResult = true;
             const resolved = resolveToolResultContent(block.content);
+            // Anthropic clients echo back the same `toolu_<uuid>` we
+            // emitted on the prior assistant turn. Translate it back to
+            // the internal `call_<uuid>` shape so the native session
+            // store's tool_call_id lookup (which sees the original
+            // `call_*` id) still matches. Ids that lack the `toolu_`
+            // prefix (legacy callers that already speak the internal
+            // shape) pass through unchanged.
             toolResults.push({
-              toolCallId: block.tool_use_id,
+              toolCallId: anthropicToolUseIdToInternal(block.tool_use_id),
               content: resolved.text,
               isError: block.is_error === true,
             });
@@ -226,20 +234,32 @@ export function mapAnthropicRequest(
         }
 
         if (seenToolResult) {
-          // `ChatMessage` (NAPI-generated) has no `isError` field, so
-          // Anthropic's `tool_result.is_error=true` is encoded as a JSON
-          // envelope `{ "is_error": true, "content": <original> }`. The
-          // envelope preserves the raw payload verbatim (unlike a text
-          // prefix, which would corrupt JSON payloads and collide with
-          // strings that legitimately start with the prefix). Every other
-          // wire shape is a successful tool result.
+          // The structured `isError` field on the internal `ChatMessage`
+          // is the authoritative signal of tool-call failure (mirroring
+          // the existing `toolCallId` pattern). Pass `tr.content`
+          // through verbatim — no JSON envelope, no in-band marker — and
+          // surface the error condition via the dedicated structured
+          // field. The Rust-side wire-format renderers (Jinja serializer
+          // for the cold-start path, ChatML formatter for the fallback
+          // template) inject a short model-facing `[tool error]` cue
+          // into the prompt when `isError === true`, but the
+          // `ChatMessage.content` itself stays byte-for-byte equal to
+          // the original payload so a successful tool result whose
+          // content happens to start with the same marker text cannot
+          // be confused with an errored one on read-back. Neither
+          // mlx-lm nor mlx-vlm have a precedent for an in-band marker
+          // here; the structured-field approach matches how
+          // `toolCallId` is plumbed and survives round-tripping cleanly.
           for (const tr of toolResults) {
-            const encoded = tr.isError ? JSON.stringify({ is_error: true, content: tr.content }) : tr.content;
-            messages.push({
+            const msg: ChatMessage = {
               role: 'tool',
-              content: encoded,
+              content: tr.content,
               toolCallId: tr.toolCallId,
-            });
+            };
+            if (tr.isError) {
+              msg.isError = true;
+            }
+            messages.push(msg);
           }
           // Trailing suffix after a tool_result prefix: accept either
           // (a) text-only (concatenated) or (b) exactly one image block.
@@ -301,8 +321,12 @@ export function mapAnthropicRequest(
             reasoningContent = (reasoningContent ?? '') + block.thinking;
           } else if (block.type === 'tool_use') {
             seenToolUse = true;
+            // Anthropic clients echo back the `toolu_<uuid>` we emitted
+            // on the prior assistant turn. Translate to the internal
+            // `call_<uuid>` shape so the native session store and the
+            // Qwen chat template paths see a consistent id family.
             toolCalls.push({
-              id: block.id,
+              id: anthropicToolUseIdToInternal(block.id),
               name: block.name,
               arguments: JSON.stringify(block.input),
             });

--- a/packages/server/src/mappers/anthropic-response.ts
+++ b/packages/server/src/mappers/anthropic-response.ts
@@ -24,6 +24,34 @@ function parseArguments(args: Record<string, unknown> | string): Record<string, 
   return args;
 }
 
+/**
+ * Translate a native tool-call id (minted as `call_<uuid>` by the Rust
+ * parser, which keeps the OpenAI Responses convention) to the Anthropic
+ * Messages wire convention (`toolu_<uuid>`). The uuid body is preserved
+ * verbatim so the inverse `anthropicToolUseIdToInternal` round-trips
+ * losslessly when clients echo the id back via `tool_result.tool_use_id`.
+ *
+ * Defensive: ids that do not have the expected `call_` prefix (e.g. a
+ * legacy caller, an in-process driver constructing its own id, or a
+ * future variant) pass through unchanged so this function never
+ * synthesizes a wrong id.
+ */
+export function internalToolCallIdToAnthropic(id: string): string {
+  return id.startsWith('call_') ? `toolu_${id.slice('call_'.length)}` : id;
+}
+
+/**
+ * Inverse of `internalToolCallIdToAnthropic`: translate an incoming
+ * Anthropic `tool_use_id` (`toolu_<uuid>`) back to the internal `call_*`
+ * shape so historical assistant turns and the tool_call_id lookup in
+ * the native session store keep matching. Ids without the expected
+ * `toolu_` prefix pass through unchanged for the same defensive reason
+ * (some legacy callers send raw `call_*` directly).
+ */
+export function anthropicToolUseIdToInternal(id: string): string {
+  return id.startsWith('toolu_') ? `call_${id.slice('toolu_'.length)}` : id;
+}
+
 export function mapStopReason(finishReason: string, hasToolCalls: boolean): 'end_turn' | 'max_tokens' | 'tool_use' {
   if (finishReason === 'length') {
     return 'max_tokens';
@@ -75,9 +103,13 @@ export function buildAnthropicContent(result: ChatResult, allowToolUse = true): 
   }
 
   for (const tc of okToolCalls) {
+    // Translate native `call_<uuid>` to Anthropic `toolu_<uuid>` at the
+    // wire boundary. The fallback `genId('toolu_')` covers the case where
+    // the native parser did not mint an id (an in-process driver or a
+    // legacy bridge — present-day Rust paths always populate it).
     content.push({
       type: 'tool_use',
-      id: tc.id ?? genId('toolu_'),
+      id: tc.id != null ? internalToolCallIdToAnthropic(tc.id) : genId('toolu_'),
       name: tc.name,
       input: parseArguments(tc.arguments),
     });

--- a/packages/server/src/model-work-coordinator.ts
+++ b/packages/server/src/model-work-coordinator.ts
@@ -76,7 +76,7 @@ export class ModelWorkCoordinator {
     // actual phase boundaries (lock acquisition, fn completion) so the
     // two intervals partition cleanly instead of both reporting total
     // elapsed time — see `ModelLoadOutcome` for the contract.
-    const owner = !this.writerActive && this.waitingWriters === 0 && this.activeReaders === 0;
+    const owner = !this.writerActive && this.waitingWriters === 0;
     const arrivedAt = Date.now();
     await this.acquireWrite();
     const lockAcquiredAt = Date.now();

--- a/packages/server/src/model-work-coordinator.ts
+++ b/packages/server/src/model-work-coordinator.ts
@@ -1,4 +1,37 @@
 /**
+ * Result of a `withModelLoad` call that surfaces who actually drove the load
+ * vs. who merely parked behind one that was already in flight. Callers use
+ * this to split observability between the request that triggered a cold
+ * weight-materialize from one that arrived a millisecond later and merely
+ * inherited the wait — without the split a 60-second cold-load shows up
+ * on every concurrent request as if each one paid for a separate load.
+ *
+ * `owner` reflects the SYNCHRONOUS state observed at lock acquisition:
+ * `true` if the writer lock was free when this caller arrived and the
+ * caller itself executed the supplied `fn`; `false` if there was already
+ * a writer active (or queued ahead of this caller) when it arrived.
+ *
+ * `waitMs` and `ownMs` partition the wall-clock interval between when
+ * the caller arrived at the coordinator and when its `fn` resolved:
+ *  - `waitMs` is time spent blocked inside `acquireWrite()` (zero for a
+ *    no-contention owner; ≈ peer's load duration for a follower).
+ *  - `ownMs` is time spent inside `fn` once the writer lock was held
+ *    (≈ load duration for an owner driving a cold load; near-zero for a
+ *    follower whose `fn` is a no-op cache lookup).
+ * Both are measured from `Date.now()` and clamped at zero to absorb
+ * monotonic-skew. Their sum equals the total elapsed time in the call,
+ * so handlers can plumb them into separate observability fields
+ * (`server_load_wait_ms` vs. `server_model_resolve_ms`) without
+ * double-counting.
+ */
+export interface ModelLoadOutcome<T> {
+  result: T;
+  owner: boolean;
+  waitMs: number;
+  ownMs: number;
+}
+
+/**
  * Process-local gate for native MLX work.
  *
  * Individual model instances already have a per-model execution mutex, but a
@@ -18,6 +51,41 @@ export class ModelWorkCoordinator {
     await this.acquireWrite();
     try {
       return await fn();
+    } finally {
+      this.releaseWrite();
+    }
+  }
+
+  /**
+   * Like {@link withModelLoad} but reports whether THIS caller owned the
+   * load (acquired the writer lock with no contention) or merely waited
+   * behind a load that was already in flight when it arrived.
+   *
+   * Decided at sync-time before any await: if neither a writer is active
+   * nor any writer is queued ahead, this caller is the owner; otherwise
+   * it is parked behind someone else's load and `owner` is `false`. The
+   * distinction is used by `/v1/messages` to split `resolve_ms` (own
+   * load + lookup) from `load_wait_ms` (waiting on a peer's load) so a
+   * 60-second cold-load does not look like 60 seconds of own work for
+   * every concurrent request.
+   */
+  async withModelLoadInstrumented<T>(fn: () => Promise<T> | T): Promise<ModelLoadOutcome<T>> {
+    // `owner` MUST be decided synchronously, before any await, so the
+    // signal reflects coordinator state at arrival rather than after
+    // any peer transition. The wait/own split is measured around the
+    // actual phase boundaries (lock acquisition, fn completion) so the
+    // two intervals partition cleanly instead of both reporting total
+    // elapsed time — see `ModelLoadOutcome` for the contract.
+    const owner = !this.writerActive && this.waitingWriters === 0 && this.activeReaders === 0;
+    const arrivedAt = Date.now();
+    await this.acquireWrite();
+    const lockAcquiredAt = Date.now();
+    try {
+      const result = await fn();
+      const fnDoneAt = Date.now();
+      const waitMs = Math.max(0, lockAcquiredAt - arrivedAt);
+      const ownMs = Math.max(0, fnDoneAt - lockAcquiredAt);
+      return { result, owner, waitMs, ownMs };
     } finally {
       this.releaseWrite();
     }

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -144,5 +144,17 @@ export async function routeRequest(
     return;
   }
 
+  // Liveness probe at `/`. Claude Code issues `HEAD /` before its first
+  // request; respond 200 so the probe doesn't leave a 404 in the logs.
+  if (path === '/') {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      sendMethodNotAllowed(res, 'GET, HEAD');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(req.method === 'HEAD' ? undefined : JSON.stringify({ service: 'mlx-node' }));
+    return;
+  }
+
   sendNotFound(res, `No route matches ${req.method} ${path}`);
 }

--- a/packages/server/src/timing.ts
+++ b/packages/server/src/timing.ts
@@ -27,8 +27,34 @@ interface TimingUsageExtensions {
   prefill_input_tokens?: number;
   /** Server-extension: prompt tokens skipped because a cached prefix was reused. */
   cached_prefix_tokens?: number;
-  /** Server-extension: time spent resolving/loading/aliasing the requested model before registry lookup. */
+  /**
+   * Server-extension: time spent resolving/loading/aliasing the requested model
+   * before registry lookup. Includes both the synchronous lookup AND any time
+   * spent driving the load. Excludes time spent blocked behind a peer
+   * request's in-flight load — that wait is reported separately via
+   * `server_load_wait_ms` so a fast follower request is not mis-attributed
+   * a long resolve when it merely inherited a cold-load wait.
+   */
   server_model_resolve_ms?: number;
+  /**
+   * Server-extension: wall-clock time this request spent blocked on the
+   * process-wide model-load writer lock. Set when the load was already
+   * in flight when this request arrived (a peer drove the load and we
+   * waited for it to finish) AND when this request itself drove the
+   * load. Inspect `server_load_owner` to disambiguate. When the writer
+   * lock was free and the resolve was a no-op (model already loaded),
+   * this field is elided.
+   */
+  server_load_wait_ms?: number;
+  /**
+   * Server-extension: `true` when this request acquired the model-load
+   * writer lock with no contention (i.e. either the model was already
+   * loaded and the call was a no-op, or this request itself drove the
+   * load). `false` when the request was parked behind a peer's in-flight
+   * load. Elided when no load coordinator is wired (single-process
+   * tests, embedded callers).
+   */
+  server_load_owner?: boolean;
   /** Server-extension: time spent waiting behind the per-model execution mutex. */
   server_queue_ms?: number;
   /** Server-extension: handler time before native inference begins, including resolve and queue wait. */
@@ -55,6 +81,8 @@ function finiteNonNegative(value: number | undefined): number | undefined {
 
 export interface ServerTimingForUsage {
   server_model_resolve_ms?: number;
+  server_load_wait_ms?: number;
+  server_load_owner?: boolean;
   server_queue_ms?: number;
   server_pre_inference_ms?: number;
   server_paged_prefill_chunk_size?: number;
@@ -163,6 +191,13 @@ function buildTimingUsageExtensions(
   const modelResolveMs = finiteNonNegative(serverTiming?.server_model_resolve_ms);
   if (modelResolveMs != null) {
     extensions.server_model_resolve_ms = modelResolveMs;
+  }
+  const loadWaitMs = finiteNonNegative(serverTiming?.server_load_wait_ms);
+  if (loadWaitMs != null) {
+    extensions.server_load_wait_ms = loadWaitMs;
+  }
+  if (typeof serverTiming?.server_load_owner === 'boolean') {
+    extensions.server_load_owner = serverTiming.server_load_owner;
   }
   const queueMs = finiteNonNegative(serverTiming?.server_queue_ms);
   if (queueMs != null) {

--- a/packages/server/src/types-anthropic.ts
+++ b/packages/server/src/types-anthropic.ts
@@ -217,6 +217,10 @@ export interface AnthropicUsage {
   cached_prefix_tokens?: number;
   /** Server-extension: time spent resolving/loading/aliasing the requested model before registry lookup. */
   server_model_resolve_ms?: number;
+  /** Server-extension: wall-clock time blocked on the process-wide model-load writer lock. */
+  server_load_wait_ms?: number;
+  /** Server-extension: true when this request acquired the model-load lock without contention. */
+  server_load_owner?: boolean;
   /** Server-extension: time spent waiting behind the per-model execution mutex. */
   server_queue_ms?: number;
   /** Server-extension: handler time before native inference begins, including resolve and queue wait. */
@@ -336,6 +340,10 @@ export interface AnthropicMessageDeltaEvent {
     cached_prefix_tokens?: number;
     /** Server-extension: time spent resolving/loading/aliasing the requested model before registry lookup. */
     server_model_resolve_ms?: number;
+    /** Server-extension: wall-clock time blocked on the process-wide model-load writer lock. */
+    server_load_wait_ms?: number;
+    /** Server-extension: true when this request acquired the model-load lock without contention. */
+    server_load_owner?: boolean;
     /** Server-extension: time spent waiting behind the per-model execution mutex. */
     server_queue_ms?: number;
     /** Server-extension: handler time before native inference begins, including resolve and queue wait. */

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -265,6 +265,8 @@ export interface ResponseUsage {
   server_prefill_tokens_per_second?: number;
   server_decode_tokens_per_second?: number;
   server_model_resolve_ms?: number;
+  server_load_wait_ms?: number;
+  server_load_owner?: boolean;
   server_queue_ms?: number;
   server_pre_inference_ms?: number;
   server_paged_prefill_chunk_size?: number;

--- a/packages/vlm/src/models/qianfan-ocr.ts
+++ b/packages/vlm/src/models/qianfan-ocr.ts
@@ -70,12 +70,20 @@ export class QianfanOCRModel extends QianfanOCRModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
+    isError?: boolean | null,
     config?: ChatConfig | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
       (callback) =>
-        _nativeQianfanOcrChatStreamSessionContinueTool.call(this, toolCallId, content, config ?? null, callback),
+        _nativeQianfanOcrChatStreamSessionContinueTool.call(
+          this,
+          toolCallId,
+          content,
+          isError ?? null,
+          config ?? null,
+          callback,
+        ),
       signal,
     );
   }

--- a/packages/vlm/src/models/qianfan-ocr.ts
+++ b/packages/vlm/src/models/qianfan-ocr.ts
@@ -70,8 +70,8 @@ export class QianfanOCRModel extends QianfanOCRModelNative {
   async *chatStreamSessionContinueTool(
     toolCallId: string,
     content: string,
-    isError?: boolean | null,
     config?: ChatConfig | null,
+    isError?: boolean | null,
     signal?: AbortSignal,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
@@ -80,8 +80,8 @@ export class QianfanOCRModel extends QianfanOCRModelNative {
           this,
           toolCallId,
           content,
-          isError ?? null,
           config ?? null,
+          isError ?? null,
           callback,
         ),
       signal,

--- a/packages/vlm/src/models/qianfan-ocr.ts
+++ b/packages/vlm/src/models/qianfan-ocr.ts
@@ -71,8 +71,8 @@ export class QianfanOCRModel extends QianfanOCRModelNative {
     toolCallId: string,
     content: string,
     config?: ChatConfig | null,
-    isError?: boolean | null,
     signal?: AbortSignal,
+    isError?: boolean | null,
   ): AsyncGenerator<ChatStreamEvent> {
     yield* _runChatStream(
       (callback) =>
@@ -81,8 +81,8 @@ export class QianfanOCRModel extends QianfanOCRModelNative {
           toolCallId,
           content,
           config ?? null,
-          isError ?? null,
           callback,
+          isError ?? null,
         ),
       signal,
     );


### PR DESCRIPTION
## Summary

Two commits surfaced by a deep review of real session logs from `mlx launch claude` traffic, then verified end-to-end on two model variants in production.

- **`feat: structured is_error field on ChatMessage`** (`4a27cfa`) — adds `is_error: Option<bool>` to the Rust `ChatMessage` struct (mirrors the existing `tool_call_id: Option<String>` pattern), threads it through the Cmd dispatcher and `ChatSession.sendToolResult` / `sendToolResultStream` direct API across all six model variants (Qwen3, Qwen3.5 Dense/MoE, Gemma4, LFM2, QianfanOCR). The chat-template renderer prepends `[tool error] ` inside the tool-response slot only when `is_error == Some(true)`; the structured field is the source of truth, the prefix is a model-facing cue. Replaces the prior in-band JSON envelope which had no structured signal and collided with valid payloads.

- **`fix: anthropic /v1/messages parsing and cold-load observability`** (`d8d0b29`) — three independent server-side fixes:
  - **Tool-call id translation at the Anthropic boundary**: native parser keeps `call_<uuid>` (correct for `/v1/responses`); `/v1/messages` now emits `toolu_<uuid>` per Anthropic spec and rewrites incoming `toolu_*` back to `call_*` for internal lookup.
  - **Suppress whitespace-only text blocks before tool_use**: adds a per-turn `pendingLeadingWhitespace` buffer in `messages.ts` that flushes alongside the first real text delta or is dropped on a tag-found / done transition. Eliminates stray `text="\n\n"` content blocks that the model emitted between `</think>` and `<tool_call>`.
  - **Partition cold-load timing in `ModelWorkCoordinator`**: prior `resolve_ms` double-counted — a follower parked behind a 60s cold load reported the same value as the owner that paid for it. `withModelLoadInstrumented` now captures `waitMs` and `ownMs` at the lock-acquired boundary so `serverLoadWaitMs` / `serverModelResolveMs` partition cleanly. `launch-claude` logger surfaces `load_wait` and `load_owner` alongside `resolve`.
  - Also switches the Anthropic tool-result error encoding to populate the new structured `isError` field instead of the prior `[error] ${content}` prefix.

## Verification

Verified clean on two real Claude Code → mlx-node sessions:

- **Qwen3.5 a3b** (`~/.mlx-node/logs/2026-05-13T15-01-03-586Z/`): 14/14 `toolu_*` ids round-trip, 0 whitespace-only blocks (down from 5–7 per turn in the pre-fix baseline), owner `resolve=56369 load_wait=0` vs follower `resolve=1 load_wait=56366` (pre-fix: both showed 60331/60336 — double-counted).
- **Gemma 4 26b** (`~/.mlx-node/logs/2026-05-13T15-24-32-289Z/`): 11/11 `toolu_*` ids round-trip across 16 tool turns, 0 spurious whitespace blocks, **`is_error: true` path hit in production** (a `Read` rejection round-tripped to Gemma's chat template; model responded with reasoning + a corrected `tool_use` instead of repeating the failed call), timing partition clean across 17 turns and a multi-model swap.

Codex adversarial review (`/codex:adversarial-review`) flagged three findings on the initial pass:
1. A claimed whitespace-drop regression — **refuted** via control-flow inspection: `pendingLeadingWhitespace` lives in handler state, not the tag buffer; the drop is intentional and `emittedText` stays in sync with `finalText` (native `split_at_think_end` strips the same whitespace).
2. Timing double-count — **valid**: addressed by moving the partition into `ModelWorkCoordinator`.
3. `is_error` collision — **valid in theory**: addressed by adding the structured field on `ChatMessage` so the marker is purely a model-facing cue, not the source of truth.

## Test plan

- [x] `yarn test run` — **1220 passed**, 6 skipped (added 5 new TS tests across mappers, messages handler, coordinator, chat-session, logger)
- [x] `cargo test -p mlx-core --lib` — **1312 passed**, 0 failed, 18 ignored (added 15 new Rust tests in tokenizer, qwen3_5/chat_common, lfm2/model, gemma4/model)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `yarn lint --type-aware --type-check` — 0 errors (6 pre-existing warnings in untouched files)
- [x] Verified on Qwen3.5 a3b real-traffic session
- [x] Verified on Gemma 4 26b real-traffic session including a production `is_error` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wire-format mappers, streaming message framing, and native model/tool continuation APIs; regressions could break Anthropic client interoperability or tool-call/session replay behavior, though changes are well-covered by new tests.
> 
> **Overview**
> **Tool-result error handling is moved from in-band content encoding to a structured flag.** `ChatMessage` gains `isError`/`is_error`, the Rust tokenizers/renderers inject a `[tool error]` marker only when flagged, and all session `*ContinueTool` entry points (sync + streaming across model variants) accept/forward the optional boolean.
> 
> **Anthropic `/v1/messages` compatibility and streaming output are tightened.** Tool-call ids are translated at the wire boundary (`call_*` ↔ `toolu_*`), `tool_result.is_error` maps to `isError` while leaving content verbatim, and streaming message handling drops whitespace-only text blocks emitted immediately before tool calls to avoid stray visible blocks.
> 
> **Observability and ops tweaks.** Cold-load metrics are partitioned into `load_wait` vs `resolve` with `load_owner` surfaced through the coordinator and `launch-claude` logger, a root `/` liveness probe is added, and CI Rust caching is adjusted to avoid caching `~/.cargo/bin` and to rotate cache keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17283dbfef4df0cef605fcac1658796140265ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->