### PR TITLE
perf(lfm2): compiled paged decode (~2× / ~1.5×) + paged-prefill last-token slice (~10% TTFT)

### DIFF
--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -1196,49 +1196,6 @@ fn apply_vision_weights(
     Ok(())
 }
 
-/// Register all sanitized weights with the C++ compiled forward pass.
-/// Uses the shared g_weights map (same API as Qwen3.5).
-/// Sets model_id AFTER all weights stored.
-fn register_gemma4_weights_with_cpp(
-    params: &HashMap<String, MxArray>,
-    inner: &Gemma4Inner,
-    model_id: u64,
-) {
-    use mlx_sys as sys;
-    use std::ffi::CString;
-
-    let _guard = crate::models::qwen3_5::model::COMPILED_WEIGHTS_RWLOCK
-        .write()
-        .unwrap();
-
-    unsafe { sys::mlx_clear_weights() };
-
-    let store = |name: &str, array: &MxArray| {
-        let c_name = CString::new(name).expect("Weight name contains null byte");
-        unsafe {
-            sys::mlx_store_weight(c_name.as_ptr(), array.as_raw_ptr());
-        }
-    };
-
-    for (name, array) in params {
-        store(name, array);
-    }
-
-    // Store pre-transposed embedding weight for tied lm_head in C++ path.
-    // Source the dense (dequantized when applicable) table from inner so
-    // quantized checkpoints don't publish a packed uint32 transpose.
-    if let Some(w_t) = inner.embed_weight_t.as_ref() {
-        store("embed_tokens.weight_t", w_t);
-    } else if let Ok(w_t) = inner.embed_tokens.get_weight().transpose(Some(&[1, 0])) {
-        store("embed_tokens.weight_t", &w_t);
-    }
-
-    let count = unsafe { sys::mlx_weight_count() };
-    info!("Registered {} weights with C++ Gemma4 forward pass", count);
-
-    unsafe { sys::mlx_set_model_id(model_id) };
-}
-
 impl Gemma4Inner {
     /// Load a Gemma4Inner from a directory containing safetensors and config.json.
     ///
@@ -1464,8 +1421,22 @@ impl Gemma4Inner {
             crate::array::memory::materialize_weights(&weight_refs)?;
         }
 
-        // Register weights with C++ compiled forward pass
-        register_gemma4_weights_with_cpp(&params, &inner, inner.model_id);
+        // NO compiled-weight registration for Gemma4. Gemma4 has NO compiled
+        // C++ forward path (there is no `mlx_gemma4*.cpp`, and Gemma4 never reads
+        // `mlx_*_get_model_id()`); its forward uses primitive-op FFI that takes
+        // weight arrays by POINTER (from this Rust `inner`/`params`), never
+        // by-name from the shared C++ `g_weights` map. The previous
+        // `register_gemma4_weights_with_cpp` was therefore vestigial for
+        // Gemma4's own inference AND actively harmful to co-resident families:
+        // it called `mlx_clear_weights()` (evicting a resident qwen3.5/lfm2
+        // compiled model's weights on every Gemma4 load) and published a
+        // Gemma4 id from a PRIVATE 0-based counter into the SHARED
+        // `g_active_model_id` atom, which could collide with a qwen3.5/lfm2 id
+        // (those draw from the shared `QWEN35_MODEL_ID_COUNTER`) and make their
+        // compiled gate false-positive against Gemma4's weights. Removing the
+        // registration closes that cross-family collision at the root and stops
+        // Gemma4 from clobbering the shared compiled registry. `inner.model_id`
+        // remains a purely local NAPI handle (never published).
 
         // NOTE: the cache-limit coordinator registration happens in
         // `Gemma4Model::load_from_dir` after this function returns,
@@ -1585,5 +1556,70 @@ mod tests {
         );
         assert!(!per_layer_quant.contains_key("layers.0.mlp.experts.gate_up_proj"));
         assert!(!per_layer_quant.contains_key("layers.0.mlp.experts.down_proj"));
+    }
+
+    /// Cross-family compiled-registry collision regression.
+    ///
+    /// Gemma4 has NO compiled C++ forward path (no `mlx_gemma4*.cpp`; its forward
+    /// uses primitive-op FFI that takes weight arrays by POINTER, never by-name
+    /// from the shared C++ `g_weights`). So a Gemma4 load MUST NOT register
+    /// weights into, or publish a model id onto, the SHARED compiled registry
+    /// (`g_active_model_id` + `g_weights`) that qwen3.5 / lfm2 own. A prior
+    /// `register_gemma4_weights_with_cpp` violated that: it `mlx_clear_weights()`
+    /// (evicting a co-resident qwen3.5/lfm2 compiled model on every Gemma4 load)
+    /// then published a Gemma4 id drawn from a PRIVATE 0-based counter onto the
+    /// shared atom — which could collide with a qwen3.5/lfm2 id (those draw from
+    /// the shared 1-based `QWEN35_MODEL_ID_COUNTER`) and make their compiled gate
+    /// false-positive against Gemma4's weights. This pins the fix: loading a
+    /// Gemma4 model leaves the shared `g_active_model_id` atom UNCHANGED.
+    ///
+    /// Race-free: holds `COMPILED_WEIGHTS_RWLOCK.write()` for the whole check, so
+    /// no concurrent registration/decode (all of which take this lock) can touch
+    /// the atom mid-test. Uses a sentinel id instead of a real qwen/lfm2 load, so
+    /// only a Gemma4 checkpoint is needed. (If Gemma4 registration is ever
+    /// re-introduced it would try to take this same write lock and the test would
+    /// block — a deliberately loud regression signal.)
+    #[test]
+    #[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH pointing to a real Gemma4 checkpoint"]
+    fn gemma4_load_does_not_touch_shared_compiled_model_id() {
+        let Ok(model_path) = std::env::var("MLX_TEST_GEMMA4_MODEL_PATH") else {
+            eprintln!("skipping: MLX_TEST_GEMMA4_MODEL_PATH unset");
+            return;
+        };
+
+        // Exclusive ownership of the shared compiled registry for the whole
+        // check (poison-recovered, matching the registration/decode lock usage).
+        let _w = crate::models::qwen3_5::model::COMPILED_WEIGHTS_RWLOCK
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+
+        // Remember whatever was published before so we leave the shared atom
+        // exactly as we found it (non-destructive to any co-resident model).
+        let original = unsafe { mlx_sys::mlx_lfm2_get_model_id() };
+
+        // Simulate a resident qwen3.5/lfm2 registration by publishing a sentinel
+        // id onto the shared atom (the same atom `mlx_lfm2_get_model_id()` reads).
+        const SENTINEL: u64 = 0x00C0_FFEE;
+        unsafe { mlx_sys::mlx_set_model_id(SENTINEL) };
+        let before = unsafe { mlx_sys::mlx_lfm2_get_model_id() };
+        assert_eq!(before, SENTINEL, "sentinel id publish failed");
+
+        // Load Gemma4 via the sync inner loader — the exact path that used to
+        // register weights / publish a model id.
+        let loaded = Gemma4Inner::load_from_dir(&model_path);
+
+        let after = unsafe { mlx_sys::mlx_lfm2_get_model_id() };
+        // Restore the pre-test atom value before releasing the lock.
+        unsafe { mlx_sys::mlx_set_model_id(original) };
+
+        let (_inner, _bytes) =
+            loaded.unwrap_or_else(|e| panic!("Gemma4Inner::load_from_dir failed: {e:?}"));
+
+        assert_eq!(
+            after, SENTINEL,
+            "Gemma4 load mutated the SHARED compiled model-id atom ({before:#x} -> {after:#x}); \
+             Gemma4 must not register into the qwen3.5/lfm2 compiled registry — cross-family \
+             model-id collision regression."
+        );
     }
 }

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -1513,7 +1513,7 @@ impl Lfm2Inner {
             );
             use_cpp_pre = false;
         }
