### PR TITLE
fix(convert): unblock 250GB+ MoE conversions (CPU stream + drain on write)

### DIFF
--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -37,6 +37,22 @@ use crate::utils::safetensors::load_safetensors_lazy;
 /// restore each other's `saved_*` fields incorrectly (e.g. both observe
 /// the already-flipped CPU device as "original", then both restore to
 /// CPU, leaving the process pinned to CPU for the next inference call).
+///
+/// **Concurrent-inference limitation (intentional):** `convert_mutex`
+/// only serializes convert-vs-convert. It does NOT block inference /
+/// training entrypoints. If a Node process runs `convert_model` while
+/// also serving inference, those inference ops resolve their stream via
+/// `default_stream(default_device())` and will be silently routed to
+/// CPU until the conversion finishes — typically minutes to hours on
+/// large MoE checkpoints, with severe latency degradation. The
+/// architecturally correct fix is to plumb explicit `Stream` arguments
+/// through every convert-used MLX FFI op so the global default is never
+/// touched; that's a substantial refactor outside the scope of this
+/// change. For the supported usage today (the `mlx convert` CLI exits
+/// after conversion; no other entrypoint in this codebase invokes
+/// convert), this is a non-issue. Callers who embed convert inside a
+/// long-lived multi-tenant Node process should serialize their own
+/// inference against convert externally.
 pub(crate) struct CpuConvertGuard {
     saved_device: i32,
     saved_stream: mlx_sys::mlx_stream,

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -20,6 +20,43 @@ use crate::models::paddleocr_vl::persistence::load_paddleocr_vl_weights;
 use crate::models::qianfan_ocr::persistence::load_qianfan_ocr_weights;
 use crate::utils::safetensors::load_safetensors_lazy;
 
+/// RAII guard that pins the MLX default device + stream to CPU for one
+/// conversion call, then restores the previous values on drop.
+///
+/// Used by the conversion path to temporarily route every MLX op through
+/// CPU for the duration of one `convert_model` /
+/// `convert_gguf_to_safetensors` call. Both the default *device* and the
+/// default *stream* must be switched: MLX dispatches stream-less ops via
+/// `default_stream(default_device())`, so flipping the stream alone is
+/// not enough — the device must be CPU too. On drop, the previous
+/// device and stream are restored so subsequent inference / training
+/// calls keep using the GPU. See the call sites for the rationale.
+struct ConvertDefaultStreamGuard {
+    saved_device: i32,
+    saved_stream: mlx_sys::mlx_stream,
+}
+
+impl ConvertDefaultStreamGuard {
+    fn enter_cpu() -> Self {
+        let saved_device = unsafe { mlx_sys::mlx_default_device() };
+        let saved_stream = unsafe { mlx_sys::mlx_default_stream(saved_device) };
+        unsafe { mlx_sys::mlx_set_default_device(0) };
+        let cpu_stream = unsafe { mlx_sys::mlx_default_stream(0) };
+        unsafe { mlx_sys::mlx_set_default_stream(cpu_stream) };
+        Self {
+            saved_device,
+            saved_stream,
+        }
+    }
+}
+
+impl Drop for ConvertDefaultStreamGuard {
+    fn drop(&mut self) {
+        unsafe { mlx_sys::mlx_set_default_stream(self.saved_stream) };
+        unsafe { mlx_sys::mlx_set_default_device(self.saved_device) };
+    }
+}
+
 /// Structure for parsing model.safetensors.index.json
 #[derive(Debug, Deserialize)]
 struct ShardedModelIndex {
@@ -115,6 +152,39 @@ pub struct ConversionResult {
 /// ```
 #[napi]
 pub async fn convert_model(options: ConversionOptions) -> Result<ConversionResult> {
+    let _convert_start = std::time::Instant::now();
+    info!(
+        target = "mlx_core::convert",
+        input_dir = %options.input_dir,
+        output_dir = %options.output_dir,
+        dtype = ?options.dtype,
+        model_type = ?options.model_type,
+        quantize = options.quantize.unwrap_or(false),
+        quant_mode = ?options.quant_mode,
+        quant_recipe = ?options.quant_recipe,
+        "convert_model start"
+    );
+    let result = convert_model_inner(options).await;
+    match &result {
+        Ok(r) => info!(
+            target = "mlx_core::convert",
+            total_seconds = _convert_start.elapsed().as_secs_f64(),
+            num_tensors = r.num_tensors,
+            num_parameters = r.num_parameters,
+            output_path = %r.output_path,
+            "convert_model finished"
+        ),
+        Err(e) => tracing::error!(
+            target = "mlx_core::convert",
+            total_seconds = _convert_start.elapsed().as_secs_f64(),
+            error = %e,
+            "convert_model failed"
+        ),
+    }
+    result
+}
+
+async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionResult> {
     let input_dir = PathBuf::from(&options.input_dir);
     let output_dir = PathBuf::from(&options.output_dir);
     let target_dtype = options.dtype.unwrap_or_else(|| "float32".to_string());
@@ -248,6 +318,18 @@ pub async fn convert_model(options: ConversionOptions) -> Result<ConversionResul
             input_dir.display()
         )));
     }
