### PR TITLE
feat(gemma4): load tied lm_head as packed-quantized (8-bit affine)

### DIFF
--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -3214,6 +3214,10 @@ impl Gemma4Inner {
         crate::models::gemma4::diagnostic::dump_norm(0, "post_final_norm", &hidden_states, None);
         let logits = if let Some(ref head) = self.lm_head {
             head.forward(&hidden_states)?
+        } else if self.embed_tokens.is_packed_quantized() {
+            // Packed tied lm_head: project through the quantized matmul without
+            // materializing the dense table.
+            self.embed_tokens.as_linear(&hidden_states)?
         } else if let Some(ref w_t) = self.embed_weight_t {
             hidden_states.matmul(w_t)?
         } else {
@@ -3899,6 +3903,10 @@ impl Gemma4Inner {
         crate::models::gemma4::diagnostic::dump_norm(0, "post_final_norm", &hidden_states, None);
         let logits = if let Some(ref head) = self.lm_head {
             head.forward(&hidden_states)?
+        } else if self.embed_tokens.is_packed_quantized() {
+            // Packed tied lm_head: project through the quantized matmul without
+            // materializing the dense table.
+            self.embed_tokens.as_linear(&hidden_states)?
         } else if let Some(ref w_t) = self.embed_weight_t {
             hidden_states.matmul(w_t)?
         } else {
@@ -4065,6 +4073,10 @@ impl Gemma4Inner {
         crate::models::gemma4::diagnostic::dump_norm(0, "post_final_norm", &hidden_states, None);
         let logits = if let Some(ref head) = self.lm_head {
             head.forward(&hidden_states)?
+        } else if self.embed_tokens.is_packed_quantized() {
+            // Packed tied lm_head: project through the quantized matmul without
+            // materializing the dense table.
+            self.embed_tokens.as_linear(&hidden_states)?
         } else if let Some(ref w_t) = self.embed_weight_t {
             hidden_states.matmul(w_t)?
         } else {
@@ -5567,6 +5579,10 @@ pub(crate) fn warmup_forward(inner: &Gemma4Inner) -> Result<()> {
         h = inner.final_norm.forward(&h)?;
         let logits = if let Some(ref head) = inner.lm_head {
             head.forward(&h)?
+        } else if inner.embed_tokens.is_packed_quantized() {
+            // Packed tied lm_head: project through the quantized matmul without
+            // materializing the dense table.
+            inner.embed_tokens.as_linear(&h)?
         } else if let Some(ref w_t) = inner.embed_weight_t {
             h.matmul(w_t)?
         } else {
@@ -5899,6 +5915,10 @@ fn forward_inner(
     // LM head or tied embeddings
     let logits = if let Some(head) = lm_head {
         head.forward(&h)?
+    } else if embedding.is_packed_quantized() {
+        // Packed tied lm_head: project through the quantized matmul without
+        // materializing the dense table.
+        embedding.as_linear(&h)?
     } else if let Some(w_t) = embed_weight_t {
         h.matmul(w_t)?
     } else {

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -867,11 +867,24 @@ struct PackedEmbedParams<'a> {
 /// (mxfp8 mode with `.biases`/non-uint8 scales, or affine mode with uint8
 /// scales), is rejected loud rather than producing garbage logits.
 ///
+/// uint8 scales are NOT exclusive to mxfp8: mxfp4 (4-bit, group_size 32) and
+/// nvfp4 (4-bit, group_size 16) also carry uint8 scales and no biases. A
+/// mode-less / stale `config.json` makes `is_mxfp8_checkpoint` resolve ANY
+/// uint8-scale table to mxfp8, so an mxfp4/nvfp4 embedding can reach this arm.
+/// Forcing 8/32 onto such a table would mis-describe it; we additionally verify
+/// the packed weight and scales shapes are self-consistent with 8-bit / gs32
+/// before accepting (8-bit packs `32/8 = 4` values per `u32`, so a genuine
+/// mxfp8 table satisfies `weight_last * 4 == scales_last * 32`, both equal to
+/// the hidden width). A 4-bit mxfp4/nvfp4 table packs 8 values per `u32`, so
+/// `weight_last` is half what mxfp8 expects and the equality fails — we reject
+/// loud at load instead of forcing 8/32 onto it.
+///
 /// Mirrors lfm2's `plq_to_packed_params` and `try_build_mxfp8_quantized_linear`,
 /// which likewise force the MX constants and null biases for mxfp8.
 fn resolve_packed_embed_params<'a>(
     key: &str,
     plq: PerLayerQuant,
+    weight: &MxArray,
     scales: &MxArray,
     biases: Option<&'a MxArray>,
 ) -> Result<PackedEmbedParams<'a>> {
@@ -889,6 +902,31 @@ fn resolve_packed_embed_params<'a>(
                 return Err(Error::from_reason(format!(
                     "gemma4 {key} load: quant mode resolves to mxfp8 but '{key}.scales' is not \
                      uint8 (E8M0) — config/tensor disagreement, refusing to load"
+                )));
+            }
+            // The mxfp8 resolution can come from a mode-less config that only saw
+            // uint8 scales (shared by mxfp4/nvfp4). Confirm the packed weight and
+            // scales last-dims are consistent with 8-bit packing at group_size 32
+            // before forcing those constants: 8-bit packs `32/MXFP8_BITS` values
+            // per u32, so a genuine mxfp8 table has
+            // `weight_last * (32 / MXFP8_BITS) == scales_last * MXFP8_GROUP_SIZE`.
+            // mxfp4/nvfp4 (4-bit) halve `weight_last`, so the equality fails and
+            // we reject rather than mis-unpack.
+            let weight_last = *weight.shape()?.to_vec().last().ok_or_else(|| {
+                Error::from_reason(format!("gemma4 {key} load: weight is 0-rank"))
+            })?;
+            let scales_last = *scales.shape()?.to_vec().last().ok_or_else(|| {
+                Error::from_reason(format!("gemma4 {key} load: scales is 0-rank"))
+            })?;
+            let weight_cols = weight_last * i64::from(32 / MXFP8_BITS);
+            let scales_cols = scales_last * i64::from(MXFP8_GROUP_SIZE);
+            if weight_cols != scales_cols {
+                return Err(Error::from_reason(format!(
+                    "gemma4 {key} load: quant mode resolved to mxfp8 but the packed weight \
+                     ({weight_last} u32 cols) and scales ({scales_last} groups) are not consistent \
+                     with 8-bit / group_size-{MXFP8_GROUP_SIZE} packing ({weight_cols} != \
+                     {scales_cols}); the table is most likely mxfp4/nvfp4 mis-resolved to mxfp8 \
+                     from a mode-less config — refusing to load with forced mxfp8 constants"
                 )));
             }
             Ok(PackedEmbedParams {
@@ -1038,7 +1076,7 @@ fn apply_weights(
         // by `default_plq` would mis-unpack an E8M0 table, since MLX honors the
         // passed bits/group_size) and drops biases, takes bits/group_size from
         // the PLQ for affine, and fails loud on any mode/tensor contradiction.
-        let packed = resolve_packed_embed_params("embed_tokens", embed_plq, scales, biases)?;
+        let packed = resolve_packed_embed_params("embed_tokens", embed_plq, w, scales, biases)?;
         // Tied (12B/27B) and untied embeddings both keep the table PACKED and
         // dequantize only the gathered rows in `forward()`; the tied lm_head
         // projects through `as_linear` (`mlx_quantized_matmul`) without ever
@@ -3254,13 +3292,18 @@ mod tests {
     /// (8 / 32) and nulls biases.
     #[test]
     fn resolve_packed_embed_mxfp8_forces_mx_constants() {
+        // Genuine mxfp8 table for hidden=64, vocab=4: 8-bit packs 4 vals/u32 so
+        // the packed weight has 64/4 = 16 u32 cols; group_size 32 gives 64/32 = 2
+        // scale groups. weight_last(16)*4 == scales_last(2)*32 == 64, so the
+        // 8-bit/gs32 self-consistency guard accepts it.
+        let weight = MxArray::zeros(&[4, 16], Some(DType::Uint32)).expect("packed weight");
         let scales = MxArray::zeros(&[4, 2], Some(DType::Uint8)).expect("uint8 scales");
         let plq = PerLayerQuant {
             bits: 4,
             group_size: 64,
             mode: PerLayerMode::Mxfp8,
         };
-        let packed = resolve_packed_embed_params("embed_tokens", plq, &scales, None)
+        let packed = resolve_packed_embed_params("embed_tokens", plq, &weight, &scales, None)
             .expect("mxfp8 with affine-default bits must resolve, not error");
         assert_eq!(packed.bits, MXFP8_BITS, "mxfp8 bits must be forced to 8");
         assert_eq!(
@@ -3271,10 +3314,39 @@ mod tests {
         assert!(packed.biases.is_none(), "mxfp8 carries no biases");
     }
 
+    /// A uint8-scale table whose packed-weight / scales shapes match mxfp4
+    /// (4-bit, group_size 32) rather than mxfp8 — but which a mode-less config
+    /// mis-resolved to `Mxfp8` via `is_mxfp8_checkpoint` (uint8 scales only) —
+    /// must be rejected loud, NOT loaded with forced 8/32 mxfp8 constants.
+    ///
+    /// hidden=64, vocab=4: 4-bit packs 8 vals/u32 so the packed weight has
+    /// 64/8 = 8 u32 cols; group_size 32 gives 64/32 = 2 scale groups. Under the
+    /// forced 8-bit reading, weight_last(8)*4 = 32 != scales_last(2)*32 = 64, so
+    /// the shapes are inconsistent with 8-bit/gs32 and the guard fires.
+    #[test]
+    fn resolve_packed_embed_mxfp4_shapes_resolved_to_mxfp8_fails_loud() {
+        let weight = MxArray::zeros(&[4, 8], Some(DType::Uint32)).expect("mxfp4-packed weight");
+        let scales = MxArray::zeros(&[4, 2], Some(DType::Uint8)).expect("uint8 scales");
+        let plq = PerLayerQuant {
+            bits: 4,
+            group_size: 32,
+            mode: PerLayerMode::Mxfp8,
+        };
+        let err = resolve_packed_embed_params("embed_tokens", plq, &weight, &scales, None)
+            .err()
+            .expect("mxfp4-shaped table mis-resolved to mxfp8 must fail loud");
+        assert!(
+            err.reason.contains("mxfp8") && err.reason.contains("mxfp4"),
+            "error names the mxfp8/mxfp4 mismatch: {}",
+            err.reason
+        );
+    }
+
     /// Affine mode threads the PLQ's own bits/group_size through and passes the
     /// `.biases` tensor (asymmetric affine has per-group biases).
     #[test]
     fn resolve_packed_embed_affine_passes_plq_params_and_biases() {
+        let weight = MxArray::zeros(&[4, 16], Some(DType::Uint32)).expect("packed weight");
         let scales = MxArray::zeros(&[4, 2], Some(DType::BFloat16)).expect("bf16 scales");
         let biases = MxArray::zeros(&[4, 2], Some(DType::BFloat16)).expect("bf16 biases");
         let plq = PerLayerQuant {
@@ -3282,8 +3354,9 @@ mod tests {
             group_size: 32,
             mode: PerLayerMode::Affine,
         };
-        let packed = resolve_packed_embed_params("embed_tokens", plq, &scales, Some(&biases))
-            .expect("affine embedding must resolve");
+        let packed =
+            resolve_packed_embed_params("embed_tokens", plq, &weight, &scales, Some(&biases))
+                .expect("affine embedding must resolve");
         assert_eq!(packed.bits, 8);
         assert_eq!(packed.group_size, 32);
         assert_eq!(packed.mode_str, "affine");
@@ -3294,6 +3367,7 @@ mod tests {
     /// with a `.biases` tensor (mxfp8 has none).
     #[test]
     fn resolve_packed_embed_mxfp8_with_biases_fails_loud() {
+        let weight = MxArray::zeros(&[4, 16], Some(DType::Uint32)).expect("packed weight");
         let scales = MxArray::zeros(&[4, 2], Some(DType::Uint8)).expect("uint8 scales");
         let biases = MxArray::zeros(&[4, 2], Some(DType::BFloat16)).expect("bf16 biases");
         let plq = PerLayerQuant {
@@ -3303,7 +3377,7 @@ mod tests {
         };
         // `.err()` (not `expect_err`) so the success type needs no `Debug` bound
         // (`PackedEmbedParams` holds `Option<&MxArray>`, and `MxArray: !Debug`).
-        let err = resolve_packed_embed_params("embed_tokens", plq, &scales, Some(&biases))
+        let err = resolve_packed_embed_params("embed_tokens", plq, &weight, &scales, Some(&biases))
             .err()
             .expect("mxfp8 + biases must fail loud");
         assert!(
@@ -3317,13 +3391,14 @@ mod tests {
     /// rather than feed an MX-format table to the affine dequant.
     #[test]
     fn resolve_packed_embed_affine_with_uint8_scales_fails_loud() {
+        let weight = MxArray::zeros(&[4, 16], Some(DType::Uint32)).expect("packed weight");
         let scales = MxArray::zeros(&[4, 2], Some(DType::Uint8)).expect("uint8 scales");
         let plq = PerLayerQuant {
             bits: 8,
             group_size: 32,
             mode: PerLayerMode::Affine,
         };
-        let err = resolve_packed_embed_params("embed_tokens", plq, &scales, None)
+        let err = resolve_packed_embed_params("embed_tokens", plq, &weight, &scales, None)
             .err()
             .expect("affine + uint8 scales must fail loud");
         assert!(

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -21,12 +21,12 @@ use crate::tokenizer::Qwen3Tokenizer;
 use super::config::Gemma4Config;
 use super::model::{Gemma4Inner, Gemma4Model, warmup_forward};
 use super::quantized_linear::{
-    DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, PerLayerMode, PerLayerQuant, is_mxfp8_checkpoint,
-    is_quantized_checkpoint, try_build_mxfp4_quantized_linear,
-    try_build_mxfp4_quantized_switch_linear, try_build_mxfp8_quantized_linear,
-    try_build_mxfp8_quantized_switch_linear, try_build_nvfp4_quantized_linear,
-    try_build_nvfp4_quantized_switch_linear, try_build_quantized_linear,
-    try_build_quantized_switch_linear, try_build_sym8_quantized_linear,
+    DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, MXFP8_BITS, MXFP8_GROUP_SIZE, MXFP8_MODE,
+    PerLayerMode, PerLayerQuant, is_mxfp8_checkpoint, is_quantized_checkpoint,
+    try_build_mxfp4_quantized_linear, try_build_mxfp4_quantized_switch_linear,
+    try_build_mxfp8_quantized_linear, try_build_mxfp8_quantized_switch_linear,
+    try_build_nvfp4_quantized_linear, try_build_nvfp4_quantized_switch_linear,
+    try_build_quantized_linear, try_build_quantized_switch_linear, try_build_sym8_quantized_linear,
 };
 
 // Quantization-block parsing now lives in `crate::models::quant_dispatch`,
@@ -837,6 +837,88 @@ fn maybe_shard_ple_embedding(
     Ok(())
 }
 
+/// Packing parameters for a quantized embedding/tied-lm_head load: the
+/// `(group_size, bits, mode_str, biases)` tuple handed to
+/// `Embedding::load_quantized_packed`.
+struct PackedEmbedParams<'a> {
+    group_size: i32,
+    bits: i32,
+    mode_str: &'static str,
+    biases: Option<&'a MxArray>,
+}
+
+/// Resolve the packed-embedding parameters so `(mode, bits, group_size, biases)`
+/// are mutually consistent before they reach `load_quantized_packed` →
+/// `mlx_quantized_matmul`/`mlx_dequantize`.
+///
+/// The on-disk tensors are the ground truth: affine packing ships a per-group
+/// `.biases` companion with floating `.scales`; MXFP8 ships uint8 (E8M0)
+/// `.scales` and NO `.biases`. We discriminate off that unambiguous tensor
+/// evidence and force the matching pack constants, so a config that disagrees
+/// with the tensors can never silently mis-lay-out the table:
+///   * mxfp8 → force `(MXFP8_GROUP_SIZE, MXFP8_BITS, "mxfp8")` (the affine 4/64
+///     default that `default_plq` carries is wrong for an E8M0 table; MLX's
+///     `quantized_matmul` honors the passed bits/group_size rather than
+///     re-deriving them, so 4/64 would mis-unpack) and drop biases.
+///   * affine → take `bits`/`group_size` from the resolved PLQ and pass the
+///     `.biases` tensor through.
+///
+/// Any other mode at this key, or a mode that contradicts the tensor evidence
+/// (mxfp8 mode with `.biases`/non-uint8 scales, or affine mode with uint8
+/// scales), is rejected loud rather than producing garbage logits.
+///
+/// Mirrors lfm2's `plq_to_packed_params` and `try_build_mxfp8_quantized_linear`,
+/// which likewise force the MX constants and null biases for mxfp8.
+fn resolve_packed_embed_params<'a>(
+    key: &str,
+    plq: PerLayerQuant,
+    scales: &MxArray,
+    biases: Option<&'a MxArray>,
+) -> Result<PackedEmbedParams<'a>> {
+    let scales_uint8 = scales.dtype().ok() == Some(DType::Uint8);
+    match plq.mode {
+        PerLayerMode::Mxfp8 => {
+            if biases.is_some() {
+                return Err(Error::from_reason(format!(
+                    "gemma4 {key} load: quant mode resolves to mxfp8 but a '{key}.biases' tensor \
+                     is present — mxfp8 has no biases (its E8M0 scales fully describe the \
+                     dequant); config/tensor disagreement, refusing to load"
+                )));
+            }
+            if !scales_uint8 {
+                return Err(Error::from_reason(format!(
+                    "gemma4 {key} load: quant mode resolves to mxfp8 but '{key}.scales' is not \
+                     uint8 (E8M0) — config/tensor disagreement, refusing to load"
+                )));
+            }
+            Ok(PackedEmbedParams {
+                group_size: MXFP8_GROUP_SIZE,
+                bits: MXFP8_BITS,
+                mode_str: MXFP8_MODE,
+                biases: None,
+            })
+        }
+        PerLayerMode::Affine => {
+            if scales_uint8 {
+                return Err(Error::from_reason(format!(
+                    "gemma4 {key} load: quant mode resolves to affine but '{key}.scales' is uint8 \
+                     (an E8M0/MX-format dtype) — config/tensor disagreement, refusing to load"
+                )));
+            }
+            Ok(PackedEmbedParams {
+                group_size: plq.group_size,
+                bits: plq.bits,
+                mode_str: "affine",
+                biases,
+            })
+        }
+        other => Err(Error::from_reason(format!(
+            "gemma4 {key} load: quant mode {other:?} is not supported for the embedding/tied \
+             lm_head; only affine and mxfp8 are supported"
+        ))),
+    }
+}
+
 /// Apply sanitized weights to a Gemma4Inner.
 fn apply_weights(
     inner: &mut Gemma4Inner,
@@ -945,30 +1027,18 @@ fn apply_weights(
         .get("embed_tokens")
         .copied()
         .unwrap_or(default_plq);
-    // Runtime quant-mode string fed to the packed backend. Only the modes the
-    // tied/untied embedding path is validated against are accepted.
-    let embed_mode_str = match embed_plq.mode {
-        PerLayerMode::Affine => "affine",
-        PerLayerMode::Mxfp8 => "mxfp8",
-        other => {
-            if embed_quantized {
-                return Err(Error::from_reason(format!(
-                    "gemma4 embed_tokens load: quant mode {other:?} is not supported for the \
-                     embedding/tied lm_head; only affine and mxfp8 are supported"
-                )));
-            }
-            "affine"
-        }
-    };
     if embed_quantized && let Some(w) = params.get("embed_tokens.weight") {
         let scales = params.get("embed_tokens.scales").ok_or_else(|| {
             Error::from_reason("Missing embed_tokens.scales for quantized embedding")
         })?;
-        // Affine packing carries a per-group `.biases` companion; MXFP8 has none
-        // (its E8M0 scales fully describe the dequant). Drive the biases-present
-        // decision off the actual tensor key, not the mode alone, so a config
-        // that disagrees with the on-disk tensors still loads the correct shape.
         let biases = params.get("embed_tokens.biases");
+        // Make `(mode, bits, group_size, biases)` mutually consistent before the
+        // packed backend feeds `mlx_quantized_matmul`/`mlx_dequantize`. The
+        // helper forces the MX pack constants for mxfp8 (the affine 4/64 carried
+        // by `default_plq` would mis-unpack an E8M0 table, since MLX honors the
+        // passed bits/group_size) and drops biases, takes bits/group_size from
+        // the PLQ for affine, and fails loud on any mode/tensor contradiction.
+        let packed = resolve_packed_embed_params("embed_tokens", embed_plq, scales, biases)?;
         // Tied (12B/27B) and untied embeddings both keep the table PACKED and
         // dequantize only the gathered rows in `forward()`; the tied lm_head
         // projects through `as_linear` (`mlx_quantized_matmul`) without ever
@@ -981,10 +1051,10 @@ fn apply_weights(
         inner.embed_tokens.load_quantized_packed(
             w,
             scales,
-            biases,
-            embed_plq.group_size,
-            embed_plq.bits,
-            embed_mode_str,
+            packed.biases,
+            packed.group_size,
+            packed.bits,
+            packed.mode_str,
         )?;
     } else if let Some(w) = params.get("embed_tokens.weight") {
         // Dense embedding fallback (no `.scales`): a stripped quant group
@@ -3174,5 +3244,92 @@ mod tests {
         p.retain(|k, _| !k.starts_with("vision_embedder.") && !k.starts_with("embed_vision."));
         validate_required_weights(&p, &text_only)
             .expect("text-only config must not require unified vision keys");
+    }
+
+    /// An mxfp8-mode embedding whose resolved PLQ still carries the affine
+    /// 4-bit / group_size-64 defaults (e.g. `default_plq` fallback, or an
+    /// override missing explicit bits/group_size) must NOT thread 4/64 into the
+    /// packed backend: MLX honors the passed bits/group_size, so 4/64 would
+    /// mis-unpack the E8M0 table. The resolver forces the MX pack constants
+    /// (8 / 32) and nulls biases.
+    #[test]
+    fn resolve_packed_embed_mxfp8_forces_mx_constants() {
+        let scales = MxArray::zeros(&[4, 2], Some(DType::Uint8)).expect("uint8 scales");
+        let plq = PerLayerQuant {
+            bits: 4,
+            group_size: 64,
+            mode: PerLayerMode::Mxfp8,
+        };
+        let packed = resolve_packed_embed_params("embed_tokens", plq, &scales, None)
+            .expect("mxfp8 with affine-default bits must resolve, not error");
+        assert_eq!(packed.bits, MXFP8_BITS, "mxfp8 bits must be forced to 8");
+        assert_eq!(
+            packed.group_size, MXFP8_GROUP_SIZE,
+            "mxfp8 group_size must be forced to 32"
+        );
+        assert_eq!(packed.mode_str, MXFP8_MODE);
+        assert!(packed.biases.is_none(), "mxfp8 carries no biases");
+    }
+
+    /// Affine mode threads the PLQ's own bits/group_size through and passes the
+    /// `.biases` tensor (asymmetric affine has per-group biases).
+    #[test]
+    fn resolve_packed_embed_affine_passes_plq_params_and_biases() {
+        let scales = MxArray::zeros(&[4, 2], Some(DType::BFloat16)).expect("bf16 scales");
+        let biases = MxArray::zeros(&[4, 2], Some(DType::BFloat16)).expect("bf16 biases");
+        let plq = PerLayerQuant {
+            bits: 8,
+            group_size: 32,
+            mode: PerLayerMode::Affine,
+        };
+        let packed = resolve_packed_embed_params("embed_tokens", plq, &scales, Some(&biases))
+            .expect("affine embedding must resolve");
+        assert_eq!(packed.bits, 8);
+        assert_eq!(packed.group_size, 32);
+        assert_eq!(packed.mode_str, "affine");
+        assert!(packed.biases.is_some(), "affine biases must pass through");
+    }
+
+    /// Mode/tensor contradiction is rejected loud: mxfp8 mode never coexists
+    /// with a `.biases` tensor (mxfp8 has none).
+    #[test]
+    fn resolve_packed_embed_mxfp8_with_biases_fails_loud() {
+        let scales = MxArray::zeros(&[4, 2], Some(DType::Uint8)).expect("uint8 scales");
+        let biases = MxArray::zeros(&[4, 2], Some(DType::BFloat16)).expect("bf16 biases");
+        let plq = PerLayerQuant {
+            bits: 8,
+            group_size: 32,
+            mode: PerLayerMode::Mxfp8,
+        };
+        // `.err()` (not `expect_err`) so the success type needs no `Debug` bound
+        // (`PackedEmbedParams` holds `Option<&MxArray>`, and `MxArray: !Debug`).
+        let err = resolve_packed_embed_params("embed_tokens", plq, &scales, Some(&biases))
+            .err()
+            .expect("mxfp8 + biases must fail loud");
+        assert!(
+            err.reason.contains("mxfp8"),
+            "error mentions mxfp8: {}",
+            err.reason
+        );
+    }
+
+    /// Affine mode with uint8 (E8M0/MX) scales is a contradiction — reject loud
+    /// rather than feed an MX-format table to the affine dequant.
+    #[test]
+    fn resolve_packed_embed_affine_with_uint8_scales_fails_loud() {
+        let scales = MxArray::zeros(&[4, 2], Some(DType::Uint8)).expect("uint8 scales");
+        let plq = PerLayerQuant {
+            bits: 8,
+            group_size: 32,
+            mode: PerLayerMode::Affine,
+        };
+        let err = resolve_packed_embed_params("embed_tokens", plq, &scales, None)
+            .err()
+            .expect("affine + uint8 scales must fail loud");
+        assert!(
+            err.reason.contains("affine"),
+            "error mentions affine: {}",
+            err.reason
+        );
     }
 }

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -925,76 +925,67 @@ fn apply_weights(
     // Embedding. Q8 / Q4 affine checkpoints carry `.scales` (+ `.biases`)
     // companions alongside `.weight` with a packed-last-dim shape, so the
     // dense `load_weight` path trips its shape guard. Route quantized
-    // embeddings through `load_quantized`, which pre-dequantizes the full
-    // table for the forward lookup and (when tied) for the lm_head matmul.
+    // embeddings through `load_quantized_packed`, which keeps the table PACKED:
+    // `forward()` dequantizes only the gathered rows, and the tied lm_head
+    // projects through `as_linear` (`mlx_quantized_matmul`) without ever
+    // materializing the dense bf16 table.
     //
-    // Defense-in-depth: `Embedding::load_quantized` calls
-    // `mlx_dequantize(..., "affine")` unconditionally, so MXFP4/MXFP8 metadata
-    // at this key would silently mis-dequantize. The convert path already
-    // forces `embed_tokens` to affine (see `apply_mxfp_upgrade` and the
-    // no-recipe path), but if a future regression or hand-edited
-    // checkpoint claims otherwise we want to fail loud rather than emit
-    // garbage outputs.
+    // Defense-in-depth: the packed backend feeds `mlx_dequantize`/
+    // `mlx_quantized_matmul` with the mode string passed below, so the mode
+    // must match the on-disk packing. Affine (Q4/Q8 with `.scales` + `.biases`)
+    // and MXFP8 (E8M0 `.scales`, no `.biases`) are both supported here; any
+    // other quant mode at this key is rejected so a regression or hand-edited
+    // checkpoint fails loud instead of silently mis-dequantizing into garbage.
     let embed_quantized = params.contains_key("embed_tokens.scales");
-    // Only enforce the affine-only guard when the embedding is actually
-    // quantized (has .scales). Dense bf16 embeddings have no tensor-side
-    // mode, so metadata claiming MXFP at the top level is irrelevant —
-    // there is nothing to mis-dequantize.
-    if embed_quantized {
-        let embed_plq = per_layer_quant
-            .get("embed_tokens")
-            .copied()
-            .unwrap_or(default_plq);
-        if embed_plq.mode != PerLayerMode::Affine {
-            return Err(Error::from_reason(format!(
-                "gemma4 embed_tokens load: Non-affine FP mode {:?} is not supported; affine only",
-                embed_plq.mode
-            )));
+    // Resolve the embedding's quant mode once, defaulting to the checkpoint
+    // default when no per-layer override is present. Only consult this when the
+    // embedding is actually quantized (has `.scales`) — a dense bf16 embedding
+    // has no tensor-side mode, so top-level MXFP metadata is irrelevant.
+    let embed_plq = per_layer_quant
+        .get("embed_tokens")
+        .copied()
+        .unwrap_or(default_plq);
+    // Runtime quant-mode string fed to the packed backend. Only the modes the
+    // tied/untied embedding path is validated against are accepted.
+    let embed_mode_str = match embed_plq.mode {
+        PerLayerMode::Affine => "affine",
+        PerLayerMode::Mxfp8 => "mxfp8",
+        other => {
+            if embed_quantized {
+                return Err(Error::from_reason(format!(
+                    "gemma4 embed_tokens load: quant mode {other:?} is not supported for the \
+                     embedding/tied lm_head; only affine and mxfp8 are supported"
+                )));
+            }
+            "affine"
         }
-    }
+    };
     if embed_quantized && let Some(w) = params.get("embed_tokens.weight") {
-        let embed_plq = per_layer_quant
-            .get("embed_tokens")
-            .copied()
-            .unwrap_or(default_plq);
         let scales = params.get("embed_tokens.scales").ok_or_else(|| {
             Error::from_reason("Missing embed_tokens.scales for quantized embedding")
         })?;
+        // Affine packing carries a per-group `.biases` companion; MXFP8 has none
+        // (its E8M0 scales fully describe the dequant). Drive the biases-present
+        // decision off the actual tensor key, not the mode alone, so a config
+        // that disagrees with the on-disk tensors still loads the correct shape.
         let biases = params.get("embed_tokens.biases");
-        if config.tie_word_embeddings {
-            // Tied lm_head reads the whole table as a dense matmul weight
-            // (`embed_weight_t` below), so it must be dequantized into one dense
-            // bf16 buffer up front.
-            inner.embed_tokens.load_quantized(
-                w,
-                scales,
-                biases,
-                embed_plq.group_size,
-                embed_plq.bits,
-            )?;
-            let dequant = inner.embed_tokens.get_weight();
-            let w_t = dequant.transpose(Some(&[1, 0]))?;
-            inner.embed_weight_t = Some(w_t);
-        } else {
-            // Untied: the table is only ever gathered one row at a time in
-            // `forward()` (never tied, never read via `get_weight()` on the hot
-            // path), so keep it PACKED and dequantize only the looked-up rows.
-            // Byte-identical to the dense path — affine dequant is per-element,
-            // so gather-then-dequant == dequant-then-gather — but the 2-bit
-            // `[vocab, hidden]` table stays packed instead of materializing a
-            // dense bf16 copy (measured ~0.63 GiB resident reclaimed for E2B:
-            // a 262144x1536 2-bit table is 0.75 GiB dense vs 0.12 GiB packed).
-            // Mirrors the PLE `embed_tokens_per_layer` packed load below; mode
-            // is guaranteed affine by the guard above.
-            inner.embed_tokens.load_quantized_packed(
-                w,
-                scales,
-                biases,
-                embed_plq.group_size,
-                embed_plq.bits,
-                "affine",
-            )?;
-        }
+        // Tied (12B/27B) and untied embeddings both keep the table PACKED and
+        // dequantize only the gathered rows in `forward()`; the tied lm_head
+        // projects through `as_linear` (`mlx_quantized_matmul`) without ever
+        // materializing the dense table (~2 GiB bf16 for the 262144x3840 12B
+        // vocab). The hot-path logits sites in `model.rs` detect the packed
+        // backend via `Embedding::is_packed_quantized()` and call `as_linear`,
+        // so `embed_weight_t` stays None and those sites take the packed branch.
+        // Mirrors LFM2's tied/quantized embedding load and the PLE packed load
+        // below; the mode string is threaded through to the dequant/matmul.
+        inner.embed_tokens.load_quantized_packed(
+            w,
+            scales,
+            biases,
+            embed_plq.group_size,
+            embed_plq.bits,
+            embed_mode_str,
+        )?;
     } else if let Some(w) = params.get("embed_tokens.weight") {
         // Dense embedding fallback (no `.scales`): a stripped quant group
         // must never reach the dense lookup / tied-lm_head matmul.


### PR DESCRIPTION
## What

Loads a **quantized tied embedding / lm_head** for gemma4 as a **packed** table instead of dequantizing the whole thing to dense bf16.

Before: a quantized `embed_tokens` went through `Embedding::load_quantized`, which dequantizes the entire table into a dense bf16 buffer and transposes it into `embed_weight_t` for the tied lm_head matmul (~2 GB bf16 for the 12B `262144x3840` vocab).

After: both tied and untied embeddings go through `load_quantized_packed`. `forward()` dequantizes only the gathered rows, and the tied lm_head projects through `Embedding::as_linear` (`mlx_quantized_matmul`, `transpose=true`) **without ever materializing the dense table**. The five logits sites in `model.rs` detect the packed backend via `is_packed_quantized()` and take the `as_linear` branch, so `embed_weight_t` stays `None` on the packed path.

The embedding quant mode is resolved from the per-layer config (`affine` or `mxfp8`) and threaded to the packed backend; biases-presence is driven off the actual `embed_tokens.biases` tensor key (affine has biases; mxfp8 does not). Any other quant mode at this key is rejected loud rather than silently mis-dequantizing.

## Why / measured (gemma4 12B QAT-q4_0, M5 Max)

Quantizing the tied head from bf16 → 8-bit affine (gs32):

| | bf16 head | 8-bit affine head |
|---|---|---|
| decode tok/s | ~46 | ~50 (equal within noise) |
| peak RSS | 8.9 GB | 8.1 GB (**−0.8 GB**) |
| on-disk | 8.3 GB | 7.5 GB (**−0.8 GB**) |
| greedy output | — | near-lossless (answers unchanged) |

Validated coherent + near-lossless on **both MLX 0.31.2 and 0.32.0**. We also bench'd mxfp8 for this head — it's perf-tied with affine and only ~90 MB smaller, so 8-bit affine is the chosen default; the loader stays mode-generic so an mxfp8 tied head also loads.

## Scope

**Load-side support.** It activates only when a checkpoint actually carries a quantized `embed_tokens` (`.scales` present + per-layer config). Dense bf16 tied models are unaffected (`is_packed_quantized()` is false → existing `embed_weight_t` path, unchanged). Auto-emitting a quantized tied head from `mlx convert` for gemma4 is a follow-up.

## Validation

- `cargo clippy --all-targets -- -D warnings` + `cargo fmt --check`: clean
- Packed-embedding unit tests green, incl. `packed_affine_as_linear_matches_dense_matmul` (guards the exact packed-`as_linear` ≡ dense-matmul equivalence the tied lm_head relies on) and `packed_mxfp8_forward_matches_dequant_full_then_gather`
- `/codex:adversarial-review`: **approve, no material findings** (verified transpose orientation, softcap-after-logits at all 5 sites, dense-tied + untied routing intact, no uncovered MTP/draft/warmup reader of `embed_weight_t`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core inference logits routing for quantized tied checkpoints; load-time guards reduce mis-dequant risk, but correctness depends on packed matmul matching the prior dense path.
> 
> **Overview**
> **Gemma4** no longer fully dequantizes a quantized `embed_tokens` into dense bf16 for a tied lm_head. Load now always uses **`load_quantized_packed`** (tied and untied), with **`resolve_packed_embed_params`** aligning affine vs mxfp8 to on-disk scales/biases and rejecting mis-resolved mxfp4/nvfp4-as-mxfp8 layouts.
> 
> At **five logits sites** in `model.rs`, when there is no separate `lm_head` and embeddings are packed, logits come from **`embed_tokens.as_linear`** (`mlx_quantized_matmul`) instead of **`embed_weight_t`** or a dense transpose of the full table—avoiding a large resident bf16 vocab matrix on the hot path.
> 
> Dense bf16 embeddings and an explicit `lm_head` are unchanged; the new behavior applies only when `.scales` are present and the packed backend is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b34999d11bf4060c48f7af2e1107f670c702a00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->