### PR TITLE
feat(convert): quantize gemma4_unified (12B) — recognize + keep vision_embedder bf16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,8 +344,14 @@ jobs:
           else
             # cargo leg: point this family's gating env var(s) at the converted
             # checkpoint so the #[ignore]'d tests un-skip; `-- --ignored` runs only those.
+            # `--test-threads=1` serializes them: each ignored test loads 2-4 full
+            # models, and libtest's default per-test thread pool would otherwise run
+            # several at once, oversubscribing the single shared Metal GPU until a
+            # command buffer trips the GPU watchdog (kIOGPUCommandBufferCallbackErrorTimeout
+            # -> SIGABRT) on the shared CI runner. One shared GPU means parallelism
+            # never sped these up anyway, so serializing costs ~nothing.
             for v in ${{ matrix.env }}; do export "$v=$ckpt"; done
-            cargo test -p mlx-core ${{ matrix.tests }} -- --ignored --nocapture
+            cargo test -p mlx-core ${{ matrix.tests }} -- --ignored --test-threads=1 --nocapture
           fi
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     if: >-
       github.event.action != 'labeled' ||
       github.event.label.name == 'model-e2e'
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
         with:
@@ -129,7 +129,7 @@ jobs:
     # Unit/integration tests don't depend on the label; skip the redundant re-run
     # a `labeled` event would otherwise spawn (build artifacts are unchanged).
     if: github.event.action != 'labeled'
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: build
     strategy:
       fail-fast: false
@@ -227,7 +227,7 @@ jobs:
       github.event.label.name == 'model-e2e' ||
       (github.event.action != 'labeled' &&
        contains(github.event.pull_request.labels.*.name, 'model-e2e'))