+
+    // Route every MLX op in this conversion through the CPU device + stream.
+    //
+    // The conversion path is slice / reshape / dtype-cast only — no real math.
+    // On GPU, materializing a 1.6 GB sliced view of a fused expert tensor backed
+    // by a 250 GB mmap'd source can stall a Metal command buffer past the macOS
+    // GPU watchdog (~5 s), surfacing as
+    // `kIOGPUCommandBufferCallbackErrorTimeout` mid-shard for large MoE models
+    // (e.g. Qwen3.5 122B-A10B with 256 experts × 48 layers). CPU has direct
+    // access to the mmap'd pages and is immune to the watchdog. `_stream_guard`
+    // restores the prior default device + stream when convert_model returns.
+    let _stream_guard = ConvertDefaultStreamGuard::enter_cpu();
 
     // Check for required files
     let config_path = input_dir.join("config.json");
@@ -660,9 +742,20 @@ pub async fn convert_model(options: ConversionOptions) -> Result<ConversionResul
     tensor_names.sort();
 
     // Save converted model — sharded output with index file (mlx-lm/mlx-vlm compatible)
-    info!("Saving converted model to: {}", output_dir.display());
+    info!(
+        target = "mlx_core::convert",
+        output_dir = %output_dir.display(),
+        num_tensors = converted_tensors.len(),
+        "starting sharded save"
+    );
 
-    crate::utils::safetensors::save_safetensors_sharded(&output_dir, &converted_tensors)?;
+    let save_start = std::time::Instant::now();
+    crate::utils::safetensors::save_safetensors_sharded(&output_dir, &mut converted_tensors)?;
+    info!(
+        target = "mlx_core::convert",
+        save_seconds = save_start.elapsed().as_secs_f64(),
+        "sharded save complete"
+    );
 
     // Write config.json — clean and sort keys to match mlx-lm/mlx-vlm save_config
     let output_config_path = output_dir.join("config.json");

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -31,13 +31,21 @@ use crate::utils::safetensors::load_safetensors_lazy;
 /// not enough — the device must be CPU too. On drop, the previous
 /// device and stream are restored so subsequent inference / training
 /// calls keep using the GPU. See the call sites for the rationale.
-struct ConvertDefaultStreamGuard {
+///
+/// MUST be acquired while holding `CONVERT_MUTEX`'s lock — otherwise two
+/// overlapping conversions can race on the process-wide MLX defaults and
+/// restore each other's `saved_*` fields incorrectly (e.g. both observe
+/// the already-flipped CPU device as "original", then both restore to
+/// CPU, leaving the process pinned to CPU for the next inference call).
+pub(crate) struct CpuConvertGuard {
     saved_device: i32,
     saved_stream: mlx_sys::mlx_stream,
 }
 
-impl ConvertDefaultStreamGuard {
-    fn enter_cpu() -> Self {
+impl CpuConvertGuard {
+    /// Enter the CPU device + stream. The caller is responsible for holding
+    /// `CONVERT_MUTEX` for the lifetime of the returned guard.
+    pub(crate) fn enter_cpu() -> Self {
         let saved_device = unsafe { mlx_sys::mlx_default_device() };
         let saved_stream = unsafe { mlx_sys::mlx_default_stream(saved_device) };
         unsafe { mlx_sys::mlx_set_default_device(0) };
@@ -50,11 +58,25 @@ impl ConvertDefaultStreamGuard {
     }
 }
 
-impl Drop for ConvertDefaultStreamGuard {
+impl Drop for CpuConvertGuard {
     fn drop(&mut self) {
         unsafe { mlx_sys::mlx_set_default_stream(self.saved_stream) };
         unsafe { mlx_sys::mlx_set_default_device(self.saved_device) };
     }
+}
+
+/// Process-wide async mutex serializing all conversion calls.
+///
+/// `convert_model` and `convert_gguf_to_safetensors` mutate MLX's
+/// process-wide default device + default stream via `CpuConvertGuard`,
+/// which is unsafe under concurrency: two overlapping conversions (or a
+/// convert during inference that depends on the GPU default) can race on
+/// the global state. Both NAPI entrypoints `.await` this mutex before
+/// constructing a `CpuConvertGuard`, so only one conversion runs at a
+/// time across the entire Node process.
+pub(crate) fn convert_mutex() -> &'static tokio::sync::Mutex<()> {
+    static CONVERT_MUTEX: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    CONVERT_MUTEX.get_or_init(|| tokio::sync::Mutex::new(()))
 }
 
 /// Structure for parsing model.safetensors.index.json
@@ -319,6 +341,11 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
         )));
     }
 
