### PR TITLE
fix(qwen3.5-VL): correct image inference (interleaved M-RoPE, patch-embed, compressed-position decode + delta lifetime)

### DIFF
--- a/crates/mlx-core/src/array/ops.rs
+++ b/crates/mlx-core/src/array/ops.rs
@@ -103,9 +103,16 @@ impl MxArray {
         MxArray::from_handle(handle, "array_matmul")
     }
 
-    /// Fused matrix multiply-add: D = beta * C + alpha * (self @ B)
-    /// where self is A. More efficient than separate matmul and add operations.
-    /// Default: alpha=1.0, beta=1.0, giving D = C + (self @ B)
+    /// Matrix multiply-add: D = beta * C + alpha * (self @ B), where self is A.
+    /// Default: alpha=1.0, beta=1.0, giving D = C + (self @ B).
+    ///
+    /// The vendored `mlx::core::addmm` in this build silently ignores the `C`
+    /// term — it returns only `alpha * (A @ B)`, dropping `beta * C`. That was
+    /// invisible for bias-free linears (the LM Q/K/V/O/MLP and the bias-free MoE
+    /// router gate all pass a zero `C`), but it corrupted every biased linear —
+    /// most visibly the vision tower, whose `qkv`, `proj`, `fc1`, `fc2` and
+    /// merger projections all carry a bias. Compute the result explicitly so the
+    /// `C` term is actually applied.
     #[napi]
     pub fn addmm(
         &self,
@@ -114,11 +121,18 @@ impl MxArray {
         alpha: Option<f64>,
         beta: Option<f64>,
     ) -> Result<MxArray> {
-        let alpha = alpha.unwrap_or(1.0) as f32;
-        let beta = beta.unwrap_or(1.0) as f32;
-        let handle =
-            unsafe { sys::mlx_array_addmm(c.handle.0, self.handle.0, b.handle.0, alpha, beta) };
-        MxArray::from_handle(handle, "array_addmm")
+        let alpha = alpha.unwrap_or(1.0);
+        let beta = beta.unwrap_or(1.0);
+
+        let mut mm = self.matmul(b)?;
+        if alpha != 1.0 {
+            mm = mm.mul_scalar(alpha)?;
+        }
+        if beta != 1.0 {
+            mm.add(&c.mul_scalar(beta)?)
+        } else {
+            mm.add(c)
+        }
     }
 
     /// Indexed matrix multiply for MoE expert selection.

--- a/crates/mlx-core/src/array/ops.rs
+++ b/crates/mlx-core/src/array/ops.rs
@@ -106,13 +106,17 @@ impl MxArray {
     /// Matrix multiply-add: D = beta * C + alpha * (self @ B), where self is A.
     /// Default: alpha=1.0, beta=1.0, giving D = C + (self @ B).
     ///
-    /// The vendored `mlx::core::addmm` in this build silently ignores the `C`
-    /// term — it returns only `alpha * (A @ B)`, dropping `beta * C`. That was
-    /// invisible for bias-free linears (the LM Q/K/V/O/MLP and the bias-free MoE
-    /// router gate all pass a zero `C`), but it corrupted every biased linear —
-    /// most visibly the vision tower, whose `qkv`, `proj`, `fc1`, `fc2` and
-    /// merger projections all carry a bias. Compute the result explicitly so the
-    /// `C` term is actually applied.
+    /// Computed explicitly (matmul, optional alpha scale, then add beta*C)
+    /// rather than via the fused `mlx::core::addmm` primitive. The fused
+    /// primitive is correct on a well-formed metallib, but this project's local
+    /// release build is known to non-deterministically miscompile fused GEMM
+    /// kernels (see the metallib-corruption notes), which manifested as the
+    /// fused addmm dropping `beta*C` and corrupting every biased linear — most
+    /// visibly the vision tower (`qkv`, `proj`, `fc1`, `fc2`, merger all carry a
+    /// bias; bias-free LM/MoE linears pass a zero `C` and were unaffected). The
+    /// explicit form keeps the `C` term robust to that build hazard; the
+    /// `nn::linear` unit tests assert it applies a non-zero `C`, so they double
+    /// as a canary if a future build corrupts the matmul kernel too.
     #[napi]
     pub fn addmm(
         &self,

--- a/crates/mlx-core/src/engine/vision.rs
+++ b/crates/mlx-core/src/engine/vision.rs
@@ -19,4 +19,10 @@ pub(crate) struct VisionMerge {
     /// M-RoPE position ids for the mixed image+text sequence. Shape
     /// `[3, 1, seq_len]` (the temporal/height/width axes), i32.
     pub position_ids: MxArray,
+    /// `max_position + 1 - seq_len` for this image prefill. Image runs
+    /// compress their placeholder tokens into fewer M-RoPE positions, so this
+    /// is NEGATIVE; it is the per-session `cached_rope_deltas` that later
+    /// decode/warm-continuation steps add to the physical KV slot to recover
+    /// the compressed rotation position. Text-only prefills compute 0.
+    pub rope_deltas: i64,
 }

--- a/crates/mlx-core/src/models/paddleocr_vl/language.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/language.rs
@@ -288,6 +288,118 @@ pub fn apply_multimodal_rotary_pos_emb(
     Ok((q_out, k_out))
 }
 
+/// Apply INTERLEAVED multimodal rotary position embedding to Q and K (internal).
+///
+/// Used by Qwen3.5-VL (`qwen3_5` / `qwen3_5_moe`). Unlike PaddleOCR-VL, whose
+/// multimodal RoPE assigns the head_dim to spatial axes in CONTIGUOUS chunks
+/// (see [`apply_multimodal_rotary_pos_emb`]), Qwen3.5-VL assigns each inv_freq
+/// index to a spatial axis with a STRIDE-3 INTERLEAVE. This mirrors mlx-vlm's
+/// `_interleaved_position_selector` (rope_utils.py):
+///   selector[idx] = 1 (height) for idx in 1, 4, 7, … up to `mrope_section[1] * 3`
+///   selector[idx] = 2 (width)  for idx in 2, 5, 8, … up to `mrope_section[2] * 3`
+///   selector[idx] = 0 (temporal) otherwise
+/// computed over the `half_dim` inv_freq axis, then mirrored across the doubled
+/// cos/sin (`emb = concat([freqs, freqs])`).
+///
+/// The per-frequency axis selection is performed with a `take_along_axis` gather
+/// over axis 0 (the `[temporal, height, width]` axis) of the doubled cos/sin,
+/// followed by the same `rotate_half` application as the sectioned path.
+///
+/// For TEXT tokens (temporal == height == width) every axis row of cos/sin is
+/// bit-identical, so any selector picks identical values — this produces output
+/// bit-identical to the sectioned [`apply_multimodal_rotary_pos_emb`]. See
+/// `test_interleaved_text_invariance`.
+///
+/// `cos`/`sin` shape: `[3, batch, seq_len, head_dim]` (axis 0 = t/h/w).
+/// `q`/`k` shape: `[batch, heads, seq_len, q_head_dim]` where `q_head_dim >=
+/// head_dim` (the trailing `q_head_dim - head_dim` dims pass through unrotated,
+/// matching qwen3_5's partial-rotary factor).
+///
+/// Note: Internal implementation detail, not exposed to TypeScript.
+pub fn apply_multimodal_rotary_pos_emb_interleaved(
+    q: &MxArray,
+    k: &MxArray,
+    cos: &MxArray,
+    sin: &MxArray,
+    mrope_section: Vec<i32>,
+) -> Result<(MxArray, MxArray)> {
+    let cos_shape = cos.shape()?; // 1 FFI call — cache and reuse below
+    let batch_size = cos_shape[1];
+    let seq_len = cos_shape[2];
+    let head_dim = cos_shape[3];
+    let half = head_dim / 2;
+    let half_usize = half as usize;
+
+    // Build the per-frequency axis selector over the half_dim inv_freq axis,
+    // matching mlx-vlm's `_interleaved_position_selector`, then mirror it across
+    // the doubled cos/sin (emb = concat([freqs, freqs]) => sel[j] = sel[j % half]).
+    let mut sel_half = vec![0i32; half_usize];
+    for (dim, offset) in [(1usize, 1usize), (2usize, 2usize)] {
+        let limit = std::cmp::min(mrope_section[dim] as usize * 3, half_usize);
+        let mut idx = offset;
+        while idx < limit {
+            sel_half[idx] = dim as i32;
+            idx += 3;
+        }
+    }
+    let mut sel_doubled = vec![0i32; head_dim as usize];
+    for (j, slot) in sel_doubled.iter_mut().enumerate() {
+        *slot = sel_half[j % half_usize];
+    }
+
+    // Gather the selected axis per frequency from cos/sin [3, batch, seq, head_dim].
+    // indices [1, 1, 1, head_dim] -> broadcast to [1, batch, seq, head_dim].
+    let indices = MxArray::from_int32(&sel_doubled, &[1, 1, 1, head_dim])?;
+    let indices = MxArray::broadcast_to(&indices, &[1, batch_size, seq_len, head_dim])?;
+
+    let cos_sel = cos.take_along_axis(&indices, 0)?; // [1, batch, seq, head_dim]
+    let sin_sel = sin.take_along_axis(&indices, 0)?;
+
+    // [1, batch, seq, head_dim] -> [batch, 1, seq, head_dim] (flat order preserved).
+    let cos_final = cos_sel.reshape(&[batch_size, 1, seq_len, head_dim])?;
+    let sin_final = sin_sel.reshape(&[batch_size, 1, seq_len, head_dim])?;
+
+    // Standard rotate_half application (identical to the sectioned path tail).
+    let rotary_dim = head_dim;
+    let q_shape = q.shape()?; // 1 FFI call
+    let q_dim = q_shape[3];
+    let q_ndim = q_shape.len();
+
+    let q_rot = q.slice_axis(3, 0, rotary_dim)?;
+    let q_pass = if rotary_dim < q_dim {
+        Some(q.slice_axis(3, rotary_dim, q_dim)?)
+    } else {
+        None
+    };
+
+    let k_rot = k.slice_axis(3, 0, rotary_dim)?;
+    let k_pass = if rotary_dim < q_dim {
+        Some(k.slice_axis(3, rotary_dim, q_dim)?)
+    } else {
+        None
+    };
+
+    let q_rotated = rotate_half(&q_rot, q_ndim, rotary_dim)?;
+    let k_rotated = rotate_half(&k_rot, q_ndim, rotary_dim)?;
+
+    let q_embed = q_rot.mul(&cos_final)?.add(&q_rotated.mul(&sin_final)?)?;
+    let k_embed = k_rot.mul(&cos_final)?.add(&k_rotated.mul(&sin_final)?)?;
+
+    let q_out = if let Some(q_pass) = q_pass {
+        MxArray::concatenate_many(vec![&q_embed, &q_pass], Some(-1))?
+    } else {
+        q_embed
+    };
+
+    let k_out = if let Some(k_pass) = k_pass {
+        MxArray::concatenate_many(vec![&k_embed, &k_pass], Some(-1))?
+    } else {
+        k_embed
+    };
+
+    Ok((q_out, k_out))
+}
+
 /// PaddleOCR Attention with mRoPE (internal)
 ///
 /// Note: This is an internal implementation detail used by PaddleOCRDecoderLayer.
@@ -1070,6 +1182,107 @@ mod tests {
         );
 
         assert!(layer.is_ok());
+    }
+
+    #[test]
+    fn test_interleaved_selection_axis_assignment() {
+        // Interleaved selector correctness (PRIMARY qwen3_5-VL fix).
+        //
+        // rotary head_dim = 12 -> half_dim = 6; mrope_section = [3, 2, 1].
+        // mlx-vlm _interleaved_position_selector([3,2,1], freq_dim=6):
+        //   dim=1 (height) offset 1: idx 1, 4 (range(1, min(2*3,6)=6, 3))      -> 1
+        //   dim=2 (width)  offset 2: idx 2    (range(2, min(1*3,6)=3, 3))      -> 2
+        //   everything else                                                    -> 0
+        //   => sel_half = [0, 1, 2, 0, 1, 0]
+        // Doubled across emb=concat([f,f]): sel_doubled = sel_half ++ sel_half.
+        //
+        // Mark each axis row with its index (cos[axis, .., j] = axis), set sin = 0
+        // and q = ones, so q_out[j] = q_rot * cos_final = cos_final = sel_doubled[j].
+        let head_dim = 12i64;
+        let mut cos_data = Vec::with_capacity(3 * head_dim as usize);
+        for axis in 0..3 {
+            for _ in 0..head_dim {
+                cos_data.push(axis as f32);
+            }
+        }
+        let cos = MxArray::from_float32(&cos_data, &[3, 1, 1, head_dim]).unwrap();
+        let sin = MxArray::zeros(&[3, 1, 1, head_dim], Some(DType::Float32)).unwrap();
+        let q = MxArray::ones(&[1, 1, 1, head_dim], Some(DType::Float32)).unwrap();
+        let k = MxArray::ones(&[1, 1, 1, head_dim], Some(DType::Float32)).unwrap();
+
+        let (q_out, _k_out) =
+            apply_multimodal_rotary_pos_emb_interleaved(&q, &k, &cos, &sin, vec![3, 2, 1]).unwrap();
+
+        let expected: [f32; 12] = [
+            0.0, 1.0, 2.0, 0.0, 1.0, 0.0, // sel_half
+            0.0, 1.0, 2.0, 0.0, 1.0, 0.0, // mirrored
+        ];
+        let got = q_out.to_float32().unwrap();
+        assert_eq!(got.as_ref(), &expected[..]);
+    }
+
+    #[test]
+    fn test_interleaved_text_invariance() {
+        // Hard gate / safety net: for TEXT tokens (temporal == height == width)
+        // the interleaved apply MUST be bit-identical to the existing sectioned
+        // apply, proving the text path cannot regress.
+        //
+        // Realistic qwen3_5 rotary geometry: rope_dims = 64 -> half_dim = 32,
+        // mrope_section = [11, 11, 10] (sum 32). cos/sin are built from a real
+        // MultimodalRoPE forward over position_ids whose three axes are EQUAL.
+        let rope_dims = 64i32;
+        let mrope =
+            MultimodalRoPE::new(rope_dims, 4096, Some(100_000.0), vec![11, 11, 10]).unwrap();
+
+        let seq_len = 5i64;
+        // position_ids [3, 1, seq] with all three (t, h, w) rows equal.
+        let mut pos_data = Vec::with_capacity(3 * seq_len as usize);
+        for _ in 0..3 {
+            for p in 0..seq_len {
+                pos_data.push(p as f32);
+            }
+        }
+        let pos = MxArray::from_float32(&pos_data, &[3, 1, seq_len]).unwrap();
+
+        // x supplies only the target dtype.
+        let x = MxArray::zeros(&[1, seq_len, rope_dims as i64], Some(DType::Float32)).unwrap();
+        let (cos, sin) = mrope.forward(&x, &pos).unwrap();
+
+        // Q/K head_dim = 96 > rope_dims = 64 to exercise the partial-rotary
+        // pass-through path that qwen3_5 uses.
+        let head_dim = 96i64;
+        let heads = 2i64;
+        let q = MxArray::random_uniform(
+            &[1, heads, seq_len, head_dim],
+            0.0,
+            1.0,
+            Some(DType::Float32),
+        )
+        .unwrap();
+        let k = MxArray::random_uniform(
+            &[1, heads, seq_len, head_dim],
+            0.0,
+            1.0,
+            Some(DType::Float32),
+        )
+        .unwrap();
+
+        let (q_sec, k_sec) =
+            apply_multimodal_rotary_pos_emb(&q, &k, &cos, &sin, vec![11, 11, 10]).unwrap();
+        let (q_int, k_int) =
+            apply_multimodal_rotary_pos_emb_interleaved(&q, &k, &cos, &sin, vec![11, 11, 10])
+                .unwrap();
+
+        assert_eq!(
+            q_sec.to_float32().unwrap().as_ref(),
+            q_int.to_float32().unwrap().as_ref(),
+            "interleaved Q must equal sectioned Q for text tokens (t==h==w)"
+        );
+        assert_eq!(
+            k_sec.to_float32().unwrap().as_ref(),
+            k_int.to_float32().unwrap().as_ref(),
+            "interleaved K must equal sectioned K for text tokens (t==h==w)"
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/models/paddleocr_vl/mod.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/mod.rs
@@ -13,7 +13,9 @@ pub mod processing;
 pub mod vision;
 
 // Re-export public items used cross-module
-pub use language::{MultimodalRoPE, apply_multimodal_rotary_pos_emb};
+pub use language::{
+    MultimodalRoPE, apply_multimodal_rotary_pos_emb, apply_multimodal_rotary_pos_emb_interleaved,
+};
 pub use persistence::load_paddleocr_vl_weights;
 pub use processing::{
     ImageProcessorConfig, ProcessedImage, ProcessedImages, aggregate_processed_images, smart_resize,

--- a/crates/mlx-core/src/models/paddleocr_vl/vision.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/vision.rs
@@ -37,7 +37,7 @@ impl PaddleOCRVisionEmbeddings {
         patch_weight: &MxArray,
         position_weight: &MxArray,
     ) -> Result<Self> {
-        let patch_embedding = PatchEmbedding::new(patch_size, patch_weight)?;
+        let patch_embedding = PatchEmbedding::new(patch_size, patch_weight, None)?;
 
         let num_patches = (image_size / patch_size).pow(2);
         let position_embedding =

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -294,6 +294,7 @@ impl Qwen3_5Attention {
         cached_prefix_len: u32,
         is_prefill: bool,
         position_ids: Option<&MxArray>,
+        rope_position_offset: i32,
     ) -> Result<MxArray> {
         let batch = x.shape_at(0)?;
         let seq_len = x.shape_at(1)?;
@@ -355,7 +356,14 @@ impl Qwen3_5Attention {
             let k_out = k_out.transpose(Some(&[0, 2, 1, 3]))?;
             (q_out, k_out)
         } else {
-            let rope_offset = first_logical_position as i32;
+            // Scalar-offset RoPE. `rope_position_offset` decouples the
+            // rotation position from the physical KV slot: a turn that
+            // warm-continues an image prefill rotates at the compressed
+            // M-RoPE position (physical slot + a negative cross-turn delta)
+            // while K/V still writes at the physical slot below. Text turns
+            // pass `rope_position_offset == first_logical_position as i32`,
+            // so this stays byte-identical to the prior behaviour.
+            let rope_offset = rope_position_offset;
             let queries = self.rope.forward(&queries, Some(rope_offset))?;
             let keys = self.rope.forward(&keys, Some(rope_offset))?;
             (queries, keys)

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -7,7 +7,9 @@ use crate::array::mask::create_causal_mask;
 use crate::inference_trace::{
     elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
 };
-use crate::models::paddleocr_vl::language::{MultimodalRoPE, apply_multimodal_rotary_pos_emb};
+use crate::models::paddleocr_vl::language::{
+    MultimodalRoPE, apply_multimodal_rotary_pos_emb_interleaved,
+};
 use crate::nn::{Activations, Linear, RMSNorm, RoPE};
 use crate::transformer::KVCache;
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
@@ -187,12 +189,14 @@ impl Qwen3_5Attention {
 
         // Apply RoPE: either M-RoPE (VLM) or standard scalar offset (text-only)
         let (queries, keys) = if let (Some(pos_ids), Some(mrope)) = (position_ids, &self.mrope) {
-            // M-RoPE: compute cos/sin from 3D position IDs [3, B, T]
+            // M-RoPE: compute cos/sin from 3D position IDs [3, B, T].
+            // Qwen3.5-VL uses the INTERLEAVED (stride-3) per-frequency axis
+            // selector, NOT PaddleOCR-VL's contiguous-chunk (sectioned) one.
             let (cos, sin) = mrope.forward(&queries, pos_ids)?;
-            // Transpose to [B, H, T, D] for apply_multimodal_rotary_pos_emb
+            // Transpose to [B, H, T, D] for the rotary apply.
             let q_t = queries.transpose(Some(&[0, 2, 1, 3]))?;
             let k_t = keys.transpose(Some(&[0, 2, 1, 3]))?;
-            let (q_out, k_out) = apply_multimodal_rotary_pos_emb(
+            let (q_out, k_out) = apply_multimodal_rotary_pos_emb_interleaved(
                 &q_t,
                 &k_t,
                 &cos,
@@ -335,10 +339,12 @@ impl Qwen3_5Attention {
         // the `None` (text-only) arm matches the flat path's scalar-offset
         // behaviour.
         let (queries, keys) = if let (Some(pos_ids), Some(mrope)) = (position_ids, &self.mrope) {
+            // Qwen3.5-VL uses the INTERLEAVED (stride-3) per-frequency axis
+            // selector, NOT PaddleOCR-VL's contiguous-chunk (sectioned) one.
             let (cos, sin) = mrope.forward(&queries, pos_ids)?;
             let q_t = queries.transpose(Some(&[0, 2, 1, 3]))?;
             let k_t = keys.transpose(Some(&[0, 2, 1, 3]))?;
-            let (q_out, k_out) = apply_multimodal_rotary_pos_emb(
+            let (q_out, k_out) = apply_multimodal_rotary_pos_emb_interleaved(
                 &q_t,
                 &k_t,
                 &cos,

--- a/crates/mlx-core/src/models/qwen3_5/decoder_layer.rs
+++ b/crates/mlx-core/src/models/qwen3_5/decoder_layer.rs
@@ -275,6 +275,7 @@ impl DecoderLayer {
         flat_cache: Option<&mut Qwen3_5LayerCache>,
         position_ids: Option<&MxArray>,
         use_kernel: bool,
+        rope_position_offset: i32,
     ) -> Result<MxArray> {
         match kind {
             Qwen3_5LayerKind::Linear => {
@@ -283,6 +284,7 @@ impl DecoderLayer {
                 let _ = first_logical_position;
                 let _ = cached_prefix_len;
                 let _ = is_prefill;
+                let _ = rope_position_offset;
                 if !matches!(self.attn, AttentionType::Linear(_)) {
                     return Err(Error::from_reason(
                         "Qwen3_5DecoderLayer::forward_paged_or_flat: kind=Linear applied to a \
@@ -316,6 +318,7 @@ impl DecoderLayer {
                     cached_prefix_len,
                     is_prefill,
                     position_ids,
+                    rope_position_offset,
                 )?;
                 // Residual.
                 let h = x.add(&attn_out)?;
@@ -349,6 +352,7 @@ impl DecoderLayer {
         is_prefill: bool,
         flat_cache: Option<&mut Qwen3_5LayerCache>,
         tape_sink: Option<&mut Option<super::gated_delta_net::GdnLayerTape>>,
+        rope_position_offset: i32,
     ) -> Result<MxArray> {
         match kind {
             Qwen3_5LayerKind::Linear => {
@@ -356,6 +360,7 @@ impl DecoderLayer {
                 let _ = first_logical_position;
                 let _ = cached_prefix_len;
                 let _ = is_prefill;
+                let _ = rope_position_offset;
                 if !matches!(self.attn, AttentionType::Linear(_)) {
                     return Err(Error::from_reason(
                         "Qwen3_5DecoderLayer::forward_paged_or_flat_with_tape: kind=Linear applied \
@@ -380,8 +385,12 @@ impl DecoderLayer {
                     }
                 };
                 let normed = self.input_layernorm.forward(x)?;
-                // MTP tape forwards are text-only (image-bearing MTP+paged turns
-                // are rejected upstream), so the scalar-offset RoPE path is used.
+                // MTP tape forwards always carry M-RoPE positions as `None`
+                // (the K+1 verify ids are re-embedded, not image features), so
+                // RoPE takes the scalar-offset path. `rope_position_offset`
+                // still carries any cross-turn delta: a text turn that
+                // warm-continues an image prefill runs paged MTP and must
+                // rotate at the compressed position, not the physical slot.
                 let attn_out = attn.forward_paged(
                     &normed,
                     adapter,
@@ -390,6 +399,7 @@ impl DecoderLayer {
                     cached_prefix_len,
                     is_prefill,
                     None,
+                    rope_position_offset,
                 )?;
                 let h = x.add(&attn_out)?;
                 let normed = self.post_attention_layernorm.forward(&h)?;

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2419,7 +2419,14 @@ impl Qwen35Inner {
         let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        // Reset the cross-turn M-RoPE delta only on a fresh/miss turn. On a
+        // warm continuation (cached_prefix_len > 0) the delta baked in by the
+        // earlier image prefill must survive so the text suffix prefill +
+        // decode keep rotating at the compressed position rather than the
+        // physical slot.
+        if cached_prefix_len == 0 {
+            self.cached_rope_deltas = None;
+        }
 
         let suffix_len = prompt_token_count
             .checked_sub(cached_prefix_len)
@@ -2589,6 +2596,10 @@ impl Qwen35Inner {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason("paged_turn_sync_core_inner: paged_adapter dropped")
             })?;
+            // Cross-turn M-RoPE delta (0 unless this text turn warm-continues
+            // an image prefill). Feeds the scalar-offset RoPE so the suffix
+            // keys stay aligned with the compressed-position image keys.
+            let rope_deltas = self.cached_rope_deltas.unwrap_or(0);
             if want_prompt_hidden {
                 let (logits, ph) = super::paged_forward::run_paged_prefill_chunk_with_hidden(
                     tokens,
@@ -2604,6 +2615,7 @@ impl Qwen35Inner {
                     &layer_kinds,
                     adapter,
                     Some(mtp_prompt_history.keep_tokens),
+                    rope_deltas,
                 )?;
                 prompt_hidden = Some(ph);
                 logits
@@ -2621,6 +2633,7 @@ impl Qwen35Inner {
                     &embedding_weight,
                     &layer_kinds,
                     adapter,
+                    rope_deltas,
                 )?
             }
         };
@@ -2778,6 +2791,7 @@ impl Qwen35Inner {
                     &embedding_weight,
                     &layer_kinds,
                     adapter,
+                    self.cached_rope_deltas.unwrap_or(0),
                 )?;
                 logits.squeeze(Some(&[1]))?
             };
@@ -2809,8 +2823,10 @@ impl Qwen35Inner {
     /// autoregressive decode loop.
     ///
     /// SINGLE-TURN ONLY: the adapter is cold-started (no cache-hit, no warm
-    /// continue) and decode uses the scalar-offset RoPE path (the physical
-    /// token count), matching the flat path's decode RoPE. This core runs plain
+    /// continue) and decode rotates at the physical token count plus the
+    /// cached M-RoPE delta (`cached_rope_deltas`), i.e. the compressed M-RoPE
+    /// position for image turns; text turns carry a delta of 0 and stay
+    /// byte-identical to the flat path's decode RoPE. This core runs plain
     /// autoregressive decode with no draft/verify; MTP weights are ignored, so
     /// an MTP-enabled session's image turns route here and decode as AR.
     #[allow(clippy::too_many_arguments)]
@@ -2908,7 +2924,10 @@ impl Qwen35Inner {
         }
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        // Store the image prefill's compressed-position delta so a later text
+        // warm-continuation rotates its queries at the same compressed M-RoPE
+        // positions the image keys were written with.
+        self.cached_rope_deltas = Some(merge.rope_deltas as i32);
 
         // Fresh per-layer caches (GDN linear slots + empty full-attention slots).
         let new_caches = (0..self.config.num_layers as usize)
@@ -3010,6 +3029,7 @@ impl Qwen35Inner {
                         &embedding_weight,
                         &layer_kinds,
                         adapter,
+                        self.cached_rope_deltas.unwrap_or(0),
                     )?;
                     logits.squeeze(Some(&[1]))?
                 };
@@ -3234,7 +3254,10 @@ impl Qwen35Inner {
         }
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        // Store the image prefill's compressed-position delta so a later text
+        // warm-continuation rotates its queries at the same compressed M-RoPE
+        // positions the image keys were written with.
+        self.cached_rope_deltas = Some(merge.rope_deltas as i32);
 
         let new_caches = (0..self.config.num_layers as usize)
             .map(|i| {
@@ -3370,6 +3393,7 @@ impl Qwen35Inner {
                         &embedding_weight,
                         &layer_kinds,
                         adapter,
+                        self.cached_rope_deltas.unwrap_or(0),
                     )?;
                     logits.squeeze(Some(&[1]))?
                 };
@@ -3668,7 +3692,12 @@ impl Qwen35Inner {
         let gdn_prefix_state = gdn_prefix_preparation.state;
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        // Reset the cross-turn M-RoPE delta only on a fresh/miss turn; preserve
+        // it on a warm continuation so the image prefill's compressed-position
+        // rotation carries into the text suffix prefill + decode.
+        if cached_prefix_len == 0 {
+            self.cached_rope_deltas = None;
+        }
 
         let suffix_len = prompt_token_count
             .checked_sub(cached_prefix_len)
@@ -3905,6 +3934,9 @@ impl Qwen35Inner {
             let adapter = self.paged_adapter.as_mut().ok_or_else(|| {
                 Error::from_reason("paged_turn_stream_core_inner: paged_adapter dropped")
             })?;
+            // Cross-turn M-RoPE delta (0 unless this text turn warm-continues
+            // an image prefill); feeds the scalar-offset RoPE for the suffix.
+            let rope_deltas = self.cached_rope_deltas.unwrap_or(0);
             if want_prompt_hidden {
                 let (logits, ph) = super::paged_forward::run_paged_prefill_chunk_with_hidden(
                     tokens,
@@ -3920,6 +3952,7 @@ impl Qwen35Inner {
                     &layer_kinds,
                     adapter,
                     Some(mtp_prompt_history.keep_tokens),
+                    rope_deltas,
                 )?;
                 prompt_hidden = Some(ph);
                 logits
@@ -3937,6 +3970,7 @@ impl Qwen35Inner {
                     &embedding_weight,
                     &layer_kinds,
                     adapter,
+                    rope_deltas,
                 )?
             }
         };
@@ -4115,6 +4149,7 @@ impl Qwen35Inner {
                     &embedding_weight,
                     &layer_kinds,
                     adapter,
+                    self.cached_rope_deltas.unwrap_or(0),
                 )?;
                 logits.squeeze(Some(&[1]))?
             };
@@ -6524,6 +6559,7 @@ impl DecodeStep for Qwen35PagedDecode<'_> {
                 &embedding_weight,
                 &layer_kinds,
                 adapter,
+                self.inner.cached_rope_deltas.unwrap_or(0),
             )?
             .squeeze(Some(&[1]))?
         };
@@ -6690,11 +6726,16 @@ impl PagedBackend for Qwen35Inner {
         )?;
         let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         // Clear the per-turn session state here (history is re-set in
-        // `save_paged_history`; rope deltas + image key are reset because the
-        // paged path does not carry them across turns).
+        // `save_paged_history`; image key is reset because the paged path does
+        // not carry it across turns). The cross-turn M-RoPE delta, however, IS
+        // carried on a warm continuation: a text turn that warm-continues an
+        // image prefill must keep rotating at the compressed position, so the
+        // delta is reset only on a fresh/miss turn (cached_prefix_len == 0).
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        if cached_prefix_len == 0 {
+            self.cached_rope_deltas = None;
+        }
 
         let suffix_len = total_budget.checked_sub(cached_prefix_len).ok_or_else(|| {
             Error::from_reason("prime_prefix_state: cached_prefix_len > total_prompt_tokens")
@@ -6728,6 +6769,10 @@ impl PagedBackend for Qwen35Inner {
             });
         let embed = self.embedding.clone();
         let embedding_weight = embed.get_weight();
+        // Cross-turn M-RoPE delta (0 unless this engine-driven text turn warm-
+        // continues an image prefill); aligns the suffix keys with the
+        // compressed-position image keys.
+        let rope_deltas = self.cached_rope_deltas.unwrap_or(0);
         let caches_ref = self
             .caches
             .as_mut()
@@ -6749,6 +6794,7 @@ impl PagedBackend for Qwen35Inner {
             &embedding_weight,
             &layer_kinds,
             adapter,
+            rope_deltas,
         )
     }
 
@@ -7217,6 +7263,9 @@ impl MtpStepper for DenseMtpStepper<'_> {
                 ids.eval();
                 let token_id = ids.item_at_int32(0)? as u32;
                 let inner = &mut *self.inner;
+                // Cross-turn M-RoPE delta carried by a text turn that warm-
+                // continues an image prefill; 0 for pure-text sessions.
+                let rope_deltas = inner.cached_rope_deltas.unwrap_or(0);
                 let caches = inner.caches.as_mut().ok_or_else(|| {
                     Error::from_reason("eager paged MTP forward_with_hidden: caches is None")
                 })?;
@@ -7231,6 +7280,7 @@ impl MtpStepper for DenseMtpStepper<'_> {
                     Some(&self.embedding_weight_t),
                     &self.layer_kinds,
                     adapter,
+                    rope_deltas,
                 )?;
                 Ok((logits, hidden, true))
             }
@@ -7307,6 +7357,9 @@ impl MtpStepper for DenseMtpStepper<'_> {
                 let id_slice: Vec<i32> = id_window.iter().take(depth + 1).copied().collect();
                 let verify_in = MxArray::from_int32(&id_slice, &[1, (depth + 1) as i64])?;
                 let inner = &mut *self.inner;
+                // Cross-turn M-RoPE delta carried by a text turn that warm-
+                // continues an image prefill; 0 for pure-text sessions.
+                let rope_deltas = inner.cached_rope_deltas.unwrap_or(0);
                 let caches = inner.caches.as_mut().ok_or_else(|| {
                     Error::from_reason("eager paged MTP verify_step: caches is None")
                 })?;
@@ -7323,6 +7376,7 @@ impl MtpStepper for DenseMtpStepper<'_> {
                     &self.layer_kinds,
                     adapter,
                     tape,
+                    rope_deltas,
                 )
             }
         }
@@ -9170,7 +9224,16 @@ pub(crate) fn get_rope_index(
 
     let position_ids = MxArray::stack(vec![&t_arr, &h_arr, &w_arr], Some(0))?;
 
-    let max_position = *all_position_ids[0].iter().max().unwrap_or(&0);
+    // Decode offset must reference the GLOBAL max M-RoPE position, i.e. the max
+    // over all three (t, h, w) axes — matching mlx-vlm's `llm_positions.max()`.
+    // For an image the spatial (h, w) axes exceed the temporal one, so an
+    // image-final prompt (no trailing text) would get a too-small delta if only
+    // axis 0 were considered.
+    let max_position = all_position_ids
+        .iter()
+        .flat_map(|axis| axis.iter().copied())
+        .max()
+        .unwrap_or(0);
     let rope_deltas = max_position + 1 - seq_len;
 
     Ok((position_ids, rope_deltas))
@@ -9338,6 +9401,7 @@ pub(crate) fn vlm_prepare_vision_features(
     Ok(VisionMerge {
         inputs_embeds,
         position_ids,
+        rope_deltas,
     })
 }
 
@@ -9488,7 +9552,7 @@ mod rope_index_tests {
             .copied()
             .collect();
         let (ids, grid) = mk_inputs(&tokens, &[(2, 4, 4)]);
-        let (pos, _) = get_rope_index(&ids, grid.as_ref(), 2, IMG).unwrap();
+        let (pos, rope_deltas) = get_rope_index(&ids, grid.as_ref(), 2, IMG).unwrap();
         let (t, h, w) = extract_positions(&pos);
         // Leading text
         assert_eq!(&t[..2], &[0, 1]);
@@ -9499,6 +9563,61 @@ mod rope_index_tests {
         assert_eq!(&t[10..], &[4, 5]);
         assert_eq!(&h[10..], &[4, 5]);
         assert_eq!(&w[10..], &[4, 5]);
+
+        // The image run compresses 8 placeholder tokens into 4 distinct
+        // temporal positions, so the running M-RoPE counter lags the physical
+        // sequence length: `rope_deltas = max_position + 1 - seq_len` MUST be
+        // negative. This is the per-session delta the paged decode/warm-
+        // continuation path adds to the physical KV slot to recover the
+        // compressed rotation position; previously it was dropped, leaving
+        // image-turn decode rotating ~|delta| positions too far ahead.
+        let max_position = *t.iter().max().unwrap() as i64; // temporal axis (axis 0)
+        let seq_len = tokens.len() as i64;
+        assert_eq!(rope_deltas, max_position + 1 - seq_len);
+        assert!(
+            rope_deltas < 0,
+            "image prefill must compress positions (rope_deltas={rope_deltas})"
+        );
+        // 2 text + 8 image (compressed to positions 2..=3) + 2 text → max
+        // temporal position 5 over 12 tokens → delta = 5 + 1 - 12 = -6.
+        assert_eq!(rope_deltas, -6);
+    }
+
+    #[test]
+    fn image_final_prompt_delta_uses_global_max_axis() {
+        // An image-FINAL prompt (no trailing text) exposes which axis feeds the
+        // decode delta: the spatial (h, w) axes outrun the temporal one, so the
+        // global max M-RoPE position lives on a spatial axis. The delta must use
+        // that global max (mlx-vlm `llm_positions.max()`), NOT the temporal axis
+        // alone — otherwise the first generated token rotates at a position
+        // INSIDE the image's spatial range instead of at global_max + 1.
+        let _g = mlx_lock().lock().unwrap();
+        // 1 text + (grid 1x4x4, spatial_merge=2 → llm grid t=1,h=2,w=2 = 4 image
+        // tokens) and NOTHING after the image.
+        let tokens: Vec<i32> = std::iter::once(TEXT_A)
+            .chain(std::iter::repeat_n(IMG, 4))
+            .collect();
+        let (ids, grid) = mk_inputs(&tokens, &[(1, 4, 4)]);
+        let (pos, rope_deltas) = get_rope_index(&ids, grid.as_ref(), 2, IMG).unwrap();
+        let (t, h, w) = extract_positions(&pos);
+
+        let t_max = *t.iter().max().unwrap() as i64;
+        let global_max = *t.iter().chain(&h).chain(&w).max().unwrap() as i64;
+        let seq_len = tokens.len() as i64;
+
+        // The spatial axes must outrun the temporal one here, else the test
+        // would not distinguish the global-max fix from the axis-0 regression.
+        assert!(
+            global_max > t_max,
+            "test grid is not asymmetric: global_max={global_max} t_max={t_max}"
+        );
+        // The delta references the GLOBAL max, not the temporal-axis max.
+        assert_eq!(rope_deltas, global_max + 1 - seq_len);
+        assert_ne!(
+            rope_deltas,
+            t_max + 1 - seq_len,
+            "delta must not use the temporal axis alone (axis-0 regression)"
+        );
     }
 
     #[test]
@@ -9944,6 +10063,7 @@ mod paged_construction_tests {
             &layer_kinds,
             adapter,
             chunk_size,
+            /* cached_rope_deltas */ 0,
         )
     }
 

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -2419,14 +2419,15 @@ impl Qwen35Inner {
         let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        // Reset the cross-turn M-RoPE delta only on a fresh/miss turn. On a
-        // warm continuation (cached_prefix_len > 0) the delta baked in by the
-        // earlier image prefill must survive so the text suffix prefill +
-        // decode keep rotating at the compressed position rather than the
-        // physical slot.
-        if cached_prefix_len == 0 {
-            self.cached_rope_deltas = None;
-        }
+        // Carry the cross-turn M-RoPE delta only when this turn extends the live
+        // image sequence (continued_live_prefix). A cold start OR a non-live
+        // prefix-cache hit (cached_prefix_len > 0 but not a live continuation)
+        // can only restore pure-text prefix blocks, so a stale image delta is
+        // dropped and the text suffix rotates at the raw physical slot.
+        self.cached_rope_deltas = super::paged_forward::rope_delta_for_paged_turn(
+            self.cached_rope_deltas,
+            continued_live_prefix,
+        );
 
         let suffix_len = prompt_token_count
             .checked_sub(cached_prefix_len)
@@ -3692,12 +3693,14 @@ impl Qwen35Inner {
         let gdn_prefix_state = gdn_prefix_preparation.state;
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        // Reset the cross-turn M-RoPE delta only on a fresh/miss turn; preserve
-        // it on a warm continuation so the image prefill's compressed-position
-        // rotation carries into the text suffix prefill + decode.
-        if cached_prefix_len == 0 {
-            self.cached_rope_deltas = None;
-        }
+        // Carry the cross-turn M-RoPE delta only when this turn extends the live
+        // image sequence (continued_live_prefix); a cold start or a non-live
+        // prefix-cache hit (text-only prefix) drops a stale image delta so the
+        // text suffix prefill + decode rotate at the raw physical slot.
+        self.cached_rope_deltas = super::paged_forward::rope_delta_for_paged_turn(
+            self.cached_rope_deltas,
+            continued_live_prefix,
+        );
 
         let suffix_len = prompt_token_count
             .checked_sub(cached_prefix_len)
@@ -6727,15 +6730,17 @@ impl PagedBackend for Qwen35Inner {
         let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         // Clear the per-turn session state here (history is re-set in
         // `save_paged_history`; image key is reset because the paged path does
-        // not carry it across turns). The cross-turn M-RoPE delta, however, IS
-        // carried on a warm continuation: a text turn that warm-continues an
-        // image prefill must keep rotating at the compressed position, so the
-        // delta is reset only on a fresh/miss turn (cached_prefix_len == 0).
+        // not carry it across turns). The cross-turn M-RoPE delta is carried
+        // only when this turn extends the live image sequence
+        // (continued_live_prefix); a cold start or a non-live prefix-cache hit
+        // (text-only prefix) drops a stale image delta so the text suffix
+        // rotates at the raw physical slot.
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        if cached_prefix_len == 0 {
-            self.cached_rope_deltas = None;
-        }
+        self.cached_rope_deltas = super::paged_forward::rope_delta_for_paged_turn(
+            self.cached_rope_deltas,
+            continued_live_prefix,
+        );
 
         let suffix_len = total_budget.checked_sub(cached_prefix_len).ok_or_else(|| {
             Error::from_reason("prime_prefix_state: cached_prefix_len > total_prompt_tokens")

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -52,6 +52,24 @@ fn bytes_to_mib(bytes: f64) -> f64 {
     bytes / (1024.0 * 1024.0)
 }
 
+/// Compute the scalar RoPE rotation offset for a paged forward step, decoupling
+/// the rotation position from the physical KV slot.
+///
+/// Image turns compress their ~hundreds of placeholder tokens into far fewer
+/// M-RoPE positions, so the running M-RoPE position trails the physical token
+/// count by `cached_rope_deltas` (negative). The paged pool still writes K/V at
+/// the PHYSICAL slot, but the query/key rotation must use the compressed
+/// position so a warm-continuation query lines up with the image-compressed
+/// keys it attends over. Text-only turns carry `cached_rope_deltas == 0`, so
+/// the result is the physical position unchanged (byte-identical to the prior
+/// behaviour).
+///
+/// `physical_position` is cast to `i32` BEFORE adding the (possibly negative)
+/// delta so the arithmetic never underflows a `u32`.
+pub(crate) fn paged_rope_offset(physical_position: u32, cached_rope_deltas: i32) -> i32 {
+    physical_position as i32 + cached_rope_deltas
+}
+
 fn trace_memory_mib() -> (f64, f64, f64) {
     (
         bytes_to_mib(crate::array::get_active_memory()),
@@ -122,6 +140,7 @@ pub(crate) fn run_paged_prefill_chunk(
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     let chunk_size = crate::array::paged_prefill_chunk_size();
     run_paged_prefill_chunk_with_size(
@@ -138,6 +157,7 @@ pub(crate) fn run_paged_prefill_chunk(
         layer_kinds,
         paged_adapter,
         chunk_size,
+        cached_rope_deltas,
     )
 }
 
@@ -163,6 +183,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
     chunk_size: i32,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     if suffix_tokens.is_empty() {
         return Err(Error::from_reason(
@@ -184,6 +205,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
             embedding_weight,
             layer_kinds,
             paged_adapter,
+            cached_rope_deltas,
         );
     }
 
@@ -232,6 +254,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
             paged_adapter,
             /* inputs_embeds */ None,
             /* position_ids */ None,
+            cached_rope_deltas,
         )?;
 
         if is_last_chunk {
@@ -312,6 +335,7 @@ fn run_paged_prefill_single_shot(
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     paged_adapter
         .record_tokens(suffix_tokens)
@@ -332,6 +356,7 @@ fn run_paged_prefill_single_shot(
         paged_adapter,
         /* inputs_embeds */ None,
         /* position_ids */ None,
+        cached_rope_deltas,
     )?;
 
     project_last_token_logits(&hidden_states, final_norm, lm_head, embedding_weight)
@@ -385,6 +410,10 @@ pub(crate) fn run_paged_vlm_prefill(
         paged_adapter,
         Some(&merge.inputs_embeds),
         Some(&merge.position_ids),
+        // Image prefill drives full-attention layers through the 3-row M-RoPE
+        // arm (`position_ids` is `Some`), so the scalar offset is unused here.
+        /* cached_rope_deltas */
+        0,
     )?;
 
     project_last_token_logits(&hidden_states, final_norm, lm_head, embedding_weight)
@@ -419,6 +448,7 @@ pub(crate) fn run_paged_prefill_chunk_with_hidden(
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
     keep_last_hidden: Option<usize>,
+    cached_rope_deltas: i32,
 ) -> Result<(MxArray, MxArray)> {
     let chunk_size = crate::array::paged_prefill_chunk_size();
     run_paged_prefill_chunk_with_hidden_with_size(
@@ -436,6 +466,7 @@ pub(crate) fn run_paged_prefill_chunk_with_hidden(
         paged_adapter,
         chunk_size,
         keep_last_hidden,
+        cached_rope_deltas,
     )
 }
 
@@ -455,6 +486,7 @@ fn run_paged_prefill_chunk_with_hidden_with_size(
     paged_adapter: &mut PagedKVCacheAdapter,
     chunk_size: i32,
     keep_last_hidden: Option<usize>,
+    cached_rope_deltas: i32,
 ) -> Result<(MxArray, MxArray)> {
     if suffix_tokens.is_empty() {
         return Err(Error::from_reason(
@@ -477,6 +509,7 @@ fn run_paged_prefill_chunk_with_hidden_with_size(
             layer_kinds,
             paged_adapter,
             keep_last_hidden,
+            cached_rope_deltas,
         );
     }
 
@@ -517,6 +550,7 @@ fn run_paged_prefill_chunk_with_hidden_with_size(
             paged_adapter,
             /* inputs_embeds */ None,
             /* position_ids */ None,
+            cached_rope_deltas,
         )?;
 
         let chunk_hidden = if overlaps_kept_tail || is_last_chunk {
@@ -605,6 +639,7 @@ fn run_paged_prefill_single_shot_with_hidden(
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
     keep_last_hidden: Option<usize>,
+    cached_rope_deltas: i32,
 ) -> Result<(MxArray, MxArray)> {
     paged_adapter
         .record_tokens(suffix_tokens)
@@ -625,6 +660,7 @@ fn run_paged_prefill_single_shot_with_hidden(
         paged_adapter,
         /* inputs_embeds */ None,
         /* position_ids */ None,
+        cached_rope_deltas,
     )?;
 
     project_last_token_logits_with_full_hidden(
@@ -655,6 +691,7 @@ fn run_paged_prefill_one_chunk(
     paged_adapter: &mut PagedKVCacheAdapter,
     inputs_embeds: Option<&MxArray>,
     position_ids: Option<&MxArray>,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     debug_assert_eq!(layers.len(), caches.len());
     debug_assert_eq!(layers.len(), layer_kinds.len());
@@ -667,6 +704,14 @@ fn run_paged_prefill_one_chunk(
             embed.forward(&input_ids)?
         }
     };
+
+    // Scalar-offset RoPE position for this chunk's queries/keys. For a text
+    // suffix that warm-continues an image prefill, the rotation must trail the
+    // physical slot by the negative cross-turn delta so the suffix keys stay
+    // consistent with the immutable compressed-M-RoPE image keys. Text-only
+    // prefill carries `cached_rope_deltas == 0` (offset == physical position),
+    // and image prefill uses the M-RoPE arm so this is ignored there.
+    let rope_position_offset = paged_rope_offset(chunk_first_position, cached_rope_deltas);
 
     for (layer_idx, ((layer, cache_slot), kind)) in layers
         .iter_mut()
@@ -691,6 +736,7 @@ fn run_paged_prefill_one_chunk(
             Some(cache_slot),
             layer_positions,
             /* use_kernel */ true,
+            rope_position_offset,
         )?;
         crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states)?;
     }
@@ -776,6 +822,7 @@ pub(crate) fn run_paged_decode_step(
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     // Capture logical position BEFORE record_tokens advances the
     // cursor.
@@ -786,6 +833,10 @@ pub(crate) fn run_paged_decode_step(
 
     let input_ids = MxArray::from_uint32(&[token_id], &[1, 1])?;
     let mut hidden_states = embed.forward(&input_ids)?;
+
+    // Decode rotates the query at the physical slot plus the cross-turn M-RoPE
+    // delta (0 for text turns) while K/V still writes at the physical slot.
+    let rope_position_offset = paged_rope_offset(first_logical_position, cached_rope_deltas);
 
     let num_layers = layers.len();
     #[allow(clippy::needless_range_loop)]
@@ -811,6 +862,7 @@ pub(crate) fn run_paged_decode_step(
             Some(cache_slot),
             /* position_ids */ None,
             /* use_kernel */ true,
+            rope_position_offset,
         )?;
     }
 
@@ -849,6 +901,7 @@ pub(crate) fn run_paged_step_with_hidden(
     embedding_weight_t: Option<&MxArray>,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
+    cached_rope_deltas: i32,
 ) -> Result<(MxArray, MxArray)> {
     let first_logical_position = paged_adapter.current_token_count();
     paged_adapter
@@ -857,6 +910,11 @@ pub(crate) fn run_paged_step_with_hidden(
 
     let input_ids = MxArray::from_uint32(&[token_id], &[1, 1])?;
     let mut hidden_states = embed.forward(&input_ids)?;
+
+    // Same cross-turn delta as `run_paged_decode_step`: a text MTP Step-A
+    // forward that warm-continues an image prefill must rotate at the
+    // compressed position.
+    let rope_position_offset = paged_rope_offset(first_logical_position, cached_rope_deltas);
 
     let num_layers = layers.len();
     #[allow(clippy::needless_range_loop)]
@@ -882,6 +940,7 @@ pub(crate) fn run_paged_step_with_hidden(
             Some(cache_slot),
             /* position_ids */ None,
             /* use_kernel */ true,
+            rope_position_offset,
         )?;
     }
 
@@ -928,6 +987,7 @@ pub(crate) fn run_paged_verify_step(
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
     tape: &mut Vec<Option<super::gated_delta_net::GdnLayerTape>>,
+    cached_rope_deltas: i32,
 ) -> Result<super::mtp_decode::MtpVerifyOutput> {
     debug_assert_eq!(layers.len(), caches.len());
     debug_assert_eq!(layers.len(), layer_kinds.len());
@@ -956,6 +1016,10 @@ pub(crate) fn run_paged_verify_step(
     let input_ids = MxArray::from_uint32(&verify_u32, &[1, verify_len as i64])?;
     let mut hidden_states = embed.forward(&input_ids)?;
 
+    // The K+1 verify ids rotate at the physical context start plus the
+    // cross-turn M-RoPE delta (0 for text turns), matching the Step-A forward.
+    let rope_position_offset = paged_rope_offset(chunk_first_position, cached_rope_deltas);
+
     let num_layers = layers.len();
     tape.clear();
     tape.resize(num_layers, None);
@@ -980,6 +1044,7 @@ pub(crate) fn run_paged_verify_step(
             /* is_prefill */ true,
             Some(cache_slot),
             Some(&mut slot),
+            rope_position_offset,
         )?;
         tape[layer_idx] = slot;
     }
@@ -996,4 +1061,64 @@ pub(crate) fn run_paged_verify_step(
     Ok(super::mtp_decode::MtpVerifyOutput::logits_only(
         logits, hiddens,
     ))
+}
+
+#[cfg(test)]
+mod rope_offset_tests {
+    //! Model-free coverage for the paged scalar-offset RoPE position helper.
+    //!
+    //! The cross-turn image-decode fix decouples the rotation position from the
+    //! physical KV slot: image prefill compresses ~hundreds of placeholder
+    //! tokens into far fewer M-RoPE positions, so a warm-continuation turn must
+    //! rotate its queries at `physical_slot + cached_rope_deltas` (the delta is
+    //! negative) while K/V still writes at the physical slot. These tests pin
+    //! that arithmetic — including the cast-before-add type-safety guard — and
+    //! the text-turn identity (`delta == 0`) that keeps text decode
+    //! byte-identical. They construct no model, so they run on any host.
+
+    use super::paged_rope_offset;
+
+    #[test]
+    fn text_turn_zero_delta_is_identity() {
+        // Text-only turns store delta 0 -> the rotation offset equals the
+        // physical KV slot exactly, keeping text decode byte-identical.
+        assert_eq!(paged_rope_offset(0, 0), 0);
+        assert_eq!(paged_rope_offset(42, 0), 42);
+        assert_eq!(paged_rope_offset(1_000_000, 0), 1_000_000);
+    }
+
+    #[test]
+    fn image_turn_negative_delta_shifts_offset_down() {
+        // An image turn compressing ~754 placeholder tokens to ~28 M-RoPE
+        // positions stores delta = 28 - 754 = -726. Decode at physical slot
+        // 754 must rotate at the compressed position 28, NOT 754; the next
+        // physical slot (755) rotates at 29.
+        let delta = -726;
+        assert_eq!(paged_rope_offset(754, delta), 28);
+        assert_eq!(paged_rope_offset(755, delta), 29);
+    }
+
+    #[test]
+    fn offset_casts_to_i32_before_adding_negative_delta() {
+        // Type-safety guard: the cast to i32 happens BEFORE the add, so a small
+        // physical position with a large negative delta yields a negative i32
+        // rather than wrapping a u32 subtraction. In practice the physical
+        // position always exceeds |delta| on a warm continuation, but the
+        // helper must not underflow if it ever did not.
+        assert_eq!(paged_rope_offset(10, -726), -716);
+        // Physical position equal to |delta| collapses to exactly 0.
+        assert_eq!(paged_rope_offset(726, -726), 0);
+    }
+
+    #[test]
+    fn resetting_delta_to_zero_restores_physical_offset() {
+        // Round-trip of the stored cross-turn delta: applying a negative delta
+        // shifts the offset, and clearing it back to 0 (a fresh text turn /
+        // `Option::unwrap_or(0)`) restores the physical position unchanged.
+        let physical = 800;
+        let with_image_delta = paged_rope_offset(physical, -726);
+        assert_eq!(with_image_delta, 74);
+        let after_reset = paged_rope_offset(physical, 0);
+        assert_eq!(after_reset, physical as i32);
+    }
 }

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -70,6 +70,36 @@ pub(crate) fn paged_rope_offset(physical_position: u32, cached_rope_deltas: i32)
     physical_position as i32 + cached_rope_deltas
 }
 
+/// Decide the cross-turn M-RoPE delta to carry into the next paged turn.
+///
+/// `cached_rope_deltas` is shared model state: an image prefill bakes in a
+/// compressed-position delta (negative) that only aligns with the image's
+/// physically-resident K/V. The delta is meaningful for exactly ONE outcome of
+/// the paged turn planner — `continued_live_prefix`, where the live image
+/// sequence is being extended and its K/V is re-attended. Every other outcome
+/// must drop it:
+/// * a cold/fresh turn carries no cross-turn delta;
+/// * a NON-live prefix-cache hit (`cached_prefix_len > 0` but
+///   `continued_live_prefix == false`) can only restore pure-text prefix blocks
+///   — image requests prefill with `skip_lookup` and never publish a hashable
+///   text stream that collides with their expanded-placeholder blocks — so the
+///   suffix must rotate at the raw physical slot (delta 0), not at the stale
+///   negative delta a prior image turn left on the shared model.
+///
+/// Keying the reset on `cached_prefix_len == 0` is therefore too weak: it leaks
+/// a stale image delta into unrelated text requests that merely share a cached
+/// text prefix.
+pub(crate) fn rope_delta_for_paged_turn(
+    cached_rope_deltas: Option<i32>,
+    continued_live_prefix: bool,
+) -> Option<i32> {
+    if continued_live_prefix {
+        cached_rope_deltas
+    } else {
+        None
+    }
+}
+
 fn trace_memory_mib() -> (f64, f64, f64) {
     (
         bytes_to_mib(crate::array::get_active_memory()),
@@ -1076,7 +1106,39 @@ mod rope_offset_tests {
     //! the text-turn identity (`delta == 0`) that keeps text decode
     //! byte-identical. They construct no model, so they run on any host.
 
-    use super::paged_rope_offset;
+    use super::{paged_rope_offset, rope_delta_for_paged_turn};
+
+    #[test]
+    fn live_continuation_preserves_image_delta() {
+        // A live continuation re-attends the image request's physically-resident
+        // compressed-position K/V, so the negative delta MUST survive to keep the
+        // text suffix rotating at the compressed position.
+        assert_eq!(rope_delta_for_paged_turn(Some(-726), true), Some(-726));
+        // Suffix at physical slot 754 then rotates at the compressed position 28.
+        let delta = rope_delta_for_paged_turn(Some(-726), true).unwrap_or(0);
+        assert_eq!(paged_rope_offset(754, delta), 28);
+    }
+
+    #[test]
+    fn cold_start_clears_delta() {
+        // A fresh/miss turn (no reused prefix) carries no cross-turn delta.
+        assert_eq!(rope_delta_for_paged_turn(Some(-726), false), None);
+        assert_eq!(rope_delta_for_paged_turn(None, false), None);
+    }
+
+    #[test]
+    fn non_live_prefix_cache_hit_clears_stale_image_delta() {
+        // Regression: a prior image turn leaves a stale negative delta on the
+        // shared model. A later TEXT request that merely HITS the cross-request
+        // prefix cache (cached_prefix_len > 0) is NOT a live image continuation
+        // (continued_live_prefix == false) — its restored blocks can only be the
+        // pure-text prefix. The stale delta must be dropped so text rotates at
+        // the raw physical slot, NOT at physical + stale_negative_delta.
+        let stale_image_delta = Some(-726);
+        let after_text_hit = rope_delta_for_paged_turn(stale_image_delta, false);
+        assert_eq!(after_text_hit, None);
+        assert_eq!(paged_rope_offset(42, after_text_hit.unwrap_or(0)), 42);
+    }
 
     #[test]
     fn text_turn_zero_delta_is_identity() {

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -1996,6 +1996,16 @@ pub(crate) fn parse_vision_config(raw: &Value) -> Qwen3_5VisionConfig {
     }
 }
 
+/// Collapse a 5D Conv3d patch-embed weight `[out, kD, kH, kW, in]` into a 2D
+/// Conv2d kernel `[out, kH, kW, in]` by summing over the temporal axis.
+///
+/// The image processor duplicates the static frame across the temporal axis, so
+/// the effective 2D kernel is the sum of the temporal slices (matches mlx-vlm
+/// `qwen3_vl/vision.py`). Summing all `kD` slices keeps this robust if `kD != 2`.
+fn collapse_patch_embed_conv3d(pe_weight: &MxArray) -> Result<MxArray> {
+    pe_weight.sum(Some(&[1]), None)
+}
+
 /// Load vision encoder weights from params.
 pub(crate) fn load_vision_weights(
     encoder: &mut Qwen3_5VisionEncoder,
@@ -2011,21 +2021,17 @@ pub(crate) fn load_vision_weights(
     let get_opt = |key: &str| -> Option<&MxArray> { params.get(key) };
 
     // Patch embedding: handle both 4D Conv2d [out, kH, kW, in] and
-    // 5D Conv3d [out, kD, kH, kW, in] formats. For Conv3d, extract
-    // temporal slice 0 for our Conv2d PatchEmbedding.
+    // 5D Conv3d [out, kD, kH, kW, in] formats. For Conv3d, the static frame is
+    // duplicated across the temporal axis, so the effective 2D kernel is the
+    // sum of the temporal slices (not a single slice).
     if let Some(pe_weight) = get_opt("patch_embed.proj.weight") {
+        let pe_bias = get_opt("patch_embed.proj.bias");
         let ndim = pe_weight.ndim()?;
         if ndim == 5 {
-            // Conv3d [out, kD, kH, kW, in] → take slice [:, 0, :, :, :]
-            let out_c = pe_weight.shape_at(0)?;
-            let kh = pe_weight.shape_at(2)?;
-            let kw = pe_weight.shape_at(3)?;
-            let in_c = pe_weight.shape_at(4)?;
-            let slice0 = pe_weight.slice(&[0, 0, 0, 0, 0], &[out_c, 1, kh, kw, in_c])?;
-            let conv2d_weight = slice0.squeeze(Some(&[1]))?;
-            encoder.set_patch_embed(&conv2d_weight)?;
+            let conv2d_weight = collapse_patch_embed_conv3d(pe_weight)?;
+            encoder.set_patch_embed(&conv2d_weight, pe_bias)?;
         } else {
-            encoder.set_patch_embed(pe_weight)?;
+            encoder.set_patch_embed(pe_weight, pe_bias)?;
         }
     }
 
@@ -2145,6 +2151,50 @@ pub fn create_random_qwen35_checkpoint<'env>(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn collapse_patch_embed_conv3d_sums_temporal_slices() {
+        // Synthetic Conv3d weight [out=2, kD=2, kH=2, kW=2, in=3] with distinct
+        // values per temporal slice. The collapse must SUM over the temporal
+        // axis (slice0 + slice1), not drop slice1.
+        let out_c = 2i64;
+        let kd = 2i64;
+        let kh = 2i64;
+        let kw = 2i64;
+        let in_c = 3i64;
+        let n = (out_c * kd * kh * kw * in_c) as usize;
+        let data: Vec<f32> = (0..n).map(|i| i as f32 * 0.5 - 3.0).collect();
+        let pe_weight = MxArray::from_float32(&data, &[out_c, kd, kh, kw, in_c]).unwrap();
+
+        let collapsed = collapse_patch_embed_conv3d(&pe_weight).unwrap();
+        collapsed.eval();
+        let shape: Vec<i64> = collapsed.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![out_c, kh, kw, in_c]);
+
+        // Expected = slice[:,0,:,:,:] + slice[:,1,:,:,:].
+        let slice0 = pe_weight
+            .slice(&[0, 0, 0, 0, 0], &[out_c, 1, kh, kw, in_c])
+            .unwrap()
+            .squeeze(Some(&[1]))
+            .unwrap();
+        let slice1 = pe_weight
+            .slice(&[0, 1, 0, 0, 0], &[out_c, 2, kh, kw, in_c])
+            .unwrap()
+            .squeeze(Some(&[1]))
+            .unwrap();
+        let expected = slice0.add(&slice1).unwrap();
+        expected.eval();
+
+        let got: Vec<f32> = collapsed.to_float32().unwrap().to_vec();
+        let exp: Vec<f32> = expected.to_float32().unwrap().to_vec();
+        assert_eq!(got.len(), exp.len());
+        for (i, (g, e)) in got.iter().zip(exp.iter()).enumerate() {
+            assert!(
+                (g - e).abs() < 1e-5,
+                "element {i}: collapsed {g} != slice0+slice1 {e}"
+            );
+        }
+    }
 
     #[test]
     fn mtp_sidecar_candidates_match_mtplx_order() {

--- a/crates/mlx-core/src/models/qwen3_5/vision.rs
+++ b/crates/mlx-core/src/models/qwen3_5/vision.rs
@@ -76,7 +76,7 @@ impl Qwen3_5VisionEncoder {
             ],
             None,
         )?;
-        let patch_embed = PatchEmbedding::new(patch_size, &dummy_weight)?;
+        let patch_embed = PatchEmbedding::new(patch_size, &dummy_weight, None)?;
 
         Ok(Self {
             config,
@@ -88,9 +88,13 @@ impl Qwen3_5VisionEncoder {
         })
     }
 
-    /// Set patch embedding weights
-    pub fn set_patch_embed(&mut self, weight: &MxArray) -> Result<()> {
-        self.patch_embed = Arc::new(PatchEmbedding::new(self.config.patch_size as u32, weight)?);
+    /// Set patch embedding weights (and optional Conv bias)
+    pub fn set_patch_embed(&mut self, weight: &MxArray, bias: Option<&MxArray>) -> Result<()> {
+        self.patch_embed = Arc::new(PatchEmbedding::new(
+            self.config.patch_size as u32,
+            weight,
+            bias,
+        )?);
         Ok(())
     }
 
@@ -123,6 +127,9 @@ impl Qwen3_5VisionEncoder {
             "visual.patch_embed.proj.weight".to_string(),
             self.patch_embed.weight(),
         );
+        if let Some(b) = self.patch_embed.bias() {
+            params.insert("visual.patch_embed.proj.bias".to_string(), b);
+        }
 
         // Position embedding
         if let Some(ref pe) = self.pos_embed {

--- a/crates/mlx-core/src/models/qwen3_5_moe/decoder_layer.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/decoder_layer.rs
@@ -172,6 +172,7 @@ impl DecoderLayer {
         flat_cache: Option<&mut Qwen3_5LayerCache>,
         position_ids: Option<&MxArray>,
         use_kernel: bool,
+        rope_position_offset: i32,
     ) -> Result<MxArray> {
         match kind {
             Qwen3_5LayerKind::Linear => {
@@ -179,6 +180,7 @@ impl DecoderLayer {
                 let _ = first_logical_position;
                 let _ = cached_prefix_len;
                 let _ = is_prefill;
+                let _ = rope_position_offset;
                 if !matches!(self.attn, AttentionType::Linear(_)) {
                     return Err(Error::from_reason(
                         "Qwen3_5MoeDecoderLayer::forward_paged_or_flat: kind=Linear applied to a \
@@ -211,6 +213,7 @@ impl DecoderLayer {
                     cached_prefix_len,
                     is_prefill,
                     position_ids,
+                    rope_position_offset,
                 )?;
                 let h = x.add(&attn_out)?;
                 let normed = self.post_attention_layernorm.forward(&h)?;

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -1539,7 +1539,10 @@ impl Qwen35MoeInner {
         }
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        // Store the image prefill's compressed-position delta so a later text
+        // warm-continuation rotates its queries at the same compressed M-RoPE
+        // positions the image keys were written with.
+        self.cached_rope_deltas = Some(merge.rope_deltas as i32);
 
         // Fresh per-layer caches (GDN linear slots + empty full-attention slots).
         self.caches = Some(fresh_moe_layer_caches(&self.config));
@@ -1632,6 +1635,7 @@ impl Qwen35MoeInner {
                         &embedding_weight,
                         &layer_kinds,
                         adapter,
+                        self.cached_rope_deltas.unwrap_or(0),
                     )?;
                     logits.squeeze(Some(&[1]))?
                 };
@@ -1847,7 +1851,10 @@ impl Qwen35MoeInner {
         }
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        // Store the image prefill's compressed-position delta so a later text
+        // warm-continuation rotates its queries at the same compressed M-RoPE
+        // positions the image keys were written with.
+        self.cached_rope_deltas = Some(merge.rope_deltas as i32);
 
         self.caches = Some(fresh_moe_layer_caches(&self.config));
 
@@ -1974,6 +1981,7 @@ impl Qwen35MoeInner {
                         &embedding_weight,
                         &layer_kinds,
                         adapter,
+                        self.cached_rope_deltas.unwrap_or(0),
                     )?;
                     logits.squeeze(Some(&[1]))?
                 };
@@ -2258,7 +2266,12 @@ impl Qwen35MoeInner {
         let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        // Reset the cross-turn M-RoPE delta only on a fresh/miss turn; preserve
+        // it on a warm continuation so the image prefill's compressed-position
+        // rotation carries into the text suffix prefill + decode.
+        if cached_prefix_len == 0 {
+            self.cached_rope_deltas = None;
+        }
 
         let suffix_len = prompt_token_count
             .checked_sub(cached_prefix_len)
@@ -2405,6 +2418,7 @@ impl Qwen35MoeInner {
                 &embedding_weight,
                 &layer_kinds,
                 adapter,
+                self.cached_rope_deltas.unwrap_or(0),
             )?
         };
 
@@ -2473,6 +2487,7 @@ impl Qwen35MoeInner {
                     &embedding_weight,
                     &layer_kinds,
                     adapter,
+                    self.cached_rope_deltas.unwrap_or(0),
                 )?;
                 logits.squeeze(Some(&[1]))?
             };
@@ -2620,7 +2635,12 @@ impl Qwen35MoeInner {
         let gdn_prefix_state = gdn_prefix_preparation.state;
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        // Reset the cross-turn M-RoPE delta only on a fresh/miss turn; preserve
+        // it on a warm continuation so the image prefill's compressed-position
+        // rotation carries into the text suffix prefill + decode.
+        if cached_prefix_len == 0 {
+            self.cached_rope_deltas = None;
+        }
 
         let suffix_len = prompt_token_count
             .checked_sub(cached_prefix_len)
@@ -2877,6 +2897,7 @@ impl Qwen35MoeInner {
                 &embedding_weight,
                 &layer_kinds,
                 adapter,
+                self.cached_rope_deltas.unwrap_or(0),
             )?
         };
 
@@ -3006,6 +3027,7 @@ impl Qwen35MoeInner {
                     &embedding_weight,
                     &layer_kinds,
                     adapter,
+                    self.cached_rope_deltas.unwrap_or(0),
                 )?;
                 if let Some(start) = forward_trace_start {
                     decode_forward_ms += elapsed_ms(start);
@@ -6116,6 +6138,7 @@ impl DecodeStep for Qwen35MoePagedDecode<'_> {
                 &embedding_weight,
                 &layer_kinds,
                 adapter,
+                self.inner.cached_rope_deltas.unwrap_or(0),
             )?
             .squeeze(Some(&[1]))?
         };
@@ -6281,11 +6304,16 @@ impl PagedBackend for Qwen35MoeInner {
         )?;
         let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         // Clear the per-turn session state here (history is re-set in
-        // `save_paged_history`; rope deltas + image key are reset because the
-        // paged path does not carry them across turns).
+        // `save_paged_history`; image key is reset because the paged path does
+        // not carry it across turns). The cross-turn M-RoPE delta IS carried on
+        // a warm continuation: a text turn that warm-continues an image prefill
+        // must keep rotating at the compressed position, so the delta is reset
+        // only on a fresh/miss turn (cached_prefix_len == 0).
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        self.cached_rope_deltas = None;
+        if cached_prefix_len == 0 {
+            self.cached_rope_deltas = None;
+        }
 
         let suffix_len = total_budget.checked_sub(cached_prefix_len).ok_or_else(|| {
             Error::from_reason("prime_prefix_state: cached_prefix_len > total_prompt_tokens")
@@ -6318,6 +6346,10 @@ impl PagedBackend for Qwen35MoeInner {
         );
         let embed = self.embedding.clone();
         let embedding_weight = embed.get_weight();
+        // Cross-turn M-RoPE delta (0 unless this engine-driven text turn warm-
+        // continues an image prefill); aligns the suffix keys with the
+        // compressed-position image keys.
+        let rope_deltas = self.cached_rope_deltas.unwrap_or(0);
         let caches_ref = self
             .caches
             .as_mut()
@@ -6339,6 +6371,7 @@ impl PagedBackend for Qwen35MoeInner {
             &embedding_weight,
             &layer_kinds,
             adapter,
+            rope_deltas,
         )
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -2266,12 +2266,14 @@ impl Qwen35MoeInner {
         let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        // Reset the cross-turn M-RoPE delta only on a fresh/miss turn; preserve
-        // it on a warm continuation so the image prefill's compressed-position
-        // rotation carries into the text suffix prefill + decode.
-        if cached_prefix_len == 0 {
-            self.cached_rope_deltas = None;
-        }
+        // Carry the cross-turn M-RoPE delta only when this turn extends the live
+        // image sequence (continued_live_prefix); a cold start or a non-live
+        // prefix-cache hit (text-only prefix) drops a stale image delta so the
+        // text suffix prefill + decode rotate at the raw physical slot.
+        self.cached_rope_deltas = crate::models::qwen3_5::paged_forward::rope_delta_for_paged_turn(
+            self.cached_rope_deltas,
+            continued_live_prefix,
+        );
 
         let suffix_len = prompt_token_count
             .checked_sub(cached_prefix_len)
@@ -2635,12 +2637,14 @@ impl Qwen35MoeInner {
         let gdn_prefix_state = gdn_prefix_preparation.state;
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        // Reset the cross-turn M-RoPE delta only on a fresh/miss turn; preserve
-        // it on a warm continuation so the image prefill's compressed-position
-        // rotation carries into the text suffix prefill + decode.
-        if cached_prefix_len == 0 {
-            self.cached_rope_deltas = None;
-        }
+        // Carry the cross-turn M-RoPE delta only when this turn extends the live
+        // image sequence (continued_live_prefix); a cold start or a non-live
+        // prefix-cache hit (text-only prefix) drops a stale image delta so the
+        // text suffix prefill + decode rotate at the raw physical slot.
+        self.cached_rope_deltas = crate::models::qwen3_5::paged_forward::rope_delta_for_paged_turn(
+            self.cached_rope_deltas,
+            continued_live_prefix,
+        );
 
         let suffix_len = prompt_token_count
             .checked_sub(cached_prefix_len)
@@ -6305,15 +6309,17 @@ impl PagedBackend for Qwen35MoeInner {
         let gdn_prefix_already_primed = gdn_prefix_preparation.already_primed;
         // Clear the per-turn session state here (history is re-set in
         // `save_paged_history`; image key is reset because the paged path does
-        // not carry it across turns). The cross-turn M-RoPE delta IS carried on
-        // a warm continuation: a text turn that warm-continues an image prefill
-        // must keep rotating at the compressed position, so the delta is reset
-        // only on a fresh/miss turn (cached_prefix_len == 0).
+        // not carry it across turns). The cross-turn M-RoPE delta is carried
+        // only when this turn extends the live image sequence
+        // (continued_live_prefix); a cold start or a non-live prefix-cache hit
+        // (text-only prefix) drops a stale image delta so the text suffix
+        // rotates at the raw physical slot.
         self.cached_token_history.clear();
         self.cached_image_key = None;
-        if cached_prefix_len == 0 {
-            self.cached_rope_deltas = None;
-        }
+        self.cached_rope_deltas = crate::models::qwen3_5::paged_forward::rope_delta_for_paged_turn(
+            self.cached_rope_deltas,
+            continued_live_prefix,
+        );
 
         let suffix_len = total_budget.checked_sub(cached_prefix_len).ok_or_else(|| {
             Error::from_reason("prime_prefix_state: cached_prefix_len > total_prompt_tokens")

--- a/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
@@ -96,6 +96,7 @@ pub(crate) fn run_paged_prefill_chunk(
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     let chunk_size = crate::array::paged_prefill_chunk_size();
     run_paged_prefill_chunk_with_size(
@@ -112,6 +113,7 @@ pub(crate) fn run_paged_prefill_chunk(
         layer_kinds,
         paged_adapter,
         chunk_size,
+        cached_rope_deltas,
     )
 }
 
@@ -166,6 +168,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
     chunk_size: i32,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     if suffix_tokens.is_empty() {
         return Err(Error::from_reason(
@@ -189,6 +192,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
             embedding_weight,
             layer_kinds,
             paged_adapter,
+            cached_rope_deltas,
         );
     }
 
@@ -250,6 +254,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
             paged_adapter,
             /* inputs_embeds */ None,
             /* position_ids */ None,
+            cached_rope_deltas,
         )?;
 
         if is_last_chunk {
@@ -353,6 +358,7 @@ pub(crate) fn run_paged_prefill_single_shot(
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     paged_adapter
         .record_tokens(suffix_tokens)
@@ -373,6 +379,7 @@ pub(crate) fn run_paged_prefill_single_shot(
         paged_adapter,
         /* inputs_embeds */ None,
         /* position_ids */ None,
+        cached_rope_deltas,
     )?;
     project_last_token_logits_moe(&hidden_states, final_norm, lm_head, embedding_weight)
 }
@@ -428,6 +435,10 @@ pub(crate) fn run_paged_vlm_prefill_moe(
         paged_adapter,
         Some(&merge.inputs_embeds),
         Some(&merge.position_ids),
+        // Image prefill drives full-attention layers through the 3-row M-RoPE
+        // arm (`position_ids` is `Some`), so the scalar offset is unused here.
+        /* cached_rope_deltas */
+        0,
     )?;
 
     project_last_token_logits_moe(&hidden_states, final_norm, lm_head, embedding_weight)
@@ -478,6 +489,7 @@ fn run_paged_prefill_one_chunk_moe(
     paged_adapter: &mut PagedKVCacheAdapter,
     inputs_embeds: Option<&MxArray>,
     position_ids: Option<&MxArray>,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     debug_assert_eq!(layers.len(), caches.len());
     debug_assert_eq!(layers.len(), layer_kinds.len());
@@ -490,6 +502,16 @@ fn run_paged_prefill_one_chunk_moe(
             embed.forward(&input_ids)?
         }
     };
+
+    // Scalar-offset RoPE position for this chunk: a text suffix that warm-
+    // continues an image prefill rotates at the physical slot plus the negative
+    // cross-turn delta so it stays consistent with the compressed-M-RoPE image
+    // keys. Text-only prefill carries `cached_rope_deltas == 0`; image prefill
+    // uses the M-RoPE arm, so this is ignored there.
+    let rope_position_offset = crate::models::qwen3_5::paged_forward::paged_rope_offset(
+        chunk_first_position,
+        cached_rope_deltas,
+    );
 
     // Layer loop. Safe-by-construction via `iter_mut().zip(...)` —
     // each iteration takes disjoint `&mut DecoderLayer` and `&mut
@@ -518,6 +540,7 @@ fn run_paged_prefill_one_chunk_moe(
             Some(cache_slot),
             layer_positions,
             true,
+            rope_position_offset,
         )?;
         // Smooth the prefill memory peak: every K layers, materialize the
         // residual stream so MLX can release the upstream graph nodes
@@ -571,6 +594,7 @@ pub(crate) fn run_paged_decode_step(
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
+    cached_rope_deltas: i32,
 ) -> Result<MxArray> {
     let first_logical_position = paged_adapter.current_token_count();
     paged_adapter
@@ -579,6 +603,13 @@ pub(crate) fn run_paged_decode_step(
 
     let input_ids = MxArray::from_uint32(&[token_id], &[1, 1])?;
     let mut hidden_states = embed.forward(&input_ids)?;
+
+    // Decode rotates the query at the physical slot plus the cross-turn M-RoPE
+    // delta (0 for text turns) while K/V still writes at the physical slot.
+    let rope_position_offset = crate::models::qwen3_5::paged_forward::paged_rope_offset(
+        first_logical_position,
+        cached_rope_deltas,
+    );
 
     let num_layers = layers.len();
     #[allow(clippy::needless_range_loop)]
@@ -603,6 +634,7 @@ pub(crate) fn run_paged_decode_step(
             Some(cache_slot),
             None,
             true,
+            rope_position_offset,
         )?;
     }
 
@@ -913,6 +945,7 @@ mod tests {
                 &layer_kinds,
                 adapter,
                 chunk_size,
+                /* cached_rope_deltas */ 0,
             ) {
                 Ok(l) => l,
                 Err(e) => {
@@ -1286,6 +1319,7 @@ mod tests {
                 &embedding_weight,
                 &layer_kinds,
                 adapter,
+                /* cached_rope_deltas */ 0,
             ) {
                 Ok(l) => l,
                 Err(e) => {
@@ -1347,6 +1381,7 @@ mod tests {
                 &layer_kinds,
                 adapter,
                 0,
+                /* cached_rope_deltas */ 0,
             )
             .expect("explicit chunk_size=0 prefill")
         };

--- a/crates/mlx-core/src/nn/linear.rs
+++ b/crates/mlx-core/src/nn/linear.rs
@@ -238,3 +238,76 @@ impl Linear {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn addmm_bias_broadcast_rank() {
+        // a [2,3] @ b [3,4] -> [2,4]; add c. Test 1D c[4] vs 2D c[1,4] vs c[2,4].
+        let a = MxArray::from_float32(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).unwrap();
+        let b = MxArray::from_float32(
+            &[1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0],
+            &[3, 4],
+        )
+        .unwrap();
+        // a@b row0 = [1, 2, 3, 1+2+3=6]; row1 = [4, 5, 6, 15]
+        let probe = |c: &MxArray, label: &str| {
+            let out = a.addmm(c, &b, None, None).unwrap();
+            let got = out.to_float32().unwrap();
+            eprintln!("[addmm c={label}] out[0]={:?}", &got[..4]);
+            got
+        };
+        let c1d = MxArray::from_float32(&[10.0, 20.0, 30.0, 40.0], &[4]).unwrap();
+        let c2d_row = MxArray::from_float32(&[10.0, 20.0, 30.0, 40.0], &[1, 4]).unwrap();
+        let c2d_full =
+            MxArray::from_float32(&[10.0, 20.0, 30.0, 40.0, 10.0, 20.0, 30.0, 40.0], &[2, 4])
+                .unwrap();
+        let g1 = probe(&c1d, "[4]");
+        let g2 = probe(&c2d_row, "[1,4]");
+        let g3 = probe(&c2d_full, "[2,4]");
+        // matmul + add (candidate fix)
+        let add_out = a
+            .matmul(&b)
+            .unwrap()
+            .add(&c1d)
+            .unwrap()
+            .to_float32()
+            .unwrap();
+        eprintln!("[matmul+add c=[4]] out[0]={:?}", &add_out[..4]);
+        // a@b[0] = [1,2,3,6]; +c = [11,22,33,46]
+        eprintln!(
+            "applies bias -> 1D-c:{} 2D-row-c:{} 2D-full-c:{} matmul+add:{}",
+            (g1[0] - 11.0).abs() < 1e-3,
+            (g2[0] - 11.0).abs() < 1e-3,
+            (g3[0] - 11.0).abs() < 1e-3,
+            (add_out[0] - 11.0).abs() < 1e-3
+        );
+    }
+
+    #[test]
+    fn linear_forward_applies_bias() {
+        // weight [out=4, in=3], bias [4], input [2,3].
+        // expected = input @ weight.T + bias
+        let weight = MxArray::from_float32(
+            &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+            &[4, 3],
+        )
+        .unwrap();
+        let bias = MxArray::from_float32(&[10.0, 20.0, 30.0, 40.0], &[4]).unwrap();
+        let lin = Linear::from_weights(&weight, Some(&bias)).unwrap();
+
+        let input = MxArray::from_float32(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).unwrap();
+        let out = lin.forward(&input).unwrap();
+        let got = out.to_float32().unwrap();
+        let want = [11.0, 22.0, 33.0, 46.0, 14.0, 25.0, 36.0, 55.0];
+        for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+            assert!(
+                (g - w).abs() < 1e-3,
+                "bias not applied at {i}: got {g}, want {w} (no-bias would be {})",
+                w - [10.0, 20.0, 30.0, 40.0][i % 4]
+            );
+        }
+    }
+}

--- a/crates/mlx-core/src/vision/embeddings.rs
+++ b/crates/mlx-core/src/vision/embeddings.rs
@@ -29,11 +29,12 @@ impl PatchEmbedding {
     /// * `in_channels` - Number of input channels (3 for RGB)
     /// * `embed_dim` - Embedding dimension
     /// * `weight` - Convolution weights [embed_dim, patch_size, patch_size, in_channels]
-    pub fn new(patch_size: u32, weight: &MxArray) -> Result<Self> {
+    /// * `bias` - Optional convolution bias [embed_dim]
+    pub fn new(patch_size: u32, weight: &MxArray, bias: Option<&MxArray>) -> Result<Self> {
         // Create conv layer with stride = kernel_size = patch_size
         let conv = Conv2d::new(
             weight,
-            None,
+            bias,
             Some(vec![patch_size, patch_size]), // stride
             Some(vec![0, 0]),                   // padding
             None,                               // dilation
@@ -75,6 +76,11 @@ impl PatchEmbedding {
     /// Get the convolution weight
     pub fn weight(&self) -> MxArray {
         self.patch_conv.weight()
+    }
+
+    /// Get the convolution bias if present
+    pub fn bias(&self) -> Option<MxArray> {
+        self.patch_conv.bias()
     }
 }
 
@@ -181,7 +187,7 @@ mod tests {
         )
         .unwrap();
 
-        let patch_embed = PatchEmbedding::new(patch_size, &weight).unwrap();
+        let patch_embed = PatchEmbedding::new(patch_size, &weight, None).unwrap();
 
         // Input: [1, 8, 8, 3] -> [1, 4, 16] (2x2 patches, 16 dim)
         let input_data: Vec<f32> = (0..(8 * 8 * 3) as usize)
@@ -194,6 +200,58 @@ mod tests {
 
         // 8/4 = 2 patches per dimension, 2*2 = 4 total patches
         assert_eq!(shape, vec![1, 4, 16]);
+    }
+
+    #[test]
+    fn test_patch_embedding_applies_bias() {
+        // With zero conv weights, the patch-embed output equals the bias,
+        // broadcast over every patch. This proves the bias is plumbed into
+        // the underlying Conv2d (previously hardcoded to None).
+        let patch_size = 4u32;
+        let in_c = 3i64;
+        let embed_dim = 5i64;
+
+        let weight = MxArray::zeros(
+            &[embed_dim, patch_size as i64, patch_size as i64, in_c],
+            None,
+        )
+        .unwrap();
+
+        let bias_data: Vec<f32> = vec![0.5, -1.0, 2.0, 3.5, -0.25];
+        let bias = MxArray::from_float32(&bias_data, &[embed_dim]).unwrap();
+
+        // Input: [1, 8, 8, 3] -> 2x2 = 4 patches.
+        let input_data: Vec<f32> = (0..(8 * 8 * 3) as usize)
+            .map(|i| (i % 256) as f32 / 255.0)
+            .collect();
+        let input = MxArray::from_float32(&input_data, &[1, 8, 8, 3]).unwrap();
+
+        // Without bias: zero weights -> all-zero output.
+        let no_bias = PatchEmbedding::new(patch_size, &weight, None).unwrap();
+        let out_no_bias = no_bias.forward(&input).unwrap();
+        out_no_bias.eval();
+        let data_no_bias: Vec<f32> = out_no_bias.to_float32().unwrap().to_vec();
+        assert!(
+            data_no_bias.iter().all(|&v| v.abs() < 1e-6),
+            "zero-weight, no-bias output must be all zeros"
+        );
+
+        // With bias: every patch equals the bias vector.
+        let with_bias = PatchEmbedding::new(patch_size, &weight, Some(&bias)).unwrap();
+        let out = with_bias.forward(&input).unwrap();
+        out.eval();
+        let shape: Vec<i64> = out.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![1, 4, 5]);
+        let data: Vec<f32> = out.to_float32().unwrap().to_vec();
+        for patch in 0..4usize {
+            for (c, &expected) in bias_data.iter().enumerate() {
+                let got = data[patch * embed_dim as usize + c];
+                assert!(
+                    (got - expected).abs() < 1e-5,
+                    "patch {patch} channel {c}: expected bias {expected}, got {got}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/mlx-core/tests/qwen3_5_moe_vl_image_chat.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_vl_image_chat.rs
@@ -216,3 +216,91 @@ async fn qwen3_5_moe_vl_image_chat_t0_capture() {
     assert_eq!(d1, d1b, "turn 1 digest is not deterministic at T=0");
     assert_eq!(d2, d2b, "turn 2 digest is not deterministic at T=0");
 }
+
+/// Keywords from `examples/ocr.png` — a "TRUNCH PARISH COUNCIL — BANK
+/// RECONCILIATION AS AT 31ST OCTOBER 2019" financial table. A model that
+/// actually READS the image transcribes several of these; a model with broken
+/// vision features hallucinates an unrelated scene (e.g. "stone/fabric") and
+/// matches none.
+const DOC_KEYWORDS: &[&str] = &[
+    "reconciliation",
+    "bank",
+    "council",
+    "trunch",
+    "october",
+    "2019",
+    "balance",
+];
+
+/// Vision-CORRECTNESS gate (distinct from the `_t0_capture` parity digest, which
+/// asserts paged==flat byte-identity and so passes even when the vision features
+/// are garbage). Sends ONE image+prompt turn at T=0 and requires the model to
+/// actually READ the document: the lowercased output must contain at least two
+/// of `DOC_KEYWORDS`. This is the TDD ground-truth gate for the qwen3.5 VL image
+/// fix — the shared vision path (qwen3_5 / qwen3_5_moe / Qwen3.6-35B-A3B)
+/// currently fails it (describes the financial table as "stone/fabric").
+///
+/// CI note: the qwen3_5 MoE checkpoint (35B-A3B, ~70GB) is excluded from the CI
+/// model-e2e matrix by size (see the `.github/workflows/ci.yml` model-test
+/// comment); like the sibling `#[ignore]` gates this runs only via the env vars
+/// locally / on opt-in, never under a plain `cargo test`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_QWEN35MOE_VL_MODEL_PATH + MLX_TEST_VLM_IMAGE_PATH for a Qwen3.5-VL MoE checkpoint + test image"]
+async fn qwen3_5_moe_vl_reads_document_text() {
+    let Ok(model_path) = std::env::var("MLX_TEST_QWEN35MOE_VL_MODEL_PATH") else {
+        eprintln!("skipping: MLX_TEST_QWEN35MOE_VL_MODEL_PATH unset");
+        return;
+    };
+    assert!(
+        Path::new(&model_path).exists(),
+        "MLX_TEST_QWEN35MOE_VL_MODEL_PATH does not exist: {model_path}"
+    );
+    let Some(image_path) = resolve_image_path() else {
+        eprintln!("skipping: no test image (set MLX_TEST_VLM_IMAGE_PATH or add examples/ocr.png)");
+        return;
+    };
+    let image = std::fs::read(&image_path).expect("failed to read test image");
+
+    let model = Qwen3_5MoeModel::load(model_path.clone())
+        .await
+        .expect("failed to load Qwen3.5-VL MoE model");
+
+    tokio::task::block_in_place(|| model.reset_caches()).expect("reset_caches failed");
+
+    // ONE image+text turn at T=0 (greedy/deterministic). max_new_tokens (512) is
+    // well past the small thinking budget so the transcription answer is emitted.
+    let turn = model
+        .chat_session_start(
+            vec![user_msg(
+                "Transcribe the text in this document. List the title and any headings you can read.",
+                Some(&image),
+            )],
+            Some(cfg(512)),
+        )
+        .await
+        .expect("document-transcription chat_session_start failed");
+
+    // Match against raw_text (thinking + answer) so a transcription counts
+    // whether the model reasons about the document or answers directly.
+    let out = turn.raw_text.to_lowercase();
+    let hits: Vec<&str> = DOC_KEYWORDS
+        .iter()
+        .copied()
+        .filter(|kw| out.contains(kw))
+        .collect();
+
+    println!(
+        "READS-DOC ntok={} finish={} hits={:?} :: {}",
+        turn.num_tokens,
+        turn.finish_reason,
+        hits,
+        oneline(&turn.raw_text)
+    );
+
+    assert!(
+        hits.len() >= 2,
+        "model did not READ the document: expected >=2 of {DOC_KEYWORDS:?}, \
+         matched {hits:?} (broken vision features?). Full output:\n{}",
+        turn.raw_text
+    );
+}

--- a/crates/mlx-core/tests/qwen3_5_vl_image_chat.rs
+++ b/crates/mlx-core/tests/qwen3_5_vl_image_chat.rs
@@ -253,3 +253,91 @@ async fn qwen3_5_vl_image_chat_t0_capture() {
     assert_eq!(d1, d1b, "turn 1 digest is not deterministic at T=0");
     assert_eq!(d2, d2b, "turn 2 digest is not deterministic at T=0");
 }
+
+/// Keywords from `examples/ocr.png` — a "TRUNCH PARISH COUNCIL — BANK
+/// RECONCILIATION AS AT 31ST OCTOBER 2019" financial table. A model that
+/// actually READS the image transcribes several of these; a model with broken
+/// vision features hallucinates an unrelated scene (e.g. "stone/fabric") and
+/// matches none.
+const DOC_KEYWORDS: &[&str] = &[
+    "reconciliation",
+    "bank",
+    "council",
+    "trunch",
+    "october",
+    "2019",
+    "balance",
+];
+
+/// Vision-CORRECTNESS gate (distinct from the `_t0_capture` parity digest, which
+/// asserts paged==flat byte-identity and so passes even when the vision features
+/// are garbage). Sends ONE image+prompt turn at T=0 and requires the model to
+/// actually READ the document: the lowercased output must contain at least two
+/// of `DOC_KEYWORDS`. This is the TDD ground-truth gate for the qwen3.5 VL image
+/// fix — the shared vision path (qwen3_5 / qwen3_5_moe / Qwen3.6-35B-A3B)
+/// currently fails it (describes the financial table as "stone/fabric").
+///
+/// CI note: the qwen3_5 MoE checkpoint (35B-A3B, ~70GB) is excluded from the CI
+/// model-e2e matrix by size (see the `.github/workflows/ci.yml` model-test
+/// comment); like the sibling `#[ignore]` gates this runs only via the env vars
+/// locally / on opt-in, never under a plain `cargo test`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_QWEN35_VL_MODEL_PATH + MLX_TEST_VLM_IMAGE_PATH for a Qwen3.5-VL dense checkpoint + test image"]
+async fn qwen3_5_vl_reads_document_text() {
+    let Ok(model_path) = std::env::var("MLX_TEST_QWEN35_VL_MODEL_PATH") else {
+        eprintln!("skipping: MLX_TEST_QWEN35_VL_MODEL_PATH unset");
+        return;
+    };
+    assert!(
+        Path::new(&model_path).exists(),
+        "MLX_TEST_QWEN35_VL_MODEL_PATH does not exist: {model_path}"
+    );
+    let Some(image_path) = resolve_image_path() else {
+        eprintln!("skipping: no test image (set MLX_TEST_VLM_IMAGE_PATH or add examples/ocr.png)");
+        return;
+    };
+    let image = std::fs::read(&image_path).expect("failed to read test image");
+
+    let model = Qwen3_5Model::load(model_path.clone())
+        .await
+        .expect("failed to load Qwen3.5-VL model");
+
+    tokio::task::block_in_place(|| model.reset_caches()).expect("reset_caches failed");
+
+    // ONE image+text turn at T=0 (greedy/deterministic). max_new_tokens (512) is
+    // well past the small thinking budget so the transcription answer is emitted.
+    let turn = model
+        .chat_session_start(
+            vec![user_msg(
+                "Transcribe the text in this document. List the title and any headings you can read.",
+                Some(&image),
+            )],
+            Some(cfg(512)),
+        )
+        .await
+        .expect("document-transcription chat_session_start failed");
+
+    // Match against raw_text (thinking + answer) so a transcription counts
+    // whether the model reasons about the document or answers directly.
+    let out = turn.raw_text.to_lowercase();
+    let hits: Vec<&str> = DOC_KEYWORDS
+        .iter()
+        .copied()
+        .filter(|kw| out.contains(kw))
+        .collect();
+
+    println!(
+        "READS-DOC ntok={} finish={} hits={:?} :: {}",
+        turn.num_tokens,
+        turn.finish_reason,
+        hits,
+        oneline(&turn.raw_text)
+    );
+
+    assert!(
+        hits.len() >= 2,
+        "model did not READ the document: expected >=2 of {DOC_KEYWORDS:?}, \
+         matched {hits:?} (broken vision features?). Full output:\n{}",
+        turn.raw_text
+    );
+}


### PR DESCRIPTION
## Summary

Fixes **Qwen3.5-VL image inference** for both the `qwen3_5` (dense) and
`qwen3_5_moe` families. Before this branch, an image turn ran end-to-end but
produced garbage descriptions — the model could not read text and hallucinated
unrelated subjects (e.g. described a bank-reconciliation table as "dark grey
stone / white fabric"). Text inference and `mlx convert` were unaffected; only
the visual-feature path was wrong.

Found via `ornith-1.0-35b` (a Qwen3.5-VL-MoE-35B-A3B post-train). Root-caused by
numeric bisection against the reference `mlx-vlm` implementation.

## Root causes & fixes (all verified vs `mlx-vlm`)

1. **Interleaved multimodal RoPE for image tokens** (`fb95c6d8`)
   Qwen3.5-VL uses the **interleaved** (stride-3 per-freq) M-RoPE selector, not
   the PaddleOCR **sectioned/contiguous** one. Text tokens (`t==h==w`) are
   identical either way — which is exactly why text always worked while images
   (`t≠h≠w`) got the wrong rotation axis on ~17% of frequencies, every attention
   layer, destroying the 2D positional structure.

2. **Patch embedding: sum Conv3d temporal slices + load `patch_embed.proj.bias`** (`6a889bdb`)
   The patch embed previously used only the first temporal slice and hard-coded
   the conv bias to `None`.

3. **Decode rotates at the compressed M-RoPE position** (`b5c4420e`)
   Image prefill compresses ~754 placeholder tokens into ~29 M-RoPE positions, so
   `rope_deltas = max_position + 1 − seq_len` (≈ −726). Decode must rotate the
   query at `physical_slot + rope_deltas` while K/V still writes at the physical
   slot. Threaded a `rope_position_offset: i32` through
   `forward_paged` / `decoder_layer` / `paged_forward` (dense + MoE share one
   `forward_paged`); the negative delta is carried on `VisionMerge.rope_deltas`
   and stored in `cached_rope_deltas` at VLM prefill. The physical position is
   cast `u32 → i32` **before** the negative add to avoid underflow.

4. **rope-delta lifetime gate** (`f7ae00ca`)
   Found by adversarial review of (3). The cross-turn delta was reset only when
   `cached_prefix_len == 0`, but the paged-turn planner also yields
   `cached_prefix_len > 0` with `continued_live_prefix == false` on a **non-live
   prefix-cache hit**. Because the model instance is shared across all sessions,
   a stale negative delta from a prior image turn could then leak into an
   unrelated **text-only** request that merely shares a cached text prefix —
   rotating that text at `physical + stale_delta` → garbage.

   Factored the decision into `rope_delta_for_paged_turn(cached_rope_deltas,
   continued_live_prefix)` (keep the delta iff it is a live image continuation,
   else clear) and wired it through all six paged reset gates (dense + MoE ×
   sync / stream / engine). This is safe because image requests prefill with
   `skip_lookup` and never publish a hashable text stream that collides with
   their expanded-placeholder blocks, so every non-live hit restores only
   pure-text prefix blocks (delta 0); only a live continuation re-attends the
   image's compressed-position K/V. Added three model-free lifecycle regression
   tests.

5. **e2e correctness gate** (`ab044b88`)
   `qwen3_5_moe_vl_reads_document_text` and `qwen3_5_vl_image_chat.rs` (dense) —
   `#[ignore]`, env-gated (`MLX_TEST_QWEN35MOE_VL_MODEL_PATH` +
   `MLX_TEST_VLM_IMAGE_PATH`), asserting the model reads ≥2 `DOC_KEYWORDS` from
   `examples/ocr.png`. These are the ground-truth gates for VL image inference.

### Note on the addmm commit (`12e89b3a` + `8e6d69d9`)

`12e89b3a` replaced the fused `mlx_array_addmm` primitive with an explicit
`matmul + add`, originally attributed to a bug in `mlx::core::addmm`. **That
premise was wrong** — PyPI MLX's `addmm` applies the `C` term correctly
(maxdiff 0) and the FFI wrapper passes its arguments correctly. The real cause
was a corrupt local metallib that miscompiled the fused GEMM kernels (the same
bad build also miscompiled the NAX gemm). The explicit form is kept as
robustness against this project's documented non-deterministic metallib
corruption — it is correctness-equivalent and vision/bias-only so the perf cost
is negligible — and the `nn::linear` C-application tests double as a build
canary. `8e6d69d9` corrects the misleading comment so it no longer claims an mlx
source bug.

## Validation

- **e2e READS-DOC** on the mxfp8-converted `ornith-1.0-35b` checkpoint: the model
  reads the document, matching all 7 keywords
  (`reconciliation, bank, council, trunch, october, 2019, balance`).
- `nn::linear` addmm/bias tests, `paged_forward` rope-offset + delta-lifetime
  tests, and the broader rope/m-rope/delta unit sweep (70 tests) pass.
- `cargo clippy -p mlx-core --all-targets -D warnings` clean; `cargo fmt` clean.
- Adversarial review of the branch: **approve, no material findings**.

> The full `cargo test -p mlx-core --lib` (debug) shows pre-existing Metal-f32
> failures (banded-attn / attention-vjp) plus a few cross-family numerical tests
> that fail only against the corrupted local **debug** metallib; all of them pass
> in release against a correctly-built metallib (and reproduce on `main`), so the
> branch introduces no new failures.

## Test plan

```bash
# unit (release, correct metallib)
cargo test --release -p mlx-core --lib -- nn::linear paged_forward rope delta

# e2e image-correctness (env-gated, sequential — large models)
MLX_TEST_QWEN35MOE_VL_MODEL_PATH=<converted-qwen3.5-vl-moe> \
MLX_TEST_VLM_IMAGE_PATH=$PWD/examples/ocr.png \
  cargo test --release -p mlx-core --test qwen3_5_moe_vl_image_chat -- \
  --ignored --nocapture qwen3_5_moe_vl_reads_document_text
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core attention RoPE, vision weights, and shared paged inference state across dense/MoE VL; incorrect delta lifetime or offset math would corrupt multi-turn or cached-prefix text, though extensive unit and env-gated e2e tests mitigate this.
> 
> **Overview**
> Fixes **Qwen3.5-VL image inference** (dense and MoE) by aligning vision, RoPE, and paged decode with `mlx-vlm`.
> 
> **Interleaved M-RoPE** — Adds `apply_multimodal_rotary_pos_emb_interleaved` and switches Qwen3.5 attention from the PaddleOCR sectioned apply so image tokens get stride-3 per-frequency axis selection; text-only paths stay unchanged via invariance tests.
> 
> **Vision tower** — `addmm` is implemented as explicit `matmul` + scaled add (avoids local metallib fused-GEMM corruption that dropped biases). Patch embed loads optional conv bias and collapses Conv3d weights by summing temporal slices instead of taking slice 0.
> 
> **Compressed M-RoPE decode** — `VisionMerge` carries `rope_deltas`; `get_rope_index` uses the global max over t/h/w axes. Paged prefill/decode/MTP thread `cached_rope_deltas` through `paged_rope_offset` and `rope_position_offset` so rotation uses compressed positions while KV stays at physical slots. `rope_delta_for_paged_turn` keeps the delta only on `continued_live_prefix` so stale image deltas do not leak into unrelated text prefix-cache hits.
> 
> **Tests** — Unit tests for interleaved RoPE, rope offset/delta lifecycle, patch embed, linear bias; env-gated e2e `reads_document_text` gates for dense and MoE VL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e6d69d9e3ca6b1b4c2ea9b5dc8e1d4d925e250c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->