### PR TITLE
test(losses): de-flake test_cross_entropy_qwen3_vocab (batch 2 → 64)

### DIFF
--- a/crates/mlx-core/src/nn/losses_test.rs
+++ b/crates/mlx-core/src/nn/losses_test.rs
@@ -614,7 +614,10 @@ mod tests {
     #[test]
     fn test_cross_entropy_qwen3_vocab() {
         // Full Qwen3 vocabulary size
-        let batch_size = 2;
+        // Large batch so the mean-reduced loss concentrates near log(vocab):
+        // random_normal/randint are unseeded, and batch=2 was flaky — one high
+        // random target logit could pull the mean below the 10.0 lower bound.
+        let batch_size = 64;
         let vocab_size = 151936;
 
         let logits =


### PR DESCRIPTION
## Problem

Main CI intermittently fails on a single Rust unit test (most recently on the PR #78 merge commit, run `28209793148`):

```
FAILED: nn::losses_test::tests::test_cross_entropy_qwen3_vocab
        crates/mlx-core/src/nn/losses_test.rs:630
        "Loss should be > 10.0, got 9.881153"
        (1868 passed, 1 failed)
```

It is **unrelated to whatever PR happens to be merging** — the test was last touched in #12 and only `convert.rs` changed in #78. It is a pre-existing flaky test.

## Root cause

The test builds random logits/targets with **no seed** and asserts a tight band on the mean-reduced loss:

```rust
logits  = random_normal([2, 151936], 0,1, None)   // None is the DTYPE arg, not a seed
targets = randint([2], 0, 151936)
loss    = mean_over_batch( logsumexp(logits) − logits[target] )   // ≈ log(151936) ≈ 11.93
assert!(10.0 < loss < 15.0)
```

With `batch_size = 2`, the loss is `≈ 12.43 − N(0, 0.71)` — a high random target logit occasionally drags the mean below `10.0` (the observed `9.88` is a ~3.5σ draw).

## Fix

Bump `batch_size` 2 → 64. The mean-reduction then concentrates the loss at `log(V)`, shrinking the spread from ±0.71 to ±0.13. Vocab is unchanged, so the large-vocab **chunking path is still exercised**.

### Verification (2,000,000-draw simulation of the exact loss model)

| batch | loss | min | P(loss<10) | P(loss>15) |
|------:|------|----:|-----------:|-----------:|
| 2 | 12.43 ± 0.71 | 9.01 | **0.030%** | 0.015% |
| 64 | 12.43 ± 0.13 | 11.82 | **0** | 0 |

At batch=64 the loss stays in `[11.8, 13.0]` across 2M draws — ~15σ from the `10.0` bound. (`logsumexp` constant measured = 12.4313, matching `ln(V)+0.5`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or loss-implementation edits; slightly more work per test run from a larger batch.
> 
> **Overview**
> Stabilizes **`test_cross_entropy_qwen3_vocab`** in `losses_test.rs` by raising **`batch_size` from 2 to 64** while keeping the Qwen3-sized vocab (151936) and the same `(10.0, 15.0)` loss band.
> 
> The test still uses unseeded random logits/targets; with a tiny batch, a lucky target logit could drag the mean cross-entropy below 10.0 and fail CI. A larger batch tightens the mean-reduced loss around `log(vocab)` so the assertion is reliable without changing what the test exercises (large-vocab / chunked cross-entropy path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0225f735edf67e1535eb4c1bcc74fc0a2f55b12f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->