+    // Serialize all conversions process-wide before touching MLX's default
+    // device + stream — see `convert_mutex` and `CpuConvertGuard` docs for
+    // the race this avoids.
+    let _convert_lock = convert_mutex().lock().await;
+
     // Route every MLX op in this conversion through the CPU device + stream.
     //
     // The conversion path is slice / reshape / dtype-cast only — no real math.
@@ -329,7 +356,7 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
     // (e.g. Qwen3.5 122B-A10B with 256 experts × 48 layers). CPU has direct
     // access to the mmap'd pages and is immune to the watchdog. `_stream_guard`
     // restores the prior default device + stream when convert_model returns.
-    let _stream_guard = ConvertDefaultStreamGuard::enter_cpu();
+    let _stream_guard = CpuConvertGuard::enter_cpu();
 
     // Check for required files
     let config_path = input_dir.join("config.json");

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -4479,7 +4479,7 @@ impl Qwen3Inner {
             }
         }
 
-        let params_clone: HashMap<String, MxArray> =
+        let mut params_clone: HashMap<String, MxArray> =
             params.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
         // Build weights.mlx metadata (shape + dtype only; full data is in safetensors).
@@ -4528,7 +4528,11 @@ impl Qwen3Inner {
             "format": "mlx-node",
             "version": "1.0"
         }));
-        crate::utils::safetensors::save_safetensors(&safetensors_path, &params_clone, metadata)?;
+        crate::utils::safetensors::save_safetensors(
+            &safetensors_path,
+            &mut params_clone,
+            metadata,
+        )?;
         info!("Saved weights.safetensors");
 
         let weights_str = serde_json::to_string_pretty(&weights_json)?;

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1353,7 +1353,7 @@ impl Qwen35Inner {
             }
         }
 
-        let params_clone: HashMap<String, MxArray> =
+        let mut params_clone: HashMap<String, MxArray> =
             params.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
         // Weights metadata
@@ -1401,7 +1401,11 @@ impl Qwen35Inner {
             "format": "mlx-node",
             "version": "1.0"
         }));
-        crate::utils::safetensors::save_safetensors(&safetensors_path, &params_clone, metadata)?;
+        crate::utils::safetensors::save_safetensors(
+            &safetensors_path,
+            &mut params_clone,
+            metadata,
+        )?;
         info!("Saved weights.safetensors");
 
         let weights_str = serde_json::to_string_pretty(&weights_json)?;

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -5303,7 +5303,7 @@ impl Qwen35MoeInner {
             }
         }
 
-        let params_clone: HashMap<String, MxArray> =
+        let mut params_clone: HashMap<String, MxArray> =
             params.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
         // Weights metadata (reference sidecar)
@@ -5351,7 +5351,11 @@ impl Qwen35MoeInner {
             "format": "mlx-node",
             "version": "1.0"
         }));
-        crate::utils::safetensors::save_safetensors(&safetensors_path, &params_clone, metadata)?;
+        crate::utils::safetensors::save_safetensors(
+            &safetensors_path,
+            &mut params_clone,
+            metadata,
+        )?;
         info!("Saved weights.safetensors");
 
         let weights_str = serde_json::to_string_pretty(&weights_json)?;

--- a/crates/mlx-core/src/training_state.rs
+++ b/crates/mlx-core/src/training_state.rs
@@ -124,7 +124,7 @@ impl ModelThreadTrainingState {
             "step": step.to_string(),
             "format": "adamw_optimizer_state",
         });
-        crate::utils::safetensors::save_safetensors(path, &tensors, Some(metadata))
+        crate::utils::safetensors::save_safetensors(path, &mut tensors, Some(metadata))
     }
 
     /// Restore AdamW moment tensors + step from a SafeTensors file.
@@ -389,7 +389,7 @@ mod tests {
             let arr = MxArray::from_float32(&[*val], &[1]).unwrap();
             tensor_map.insert(key.to_string(), arr);
         }
-        crate::utils::safetensors::save_safetensors(path, &tensor_map, metadata).unwrap();
+        crate::utils::safetensors::save_safetensors(path, &mut tensor_map, metadata).unwrap();
     }
 
     // =========================================================================