-    runs-on: macos-latest
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:
@@ -359,7 +359,7 @@ jobs:
     # Lint doesn't depend on the label; skip the redundant re-run a `labeled`
     # event would otherwise spawn.
     if: github.event.action != 'labeled'
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
         with:

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -1344,7 +1344,7 @@ pub(crate) mod recipe {
 
     impl ConversionRecipe for Gemma4Recipe {
         fn model_types(&self) -> &'static [&'static str] {
-            &["gemma4"]
+            &["gemma4", "gemma4_unified"]
         }
 
         fn sanitize(
@@ -1407,6 +1407,7 @@ pub(crate) mod recipe {
                     || stripped.starts_with("audio_encoder.")
                     || stripped.starts_with("embed_audio.")
                     || stripped.starts_with("embed_vision.")
+                    || stripped.starts_with("vision_embedder.")
                     || stripped.starts_with("multi_modal_projector.")
                 {
                     // Apply PyTorch→MLX layout conversions for conv weights
@@ -1500,6 +1501,7 @@ pub(crate) mod recipe {
         "qianfan-ocr",
         "privacy-filter",
         "gemma4",
+        "gemma4_unified",
     ];
 
     /// Resolve a [`ConversionRecipe`] for an exact HuggingFace `model_type`
@@ -1513,7 +1515,7 @@ pub(crate) mod recipe {
             "paddleocr-vl" => Some(Box::new(PaddleOcrVlRecipe)),
             "qianfan-ocr" => Some(Box::new(QianfanOcrRecipe)),
             "privacy-filter" => Some(Box::new(PrivacyFilterRecipe)),
-            "gemma4" => Some(Box::new(Gemma4Recipe)),
+            "gemma4" | "gemma4_unified" => Some(Box::new(Gemma4Recipe)),
             _ => None,
         }
     }
@@ -2859,6 +2861,13 @@ fn should_quantize(key: &str, embed_quantizable: bool) -> bool {
 
     // Exclude vision encoder weights (keep bf16 for quality)
     if key.contains("vision_tower") || key.contains("visual.") {
+        return false;
+    }
+
+    // Encoder-free unified vision patch projection (`vision_embedder.patch_dense`).
+    // The loader installs `vision_embedder.*` as dense bf16 only (no quantized
+    // branch), so quantizing it would corrupt the unified vision path. Keep bf16.
+    if key.contains("vision_embedder") {
         return false;
     }
 
@@ -5473,9 +5482,13 @@ mod tests {
             );
 
             // sym8_supported == old sym8 allowlist (NOTE qwen3_5_moe excluded).
+            // gemma4_unified routes to Gemma4Recipe and supports sym8 like gemma4.
             assert_eq!(
                 r.sym8_supported(),
-                matches!(mt, "qwen3_5" | "lfm2" | "lfm2_moe" | "gemma4"),
+                matches!(
+                    mt,
+                    "qwen3_5" | "lfm2" | "lfm2_moe" | "gemma4" | "gemma4_unified"
+                ),
                 "{mt}: sym8_supported mismatch vs inline sym8 allowlist"
             );
 
@@ -5615,6 +5628,103 @@ mod tests {
                 "language_model.model.layers.0.mlp.experts.switch_glu.down_proj.weight"
             ),
             "down_proj must be renamed to switch_glu.down_proj.weight"
+        );
+    }
+
+    /// The encoder-free `gemma4_unified` loader installs `vision_embedder.*` as
+    /// dense bf16 only (`apply_unified_vision_embedder_weights`, no `.scales`
+    /// branch), so `should_quantize` must refuse it under any wrapper depth or
+    /// the quantized checkpoint corrupts the unified vision path. The sibling
+    /// `embed_vision.embedding_projection` DOES have an affine loader branch and
+    /// must keep quantizing — this pins the exclusion to `vision_embedder` only.
+    #[test]
+    fn should_quantize_excludes_unified_vision_embedder() {
+        // vision_embedder patch projection → never quantized (bf16-only loader).
+        assert!(!should_quantize(
+            "language_model.model.vision_embedder.patch_dense.weight",
+            false
+        ));
+        assert!(!should_quantize(
+            "vision_embedder.patch_dense.weight",
+            false
+        ));
+
+        // Positive controls: ordinary text MLP weight quantizes, and the
+        // affine-loadable embed_vision projection must NOT be caught by the
+        // exclusion (guards against an over-broad `vision` substring match).
+        assert!(should_quantize(
+            "language_model.model.layers.0.mlp.gate_proj.weight",
+            false
+        ));
+        assert!(should_quantize(
+            "embed_vision.embedding_projection.weight",
+            false
+        ));
+    }
+
+    /// `gemma4_unified` must be a first-class convertible model_type: it resolves
+    /// to a recipe (the shared `Gemma4Recipe`) and appears in the registry's
+    /// single source of truth. Explicit guard alongside the registry-consistency
+    /// test in `recipe_registry_reproduces_inline_flags`.
+    #[test]
+    fn gemma4_unified_is_convertible() {
+        assert!(recipe::recipe_for("gemma4_unified").is_some());
+        assert!(recipe::CONVERTIBLE_MODEL_TYPES.contains(&"gemma4_unified"));
+        // Routes to the same recipe family as gemma4, and self-declares coverage.
+        assert!(
+            recipe::recipe_for("gemma4_unified")
+                .unwrap()
+                .model_types()
+                .contains(&"gemma4_unified")
+        );
+    }
+
+    /// `vision_embedder.*` must be written at its BARE key (sibling of
+    /// `embed_vision.*`), not mis-prefixed under `language_model.model.`. The
+    /// loader installs it from the bare key; the multimodal-keep block in
+    /// `Gemma4Recipe::sanitize` must route it there instead of falling through to
+    /// the text re-prefix step.
+    #[test]
+    fn gemma4_recipe_sanitize_keeps_vision_embedder_bare() {
+        let f32 = |numel: usize, shape: &[i64]| {
+            MxArray::from_float32(&vec![1.0f32; numel], shape).expect("from_float32")
+        };
+
+        let mut weights: HashMap<String, MxArray> = HashMap::new();
+        weights.insert(
+            "model.vision_embedder.patch_dense.weight".into(),
+            f32(4 * 4, &[4, 4]),
+        );
+        weights.insert(
+            "model.vision_embedder.pos_embedding".into(),
+            f32(4 * 4, &[4, 4]),
+        );
+
+        let out = recipe::Gemma4Recipe
+            .sanitize(
+                weights,
+                &serde_json::json!({}),
+                "bfloat16",
+                /* tie_word_embeddings */ true,
+                /* verbose */ false,
+            )
+            .expect("gemma4 sanitize");
+
+        assert!(
+            out.contains_key("vision_embedder.patch_dense.weight"),
+            "vision_embedder.patch_dense.weight must be kept bare; got {:?}",
+            out.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            out.contains_key("vision_embedder.pos_embedding"),
+            "vision_embedder.pos_embedding must be kept bare; got {:?}",
+            out.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !out.keys()
+                .any(|k| k.contains("language_model.model.vision_embedder")),
+            "vision_embedder must NOT be re-prefixed under language_model.model.; got {:?}",
+            out.keys().collect::<Vec<_>>()
         );
     }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,7 +99,7 @@ Auto-detected by the `.gguf` extension. Supports BF16, F16, F32, Q4_0, Q4_1, Q8_
 The converter auto-detects model families and applies family-specific sanitization passes:
 
 - `qwen3_5`, `qwen3_5_moe`
-- `gemma4`
+- `gemma4`, `gemma4_unified`
 - `paddleocr-vl`, `qianfan-ocr`
 - `pp-lcnet-ori`, `uvdoc`
 

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -18,12 +18,12 @@ import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 
 vi.mock('@mlx-node/core', () => ({
-  convertModel: vi.fn(async () => ({})),
+  convertModel: vi.fn(async () => ({ numTensors: 0, numParameters: 0, outputPath: '', tensorNames: [] })),
   convertForeignWeights: vi.fn(() => ({})),
   convertGgufToSafetensors: vi.fn(async () => ({})),
 }));
 
-import { convertGgufToSafetensors } from '@mlx-node/core';
+import { convertModel, convertGgufToSafetensors } from '@mlx-node/core';
 
 import { run as runConvert } from '../src/commands/convert.js';
 
@@ -58,5 +58,44 @@ describe('mlx convert GGUF validation', () => {
     expect(errors).toContain('--q-mode sym8 is not supported for GGUF input');
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(convertGgufToSafetensors).not.toHaveBeenCalled();
+  });
+});
+
+describe('mlx convert model-type auto-detection', () => {
+  // Drive run() against a synthetic config.json (no --model-type) and read back
+  // the modelType handed to the mocked native convertModel. This guards the
+  // gemma4_unified pass-through: collapsing it to 'gemma4' would dead-code the
+  // native recipe_for("gemma4_unified") arm and misroute gemma-QAT unified
+  // checkpoints into the E2B-only prequantized importer.
+  const detectModelType = async (configModelType: string): Promise<unknown> => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+
+    const inputDir = mkdtempSync(join(tmpdir(), 'mlx-convert-detect-in-'));
+    writeFileSync(join(inputDir, 'config.json'), JSON.stringify({ model_type: configModelType }));
+    const outputDir = join(tmp, 'out');
+
+    await runConvert(['--input', inputDir, '--output', outputDir]);
+
+    const mock = vi.mocked(convertModel);
+    expect(mock).toHaveBeenCalledTimes(1);
+    const opts = mock.mock.calls[0]![0] as { modelType?: unknown };
+    rmSync(inputDir, { recursive: true, force: true });
+    return opts.modelType;
+  };
+
+  it("passes 'gemma4_unified' through unchanged (does NOT collapse to 'gemma4')", async () => {
+    expect(await detectModelType('gemma4_unified')).toBe('gemma4_unified');
+  });
+
+  it("collapses 'gemma4' to 'gemma4'", async () => {
+    expect(await detectModelType('gemma4')).toBe('gemma4');
+  });
+
+  it("collapses 'gemma4_text' to 'gemma4'", async () => {
+    expect(await detectModelType('gemma4_text')).toBe('gemma4');
   });
 });

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -67,7 +67,7 @@ describe('mlx convert model-type auto-detection', () => {
   // gemma4_unified pass-through: collapsing it to 'gemma4' would dead-code the
   // native recipe_for("gemma4_unified") arm and misroute gemma-QAT unified
   // checkpoints into the E2B-only prequantized importer.
-  const detectModelType = async (configModelType: string): Promise<unknown> => {
+  const detectModelTypeFromConfig = async (config: Record<string, unknown>): Promise<unknown> => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
@@ -75,7 +75,7 @@ describe('mlx convert model-type auto-detection', () => {
     }) as never);
 
     const inputDir = mkdtempSync(join(tmpdir(), 'mlx-convert-detect-in-'));
-    writeFileSync(join(inputDir, 'config.json'), JSON.stringify({ model_type: configModelType }));
+    writeFileSync(join(inputDir, 'config.json'), JSON.stringify(config));
     const outputDir = join(tmp, 'out');
 
     await runConvert(['--input', inputDir, '--output', outputDir]);
@@ -87,6 +87,9 @@ describe('mlx convert model-type auto-detection', () => {
     return opts.modelType;
   };
 
+  const detectModelType = async (configModelType: string): Promise<unknown> =>
+    detectModelTypeFromConfig({ model_type: configModelType });
+
   it("passes 'gemma4_unified' through unchanged (does NOT collapse to 'gemma4')", async () => {
     expect(await detectModelType('gemma4_unified')).toBe('gemma4_unified');
   });
@@ -97,5 +100,16 @@ describe('mlx convert model-type auto-detection', () => {
 
   it("collapses 'gemma4_text' to 'gemma4'", async () => {
     expect(await detectModelType('gemma4_text')).toBe('gemma4');
+  });
+
+  it("detects an architecture-only unified config (no model_type) as 'gemma4_unified'", async () => {
+    // Mirrors the runtime loader: a config with no `model_type` but with
+    // `architectures: ['Gemma4UnifiedForConditionalGeneration']` must resolve
+    // to 'gemma4_unified' so Gemma4Recipe::sanitize runs. Without the
+    // converter arm, modelType would stay undefined and the output would be
+    // unloadable.
+    expect(await detectModelTypeFromConfig({ architectures: ['Gemma4UnifiedForConditionalGeneration'] })).toBe(
+      'gemma4_unified',
+    );
   });
 });

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -434,12 +434,21 @@ export async function run(argv: string[]) {
       } else if (config.model_type === 'qwen3_5_moe' || config.model_type === 'qwen3_5') {
         modelType = config.model_type;
         console.log(`Auto-detected model type: ${modelType} (from config.json)`);
-      } else if (
-        config.model_type === 'gemma4' ||
-        config.model_type === 'gemma4_text' ||
-        config.model_type === 'gemma4_unified'
-      ) {
+      } else if (config.model_type === 'gemma4' || config.model_type === 'gemma4_text') {
         modelType = 'gemma4';
+        console.log(`Auto-detected model type: ${modelType} (from config.json)`);
+      } else if (config.model_type === 'gemma4_unified') {
+        // Pass the raw 'gemma4_unified' string through unchanged. Native
+        // recipe_for resolves it to the shared Gemma4Recipe, so every
+        // recipe-keyed code path (sym8_supported, sanitizer, embed_quantizable,
+        // mtp_policy, etc.) behaves identically to 'gemma4'. Collapsing it to
+        // 'gemma4' here would (a) make the native recipe_for("gemma4_unified")
+        // arm dead code, and (b) misroute a unified checkpoint that carries
+        // gemma-QAT metadata into the E2B-only prequantized importer, whose
+        // gate keys on the exact string "gemma4" (and which then hard-errors in
+        // validate_e2b_qat_schedule). The exact-"gemma4" gate must not match
+        // unified, so the raw string has to reach the native side.
+        modelType = 'gemma4_unified';
         console.log(`Auto-detected model type: ${modelType} (from config.json)`);
       } else if (config.model_type === 'lfm2_moe' || config.model_type === 'lfm2') {
         modelType = config.model_type;

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -437,7 +437,10 @@ export async function run(argv: string[]) {
       } else if (config.model_type === 'gemma4' || config.model_type === 'gemma4_text') {
         modelType = 'gemma4';
         console.log(`Auto-detected model type: ${modelType} (from config.json)`);
-      } else if (config.model_type === 'gemma4_unified') {
+      } else if (
+        config.model_type === 'gemma4_unified' ||
+        (Array.isArray(config.architectures) && config.architectures.includes('Gemma4UnifiedForConditionalGeneration'))
+      ) {
         // Pass the raw 'gemma4_unified' string through unchanged. Native
         // recipe_for resolves it to the shared Gemma4Recipe, so every
         // recipe-keyed code path (sym8_supported, sanitizer, embed_quantizable,
@@ -448,6 +451,16 @@ export async function run(argv: string[]) {
         // gate keys on the exact string "gemma4" (and which then hard-errors in
         // validate_e2b_qat_schedule). The exact-"gemma4" gate must not match
         // unified, so the raw string has to reach the native side.
+        //
+        // The architecture-only arm (no `model_type`, only
+        // `architectures: ['Gemma4UnifiedForConditionalGeneration']`) mirrors
+        // the runtime loader, which also flags this shape as unified
+        // (model-loader.ts maps it to gemma4; persistence.rs parse_config sets
+        // is_unified on EITHER model_type == "gemma4_unified" OR that
+        // architecture). Without this, an architecture-only config would leave
+        // modelType undefined and skip Gemma4Recipe::sanitize, producing
+        // unloadable output. It maps to 'gemma4_unified' (not 'gemma4') so the
+        // E2B-importer gate above still cannot match it.
         modelType = 'gemma4_unified';
         console.log(`Auto-detected model type: ${modelType} (from config.json)`);
       } else if (config.model_type === 'lfm2_moe' || config.model_type === 'lfm2') {

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -434,7 +434,11 @@ export async function run(argv: string[]) {
       } else if (config.model_type === 'qwen3_5_moe' || config.model_type === 'qwen3_5') {
         modelType = config.model_type;
         console.log(`Auto-detected model type: ${modelType} (from config.json)`);
-      } else if (config.model_type === 'gemma4' || config.model_type === 'gemma4_text') {
+      } else if (
+        config.model_type === 'gemma4' ||
+        config.model_type === 'gemma4_text' ||
+        config.model_type === 'gemma4_unified'
+      ) {
         modelType = 'gemma4';
         console.log(`Auto-detected model type: ${modelType} (from config.json)`);
       } else if (config.model_type === 'lfm2_moe' || config.model_type === 'lfm2') {


### PR DESCRIPTION
## What

Enable `mlx convert` to quantize **`gemma4_unified`** (Gemma 4 12B — encoder-free text+vision+audio) checkpoints. The runtime loader already supports `gemma4_unified` (PR #74); only the **converter** didn't recognize it, and the default quant predicate would have corrupted one vision weight.

Motivating model: `google/gemma-4-12B-it-qat-q4_0-unquantized` (dense 12B, bf16, QAT-trained for llama.cpp `q4_0`). The best quality+speed target is **4-bit affine group_size 32** — near-bf16 quality at 4-bit memory/speed.

```
mlx convert <ckpt> -o <out> --quantize --q-mode affine --q-bits 4 --q-group-size 32
```

## Changes

1. **Recognize `gemma4_unified`** — `Gemma4Recipe::model_types` / `recipe_for` / `CONVERTIBLE_MODEL_TYPES` route it to the existing shared `Gemma4Recipe` (it is dense — no MoE split, sym8-supported, no MTP — so it behaves identically to `gemma4` on every `recipe_for`-keyed path).
2. **Keep `vision_embedder.*` bf16** — `should_quantize()` excludes any key containing `vision_embedder`. The encoder-free unified vision patch projection is installed **dense-bf16-only** by the loader (`apply_unified_vision_embedder_weights`, no `.scales` branch), so quantizing `patch_dense.weight` would corrupt the vision path. `embed_vision`/`embed_audio` projections **still quantize** (they have affine loader branches). `vision_embedder` is unified-only → zero collateral on other families.
3. **Sanitize keeps `vision_embedder.*` bare** — sibling of `embed_vision.*`, not mis-prefixed under `language_model.model.`.
4. **CLI passes `gemma4_unified` through unchanged** — *not* collapsed to `'gemma4'`. The driver's `model_type` is the CLI value, and the gemma-QAT (wNa8o8) prequantized importer gate is exact `Some("gemma4")`; collapsing would (a) dead-code the native `recipe_for("gemma4_unified")` arm and (b) misroute a gemma-QAT unified checkpoint into the E2B-only importer.

## End-to-end validation

Converted the real 23GB checkpoint → **8.4GB** `{bits:4, group_size:32, mode:affine}`:
- auto-detected `gemma4_unified` (passthrough confirmed)
- `vision_embedder.*` → **bf16, no `.scales`** ✓ · text / `embed_vision` / `embed_audio` → quantized (U32 + scales) ✓
- model **loads and generates coherent text** (e.g. *"The capital of France is Paris."*)

## Tests

- Rust: `should_quantize` excludes `vision_embedder` (with positive controls that `embed_vision` + text layers still quantize); `gemma4_unified` resolves to a recipe + is in `CONVERTIBLE_MODEL_TYPES`; sanitize keeps `vision_embedder.*` bare; extended `recipe_registry_reproduces_inline_flags` (sym8 allowlist).
- TS: `convert-cmd.test.ts` drives `run()` and asserts the `modelType` handed to native is `gemma4_unified` (and `gemma4`/`gemma4_text` still map to `gemma4`).
- Gates: `convert::` 106 pass, fmt + clippy clean, CLI test 4/4, typecheck clean.

## Review

Three `/codex:adversarial-review` cycles → final verdict **approve, no material findings**. The CLI-collapse misroute (cycle #1) was fixed; a flagged sanitize-test SIGABRT (cycle #2) was confirmed to be a review-harness/metallib environment artifact (the pre-existing `gemma4_recipe_sanitize_transforms` test aborts identically; CI runs one process per binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversion routing and quantization rules for a new model type (wrong passthrough could misroute QAT checkpoints); CI runner change is low risk but affects all macOS jobs.
> 
> **Overview**
> Adds first-class **`gemma4_unified`** support in `mlx convert` so encoder-free Gemma 4 unified checkpoints can be quantized without breaking vision or misrouting QAT imports.
> 
> The native converter registers **`gemma4_unified`** on the shared **`Gemma4Recipe`**, excludes **`vision_embedder.*`** from quantization (bf16-only loader path), and keeps those weights at **bare keys** during sanitize. The CLI **auto-detects** `gemma4_unified` (including architecture-only configs) and **passes the string through** instead of collapsing to `gemma4`, avoiding the E2B prequantized importer gate.
> 
> CI moves macOS jobs to **`macos-26`** and runs ignored cargo model e2e tests with **`--test-threads=1`** to avoid Metal GPU watchdog timeouts on shared runners. Docs and TS/Rust tests cover detection, quant exclusions, and sanitize routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb4e8e0b1b6db5ee62fd01ac6656bfe320189513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->