-        let _compiled_lock = if use_cpp_pre {
+        let mut _compiled_lock = if use_cpp_pre {
             Some(
                 crate::models::qwen3_5::model::COMPILED_LIFECYCLE_MUTEX
                     .lock()
@@ -1572,6 +1572,19 @@ impl Lfm2Inner {
         } else {
             false
         };
+
+        // When the compiled-paged session did NOT come up (model_id eviction,
+        // block_size mismatch, or seed failure), the decode loop runs the pure-Rust
+        // eager paged path, which touches none of the C++ compiled globals. Holding
+        // the cross-family lifecycle mutex / weight read lock across that whole loop
+        // is needless and blocks weight registration (.write()) and other compiled
+        // startups (.lock()) for the entire generation. Drop them now. Safe because
+        // cpp_session_ready==false here implies _paged_reset_guard is None (no seed
+        // ran), so the reset-while-locks-held drop-order invariant is vacuous.
+        if !cpp_session_ready {
+            _weight_guard = None;
+            _compiled_lock = None;
+        }
 
         // RAII guard: resets the compiled-PAGED C++ globals
         // (`mlx_lfm2_paged_reset`) on EVERY exit path — including a `?`
@@ -2106,17 +2119,7 @@ impl Lfm2Inner {
     /// for full-attention layers (paged_idx counts only those layers in
     /// their original order) and `Conv` for conv layers.
     fn compute_layer_kinds(&self) -> Vec<Lfm2LayerKind> {
-        let mut kinds = Vec::with_capacity(self.layers.len());
-        let mut paged_idx: u32 = 0;
-        for i in 0..self.layers.len() {
-            if self.config.is_attention_layer(i) {
-                kinds.push(Lfm2LayerKind::FullAttention { paged_idx });
-                paged_idx += 1;
-            } else {
-                kinds.push(Lfm2LayerKind::Conv);
-            }
-        }
-        kinds
+        compute_layer_kinds_for(&self.config, self.layers.len())
     }
 
     /// Block-paged streaming variant of [`Self::chat_stream_sync_core`].

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -28,6 +28,21 @@ use super::config::Lfm2Config;
 use super::decoder_layer::{Lfm2DecoderLayer, Lfm2LayerKind};
 use super::layer_cache::Lfm2LayerCache;
 
+/// Whether the paged-prefill last-token slice optimization is enabled.
+///
+/// When ON (default), the eager paged prefill slices the residual stream to the
+/// final token BEFORE the output norm + `lm_head` projection, so the largest
+/// matmul only runs over the single row whose logits the caller consumes —
+/// byte-identical, since the discarded rows are never read and all cache writes
+/// already happened in the per-layer loop. Set `MLX_LFM2_DISABLE_LAST_TOKEN_SLICE`
+/// (any value) to fall back to the old "project full T, then slice" behavior for
+/// same-binary A/B baselining. The env var is read once on first call and cached;
+/// subsequent reads hit the `OnceLock` fast path.
+fn last_token_slice_enabled() -> bool {
+    static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHED.get_or_init(|| std::env::var_os("MLX_LFM2_DISABLE_LAST_TOKEN_SLICE").is_none())
+}
+
 /// Internal model state owned exclusively by the dedicated model thread.
 ///
 /// No `Arc<RwLock<>>` — the model thread has sole ownership.
@@ -1923,14 +1938,32 @@ impl Lfm2Inner {
 
         // Output norm + lm_head. Tied path → `Embedding::as_linear` (packed
         // quantized matmul or dense `h @ weight^T`).
-        hidden_states = self.embedding_norm.forward(&hidden_states)?;
+        //
+        // OPT (`MLX_LFM2_DISABLE_LAST_TOKEN_SLICE` unset, default ON): only the
+        // FINAL token's logits are ever consumed by the caller, yet the output
+        // norm + lm_head (vocab 65536 × hidden 2048 matmul) would otherwise run
+        // over the full `[1, T, hidden]` residual stream. Slice to the last row
+        // BEFORE the projection so the largest matmul does ~T× less work. This
+        // is byte-identical: every attention / conv cache write already happened
+        // in the per-layer loop above, and the discarded rows are never read.
+        // Setting the toggle reproduces the old "project full T, then slice"
+        // behavior for same-binary A/B baselining.
+        let proj_input = if last_token_slice_enabled() {
+            let seq_len_h = hidden_states.shape_at(1)?;
+            hidden_states.slice_axis(1, seq_len_h - 1, seq_len_h)?
+        } else {
+            hidden_states
+        };
+        let hidden_states = self.embedding_norm.forward(&proj_input)?;
         let logits = if let Some(ref head) = self.lm_head {
             head.forward(&hidden_states)?
         } else {
             self.embed_tokens.as_linear(&hidden_states)?
         };
 
-        // Slice the last token's logits.
+        // Slice the last token's logits. When the opt is ON `logits` already has
+        // T=1, so this is a no-op slice; when OFF it picks the final row as
+        // before. Either way the returned shape is unchanged.
         let seq_len = logits.shape_at(1)?;
         let last = logits
             .slice_axis(1, seq_len - 1, seq_len)?

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -67,6 +67,22 @@ pub(crate) struct Lfm2Inner {
     /// [`Lfm2Inner::compiled_path_active`] to gate the (not-yet-enabled)
     /// compiled path.
     pub(crate) model_id: u64,
+    /// True iff EVERY registered floating weight is BFloat16 (with the sole
+    /// intentional exception of `*.expert_bias`, kept F32 on MoE checkpoints).
+    /// Computed once at load time over the full registered param map (see
+    /// `all_registered_float_weights_are_bf16` in `persistence.rs`) and consulted
+    /// by [`Lfm2Inner::paged_compiled_decode_setup`] to gate compiled-PAGED
+    /// decode: the compiled-paged graph + paged KV pools are bf16-only
+    /// (`KvDtype::Bf16`, bf16 static mask), and the paged graph consumes far more
+    /// than q/k/v — operator/FFN/final norms, q/k norms, out_proj, conv
+    /// weights/biases, dense-MLP or MoE router/expert weights, and (untied)
+    /// lm_head — any of which, if non-bf16, would flow a non-bf16 hidden state /
+    /// q / k / v into the bf16-only `paged_kv_write`/`paged_attention`. A
+    /// load-time scan of the whole map is authoritative (it sees exactly what
+    /// the C++ `get_weight` reads) and matches the graph, not a hand-picked
+    /// subset. `false` until weights register (defaults safe: a model that
+    /// somehow reached decode unregistered falls back to eager paged).
+    pub(crate) all_float_weights_bf16: bool,
 }
 
 /// Commands dispatched from NAPI methods to the dedicated model thread.
@@ -241,6 +257,30 @@ pub(crate) fn build_lfm2_tool_delta_text(content: &str, is_error: Option<bool>) 
     format!("\n<|im_start|>tool\n{rendered_content}<|im_end|>\n<|im_start|>assistant\n")
 }
 
+/// Holds the compiled-paged decode session state + RAII guards for one
+/// paged decode turn. All guards are over GLOBAL statics / unit, so this
+/// struct does NOT borrow `self`. Created by `paged_compiled_decode_setup`,
+/// consumed across the whole decode loop, dropped at loop exit (the
+/// `Lfm2PagedResetGuard` resets the C++ paged globals on EVERY exit path).
+struct Lfm2PagedCompiledState {
+    // DROP ORDER IS LOAD-BEARING. Struct fields drop in DECLARATION order, so
+    // these three guards MUST be listed reset-guard → weight-guard → lock so
+    // that `Lfm2PagedResetGuard::drop()` (→ `mlx_lfm2_paged_reset()`) runs
+    // WHILE the lifecycle mutex + weight read lock are STILL held. This matches
+    // the original local-variable reverse-drop order (locals declared
+    // lock→weight→reset dropped reset→weight→lock). If the reset ran AFTER the
+    // lifecycle mutex released, another compiled-paged request could acquire
+    // the mutex and seed/use the shared process-global paged state in the
+    // window before this request's delayed reset cleared it → cross-request
+    // null forwards / decode corruption. Do NOT reorder these three fields.
+    _paged_reset_guard: Option<Lfm2PagedResetGuard>,
+    _weight_guard: Option<std::sync::RwLockReadGuard<'static, ()>>,
+    _compiled_lock: Option<std::sync::MutexGuard<'static, ()>>,
+    cpp_session_ready: bool,
+    cpp_compiled_step_completed: bool,
+    max_blocks_per_seq: u32,
+}
+
 impl Lfm2Inner {
     /// Create a new Lfm2Inner with empty (uninitialized) weights.
     pub(crate) fn new(config: Lfm2Config) -> Result<Self> {
@@ -374,6 +414,10 @@ impl Lfm2Inner {
             // this counter.
             model_id: crate::models::qwen3_5::model::QWEN35_MODEL_ID_COUNTER
                 .fetch_add(1, Ordering::Relaxed),
+            // Safe default: not bf16-clean until the load path verifies the
+            // registered weights (set in `persistence.rs` alongside the C++
+            // weight registration). A non-match keeps compiled-PAGED OFF.
+            all_float_weights_bf16: false,
         })
     }
 
@@ -387,11 +431,13 @@ impl Lfm2Inner {
     /// atom) equals this model's [`Lfm2Inner::model_id`].
     ///
     /// The id is published ONLY by `register_weights_with_cpp` (load time), which
-    /// is invoked for a bf16/f16, flat-cache, conv_bias=false checkpoint —
-    /// DENSE or sparse-MoE (Phase 3c lifted the MoE exclusion). The gate is
-    /// structurally false for paged and quantized checkpoints (those never
-    /// register), and false until an lfm2 model has registered its weights into
-    /// the shared map.
+    /// P4 invokes for ANY non-quantized bf16/f16 checkpoint — DENSE or
+    /// sparse-MoE, FLAT or PAGED (Phase 3c lifted the MoE exclusion; P4 lifted
+    /// the paged exclusion). The single registered weight map + `model_id` serve
+    /// BOTH the flat (`lfm2_decode_fn`) and paged (`lfm2_decode_fn_paged`)
+    /// compiled graphs; the per-step dispatcher picks the right one. The gate is
+    /// structurally false for quantized checkpoints (those never register), and
+    /// false until an lfm2 model has registered its weights into the shared map.
     pub(crate) fn compiled_path_active(&self) -> bool {
         let active = unsafe { mlx_sys::mlx_lfm2_get_model_id() };
         active != 0 && active == self.model_id
@@ -1373,6 +1419,265 @@ impl Lfm2Inner {
         Ok(result)
     }
 
+    /// Set up the compiled-PAGED decode session for one decode turn (shared by
+    /// the non-streaming `chat_sync_core_paged_inner` and the streaming
+    /// `chat_stream_sync_core_paged_inner`).
+    ///
+    /// Acquires the cross-family compiled lifecycle lock + weight read lock,
+    /// re-checks ownership, gates on block_size + bf16 weights, seeds the C++
+    /// paged graph once from the live post-prefill adapter pools + conv state,
+    /// and arms the RAII reset guard. Returns the populated
+    /// [`Lfm2PagedCompiledState`], which the caller threads into
+    /// `paged_compiled_decode_step` for every step and drops at loop exit.
+    ///
+    /// MUST be called AFTER prefill (the adapter pools + conv caches are read
+    /// here) and BEFORE the decode loop.
+    fn paged_compiled_decode_setup(&mut self) -> Result<Lfm2PagedCompiledState> {
+        // ===== Compiled C++ PAGED decode-path dispatch (P4) =====
+        //
+        // Mirrors the FLAT path's lock contract (`chat_sync_core`) and qwen3.5's
+        // paged `cpp_session_ready` gate. The compiled-PAGED decode runs only
+        // when ALL of:
+        //   1. `compiled_path_active()` — weights registered for our model_id.
+        //      (The P4-widened registration gate publishes the id for ANY
+        //      non-quantized bf16/f16 checkpoint, FLAT or PAGED, so this is the
+        //      bf16/f16 + non-quant condition; a quantized checkpoint never
+        //      registers and is structurally `false` here.)
+        //   1b. The model weights are bf16. The paged adapter's `LayerKVPool` is
+        //      always BFloat16 and the C++ paged graph hard-codes `KvDtype::Bf16`
+        //      (its static attn mask + pool/scale dtype probes are bf16/f32), so
+        //      an f16 checkpoint would be REJECTED by the first compiled-paged
+        //      forward and silently fall back at step 0. Gate it OUT here so an
+        //      f16 paged checkpoint takes the correct pure-Rust eager paged path
+        //      with no wasted seed and no lying engagement signal.
+        //   2. `adapter.block_size() == CPP_PAGED_REQUIRED_BLOCK_SIZE` (16): the
+        //      compiled-paged graph hard-codes block_size=16 in its
+        //      `paged_kv_write` / `paged_attention` calls.
+        //   3. `init_lfm2_paged_compiled_session` succeeds (every attn layer has
+        //      a usable `LayerKVPool` slot; every conv layer's
+        //      `Lfm2LayerCache::Conv` state is populated by the eager paged
+        //      prefill above; the C++ `g_lfm2_paged_inited` is set after init
+        //      catches no exception).
+        //
+        // LOCK CONTRACT (same as the flat path): registration is the WRITER
+        // (`register_weights_with_cpp` holds `COMPILED_WEIGHTS_RWLOCK.write()`,
+        // clears + stores, bumps the compile epoch, publishes model_id LAST).
+        // Decode is the READER: the `_weight_guard` (`.read()`, poison-recovered)
+        // spans the `mlx_lfm2_get_model_id()` re-check, the seed
+        // (`init_lfm2_paged_compiled_session` → `mlx_lfm2_moe_init_paged`), and
+        // EVERY `forward_lfm2_cpp_paged` step, so the (epoch, id) pair validated
+        // is exactly the one the compiled-paged graph executes against.
+        //
+        // CONV STATE: unlike qwen's GDN linear caches, lfm2 needs NO cross-turn
+        // conv export — the eager paged path reprefills conv from token 0 each
+        // turn (see `chat_sync_core_paged`'s per-turn `self.caches =
+        // init_caches(..)`), so the compiled-paged graph threads conv state
+        // WITHIN a turn only (in the C++ paged globals) and there is no
+        // post-loop export step (plan risk #5).
+        use crate::models::qwen3_5::model::CPP_PAGED_REQUIRED_BLOCK_SIZE;
+        let mut use_cpp_pre = self.compiled_path_active();
+        // bf16-only gate (1b): the compiled-PAGED graph + paged KV pools are
+        // bf16-only (KvDtype::Bf16, bf16 static mask). The gate MUST match what
+        // the graph consumes, not a hand-picked subset: `lfm2_decode_fn_paged`
+        // reads operator/FFN/final norms, q/k norms, attention out_proj, conv
+        // weights/biases, dense-MLP or MoE router/expert weights, and the
+        // (untied) lm_head in addition to q/k/v — any non-bf16 float among them
+        // makes the hidden state (hence q/new_k/new_v) non-bf16 before the
+        // bf16-only `paged_kv_write`/`paged_attention` (step-0 trip at best, an
+        // out-of-contract forward at worst). So we gate on the authoritative
+        // load-time `all_float_weights_bf16` flag (computed once over the whole
+        // registered param map). Non-bf16 → pure-Rust eager paged, with no wasted
+        // seed and no lying engagement signal. `*.expert_bias` (intentional F32
+        // on MoE) is the one allowed exception, handled in the load-time scan.
+        // Quantized checkpoints are already excluded by `compiled_path_active()`.
+        if use_cpp_pre && !self.all_float_weights_bf16 {
+            warn!(
+                "lfm2 compiled paged decode: model has a non-bf16 float weight (embedding, norm, \
+                 projection, conv, FFN/MoE, or lm_head); the compiled-PAGED graph + paged KV pools \
+                 are bf16-only, so using the pure-Rust eager paged decode path for this request."
+            );
+            use_cpp_pre = false;
+        }
+        let _compiled_lock = if use_cpp_pre {
+            Some(
+                crate::models::qwen3_5::model::COMPILED_LIFECYCLE_MUTEX
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner()),
+            )
+        } else {
+            None
+        };
+        let mut _weight_guard = None;
+        let cpp_session_ready = if use_cpp_pre {
+            let guard = crate::models::qwen3_5::model::COMPILED_WEIGHTS_RWLOCK
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
+            // Re-check ownership under the read lock — a concurrent load of a
+            // different model could have evicted us between the probe and here.
+            if unsafe { mlx_sys::mlx_lfm2_get_model_id() } == self.model_id {
+                _weight_guard = Some(guard);
+                // Seed the compiled-paged graph ONCE from the live post-prefill
+                // adapter pools + conv state. On any failure drop back to the
+                // pure-Rust paged decode for the whole turn.
+                let caches_ref = &self.caches;
+                let adapter_ref = self.paged_adapter.as_ref().ok_or_else(|| {
+                    Error::from_reason(
+                        "paged_compiled_decode_setup: paged_adapter dropped post-prefill",
+                    )
+                })?;
+                if adapter_ref.block_size() != CPP_PAGED_REQUIRED_BLOCK_SIZE {
+                    warn!(
+                        "lfm2 compiled paged decode: adapter block_size={} but compiled graph \
+                         requires {}; falling back to pure-Rust paged decode",
+                        adapter_ref.block_size(),
+                        CPP_PAGED_REQUIRED_BLOCK_SIZE
+                    );
+                    false
+                } else {
+                    let prefill_offset = adapter_ref.current_token_count() as i32;
+                    match init_lfm2_paged_compiled_session(
+                        &self.config,
+                        caches_ref,
+                        adapter_ref,
+                        prefill_offset,
+                    ) {
+                        Ok(()) => true,
+                        Err(e) => {
+                            warn!(
+                                "lfm2 compiled paged decode: seed failed ({e}); falling back to \
+                                 pure-Rust paged decode"
+                            );
+                            false
+                        }
+                    }
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        // RAII guard: resets the compiled-PAGED C++ globals
+        // (`mlx_lfm2_paged_reset`) on EVERY exit path — including a `?`
+        // early-return or a first-step fallback that flips `cpp_session_ready`
+        // off — so the next request never seeds against stale paged pools.
+        // Armed iff the seed succeeded.
+        let _paged_reset_guard = cpp_session_ready.then_some(Lfm2PagedResetGuard);
+
+        // Compile-cached `max_blocks_per_seq` shape — `max_position_embeddings`
+        // div_ceil block_size keeps the compile-cache key stable across every
+        // decode step within one turn (matches qwen's paged decode loop).
+        let max_blocks_per_seq: u32 = {
+            let adapter = self.paged_adapter.as_ref().ok_or_else(|| {
+                Error::from_reason("paged_compiled_decode_setup: paged_adapter dropped pre-decode")
+            })?;
+            let max_seq = self.config.max_position_embeddings as u32;
+            max_seq.div_ceil(adapter.block_size())
+        };
+
+        Ok(Lfm2PagedCompiledState {
+            cpp_session_ready,
+            // Tracks whether ANY compiled-paged step has completed this turn.
+            // After a successful compiled step the C++ side has advanced its
+            // per-conv-layer state global (and the adapter's paged pool via
+            // `paged_kv_write`), but the conv state is NOT imported back into
+            // `self.caches`. Falling back to the pure-Rust decode after that
+            // point would run conv from stale pre-step state while
+            // `paged_adapter` + `token_history` have advanced — silently
+            // corrupting the response. So a mid-turn failure (after the first
+            // successful compiled step) PROPAGATES; only a first-step failure
+            // falls back (mirrors qwen's `should_propagate_compiled_paged_error`).
+            cpp_compiled_step_completed: false,
+            max_blocks_per_seq,
+            _compiled_lock,
+            _weight_guard,
+            _paged_reset_guard,
+        })
+    }
+
+    /// Run one compiled-PAGED decode step (shared by both paged decode loops).
+    ///
+    /// Dispatches to the compiled C++ paged forward when `st.cpp_session_ready`,
+    /// else the pure-Rust paged decode. Returns the `[1, vocab]` logits (both
+    /// branches produce the same 2D shape). On a FIRST-step compiled failure it
+    /// rolls back the token cursor, flips `st.cpp_session_ready = false`, and
+    /// re-runs the token through the pure-Rust path. After ANY compiled step has
+    /// succeeded a mid-decode failure PROPAGATES as fatal (the C++ conv state has
+    /// advanced but is never imported back into `self.caches`).
+    fn paged_compiled_decode_step(
+        &mut self,
+        st: &mut Lfm2PagedCompiledState,
+        token_id: u32,
+        step: i32,
+    ) -> Result<MxArray> {
+        // Decode forward. Compiled-paged when `cpp_session_ready`, else the
+        // pure-Rust paged decode.
+        //
+        // Defense-in-depth: if the C++ compiled-paged forward returns null on
+        // the FIRST step, roll back the `record_tokens` cursor advance, flip
+        // `cpp_session_ready = false`, and re-run this token through
+        // `run_paged_decode_step` (which re-calls `record_tokens` on the
+        // now-rolled-back cursor). After ANY compiled step has succeeded the
+        // C++ conv state has advanced but is never imported back into
+        // `self.caches`, so a Rust fallback would read stale state —
+        // propagate the error as fatal instead of silently corrupting.
+        if st.cpp_session_ready {
+            let embedding_weight = self.embed_tokens.get_weight();
+            let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
+                Error::from_reason(
+                    "paged_compiled_decode_step: paged_adapter dropped mid-decode (cpp)",
+                )
+            })?;
+            adapter
+                .record_tokens(&[token_id])
+                .map_err(Error::from_reason)?;
+            let inputs = adapter
+                .build_paged_attention_inputs(1, 1, st.max_blocks_per_seq)
+                .map_err(Error::from_reason)?;
+            let input_ids = MxArray::from_uint32(&[token_id], &[1, 1])?;
+            match forward_lfm2_cpp_paged(&input_ids, &embedding_weight, &inputs) {
+                Ok(logits) => {
+                    st.cpp_compiled_step_completed = true;
+                    // Compiled-paged logits are [B, vocab] (already 2D).
+                    Ok(logits)
+                }
+                Err(e) => {
+                    if crate::models::qwen3_5::chat_common::should_propagate_compiled_paged_error(
+                        st.cpp_compiled_step_completed,
+                    ) {
+                        warn!(
+                            "lfm2 compiled paged forward failed mid-decode (step={step}) AFTER \
+                             an earlier compiled step succeeded. The C++ conv state has \
+                             advanced but is not imported back into self.caches, so a \
+                             pure-Rust fallback would run from stale state and silently \
+                             corrupt the response. Propagating as fatal. cause: {e}"
+                        );
+                        adapter
+                            .rollback_last_tokens(1)
+                            .map_err(Error::from_reason)?;
+                        return Err(e);
+                    }
+                    warn!(
+                        "lfm2 compiled paged forward failed on first decode step \
+                         (step={step}); rolling back token cursor and falling back to \
+                         pure-Rust paged decode for the rest of this request. cause: {e}"
+                    );
+                    adapter
+                        .rollback_last_tokens(1)
+                        .map_err(Error::from_reason)?;
+                    st.cpp_session_ready = false;
+                    // Re-run this token through the pure-Rust paged decode
+                    // (re-records the token on the rolled-back cursor).
+                    self.run_paged_decode_step(token_id)?.squeeze(Some(&[1]))
+                }
+            }
+        } else {
+            // Pure-Rust paged decode fallback.
+            self.run_paged_decode_step(token_id)?.squeeze(Some(&[1]))
+        }
+    }
+
     /// Inner forward + decode loop for `chat_sync_core_paged`. Split out
     /// so the caller can wrap it with `release_request` on either path.
     #[allow(clippy::too_many_arguments)]
@@ -1418,6 +1723,15 @@ impl Lfm2Inner {
             *first_token_instant = Some(std::time::Instant::now());
         }
 
+        // ===== Compiled C++ PAGED decode-path dispatch (P4) =====
+        // Acquire the locks, gate, and seed the compiled-paged session for this
+        // turn. The returned state holds the RAII guards (compiled lifecycle
+        // mutex, weight read lock, paged reset guard) that span the whole decode
+        // loop; the same setup + per-step dispatch is shared with the streaming
+        // path (`chat_stream_sync_core_paged_inner`). See
+        // `paged_compiled_decode_setup` / `paged_compiled_decode_step`.
+        let mut paged_st = self.paged_compiled_decode_setup()?;
+
         // === DECODE LOOP ===
         let max_new_tokens = p.max_new_tokens;
         let mut generated_tokens: Vec<u32> = Vec::with_capacity(max_new_tokens.max(0) as usize);
@@ -1446,9 +1760,9 @@ impl Lfm2Inner {
                 break;
             }
 
-            // Decode forward
-            let next_logits = self.run_paged_decode_step(token_id)?;
-            let next_logits = next_logits.squeeze(Some(&[1]))?;
+            // Decode forward (compiled-paged when seeded, else pure-Rust paged)
+            // via the shared per-step dispatcher (mirrored by the streaming path).
+            let next_logits = self.paged_compiled_decode_step(&mut paged_st, token_id, step)?;
 
             let next_logits = if reasoning_tracker.should_force_think_end() {
                 let forced_id = reasoning_tracker.forced_token_id() as i32;
@@ -2107,6 +2421,16 @@ impl Lfm2Inner {
             *first_token_instant = Some(std::time::Instant::now());
         }
 
+        // ===== Compiled C++ PAGED decode-path dispatch (P4) =====
+        // Same setup the non-streaming path uses: acquire the compiled lifecycle
+        // + weight locks, gate, and seed the compiled-paged session for this
+        // turn. The returned state holds the RAII guards spanning the whole
+        // streaming decode loop. A fatal mid-turn compiled failure surfaced by
+        // `paged_compiled_decode_step` propagates out of this streaming function
+        // via `?` (correct — the C++ conv state has advanced and cannot be
+        // recovered into `self.caches`).
+        let mut paged_st = self.paged_compiled_decode_setup()?;
+
         // === STREAMING DECODE LOOP ===
         let max_new_tokens = p.max_new_tokens;
         let mut generated_tokens: Vec<u32> = Vec::with_capacity(max_new_tokens.max(0) as usize);
@@ -2172,9 +2496,9 @@ impl Lfm2Inner {
                 break;
             }
 
-            // Decode forward
-            let next_logits = self.run_paged_decode_step(token_id)?;
-            let next_logits = next_logits.squeeze(Some(&[1]))?;
+            // Decode forward (compiled-paged when seeded, else pure-Rust paged)
+            // via the shared per-step dispatcher (mirrors the non-streaming path).
+            let next_logits = self.paged_compiled_decode_step(&mut paged_st, token_id, step)?;
 
             let next_logits = if reasoning_tracker.should_force_think_end() {
                 let forced_id = reasoning_tracker.forced_token_id() as i32;
@@ -3466,6 +3790,322 @@ impl Drop for Lfm2CompiledResetGuard {
             mlx_sys::mlx_lfm2_moe_reset();
         }
     }
+}
+
+/// RAII guard that calls `mlx_lfm2_paged_reset()` on drop, tearing down the
+/// compiled-PAGED lfm2 decode globals (per-layer pools / scales / conv-state,
+/// offset, inited flag).
+///
+/// DISTINCT from [`Lfm2CompiledResetGuard`] (the FLAT path, which calls
+/// `mlx_lfm2_moe_reset()`): the flat and paged decode families own strictly
+/// separate C++ state and must each reset their own. Like the flat guard, this
+/// ensures the compiled-paged globals are always torn down even when the decode
+/// loop returns early via `?`, so the next generation never seeds against stale
+/// paged pools.
+///
+/// Armed by `chat_sync_core_paged_inner` (P4) when the compiled-paged seed
+/// succeeds.
+struct Lfm2PagedResetGuard;
+
+impl Drop for Lfm2PagedResetGuard {
+    fn drop(&mut self) {
+        unsafe {
+            mlx_sys::mlx_lfm2_paged_reset();
+        }
+    }
+}
+
+/// Initialize the compiled-PAGED lfm2 decode graph from the live post-prefill
+/// state — the adapter's per-attention-layer paged KV pool/scale arrays AND the
+/// per-conv-layer conv-state arrays already populated by the pure-Rust eager
+/// paged prefill (`run_paged_prefill_chunk`).
+///
+/// Mirrors qwen3.5's `init_paged_dense_compiled_session` (qwen3_5/model.rs) but
+/// for lfm2's irregular conv/attn interleave: instead of a modulo `is_linear`
+/// test, the per-layer dispatch is driven by the explicit
+/// `config.is_attention_layer(i)` map (built into `is_attn` and passed to C++).
+///
+/// # Layer-index contract
+///
+/// The C++ FFI (`mlx_lfm2_moe_init_paged`) accepts five per-layer handle arrays
+/// of size `num_layers` (absolute decoder count). For each absolute layer `i`:
+/// * Attention layer: `k_pool_handles[i]` / `v_pool_handles[i]` /
+///   `k_scale_handles[i]` / `v_scale_handles[i]` come from the adapter's
+///   `LayerKVPool` at the COMPACT (attention-layer) ordinal `paged_idx`; the
+///   `conv_state_handles[i]` slot is null. The compact-ordinal mapping is
+///   computed by [`Lfm2Inner::compute_layer_kinds`], the same helper the
+///   production eager paged dispatch uses.
+/// * Conv layer: `conv_state_handles[i]` is the layer's conv state
+///   `[B, l_cache-1, hidden]` from its `Lfm2LayerCache::Conv(ArraysCache)` slot
+///   0; the pool/scale slots are null. (No cross-turn conv export is needed —
+///   the eager paged path reprefills conv from token 0 each turn — so the
+///   compiled graph threads conv state WITHIN a turn only.)
+///
+/// # Caller contract
+///
+/// 1. `caches` is fully populated by a prior pure-Rust eager paged prefill.
+/// 2. `adapter.block_size() == CPP_PAGED_REQUIRED_BLOCK_SIZE` (16): the compiled
+///    paged graph hard-codes `block_size=16` into its `paged_kv_write` /
+///    `paged_attention` calls. The caller MUST gate on this before invoking.
+/// 3. The C++ weights for this model are still registered (caller verified
+///    `mlx_lfm2_get_model_id() == self.model_id` and holds the read lock).
+///
+/// `prefill_offset` is the global token cursor the compiled paged graph's
+/// `g_lfm2_paged_offset_int` starts incrementing from; the caller passes
+/// `adapter.current_token_count() as i32`. Every attention layer shares this
+/// single adapter cursor (paged attention has ONE logical sequence position, not
+/// a per-layer KVCache offset like the flat path), so there is no per-layer
+/// offset to disagree — the consistency invariant the flat seed checks is
+/// structurally guaranteed here. We still validate the cursor is non-negative
+/// and that the cache vector length matches the config so a corrupt session
+/// falls back to native rather than seeding a wrong position.
+///
+/// On any failure (cache-length mismatch, missing pool/scale handle, missing
+/// conv state, or the C++ FFI returning a non-zero status), returns `Err` so the
+/// caller falls back to the pure-Rust eager paged decode path.
+fn init_lfm2_paged_compiled_session(
+    config: &Lfm2Config,
+    caches: &[Lfm2LayerCache],
+    paged_adapter: &PagedKVCacheAdapter,
+    prefill_offset: i32,
+) -> Result<()> {
+    let num_layers_us = config.num_hidden_layers as usize;
+    if caches.len() != num_layers_us {
+        return Err(Error::from_reason(format!(
+            "init_lfm2_paged_compiled_session: caches.len()={} but config.num_hidden_layers={}",
+            caches.len(),
+            num_layers_us
+        )));
+    }
+    if prefill_offset < 0 {
+        return Err(Error::from_reason(format!(
+            "init_lfm2_paged_compiled_session: negative prefill_offset={prefill_offset}; refusing \
+             to seed a wrong position. Caller must fall back to the pure-Rust paged path."
+        )));
+    }
+
+    // Per-layer attn/conv dispatch — built DYNAMICALLY from config (lfm2 mixes
+    // conv/attn irregularly; never a modulo/hardcoded pattern). Mirrors the flat
+    // seed's `is_attn` construction.
+    let is_attn: Vec<i32> = (0..num_layers_us)
+        .map(|i| i32::from(config.is_attention_layer(i)))
+        .collect();
+
+    // Compact-ordinal mapping (paged_idx counts only attention layers), the same
+    // helper the eager paged forward uses.
+    let layer_kinds = compute_layer_kinds_for(config, num_layers_us);
+
+    let mut k_pool_handles: Vec<*mut mlx_sys::mlx_array> =
+        vec![std::ptr::null_mut(); num_layers_us];
+    let mut v_pool_handles: Vec<*mut mlx_sys::mlx_array> =
+        vec![std::ptr::null_mut(); num_layers_us];
+    let mut k_scale_handles: Vec<*mut mlx_sys::mlx_array> =
+        vec![std::ptr::null_mut(); num_layers_us];
+    let mut v_scale_handles: Vec<*mut mlx_sys::mlx_array> =
+        vec![std::ptr::null_mut(); num_layers_us];
+    let mut conv_state_handles: Vec<*mut mlx_sys::mlx_array> =
+        vec![std::ptr::null_mut(); num_layers_us];
+
+    // Hold every wrapping `MxArray` alive across the FFI call so the C++ side has
+    // time to copy each handle into its own globals before the temporaries drop.
+    let mut held_arrays: Vec<MxArray> = Vec::with_capacity(num_layers_us * 4);
+
+    for (i, kind) in layer_kinds.iter().enumerate() {
+        match kind {
+            Lfm2LayerKind::FullAttention { paged_idx } => {
+                let k_arr = paged_adapter.key_pool_array(*paged_idx).map_err(|e| {
+                    Error::from_reason(format!(
+                        "init_lfm2_paged_compiled_session: key_pool_array(layer={i}, \
+                         paged_idx={paged_idx}): {e}",
+                    ))
+                })?;
+                let v_arr = paged_adapter.value_pool_array(*paged_idx).map_err(|e| {
+                    Error::from_reason(format!(
+                        "init_lfm2_paged_compiled_session: value_pool_array(layer={i}, \
+                         paged_idx={paged_idx}): {e}",
+                    ))
+                })?;
+                let ks_arr = paged_adapter.k_scale_array(*paged_idx).map_err(|e| {
+                    Error::from_reason(format!(
+                        "init_lfm2_paged_compiled_session: k_scale_array(layer={i}, \
+                         paged_idx={paged_idx}): {e}",
+                    ))
+                })?;
+                let vs_arr = paged_adapter.v_scale_array(*paged_idx).map_err(|e| {
+                    Error::from_reason(format!(
+                        "init_lfm2_paged_compiled_session: v_scale_array(layer={i}, \
+                         paged_idx={paged_idx}): {e}",
+                    ))
+                })?;
+                k_pool_handles[i] = k_arr.as_raw_ptr();
+                v_pool_handles[i] = v_arr.as_raw_ptr();
+                k_scale_handles[i] = ks_arr.as_raw_ptr();
+                v_scale_handles[i] = vs_arr.as_raw_ptr();
+                held_arrays.push(k_arr);
+                held_arrays.push(v_arr);
+                held_arrays.push(ks_arr);
+                held_arrays.push(vs_arr);
+            }
+            Lfm2LayerKind::Conv => {
+                // Conv state lives in `self.caches[i]` (NOT the adapter): the
+                // eager paged prefill writes it into the layer's
+                // `Lfm2LayerCache::Conv(ArraysCache)` slot 0 as
+                // `[B, l_cache-1, hidden]`.
+                let conv_cache = match &caches[i] {
+                    Lfm2LayerCache::Conv(c) => c,
+                    Lfm2LayerCache::Attention(_) => {
+                        return Err(Error::from_reason(format!(
+                            "init_lfm2_paged_compiled_session: layer {i} is Conv by config but \
+                             cache slot is Attention",
+                        )));
+                    }
+                };
+                let state = conv_cache.get(0).ok_or_else(|| {
+                    Error::from_reason(format!(
+                        "init_lfm2_paged_compiled_session: layer {i} conv_state not populated; \
+                         the eager paged prefill must run before C++ paged init",
+                    ))
+                })?;
+                conv_state_handles[i] = state.as_raw_ptr();
+            }
+        }
+    }
+
+    let status = unsafe {
+        mlx_sys::mlx_lfm2_moe_init_paged(
+            config.num_hidden_layers,
+            config.hidden_size,
+            config.num_attention_heads,
+            config.num_key_value_heads,
+            config.head_dim(),
+            config.rope_theta as f32,
+            config.norm_eps as f32,
+            config.conv_l_cache,
+            config.num_experts.unwrap_or(0),
+            config.num_experts_per_tok.unwrap_or(0),
+            config.num_dense_layers.unwrap_or(0),
+            i32::from(config.norm_topk_prob.unwrap_or(true)),
+            i32::from(config.use_expert_bias.unwrap_or(true)),
+            i32::from(config.tie_embedding),
+            i32::from(config.conv_bias),
+            // max_kv_len is accepted for ABI symmetry with the flat init; the
+            // paged graph sizes its pools from the adapter, so any non-negative
+            // value is fine here. Pass the global position so the field carries a
+            // meaningful sequence length rather than 0.
+            prefill_offset,
+            1, // batch_size
+            crate::models::qwen3_5::model::CPP_PAGED_REQUIRED_BLOCK_SIZE as i32,
+            is_attn.as_ptr(),
+            k_pool_handles.as_mut_ptr(),
+            v_pool_handles.as_mut_ptr(),
+            k_scale_handles.as_mut_ptr(),
+            v_scale_handles.as_mut_ptr(),
+            conv_state_handles.as_mut_ptr(),
+            prefill_offset,
+        )
+    };
+
+    // Drop the held wrappers only AFTER the FFI call returns: the C++ init copies
+    // each handle into its globals (and force-evals the attn pools), so by here
+    // it no longer needs our temporaries alive.
+    drop(held_arrays);
+
+    // The C++ side returns 0 on success, -1 on failure (missing handle, bad
+    // block_size, dtype mismatch, or any caught exception). On failure it leaves
+    // `g_lfm2_paged_inited` cleared so a subsequent `mlx_lfm2_moe_forward_paged`
+    // would null its logits; surfacing the status here lets the caller fall back
+    // to the pure-Rust paged path before any decode-step FFI is dispatched.
+    if status != 0 {
+        // Belt-and-suspenders: the C++ init now clears the paged globals on every
+        // failure path itself, but a failed init mutates process-wide GPU-backed
+        // state, so we also fire the reset from the Rust side. `mlx_lfm2_paged_reset`
+        // is idempotent (clears config/is_attn/pool/scale vectors + offset + inited
+        // flag), so a double reset is harmless. This guarantees no stale imported
+        // array handles / populated pool vectors leak when the seed aborts and the
+        // caller drops back to the pure-Rust paged path (no `Lfm2PagedResetGuard`
+        // is armed on the Err branch).
+        unsafe { mlx_sys::mlx_lfm2_paged_reset() };
+        return Err(Error::from_reason(format!(
+            "init_lfm2_paged_compiled_session: mlx_lfm2_moe_init_paged returned status={status} \
+             (expected 0); see stderr for the C++ diagnostic. Caller must fall back to the \
+             pure-Rust paged path."
+        )));
+    }
+
+    Ok(())
+}
+
+/// Single-token decode step using the C++ compiled-PAGED forward pass.
+///
+/// Per-step wrapper mirroring qwen3.5's `forward_dense_cpp_paged`: threads the
+/// paged-attention inputs (offset_arr, block_table, slot_mapping,
+/// num_valid_tokens, num_valid_blocks, seq_lens) so each attention layer writes
+/// its new K/V into the adapter's paged Metal pool via `paged_kv_write` and
+/// gathers via `paged_attention`, while conv layers thread their state through
+/// the compiled graph's cache slots.
+///
+/// Caller contract (enforced in the P4 decode loop, not here):
+/// * `init_lfm2_paged_compiled_session` has been called this turn (so
+///   `g_lfm2_paged_inited == true`).
+/// * `adapter.record_tokens(&[token_id])` has advanced the cursor (and lazily
+///   allocated any new block) for this step.
+/// * `inputs` was just built via
+///   `adapter.build_paged_attention_inputs(1, 1, max_blocks_per_seq)`.
+///
+/// On any FFI failure (`output_logits == null`) returns `Err` so the dispatcher
+/// can fall back to the pure-Rust paged decode (first step) or propagate (after
+/// a compiled step has mutated the C++ paged globals).
+fn forward_lfm2_cpp_paged(
+    input_ids: &MxArray,
+    embedding_weight: &MxArray,
+    inputs: &crate::transformer::paged_attention_inputs::PagedAttentionInputs,
+) -> Result<MxArray> {
+    let mut output_ptr: *mut mlx_sys::mlx_array = std::ptr::null_mut();
+    let mut cache_offset_out: i32 = 0;
+    unsafe {
+        mlx_sys::mlx_lfm2_moe_forward_paged(
+            input_ids.as_raw_ptr(),
+            embedding_weight.as_raw_ptr(),
+            inputs.offset_arr.as_raw_ptr(),
+            inputs.block_table.as_raw_ptr(),
+            inputs.slot_mapping.as_raw_ptr(),
+            inputs.num_valid_tokens.as_raw_ptr(),
+            inputs.num_valid_blocks.as_raw_ptr(),
+            inputs.seq_lens.as_raw_ptr(),
+            &mut output_ptr,
+            &mut cache_offset_out,
+        );
+    }
+
+    if output_ptr.is_null() {
+        return Err(Error::from_reason(
+            "lfm2 compiled paged forward step returned null — check stderr for diagnostic. \
+             (Common causes: g_lfm2_paged_inited = false, slot_mapping shape != [1], \
+             input_ids size != 1, or weights cleared by another model load.)",
+        ));
+    }
+
+    MxArray::from_handle(output_ptr, "lfm2 compiled paged forward logits")
+}
+
+/// Free-function form of [`Lfm2Inner::compute_layer_kinds`] usable without a
+/// `self` borrow (the paged compiled session init only has `&Lfm2Config` +
+/// `&[Lfm2LayerCache]`, not the whole `Lfm2Inner`). Identical mapping:
+/// `FullAttention { paged_idx }` for attention layers (paged_idx counts only
+/// those, in original order) and `Conv` otherwise. Called by
+/// `init_lfm2_paged_compiled_session` (P4 decode-loop wiring).
+fn compute_layer_kinds_for(config: &Lfm2Config, num_layers: usize) -> Vec<Lfm2LayerKind> {
+    let mut kinds = Vec::with_capacity(num_layers);
+    let mut paged_idx: u32 = 0;
+    for i in 0..num_layers {
+        if config.is_attention_layer(i) {
+            kinds.push(Lfm2LayerKind::FullAttention { paged_idx });
+            paged_idx += 1;
+        } else {
+            kinds.push(Lfm2LayerKind::Conv);
+        }
+    }
+    kinds
 }
 
 fn init_caches(config: &Lfm2Config) -> Vec<Lfm2LayerCache> {

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -1695,6 +1695,23 @@ impl Lfm2Inner {
                         .rollback_last_tokens(1)
                         .map_err(Error::from_reason)?;
                     st.cpp_session_ready = false;
+                    // The rest of this turn runs pure-Rust eager paged decode
+                    // (`run_paged_decode_step` touches none of the C++ compiled
+                    // paged globals), so the seeded compiled-paged session is now
+                    // dead. Tear it down and release the process-wide locks NOW
+                    // instead of pinning them for the whole generation (they
+                    // otherwise block weight registration `.write()` / other
+                    // compiled startups `.lock()`).
+                    //
+                    // ORDER IS LOAD-BEARING (mirrors the struct field drop order,
+                    // see `Lfm2PagedCompiledState`): drop the reset guard FIRST so
+                    // `mlx_lfm2_paged_reset()` runs WHILE the lifecycle mutex +
+                    // weight read lock are STILL held; only THEN release the locks.
+                    // After this all three guards are None, so the struct's
+                    // eventual drop is a no-op (no double reset / double release).
+                    drop(st._paged_reset_guard.take());
+                    st._weight_guard = None;
+                    st._compiled_lock = None;
                     // Re-run this token through the pure-Rust paged decode
                     // (re-records the token on the rolled-back cursor).
                     self.run_paged_decode_step(token_id)?.squeeze(Some(&[1]))

--- a/crates/mlx-core/src/models/lfm2/persistence.rs
+++ b/crates/mlx-core/src/models/lfm2/persistence.rs
@@ -1376,7 +1376,24 @@ impl Lfm2Inner {
         // dispatch keys on `paged_adapter.is_some()`, so this is an authoritative
         // load-time predictor of which decode loop this instance will run.
         let is_flat = inner.config.use_block_paged_cache == Some(false);
-        if should_register_compiled(is_quantized, is_flat, all_float_weights_bf16) {
+        // Compiled-PAGED ALSO hard-requires block_size == CPP_PAGED_REQUIRED_BLOCK_SIZE
+        // (16): `paged_compiled_decode_setup` falls back to eager when
+        // `adapter.block_size() != 16`. The adapter's block size is fixed once at
+        // `Lfm2Inner::new` as `config.paged_block_size.unwrap_or(16)` and is
+        // immutable thereafter, so this load-time value authoritatively predicts
+        // the decode-time gate. `unwrap_or(16)` matches that construction, so a
+        // `None` config still passes (None builds a 16-block adapter that DOES arm
+        // compiled). A bf16 *paged* checkpoint with `paged_block_size` 8/32 can use
+        // no compiled path, so registering it would only evict another model's
+        // compiled slot — same needless eviction the dtype gate closed for f16.
+        let paged_block_size_ok = inner.config.paged_block_size.unwrap_or(16)
+            == crate::models::qwen3_5::model::CPP_PAGED_REQUIRED_BLOCK_SIZE;
+        if should_register_compiled(
+            is_quantized,
+            is_flat,
+            all_float_weights_bf16,
+            paged_block_size_ok,
+        ) {
             register_weights_with_cpp(&params, inner.model_id, &inner.config)?;
             // Record the bf16-clean flag (only meaningful once registered) so
             // `paged_compiled_decode_setup` can gate compiled-paged on this
@@ -1496,17 +1513,27 @@ fn all_registered_float_weights_are_bf16(params: &HashMap<String, MxArray>) -> R
 ///   * quantized → never (the compiled `linear_proj` would mis-dispatch the
 ///     quant mode; quantized compiled decode is deferred);
 ///   * flat (`use_block_paged_cache == Some(false)`) → always register: the flat
-///     compiled graph is dtype-generic, so bf16 AND f16 flat checkpoints run it;
-///   * paged (default) → register ONLY when bf16-clean: compiled-PAGED is
-///     bf16-only, so a non-bf16 paged checkpoint is forced onto eager paged by
-///     `paged_compiled_decode_setup` (`!all_float_weights_bf16`). Registering it
+///     compiled graph is dtype/block-generic (a flat instance has no paged
+///     adapter, so there is no block size to consult), so bf16 AND f16 flat
+///     checkpoints run it — `paged_block_size_ok` is intentionally NOT consulted
+///     for the flat arm;
+///   * paged (default) → register ONLY when BOTH `all_float_weights_bf16` AND
+///     `paged_block_size_ok`: compiled-PAGED is bf16-only AND hard-codes
+///     block_size == 16, so `paged_compiled_decode_setup` forces a non-bf16 OR
+///     non-16-block paged checkpoint onto eager paged. Registering such a model
 ///     would evict another model's compiled path for ZERO benefit, so skip it.
+///
+/// `{not quantized, all-float-bf16, block_size == 16}` is the complete set of
+/// load-time-knowable preconditions for the paged compiled path; every other
+/// decline (model-id eviction race, seed-time pool failures, mid-cycle forward
+/// errors) is runtime-only and handled by the lock-release + RAII reset fallback.
 fn should_register_compiled(
     is_quantized: bool,
     is_flat: bool,
     all_float_weights_bf16: bool,
+    paged_block_size_ok: bool,
 ) -> bool {
-    !is_quantized && (is_flat || all_float_weights_bf16)
+    !is_quantized && (is_flat || (all_float_weights_bf16 && paged_block_size_ok))
 }
 
 fn register_weights_with_cpp(
@@ -1900,39 +1927,61 @@ mod tests {
         }
     }
 
-    /// Registration-gate regression (PR #66 review P2): registering publishes
+    /// Registration-gate regression (PR #66 review): registering publishes
     /// `model_id` into the single, cross-family `g_active_model_id` slot and
-    /// EVICTS any resident compiled model. So we must register only when this
-    /// model can itself take a compiled path. The one case the widened gate would
-    /// have gotten wrong is **f16 + paged** (default cache): compiled-PAGED is
-    /// bf16-only, so it can never use the registered path — registering it would
-    /// be a pure-downside eviction. Every other non-quantized case must STILL
-    /// register (flat is dtype-generic; bf16-paged uses compiled-paged).
+    /// EVICTS any resident compiled model, so we must register only when this
+    /// model can itself take a compiled path. Compiled-PAGED has TWO load-time
+    /// preconditions beyond `!is_quantized`: bf16-clean weights AND block_size ==
+    /// 16. The two cases the widened gate would otherwise get wrong are **f16 +
+    /// paged** (compiled-PAGED is bf16-only) and **bf16 + paged + block != 16**
+    /// (compiled-PAGED hard-codes block 16) — both fall back to eager paged, so
+    /// registering them is a pure-downside eviction. Flat is dtype/block-generic
+    /// (no paged adapter), so it must register regardless of dtype OR block.
+    ///
+    /// Args: `should_register_compiled(is_quantized, is_flat, all_bf16, block16_ok)`.
     #[test]
-    fn compiled_registration_gate_skips_only_f16_paged() {
-        // flat (use_block_paged_cache==Some(false)) → always register, any dtype.
+    fn compiled_registration_gate_skips_f16_or_nonblock16_paged() {
+        // flat (use_block_paged_cache==Some(false)) → always register, any dtype,
+        // any block (a flat instance has no paged adapter → block is irrelevant).
         assert!(
-            should_register_compiled(/*quant*/ false, /*flat*/ true, /*bf16*/ true),
+            should_register_compiled(
+                /*quant*/ false, /*flat*/ true, /*bf16*/ true, /*blk16*/ true
+            ),
             "bf16 flat must register (compiled-flat)"
         );
         assert!(
-            should_register_compiled(false, true, false),
+            should_register_compiled(false, true, false, true),
             "f16 flat must register (compiled-flat is dtype-generic)"
         );
-        // paged (default) → register only when bf16-clean.
         assert!(
-            should_register_compiled(false, false, true),
-            "bf16 paged must register (compiled-paged)"
+            should_register_compiled(false, true, true, false),
+            "flat must register regardless of paged_block_size (flat compiled graph \
+             has no adapter / is block-generic)"
+        );
+        // paged (default) → register only when bf16-clean AND block_size == 16.
+        assert!(
+            should_register_compiled(false, false, true, true),
+            "bf16 paged + block16 must register (compiled-paged)"
         );
         assert!(
-            !should_register_compiled(false, false, false),
+            !should_register_compiled(false, false, false, true),
             "f16 paged must NOT register — it can only run eager paged, so \
              registering would evict another model's compiled path for nothing"
         );
-        // quantized → never, regardless of flat/dtype.
-        assert!(!should_register_compiled(true, true, false));
-        assert!(!should_register_compiled(true, false, true));
-        assert!(!should_register_compiled(true, true, true));
+        assert!(
+            !should_register_compiled(false, false, true, false),
+            "bf16 paged with block_size != 16 must NOT register — compiled-paged \
+             hard-requires block16, so registering would evict for nothing"
+        );
+        assert!(
+            !should_register_compiled(false, false, false, false),
+            "f16 paged + block != 16 must NOT register (neither precondition met)"
+        );
+        // quantized → never, regardless of flat/dtype/block.
+        assert!(!should_register_compiled(true, true, false, true));
+        assert!(!should_register_compiled(true, false, true, true));
+        assert!(!should_register_compiled(true, true, true, true));
+        assert!(!should_register_compiled(true, false, true, false));
     }
 
     /// F1 regression: a `use_expert_bias=true` flat bf16 MoE checkpoint that

--- a/crates/mlx-core/src/models/lfm2/persistence.rs
+++ b/crates/mlx-core/src/models/lfm2/persistence.rs
@@ -1323,35 +1323,53 @@ impl Lfm2Inner {
             crate::array::memory::materialize_weights(&weight_refs)?;
         }
 
-        // Register weights with the compiled C++ decode path for a non-paged,
-        // bf16/f16 checkpoint — DENSE or sparse-MoE. Phase 3c lifted the MoE
-        // exclusion: `lfm2_decode_fn`'s MoE branch (driven by the MoE config
-        // threaded into `mlx_lfm2_moe_init_from_prefill`) applies the sparse
-        // top-k `lfm2_switch_linear` FFN to MoE layers and `lfm2_dense_mlp` to
-        // the dense layers, matching the native `Lfm2Inner::forward`. Because
+        // Register weights with the compiled C++ decode path for a non-quantized
+        // bf16/f16 checkpoint — DENSE or sparse-MoE, FLAT or PAGED. Phase 3c
+        // lifted the MoE exclusion: `lfm2_decode_fn`'s MoE branch (driven by the
+        // MoE config threaded into `mlx_lfm2_moe_init_from_prefill`) applies the
+        // sparse top-k `lfm2_switch_linear` FFN to MoE layers and `lfm2_dense_mlp`
+        // to the dense layers, matching the native `Lfm2Inner::forward`. Because
         // `compiled_path_active()` is a pure id-equality probe and the id is
         // published ONLY here, gating the registration makes the compiled path
         // structurally impossible for the checkpoints still excluded below.
         //
-        // Still excluded (Phase-2 guards intact):
-        //   * paged checkpoints — the flat compiled decode graph is incompatible
-        //     with the block-paged adapter, so only `use_block_paged_cache ==
-        //     Some(false)` registers.
+        // P4 WIDENED the gate: a non-quantized bf16/f16 PAGED checkpoint now ALSO
+        // registers, so the compiled-PAGED decode graph
+        // (`lfm2_decode_fn_paged`, seeded by `init_lfm2_paged_compiled_session` →
+        // `mlx_lfm2_moe_init_paged`) can read weights via `get_weight`. The same
+        // single weight map and `model_id` serve BOTH the flat
+        // (`lfm2_decode_fn`) and paged (`lfm2_decode_fn_paged`) compiled graphs;
+        // the per-step dispatcher (`chat_sync_core` flat vs
+        // `chat_sync_core_paged_inner` paged) picks the right graph. The
+        // single-owner `g_weights`/`model_id` clobber contract is unchanged:
+        // `register_weights_with_cpp` still clears the map, stores, bumps the
+        // compile epoch, then publishes `model_id` LAST under
+        // `COMPILED_WEIGHTS_RWLOCK.write()`.
+        //
+        // Still excluded:
         //   * quantized checkpoints — the compiled `linear_proj` infers the quant
         //     mode and would mis-dispatch MXFP4 / NVFP4 as MXFP8 (registration
         //     stores no authoritative quant-info), so quantized compiled decode
         //     (incl. quantized MoE = Phase 3b) is deferred. Quantized tensors
         //     carry `.scales`-suffixed keys; bf16/f16 checkpoints have none.
         //
-        // `conv_bias=true` checkpoints ARE now supported (Phase 4 Piece 1): the
-        // `conv_bias` flag is threaded into `mlx_lfm2_moe_init_from_prefill`, so
-        // `lfm2_decode_fn` calls `lfm2_conv_pure_fn` with `cfg.conv_bias` and the
-        // three conv biases (`conv.in_proj.bias`, `conv.conv.bias`,
-        // `conv.out_proj.bias`) flow through the generic store loop under the same
-        // keys `get_weight` reads.
+        // `conv_bias=true` checkpoints ARE supported (Phase 4 Piece 1): the
+        // `conv_bias` flag is threaded into `mlx_lfm2_moe_init_from_prefill` /
+        // `mlx_lfm2_moe_init_paged`, so the conv pure-fn adds the three conv
+        // biases (`conv.in_proj.bias`, `conv.conv.bias`, `conv.out_proj.bias`)
+        // which flow through the generic store loop under the same keys
+        // `get_weight` reads.
         let is_quantized = params.keys().any(|k| k.ends_with(".scales"));
-        if inner.config.use_block_paged_cache == Some(false) && !is_quantized {
+        if !is_quantized {
             register_weights_with_cpp(&params, inner.model_id, &inner.config)?;
+            // Compiled-PAGED decode is bf16-only (the paged KV pools + graph
+            // hard-code `KvDtype::Bf16`). Record (once, over the SAME param map we
+            // just registered) whether every registered float weight is BFloat16
+            // so `paged_compiled_decode_setup` can gate compiled-paged on an
+            // authoritative whole-model invariant rather than a hand-picked tensor
+            // subset. The flat compiled path is unaffected (it does not consult
+            // this flag); a non-bf16 checkpoint still registers and runs flat.
+            inner.all_float_weights_bf16 = all_registered_float_weights_are_bf16(&params)?;
         }
 
         // NOTE: the cache-limit coordinator registration happens in
@@ -1415,11 +1433,46 @@ impl Lfm2Inner {
 ///
 /// Still returns early (storing nothing, publishing no id) for quantized
 /// (`.scales`-suffixed, incl. quantized MoE = Phase 3b) checkpoints, mirroring
-/// the call-site gate. The caller also gates on `use_block_paged_cache ==
-/// Some(false)`; these are belt-and-suspenders. `conv_bias=true` checkpoints ARE
-/// registered (Phase 4 Piece 1): the three conv biases ride the generic store
-/// loop under the same keys `lfm2_conv_pure_fn`'s `get_weight` reads, and the
-/// `conv_bias` flag is threaded to the compiled decode via the config FFI.
+/// the call-site gate. P4 widened the call-site gate to register BOTH flat
+/// (`use_block_paged_cache == Some(false)`) AND paged (the default) bf16/f16
+/// checkpoints, so this registration is no longer flat-only; the per-step
+/// dispatcher picks the flat (`lfm2_decode_fn`) or paged (`lfm2_decode_fn_paged`)
+/// compiled graph against the SAME registered weight map. `conv_bias=true`
+/// checkpoints ARE registered (Phase 4 Piece 1): the three conv biases ride the
+/// generic store loop under the same keys `lfm2_conv_pure_fn`'s `get_weight`
+/// reads, and the `conv_bias` flag is threaded to the compiled decode via the
+/// config FFI.
+/// Whether EVERY registered floating weight is BFloat16 — the invariant the
+/// compiled-PAGED decode graph requires (its paged KV pools + static mask are
+/// bf16-only; a non-bf16 float anywhere in the per-layer chain would flow a
+/// non-bf16 hidden state / q / k / v into the bf16-only
+/// `paged_kv_write`/`paged_attention`). Scans the SAME `params` map that is
+/// registered into the C++ weight store, so it sees exactly what `get_weight`
+/// will hand the graph — authoritative, and matched to the graph rather than a
+/// hand-picked tensor subset.
+///
+/// EXCEPTION: `*.expert_bias` is intentionally F32 on MoE checkpoints (the
+/// router bias is kept in f32 for headroom; the eager AND flat-compiled paths
+/// already run the 8B-A1B checkpoint with an f32 `expert_bias`, and
+/// compiled-PAGED is byte-identical to eager-paged on it), so it is skipped.
+/// Non-float tensors (integer index/scale buffers — none in current lfm2
+/// checkpoints) are ignored: the bf16 contract is about float math, not
+/// integer buffers. Quantized checkpoints never reach here (the caller gates on
+/// `!is_quantized`).
+fn all_registered_float_weights_are_bf16(params: &HashMap<String, MxArray>) -> Result<bool> {
+    for (key, weight) in params {
+        if key.ends_with(".expert_bias") {
+            continue;
+        }
+        let dt = weight.dtype()?;
+        let is_float = matches!(dt, DType::Float32 | DType::Float16 | DType::BFloat16);
+        if is_float && dt != DType::BFloat16 {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 fn register_weights_with_cpp(
     params: &HashMap<String, MxArray>,
     model_id: u64,
@@ -1628,6 +1681,17 @@ mod tests {
         MxArray::from_float32(&data, shape).expect("from_float32")
     }
 
+    /// f16 array of the given shape filled with `fill` (for the mixed-dtype
+    /// compiled-PAGED gate regression).
+    fn f16(shape: &[i64], fill: f32) -> MxArray {
+        let n: i64 = shape.iter().product();
+        let data: Vec<f32> = vec![fill; n.max(0) as usize];
+        MxArray::from_float32(&data, shape)
+            .expect("from_float32")
+            .astype(DType::Float16)
+            .expect("astype f16")
+    }
+
     /// Build a full, correctly-shaped bf16 param map for `tiny_moe_config`.
     /// Both layers are MoE (num_dense_layers=0); layer 0 is conv, layer 1 is
     /// attention. `expert_bias` (NONZERO) is included on both MoE layers.
@@ -1742,6 +1806,60 @@ mod tests {
             assert!(
                 moe.expert_bias_is_some(),
                 "layer {i}: use_expert_bias=true but loader did not apply expert_bias"
+            );
+        }
+    }
+
+    /// F3 regression (compiled-PAGED bf16-only gate): a full bf16 MoE param map
+    /// (q/k/v included) PLUS the intentional f32 `*.expert_bias` is bf16-clean,
+    /// so `all_registered_float_weights_are_bf16` is TRUE — the 8B-A1B
+    /// checkpoint's exact dtype shape, which must keep engaging compiled-paged.
+    #[test]
+    fn bf16_gate_accepts_all_bf16_with_f32_expert_bias() {
+        let params = full_bf16_moe_params();
+        // Sanity: the fixture really does carry an f32 expert_bias (the one
+        // allowed non-bf16 float), else this test would be vacuous.
+        assert!(
+            params.keys().any(|k| k.ends_with(".expert_bias")),
+            "fixture must include an f32 expert_bias for the exception to matter"
+        );
+        assert!(
+            all_registered_float_weights_are_bf16(&params).expect("dtype scan"),
+            "all-bf16 weights + f32 expert_bias must pass the bf16-only gate"
+        );
+    }
+
+    /// F3 regression: bf16 q/k/v but an f16 weight ELSEWHERE in the per-layer
+    /// chain (norm / conv / FFN / out_proj / lm_head) must make the gate FALSE.
+    /// This is exactly the mixed-dtype hole the adversarial re-review flagged: an
+    /// f16 upstream weight makes the hidden state (hence q/new_k/new_v) non-bf16
+    /// before the bf16-only `paged_kv_write`/`paged_attention`, so compiled-paged
+    /// must fall back to eager. Checking embed+q/k/v alone (the prior gate) would
+    /// have WRONGLY admitted every one of these.
+    #[test]
+    fn bf16_gate_rejects_f16_weight_outside_qkv() {
+        // Each key is bf16 in the fixture and consumed by lfm2_decode_fn_paged;
+        // flipping any single one to f16 (q/k/v left bf16) must trip the gate.
+        for key in [
+            "embed_tokens.weight",
+            "embedding_norm.weight",                             // final norm
+            "layers.0.operator_norm.weight", // per-layer norm (upstream of attn)
+            "layers.0.conv.conv.weight",     // conv weight (upstream of attn)
+            "layers.0.conv.in_proj.weight",  // conv in-proj
+            "layers.1.self_attn.out_proj.weight", // attention out_proj
+            "layers.1.feed_forward.switch_mlp.gate_proj.weight", // MoE expert
+            "layers.1.feed_forward.gate.weight", // MoE router
+        ] {
+            let mut params = full_bf16_moe_params();
+            assert!(
+                params.contains_key(key),
+                "fixture missing expected key {key}; update the regression"
+            );
+            // q/k/v stay bf16 — only this upstream weight goes f16.
+            params.insert(key.to_string(), f16(&[1], 0.0));
+            assert!(
+                !all_registered_float_weights_are_bf16(&params).expect("dtype scan"),
+                "an f16 `{key}` (q/k/v still bf16) must FAIL the compiled-paged bf16-only gate"
             );
         }
     }

--- a/crates/mlx-core/src/models/lfm2/persistence.rs
+++ b/crates/mlx-core/src/models/lfm2/persistence.rs
@@ -1360,16 +1360,30 @@ impl Lfm2Inner {
         // which flow through the generic store loop under the same keys
         // `get_weight` reads.
         let is_quantized = params.keys().any(|k| k.ends_with(".scales"));
-        if !is_quantized {
+        // Compiled-PAGED decode is bf16-only (the paged KV pools + static mask
+        // hard-code `KvDtype::Bf16`); compiled-FLAT is dtype-generic. Compute the
+        // whole-model bf16-clean invariant FIRST (read-only dtype scan over the
+        // still-live `params`; `*.expert_bias` F32 on MoE is the one allowed
+        // exception, handled inside the scan) so the registration decision and
+        // the `paged_compiled_decode_setup` gate share one authoritative flag.
+        let all_float_weights_bf16 = if is_quantized {
+            false
+        } else {
+            all_registered_float_weights_are_bf16(&params)?
+        };
+        // Flat is selected iff `use_block_paged_cache == Some(false)`; `None` /
+        // `Some(true)` build the paged adapter at `Lfm2Inner::new` and the decode
+        // dispatch keys on `paged_adapter.is_some()`, so this is an authoritative
+        // load-time predictor of which decode loop this instance will run.
+        let is_flat = inner.config.use_block_paged_cache == Some(false);
+        if should_register_compiled(is_quantized, is_flat, all_float_weights_bf16) {
             register_weights_with_cpp(&params, inner.model_id, &inner.config)?;
-            // Compiled-PAGED decode is bf16-only (the paged KV pools + graph
-            // hard-code `KvDtype::Bf16`). Record (once, over the SAME param map we
-            // just registered) whether every registered float weight is BFloat16
-            // so `paged_compiled_decode_setup` can gate compiled-paged on an
-            // authoritative whole-model invariant rather than a hand-picked tensor
-            // subset. The flat compiled path is unaffected (it does not consult
-            // this flag); a non-bf16 checkpoint still registers and runs flat.
-            inner.all_float_weights_bf16 = all_registered_float_weights_are_bf16(&params)?;
+            // Record the bf16-clean flag (only meaningful once registered) so
+            // `paged_compiled_decode_setup` can gate compiled-paged on this
+            // authoritative whole-model invariant rather than a hand-picked
+            // tensor subset. The flat compiled path does not consult this flag; a
+            // non-bf16 flat checkpoint still registers and runs flat.
+            inner.all_float_weights_bf16 = all_float_weights_bf16;
         }
 
         // NOTE: the cache-limit coordinator registration happens in
@@ -1471,6 +1485,28 @@ fn all_registered_float_weights_are_bf16(params: &HashMap<String, MxArray>) -> R
         }
     }
     Ok(true)
+}
+
+/// Decide whether to register this checkpoint's weights into the shared compiled
+/// registry. Registration is NOT free: it clears `g_weights` and publishes
+/// `model_id` into the single, process-global, cross-family `g_active_model_id`
+/// slot, EVICTING any resident qwen/lfm compiled model (its `compiled_path_active()`
+/// id-equality probe then fails until reload). So register ONLY when this model
+/// will itself take a compiled path:
+///   * quantized → never (the compiled `linear_proj` would mis-dispatch the
+///     quant mode; quantized compiled decode is deferred);
+///   * flat (`use_block_paged_cache == Some(false)`) → always register: the flat
+///     compiled graph is dtype-generic, so bf16 AND f16 flat checkpoints run it;
+///   * paged (default) → register ONLY when bf16-clean: compiled-PAGED is
+///     bf16-only, so a non-bf16 paged checkpoint is forced onto eager paged by
+///     `paged_compiled_decode_setup` (`!all_float_weights_bf16`). Registering it
+///     would evict another model's compiled path for ZERO benefit, so skip it.
+fn should_register_compiled(
+    is_quantized: bool,
+    is_flat: bool,
+    all_float_weights_bf16: bool,
+) -> bool {
+    !is_quantized && (is_flat || all_float_weights_bf16)
 }
 
 fn register_weights_with_cpp(
@@ -1862,6 +1898,41 @@ mod tests {
                 "an f16 `{key}` (q/k/v still bf16) must FAIL the compiled-paged bf16-only gate"
             );
         }
+    }
+
+    /// Registration-gate regression (PR #66 review P2): registering publishes
+    /// `model_id` into the single, cross-family `g_active_model_id` slot and
+    /// EVICTS any resident compiled model. So we must register only when this
+    /// model can itself take a compiled path. The one case the widened gate would
+    /// have gotten wrong is **f16 + paged** (default cache): compiled-PAGED is
+    /// bf16-only, so it can never use the registered path — registering it would
+    /// be a pure-downside eviction. Every other non-quantized case must STILL
+    /// register (flat is dtype-generic; bf16-paged uses compiled-paged).
+    #[test]
+    fn compiled_registration_gate_skips_only_f16_paged() {
+        // flat (use_block_paged_cache==Some(false)) → always register, any dtype.
+        assert!(
+            should_register_compiled(/*quant*/ false, /*flat*/ true, /*bf16*/ true),
+            "bf16 flat must register (compiled-flat)"
+        );
+        assert!(
+            should_register_compiled(false, true, false),
+            "f16 flat must register (compiled-flat is dtype-generic)"
+        );
+        // paged (default) → register only when bf16-clean.
+        assert!(
+            should_register_compiled(false, false, true),
+            "bf16 paged must register (compiled-paged)"
+        );
+        assert!(
+            !should_register_compiled(false, false, false),
+            "f16 paged must NOT register — it can only run eager paged, so \
+             registering would evict another model's compiled path for nothing"
+        );
+        // quantized → never, regardless of flat/dtype.
+        assert!(!should_register_compiled(true, true, false));
+        assert!(!should_register_compiled(true, false, true));
+        assert!(!should_register_compiled(true, true, true));
     }
 
     /// F1 regression: a `use_expert_bias=true` flat bf16 MoE checkpoint that

--- a/crates/mlx-core/tests/lfm2_compiled_e2e.rs
+++ b/crates/mlx-core/tests/lfm2_compiled_e2e.rs
@@ -81,7 +81,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use mlx_core::models::lfm2::model::Lfm2Model;
-use mlx_core::models::qwen3_5::model::{ChatConfig, ChatResult};
+use mlx_core::models::qwen3_5::model::{ChatConfig, ChatResult, ChatStreamChunk};
 use mlx_core::tokenizer::ChatMessage;
 
 /// New tokens decoded per run for the short-prompt tests. Spec requires N >= 48;
@@ -294,25 +294,35 @@ fn greedy_chat_config(max_new_tokens: i32, reuse_cache: bool) -> ChatConfig {
     }
 }
 
-/// Greedy config with REASONING DISABLED (`reasoning_effort: "none"` →
-/// `enable_thinking=Some(false)`, `include_reasoning=Some(false)`).
+/// Greedy config with MINIMAL reasoning + VERBATIM `raw_text`.
 ///
-/// This is the config that makes a thinking-checkpoint reply round-trip
-/// through re-templating, which is required to reach the warm strict-extend
-/// path via `chat_session_start` (see `lfm2_warm_reuse_offset_fix`). With
-/// thinking enabled, `finalize_chat_result` strips the reasoning span out of
-/// `ChatResult.text`, so echoing `text` back in the next turn's history no
-/// longer reproduces the raw generated tokens that were cached — the prefix
-/// verifier misses and the turn cold-prefills. With thinking disabled,
-/// `parse_thinking_and_tools` passes the decoded text through verbatim
-/// (`text == raw_text`), so `assistant_message(&r1.text)` re-renders to the
-/// exact cached token prefix and `verify_cache_prefix` takes the strict-extend
-/// branch.
+/// `reasoning_effort: "none"` (+ `thinking_token_budget: None`) forces the
+/// thinking budget to `0` via `default_thinking_budget_for_effort`, so the
+/// model emits a degenerate empty `<think></think>` span on the first two
+/// decode steps and then answers — deterministic and short. (LFM2's chat
+/// template IGNORES `enable_thinking`; the runtime hard-codes
+/// `thinking_enabled = true` in `chat_sync_core`, so "none" controls the
+/// reasoning BUDGET, not whether reasoning is parsed.)
+///
+/// `include_reasoning: Some(true)` is LOAD-BEARING for the warm strict-extend
+/// reachability via `chat_session_start` (see `lfm2_warm_reuse_offset_fix`):
+/// `save_cache_state` persists the RAW generated tokens, which BEGIN with the
+/// `<think></think>` markers. `ChatResult.text` always has that reasoning span
+/// stripped (`parse_thinking_and_tools` splits at `</think>` whenever
+/// `thinking_enabled` — always true on LFM2), so echoing `text` back in the
+/// next turn's history drops the `<think></think>` tokens and the re-templated
+/// prompt diverges from the cache at the first generated token (verifier
+/// returns 0, full prefill). With `include_reasoning: Some(true)`,
+/// `ChatResult.raw_text` is the FULL verbatim decode (markers included), which
+/// round-trips token-exact through the tokenizer, so echoing `r.raw_text`
+/// re-renders the exact cached prefix and `verify_cache_prefix` takes the
+/// strict-extend branch. (`text` is unaffected by `include_reasoning`, so the
+/// warm-vs-cold output comparison is identical either way.)
 fn greedy_chat_config_no_thinking(max_new_tokens: i32, reuse_cache: bool) -> ChatConfig {
     ChatConfig {
         reasoning_effort: Some("none".to_string()),
         thinking_token_budget: None,
-        include_reasoning: Some(false),
+        include_reasoning: Some(true),
         ..greedy_chat_config(max_new_tokens, reuse_cache)
     }
 }
@@ -511,11 +521,18 @@ fn gated() -> bool {
 }
 
 fn no_compile_env() -> bool {
-    // Match the C++ side EXACTLY: `std::getenv("MLX_NO_COMPILE") != nullptr`
-    // selects the eager `lfm2_decode_fn` branch for ANY value (incl. "0").
-    // Using `== Ok("1")` here would desync: `MLX_NO_COMPILE=0` would run the
-    // eager C++ branch while the test still believed the compiled graph ran.
+    // Match the C++ side EXACTLY: the paged forward selects the eager branch when
+    // `std::getenv("MLX_NO_COMPILE") != nullptr || std::getenv("MLX_DISABLE_COMPILE")
+    // != nullptr` — for ANY value (incl. "0"). Using `== Ok("1")` here would
+    // desync: `MLX_NO_COMPILE=0` would run the eager C++ branch while the test
+    // still believed the compiled graph ran.
+    //
+    // MLX_DISABLE_COMPILE makes MLX's `compile()` a no-op, so the compiled-paged
+    // counter never bumps under it; engagement tests that early-skip under
+    // no-compile MUST also skip here, or they'd assert a false-positive
+    // call-delta. (The C++ `no_compile` latch now ORs both env vars too.)
     std::env::var_os("MLX_NO_COMPILE").is_some()
+        || std::env::var_os("MLX_DISABLE_COMPILE").is_some()
 }
 
 /// Workspace-`target/` path for the cross-invocation native-flat artifact. PID
@@ -633,6 +650,70 @@ async fn run_paged_single(src: &Path, suffix: &str, prompt: &str, max_new: i32) 
         .await
         .unwrap_or_else(|e| panic!("paged chat_session_start ({suffix}): {e:?}"));
     let after = unsafe { mlx_sys::mlx_lfm2_moe_forward_call_count() };
+    let out = run_outcome(suffix, &r, after.saturating_sub(before));
+    drop(model);
+    out
+}
+
+/// Load a paged (`use_block_paged_cache:true`) model and run a single-turn
+/// greedy decode, capturing the COMPILED-PAGED engagement delta
+/// (`mlx_lfm2_moe_compiled_paged_call_count`) — the per-step counter bumped only
+/// inside the traced `compiled_lfm2_decode_paged()` branch. This is the P4 proof
+/// that the default paged path runs the compiled-paged graph (not the eager
+/// pure-Rust paged decode). `clone_model_dir(.., true)` sets `paged_block_size:
+/// 16`, exactly what `init_lfm2_paged_compiled_session` requires.
+async fn run_paged_compiled(src: &Path, suffix: &str, prompt: &str, max_new: i32) -> RunOutcome {
+    let dir = clone_model_dir(src, suffix, true)
+        .unwrap_or_else(|e| panic!("clone paged-compiled dir ({suffix}): {e}"));
+    let model = Lfm2Model::load_from_dir(&dir.to_string_lossy())
+        .await
+        .unwrap_or_else(|e| panic!("load paged-compiled model ({suffix}): {e:?}"));
+    let before = unsafe { mlx_sys::mlx_lfm2_moe_compiled_paged_call_count() };
+    let r = model
+        .chat_session_start(
+            vec![user_message(prompt)],
+            Some(greedy_chat_config(max_new, true)),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("paged-compiled chat_session_start ({suffix}): {e:?}"));
+    let after = unsafe { mlx_sys::mlx_lfm2_moe_compiled_paged_call_count() };
+    let out = run_outcome(suffix, &r, after.saturating_sub(before));
+    drop(model);
+    out
+}
+
+/// Load a paged (`use_block_paged_cache:true`) model and run a single-turn greedy
+/// decode under the EAGER paged path, capturing the PAGED-FORWARD engagement delta
+/// (`mlx_lfm2_moe_paged_forward_call_count`) — the per-step counter bumped at the
+/// top of `mlx_lfm2_moe_forward_paged` for BOTH the compiled AND the eager
+/// `MLX_NO_COMPILE` arm.
+///
+/// This is the helper the EAGER-paged reference uses (run as a SEPARATE process
+/// with `MLX_NO_COMPILE=1`, since the C++ `static bool no_compile` latches once per
+/// process). Under `MLX_NO_COMPILE=1` the Rust gate `compiled_path_active()` stays
+/// ON (it does NOT read `MLX_NO_COMPILE`, exactly like the flat path), so the
+/// decode loop still routes through `forward_lfm2_cpp_paged` →
+/// `mlx_lfm2_moe_forward_paged`, which runs the EAGER `lfm2_decode_fn_paged` arm
+/// (same paged KV-pool / conv layout / RoPE / offset logic, just not
+/// `mlx::core::compile`d). The compiled-paged counter never bumps in that arm, so
+/// the paged-forward counter is the only "C++ paged forward engaged" proof the
+/// eager run has — a nonzero delta rules out a silent fallback to the pure-Rust
+/// `run_paged_decode_step` (which would never enter the C++ FFI).
+async fn run_paged_eager(src: &Path, suffix: &str, prompt: &str, max_new: i32) -> RunOutcome {
+    let dir = clone_model_dir(src, suffix, true)
+        .unwrap_or_else(|e| panic!("clone paged-eager dir ({suffix}): {e}"));
+    let model = Lfm2Model::load_from_dir(&dir.to_string_lossy())
+        .await
+        .unwrap_or_else(|e| panic!("load paged-eager model ({suffix}): {e:?}"));
+    let before = unsafe { mlx_sys::mlx_lfm2_moe_paged_forward_call_count() };
+    let r = model
+        .chat_session_start(
+            vec![user_message(prompt)],
+            Some(greedy_chat_config(max_new, true)),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("paged-eager chat_session_start ({suffix}): {e:?}"));
+    let after = unsafe { mlx_sys::mlx_lfm2_moe_paged_forward_call_count() };
     let out = run_outcome(suffix, &r, after.saturating_sub(before));
     drop(model);
     out
@@ -924,6 +1005,351 @@ async fn lfm2_compiled_flat_vs_paged_e2e_parity() {
         "[PASS] compiled-flat engaged ({} calls) and agrees with paged within \
          tail tolerance ({tail}B <= {TAIL_TOLERANCE_BYTES}B)",
         flat.call_delta
+    );
+}
+
+// =============================================================================
+// P4: COMPILED-PAGED engagement + coherence (DENSE 1.2B).
+//
+// The P4 deliverable: the DEFAULT paged decode path now runs the COMPILED-PAGED
+// graph (`lfm2_decode_fn_paged`), not the eager pure-Rust paged decode. This
+// test loads the 1.2B dense checkpoint with `use_block_paged_cache:true`
+// (paged is also the production default), decodes N tokens, and proves:
+//   1. ENGAGEMENT: `mlx_lfm2_moe_compiled_paged_call_count` advanced by ~N-1
+//      (the last sampled token is never fed forward). A delta of 0 means a
+//      silent fallback to the eager paged decode → hard fail.
+//   2. COHERENCE: the compiled-paged text agrees with the compiled-FLAT decode
+//      everywhere except (at most) a short trailing argmax-tie flip — the same
+//      flat-vs-paged-graph tolerance the existing parity test uses. (Both are
+//      now compiled; the residual divergence is pure flat-vs-paged bf16 noise.)
+//
+// Under `MLX_NO_COMPILE=1` the paged path is the EAGER C++ paged graph, so the
+// compiled-paged counter never bumps — skip cleanly so a whole-binary
+// `MLX_NO_COMPILE=1` invocation doesn't spuriously fail here (the dedicated
+// eager-vs-compiled capture tests own that mode).
+// =============================================================================
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lfm2_compiled_paged_engagement_dense() {
+    if !gated() {
+        eprintln!("[skip] LFM2_COMPILED_E2E != 1");
+        return;
+    }
+    if no_compile_env() {
+        eprintln!("[skip] MLX_NO_COMPILE=1 — compiled-paged engagement test is compile-mode-only");
+        return;
+    }
+    let Some(src) = resolve_source_model() else {
+        return;
+    };
+    eprintln!("[paged-compiled] checkpoint: {}", src.display());
+
+    let prompt = "What is the capital of France? Answer in one short sentence.";
+
+    // ---- Compiled-PAGED path (under test) --------------------------------
+    let paged = run_paged_compiled(&src, "paged-compiled", prompt, N_NEW_TOKENS).await;
+
+    // ENGAGEMENT GATE: delta == 0 => silent eager fallback => hard fail.
+    assert!(
+        paged.call_delta >= MIN_COMPILED_CALL_DELTA,
+        "COMPILED-PAGED PATH DID NOT ENGAGE: compiled_paged_call_count delta = {} \
+         (model_id={}, weight_count={}). The paged decode silently fell back to the \
+         eager pure-Rust paged decode.",
+        paged.call_delta,
+        paged.model_id,
+        paged.weight_count
+    );
+    assert_ne!(
+        paged.model_id, 0,
+        "compiled-paged model id was not published"
+    );
+    assert_eq!(
+        paged.weight_count, EXPECTED_WEIGHT_COUNT,
+        "unexpected registered weight count (paged registration must match flat)"
+    );
+
+    // COHERENCE: compiled-paged vs compiled-flat. Both compiled; a late argmax
+    // tie can flip the last token or two — require agreement everywhere else.
+    let flat = run_flat_single(&src, "paged-compiled-flatref", prompt, N_NEW_TOKENS).await;
+    let tail = tail_diff_bytes(&paged.text, &flat.text);
+    eprintln!(
+        "[paged-compiled] vs compiled-flat: tail_diff={tail}B (common_prefix={}B)",
+        common_prefix_len(&paged.text, &flat.text)
+    );
+    assert_tail_only_divergence("paged-compiled-vs-flat", &paged.text, &flat.text);
+    assert_eq!(
+        paged.num_tokens, flat.num_tokens,
+        "num_tokens mismatch: paged-compiled={} flat={}",
+        paged.num_tokens, flat.num_tokens
+    );
+
+    eprintln!(
+        "[PASS] compiled-PAGED engaged ({} compiled-paged calls) and agrees with \
+         compiled-flat within tail tolerance ({tail}B <= {TAIL_TOLERANCE_BYTES}B). \
+         text snippet: {:?}",
+        paged.call_delta,
+        &paged.text.chars().take(80).collect::<String>()
+    );
+}
+
+// =============================================================================
+// P5: COMPILED-PAGED vs EAGER-PAGED parity (DENSE + MoE).
+//
+// The make-or-break P5 gate: the COMPILED-paged decode graph
+// (`lfm2_decode_fn_paged` wrapped in `mlx::core::compile`) must be byte-greedy
+// IDENTICAL to the EAGER-paged decode graph (the SAME `lfm2_decode_fn_paged`, run
+// directly under `MLX_NO_COMPILE=1`). The two share EVERY paged numeric: the same
+// `paged_kv_write` / `paged_attention` ops over the same block-paged Metal pools,
+// the same per-head Q/K RMSNorm + neox RoPE(array offset), the same conv-state
+// threading and FFN dispatch — the ONLY difference is whether the graph is
+// `mlx::core::compile`d. So byte-identity is the verdict that `compile()`
+// faithfully preserves the eager paged graph (an early divergence would be a real
+// compile() topology/offset bug, the only thing that differs between the runs).
+//
+// This is the PAGED twin of the flat `lfm2_eager_flat_vs_compiled_capture`
+// verdict, and it is split the SAME way for the SAME reason: the C++
+// `static bool no_compile` in `mlx_lfm2_moe_forward_paged` latches ONCE per
+// process, so the eager reference MUST be a SEPARATE `cargo test` invocation with
+// `MLX_NO_COMPILE=1`. The two halves communicate through a topology-qualified
+// artifact file in the workspace `target/`, never an in-process env toggle:
+//
+//   * THIS test (`lfm2_compiled_paged_vs_eager_paged`, compiled-mode only): runs
+//     the compiled-paged decode, asserts ENGAGEMENT via the compiled-paged
+//     counter (`mlx_lfm2_moe_compiled_paged_call_count` delta > 0 — a 0 delta is a
+//     silent fallback to the eager pure-Rust paged decode), and writes the
+//     compiled-paged text to `lfm2[_moe]_e2e_compiled_paged.txt`.
+//   * The capture test below (`lfm2_eager_paged_vs_compiled_paged_capture`,
+//     `MLX_NO_COMPILE=1` only): runs the eager-paged decode, asserts the C++ paged
+//     forward ENGAGED (`mlx_lfm2_moe_paged_forward_call_count` delta — the only
+//     signal the eager arm produces), and diffs eager-paged vs the compiled-paged
+//     artifact for BYTE-GREEDY equality across >= N_NEW_TOKENS (48) tokens.
+//
+// Dense is covered by the shared `resolve_source_model` default; MoE is gated on
+// `LFM2_MOE_MODEL_PATH` (the topology-qualified artifact name keeps them from
+// colliding). Skips cleanly under `MLX_NO_COMPILE=1` (the capture test owns that
+// mode) so a whole-binary `MLX_NO_COMPILE=1` invocation doesn't spuriously fail.
+// =============================================================================
+
+/// Artifact name for the compiled-PAGED decode text, topology-qualified so the
+/// dense (`lfm2_e2e_compiled_paged.txt`) and MoE (`lfm2_moe_e2e_compiled_paged.txt`)
+/// runs never diff against each other's stale text.
+fn compiled_paged_artifact_name(is_moe: bool) -> &'static str {
+    if is_moe {
+        "lfm2_moe_e2e_compiled_paged.txt"
+    } else {
+        "lfm2_e2e_compiled_paged.txt"
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lfm2_compiled_paged_vs_eager_paged() {
+    if !gated() {
+        eprintln!("[skip] LFM2_COMPILED_E2E != 1");
+        return;
+    }
+    if no_compile_env() {
+        eprintln!(
+            "[skip] MLX_NO_COMPILE=1 — compiled-paged writer is compiled-mode-only \
+             (the eager-paged capture test owns MLX_NO_COMPILE=1)"
+        );
+        return;
+    }
+    let Some(src) = resolve_source_model() else {
+        return;
+    };
+    let comp_is_moe = is_moe_config(&src);
+    eprintln!(
+        "[paged-parity] checkpoint: {} (is_moe={comp_is_moe})",
+        src.display()
+    );
+
+    let prompt = "What is the capital of France? Answer in one short sentence.";
+
+    // ---- Compiled-PAGED path (under test) --------------------------------
+    let paged = run_paged_compiled(&src, "paged-parity-compiled", prompt, N_NEW_TOKENS).await;
+
+    // ENGAGEMENT GATE: delta == 0 => silent eager pure-Rust fallback => hard fail.
+    // (delta>0 is the explicit P5 requirement.)
+    assert!(
+        paged.call_delta >= MIN_COMPILED_CALL_DELTA,
+        "COMPILED-PAGED PATH DID NOT ENGAGE: compiled_paged_call_count delta = {} \
+         (model_id={}, weight_count={}). The paged decode silently fell back to the \
+         eager pure-Rust paged decode — the compiled-paged graph never ran, so the \
+         parity comparison would be meaningless.",
+        paged.call_delta,
+        paged.model_id,
+        paged.weight_count
+    );
+    assert_ne!(
+        paged.model_id, 0,
+        "compiled-paged model id was not published"
+    );
+    // FULL-GENERATION: the eager-paged capture diffs the WHOLE text, so the
+    // compiled writer must decode the full N tokens (no early stop) or the eager
+    // side could pass a short prefix while hiding a downstream divergence.
+    assert_eq!(
+        paged.num_tokens, N_NEW_TOKENS as u32,
+        "compiled-paged: generated {} tokens but expected the full {} — an early stop \
+         shrinks the byte-greedy parity window the eager-paged capture diffs against",
+        paged.num_tokens, N_NEW_TOKENS
+    );
+
+    // Persist the compiled-paged decode text so a SEPARATE `MLX_NO_COMPILE=1`
+    // invocation (the eager-paged capture below) can diff against it for the
+    // byte-greedy parity verdict.
+    let art = artifact_path(compiled_paged_artifact_name(comp_is_moe));
+    if let Err(e) = fs::write(&art, &paged.text) {
+        eprintln!("[warn] could not write compiled-paged artifact {art:?}: {e}");
+    } else {
+        eprintln!(
+            "[paged-parity] wrote compiled-paged artifact: {}",
+            art.display()
+        );
+    }
+
+    eprintln!(
+        "[PASS] compiled-PAGED engaged ({} compiled-paged calls, {} tokens); \
+         artifact written for the MLX_NO_COMPILE=1 eager-paged byte-greedy diff. \
+         text snippet: {:?}",
+        paged.call_delta,
+        paged.num_tokens,
+        &paged.text.chars().take(80).collect::<String>()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lfm2_eager_paged_vs_compiled_paged_capture() {
+    if !gated() {
+        eprintln!("[skip] LFM2_COMPILED_E2E != 1");
+        return;
+    }
+    if !no_compile_env() {
+        eprintln!(
+            "[skip] eager-paged capture requires MLX_NO_COMPILE=1 (run as a SEPARATE \
+             cargo test invocation with that env set; the static no_compile flag latches \
+             once per process)"
+        );
+        return;
+    }
+    let Some(src) = resolve_source_model() else {
+        return;
+    };
+    let eager_is_moe = is_moe_config(&src);
+    eprintln!(
+        "[eager-paged] checkpoint: {} (is_moe={eager_is_moe})",
+        src.display()
+    );
+
+    let prompt = "What is the capital of France? Answer in one short sentence.";
+
+    // ---- Eager-PAGED reference (MLX_NO_COMPILE=1) ------------------------
+    let eager = run_paged_eager(&src, "paged-parity-eager", prompt, N_NEW_TOKENS).await;
+
+    // ENGAGEMENT: under MLX_NO_COMPILE=1 the Rust gate still routes through the C++
+    // paged forward (it does NOT read MLX_NO_COMPILE — only the env flag INSIDE
+    // mlx_lfm2_moe_forward_paged swaps compile→eager). So the paged-forward counter
+    // MUST advance ~N-1; a 0 delta means the Rust caller silently fell back to the
+    // pure-Rust paged decode and the eager C++ graph never ran — the comparison
+    // would be meaningless. (The compiled-paged counter never bumps in this arm,
+    // which is exactly WHY a separate paged-forward counter exists.)
+    assert!(
+        eager.call_delta >= MIN_COMPILED_CALL_DELTA,
+        "eager-paged (MLX_NO_COMPILE=1) did not run the C++ paged forward \
+         (paged_forward_call_count delta = {}). Expected ~N-1: MLX_NO_COMPILE only \
+         swaps compile→eager INSIDE mlx_lfm2_moe_forward_paged; it does not disable \
+         the Rust gate. A 0 delta is a silent fallback to the pure-Rust paged decode.",
+        eager.call_delta
+    );
+    assert_eq!(
+        eager.num_tokens, N_NEW_TOKENS as u32,
+        "eager-paged: generated {} tokens but expected the full {} — an early stop \
+         shrinks the byte-greedy parity window below the compiled-paged artifact",
+        eager.num_tokens, N_NEW_TOKENS
+    );
+    eprintln!(
+        "[eager-paged] C++ paged forward ran (call_delta={}, model_id={}, num_tokens={})",
+        eager.call_delta, eager.model_id, eager.num_tokens
+    );
+
+    // Persist for symmetry / debugging.
+    let eager_art = artifact_path(if eager_is_moe {
+        "lfm2_moe_e2e_eager_paged.txt"
+    } else {
+        "lfm2_e2e_eager_paged.txt"
+    });
+    let _ = fs::write(&eager_art, &eager.text);
+
+    // ---- BYTE-GREEDY PARITY VERDICT: eager-paged vs compiled-paged -------
+    // Read the topology-matched compiled-paged artifact written by
+    // `lfm2_compiled_paged_vs_eager_paged` (run the default/compiled suite FIRST).
+    let comp_art = artifact_path(compiled_paged_artifact_name(eager_is_moe));
+    let compiled_text = fs::read_to_string(&comp_art).unwrap_or_else(|e| {
+        panic!(
+            "[eager-paged] compiled-paged artifact not found at {} ({e}); run the \
+             default (compiled) suite FIRST to produce it \
+             (LFM2_COMPILED_E2E=1 ... lfm2_compiled_paged_vs_eager_paged), then re-run \
+             this with MLX_NO_COMPILE=1. eager-paged text captured to {}.",
+            comp_art.display(),
+            eager_art.display()
+        )
+    });
+
+    let lcp = common_prefix_len(&eager.text, &compiled_text);
+    let tail = tail_diff_bytes(&eager.text, &compiled_text);
+    eprintln!(
+        "[VERDICT] eager-paged vs compiled-paged: common_prefix={lcp}B eager_len={}B \
+         compiled_len={}B tail_diff={tail}B",
+        eager.text.len(),
+        compiled_text.len()
+    );
+
+    // The two runs share the SAME paged graph (only compile() differs), so the
+    // expected verdict is BYTE-IDENTICAL — exactly like the flat eager-vs-compiled
+    // case. Assert byte equality as the strict gate; `assert_tail_only_divergence`
+    // is the loud-failure path if compile() introduced any divergence (early =>
+    // a real compile() topology/offset bug; late tail => a benign argmax tie that
+    // we still surface).
+    if eager.text == compiled_text {
+        eprintln!(
+            "[VERDICT] BYTE-IDENTICAL ({} bytes / {} tokens) — `compile()` faithfully \
+             preserves the eager paged decode graph; the compiled-paged port is \
+             numerically exact.",
+            eager.text.len(),
+            eager.num_tokens
+        );
+    } else {
+        eprintln!("[VERDICT] eager and compiled PAGED differ — investigate (see tails below)");
+        eprintln!(
+            "[VERDICT] eager_tail    = {:?}",
+            &eager.text[lcp.min(eager.text.len())..]
+        );
+        eprintln!(
+            "[VERDICT] compiled_tail = {:?}",
+            &compiled_text[lcp.min(compiled_text.len())..]
+        );
+    }
+    assert_tail_only_divergence("eager-paged-vs-compiled-paged", &eager.text, &compiled_text);
+
+    // BYTE-GREEDY across >= 48 tokens (spec): both sides generated N_NEW_TOKENS
+    // (48) and the shared byte prefix must span essentially all of it (allowing
+    // only the late argmax-tie tail). A short shared prefix would already have
+    // failed `assert_tail_only_divergence` above; this asserts the agreed span is
+    // long enough to actually cover the 48-token greedy decode.
+    let min_shared = compiled_text.len().saturating_sub(TAIL_TOLERANCE_BYTES);
+    assert!(
+        lcp >= min_shared,
+        "[eager-paged-vs-compiled-paged] byte-greedy parity over the full {}-token \
+         decode FAILED: shared prefix is only {lcp}B but the compiled-paged text is \
+         {}B (need >= {min_shared}B, i.e. agreement minus the <= {TAIL_TOLERANCE_BYTES}B \
+         argmax-tie tail).",
+        N_NEW_TOKENS,
+        compiled_text.len()
+    );
+
+    eprintln!(
+        "[PASS] eager-paged vs compiled-paged BYTE-GREEDY parity holds over the full \
+         {}-token decode (shared prefix {lcp}B, tail_diff {tail}B <= {TAIL_TOLERANCE_BYTES}B); \
+         compile() is faithful to the eager paged graph.",
+        N_NEW_TOKENS
     );
 }
 
@@ -1270,7 +1696,7 @@ async fn lfm2_long_prompt_offset_fix() {
 //
 // We drive that here with TWO `chat_session_start` calls on ONE live model:
 //   turn 1: [user1]
-//   turn 2: [user1, assistant(reply1), user2]   (a superset prompt)
+//   turn 2: [user1, assistant(raw_reply1), user2]   (a superset prompt)
 // Turn 2's tokenized prompt begins with turn 1's persisted history, so the
 // strict-extend branch fires; the compiled path stays engaged (call_delta ~N-1),
 // and the seed offset comes from the live KV position. Pre-fix this seeded the
@@ -1279,38 +1705,42 @@ async fn lfm2_long_prompt_offset_fix() {
 // coherently.
 //
 // REACHABILITY (verified empirically on this lfm2.5-1.2b-THINKING checkpoint,
-// 2026-05-30) — load-bearing, hence `greedy_chat_config_no_thinking`:
+// 2026-06-02) — load-bearing, hence the `r1.raw_text` echo + the
+// `include_reasoning: Some(true)` in `greedy_chat_config_no_thinking`:
 //
 //   The strict-extend branch only fires when turn 2's tokenized prompt is a
 //   byte-prefix of `cached_token_history` (= turn-1 template tokens + turn-1
-//   RAW generated tokens, see `save_cache_state`). Turn 2 re-templates
-//   `assistant_message(&r1.text)`. The round-trip therefore depends on whether
-//   `r1.text` equals the raw generated tokens that were cached:
+//   RAW generated tokens, see `save_cache_state`). LFM2's chat template IGNORES
+//   `enable_thinking` and `chat_sync_core` hard-codes `thinking_enabled = true`,
+//   so the model ALWAYS emits a `<think>…</think>` span (here `reasoning_effort:
+//   "none"` forces the budget to 0 → a degenerate empty `<think></think>` as
+//   the first two generated tokens) and `parse_thinking_and_tools` ALWAYS splits
+//   the decoded text at `</think>`. Therefore the round-trip turns on WHICH
+//   field turn 2 echoes:
 //
-//     * Reasoning ENABLED (the suite's `greedy_chat_config`, reasoning_effort
-//       unset -> thinking_enabled defaults true): `finalize_chat_result` /
-//       `parse_thinking_and_tools` SPLIT the decoded text at `</think>` and
-//       return only the post-`</think>` content in `ChatResult.text`. The
-//       cached tokens still include the `<think>…</think>` reasoning span, so
-//       echoing the stripped `text` produces a prompt that does NOT prefix the
-//       cache. `verify_cache_prefix` returns 0 -> full prefill ->
-//       `cached_tokens=0`. Observed: turn2 call_delta=23, cached_tokens=0.
-//       (This is what the freshly-hardened `cached_tokens>0` assertion caught.)
+//     * Echoing `ChatResult.text` (reasoning-stripped): the `<think></think>`
+//       markers — the FIRST generated tokens in the cache — are gone, so the
+//       re-templated prompt diverges from the cache at the very first generated
+//       token. `verify_cache_prefix` returns 0 -> full prefill ->
+//       `cached_tokens=0`. (This is what the `cached_tokens>0` assertion caught;
+//       the prior comment's "reasoning-disabled -> verbatim text" claim was
+//       wrong because LFM2 never disables reasoning parsing.)
 //
-//     * Reasoning DISABLED (`reasoning_effort:"none"` -> enable_thinking=false,
-//       include_reasoning=false): `parse_thinking_and_tools` takes the
-//       `!thinking_enabled` branch and passes the decoded text through VERBATIM
-//       (`text == raw_text`, the leading literal `<think>` and all). Echoing
-//       `r1.text` reproduces the exact cached token prefix, the strict-extend
-//       branch fires, and the offset seed runs on a NON-ZERO prefix. Observed:
-//       turn2 call_delta=23, cached_tokens=22.
+//     * Echoing `ChatResult.raw_text` with `include_reasoning: Some(true)`
+//       (the FULL verbatim decode, `<think></think>` markers and all): this
+//       round-trips token-exact through the tokenizer (empirically verified,
+//       including across the max_new mid-word truncation boundary), so the
+//       re-templated prompt reproduces the EXACT cached token prefix, the
+//       strict-extend branch fires, and the offset seed runs on a NON-ZERO
+//       prefix. Observed: turn2 call_delta=23, cached_tokens=45.
 //
 //   So warm strict-extend reuse IS reachable through the public
-//   `chat_session_start` API for this checkpoint — but only with reasoning
-//   disabled, which is why turn 1 and turn 2 both use
-//   `greedy_chat_config_no_thinking`. (`chat_session_continue` is hard-wired
-//   NATIVE at model.rs ~2604 and can never exercise the compiled warm path, so
-//   the resend-superset pattern is the only public route — it works here.)
+//   `chat_session_start` API for this checkpoint — by echoing the VERBATIM
+//   `raw_text` (not the stripped `text`), which is why turn 1 captures
+//   `r1.raw_text` and turn 2 (and the cold oracle) echo it.
+//   (`chat_session_continue` is hard-wired NATIVE at model.rs ~2604 and can
+//   never exercise the compiled warm path, so the resend-superset pattern is the
+//   only public route — it works here.)
 //
 // Oracle: a FRESH-session run of the identical turn-2 prompt (no warm prefix),
 // same reasoning-disabled config. Same compiled flat graph, same full prompt,
@@ -1350,15 +1780,20 @@ async fn lfm2_warm_reuse_offset_fix() {
         // Turn 1: fresh session. Compiled path engages and persists the
         // [user1, assistant(reply1)] history for the next strict-extend hit.
         //
-        // REASONING DISABLED (`greedy_chat_config_no_thinking`) is LOAD-BEARING
-        // for reachability on this THINKING checkpoint. See the strict-extend
-        // reachability note above `lfm2_warm_reuse_offset_fix`: with reasoning
-        // enabled, `finalize_chat_result` strips the `<think>…</think>` span out
-        // of `ChatResult.text`, so echoing `text` in turn 2's history no longer
-        // reproduces the raw cached tokens and `verify_cache_prefix` misses
-        // (cached_tokens=0, full prefill). With reasoning disabled the reply is
-        // verbatim (`text == raw_text`), so `assistant_message(&r1.text)`
-        // re-renders the exact cached prefix and the strict-extend branch fires.
+        // We echo `r1.raw_text` (NOT `r1.text`) into turn 2's history. This is
+        // LOAD-BEARING for reachability on this THINKING checkpoint: LFM2 ALWAYS
+        // parses reasoning (`thinking_enabled` is hard-coded true in
+        // `chat_sync_core`; the chat template ignores `enable_thinking`), so
+        // `ChatResult.text` always has the leading `<think></think>` span
+        // stripped. But `save_cache_state` persists the RAW generated tokens,
+        // which BEGIN with those `<think></think>` markers — so echoing the
+        // stripped `text` drops them and the re-templated turn-2 prompt diverges
+        // from the cache at the first generated token (`verify_cache_prefix`
+        // returns 0 → full prefill → `cached_tokens=0`). `greedy_chat_config_no_thinking`
+        // sets `include_reasoning: Some(true)` so `r1.raw_text` is the FULL
+        // verbatim decode (markers included); it round-trips token-exact through
+        // the tokenizer, so `assistant_message(&r1.raw_text)` re-renders the
+        // EXACT cached prefix and the strict-extend branch fires (cached_tokens>0).
         let before_t1 = unsafe { mlx_sys::mlx_lfm2_moe_forward_call_count() };
         let r1 = model
             .chat_session_start(
@@ -1370,21 +1805,24 @@ async fn lfm2_warm_reuse_offset_fix() {
         let after_t1 = unsafe { mlx_sys::mlx_lfm2_moe_forward_call_count() };
         let turn1_delta = after_t1.saturating_sub(before_t1);
         eprintln!(
-            "[warm-flat] turn1 call_delta={turn1_delta} text={:?}",
-            r1.text
+            "[warm-flat] turn1 call_delta={turn1_delta} text={:?} raw_text={:?}",
+            r1.text, r1.raw_text
         );
 
         // Turn 2: a NEW session-start whose message list replays the prior turn
-        // (user1 + assistant reply1) and appends user2. The tokenized prompt is
-        // a STRICT EXTENSION of the persisted history, so `chat_sync_core` takes
-        // the strict-extend branch (prefill only the user2 tail) AND keeps the
-        // compiled path engaged — exactly fix #1's warm-reuse seed path.
+        // (user1 + assistant RAW reply1) and appends user2. Echoing the VERBATIM
+        // `r1.raw_text` (markers and all) — not the reasoning-stripped `r1.text` —
+        // makes the tokenized prompt a STRICT EXTENSION of the persisted history
+        // (which `save_cache_state` stored as the raw generated tokens), so
+        // `chat_sync_core` takes the strict-extend branch (prefill only the user2
+        // tail) AND keeps the compiled path engaged — exactly fix #1's warm-reuse
+        // seed path.
         let before_t2 = unsafe { mlx_sys::mlx_lfm2_moe_forward_call_count() };
         let r2 = model
             .chat_session_start(
                 vec![
                     user_message(user1),
-                    assistant_message(&r1.text),
+                    assistant_message(&r1.raw_text),
                     user_message(user2),
                 ],
                 Some(greedy_chat_config_no_thinking(max_new, true)),
@@ -1399,7 +1837,9 @@ async fn lfm2_warm_reuse_offset_fix() {
             r2.text
         );
         drop(model);
-        (turn1_delta, turn2_delta, turn2_cached, r2.text, r1.text)
+        // Return `r1.raw_text` (the VERBATIM reply echoed into turn 2) so the
+        // cold oracle below replays the IDENTICAL turn-2 prompt — apples-to-apples.
+        (turn1_delta, turn2_delta, turn2_cached, r2.text, r1.raw_text)
     };
 
     // Turn 1 (session anchor) MUST engage the compiled path.
@@ -1453,11 +1893,14 @@ async fn lfm2_warm_reuse_offset_fix() {
             .chat_session_start(
                 vec![
                     user_message(user1),
+                    // Echo the SAME verbatim `raw_text` the warm turn 2 echoed so
+                    // the templated turn-2 prompt is byte-identical between the
+                    // warm-reuse run and this cold oracle.
                     assistant_message(&turn1_reply),
                     user_message(user2),
                 ],
-                // Same reasoning-disabled config as the warm run so this is a
-                // like-for-like full-prefill oracle of the identical prompt.
+                // Same config as the warm run so this is a like-for-like
+                // full-prefill oracle of the identical prompt.
                 Some(greedy_chat_config_no_thinking(max_new, true)),
             )
             .await
@@ -1792,5 +2235,199 @@ async fn lfm2_moe_compiled_flat_vs_mlx_lm_golden() {
          {lcp}-byte early prefix (>= {GOLDEN_MIN_PREFIX_BYTES_MOE}); compiled path engaged \
          (call_delta={}).",
         flat.call_delta
+    );
+}
+
+// =============================================================================
+// P4 (STREAMING): COMPILED-PAGED engagement + non-stream parity (DENSE 1.2B).
+//
+// The non-streaming paged decode loop (`chat_sync_core_paged_inner`) was already
+// proven to engage the compiled-paged C++ graph by
+// `lfm2_compiled_paged_engagement_dense` / `lfm2_compiled_paged_vs_eager_paged`.
+// The STREAMING paged decode loop (`chat_stream_sync_core_paged_inner`) was JUST
+// wired into the SAME shared compiled-paged helpers
+// (`Lfm2Inner::paged_compiled_decode_setup` + `paged_compiled_decode_step`); this
+// test is its dedicated regression gate. It proves two things on the real 1.2B
+// dense checkpoint with `use_block_paged_cache:true` (the production default):
+//
+//   1. ENGAGEMENT — `mlx_lfm2_moe_compiled_paged_call_count` advances by ~N-1
+//      across a STREAMING decode. Before the streaming loop was wired to the
+//      compiled-paged path this delta was 0 (the stream silently ran the eager
+//      pure-Rust paged decode). A 0 delta here is the exact pre-fix failure and
+//      is a HARD FAIL.
+//   2. PARITY — the text reconstructed from the streaming delta chunks
+//      (`chunk.text`, concatenated) is BYTE-IDENTICAL to the non-streaming
+//      compiled-paged `ChatResult.text` reference. Both run the SAME compiled-
+//      paged graph at temperature 0 over the SAME prompt/config, so the only
+//      tolerated divergence is a late argmax-tie tail (`TAIL_TOLERANCE_BYTES`,
+//      the suite's shared comparison budget) — an early divergence is a real
+//      streaming-seam bug.
+//
+// Each side loads a FRESH model from its OWN cloned checkpoint dir (matching the
+// `run_*` helpers) so there is no cross-run cache state. Under `MLX_NO_COMPILE=1`
+// the paged path is the eager C++ graph and the compiled-paged counter never
+// bumps, so skip cleanly (the eager-paged capture tests own that mode).
+// =============================================================================
+
+/// Drain the LFM2 streaming receiver for one turn, concatenating the delta
+/// `chunk.text` (the SAME reconstruction the proven session test
+/// `lfm2_session_stream_matches_non_stream_byte_for_byte` uses to match
+/// `ChatResult.text`). Returns the reconstructed text, the terminal
+/// `finish_reason`, and the terminal `num_tokens`. Panics if the stream never
+/// reaches `done == true` (a stream that closes without a terminal chunk is a
+/// hard bug, not a benign early stop).
+async fn drain_lfm2_stream_text(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<napi::Result<ChatStreamChunk>>,
+) -> (String, String, u32) {
+    let mut text = String::new();
+    let mut finish_reason = String::new();
+    let mut num_tokens = 0u32;
+    let mut saw_done = false;
+    while let Some(result) = rx.recv().await {
+        let chunk = result.expect("lfm2 stream chunk error");
+        if chunk.done {
+            saw_done = true;
+            finish_reason = chunk.finish_reason.unwrap_or_default();
+            num_tokens = chunk.num_tokens.unwrap_or(0);
+            break;
+        }
+        text.push_str(&chunk.text);
+    }
+    assert!(saw_done, "lfm2 stream never reached done=true");
+    (text, finish_reason, num_tokens)
+}
+
+/// Strip a LEADING empty `<think></think>` reasoning wrapper (and the single
+/// following newline, if present) from a streamed reconstruction. With
+/// `thinking_token_budget: Some(0)` the template opens then immediately closes
+/// thinking, so the streamed delta chunks carry an empty `<think></think>\n`
+/// that the non-streaming `ChatResult.text` already had stripped by
+/// `finalize_chat_result`. Stripping it here makes the stream-vs-non-stream
+/// comparison content-vs-content. Only an EMPTY leading wrapper is removed; any
+/// non-empty `<think>…content…</think>` is left intact so a real reasoning-span
+/// divergence would still surface. Returns the input unchanged if no empty
+/// wrapper is present (so it is a no-op on the already-stripped reference).
+fn strip_leading_empty_think(s: &str) -> &str {
+    const EMPTY: &str = "<think></think>";
+    if let Some(rest) = s.strip_prefix(EMPTY) {
+        rest.strip_prefix('\n').unwrap_or(rest)
+    } else {
+        s
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lfm2_compiled_paged_streaming_engagement_and_parity_dense() {
+    if !gated() {
+        eprintln!("[skip] LFM2_COMPILED_E2E != 1");
+        return;
+    }
+    if no_compile_env() {
+        // The streaming-compiled engagement signal is the compiled-paged counter,
+        // which never bumps under MLX_NO_COMPILE=1 (the paged path is the eager C++
+        // graph there). Skip cleanly so a whole-binary MLX_NO_COMPILE=1 invocation
+        // doesn't spuriously fail (the eager-paged capture tests own that mode).
+        eprintln!(
+            "[skip] MLX_NO_COMPILE=1 — streaming compiled-paged engagement test is compile-mode-only"
+        );
+        return;
+    }
+    let Some(src) = resolve_source_model() else {
+        return;
+    };
+    eprintln!("[paged-compiled-stream] checkpoint: {}", src.display());
+
+    let prompt = "What is the capital of France? Answer in one short sentence.";
+
+    // ---- NON-STREAMING reference (compiled-paged) ------------------------
+    // Reuse the proven non-streaming compiled-paged helper: it loads a fresh paged
+    // model, runs `chat_session_start`, and reports the compiled-paged call delta.
+    let reference =
+        run_paged_compiled(&src, "paged-compiled-stream-ref", prompt, N_NEW_TOKENS).await;
+    assert!(
+        reference.call_delta >= MIN_COMPILED_CALL_DELTA,
+        "REFERENCE non-streaming compiled-paged path did not engage (call_delta={}, \
+         model_id={}, weight_count={}); the parity comparison would be meaningless.",
+        reference.call_delta,
+        reference.model_id,
+        reference.weight_count
+    );
+    eprintln!(
+        "[paged-compiled-stream] non-streaming reference engaged (call_delta={}, num_tokens={}, finish={})",
+        reference.call_delta, reference.num_tokens, reference.finish_reason
+    );
+
+    // ---- STREAMING under test (compiled-paged) --------------------------
+    // Fresh model from its own cloned paged dir to avoid cross-run cache state,
+    // exactly like the `run_*` helpers. `clone_model_dir(.., true)` sets
+    // `paged_block_size: 16`, which `init_lfm2_paged_compiled_session` requires.
+    let stream_dir = clone_model_dir(&src, "paged-compiled-stream", true)
+        .unwrap_or_else(|e| panic!("clone paged-compiled-stream dir: {e}"));
+    let stream_model = Lfm2Model::load_from_dir(&stream_dir.to_string_lossy())
+        .await
+        .unwrap_or_else(|e| panic!("load paged-compiled-stream model: {e:?}"));
+
+    let before = unsafe { mlx_sys::mlx_lfm2_moe_compiled_paged_call_count() };
+    let (handle, rx) = stream_model
+        .chat_stream_session_start_for_test(
+            vec![user_message(prompt)],
+            Some(greedy_chat_config(N_NEW_TOKENS, true)),
+        )
+        .unwrap_or_else(|e| panic!("chat_stream_session_start_for_test dispatch failed: {e:?}"));
+    let (stream_text, stream_finish, stream_tokens) = drain_lfm2_stream_text(rx).await;
+    let after = unsafe { mlx_sys::mlx_lfm2_moe_compiled_paged_call_count() };
+    let stream_call_delta = after.saturating_sub(before);
+    drop(handle);
+    drop(stream_model);
+
+    eprintln!(
+        "[paged-compiled-stream] STREAMING run: call_delta={stream_call_delta} num_tokens={stream_tokens} finish={stream_finish}"
+    );
+    eprintln!("[paged-compiled-stream] stream_text = {stream_text:?}");
+
+    // ---- ASSERT 1: STREAMING compiled-paged ENGAGEMENT ------------------
+    // This is the whole point: pre-fix the streaming loop ran the eager pure-Rust
+    // paged decode and left this delta at 0.
+    assert!(
+        stream_call_delta >= MIN_COMPILED_CALL_DELTA,
+        "STREAMING compiled-paged path did not engage (call_delta={stream_call_delta}) — \
+         chat_stream_sync_core_paged_inner is not wired to compiled-paged. Expected ~N-1 \
+         compiled-paged forward calls (>= {MIN_COMPILED_CALL_DELTA}); a 0/low delta means the \
+         streaming decode silently fell back to the eager pure-Rust paged decode."
+    );
+
+    // ---- ASSERT 2: STREAMING == NON-STREAMING reference -----------------
+    // Both run the SAME compiled-paged graph at temperature 0, so the GENERATED
+    // CONTENT must be byte-identical save for at most a late argmax-tie tail.
+    //
+    // ONE representation difference must be normalized first: with
+    // `thinking_token_budget: Some(0)` the template opens then immediately forces
+    // a `</think>`, so the run emits an EMPTY `<think></think>\n` reasoning block.
+    // The non-streaming `ChatResult.text` (`reference.text`) has that empty span
+    // stripped by `finalize_chat_result`, but the streaming delta chunks emit it
+    // verbatim, so the raw streamed text carries a leading `<think></think>\n` the
+    // reference does not. That is a FORMATTING difference, not a decode
+    // divergence (the post-wrapper content is what proves parity). Strip a leading
+    // empty-think wrapper from the streamed reconstruction so the comparison is
+    // content-vs-content (the strip is a no-op on the already-stripped reference).
+    let stream_content = strip_leading_empty_think(&stream_text);
+    let tail = tail_diff_bytes(stream_content, &reference.text);
+    eprintln!(
+        "[paged-compiled-stream] stream-vs-nonstream: tail_diff={tail}B (common_prefix={}B) \
+         (streamed had empty-think wrapper stripped: {})",
+        common_prefix_len(stream_content, &reference.text),
+        stream_content.len() != stream_text.len()
+    );
+    assert_tail_only_divergence(
+        "paged-compiled-stream-vs-nonstream",
+        stream_content,
+        &reference.text,
+    );
+
+    eprintln!(
+        "[PASS] STREAMING compiled-PAGED engaged ({stream_call_delta} compiled-paged calls) and \
+         agrees with the non-streaming compiled-paged reference within tail tolerance \
+         ({tail}B <= {TAIL_TOLERANCE_BYTES}B). content snippet: {:?}",
+        &stream_content.chars().take(80).collect::<String>()
     );
 }

--- a/crates/mlx-sys/src/lib.rs
+++ b/crates/mlx-sys/src/lib.rs
@@ -1924,6 +1924,116 @@ unsafe extern "C-unwind" {
     /// mutex, so the closure swap is thread-safe regardless of caller locking.
     pub fn mlx_lfm2_invalidate_compiled();
 
+    // ============================================
+    // Phase P2: compiled-PAGED lfm2 decode forward FFI. Drives the
+    // compiled-paged decode graph (`lfm2_decode_fn_paged` /
+    // `compiled_lfm2_decode_paged`) over the shared block-paged Metal pools.
+    // STRICTLY separate from the flat lifecycle above — the two decode paths
+    // never alias; `mlx_lfm2_paged_reset` wipes ONLY the paged globals.
+    // bf16/f16 only (quantized stays eager); decode-only (prefill stays eager
+    // pure-Rust paged, then seeds this). Covers BOTH dense lfm2 and lfm2_moe.
+    // ============================================
+
+    /// Initialize the compiled-paged lfm2 decode graph from post-prefill state.
+    ///
+    /// `is_attn` is a `num_layers`-long per-layer dispatch map (1 = full
+    /// attention, 0 = conv), built dynamically from `config.is_attention_layer`.
+    /// It is appended BEFORE the per-layer handle arrays and the C++ param order
+    /// (`mlx_lfm2_moe_init_paged` in mlx_lfm2_moe.cpp) MUST match this
+    /// byte-for-byte or the ABI is silently miswired.
+    ///
+    /// Per-layer handle import (length `num_layers` each):
+    /// attn layer i → `k_pool_handles[i]` / `v_pool_handles[i]` /
+    /// `k_scale_handles[i]` / `v_scale_handles[i]` (null on any → bail, returns
+    /// `-1`); conv layer i → `conv_state_handles[i]` (the conv state
+    /// `[B,l_cache-1,hidden]`; null → bail). Conv-layer pool/scale slots and
+    /// attn-layer conv-state slots may be null (placeholders are stored).
+    ///
+    /// `block_size` MUST be 16 (the paged graph hard-codes it, matching qwen's
+    /// `attn_for_compile_paged`); any other value returns `-1`. The init
+    /// force-evals the attn pools to surface a Metal OOM / layout / dtype fault
+    /// HERE rather than inside the first forward.
+    ///
+    /// Returns `0` on success, `-1` on failure. On failure the C++ side clears
+    /// `g_lfm2_paged_inited` and emits a stderr diagnostic; the Rust caller MUST
+    /// inspect the return value and fall back to the pure-Rust paged decode.
+    #[allow(clippy::too_many_arguments)]
+    pub fn mlx_lfm2_moe_init_paged(
+        num_layers: i32,
+        hidden_size: i32,
+        num_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        rope_theta: f32,
+        norm_eps: f32,
+        conv_l_cache: i32,
+        num_experts: i32,
+        num_experts_per_tok: i32,
+        num_dense_layers: i32,
+        norm_topk_prob: i32,
+        use_expert_bias: i32,
+        tie_embedding: i32,
+        conv_bias: i32,
+        max_kv_len: i32,
+        batch_size: i32,
+        block_size: i32,
+        is_attn: *const i32,
+        k_pool_handles: *mut *mut mlx_array,
+        v_pool_handles: *mut *mut mlx_array,
+        k_scale_handles: *mut *mut mlx_array,
+        v_scale_handles: *mut *mut mlx_array,
+        conv_state_handles: *mut *mut mlx_array,
+        prefill_offset: i32,
+    ) -> i32;
+
+    /// Run one compiled-paged lfm2 decode step. Inputs (PagedAttentionInputs)
+    /// come from the Rust adapter's `build_paged_attention_inputs`; the per-layer
+    /// pool/scale/conv-state globals come from `mlx_lfm2_moe_init_paged`. Sets
+    /// `*output_logits` to a heap-allocated `mlx_array*` (caller owns) on
+    /// success, or `nullptr` on error / when not initialized. `cache_offset_out`
+    /// receives the post-step offset.
+    ///
+    /// **Decode-only contract.** `input_ids` MUST have exactly one element and
+    /// `slot_mapping` MUST be `[1]`. Violating it returns null logits + a stderr
+    /// diagnostic, leaving global state untouched so the caller can fall back to
+    /// the pure-Rust paged decode. The traced-compiled-paged engagement counter
+    /// (`mlx_lfm2_moe_compiled_paged_call_count`) is bumped ONLY in the compiled
+    /// arm (not under `MLX_NO_COMPILE`).
+    pub fn mlx_lfm2_moe_forward_paged(
+        input_ids: *mut mlx_array,
+        embedding_weight: *mut mlx_array,
+        offset_arr: *mut mlx_array,
+        block_table: *mut mlx_array,
+        slot_mapping: *mut mlx_array,
+        num_valid_tokens: *mut mlx_array,
+        num_valid_blocks: *mut mlx_array,
+        seq_lens: *mut mlx_array,
+        output_logits: *mut *mut mlx_array,
+        cache_offset_out: *mut i32,
+    );
+
+    /// Tear down ONLY the compiled-paged decode state (config, is_attn, per-layer
+    /// pools/scales/conv-state, offset, inited flag). Does NOT touch the flat
+    /// lfm2 globals, the shared model-id atom, or the engagement counter.
+    pub fn mlx_lfm2_paged_reset();
+
+    /// Cumulative count of `mlx_lfm2_moe_forward_paged` calls that took the
+    /// TRACED `compiled_lfm2_decode_paged()` branch — i.e. NOT the eager
+    /// `MLX_NO_COMPILE` arm. Distinct from the flat
+    /// `mlx_lfm2_moe_compiled_decode_call_count`; proves the compiled-paged
+    /// closure actually ran. NOT reset by `mlx_lfm2_paged_reset`.
+    pub fn mlx_lfm2_moe_compiled_paged_call_count() -> u64;
+
+    /// Cumulative count of `mlx_lfm2_moe_forward_paged` calls that ran the C++
+    /// paged decode — BOTH the compiled AND the eager `MLX_NO_COMPILE` arm. The
+    /// paged analogue of the flat `mlx_lfm2_moe_forward_call_count`; it is the
+    /// ONLY engagement signal the EAGER-paged (`MLX_NO_COMPILE=1`) run produces,
+    /// since `mlx_lfm2_moe_compiled_paged_call_count` never bumps in that arm. A
+    /// nonzero before/after delta proves the C++ paged forward engaged rather than
+    /// the Rust caller silently falling back to the pure-Rust paged decode. NOT
+    /// reset by `mlx_lfm2_paged_reset`.
+    pub fn mlx_lfm2_moe_paged_forward_call_count() -> u64;
+
     /// TEST-ONLY component probe: run a sequence of `T` lfm2 attention decode
     /// steps (B=1, `x_seq` is `[T, hidden]`) through the compiled
     /// `lfm2_attn_pure_fn`, threading the KV cache, and return the LAST step's

--- a/crates/mlx-sys/src/mlx_lfm2_common.h
+++ b/crates/mlx-sys/src/mlx_lfm2_common.h
@@ -225,6 +225,145 @@ inline Lfm2AttnResult lfm2_attn_pure_fn_arr(
 }
 
 // =====================================================================
+// PAGED-cache variant of `lfm2_attn_pure_fn_arr` for the COMPILED-PAGED
+// decode graph (Phase P1).
+//
+// Identical lfm2 attention MATH up through RoPE to the flat array-offset fn
+// above (GQA, per-head Q/K RMSNorm, NO q-gate/bias, neox RoPE over the full
+// head_dim applied AFTER the transpose, out_proj). The ONLY substitution is the
+// KV-cache + SDPA step: instead of `slice_update` into a fixed-shape padded KV
+// cache + masked `scaled_dot_product_attention`, it writes the new K/V into the
+// shared block-paged Metal pool via `mlx::core::fast::paged_kv_write` and gathers
+// + attends over the pool via `mlx::core::fast::paged_attention` — exactly the
+// ops qwen35's `attn_for_compile_paged` uses (the call shapes/flags are copied
+// from there to guarantee parity).
+//
+// PARITY with the EAGER `Lfm2Attention::forward_paged` (attention.rs:177-314,
+// decode arm): that path transposes to [B,H,T,D] THEN ropes (with offset =
+// first_logical_position), then transposes K/V back to [num_tokens,n_kv,D] for
+// `update_keys_values` (which wraps paged_kv_write) and squeezes Q to
+// [1,num_heads,head_dim] for `gather_kv_for_decode` (which wraps paged_attention)
+// with scale=self.scale and softcap=1.0. The eager API's softcap=1.0 means
+// DISABLED and maps to the graph op's softcap=0.0f used here. T=1 for decode, so
+// the lfm2 "transpose-THEN-rope" ordering is preserved here verbatim and is
+// numerically identical to the eager path.
+//
+// Layout contract (block_size=16, x_pack=8, bf16, sliding_window=0):
+//   k_pool: [num_blocks, num_kv_heads, head_dim/x_pack, block_size, x_pack]
+//   v_pool: [num_blocks, num_kv_heads, head_dim, block_size]
+//   k_scale/v_scale: [1] f32 placeholders (1.0; FP8 calibration is future work)
+//   block_table: [1, max_blocks_per_seq] int32; slot_mapping: [num_tokens] int64
+//   seq_lens:   [1] int32 (validity is handled by paged_attention via seq_lens —
+//               NO additive mask is constructed here, unlike the flat fn).
+// Returns Lfm2AttnResult{output, keys=new_k_pool, values=new_v_pool}: keys/values
+// are the POST-WRITE pool tensors so the compile graph's dependency edge flows
+// through paged_kv_write's outputs into paged_attention's inputs, and the caller
+// can stash them back into the global pool slots (mirrors qwen's re-purposing of
+// AttnPureResult.{keys,values}).
+// =====================================================================
+inline Lfm2AttnResult lfm2_attn_pure_fn_arr_paged(
+    const array& x,                     // [B, hidden] — 2D decode
+    int layer_idx,
+    const array& k_pool,                // [num_blocks, n_kv, head_dim/x, block, x]
+    const array& v_pool,                // [num_blocks, n_kv, head_dim, block]
+    const array& k_scale,               // [1] f32 placeholder
+    const array& v_scale,               // [1] f32 placeholder
+    const array& offset_arr,            // [1] int32 RoPE position
+    const array& block_table,           // [1, max_blocks_per_seq] int32
+    const array& slot_mapping,          // [num_tokens] int64
+    const array& seq_lens,              // [1] int32
+    int block_size,
+    const Lfm2MoeConfig& cfg) {
+  using namespace qwen35_common;
+  int B = x.shape(0);
+  std::string pfx = "layers." + std::to_string(layer_idx) + ".self_attn.";
+
+  // ---- Q/K/V projections — NO bias, NO 2x gate width (lfm2 specifics). ----
+  auto queries = linear_proj(x, pfx + "q_proj");
+  auto keys = linear_proj(x, pfx + "k_proj");
+  auto values = linear_proj(x, pfx + "v_proj");
+
+  queries = reshape(queries, {B, 1, cfg.num_heads, cfg.head_dim});
+  keys = reshape(keys, {B, 1, cfg.num_kv_heads, cfg.head_dim});
+  values = reshape(values, {B, 1, cfg.num_kv_heads, cfg.head_dim});
+
+  // Per-head Q/K RMSNorm over head_dim (eps = norm_eps). V: none.
+  queries =
+      mlx::core::fast::rms_norm(queries, get_weight(pfx + "q_layernorm.weight"), cfg.norm_eps);
+  keys = mlx::core::fast::rms_norm(keys, get_weight(pfx + "k_layernorm.weight"), cfg.norm_eps);
+
+  // Transpose to [B,H,T,D] FIRST, then RoPE (lfm2 ordering — position axis = T).
+  queries = transpose(queries, {0, 2, 1, 3});
+  keys = transpose(keys, {0, 2, 1, 3});
+  values = transpose(values, {0, 2, 1, 3});
+
+  // neox RoPE over the FULL head_dim, ARRAY offset overload (graph-safe).
+  queries =
+      mlx::core::fast::rope(queries, cfg.head_dim, false, cfg.rope_theta, 1.0f, offset_arr);
+  keys = mlx::core::fast::rope(keys, cfg.head_dim, false, cfg.rope_theta, 1.0f, offset_arr);
+
+  // ---- Convert to the paged layouts the fast ops expect ----
+  //   new_k / new_v: [num_tokens, num_kv_heads, head_dim]
+  //   q_pa:          [num_tokens, num_heads,    head_dim]
+  // For decode B == num_tokens == 1 and the time axis is 1. Mirror the eager
+  // path's [B,H,T,D] -> [B,T,Hkv,D] -> [B*T,Hkv,D] for K/V (attention.rs:227-236)
+  // and squeeze Q (attention.rs:289-293).
+  int num_tokens = B;  // single-token decode
+  auto new_k = reshape(transpose(keys, {0, 2, 1, 3}),
+                       {num_tokens, cfg.num_kv_heads, cfg.head_dim});
+  auto new_v = reshape(transpose(values, {0, 2, 1, 3}),
+                       {num_tokens, cfg.num_kv_heads, cfg.head_dim});
+  auto q_pa = reshape(transpose(queries, {0, 2, 1, 3}),
+                      {num_tokens, cfg.num_heads, cfg.head_dim});
+
+  // Phase P1 hard-coded contract (matches qwen attn_for_compile_paged):
+  // bf16 cache, x_pack=8, sliding=0.
+  constexpr int X_PACK = 8;
+  constexpr int SLIDING_WINDOW = 0;
+  const auto kv_dtype = mlx::core::fast::KvDtype::Bf16;
+
+  // 1) Write the new K/V into the paged pool.
+  auto write_pair = mlx::core::fast::paged_kv_write(
+      k_pool, v_pool,
+      new_k, new_v,
+      slot_mapping,
+      k_scale, v_scale,
+      block_size,
+      cfg.num_kv_heads,
+      cfg.head_dim,
+      X_PACK,
+      kv_dtype);
+  auto new_k_pool = std::move(write_pair.first);
+  auto new_v_pool = std::move(write_pair.second);
+
+  // 2) Gather + attend via the paged kernel against the just-written pool.
+  //    Using the post-write outputs makes the read-after-write dependency
+  //    edge explicit for the MLX scheduler. scale = head_dim^-0.5, softcap=0
+  //    (== the eager softcap=1.0/disabled), sliding=0.
+  float scale = std::pow(static_cast<float>(cfg.head_dim), -0.5f);
+  auto attn_out = mlx::core::fast::paged_attention(
+      q_pa,
+      new_k_pool, new_v_pool,
+      block_table, seq_lens,
+      k_scale, v_scale,
+      scale,
+      /*softcap=*/0.0f,
+      SLIDING_WINDOW,
+      block_size,
+      cfg.num_heads,
+      cfg.num_kv_heads,
+      cfg.head_dim,
+      kv_dtype);
+
+  // attn_out: [num_tokens, num_heads, head_dim] -> [B, H*D]. lfm2 has NO gate.
+  attn_out = reshape(attn_out, {B, cfg.num_heads * cfg.head_dim});
+  auto output = linear_proj(attn_out, pfx + "out_proj");
+
+  // keys/values re-purposed as the post-write pools (caller stashes them back).
+  return {output, new_k_pool, new_v_pool};
+}
+
+// =====================================================================
 // Dense SwiGLU MLP for an lfm2 layer (mirrors `MLP::forward` / lfm2.py).
 //   down_proj(swiglu(gate_proj(x), up_proj(x))), keys
 //   layers.{i}.feed_forward.{gate,up,down}_proj.

--- a/crates/mlx-sys/src/mlx_lfm2_moe.cpp
+++ b/crates/mlx-sys/src/mlx_lfm2_moe.cpp
@@ -195,6 +195,99 @@ bool g_lfm2_inited = false;
 uint64_t g_lfm2_forward_calls = 0;
 uint64_t g_lfm2_compiled_decode_calls = 0;
 
+// =====================================================================
+// PAGED decode state (Phase P1 — the compiled-paged graph). Strictly SEPARATE
+// from the flat globals above so the two paths never alias. The flat path threads
+// a fixed-shape padded KV cache + additive mask; the paged path threads the
+// shared block-paged Metal pools (`mlx::core::fast::paged_kv_write` /
+// `paged_attention`) plus per-turn conv state.
+//
+// CONV-STATE THREADING CONTRACT (the [HIGH] finding — design (A)):
+//   Conv state is threaded EXACTLY like qwen's linear caches: as a graph
+//   input/output cache SLOT, NOT via a side global. `lfm2_decode_fn_paged`
+//   reads each conv layer's prior state from its stride-4 INPUT slot
+//   (`inputs[base+0]`) and writes the new state to its stride-2 OUTPUT slot
+//   (`new_caches[i*kPerLayerOut]`). There is NO separate conv-state global —
+//   the per-turn storage that P2's `mlx_lfm2_moe_forward_paged` re-feeds each
+//   step is the per-layer slot vector `g_lfm2_paged_k_pools[i]`, REUSED to hold
+//   the conv state for conv layers (this is qwen's exact convention: qwen
+//   stores attn pools in `g_dense_k_pools[i]` and threads linear/conv caches in
+//   the parallel `g_dense_paged_linear_caches` slots, indexed by the same `i`
+//   with a placeholder in the other vector). Because lfm2's conv state is a
+//   SINGLE tensor per conv layer (no second recurrent-state tensor like qwen's
+//   linear cache), one slot per layer suffices, so we overload the existing
+//   `g_lfm2_paged_k_pools` vector instead of adding a `num_layers*2` cache
+//   vector. A side global would silently desync the conv recurrence (stale
+//   state fed each step), so it does NOT exist.
+//
+//   g_lfm2_paged_config       POD shape for `lfm2_decode_fn_paged`.
+//   g_lfm2_paged_is_attn      per-ABSOLUTE-layer dispatch (1=attn, 0=conv),
+//                             length num_layers (kept OUT of the POD).
+//   g_lfm2_paged_k_pools      per-ABSOLUTE-layer slot, length num_layers. DUAL
+//                             PURPOSE by layer kind (design (A) above):
+//                               * attn layer i: holds the paged K pool;
+//                               * conv layer i: holds the conv state
+//                                 [B, l_cache-1, hidden].
+//                             P2 feeds this into `fn_inputs[base+0]` and writes
+//                             back `outputs[2+i*2]` here every step. Threaded
+//                             WITHIN a turn only (the eager paged path reprefills
+//                             conv each turn, so there is no cross-turn conv
+//                             export — see plan risk #5).
+//   g_lfm2_paged_v_pools /    per-ABSOLUTE-layer paged pools / scales. Meaningful
+//   g_lfm2_paged_k_scales /   for attn layers only; conv layers hold bf16/f32
+//   g_lfm2_paged_v_scales     placeholders so per-layer indexing stays uniform
+//                             (mirrors qwen's per-layer parallel-vector
+//                             convention — lfm2 mixes attn/conv irregularly, so a
+//                             modulo `is_linear` test like qwen's does NOT apply;
+//                             the explicit is_attn vector drives dispatch).
+//   g_lfm2_paged_offset_int   current decode position (RoPE offset for next step).
+//   g_lfm2_paged_inited       gates the (P2) paged forward FFI.
+//   g_lfm2_paged_forward_calls  cumulative count of mlx_lfm2_moe_forward_paged
+//                             calls that ran the C++ paged decode (BOTH the
+//                             compiled AND the eager MLX_NO_COMPILE arm). This is
+//                             the paged analogue of the flat g_lfm2_forward_calls:
+//                             it proves the paged C++ forward engaged (vs the Rust
+//                             caller silently falling back to the pure-Rust paged
+//                             decode), which is the ONLY engagement signal the
+//                             EAGER-paged (MLX_NO_COMPILE=1) run has — the compiled
+//                             counter below never bumps in that arm. NOT reset by
+//                             mlx_lfm2_paged_reset.
+//   g_lfm2_compiled_paged_decode_calls  cumulative count of forwards that took the
+//                             TRACED compiled_lfm2_decode_paged() branch (NOT the
+//                             eager MLX_NO_COMPILE arm). Process-lifetime
+//                             engagement signal; incremented only in the compiled
+//                             arm (P2). Distinct from the flat counter above.
+// =====================================================================
+lfm2_common::Lfm2MoeConfig g_lfm2_paged_config;
+std::vector<int> g_lfm2_paged_is_attn;
+std::vector<array> g_lfm2_paged_k_pools;       // [num_layers]
+std::vector<array> g_lfm2_paged_v_pools;       // [num_layers]
+std::vector<array> g_lfm2_paged_k_scales;      // [num_layers]
+std::vector<array> g_lfm2_paged_v_scales;      // [num_layers]
+int g_lfm2_paged_offset_int = 0;
+bool g_lfm2_paged_inited = false;
+uint64_t g_lfm2_paged_forward_calls = 0;
+uint64_t g_lfm2_compiled_paged_decode_calls = 0;
+
+// Tear down ONLY the compiled-PAGED decode state — config, is_attn dispatch,
+// per-layer pools/scales/conv-state, offset, inited flag. Does NOT touch the
+// flat globals (g_lfm2_caches / g_lfm2_offset_int / g_lfm2_inited), the shared
+// model-id atom (owned by mlx_clear_weights), or the engagement counters
+// (g_lfm2_paged_forward_calls / g_lfm2_compiled_paged_decode_calls are
+// process-lifetime signals). Defined BEFORE `mlx_lfm2_moe_init_paged` so init
+// can reset stale/aborted state from inside its failure paths; also called by
+// the public `extern "C" mlx_lfm2_paged_reset()`.
+static void lfm2_reset_paged_globals() {
+  g_lfm2_paged_config = lfm2_common::Lfm2MoeConfig{};
+  g_lfm2_paged_is_attn.clear();
+  g_lfm2_paged_k_pools.clear();
+  g_lfm2_paged_v_pools.clear();
+  g_lfm2_paged_k_scales.clear();
+  g_lfm2_paged_v_scales.clear();
+  g_lfm2_paged_offset_int = 0;
+  g_lfm2_paged_inited = false;
+}
+
 // ---------------------------------------------------------------------------
 // REBUILDABLE compiled-decode closure (Phase 3c hardening).
 //
@@ -303,6 +396,191 @@ void lfm2_reset_compiled_closure_same_epoch() {
   g_lfm2_compiled.reset();
   g_lfm2_compiled_epoch_built = 0;
 }
+
+// =====================================================================
+// PAGED single-token decode loop over the lfm2 backbone (Phase P1).
+//
+// A fork of `lfm2_decode_fn` that swaps the flat fixed-shape padded KV cache +
+// additive-mask SDPA for the block-paged KV pool (`mlx::core::fast::
+// paged_kv_write` / `paged_attention`). Conv layers and the dense/MoE FFN
+// dispatch are IDENTICAL to the flat fn — only the attention layers differ. NO
+// additive mask is constructed: `paged_attention` handles validity via
+// `seq_lens`. Modeled on qwen35's `dense_compiled_decode_fn_paged` /
+// `moe_compiled_decode_fn_paged` (per-ABSOLUTE-layer stride-4 inputs, stride-2
+// outputs) but driven by the explicit `g_lfm2_paged_is_attn` dispatch (lfm2 mixes
+// conv/attn irregularly, so qwen's modulo `is_linear` test does NOT apply).
+//
+// INPUT vector layout (all arrays — order is the compile-cache key):
+//   [0]                  h:                 [B, hidden] embedded input
+//   [1]                  offset_arr:        [1] int32 (RoPE position)
+//   [2]                  block_table:       [1, max_blocks_per_seq] int32
+//   [3]                  slot_mapping:      [num_tokens] int64
+//   [4]                  num_valid_tokens:  [1] int32 (informational/unused)
+//   [5]                  num_valid_blocks:  [1] int32 (informational/unused)
+//   [6]                  seq_lens:          [1] int32
+//   For each ABSOLUTE layer i in [0, num_layers) (stride 4 = kPerLayer):
+//     If conv layer (g_lfm2_paged_is_attn[i] == 0):
+//       [7 + i*4 + 0]    conv_state:        [B, l_cache-1, hidden]
+//       [7 + i*4 + 1..3] placeholders       (unused — keep stride uniform)
+//     If attn layer (g_lfm2_paged_is_attn[i] == 1):
+//       [7 + i*4 + 0]    k_pool
+//       [7 + i*4 + 1]    v_pool
+//       [7 + i*4 + 2]    k_scale            [1] f32
+//       [7 + i*4 + 3]    v_scale            [1] f32
+//
+// OUTPUT vector layout (stride 2 = kPerLayerOut, matching qwen's paged graph):
+//   [0]                  logits:            [B, vocab]
+//   [1]                  new_offset:        offset_arr + 1
+//   For each ABSOLUTE layer i:
+//     If conv layer:
+//       [2 + i*2 + 0]    new_conv_state
+//       [2 + i*2 + 1]    placeholder        (scalar bf16 zero — unused)
+//     If attn layer:
+//       [2 + i*2 + 0]    new_k_pool         (post-write pool tensor)
+//       [2 + i*2 + 1]    new_v_pool         (post-write pool tensor)
+//
+// The 4-input / 2-output stride is identical to the qwen paged graphs and the
+// flat lfm2 graph's 2-output stride, so P2's `mlx_lfm2_moe_forward_paged` writes
+// the post-step caches back with the SAME indexing the flat forward uses (attn:
+// pools, conv: conv state in slot.a, slot.b left as the seeded scalar zero).
+// =====================================================================
+std::vector<array> lfm2_decode_fn_paged(const std::vector<array>& inputs) {
+  using namespace lfm2_common;
+  using namespace qwen35_common;
+  const auto& cfg = g_lfm2_paged_config;
+  auto h = inputs[0];           // [B, hidden]
+  auto offset_arr = inputs[1];  // [1] int32
+  auto block_table = inputs[2];
+  auto slot_mapping = inputs[3];
+  // inputs[4] num_valid_tokens, inputs[5] num_valid_blocks: informational
+  // (paged_attention uses seq_lens for validity). Kept in the input vector for a
+  // uniform header with qwen's paged graphs; not read here.
+  auto seq_lens = inputs[6];
+
+  // Phase P1 hard-coded contract (matches qwen attn_for_compile_paged).
+  constexpr int BLOCK_SIZE = 16;
+
+  constexpr int kHeader = 7;
+  constexpr int kPerLayer = 4;     // input stride per layer
+  constexpr int kPerLayerOut = 2;  // output stride per layer
+
+  // Pre-seed all output cache slots (conv slot.b / placeholders stay scalar zero).
+  std::vector<array> new_caches;
+  new_caches.reserve(cfg.num_layers * kPerLayerOut);
+  for (int i = 0; i < cfg.num_layers * kPerLayerOut; i++) {
+    new_caches.push_back(zeros({}, mlx::core::bfloat16));
+  }
+
+  for (int i = 0; i < cfg.num_layers; i++) {
+    std::string lp = "layers." + std::to_string(i);
+    int base = kHeader + i * kPerLayer;
+
+    // (1) operator_norm BEFORE the op, residual after.
+    auto normed =
+        mlx::core::fast::rms_norm(h, get_weight(lp + ".operator_norm.weight"), cfg.norm_eps);
+    if (g_lfm2_paged_is_attn[i]) {
+      const auto& k_pool = inputs[base + 0];
+      const auto& v_pool = inputs[base + 1];
+      const auto& k_scale = inputs[base + 2];
+      const auto& v_scale = inputs[base + 3];
+      auto res = lfm2_attn_pure_fn_arr_paged(
+          normed, i, k_pool, v_pool, k_scale, v_scale, offset_arr, block_table,
+          slot_mapping, seq_lens, BLOCK_SIZE, cfg);
+      h = h + res.output;
+      // lfm2_attn_pure_fn_arr_paged stashes new_k_pool/new_v_pool in keys/values.
+      new_caches[i * kPerLayerOut] = res.keys;
+      new_caches[i * kPerLayerOut + 1] = res.values;
+    } else {
+      const auto& cs = inputs[base + 0];
+      auto res = lfm2_conv_pure_fn(normed, i, cs, cfg.conv_l_cache, cfg.hidden_size,
+                                   /*conv_bias=*/cfg.conv_bias);
+      h = h + res.output;
+      new_caches[i * kPerLayerOut] = res.new_state;
+      // slot.b left as the pre-seeded scalar zero (unused for conv layers).
+    }
+
+    // (2) ffn_norm BEFORE the FFN, residual after — IDENTICAL dispatch to the
+    // flat lfm2_decode_fn (dense SwiGLU vs sparse MoE).
+    auto ffn_in =
+        mlx::core::fast::rms_norm(h, get_weight(lp + ".ffn_norm.weight"), cfg.norm_eps);
+    bool is_moe_layer = cfg.num_experts > 0 && i >= cfg.num_dense_layers;
+    if (is_moe_layer) {
+      h = h + lfm2_moe_ffn(ffn_in, i, cfg);
+    } else {
+      h = h + lfm2_dense_mlp(ffn_in, i);
+    }
+  }
+
+  // Final norm + tied/untied LM head (identical to the flat fn).
+  h = mlx::core::fast::rms_norm(h, get_weight("embedding_norm.weight"), cfg.norm_eps);
+  h = cfg.tie_embedding ? linear_proj(h, "embed_tokens") : linear_proj(h, "lm_head");
+
+  auto new_offset = offset_arr + array(1, mlx::core::int32);
+  std::vector<array> out;
+  out.reserve(2 + cfg.num_layers * kPerLayerOut);
+  out.push_back(h);
+  out.push_back(new_offset);
+  for (auto& c : new_caches) {
+    out.push_back(c);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// REBUILDABLE compiled-PAGED-decode closure (Phase P1).
+//
+// A SECOND epoch-keyed closure that mirrors `compiled_lfm2_decode()` exactly but
+// for `lfm2_decode_fn_paged`, with a DISTINCT `fun_id` base so the flat and paged
+// MLX compile caches NEVER collide (re-wrapping `compile()` on two different
+// target functions already keys on distinct addresses, but to be defensive the
+// per-epoch ids are derived from a separate static anchor too).
+//
+// It SHARES `g_lfm2_compile_epoch` for invalidation — so a single
+// `mlx_lfm2_invalidate_compiled()` on (re)registration retraces BOTH the flat and
+// paged closures against the freshly-stored weight constants — but keeps its OWN
+// non-atomic optional / epoch_built / fun_id_built state guarded by its OWN mutex
+// `g_lfm2_compiled_paged_mu` (a concurrent flat rebuild and paged rebuild touch
+// disjoint state, so two mutexes avoid needless contention; both observe the same
+// shared atomic epoch).
+// ---------------------------------------------------------------------------
+std::mutex g_lfm2_compiled_paged_mu;
+std::optional<std::function<std::vector<array>(const std::vector<array>&)>>
+    g_lfm2_compiled_paged;
+uint64_t g_lfm2_compiled_paged_epoch_built = 0;
+std::uintptr_t g_lfm2_compiled_paged_fun_id_built = 0;  // 0 == none installed
+bool g_lfm2_has_compiled_paged_fun_id = false;
+
+// lfm2 PAGED-LOCAL fun_id base: a SEPARATE static anchor address, distinct from
+// `lfm2_fun_id_base()` (the flat path's anchor), so the flat and paged per-epoch
+// ids can never collide even at the same epoch.
+inline std::uintptr_t lfm2_paged_fun_id_base() {
+  static char anchor = 0;
+  return reinterpret_cast<std::uintptr_t>(&anchor);
+}
+
+// Returns a stable, owned COPY of the compiled-paged decode closure, re-tracing
+// it under a fresh per-epoch `fun_id` if the shared registration epoch advanced
+// since it was last built. Same lower-level `detail::compile` + `compile_erase`
+// scheme and same by-value return contract as `compiled_lfm2_decode()` (see that
+// function's thread-safety notes); only the target fn, mutex, and fun_id base
+// differ. fun_id scheme: `lfm2_paged_fun_id_base() ^ ((epoch << 1) | 1)`.
+std::function<std::vector<array>(const std::vector<array>&)> compiled_lfm2_decode_paged() {
+  std::lock_guard<std::mutex> lk(g_lfm2_compiled_paged_mu);
+  uint64_t cur = g_lfm2_compile_epoch.load(std::memory_order_acquire);
+  if (!g_lfm2_compiled_paged.has_value() || g_lfm2_compiled_paged_epoch_built != cur) {
+    if (g_lfm2_has_compiled_paged_fun_id) {
+      mlx::core::detail::compile_erase(g_lfm2_compiled_paged_fun_id_built);
+    }
+    std::uintptr_t fun_id =
+        lfm2_paged_fun_id_base() ^ static_cast<std::uintptr_t>((cur << 1) | 1ull);
+    g_lfm2_compiled_paged = mlx::core::detail::compile(lfm2_decode_fn_paged, fun_id);
+    g_lfm2_compiled_paged_epoch_built = cur;
+    g_lfm2_compiled_paged_fun_id_built = fun_id;
+    g_lfm2_has_compiled_paged_fun_id = true;
+  }
+  return *g_lfm2_compiled_paged;
+}
+
 // =============================================================================
 // TEST-ONLY shared synthetic-MoE helpers (used by the compiled-vs-eager probe
 // AND the no-bump warm probe). Extracted from `mlx_lfm2_probe_moe_compiled_vs_eager`
@@ -797,6 +1075,415 @@ void mlx_lfm2_moe_reset() {
 // re-capture B's weights instead of reusing A's frozen graph.
 void mlx_lfm2_invalidate_compiled() {
   g_lfm2_compile_epoch.fetch_add(1, std::memory_order_acq_rel);
+}
+
+// =============================================================================
+// PAGED forward FFI (Phase P2). Mirrors qwen35's
+// `mlx_qwen35_init_paged` / `mlx_qwen35_forward_paged` /
+// `mlx_qwen35_compiled_reset` (paged half) and the flat lfm2
+// `mlx_lfm2_moe_init_from_prefill` / `mlx_lfm2_moe_forward` style. Drives the
+// compiled-PAGED decode graph (`lfm2_decode_fn_paged` / `compiled_lfm2_decode_paged`)
+// over the shared block-paged Metal pools. STRICTLY separate from the flat
+// globals/lifecycle above — the two decode paths never alias.
+//
+// bf16/f16 ONLY (quantized stays eager). Decode-only: prefill stays eager
+// pure-Rust paged; this is SEEDED from the post-prefill adapter pools + conv
+// state. Covers BOTH dense lfm2 and lfm2_moe in ONE decode fn (the FFN dispatch
+// is reused unchanged via g_lfm2_paged_config.num_experts / num_dense_layers).
+// =============================================================================
+
+// Initialize the compiled-paged lfm2 decode graph from post-prefill state.
+//
+// `is_attn` (length num_layers, 1=attn/0=conv) drives the per-layer dispatch
+// and is built dynamically Rust-side from config.is_attention_layer; it is NEVER
+// a modulo/hardcoded pattern (lfm2 mixes conv/attn irregularly).
+//
+// Per-layer handle import (design (A) — see the g_lfm2_paged_* contract above):
+//   attn layer i: k_pool_handles[i] -> g_lfm2_paged_k_pools[i]
+//                 v_pool_handles[i] -> g_lfm2_paged_v_pools[i]
+//                 k_scale_handles[i] -> g_lfm2_paged_k_scales[i]
+//                 v_scale_handles[i] -> g_lfm2_paged_v_scales[i]
+//                 (null on any -> bail, g_lfm2_paged_inited=false, return -1).
+//   conv layer i: conv_state_handles[i] -> g_lfm2_paged_k_pools[i]
+//                 (the k_pools vector is REUSED to hold conv state for conv
+//                 layers — one tensor per conv layer suffices). The v_pool /
+//                 k_scale / v_scale slots get bf16/f32 placeholders so per-layer
+//                 indexing stays uniform; they are never read for conv layers.
+//                 (null conv_state -> bail.)
+//
+// max_kv_len / block_size are accepted for ABI symmetry with the flat init and
+// qwen's paged init; the paged graph hard-codes block_size=16 internally
+// (matches qwen attn_for_compile_paged), so block_size MUST be 16 here.
+//
+// Force-evals the attn pools at init to surface a Metal OOM / layout / dtype
+// fault HERE rather than inside the first forward (where the Rust caller's
+// record_tokens has already mutated adapter state). Returns 0 on success, -1 on
+// failure; on failure g_lfm2_paged_inited is cleared and a stderr diagnostic is
+// emitted, so the Rust caller MUST inspect the return value and fall back to the
+// pure-Rust paged decode.
+int32_t mlx_lfm2_moe_init_paged(
+    int num_layers,
+    int hidden_size,
+    int num_heads,
+    int num_kv_heads,
+    int head_dim,
+    float rope_theta,
+    float norm_eps,
+    int conv_l_cache,
+    int num_experts,
+    int num_experts_per_tok,
+    int num_dense_layers,
+    int norm_topk_prob,
+    int use_expert_bias,
+    int tie_embedding,
+    int conv_bias,
+    int max_kv_len,
+    int batch_size,
+    int block_size,
+    const int32_t* is_attn,
+    // Per-layer paged storage (length num_layers). Conv-layer pool/scale slots
+    // may be null (placeholders are stored).
+    mlx_array** k_pool_handles,
+    mlx_array** v_pool_handles,
+    mlx_array** k_scale_handles,
+    mlx_array** v_scale_handles,
+    // Per-layer conv state (length num_layers). Attn-layer slots may be null.
+    mlx_array** conv_state_handles,
+    int prefill_offset) {
+  // Clear any stale state from a prior aborted init (a previous failure could
+  // have left partially-populated pool/scale vectors + imported array handles
+  // resident — GPU-backed leak). Every failure path below + the catch blocks
+  // also reset, so init never leaves mutated globals behind on failure.
+  lfm2_reset_paged_globals();
+  try {
+    // The paged graph hard-codes block_size=16 (matches qwen
+    // attn_for_compile_paged); reject any other value loudly rather than
+    // silently miswiring the pool layout.
+    if (block_size != 16) {
+      std::cerr << "[MLX] mlx_lfm2_moe_init_paged: block_size must be 16, got "
+                << block_size << std::endl;
+      lfm2_reset_paged_globals();
+      return -1;
+    }
+
+    g_lfm2_paged_config = Lfm2MoeConfig{};
+    g_lfm2_paged_config.num_layers = num_layers;
+    g_lfm2_paged_config.hidden_size = hidden_size;
+    g_lfm2_paged_config.num_heads = num_heads;
+    g_lfm2_paged_config.num_kv_heads = num_kv_heads;
+    g_lfm2_paged_config.head_dim = head_dim;
+    g_lfm2_paged_config.rope_theta = rope_theta;
+    g_lfm2_paged_config.norm_eps = norm_eps;
+    g_lfm2_paged_config.conv_l_cache = conv_l_cache;
+    g_lfm2_paged_config.num_experts = num_experts;
+    g_lfm2_paged_config.num_experts_per_tok = num_experts_per_tok;
+    g_lfm2_paged_config.num_dense_layers = num_dense_layers;
+    g_lfm2_paged_config.norm_topk_prob = norm_topk_prob != 0;
+    g_lfm2_paged_config.use_expert_bias = use_expert_bias != 0;
+    g_lfm2_paged_config.tie_embedding = tie_embedding != 0;
+    g_lfm2_paged_config.conv_bias = conv_bias != 0;
+    g_lfm2_paged_config.max_kv_len = max_kv_len;
+    g_lfm2_paged_config.batch_size = batch_size;
+    // NOTE: Lfm2MoeConfig has NO rope_dims — RoPE is over the full head_dim.
+
+    g_lfm2_paged_is_attn.assign(is_attn, is_attn + num_layers);
+
+    g_lfm2_paged_k_pools.clear();
+    g_lfm2_paged_v_pools.clear();
+    g_lfm2_paged_k_scales.clear();
+    g_lfm2_paged_v_scales.clear();
+    g_lfm2_paged_k_pools.reserve(num_layers);
+    g_lfm2_paged_v_pools.reserve(num_layers);
+    g_lfm2_paged_k_scales.reserve(num_layers);
+    g_lfm2_paged_v_scales.reserve(num_layers);
+    g_lfm2_paged_inited = false;
+
+    auto bf16_placeholder = []() { return zeros({}, mlx::core::bfloat16); };
+    auto f32_placeholder = []() { return array(1.0f, mlx::core::float32); };
+
+    for (int i = 0; i < num_layers; i++) {
+      if (is_attn[i]) {
+        if (!k_pool_handles || !v_pool_handles || !k_scale_handles ||
+            !v_scale_handles || !k_pool_handles[i] || !v_pool_handles[i] ||
+            !k_scale_handles[i] || !v_scale_handles[i]) {
+          std::cerr << "[MLX] mlx_lfm2_moe_init_paged: missing pool/scale handle "
+                       "for attn layer "
+                    << i << std::endl;
+          lfm2_reset_paged_globals();
+          return -1;
+        }
+        g_lfm2_paged_k_pools.push_back(*reinterpret_cast<array*>(k_pool_handles[i]));
+        g_lfm2_paged_v_pools.push_back(*reinterpret_cast<array*>(v_pool_handles[i]));
+        g_lfm2_paged_k_scales.push_back(*reinterpret_cast<array*>(k_scale_handles[i]));
+        g_lfm2_paged_v_scales.push_back(*reinterpret_cast<array*>(v_scale_handles[i]));
+      } else {
+        // Conv layer: g_lfm2_paged_k_pools[i] holds the conv state (design (A)).
+        // v_pool / k_scale / v_scale are unread placeholders for stride symmetry.
+        if (!conv_state_handles || !conv_state_handles[i]) {
+          std::cerr << "[MLX] mlx_lfm2_moe_init_paged: missing conv-state handle "
+                       "for conv layer "
+                    << i << std::endl;
+          lfm2_reset_paged_globals();
+          return -1;
+        }
+        g_lfm2_paged_k_pools.push_back(*reinterpret_cast<array*>(conv_state_handles[i]));
+        g_lfm2_paged_v_pools.push_back(bf16_placeholder());
+        g_lfm2_paged_k_scales.push_back(f32_placeholder());
+        g_lfm2_paged_v_scales.push_back(f32_placeholder());
+      }
+    }
+
+    g_lfm2_paged_offset_int = prefill_offset;
+
+    // Defense-in-depth: validate the attn pool/scale dtype contract and
+    // force-eval them so a Metal-allocation or layout fault throws HERE (init),
+    // not inside the first forward.
+    {
+      std::vector<array> probe;
+      probe.reserve(num_layers * 4 + 1);
+      for (int i = 0; i < num_layers; i++) {
+        if (!is_attn[i]) continue;
+        if (g_lfm2_paged_k_pools[i].dtype() != mlx::core::bfloat16) {
+          std::cerr << "[MLX] mlx_lfm2_moe_init_paged: layer " << i
+                    << " k_pool dtype != bf16" << std::endl;
+          lfm2_reset_paged_globals();
+          return -1;
+        }
+        if (g_lfm2_paged_v_pools[i].dtype() != mlx::core::bfloat16) {
+          std::cerr << "[MLX] mlx_lfm2_moe_init_paged: layer " << i
+                    << " v_pool dtype != bf16" << std::endl;
+          lfm2_reset_paged_globals();
+          return -1;
+        }
+        if (g_lfm2_paged_k_scales[i].dtype() != mlx::core::float32) {
+          std::cerr << "[MLX] mlx_lfm2_moe_init_paged: layer " << i
+                    << " k_scale dtype != f32" << std::endl;
+          lfm2_reset_paged_globals();
+          return -1;
+        }
+        if (g_lfm2_paged_v_scales[i].dtype() != mlx::core::float32) {
+          std::cerr << "[MLX] mlx_lfm2_moe_init_paged: layer " << i
+                    << " v_scale dtype != f32" << std::endl;
+          lfm2_reset_paged_globals();
+          return -1;
+        }
+        probe.push_back(g_lfm2_paged_k_pools[i]);
+        probe.push_back(g_lfm2_paged_v_pools[i]);
+        probe.push_back(g_lfm2_paged_k_scales[i]);
+        probe.push_back(g_lfm2_paged_v_scales[i]);
+      }
+      // Break the lazy RNG split chain from model init, and force-eval the pool /
+      // scale layout in the same batch so any Metal/layout error throws here.
+      auto rng_key = mlx::core::random::KeySequence::default_().next();
+      probe.push_back(rng_key);
+      mlx::core::eval(std::move(probe));
+    }
+
+    g_lfm2_paged_inited = true;
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "[MLX] mlx_lfm2_moe_init_paged: " << e.what() << std::endl;
+    // Reset BEFORE returning so a partially-populated init (imported handles /
+    // pool vectors mutated before the throw) leaves no stale GPU-backed state.
+    lfm2_reset_paged_globals();
+    return -1;
+  } catch (...) {
+    std::cerr << "[MLX] mlx_lfm2_moe_init_paged: unknown exception" << std::endl;
+    lfm2_reset_paged_globals();
+    return -1;
+  }
+}
+
+// Single-token compiled-paged decode step. Inputs (PagedAttentionInputs) come
+// from the Rust adapter's `build_paged_attention_inputs`; the per-layer pool /
+// scale / conv-state globals come from `mlx_lfm2_moe_init_paged`. Writes a null
+// *output_logits when the graph is not initialized (or on error) so the caller
+// falls back to the pure-Rust paged decode.
+//
+// DECODE-ONLY contract (mirrors qwen): `input_ids` MUST have exactly one element
+// and `slot_mapping` MUST be `[1]`. The compiled-paged branch increments
+// g_lfm2_compiled_paged_decode_calls ONLY in the compiled arm (NOT the eager
+// MLX_NO_COMPILE arm) — the engagement signal that the traced closure ran.
+void mlx_lfm2_moe_forward_paged(
+    mlx_array* input_ids_ptr,
+    mlx_array* embedding_weight_ptr,
+    mlx_array* offset_arr_ptr,
+    mlx_array* block_table_ptr,
+    mlx_array* slot_mapping_ptr,
+    mlx_array* num_valid_tokens_ptr,
+    mlx_array* num_valid_blocks_ptr,
+    mlx_array* seq_lens_ptr,
+    mlx_array** output_logits,
+    int* cache_offset_out) {
+  if (!g_lfm2_paged_inited) {
+    if (output_logits) *output_logits = nullptr;
+    return;
+  }
+  if (!input_ids_ptr || !embedding_weight_ptr || !output_logits ||
+      !offset_arr_ptr || !block_table_ptr || !slot_mapping_ptr ||
+      !num_valid_tokens_ptr || !num_valid_blocks_ptr || !seq_lens_ptr) {
+    if (output_logits) *output_logits = nullptr;
+    return;
+  }
+  const auto& cfg = g_lfm2_paged_config;
+
+  try {
+    auto& input_ids = *reinterpret_cast<array*>(input_ids_ptr);
+    auto& embedding = *reinterpret_cast<array*>(embedding_weight_ptr);
+    auto& offset_arr = *reinterpret_cast<array*>(offset_arr_ptr);
+    auto& block_table = *reinterpret_cast<array*>(block_table_ptr);
+    auto& slot_mapping = *reinterpret_cast<array*>(slot_mapping_ptr);
+    auto& num_valid_tokens = *reinterpret_cast<array*>(num_valid_tokens_ptr);
+    auto& num_valid_blocks = *reinterpret_cast<array*>(num_valid_blocks_ptr);
+    auto& seq_lens = *reinterpret_cast<array*>(seq_lens_ptr);
+
+    // Decode-only contract: single-token. `paged_kv_write` requires
+    // slot_mapping.shape(0) == new_k.shape(0) (== num_tokens == 1).
+    if (input_ids.size() != 1) {
+      fprintf(stderr,
+              "[MLX] mlx_lfm2_moe_forward_paged: decode-only contract violated — "
+              "input_ids.size() = %lld, expected 1\n",
+              static_cast<long long>(input_ids.size()));
+      fflush(stderr);
+      *output_logits = nullptr;
+      return;
+    }
+    if (slot_mapping.ndim() != 1 || slot_mapping.shape(0) != 1) {
+      fprintf(stderr,
+              "[MLX] mlx_lfm2_moe_forward_paged: decode-only contract violated — "
+              "slot_mapping shape must be [1], got ndim=%d, shape[0]=%lld\n",
+              slot_mapping.ndim(),
+              slot_mapping.ndim() >= 1 ? static_cast<long long>(slot_mapping.shape(0))
+                                       : -1LL);
+      fflush(stderr);
+      *output_logits = nullptr;
+      return;
+    }
+
+    // Engagement counter: this forward is past the inited + decode-only contract
+    // checks, so the C++ paged decode WILL run (compiled or eager). Bump BEFORE
+    // the compiled/eager branch — this is the paged analogue of the flat
+    // g_lfm2_forward_calls and is the only "paged C++ forward engaged" signal the
+    // EAGER (MLX_NO_COMPILE=1) arm produces (the compiled counter never bumps
+    // there). A Rust caller that fell back to the pure-Rust paged decode would
+    // never reach here, so a nonzero delta proves the C++ paged path ran.
+    g_lfm2_paged_forward_calls++;
+
+    // Embedding lookup: [B,1] -> [B, hidden] (2D, matching lfm2_decode_fn_paged h).
+    auto flat_ids = reshape(input_ids, {-1});
+    auto h = take(embedding, flat_ids, 0);
+
+    // Assemble fn_inputs in the P1 stride-4 order (see lfm2_decode_fn_paged):
+    //   [0..6] header, then per ABSOLUTE layer i (stride 4):
+    //     attn: k_pool, v_pool, k_scale, v_scale
+    //     conv: conv_state, placeholder*3
+    std::vector<array> fn_inputs;
+    fn_inputs.reserve(7 + cfg.num_layers * 4);
+    fn_inputs.push_back(std::move(h));
+    fn_inputs.push_back(offset_arr);
+    fn_inputs.push_back(block_table);
+    fn_inputs.push_back(slot_mapping);
+    fn_inputs.push_back(num_valid_tokens);
+    fn_inputs.push_back(num_valid_blocks);
+    fn_inputs.push_back(seq_lens);
+    for (int i = 0; i < cfg.num_layers; i++) {
+      if (g_lfm2_paged_is_attn[i]) {
+        fn_inputs.push_back(g_lfm2_paged_k_pools[i]);
+        fn_inputs.push_back(g_lfm2_paged_v_pools[i]);
+        fn_inputs.push_back(g_lfm2_paged_k_scales[i]);
+        fn_inputs.push_back(g_lfm2_paged_v_scales[i]);
+      } else {
+        // Conv layer: slot 0 is the conv state (held in g_lfm2_paged_k_pools[i]);
+        // the other 3 are unused placeholders (held in the parallel vectors).
+        fn_inputs.push_back(g_lfm2_paged_k_pools[i]);
+        fn_inputs.push_back(g_lfm2_paged_v_pools[i]);
+        fn_inputs.push_back(g_lfm2_paged_k_scales[i]);
+        fn_inputs.push_back(g_lfm2_paged_v_scales[i]);
+      }
+    }
+
+    // MLX_NO_COMPILE=1 disables compilation for A/B testing — EXACTLY like the
+    // flat mlx_lfm2_moe_forward. Take an OWNED copy of the compiled closure into
+    // a local before invoking it (compiled_lfm2_decode_paged() returns by value;
+    // a concurrent invalidate+recompile cannot dangle this handle mid-call).
+    //
+    // ALSO honor MLX_DISABLE_COMPILE: MLX's own `compile()` becomes a no-op under
+    // MLX_DISABLE_COMPILE (it returns the eager fn unchanged). If we only checked
+    // MLX_NO_COMPILE we would still take the `else` arm and bump
+    // g_lfm2_compiled_paged_decode_calls even though NO traced/compiled graph
+    // actually ran — the engagement counter would lie. Treat either env var as
+    // "no compiled graph" so the compiled counter only bumps when a real compiled
+    // closure executes.
+    static bool no_compile = std::getenv("MLX_NO_COMPILE") != nullptr ||
+                             std::getenv("MLX_DISABLE_COMPILE") != nullptr;
+    std::vector<array> outputs;
+    if (no_compile) {
+      outputs = lfm2_decode_fn_paged(fn_inputs);
+    } else {
+      auto compiled = compiled_lfm2_decode_paged();
+      // Bump the TRACED-branch counter ONLY here (never in the no_compile arm).
+      g_lfm2_compiled_paged_decode_calls++;
+      outputs = compiled(fn_inputs);
+    }
+
+    if (output_logits) {
+      *output_logits = reinterpret_cast<mlx_array*>(new array(outputs[0]));
+    }
+    g_lfm2_paged_offset_int++;
+    // Stash post-step caches back into the per-layer slots (stride 2 output):
+    //   attn: outputs[2+i*2] = new_k_pool, outputs[2+i*2+1] = new_v_pool
+    //   conv: outputs[2+i*2] = new_conv_state (-> k_pools[i]); slot.b unused.
+    for (int i = 0; i < cfg.num_layers; i++) {
+      auto& a = outputs[2 + i * 2];
+      auto& b = outputs[2 + i * 2 + 1];
+      if (g_lfm2_paged_is_attn[i]) {
+        g_lfm2_paged_k_pools[i] = a;
+        g_lfm2_paged_v_pools[i] = b;
+      } else {
+        // Conv state threaded WITHIN the turn via the k_pools slot. slot.b is the
+        // unused scalar placeholder — leave the placeholder in place.
+        g_lfm2_paged_k_pools[i] = a;
+      }
+    }
+
+    if (cache_offset_out) {
+      *cache_offset_out = g_lfm2_paged_offset_int;
+    }
+  } catch (const std::exception& e) {
+    fprintf(stderr, "[MLX] Exception in mlx_lfm2_moe_forward_paged: %s\n", e.what());
+    fflush(stderr);
+    if (output_logits) *output_logits = nullptr;
+  } catch (...) {
+    fprintf(stderr, "[MLX] Unknown exception in mlx_lfm2_moe_forward_paged\n");
+    fflush(stderr);
+    if (output_logits) *output_logits = nullptr;
+  }
+}
+
+// Tear down ONLY the compiled-paged decode state — config, is_attn dispatch,
+// per-layer pools/scales/conv-state, offset, inited flag. Does NOT touch the
+// flat globals (g_lfm2_caches / g_lfm2_offset_int / g_lfm2_inited), the shared
+// model-id atom (owned by mlx_clear_weights), or the engagement counter (a
+// process-lifetime signal). Mirrors the paged half of mlx_qwen35_compiled_reset.
+// Delegates to the file-static `lfm2_reset_paged_globals()` so init failure
+// paths and the public reset share one source of truth for the global set.
+void mlx_lfm2_paged_reset() { lfm2_reset_paged_globals(); }
+
+// Cumulative count of forwards that took the TRACED compiled_lfm2_decode_paged()
+// branch (NOT the eager MLX_NO_COMPILE arm). Distinct from the flat counter
+// (mlx_lfm2_moe_compiled_decode_call_count). Process-lifetime engagement signal;
+// intentionally NOT reset by mlx_lfm2_paged_reset.
+uint64_t mlx_lfm2_moe_compiled_paged_call_count() {
+  return g_lfm2_compiled_paged_decode_calls;
+}
+
+// Cumulative count of mlx_lfm2_moe_forward_paged calls that ran the C++ paged
+// decode (BOTH the compiled AND the eager MLX_NO_COMPILE arm). The paged analogue
+// of the flat mlx_lfm2_moe_forward_call_count; the ONLY engagement signal the
+// EAGER-paged (MLX_NO_COMPILE=1) run has, since the compiled-paged counter above
+// never bumps in that arm. Process-lifetime; NOT reset by mlx_lfm2_paged_reset.
+uint64_t mlx_lfm2_moe_paged_forward_call_count() {
+  return g_lfm2_paged_forward_calls;
 }
 
 // =============================================================================

--- a/examples/lfm2-perf-ab.ts
+++ b/examples/lfm2-perf-ab.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * lfm2 perf A/B harness — single-arm measurement primitive.
+ *
+ * One invocation = one model load + warmup + N measured reps in ONE
+ * thermal/process arm. The ARM (baseline vs optimized) is selected by the
+ * caller via a `MLX_LFM2_DISABLE_<OPT>` env var, read once at process
+ * start on the Rust side (the idiomatic toggle pattern in this repo).
+ *
+ * The thermally-fair A/B is done by the orchestrator
+ * (`examples/lfm2-perf-pair.py`), which launches this script alternately
+ * with/without the toggle env, pairs adjacent runs, and takes the median
+ * of per-pair ratios (drift-canceling) plus a control band.
+ *
+ * Metrics come from the native `reportPerformance` path (measured AFTER
+ * model load, so load variance does not pollute them).
+ *
+ * Usage:
+ *   [MLX_LFM2_DISABLE_X=1] oxnode examples/lfm2-perf-ab.ts \
+ *     --model lfm2.5-1.2b-thinking-mlx --mode ttft|decode \
+ *     --prompt-tokens 1500 --max-new 4 --reps 4 --warmup 1 [--emit-text]
+ *
+ * Output: exactly one line beginning `RESULT_JSON:` followed by JSON.
+ */
+
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { ChatSession, loadModel, type SessionCapableModel } from '@mlx-node/lm';
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    model: { type: 'string', default: 'lfm2.5-1.2b-thinking-mlx' },
+    mode: { type: 'string', default: 'decode' }, // 'ttft' | 'decode'
+    'prompt-tokens': { type: 'string', default: '64' },
+    'max-new': { type: 'string', default: '256' },
+    reps: { type: 'string', default: '4' },
+    warmup: { type: 'string', default: '1' },
+    'emit-text': { type: 'boolean', default: false },
+  },
+});
+
+const modelName = values.model!;
+const mode = values.mode!;
+const promptTokens = Number.parseInt(values['prompt-tokens']!, 10);
+const maxNew = Number.parseInt(values['max-new']!, 10);
+const reps = Number.parseInt(values.reps!, 10);
+const warmup = Number.parseInt(values.warmup!, 10);
+const emitText = values['emit-text']!;
+
+const MODEL_PATH = resolve(process.cwd(), '.cache', 'models', modelName);
+
+const SENT = 'The quick brown fox jumps over the lazy dog beside the quiet river as the evening sun slowly sets. ';
+function buildPrompt(nonce: string): string {
+  const copies = Math.max(1, Math.ceil(promptTokens / 16));
+  return `${nonce}Read the following text and then answer in detail.\n${SENT.repeat(copies)}\nNow write a long continuation.`;
+}
+
+function median(xs: number[]): number {
+  const f = xs.filter((x) => Number.isFinite(x));
+  if (f.length === 0) return Number.NaN;
+  const s = [...f].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+const relevantToggles: Record<string, string> = {};
+for (const [k, v] of Object.entries(process.env)) {
+  if (k.startsWith('MLX_LFM2_') || k === 'MLX_NO_COMPILE' || k === 'MLX_DISABLE_COMPILE') {
+    relevantToggles[k] = v ?? '';
+  }
+}
+
+const loaded = await loadModel(MODEL_PATH);
+
+async function oneTurn(
+  nonce: string,
+): Promise<{ ttftMs: number; prefillTps: number; decodeTps: number; text: string }> {
+  // Fresh session per turn → turn-1 cold prefill (no warm-continue confound).
+  const session = new ChatSession(loaded as unknown as SessionCapableModel, {
+    system: 'You are a helpful assistant.',
+  });
+  const res = await session.send(buildPrompt(nonce), {
+    config: { maxNewTokens: maxNew, temperature: 0, reportPerformance: true },
+  });
+  const p = res.performance;
+  return {
+    ttftMs: p?.ttftMs ?? Number.NaN,
+    prefillTps: p?.prefillTokensPerSecond ?? Number.NaN,
+    decodeTps: p?.decodeTokensPerSecond ?? Number.NaN,
+    text: res.text ?? '',
+  };
+}
+
+for (let i = 0; i < warmup; i++) await oneTurn(`warmup-${i} `);
+
+const ttftMs: number[] = [];
+const prefillTps: number[] = [];
+const decodeTps: number[] = [];
+let firstText = '';
+const hasher = createHash('sha256');
+
+for (let r = 0; r < reps; r++) {
+  // ttft: unique nonce per rep → cold prefill (miss the content-addressed
+  // prefix cache) so we measure real prefill cost. decode: decodeTps is
+  // cache-independent; keep the prompt FIXED so --emit-text is deterministic
+  // across arms for byte-identical checks.
+  const nonce = mode === 'ttft' ? `rep-${r} ` : '';
+  const t = await oneTurn(nonce);
+  ttftMs.push(t.ttftMs);
+  prefillTps.push(t.prefillTps);
+  decodeTps.push(t.decodeTps);
+  if (r === 0) firstText = t.text;
+  hasher.update(t.text);
+}
+
+const out = {
+  model: modelName,
+  mode,
+  promptTokens,
+  maxNew,
+  reps,
+  warmup,
+  toggles: relevantToggles,
+  ttftMs,
+  prefillTps,
+  decodeTps,
+  medTtftMs: median(ttftMs),
+  medPrefillTps: median(prefillTps),
+  medDecodeTps: median(decodeTps),
+  ...(emitText ? { textHash: hasher.digest('hex'), firstText: firstText.slice(0, 400) } : {}),
+};
+
+console.log(`RESULT_JSON:${JSON.stringify(out)}`);

--- a/examples/lfm2-perf-pair.py
+++ b/examples/lfm2-perf-pair.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+lfm2 perf A/B orchestrator — thermally-fair paired measurement + verdict.
+
+Launches the single-arm harness (examples/lfm2-perf-ab.ts) alternately with
+and without a MLX_LFM2_DISABLE_<OPT> toggle, BACK TO BACK (adjacent processes
+share a thermal window). Each pair yields one unit-free ratio; the median of
+per-pair ratios cancels the ~15% cross-run thermal drift seen on M5 Max.
+
+A CONTROL set runs BOTH arms with the toggle SET (identical code path) to
+measure the ratio noise floor. An optimization counts as a REAL win only if
+its median ratio improvement exceeds the worst control deviation AND the sign
+is consistent across pairs.
+
+Ratio convention (>1.0 = optimized faster):
+  decode -> medDecodeTps_opt / medDecodeTps_base   (higher tok/s better)
+  ttft   -> medTtftMs_base   / medTtftMs_opt        (lower ms better)
+           plus prefill -> medPrefillTps_opt / medPrefillTps_base
+
+Usage:
+  python3 examples/lfm2-perf-pair.py \
+    --model lfm2.5-1.2b-thinking-mlx --mode ttft \
+    --toggle MLX_LFM2_DISABLE_LAST_TOKEN_SLICE \
+    --prompt-tokens 1500 --max-new 4 --reps 4 --warmup 1 \
+    --pairs 5 --control-pairs 3
+
+Prints a human summary then one line `VERDICT_JSON:{...}`.
+"""
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+
+HARNESS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "lfm2-perf-ab.ts")
+
+
+def run_arm(args, toggle_set: bool) -> dict:
+    env = dict(os.environ)
+    if args.toggle:
+        if toggle_set:
+            env[args.toggle] = "1"
+        else:
+            env.pop(args.toggle, None)
+    cmd = [
+        "oxnode", HARNESS,
+        "--model", args.model,
+        "--mode", args.mode,
+        "--prompt-tokens", str(args.prompt_tokens),
+        "--max-new", str(args.max_new),
+        "--reps", str(args.reps),
+        "--warmup", str(args.warmup),
+    ]
+    p = subprocess.run(cmd, env=env, cwd=os.getcwd(), capture_output=True, text=True, timeout=args.timeout)
+    line = next((l for l in p.stdout.splitlines() if l.startswith("RESULT_JSON:")), None)
+    if line is None:
+        sys.stderr.write(f"[arm toggle={toggle_set}] no RESULT_JSON. stderr tail:\n{p.stderr[-1500:]}\n")
+        raise RuntimeError("harness produced no RESULT_JSON")
+    return json.loads(line[len("RESULT_JSON:"):])
+
+
+def metric(args, r: dict) -> float:
+    return r["medTtftMs"] if args.mode == "ttft" else r["medDecodeTps"]
+
+
+def ratio(args, base: dict, opt: dict) -> float:
+    if args.mode == "ttft":
+        return metric(args, base) / metric(args, opt)  # lower ms better -> invert
+    return metric(args, opt) / metric(args, base)        # higher tok/s better
+
+
+def prefill_ratio(base: dict, opt: dict):
+    b, o = base.get("medPrefillTps"), opt.get("medPrefillTps")
+    if b and o and b > 0:
+        return o / b
+    return None
+
+
+def collect(args, pairs: int, control: bool, label: str):
+    ratios, pref_ratios = [], []
+    for i in range(pairs):
+        # alternate order each pair to cancel order/thermal bias
+        if i % 2 == 0:
+            base = run_arm(args, True)
+            opt = run_arm(args, True if control else False)
+        else:
+            opt = run_arm(args, True if control else False)
+            base = run_arm(args, True)
+        rr = ratio(args, base, opt)
+        ratios.append(rr)
+        pr = prefill_ratio(base, opt)
+        if pr is not None:
+            pref_ratios.append(pr)
+        bm, om = metric(args, base), metric(args, opt)
+        extra = f" prefillR={pr:.3f}" if pr is not None else ""
+        print(f"  [{label} pair {i+1}/{pairs}] base={bm:.2f} opt={om:.2f} ratio={rr:.4f}{extra}", flush=True)
+    return ratios, pref_ratios
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="lfm2.5-1.2b-thinking-mlx")
+    ap.add_argument("--mode", default="decode", choices=["ttft", "decode"])
+    ap.add_argument("--toggle", required=True, help="MLX_LFM2_DISABLE_* env var")
+    ap.add_argument("--prompt-tokens", type=int, default=64)
+    ap.add_argument("--max-new", type=int, default=256)
+    ap.add_argument("--reps", type=int, default=4, help="inner reps per process arm")
+    ap.add_argument("--warmup", type=int, default=1)
+    ap.add_argument("--pairs", type=int, default=5)
+    ap.add_argument("--control-pairs", type=int, default=3)
+    ap.add_argument("--timeout", type=int, default=900)
+    args = ap.parse_args()
+
+    print(f"== MEASUREMENT ({args.mode}, toggle={args.toggle}, model={args.model}) ==", flush=True)
+    m_ratios, m_pref = collect(args, args.pairs, control=False, label="measure")
+    print(f"== CONTROL (both arms baseline; ratio noise floor) ==", flush=True)
+    c_ratios, _ = collect(args, args.control_pairs, control=True, label="control")
+
+    med = statistics.median(m_ratios)
+    signal = med - 1.0
+    # Robust noise floor: median absolute deviation of control ratios from 1.0
+    # (the max-dev is too outlier-sensitive at small N). Floor at 1.5% so we
+    # never claim a win smaller than the harness's own resolution.
+    control_devs = sorted(abs(r - 1.0) for r in c_ratios)
+    control_band = max(statistics.median(control_devs) if control_devs else 0.0, 0.015)
+    control_strict = max((abs(r - 1.0) for r in c_ratios), default=0.0)
+    control_med = statistics.median(c_ratios) if c_ratios else 1.0
+    same_side = sum(1 for r in m_ratios if (r > 1.0) == (med > 1.0))
+    consistent = same_side >= (len(m_ratios) * 3 + 3) // 4  # >=75%
+    real_win = (signal > control_band) and consistent and (med > 1.0)
+    regression = (med < 1.0) and (abs(signal) > control_band) and consistent
+
+    pref_med = statistics.median(m_pref) if m_pref else None
+
+    verdict = {
+        "mode": args.mode,
+        "toggle": args.toggle,
+        "model": args.model,
+        "median_ratio": round(med, 4),
+        "pct_change": round(signal * 100, 2),
+        "measure_ratios": [round(r, 4) for r in m_ratios],
+        "control_ratios": [round(r, 4) for r in c_ratios],
+        "control_band": round(control_band, 4),
+        "control_strict": round(control_strict, 4),
+        "control_median": round(control_med, 4),
+        "prefill_median_ratio": round(pref_med, 4) if pref_med is not None else None,
+        "consistent_sign": consistent,
+        "real_win": bool(real_win),
+        "regression": bool(regression),
+    }
+    print("\n== SUMMARY ==")
+    print(f"  median ratio = {med:.4f}  ({signal*100:+.2f}%)   control band = ±{control_band*100:.2f}%")
+    if pref_med is not None:
+        print(f"  prefill median ratio = {pref_med:.4f}  ({(pref_med-1)*100:+.2f}%)")
+    print(f"  REAL WIN = {real_win}   (signal {signal*100:+.2f}% vs noise ±{control_band*100:.2f}%, consistent={consistent})")
+    print(f"VERDICT_JSON:{json.dumps(verdict)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Ports qwen3_5's **compiled-paged decode** to `lfm2` + `lfm2_moe` so the **default** paged decode runs inside an `mlx::core::compile` graph instead of the eager pure-Rust layer-by-layer loop. `block_table` / `slot_mapping` / `offset` are threaded as **array inputs** (the trace stays static across steps), and `fast::paged_kv_write` + `fast::paged_attention` run over the shared `LayerKVPool` Metal buffers.

- **Decode-only** — prefill stays eager paged, then *seeds* the compiled decode (compiled prefill is a separate effort, exactly like qwen).
- **Dense + MoE** in one decode fn; **bf16/f16 only** (quantized stays eager, same gate as the flat path).
- Gated default-ON with eager fallback on first-step init/forward failure.

## Perf (the payoff)

Interleaved A/B, same binary, warm, temp 0, 256-tok, M5 Max — vs the old pure-Rust paged ceiling (~42/35 tok/s):

| checkpoint | old pure-Rust | new compiled-paged | ratio |
|---|---|---|---|
| 1.2B dense | ~42 | ~149 (med) | **~1.96×** |
| 8B MoE | ~35 | ~70 (med) | **~1.47×** |

`sendStream` rides the same compiled graph as `send` (within ~3% noise). Absolute numbers swing ±15–20% with thermal; the interleaved ratio is the stable figure.

> Note: the **flat** compiled port was parity (flat-eager is already atomic C++). This **paged** port is the real win because paged-eager was pure-Rust layer-by-layer.

## Both paged loops wired + measured

`lfm2` has **two** paged decode loops — `chat_sync_core_paged_inner` (non-streaming, `ChatSession.send()`) and `chat_stream_sync_core_paged_inner` (streaming, `ChatSession.sendStream()`). Both now share `paged_compiled_decode_setup` / `paged_compiled_decode_step`.

## Validation

- eager-paged ≡ compiled-paged **byte-identical** (greedy) on 1.2B dense + 8B MoE
- streaming ≡ non-streaming **byte-identical**
- counter-based engagement assertions (no thermal-noise dependence)
- lfm2 compiled e2e **13/13** + eager **13/13**; +2 bf16-gate unit tests; +gemma4 collision regression
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean, `yarn build:native` clean

## Codex adversarial review (3 rounds) — all findings resolved

| | Finding | Fix |
|---|---|---|
| F1 | streaming bypassed compiled-paged | shared `paged_compiled_decode_setup`/`step`; `Lfm2PagedCompiledState` RAII guards declared reset → weight → lock so the C++ reset runs while the global locks are still held (Rust drops struct fields in declaration order) |
| F2 | failed paged-init leaked mutated C++ globals | `lfm2_reset_paged_globals()` on every init error path + both catch blocks |
| F3 | bf16-only gate too narrow | authoritative load-time `all_float_weights_bf16` flag over the whole registered param map (allows the intentional f32 `*.expert_bias` on MoE) |
| F4 | `MLX_DISABLE_COMPILE` made the engagement counter lie | eager branch + test both honor the var |
| F5 | **cross-family model-id collision** | The compiled registry (`g_weights` + `g_active_model_id`) is ONE process-global owned by the last registrant. Gemma4 drew its id from a **private** counter while publishing onto the **shared** atom → its id could collide with lfm2/qwen and false-positive their gate (and its `mlx_clear_weights` evicted co-resident compiled models). Gemma4 has **no compiled C++ forward path**, so its registration was vestigial → **deleted**. Every registry-sharing family now draws from the shared 1-based `QWEN35_MODEL_ID_COUNTER`. +race-free regression test. |

## Files

- `crates/mlx-sys/src/mlx_lfm2_common.h` — `lfm2_attn_pure_fn_arr_paged`
- `crates/mlx-sys/src/mlx_lfm2_moe.cpp` — `lfm2_decode_fn_paged`, paged globals, init/forward/reset/counter
- `crates/mlx-sys/src/lib.rs` — FFI decls
- `crates/mlx-core/src/models/lfm2/{model,persistence}.rs` — session, per-step wrapper, registration-gate widening, bf16 flag
- `crates/mlx-core/src/models/gemma4/persistence.rs` — F5 deletion + regression test
- `crates/mlx-core/tests/lfm2_compiled_e2e.rs` — parity + engagement tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the primary LFM2 inference/decode path and process-global compiled weight/model-id state; cross-family registry bugs were real and fixes need careful co-residency testing.
> 
> **Overview**
> Adds **compiled-paged decode** for LFM2/LFM2-MoE: new C++ graph (`lfm2_decode_fn_paged`, paged KV ops, separate globals/FFI) and Rust hooks that seed from post-prefill paged pools + conv state, then run decode through `paged_compiled_decode_setup` / `paged_compiled_decode_step` in **both** non-streaming and streaming paged loops, with locks, RAII reset, bf16/block-16 gates, and eager fallback on first-step failure.
> 
> **Load/registration** now registers non-quantized bf16/f16 **paged** checkpoints into the shared compiled registry when weights are all bf16 and block size is 16 (`should_register_compiled`, `all_float_weights_bf16`); flat path unchanged in spirit.
> 
> **Gemma4** stops calling into the shared compiled weight map (`register_gemma4_weights_with_cpp` removed) so loads no longer `mlx_clear_weights` or publish colliding model ids against qwen/LFM2; regression test added.
> 
> **Prefill (default ON):** slice to the last token before output norm + `lm_head` in eager paged prefill; toggle `MLX_LFM2_DISABLE_LAST_TOKEN_SLICE`.
> 
> E2E tests cover compiled-paged engagement, eager vs compiled-paged byte parity, streaming parity, and warm-cache fixes (`raw_text` echo). New paired perf harness scripts under `examples/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5b4beb534095ef87cb28f8cfa8c0342d6c2182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Follow-up: prove-or-revert perf pass (decode → prefill)

After the compiled-paged decode landed, a deep-review of the lfm2 inference control flow surfaced further levers. Each candidate was implemented behind a `MLX_LFM2_DISABLE_*` env toggle (same-binary A/B), then verified through a hard gate before being kept: **build + `clippy -D warnings` + `fmt` → byte-identical correctness (toggle-on == toggle-off at T=0) → thermally-fair paired perf A/B → keep only if the measured gain beats the noise floor, else revert.**

> Measurement note: cross-invocation tok/s drifts ~15% on M5 Max (thermal). The A/B orchestrator (`examples/lfm2-perf-pair.py`) interleaves baseline/optimized arms back-to-back, takes the **median of per-pair ratios** (drift-canceling), and gates a "real win" on a **control band** measured from a no-op run (validated: a no-op toggle reads +0.79%, `real_win=false`; robust floor ≈1.5–2.2%).

### Kept (proven)
**`perf(lfm2): project lm_head on T=1 in paged prefill`** — the eager paged prefill ran `embedding_norm` + `lm_head` (vocab 65536 × hidden 2048) over the full `[1,T,hidden]` residual stream then sliced the last token; now it slices **before** the projection so the largest matmul runs on T=1.

- **Byte-identical at T=0** (toggle on==off on 1.2B + 8B; full `lfm2_compiled_e2e` **13/13** on both compiled and `MLX_NO_COMPILE` arms).
- Measured **TTFT median ratio 1.0965 (+9.65%, 1.2B) / 1.1194 (+11.94%, 8B)** vs control band ±1.5/2.2%. The win is fully attributable to the output projection (prefill ratio == total ratio).
- Gated by `MLX_LFM2_DISABLE_LAST_TOKEN_SLICE` (default ON).

### Tested & rejected (honest — not a measured win)
**drop the redundant post-prefill `synchronize`** — byte-identical, but measured **+0.07%, inside the ±1.5% noise floor** (inconsistent sign), so reverted rather than claimed.

### Tooling
`examples/lfm2-perf-ab.ts` (single-arm, `reportPerformance` metrics) + `examples/lfm2-perf-pair.py` (paired orchestrator + verdict).

### Not in this PR (bigger follow-ups)
- **Quantized compiled-paged decode** (~1.4–1.9× for the realistic quantized deployment shape) — blocked today by a one-line `.scales` gate; kernels (`quantized_matmul`/`gather_qmm`) + the qwen3_5_moe registry template already exist.
- **Decode lookahead** (async_eval pipelining) — needs the on-device-token enabler first.