--- a/crates/mlx-core/src/utils/foreign_weights.rs
+++ b/crates/mlx-core/src/utils/foreign_weights.rs
@@ -69,7 +69,7 @@ pub fn convert_foreign_weights(
         ))
     })?;
 
-    let (tensors, config_json) = match options.model_type.as_str() {
+    let (mut tensors, config_json) = match options.model_type.as_str() {
         "pp-lcnet-ori" => convert_pp_lcnet_ori(&input_path, verbose)?,
         "uvdoc" => convert_uvdoc(&input_path, verbose)?,
         other => {
@@ -81,9 +81,9 @@ pub fn convert_foreign_weights(
 
     // Save SafeTensors
     let weights_path = output_dir.join("model.safetensors");
-    save_safetensors(&weights_path, &tensors, None)?;
-
+    // Capture names BEFORE save (save drains the map for memory reasons).
     let mut tensor_names: Vec<String> = tensors.keys().cloned().collect();
+    save_safetensors(&weights_path, &mut tensors, None)?;
     tensor_names.sort();
     let num_tensors = tensor_names.len() as i32;
 

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -1264,35 +1264,6 @@ pub struct GgufConversionResult {
     pub source_format: String,
 }
 
-/// RAII guard that pins the MLX default device + stream to CPU for one
-/// GGUF conversion call, then restores the previous values on drop.
-/// See `convert::ConvertDefaultStreamGuard` for the rationale.
-struct ConvertGgufDefaultStreamGuard {
-    saved_device: i32,
-    saved_stream: mlx_sys::mlx_stream,
-}
-
-impl ConvertGgufDefaultStreamGuard {
-    fn enter_cpu() -> Self {
-        let saved_device = unsafe { mlx_sys::mlx_default_device() };
-        let saved_stream = unsafe { mlx_sys::mlx_default_stream(saved_device) };
-        unsafe { mlx_sys::mlx_set_default_device(0) };
-        let cpu_stream = unsafe { mlx_sys::mlx_default_stream(0) };
-        unsafe { mlx_sys::mlx_set_default_stream(cpu_stream) };
-        Self {
-            saved_device,
-            saved_stream,
-        }
-    }
-}
-
-impl Drop for ConvertGgufDefaultStreamGuard {
-    fn drop(&mut self) {
-        unsafe { mlx_sys::mlx_set_default_stream(self.saved_stream) };
-        unsafe { mlx_sys::mlx_set_default_device(self.saved_device) };
-    }
-}
-
 #[napi]
 pub async fn convert_gguf_to_safetensors(
     options: GgufConversionOptions,
@@ -1308,10 +1279,14 @@ pub async fn convert_gguf_to_safetensors(
         )));
     }
 
-    // Route every MLX op in this conversion through the CPU device + stream.
-    // See `convert_model` for the full rationale — same reasoning applies
-    // here for GGUF→SafeTensors conversion of huge MoE checkpoints.
-    let _stream_guard = ConvertGgufDefaultStreamGuard::enter_cpu();
+    // Serialize all conversions process-wide before touching MLX's default
+    // device + stream. Then route every MLX op through CPU for the duration
+    // of this call. See `crate::convert::convert_mutex` and
+    // `crate::convert::CpuConvertGuard` for the full rationale — same
+    // reasoning applies here for GGUF→SafeTensors conversion of huge MoE
+    // checkpoints.
+    let _convert_lock = crate::convert::convert_mutex().lock().await;
+    let _stream_guard = crate::convert::CpuConvertGuard::enter_cpu();
 
     // Parse GGUF header and metadata
     info!("Parsing GGUF file: {}", input_path.display());
@@ -1603,6 +1578,12 @@ pub async fn convert_gguf_to_safetensors(
         .unwrap_or("model.safetensors");
     let safetensors_path = output_dir.join(safetensors_filename);
     info!("Saving to {}", safetensors_path.display());
+    // Capture tensor names BEFORE `save_safetensors` — it drains `weights`
+    // as it streams each tensor to disk so MLX-allocated backing buffers
+    // can be released immediately on large MoE checkpoints. Reading
+    // `weights.keys()` after the save would return an empty list and the
+    // GgufConversionResult would report num_tensors = 0 to JS callers.
+    let tensor_names: Vec<String> = weights.keys().cloned().collect();
     // Add "format: mlx" metadata so loaders (e.g., mlx-vlm) know weights are
     // already in MLX layout and skip sanitize (which would double-apply +1.0 to norms).
     let st_metadata = serde_json::json!({ "format": "mlx" });
@@ -1685,8 +1666,6 @@ pub async fn convert_gguf_to_safetensors(
         .map(|(t, c)| format!("{t}({c})"))
         .collect::<Vec<_>>()
         .join(", ");
-
-    let tensor_names: Vec<String> = weights.keys().cloned().collect();
 
     Ok(GgufConversionResult {
         num_tensors: tensor_names.len() as i32,

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -1264,6 +1264,35 @@ pub struct GgufConversionResult {
     pub source_format: String,
 }
 
+/// RAII guard that pins the MLX default device + stream to CPU for one
+/// GGUF conversion call, then restores the previous values on drop.
+/// See `convert::ConvertDefaultStreamGuard` for the rationale.
+struct ConvertGgufDefaultStreamGuard {
+    saved_device: i32,
+    saved_stream: mlx_sys::mlx_stream,
+}
+
+impl ConvertGgufDefaultStreamGuard {
+    fn enter_cpu() -> Self {
+        let saved_device = unsafe { mlx_sys::mlx_default_device() };
+        let saved_stream = unsafe { mlx_sys::mlx_default_stream(saved_device) };
+        unsafe { mlx_sys::mlx_set_default_device(0) };
+        let cpu_stream = unsafe { mlx_sys::mlx_default_stream(0) };
+        unsafe { mlx_sys::mlx_set_default_stream(cpu_stream) };
+        Self {
+            saved_device,
+            saved_stream,
+        }
+    }
+}
+
+impl Drop for ConvertGgufDefaultStreamGuard {
+    fn drop(&mut self) {
+        unsafe { mlx_sys::mlx_set_default_stream(self.saved_stream) };
+        unsafe { mlx_sys::mlx_set_default_device(self.saved_device) };
+    }
+}
+
 #[napi]
 pub async fn convert_gguf_to_safetensors(
     options: GgufConversionOptions,
@@ -1278,6 +1307,11 @@ pub async fn convert_gguf_to_safetensors(
             input_path.display()
         )));
     }
+
+    // Route every MLX op in this conversion through the CPU device + stream.
+    // See `convert_model` for the full rationale — same reasoning applies
+    // here for GGUF→SafeTensors conversion of huge MoE checkpoints.
+    let _stream_guard = ConvertGgufDefaultStreamGuard::enter_cpu();
 
     // Parse GGUF header and metadata
     info!("Parsing GGUF file: {}", input_path.display());
@@ -1572,7 +1606,7 @@ pub async fn convert_gguf_to_safetensors(
     // Add "format: mlx" metadata so loaders (e.g., mlx-vlm) know weights are
     // already in MLX layout and skip sanitize (which would double-apply +1.0 to norms).
     let st_metadata = serde_json::json!({ "format": "mlx" });
-    save_safetensors(&safetensors_path, &weights, Some(st_metadata))?;
+    save_safetensors(&safetensors_path, &mut weights, Some(st_metadata))?;
 
     // Only write config.json and tokenizer files for the primary model file.
     // Secondary files (e.g., vision.safetensors for mmproj) should not overwrite

--- a/crates/mlx-core/src/utils/safetensors.rs
+++ b/crates/mlx-core/src/utils/safetensors.rs
@@ -318,6 +318,24 @@ fn bytes_to_u16(bytes: &[u8]) -> Vec<u16> {
 /// Maximum shard size in bytes (5 GB), matching mlx-lm and mlx-vlm.
 const MAX_SHARD_SIZE: usize = 5 << 30;
 
+/// Snapshot MLX's allocator counters in MB. Returns `(active, peak, cache)`.
+/// Each accessor is fallible (returns -1 if the Metal allocator is
+/// uninitialised, e.g. CPU-only host or convert path that never touched the
+/// GPU), in which case we report `0` so the log line still emits cleanly.
+fn current_mlx_memory_stats_mb() -> (u64, u64, u64) {
+    use mlx_sys as sys;
+    let to_mb = |bytes: u64| bytes / (1u64 << 20);
+    let mut active: u64 = 0;
+    let mut peak: u64 = 0;
+    let mut cache: u64 = 0;
+    unsafe {
+        let _ = sys::mlx_get_active_memory(&mut active);
+        let _ = sys::mlx_get_peak_memory(&mut peak);
+        let _ = sys::mlx_get_cache_memory(&mut cache);
+    }
+    (to_mb(active), to_mb(peak), to_mb(cache))
+}
+
 /// Save tensors to SafeTensors format.
 ///
 /// Uses a two-pass streaming approach to avoid materializing all tensor bytes
@@ -325,9 +343,17 @@ const MAX_SHARD_SIZE: usize = 5 << 30;
 ///
 /// Pass 1: Compute byte sizes from array metadata (no evaluation), build header.
 /// Pass 2: Write header, then stream each tensor's bytes to disk one at a time.
+///
+/// `tensors` is borrowed `&mut` so each entry can be `.remove(name)`d after
+/// its bytes hit disk. Dropping the `MxArray` releases the MLX-allocated
+/// backing buffer immediately, which is critical for very large MoE
+/// checkpoints — otherwise materialized contiguous buffers for 144+ expert
+/// tensors stay live across the whole sharded save and exhaust RAM
+/// (observed: 162 GB MLX active memory at shard 34 of 49 on a 128 GB host,
+/// triggering silent OOM-kill).
 fn save_safetensors_single<P: AsRef<Path>>(
     path: P,
-    tensors: &HashMap<String, MxArray>,
+    tensors: &mut HashMap<String, MxArray>,
     names: &[String],
     metadata: Option<serde_json::Value>,
 ) -> Result<()> {
@@ -379,9 +405,27 @@ fn save_safetensors_single<P: AsRef<Path>>(
         .write_all(header_bytes)
         .map_err(|e| Error::from_reason(format!("Failed to write header: {}", e)))?;
 
-    // Stream each tensor: materialize → write → drop
+    // Stream each tensor: materialize → write → drop.
+    // - DEBUG: per-tensor timing (off in production)
+    // - INFO:  any single tensor that took >2 s to materialize, since on a
+    //          GPU stream that means we're approaching the macOS Metal
+    //          command-buffer watchdog (~5 s) and on a CPU stream it means
+    //          we're likely paging in a cold mmap region — both are signal
+    //          you want in production logs.
+    let trace_enabled = tracing::enabled!(tracing::Level::DEBUG);
     for name in names {
         let array = tensors.get(name).unwrap();
+        let t0 = std::time::Instant::now();
+        if trace_enabled {
+            let dtype = array.dtype().ok();
+            let shape = array.shape().ok();
+            tracing::debug!(
+                tensor = %name,
+                ?dtype,
+                shape = ?shape.as_ref().map(|s| s.as_ref().to_vec()),
+                "materializing tensor"
+            );
+        }
         let bytes = array_to_bytes(array).map_err(|e| {
             let dtype = array.dtype().ok();
             let shape = array.shape().ok();
@@ -393,10 +437,31 @@ fn save_safetensors_single<P: AsRef<Path>>(
                 e
             ))
         })?;
+        let elapsed = t0.elapsed();
+        if trace_enabled {
+            tracing::debug!(
+                tensor = %name,
+                bytes = bytes.len(),
+                elapsed_ms = elapsed.as_millis() as u64,
+                "tensor written"
+            );
+        } else if elapsed.as_millis() >= 2000 {
+            tracing::info!(
+                tensor = %name,
+                bytes = bytes.len(),
+                elapsed_ms = elapsed.as_millis() as u64,
+                "slow tensor materialization"
+            );
+        }
         writer
             .write_all(&bytes)
             .map_err(|e| Error::from_reason(format!("Failed to write tensor {}: {}", name, e)))?;
-        // `bytes` is dropped here, freeing memory before the next tensor
+        drop(bytes);
+
+        // Release the MLX backing buffer for this tensor now that its bytes
+        // are on disk. See the function-level doc on `tensors: &mut` for the
+        // reason this is load-bearing on huge MoE checkpoints.
+        tensors.remove(name);
     }
 
     writer
@@ -407,9 +472,11 @@ fn save_safetensors_single<P: AsRef<Path>>(
 }
 
 /// Save tensors to a single SafeTensors file (legacy API for non-sharded use cases).
+///
+/// Note: drains `tensors` as it writes — see `save_safetensors_single`'s docs.
 pub fn save_safetensors<P: AsRef<Path>>(
     path: P,
-    tensors: &HashMap<String, MxArray>,
+    tensors: &mut HashMap<String, MxArray>,
     metadata: Option<serde_json::Value>,
 ) -> Result<()> {
     let mut names: Vec<String> = tensors.keys().cloned().collect();
@@ -423,9 +490,13 @@ pub fn save_safetensors<P: AsRef<Path>>(
 /// - If total size ≤ 5GB, writes a single `model.safetensors`
 /// - Always writes `model.safetensors.index.json` with `{metadata: {total_size}, weight_map}`
 /// - SafeTensors metadata is `{"format": "mlx"}` for compatibility
+///
+/// Note: drains `tensors` as it writes — see `save_safetensors_single`'s docs.
+/// On return (success or failure) `tensors` may be partially drained; callers
+/// shouldn't rely on its contents post-call.
 pub fn save_safetensors_sharded(
     output_dir: &Path,
-    tensors: &HashMap<String, MxArray>,
+    tensors: &mut HashMap<String, MxArray>,
 ) -> Result<()> {
     use tracing::info;
 
@@ -475,6 +546,9 @@ pub fn save_safetensors_sharded(
     let mut weight_map: std::collections::BTreeMap<String, String> =
         std::collections::BTreeMap::new();
 
+    let convert_start = std::time::Instant::now();
+    let mut bytes_written_total: u64 = 0;
+
     for (i, shard_names) in shards.iter().enumerate() {
         let shard_filename = if num_shards == 1 {
             "model.safetensors".to_string()
@@ -483,13 +557,44 @@ pub fn save_safetensors_sharded(
         };
 
         let shard_path = output_dir.join(&shard_filename);
+        let shard_bytes: u64 = shard_names
+            .iter()
+            .map(|n| {
+                let a = tensors.get(n).unwrap();
+                a.size().unwrap_or(0) * (a.dtype().map(|d| d.byte_size()).unwrap_or(0) as u64)
+            })
+            .sum();
         info!(
-            "  Writing shard: {} ({} tensors)",
-            shard_filename,
-            shard_names.len()
+            shard_index = i + 1,
+            shard_count = num_shards,
+            shard_file = %shard_filename,
+            tensors = shard_names.len(),
+            shard_mb = (shard_bytes as f64 / (1u64 << 20) as f64),
+            "writing shard"
         );
 
+        let shard_start = std::time::Instant::now();
         save_safetensors_single(&shard_path, tensors, shard_names, Some(metadata.clone()))?;
+        let shard_elapsed = shard_start.elapsed();
+        bytes_written_total += shard_bytes;
+        let convert_elapsed_s = convert_start.elapsed().as_secs_f64().max(1e-6);
+
+        // Snapshot MLX memory after each shard. Helps catch lazy-graph
+        // accumulation, allocator leaks, or runaway page-cache growth that
+        // could silently OOM the process mid-convert on huge MoE checkpoints.
+        let (active_mb, peak_mb, cache_mb) = current_mlx_memory_stats_mb();
+        info!(
+            shard_index = i + 1,
+            shard_count = num_shards,
+            shard_file = %shard_filename,
+            shard_ms = shard_elapsed.as_millis() as u64,
+            shard_mb = (shard_bytes as f64 / (1u64 << 20) as f64),
+            avg_mbps = (bytes_written_total as f64 / (1u64 << 20) as f64) / convert_elapsed_s,
+            mlx_active_mb = active_mb,
+            mlx_peak_mb = peak_mb,
+            mlx_cache_mb = cache_mb,
+            "shard written"
+        );
 
         for name in shard_names {
             weight_map.insert(name.clone(), shard_filename.clone());

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -542,6 +542,8 @@ unsafe extern "C-unwind" {
     pub fn mlx_new_stream(device_type: i32) -> mlx_stream;
     pub fn mlx_set_default_stream(stream: mlx_stream);
     pub fn mlx_stream_synchronize(stream: mlx_stream);
+    pub fn mlx_default_device() -> i32;
+    pub fn mlx_set_default_device(device_type: i32);
 
     // Metal operations (for memory management).
     //

--- a/crates/mlx-sys/src/mlx_stream.cpp
+++ b/crates/mlx-sys/src/mlx_stream.cpp
@@ -52,6 +52,24 @@ void mlx_set_default_stream(mlx_stream stream) {
   }
 }
 
+// Get the current default device (0 = CPU, 1 = GPU)
+int32_t mlx_default_device() {
+  auto dev = mlx::core::default_device();
+  return (dev == mlx::core::Device::cpu) ? 0 : 1;
+}
+
+// Set the current default device (0 = CPU, 1 = GPU). Logs and ignores on
+// exception (e.g. requested GPU but Metal unavailable).
+void mlx_set_default_device(int32_t device_type) {
+  try {
+    mlx::core::set_default_device(to_device_helper(device_type));
+  } catch (const std::exception& e) {
+    std::cerr << "[MLX] Exception in set_default_device: " << e.what() << std::endl;
+  } catch (...) {
+    std::cerr << "[MLX] Unknown exception in set_default_device" << std::endl;
+  }
+}
+
 // Synchronize with the given stream
 void mlx_stream_synchronize(mlx_stream stream) {
   try {


### PR DESCRIPTION
## Summary

`mlx convert` on a 250 GB Qwen3.5 122B-A10B checkpoint (256 experts × 48 layers) failed two different ways:

1. **macOS Metal watchdog kill** (~5 s) when materializing a 1.6 GB sliced view of a fused \`experts.gate_up_proj\` backed by a cold mmap'd HF shard — surfaces as \`kIOGPUCommandBufferCallbackErrorTimeout\` mid-shard.
2. **Silent OOM-kill at shard 35/49** with MLX allocator at 162 GB active memory — each materialized contiguous backing buffer stayed live in the in-memory \`HashMap<String, MxArray>\` for the entire sharded save, blowing through 128 GB RAM.

Both fixes are required to convert this checkpoint at all.

### Fix 1: CPU device + stream for convert

Conversion does only slice / reshape / dtype-cast — no real math — so the CPU is semantically correct and immune to the Metal watchdog. A new RAII guard (\`ConvertDefaultStreamGuard\` / \`ConvertGgufDefaultStreamGuard\`) flips both \`set_default_device(CPU)\` AND \`set_default_stream(cpu_default)\` at the start of \`convert_model\` / \`convert_gguf_to_safetensors\` and restores the previous values on drop.

Setting the stream alone is NOT enough — MLX dispatches stream-less ops via \`default_stream(default_device())\`, so the device pin is load-bearing. New FFI shims \`mlx_default_device\` / \`mlx_set_default_device\` are added to \`mlx-sys\`.

### Fix 2: Drain the tensor map as each tensor is written

\`save_safetensors_single\` / \`_sharded\` / \`save_safetensors\` now take \`&mut HashMap<String, MxArray>\` and call \`.remove(name)\` after each tensor's bytes hit disk. This releases the MLX backing buffer immediately and keeps MLX active memory bounded at ~4.6 GB peak instead of growing unbounded.

All callers updated: \`convert.rs\`, \`training_state.rs\`, \`gguf.rs\`, \`foreign_weights.rs\`, \`qwen3/qwen3_5/qwen3_5_moe/model.rs\`.

### Production logs

\`info!\` level now exposes:
- convert begin/end with structured fields (\`input_dir\`, \`output_dir\`, \`model_type\`, \`quantize\`, \`total_seconds\`, \`num_tensors\`, \`num_parameters\`)
- per-shard timing, MB, avg MB/s, MLX \`active_mb\` / \`peak_mb\` / \`cache_mb\`
- any single-tensor materialization ≥ 2 s (watchdog / cold-mmap signal)

\`debug!\` level keeps the full per-tensor trace for deep debugging via \`MLX_NODE_LOG=\"mlx_core::utils::safetensors=debug\"\`.

## Verification (Qwen3.5 122B-A10B, 250 GB → bf16 MLX)

| | Before | After |
|---|---|---|
| Result | Died at shard 3/49 (Metal watchdog), then shard 35/49 (OOM-kill) | ✓ 49/49 in 11:40 |
| MLX peak memory | 162 GB | **4.6 GB** |
| MLX active (steady-state) | growing unbounded | 0 MB |
| Avg throughput | n/a (crash) | 334 MB/s sustained |

\`cargo clippy --all-targets -- -D warnings\` and \`cargo fmt --check\` both clean.

## Test plan

- [x] Qwen3.5 122B-A10B full bf16 conversion completes end-to-end (49 shards + index)
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`
- [ ] Spot-check that small / already-working conversions (Qwen3 0.6B, smaller MoE) still work — same code path now uses CPU stream, expected to be a no-op or trivially faster
- [ ] Spot-check that GGUF→SafeTensors path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process-wide MLX default device/stream during convert (documented inference overlap risk) and mutates save APIs site-wide; behavior is intentional for CLI convert but embedders must serialize inference.
> 
> **Overview**
> Large HuggingFace / GGUF → MLX conversions are made reliable on huge MoE checkpoints by **routing convert work on CPU** and **releasing MLX memory as each tensor is written**.
> 
> A new **`CpuConvertGuard`** temporarily sets MLX’s default **device and stream** to CPU for `convert_model` and `convert_gguf_to_safetensors`, then restores them on drop—avoiding Metal watchdog timeouts when materializing multi‑GB mmap-backed expert slices. A process-wide **`convert_mutex`** serializes conversions so global MLX defaults aren’t raced. **`mlx_default_device` / `mlx_set_default_device`** are added in `mlx-sys` to support this.
> 
> **SafeTensors writers** now take `&mut HashMap<String, MxArray>` and **`.remove` each tensor after it’s serialized**, so backing buffers don’t accumulate through 49‑shard saves (fixes silent OOM on ~250 GB models). Call sites in convert, GGUF, foreign weights, Qwen saves, and optimizer state were updated; GGUF/foreign paths **snapshot tensor names before save** because the map may be drained.
> 
> **Structured logging** was added for convert start/end, sharded save duration, per-shard throughput, MLX active/peak/cache MB, and slow (≥2 s) tensor materializations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba9c3ec1303a6ee09878191f4cc054fc90e06f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->