### PR TITLE
fix(convert): apply imatrix AWQ on VLM checkpoints + compensate GDN in_proj_a/b

### DIFF
--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -2301,7 +2301,14 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
     if let Some(ref imatrix_path) = imatrix_path {
         let imatrix = crate::utils::imatrix::parse_imatrix(imatrix_path)?;
         let num_layers = infer_num_layers_from_weights(&converted_tensors);
-        apply_awq_prescaling(&mut converted_tensors, &imatrix, 0.5, num_layers)?;
+        let modified = apply_awq_prescaling(&mut converted_tensors, &imatrix, 0.5, num_layers)?;
+        if modified == 0 {
+            warn!(
+                "AWQ pre-scaling modified 0 weight tensors despite an imatrix being provided — \
+                 the imatrix keys did not match any target weights (importance applied to nothing). \
+                 Check that the imatrix corresponds to this model."
+            );
+        }
     }
 
     // Apply quantization if requested
@@ -3657,9 +3664,13 @@ pub(crate) fn build_qwen35_recipe(
 /// ## AWQ Pre-Scaling
 ///
 /// imatrix is **required** — attention/SSM weights fed by input_layernorm can
-/// be AWQ-corrected (layernorm absorbs inverse scales). `o_proj`, `out_proj`,
-/// and the split `in_proj_a`/`in_proj_b` have no preceding norm so cannot be
-/// AWQ-corrected; they are quantized at 8-bit affine (group_size 64) rather
+/// be AWQ-corrected (layernorm absorbs inverse scales). `o_proj` and `out_proj`
+/// have no preceding norm so cannot be AWQ-corrected. The split
+/// `in_proj_a`/`in_proj_b` DO share input_layernorm with `in_proj_qkv`/`in_proj_z`
+/// (Group D), so they are not part of the importance-derived scale but their
+/// columns are still multiplied by that scale to keep the reparametrization
+/// output-preserving. All of these are quantized at 8-bit affine (group_size 64)
+/// rather
 /// than left bf16 so they route through MLX's row-independent `qmv` kernel —
 /// required for MTP/AR T=0 bit-exactness (a bf16 `matmul` dispatches `gemv` at
 /// M=1 but split-K `steel_matmul` at M>=2, and the differing reduction order
@@ -5130,7 +5141,7 @@ pub(crate) fn apply_awq_prescaling(
     imatrix: &crate::utils::imatrix::ImatrixData,
     ratio: f32,
     num_layers: usize,
-) -> Result<()> {
+) -> Result<usize> {
     info!(
         "Applying AWQ pre-scaling: {} layers, ratio={}, {} imatrix entries",
         num_layers,
@@ -5234,16 +5245,29 @@ pub(crate) fn apply_awq_prescaling(
             }
         }
 
-        // ── Group D: input_layernorm → linear_attn.in_proj_qkv + in_proj_z ──
-        // (Only present in GatedDeltaNet layers)
+        // ── Group D: input_layernorm → linear_attn.in_proj_qkv + in_proj_z
+        //                              + in_proj_a + in_proj_b ──
+        // (Only present in GatedDeltaNet layers.) All four in_proj_* projections
+        // read the SAME input_layernorm output (see gated_delta_net.rs forward:
+        // both in_proj_qkvz and in_proj_ba matmul the normed input). The AWQ
+        // scale `s` is derived from qkv+z importance, but because the shared
+        // input_layernorm is divided by `s` below, EVERY consumer of that norm
+        // must have its input columns multiplied by `s` for the reparametrization
+        // to stay output-preserving. Omitting in_proj_a/in_proj_b would leave
+        // their inputs divided by `s` with un-compensated weights, distorting the
+        // GDN decay (`a`) and beta (`b`) gates. Their bit-width (8-bit affine) is
+        // orthogonal and unchanged — this is a correctness compensation, not a
+        // quantization-quality tweak.
         let qkv_key = format!("{prefix}.linear_attn.in_proj_qkv.weight");
         let z_key = format!("{prefix}.linear_attn.in_proj_z.weight");
+        let a_key = format!("{prefix}.linear_attn.in_proj_a.weight");
+        let b_key = format!("{prefix}.linear_attn.in_proj_b.weight");
 
         // Only apply if this layer has linear_attn weights (GDN layer)
         if weights.contains_key(&qkv_key)
             && let Some(scales) = compute_multi_key_scales(imatrix, &[&qkv_key, &z_key], ratio)?
         {
-            for proj_key in [&qkv_key, &z_key] {
+            for proj_key in [&qkv_key, &z_key, &a_key, &b_key] {
                 if let Some(proj) = weights.remove(proj_key) {
                     let scaled = scale_columns(&proj, &scales)?;
                     weights.insert(proj_key.to_string(), scaled);
@@ -5277,7 +5301,19 @@ pub(crate) fn apply_awq_prescaling(
         "AWQ pre-scaling complete: modified {} weight tensors",
         modified
     );
-    Ok(())
+    Ok(modified)
+}
+
+/// Map a (possibly VLM-wrapped) weight key to its canonical imatrix key.
+///
+/// Imatrix importance is always keyed with the canonical `model.layers.N.*`
+/// names produced by `gguf_name_to_hf` from a `blk.N.*` GGUF. Sanitized VLM
+/// checkpoints (e.g. qwen3_5_moe `*ForConditionalGeneration`) instead carry the
+/// `language_model.model.layers.N.*` prefix on their weights. Stripping the
+/// `language_model.` wrapper aligns the lookup with the imatrix; plain
+/// `model.layers.*` keys pass through unchanged.
+fn imatrix_lookup_key(key: &str) -> &str {
+    key.strip_prefix("language_model.").unwrap_or(key)
 }
 
 /// Compute AWQ scales for Group A (norm → gate_proj + up_proj).
@@ -5288,8 +5324,8 @@ fn compute_group_a_scales(
     up_key: &str,
     ratio: f32,
 ) -> Result<Option<MxArray>> {
-    let gate_imp = imatrix.importance.get(gate_key);
-    let up_imp = imatrix.importance.get(up_key);
+    let gate_imp = imatrix.importance.get(imatrix_lookup_key(gate_key));
+    let up_imp = imatrix.importance.get(imatrix_lookup_key(up_key));
 
     match (gate_imp, up_imp) {
         (Some(g), Some(u)) => {
@@ -5314,7 +5350,7 @@ fn compute_multi_key_scales(
 ) -> Result<Option<MxArray>> {
     let importances: Vec<&Vec<f32>> = keys
         .iter()
-        .filter_map(|k| imatrix.importance.get(*k))
+        .filter_map(|k| imatrix.importance.get(imatrix_lookup_key(k)))
         .collect();
 
     if importances.is_empty() {
@@ -5325,7 +5361,7 @@ fn compute_multi_key_scales(
     if importances.len() < keys.len() {
         let missing: Vec<&str> = keys
             .iter()
-            .filter(|k| !imatrix.importance.contains_key(**k))
+            .filter(|k| !imatrix.importance.contains_key(imatrix_lookup_key(k)))
             .copied()
             .collect();
         warn!(
@@ -5372,7 +5408,7 @@ fn compute_scales_for_key(
     key: &str,
     ratio: f32,
 ) -> Result<Option<MxArray>> {
-    match imatrix.importance.get(key) {
+    match imatrix.importance.get(imatrix_lookup_key(key)) {
         Some(imp) => {
             let scales = compute_normalized_scales(imp, ratio)?;
             Ok(Some(scales))
@@ -5443,6 +5479,114 @@ pub(crate) fn infer_num_layers_from_weights(weights: &HashMap<String, MxArray>) 
 mod tests {
     use super::*;
     use crate::convert::recipe::{self, ConversionRecipe};
+
+    /// AWQ pre-scaling must fire on VLM-wrapped checkpoints whose sanitized
+    /// weights carry the `language_model.model.layers.*` prefix (e.g. the
+    /// qwen3_5_moe `qwen-agentworld` checkpoint), while the imatrix is always
+    /// keyed with the canonical `model.layers.*` names produced by
+    /// `gguf_name_to_hf`. Regression: that prefix mismatch silently turned AWQ
+    /// into a no-op (`modified == 0`), so the unsloth recipe's low-bit
+    /// attention/SSM projections shipped without importance correction.
+    #[test]
+    fn awq_prescaling_matches_vlm_prefixed_weights() {
+        use crate::utils::imatrix::ImatrixData;
+
+        const K: i64 = 4; // input features (columns)
+        const N: i64 = 2; // output features (rows)
+
+        let ones = |shape: &[i64]| {
+            let numel: usize = shape.iter().product::<i64>() as usize;
+            MxArray::from_float32(&vec![1.0f32; numel], shape).expect("from_float32")
+        };
+
+        // Sanitized VLM-wrapped weights: GDN layer 0 + full-attention layer 1.
+        let mut weights: HashMap<String, MxArray> = HashMap::new();
+        // Layer 0 — GatedDeltaNet (linear_attn) → exercises AWQ Group D.
+        // in_proj_a/in_proj_b also read the shared input_layernorm output (see
+        // gated_delta_net.rs forward), so Group D must compensate their columns
+        // too — otherwise the norm-division distorts the GDN decay/beta gates.
+        weights.insert(
+            "language_model.model.layers.0.linear_attn.in_proj_qkv.weight".into(),
+            ones(&[N, K]),
+        );
+        weights.insert(
+            "language_model.model.layers.0.linear_attn.in_proj_z.weight".into(),
+            ones(&[N, K]),
+        );
+        weights.insert(
+            "language_model.model.layers.0.linear_attn.in_proj_a.weight".into(),
+            ones(&[N, K]),
+        );
+        weights.insert(
+            "language_model.model.layers.0.linear_attn.in_proj_b.weight".into(),
+            ones(&[N, K]),
+        );
+        weights.insert(
+            "language_model.model.layers.0.input_layernorm.weight".into(),
+            ones(&[K]),
+        );
+        // Layer 1 — full attention → exercises AWQ Group C.
+        weights.insert(
+            "language_model.model.layers.1.self_attn.q_proj.weight".into(),
+            ones(&[N, K]),
+        );
+        weights.insert(
+            "language_model.model.layers.1.self_attn.k_proj.weight".into(),
+            ones(&[N, K]),
+        );
+        weights.insert(
+            "language_model.model.layers.1.self_attn.v_proj.weight".into(),
+            ones(&[N, K]),
+        );
+        weights.insert(
+            "language_model.model.layers.1.input_layernorm.weight".into(),
+            ones(&[K]),
+        );
+
+        // imatrix keyed with canonical `model.layers.*` names (no
+        // `language_model.`), exactly as gguf_name_to_hf emits them from a
+        // `blk.N.*` imatrix GGUF.
+        let importance: HashMap<String, Vec<f32>> = [
+            (
+                "model.layers.0.linear_attn.in_proj_qkv.weight",
+                vec![1.0, 2.0, 3.0, 4.0],
+            ),
+            (
+                "model.layers.0.linear_attn.in_proj_z.weight",
+                vec![4.0, 3.0, 2.0, 1.0],
+            ),
+            (
+                "model.layers.1.self_attn.q_proj.weight",
+                vec![1.0, 2.0, 3.0, 4.0],
+            ),
+            (
+                "model.layers.1.self_attn.k_proj.weight",
+                vec![2.0, 2.0, 2.0, 2.0],
+            ),
+            (
+                "model.layers.1.self_attn.v_proj.weight",
+                vec![4.0, 3.0, 2.0, 1.0],
+            ),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+        let imatrix = ImatrixData {
+            importance,
+            chunk_count: 1,
+            chunk_size: 1,
+        };
+
+        let modified = apply_awq_prescaling(&mut weights, &imatrix, 0.5, 2).expect("awq");
+
+        // Group D (qkv + z + a + b + norm = 5) on layer 0, Group C (q + k + v +
+        // norm = 4) on layer 1. Before the prefix-decoupling fix this was 0
+        // (silent no-op); before the a/b-compensation fix it was 7 (a/b skipped).
+        assert_eq!(
+            modified, 9,
+            "AWQ must fire on VLM-prefixed weights and compensate in_proj_a/in_proj_b"
+        );
+    }
 
     /// Registry-consistency gate: for the exhaustive set of supported
     /// `model_type` strings (plus a non-convertible control), the four


### PR DESCRIPTION
## Summary

Converting `qwen-agentworld-35b-a3b` (a `qwen3_5_moe`
`*ForConditionalGeneration`, GatedDeltaNet hybrid) to **unsloth + mxfp8** with an
imatrix surfaced two real bugs in `apply_awq_prescaling` that silently degrade
AWQ for **VLM-wrapped** and **GDN** checkpoints. Both are fixed here with a unit
test, and validated end-to-end on the real model.

## Bug 1 — imatrix AWQ was a silent no-op on VLM checkpoints

imatrix importance is always keyed canonical `model.layers.N.*` (produced by
`gguf_name_to_hf` from `blk.N.*`). But sanitized VLM checkpoints carry
`language_model.model.layers.N.*`, and `apply_awq_prescaling` auto-detected that
prefix and used it for **both** the weight ops **and** the importance lookups →
every `importance.get` missed → `modified 0`, with no warning (the missing-key
warning only fires on a *partial* match).

**Fix:** `imatrix_lookup_key()` strips the `language_model.` wrapper before the
importance lookup; weight ops keep the detected prefix. `apply_awq_prescaling`
now returns the modified count, and the caller emits a `warn!` when it is 0
despite an imatrix being supplied (so this class of silent no-op is visible).

## Bug 2 — AWQ Group D distorted GDN `in_proj_a` / `in_proj_b`

Group D divides the shared `input_layernorm` by per-channel `s` but scaled only
`in_proj_qkv` + `in_proj_z`. All four `in_proj_*` projections read the **same**
`input_layernorm` output:

- `decoder_layer.rs:203,207` — `normed = input_layernorm.forward(x)` → `gdn.forward(&normed, …)`
- `gated_delta_net.rs:264/270-271` — that `normed` feeds **both** `in_proj_qkvz` **and** `in_proj_ba` (= b ++ a)

So leaving `in_proj_a`/`in_proj_b` unscaled divided their inputs by `s` (here
~0.18–5.5×/channel) with un-compensated weights → corrupted GDN decay (`a`) and
beta (`b`) gates. The reparametrization is output-preserving only if *every*
consumer of the divided norm is column-scaled by `s`.

**Fix:** column-scale `in_proj_a`/`in_proj_b` by the same `s` (their 8-bit-affine
bit-width is orthogonal and unchanged). Also corrects the stale doc comment that
claimed a/b "have no preceding norm" — only `o_proj`/`out_proj` lack one.

## Test

`awq_prescaling_matches_vlm_prefixed_weights`: VLM-prefixed GDN (Group D) +
full-attention (Group C) layers with a canonically-keyed imatrix must report
`modified == 9`.

```
modified == 0  before fix 1 (prefix mismatch → no-op)
modified == 7  before fix 2 (a/b skipped)
modified == 9  after both fixes
```

## Validation

- `cargo test -p mlx-core --lib convert::` → 104 passed; clippy + fmt clean.
- Real convert of `qwen-agentworld-35b-a3b` with `--q-recipe unsloth --q-mxfp
  --q-bits 4 --imatrix-path …` (67GB bf16 → ~20GB, 4 shards) → coherent
  generation.
- On-artifact AWQ fingerprint `conv/(orig+1)`: per-channel **non-uniform** on
  `input_layernorm` (Group C full-attn + Group D GDN), ≈1.0 on
  `post_attention_layernorm` (Group A correctly inert — no dense FFN in MoE).

> Note: `--q-recipe unsloth --q-mode mxfp8` is rejected by the CLI (recipes allow
> only `affine`|`nvfp4`); the recipe+micro-scaling path is `--q-mxfp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quantization weight math on convert for VLM and GDN models; incorrect scaling would affect model quality, but scope is limited to the AWQ path with an imatrix and is covered by a targeted regression test.
> 
> **Overview**
> Fixes **AWQ pre-scaling** during convert so imatrix-based importance actually applies on **VLM-wrapped** checkpoints and stays **mathematically consistent** on **GatedDeltaNet** layers.
> 
> **VLM / imatrix key mismatch:** Weight keys stay on the detected prefix (e.g. `language_model.model.layers.*`) while imatrix lookups now strip `language_model.` via `imatrix_lookup_key`, matching canonical `model.layers.*` entries from GGUF imatrix files. Previously every lookup missed and AWQ did nothing with no signal. `apply_awq_prescaling` now returns a **modified tensor count**; the convert path **warns** when an imatrix was supplied but zero weights were touched.
> 
> **GDN Group D:** When AWQ divides shared `input_layernorm` and column-scales `in_proj_qkv` / `in_proj_z`, it also column-scales **`in_proj_a` and `in_proj_b`** with the same scale (importance still derived from qkv+z). Those projections share the normed input; skipping them left gates wrongly scaled. Docs for the unsloth recipe are updated to reflect this.
> 
> Adds regression test **`awq_prescaling_matches_vlm_prefixed_weights`** expecting `modified == 9`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43468d0cc87e1e6193ab70d66e699e9a74ac7203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->