### PR TITLE
feat(server): honor stop_sequences in /v1/messages + loosen Qwen repetition cutoff

### DIFF
--- a/__test__/server/anthropic-request-mapper.test.ts
+++ b/__test__/server/anthropic-request-mapper.test.ts
@@ -988,31 +988,48 @@ describe('mapAnthropicRequest', () => {
     expect(config.tools).toHaveLength(2);
   });
 
-  it('rejects non-empty stop_sequences (no native ChatConfig.stopSequences yet)', () => {
-    // `stop_sequences` is parsed into the type but `ChatConfig` has no
-    // matching field. Silently dropping the field would let a client believe
-    // its stop strings are honoured. Reject explicitly until native support
-    // lands.
-    expect(() =>
-      mapAnthropicRequest({
-        model: 'claude-3-5-sonnet-20241022',
-        max_tokens: 1024,
-        messages: [{ role: 'user', content: 'Hello' }],
-        stop_sequences: ['STOP'],
-      }),
-    ).toThrow(/stop_sequences.*not supported/i);
+  it('accepts non-empty stop_sequences and threads them out as stopSequences', () => {
+    // `stop_sequences` is now carried out of the mapper (on the widened
+    // return) so a downstream consumer can honour the stop strings. It must
+    // NOT be added to `ChatConfig` (that would need a native rebuild).
+    const { config, stopSequences } = mapAnthropicRequest({
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+      stop_sequences: ['STOP'],
+    });
+    expect(stopSequences).toEqual(['STOP']);
+    expect(config).not.toHaveProperty('stopSequences');
+    expect(config).not.toHaveProperty('stop');
   });
 
-  it('accepts empty stop_sequences array (treated as absent)', () => {
-    // Empty array carries no semantics — accept silently rather than 400 on
-    // a no-op field.
-    const { messages } = mapAnthropicRequest({
+  it('treats empty stop_sequences array as no stop strings', () => {
+    const { stopSequences } = mapAnthropicRequest({
       model: 'claude-3-5-sonnet-20241022',
       max_tokens: 1024,
       messages: [{ role: 'user', content: 'Hello' }],
       stop_sequences: [],
     });
-    expect(messages).toEqual([{ role: 'user', content: 'Hello' }]);
+    expect(stopSequences).toEqual([]);
+  });
+
+  it('treats absent stop_sequences as no stop strings', () => {
+    const { stopSequences } = mapAnthropicRequest({
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+    expect(stopSequences).toEqual([]);
+  });
+
+  it('filters empty strings out of stop_sequences', () => {
+    const { stopSequences } = mapAnthropicRequest({
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+      stop_sequences: ['', 'X'],
+    });
+    expect(stopSequences).toEqual(['X']);
   });
 
   it('maps max_tokens to maxNewTokens in config', () => {

--- a/__test__/server/anthropic-request-mapper.test.ts
+++ b/__test__/server/anthropic-request-mapper.test.ts
@@ -1032,6 +1032,29 @@ describe('mapAnthropicRequest', () => {
     expect(stopSequences).toEqual(['X']);
   });
 
+  it('filters whitespace-only strings out of stop_sequences', () => {
+    // The real Anthropic API rejects whitespace-only stops with a 400, and
+    // keeping them live would silently truncate normal output at the first
+    // space/newline. Dropping them makes such entries a no-op.
+    const { stopSequences } = mapAnthropicRequest({
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+      stop_sequences: [' ', '\n', '\t', '  ', 'X'],
+    });
+    expect(stopSequences).toEqual(['X']);
+  });
+
+  it('treats an all-whitespace stop_sequences array as no stop strings', () => {
+    const { stopSequences } = mapAnthropicRequest({
+      model: 'claude-3-5-sonnet-20241022',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+      stop_sequences: [' ', '\n'],
+    });
+    expect(stopSequences).toEqual([]);
+  });
+
   it('maps max_tokens to maxNewTokens in config', () => {
     const { config } = mapAnthropicRequest({
       model: 'claude-3-5-sonnet-20241022',

--- a/__test__/server/anthropic-response-mapper.test.ts
+++ b/__test__/server/anthropic-response-mapper.test.ts
@@ -63,6 +63,18 @@ describe('mapStopReason', () => {
   it('maps unknown reason with tool calls to "tool_use"', () => {
     expect(mapStopReason('unknown', true)).toBe('tool_use');
   });
+
+  it('returns "stop_sequence" when a stop sequence matched', () => {
+    expect(mapStopReason('stop', false, 'HALT')).toBe('stop_sequence');
+  });
+
+  it('prioritises a matched stop sequence over "max_tokens"', () => {
+    expect(mapStopReason('length', false, 'HALT')).toBe('stop_sequence');
+  });
+
+  it('ignores a null matched stop sequence and keeps existing mapping', () => {
+    expect(mapStopReason('length', false, null)).toBe('max_tokens');
+  });
 });
 
 describe('buildAnthropicResponse', () => {
@@ -197,6 +209,14 @@ describe('buildAnthropicResponse', () => {
     const response = buildAnthropicResponse(result, baseReq, 'msg_len');
 
     expect(response.stop_reason).toBe('max_tokens');
+  });
+
+  it('stop_reason is "stop_sequence" with a non-null stop_sequence when a stop sequence matched', () => {
+    const result = makeChatResult();
+    const response = buildAnthropicResponse(result, baseReq, 'msg_stop_seq', undefined, true, undefined, 'HALT');
+
+    expect(response.stop_reason).toBe('stop_sequence');
+    expect(response.stop_sequence).toBe('HALT');
   });
 
   it('usage maps promptTokens → input_tokens and numTokens → output_tokens', () => {
@@ -537,6 +557,13 @@ describe('buildMessageDelta', () => {
     expect(event.delta.stop_reason).toBe('end_turn');
     expect(event.delta.stop_sequence).toBeNull();
     expect(event.usage.output_tokens).toBe(42);
+  });
+
+  it('emits stop_reason "stop_sequence" with the matched stop_sequence', () => {
+    const event = buildMessageDelta('stop_sequence', 5, undefined, undefined, undefined, undefined, 'HALT');
+
+    expect(event.delta.stop_reason).toBe('stop_sequence');
+    expect(event.delta.stop_sequence).toBe('HALT');
   });
 
   it('passes through input_tokens when supplied without cachedTokens', () => {

--- a/__test__/server/anthropic-response-mapper.test.ts
+++ b/__test__/server/anthropic-response-mapper.test.ts
@@ -219,6 +219,30 @@ describe('buildAnthropicResponse', () => {
     expect(response.stop_sequence).toBe('HALT');
   });
 
+  it('suppresses tool_use blocks when a stop sequence matched (stop wins over tool_use)', () => {
+    // A matched stop halts generation at its position, so a tool call whose
+    // tag would have followed the stop boundary must not be emitted alongside
+    // `stop_reason: 'stop_sequence'`. The truncated visible text stays.
+    const result = makeChatResult({
+      text: 'keep this ',
+      toolCalls: [
+        {
+          id: 'toolu_stop',
+          name: 'get_weather',
+          arguments: '{"city":"SF"}',
+          status: 'ok',
+          rawContent: '',
+        },
+      ],
+    });
+    const response = buildAnthropicResponse(result, baseReq, 'msg_stop_tool', undefined, true, undefined, 'HALT');
+
+    expect(response.stop_reason).toBe('stop_sequence');
+    expect(response.stop_sequence).toBe('HALT');
+    expect(response.content.some((b) => b.type === 'tool_use')).toBe(false);
+    expect(response.content).toEqual([{ type: 'text', text: 'keep this ' }]);
+  });
+
   it('usage maps promptTokens → input_tokens and numTokens → output_tokens', () => {
     const result = makeChatResult({ promptTokens: 42, numTokens: 7 });
     const response = buildAnthropicResponse(result, baseReq, 'msg_usage');

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -2849,6 +2849,154 @@ describe('handleCreateMessage', () => {
       expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
       expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
     });
+
+    it('streaming: counts parked leading whitespace in the terminal overlap so a held stop never replays it', async () => {
+      // Wave #3 regression: the streamed delta " H" parks " " in
+      // `pendingLeadingWhitespace` (whitespace-only, no block open yet) and holds
+      // "H" in the stop detector (prefix of "HALT"). The native done text
+      // " HALTtail" carries the full visible text. The terminal overlap basis must
+      // include the parked " " so the recovered tail is only "ALTtail" (which
+      // completes the held "HALT") instead of the whole " HALTtail" — otherwise the
+      // already-received " H" gets replayed and the "H" of the stop leaks. Correct:
+      // emit exactly the pre-stop whitespace " ", matching the non-streaming result.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: ' H', done: false, isReasoning: false },
+        {
+          text: ' HALTtail',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 8,
+          promptTokens: 4,
+          reasoningTokens: 0,
+          rawText: ' HALTtail',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).toBe(' ');
+      expect(streamedText).not.toContain('H');
+      expect(streamedText).not.toContain('HALT');
+      expect(streamedText).not.toContain('tail');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
+    });
+
+    it('streaming: no-op with no stop_sequences never replays parked whitespace + tag residue', async () => {
+      // Wave #3 regression (C8 no-op): with NO stop_sequences the streamed delta
+      // " <" parks " " in `pendingLeadingWhitespace` and holds "<" in the tag
+      // buffer (possible tag start). The native done text " <x" carries the full
+      // visible text. The terminal overlap basis must include the parked " " and
+      // the held "<" so the recovered tail is only "x" — otherwise " <x" replays
+      // and the wire shows the duplicated " < <x". Correct: emit " <x" exactly once.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: ' <', done: false, isReasoning: false },
+        {
+          text: ' <x',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 4,
+          promptTokens: 2,
+          reasoningTokens: 0,
+          rawText: ' <x',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).toBe(' <x');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('end_turn');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe(null);
+    });
+
+    it('streaming: no-op control recovers only the unsent suffix after parked whitespace (no stop_sequences)', async () => {
+      // Wave #3 control: with NO stop_sequences the streamed delta " H" opens a
+      // text block immediately (non-whitespace), and the native done text " Htail"
+      // recovers only the unsent "tail". The combined stream is exactly " Htail" —
+      // byte-identical to the no-stop behavior, no duplication, no drop.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: ' H', done: false, isReasoning: false },
+        {
+          text: ' Htail',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 6,
+          promptTokens: 3,
+          reasoningTokens: 0,
+          rawText: ' Htail',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).toBe(' Htail');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('end_turn');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe(null);
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -2290,8 +2290,198 @@ describe('handleCreateMessage', () => {
       expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
       expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
 
+      // The tool call's tag came AFTER the stop boundary, so no tool_use
+      // content block may be emitted alongside the stop_sequence terminal.
+      const toolBlock = events.find(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'tool_use',
+      );
+      expect(toolBlock).toBeUndefined();
+
       const msgStop = events.find((e) => e.event === 'message_stop');
       expect(msgStop).toBeDefined();
+    });
+
+    it('non-streaming: suppresses the tool_use block when a stop matched in the visible text', async () => {
+      // Non-streaming sibling of the stop-before-tool case: the visible text
+      // carries a stop string and the native result also parsed a tool call.
+      // The truncated text wins and the tool_use block must be dropped.
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel(
+        makeChatResult({
+          text: 'keep this HALT drop this',
+          rawText: 'keep this HALT <tool_call>{"name":"get_weather"}</tool_call>',
+          finishReason: 'stop',
+          toolCalls: [
+            {
+              status: 'ok',
+              id: 'toolu_stop_ns',
+              name: 'get_weather',
+              arguments: '{"location":"NYC"}',
+            } as ToolCallResult,
+          ],
+          numTokens: 12,
+          promptTokens: 6,
+        }),
+      );
+      registry.register('test-model', mockModel);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stop_sequences: ['HALT'],
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.stop_reason).toBe('stop_sequence');
+      expect(parsed.stop_sequence).toBe('HALT');
+      expect(parsed.content.some((b: any) => b.type === 'tool_use')).toBe(false);
+      expect(parsed.content).toEqual([{ type: 'text', text: 'keep this ' }]);
+    });
+
+    it('streaming: honors a stop sequence hidden in suppressed/recovered text on a no-tools turn', async () => {
+      // Finding 1: the done-path recovery branch re-emits native final text
+      // that the tag buffer suppressed (here the visible bytes around a
+      // `<tool_call>` on a request with NO tools). A stop string living in
+      // that recovered tail was never routed through the detector, so it
+      // leaked and the terminal kept the native reason. The recovered text
+      // must run through the SAME detector before emission.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'Sure <tool_call>{"name":"x"}</tool_call> STOP now', done: false, isReasoning: false },
+        {
+          text: 'Sure  STOP now',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [{ status: 'ok', id: 'call_x', name: 'x', arguments: '{}' }],
+          thinking: null,
+          numTokens: 12,
+          promptTokens: 6,
+          reasoningTokens: 0,
+          rawText: 'Sure <tool_call>{"name":"x"}</tool_call> STOP now',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['STOP'],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).not.toContain('STOP');
+      expect(streamedText).not.toContain('now');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect(msgDelta).toBeDefined();
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('STOP');
+
+      const msgStop = events.find((e) => e.event === 'message_stop');
+      expect(msgStop).toBeDefined();
+    });
+
+    it('streaming: flushes parked pre-stop whitespace as the truncated prefix', async () => {
+      // Finding 5: when the same push that cleared a whitespace-only safe
+      // prefix also matched the stop, that whitespace was parked in
+      // `pendingLeadingWhitespace` and then dropped at done, so streaming
+      // returned no text while non-streaming returned the leading whitespace.
+      // The parked safe bytes must be flushed as the truncated prefix.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: ' HALTtail', done: false, isReasoning: false },
+        {
+          text: ' HALTtail',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 8,
+          promptTokens: 4,
+          reasoningTokens: 0,
+          rawText: ' HALTtail',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      // Exactly the safe pre-stop prefix " ", matching the non-streaming result.
+      expect(streamedText).toBe(' ');
+      expect(streamedText).not.toContain('HALT');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
+    });
+
+    it('non-streaming: returns the leading whitespace prefix when a stop matches right after it', async () => {
+      // Non-streaming counterpart of the parked-whitespace streaming case:
+      // the result text " HALTtail" truncates to " " (the safe prefix).
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel(
+        makeChatResult({
+          text: ' HALTtail',
+          rawText: ' HALTtail',
+          finishReason: 'stop',
+          numTokens: 8,
+          promptTokens: 4,
+        }),
+      );
+      registry.register('test-model', mockModel);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.content).toEqual([{ type: 'text', text: ' ' }]);
+      expect(parsed.stop_reason).toBe('stop_sequence');
+      expect(parsed.stop_sequence).toBe('HALT');
     });
 
     it('streaming: releases a benign held partial when a tool-call tag interrupts it', async () => {

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -2348,6 +2348,62 @@ describe('handleCreateMessage', () => {
       expect((msgDelta!.data['delta'] as any).stop_sequence).toBe(null);
     });
 
+    it('streaming: preserves order of buffered leading whitespace and a held stop-prefix before a tool-call tag', async () => {
+      // Re-review of the `tagFound` fix: a turn-leading whitespace-only delta
+      // (" ") and a stop-prefix ("H" of "HALT") arrive together as " H", then a
+      // bare `<tool_call>` follows. The detector clears the leading " " (visible)
+      // and holds "H"; the " " parks in `pendingLeadingWhitespace` because no
+      // text block is open yet. At the tag, `pendingLeadingWhitespace` is text
+      // that ALREADY passed the detector, so it must be prepended OUTSIDE the
+      // buffer. Re-pushing it would queue it after the held "H" and emit "H "
+      // (order inverted). The visible run is " H" and "H" can never become
+      // "HALT", so no stop matches and the tool call drives the terminal.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: ' H', done: false, isReasoning: false },
+        { text: '<tool_call>{"name":"get_weather"}', done: false, isReasoning: false },
+        {
+          text: '',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [{ status: 'ok', id: 'toolu_w4', name: 'get_weather', arguments: '{"location":"NYC"}' }],
+          thinking: null,
+          numTokens: 9,
+          promptTokens: 5,
+          reasoningTokens: 0,
+          rawText: ' H<tool_call>{"name":"get_weather"}',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      // Order preserved (" H", not "H "), nothing leaked, nothing dropped.
+      expect(streamedText).toBe(' H');
+
+      // No stop matched, so the tool call drives the terminal.
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('tool_use');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe(null);
+    });
+
     it('streaming: leaves the pre-tag visible text untouched when no stop_sequences are configured', async () => {
       // Finding 2: with `stop_sequences` absent the detector is a pass-through,
       // so the `tagFound` path stays byte-identical — the full visible prefix

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -2234,6 +2234,167 @@ describe('handleCreateMessage', () => {
       expect((msgDelta!.data['delta'] as any).stop_reason).toBe('end_turn');
       expect((msgDelta!.data['delta'] as any).stop_sequence).toBe(null);
     });
+
+    it('streaming: honors a stop sequence that lands in the visible text before a tool-call tag', async () => {
+      // Finding 1: the `tagFound` emit path used to write the visible text
+      // before a structural marker (`cleanPrefix`) straight to the wire
+      // without consulting the stop-sequence detector, so a stop string in
+      // that prefix leaked and `stop_reason` stayed `tool_use`. The model
+      // emits "keep this HALT " immediately followed by a `<tool_call>` in
+      // the SAME delta, so the tag buffer reports `tagFound` with
+      // `cleanPrefix === "keep this HALT "`.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'keep this HALT <tool_call>{"name":"get_weather"}', done: false, isReasoning: false },
+        {
+          text: '',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [{ status: 'ok', id: 'toolu_w1', name: 'get_weather', arguments: '{"location":"NYC"}' }],
+          thinking: null,
+          numTokens: 12,
+          promptTokens: 6,
+          reasoningTokens: 0,
+          rawText: 'keep this HALT <tool_call>{"name":"get_weather"}',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).toBe('keep this ');
+      expect(streamedText).not.toContain('HALT');
+      expect(streamedText).not.toContain('<tool_call>');
+
+      // The stop match wins over the tool call: `stop_reason` is
+      // `stop_sequence`, not `tool_use`.
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect(msgDelta).toBeDefined();
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
+
+      const msgStop = events.find((e) => e.event === 'message_stop');
+      expect(msgStop).toBeDefined();
+    });
+
+    it('streaming: releases a benign held partial when a tool-call tag interrupts it', async () => {
+      // Finding 1 (consequence 2): when the detector holds a benign partial
+      // (a prefix of a stop sequence, e.g. "H" of "HALT") and the next delta
+      // is a structural marker, the partial used to be stranded in the
+      // detector and dropped by the suppressed-terminal residue gate. The
+      // `tagFound` path now flushes the detector, releasing the partial as
+      // visible text. Here "keep H" holds "H"; the next delta is a bare
+      // `<tool_call>` (cleanPrefix === ""), and "H" can never become "HALT".
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'keep H', done: false, isReasoning: false },
+        { text: '<tool_call>{"name":"get_weather"}', done: false, isReasoning: false },
+        {
+          text: '',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [{ status: 'ok', id: 'toolu_w2', name: 'get_weather', arguments: '{"location":"NYC"}' }],
+          thinking: null,
+          numTokens: 10,
+          promptTokens: 5,
+          reasoningTokens: 0,
+          rawText: 'keep H<tool_call>{"name":"get_weather"}',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      // The benign "H" is preserved, not dropped.
+      expect(streamedText).toBe('keep H');
+
+      // No stop matched, so the tool call drives the terminal as before.
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('tool_use');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe(null);
+    });
+
+    it('streaming: leaves the pre-tag visible text untouched when no stop_sequences are configured', async () => {
+      // Finding 2: with `stop_sequences` absent the detector is a pass-through,
+      // so the `tagFound` path stays byte-identical — the full visible prefix
+      // (here "keep this HALT ", stop string and all) reaches the wire and
+      // `stop_sequence` is null. Same stream as the honor test above, minus
+      // `stop_sequences`.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'keep this HALT <tool_call>{"name":"get_weather"}', done: false, isReasoning: false },
+        {
+          text: '',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [{ status: 'ok', id: 'toolu_w3', name: 'get_weather', arguments: '{"location":"NYC"}' }],
+          thinking: null,
+          numTokens: 12,
+          promptTokens: 6,
+          reasoningTokens: 0,
+          rawText: 'keep this HALT <tool_call>{"name":"get_weather"}',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).toBe('keep this HALT ');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('tool_use');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe(null);
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -2025,6 +2025,218 @@ describe('handleCreateMessage', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Stop sequences (honoring Anthropic `stop_sequences`)
+  // -----------------------------------------------------------------------
+
+  describe('stop sequences', () => {
+    it('non-streaming: truncates text at the stop sequence and reports stop_sequence', async () => {
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel(
+        makeChatResult({
+          text: 'keep this HALT drop this',
+          rawText: 'keep this HALT drop this',
+          finishReason: 'stop',
+          numTokens: 12,
+          promptTokens: 6,
+        }),
+      );
+      registry.register('test-model', mockModel);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.type).toBe('message');
+      expect(parsed.content).toHaveLength(1);
+      expect(parsed.content[0].type).toBe('text');
+      expect(parsed.content[0].text).toBe('keep this ');
+      expect(parsed.stop_reason).toBe('stop_sequence');
+      expect(parsed.stop_sequence).toBe('HALT');
+    });
+
+    it('streaming: suppresses the stop sequence + tail and reports stop_sequence', async () => {
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'keep this HALT drop this', done: false, isReasoning: false },
+        {
+          text: 'keep this HALT drop this',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 12,
+          promptTokens: 6,
+          reasoningTokens: 0,
+          rawText: 'keep this HALT drop this',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).toBe('keep this ');
+      expect(streamedText).not.toContain('HALT');
+      expect(streamedText).not.toContain('drop this');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect(msgDelta).toBeDefined();
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
+
+      const msgStop = events.find((e) => e.event === 'message_stop');
+      expect(msgStop).toBeDefined();
+    });
+
+    it('streaming: detects a stop sequence split across two deltas', async () => {
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'keep HA', done: false, isReasoning: false },
+        { text: 'LTdrop', done: false, isReasoning: false },
+        {
+          text: 'keep HALTdrop',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 10,
+          promptTokens: 5,
+          reasoningTokens: 0,
+          rawText: 'keep HALTdrop',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).toBe('keep ');
+      expect(streamedText).not.toContain('HALT');
+      expect(streamedText).not.toContain('drop');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
+    });
+
+    it('non-streaming: leaves text and stop_reason untouched when no stop sequence matches', async () => {
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel(
+        makeChatResult({
+          text: 'keep this whole thing',
+          rawText: 'keep this whole thing',
+          finishReason: 'stop',
+          numTokens: 9,
+          promptTokens: 4,
+        }),
+      );
+      registry.register('test-model', mockModel);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.content[0].text).toBe('keep this whole thing');
+      expect(parsed.stop_reason).toBe('end_turn');
+      expect(parsed.stop_sequence).toBe(null);
+    });
+
+    it('streaming: leaves text and stop_reason untouched when no stop sequence matches', async () => {
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'keep ', done: false, isReasoning: false },
+        { text: 'this whole thing', done: false, isReasoning: false },
+        {
+          text: 'keep this whole thing',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 9,
+          promptTokens: 4,
+          reasoningTokens: 0,
+          rawText: 'keep this whole thing',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).toBe('keep this whole thing');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('end_turn');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe(null);
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Error handling
   // -----------------------------------------------------------------------
 

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -2574,6 +2574,63 @@ describe('handleCreateMessage', () => {
       expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
     });
 
+    it('streaming: opens an empty text block when a stop sequence consumes all visible output', async () => {
+      // Parity with the non-streaming path: when the stop matches at the very
+      // start so the visible text collapses to '', the reconstructed content
+      // must be [{type:'text', text:''}] — a text block opened and closed with
+      // no body, exactly like buildAnthropicContent. The old `body.length > 0`
+      // guard skipped the block entirely, so a client rebuilding from SSE saw
+      // `content: []` while the non-streaming sibling returned an empty block.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'STOPhello', done: false, isReasoning: false },
+        {
+          text: 'STOPhello',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 5,
+          promptTokens: 3,
+          reasoningTokens: 0,
+          rawText: 'STOPhello',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['STOP'],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+
+      // Exactly one text block, opened with empty text — the empty-collapse block.
+      const textStarts = events.filter(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'text',
+      );
+      expect(textStarts).toHaveLength(1);
+      expect((textStarts[0].data['content_block'] as any).text).toBe('');
+
+      // The stop ate everything: no visible text leaked and no empty text_delta.
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      expect(textDeltas).toHaveLength(0);
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('STOP');
+    });
+
     it('non-streaming: returns the leading whitespace prefix when a stop matches right after it', async () => {
       // Non-streaming counterpart of the parked-whitespace streaming case:
       // the result text " HALTtail" truncates to " " (the safe prefix).
@@ -2606,6 +2663,41 @@ describe('handleCreateMessage', () => {
       expect(parsed.content).toEqual([{ type: 'text', text: ' ' }]);
       expect(parsed.stop_reason).toBe('stop_sequence');
       expect(parsed.stop_sequence).toBe('HALT');
+    });
+
+    it('non-streaming: returns an empty text block when a stop sequence consumes all visible output', async () => {
+      // Sibling/parity anchor of the streaming empty-collapse case: the result
+      // text "STOPhello" truncates to '' and the content is a single empty text
+      // block — the target the streaming path now matches.
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel(
+        makeChatResult({
+          text: 'STOPhello',
+          rawText: 'STOPhello',
+          finishReason: 'stop',
+          numTokens: 5,
+          promptTokens: 3,
+        }),
+      );
+      registry.register('test-model', mockModel);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stop_sequences: ['STOP'],
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.content).toEqual([{ type: 'text', text: '' }]);
+      expect(parsed.stop_reason).toBe('stop_sequence');
+      expect(parsed.stop_sequence).toBe('STOP');
     });
 
     it('streaming: releases a benign held partial when a tool-call tag interrupts it', async () => {

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -425,15 +425,12 @@ describe('handleCreateMessage', () => {
       expect(sessionReg.size).toBe(sizeBefore);
     });
 
-    it('returns 400 when stop_sequences is non-empty (no warm slot touched)', async () => {
-      // End-to-end: native `ChatConfig` has no `stopSequences` field, so the
-      // mapper rejects the field rather than silently dropping it. The 400
-      // must propagate via the outer try/catch in the handler, and the warm
-      // slot must remain untouched.
+    it('accepts non-empty stop_sequences instead of rejecting with 400', async () => {
+      // End-to-end: the mapper no longer rejects `stop_sequences`; it threads
+      // the stop strings out so a downstream consumer can honour them. The
+      // request must proceed normally rather than 400.
       const registry = new ModelRegistry();
       registry.register('test-model', createMockModel());
-      const sessionReg = registry.getSessionRegistry('test-model')!;
-      const sizeBefore = sessionReg.size;
       const { res, getStatus, getBody } = createMockRes();
 
       await handleCreateMessage(
@@ -447,12 +444,9 @@ describe('handleCreateMessage', () => {
         registry,
       );
 
-      expect(getStatus()).toBe(400);
+      expect(getStatus()).toBe(200);
       const parsed = JSON.parse(getBody());
-      expect(parsed.type).toBe('error');
-      expect(parsed.error.type).toBe('invalid_request_error');
-      expect(parsed.error.message).toContain('stop_sequences');
-      expect(sessionReg.size).toBe(sizeBefore);
+      expect(parsed.type).toBe('message');
     });
   });
 

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -2641,6 +2641,214 @@ describe('handleCreateMessage', () => {
       expect((msgDelta!.data['delta'] as any).stop_reason).toBe('tool_use');
       expect((msgDelta!.data['delta'] as any).stop_sequence).toBe(null);
     });
+
+    it('streaming: detects a stop split across a held partial and recovered terminal text', async () => {
+      // Finding B: the streamed delta "HA" is held by the detector (prefix of
+      // "HALT"); the native done text "HALTtail" completes the stop. The held
+      // partial must stay in the buffer while the terminal/recovered text is
+      // scanned so "HALT" is caught across the boundary instead of leaking.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'HA', done: false, isReasoning: false },
+        {
+          text: 'HALTtail',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 8,
+          promptTokens: 4,
+          reasoningTokens: 0,
+          rawText: 'HALTtail',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).not.toContain('HALT');
+      expect(streamedText).not.toContain('tail');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect(msgDelta).toBeDefined();
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
+    });
+
+    it('streaming: detects a stop split across a held partial and tag-suppressed recovered text', async () => {
+      // Finding B (tag-suppression variant): the model emits "HA", then a
+      // suppressed <tool_call> on a no-tools turn, then "LTtail". The native
+      // cleaned done text "HALTtail" reconstitutes the visible text. The held
+      // "HA" must still be buffered when the recovered tail is scanned, so the
+      // already-streamed bytes never include any part of the matched stop.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'HA<tool_call>{}</tool_call>LTtail', done: false, isReasoning: false },
+        {
+          text: 'HALTtail',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [],
+          thinking: null,
+          numTokens: 8,
+          promptTokens: 4,
+          reasoningTokens: 0,
+          rawText: 'HA<tool_call>{}</tool_call>LTtail',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).not.toContain('HALT');
+      expect(streamedText).not.toContain('tail');
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect(msgDelta).toBeDefined();
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
+    });
+
+    it('streaming: suppresses the tool_use block when a stop matches in recovered terminal text', async () => {
+      // Finding C: tools enabled, streamed "prefix ", native done text
+      // "prefix HALT tail" plus one ok tool call. The stop is found only in
+      // the recovered terminal text, so the tool call must be suppressed and
+      // stop_reason must be stop_sequence — a streamed response must never
+      // carry both a tool_use block and stop_sequence. Matches non-streaming.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'prefix ', done: false, isReasoning: false },
+        {
+          text: 'prefix HALT tail',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [{ status: 'ok', id: 'call_w', name: 'get_weather', arguments: '{"location":"NYC"}' }],
+          thinking: null,
+          numTokens: 10,
+          promptTokens: 5,
+          reasoningTokens: 0,
+          rawText: 'prefix HALT tail',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).not.toContain('HALT');
+
+      const toolBlock = events.find(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'tool_use',
+      );
+      expect(toolBlock).toBeUndefined();
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect(msgDelta).toBeDefined();
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
+    });
+
+    it('streaming: suppresses the tool_use block when a stop matches in tag-suppressed recovered text', async () => {
+      // Finding C (tag-suppression variant): the model emits "prefix ", a
+      // suppressed <tool_call>, then "HALT tail". The native cleaned done text
+      // "prefix HALT tail" surfaces the stop. Tools must be suppressed and the
+      // terminal must be stop_sequence — never both.
+      const registry = new ModelRegistry();
+      const streamEvents = [
+        { text: 'prefix <tool_call>{"name":"get_weather"}</tool_call>HALT tail', done: false, isReasoning: false },
+        {
+          text: 'prefix HALT tail',
+          done: true,
+          finishReason: 'stop',
+          toolCalls: [{ status: 'ok', id: 'call_w', name: 'get_weather', arguments: '{"location":"NYC"}' }],
+          thinking: null,
+          numTokens: 10,
+          promptTokens: 5,
+          reasoningTokens: 0,
+          rawText: 'prefix <tool_call>{"name":"get_weather"}</tool_call>HALT tail',
+        },
+      ];
+      registry.register('test-model', createMockStreamModel(streamEvents));
+      const { res, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stream: true,
+          stop_sequences: ['HALT'],
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+        },
+        registry,
+      );
+
+      const events = parseSSE(getBody());
+      const textDeltas = events.filter(
+        (e) => e.event === 'content_block_delta' && (e.data['delta'] as any).type === 'text_delta',
+      );
+      const streamedText = textDeltas.map((d) => (d.data['delta'] as any).text as string).join('');
+      expect(streamedText).not.toContain('HALT');
+
+      const toolBlock = events.find(
+        (e) => e.event === 'content_block_start' && (e.data['content_block'] as any).type === 'tool_use',
+      );
+      expect(toolBlock).toBeUndefined();
+
+      const msgDelta = events.find((e) => e.event === 'message_delta');
+      expect(msgDelta).toBeDefined();
+      expect((msgDelta!.data['delta'] as any).stop_reason).toBe('stop_sequence');
+      expect((msgDelta!.data['delta'] as any).stop_sequence).toBe('HALT');
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/__test__/server/messages-handler.test.ts
+++ b/__test__/server/messages-handler.test.ts
@@ -2346,6 +2346,130 @@ describe('handleCreateMessage', () => {
       expect(parsed.content).toEqual([{ type: 'text', text: 'keep this ' }]);
     });
 
+    it('non-streaming: resolves a held overlapping stop at flush', async () => {
+      // BUG A: `push()` holds a complete stop ('HALT') because a longer
+      // overlapping stop ('HALTED') is still viable, so it returns
+      // `matched:null`. Without a follow-up `flush()` the held stop leaks as
+      // normal text with `stop_reason: end_turn`. The non-streaming path must
+      // push+flush like the streaming done-path.
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel(
+        makeChatResult({
+          text: 'keep HALT',
+          rawText: 'keep HALT',
+          finishReason: 'stop',
+          numTokens: 6,
+          promptTokens: 3,
+        }),
+      );
+      registry.register('test-model', mockModel);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stop_sequences: ['HALT', 'HALTED'],
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.content).toHaveLength(1);
+      expect(parsed.content[0].type).toBe('text');
+      expect(parsed.content[0].text).toBe('keep ');
+      expect(parsed.stop_reason).toBe('stop_sequence');
+      expect(parsed.stop_sequence).toBe('HALT');
+    });
+
+    it('non-streaming: honors a stop sequence inside recovered suppressed-tool text', async () => {
+      // BUG B: the request disallows tools, but the native parser still
+      // produced a tool call and `result.text` is empty, so
+      // `buildAnthropicContent` emits `recoverSuppressedToolCallText(rawText)`
+      // as the visible text. The stop scan must run over THAT recovered text,
+      // not the empty `result.text` — otherwise a stop inside it leaks with
+      // `stop_reason: end_turn`.
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel(
+        makeChatResult({
+          text: '',
+          rawText: 'Sure STOP <tool_call>{"name":"get_weather","arguments":{}}</tool_call>',
+          finishReason: 'stop',
+          toolCalls: [
+            {
+              status: 'ok',
+              id: 'call_x',
+              name: 'get_weather',
+              arguments: '{}',
+            } as ToolCallResult,
+          ],
+          numTokens: 12,
+          promptTokens: 6,
+        }),
+      );
+      registry.register('test-model', mockModel);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stop_sequences: ['STOP'],
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.content.some((b: any) => b.type === 'tool_use')).toBe(false);
+      const textBlock = parsed.content.find((b: any) => b.type === 'text');
+      expect(textBlock).toBeDefined();
+      expect(textBlock.text).toBe('Sure ');
+      expect(parsed.stop_reason).toBe('stop_sequence');
+      expect(parsed.stop_sequence).toBe('STOP');
+    });
+
+    it('non-streaming: keeps a trailing incomplete partial when no stop completes', async () => {
+      // Control for the flush() addition: 'keep HAL' ends in a prefix of
+      // 'HALT' but never completes it. `flush()` must release the held partial
+      // as normal text — nothing may be dropped and no false truncation may
+      // occur.
+      const registry = new ModelRegistry();
+      const mockModel = createMockModel(
+        makeChatResult({
+          text: 'keep HAL',
+          rawText: 'keep HAL',
+          finishReason: 'stop',
+          numTokens: 6,
+          promptTokens: 3,
+        }),
+      );
+      registry.register('test-model', mockModel);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleCreateMessage(
+        res,
+        {
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'go' }],
+          max_tokens: 100,
+          stop_sequences: ['HALT'],
+        },
+        registry,
+      );
+
+      expect(getStatus()).toBe(200);
+      const parsed = JSON.parse(getBody());
+      expect(parsed.content[0].text).toBe('keep HAL');
+      expect(parsed.stop_reason).toBe('end_turn');
+      expect(parsed.stop_sequence).toBe(null);
+    });
+
     it('streaming: honors a stop sequence hidden in suppressed/recovered text on a no-tools turn', async () => {
       // Finding 1: the done-path recovery branch re-emits native final text
       // that the tag buffer suppressed (here the visible bytes around a

--- a/__test__/server/presets.test.ts
+++ b/__test__/server/presets.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Coverage for the launch-preset anti-repetition cutoff values.
+ *
+ * A live Claude Code session on Ornith (qwen3_5_moe) truncated an
+ * ASCII box mid-diagram: a run of repeated `─` tripped the native
+ * sampler's consecutive-token cutoff (`max_consecutive_tokens`
+ * default 16) → finish_reason `"repetition"` → `stop_reason:"end_turn"`.
+ * The Qwen launch presets loosen the cutoff so legit repeated content
+ * (box borders, separators, tables) survives while a true runaway loop
+ * still stops.
+ *
+ * The merge-survival tests drive the REAL `ChatSession.mergeConfig`
+ * through `ModelRegistry.register({ samplingDefaults }) → getOrCreate →
+ * session.send`, observing the merged ChatConfig the session forwards
+ * to `chatSessionStart` (a session-capable mock — no native model).
+ */
+
+import type { ChatConfig, ChatMessage, ChatResult, ToolCallResult } from '@mlx-node/core';
+import type { SessionCapableModel } from '@mlx-node/lm';
+import {
+  GEMMA4_SAMPLING_DEFAULTS,
+  LAUNCH_PRESETS,
+  LFM2_SAMPLING_DEFAULTS,
+  ModelRegistry,
+  QWEN_SAMPLING_DEFAULTS,
+} from '@mlx-node/server';
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+// ---------------------------------------------------------------------------
+// Mock model (mirrors sampling-defaults.test.ts): captures the merged
+// ChatConfig that ChatSession passes down to chatSessionStart.
+// ---------------------------------------------------------------------------
+
+interface CapturingModel extends SessionCapableModel {
+  lastStartConfig: ChatConfig | null | undefined;
+  startCallCount: number;
+}
+
+function createCapturingModel(): CapturingModel {
+  const emptyResult: ChatResult = {
+    text: '',
+    toolCalls: [] as ToolCallResult[],
+    thinking: null,
+    numTokens: 0,
+    promptTokens: 0,
+    reasoningTokens: 0,
+    finishReason: 'stop',
+    rawText: '',
+  } as unknown as ChatResult;
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async function* emptyStream(): AsyncGenerator<Record<string, unknown>> {
+    yield { done: true, text: '', finishReason: 'stop', toolCalls: [], numTokens: 0, promptTokens: 0 };
+  }
+
+  const model = {
+    lastStartConfig: undefined as ChatConfig | null | undefined,
+    startCallCount: 0,
+    chatSessionStart: vi.fn(async (_messages: ChatMessage[], config?: ChatConfig | null) => {
+      model.lastStartConfig = config;
+      model.startCallCount += 1;
+      return emptyResult;
+    }),
+    chatSessionContinue: vi.fn().mockResolvedValue(emptyResult),
+    chatSessionContinueTool: vi.fn().mockResolvedValue(emptyResult),
+    chatStreamSessionStart: vi.fn(() => emptyStream()),
+    chatStreamSessionContinue: vi.fn(() => emptyStream()),
+    chatStreamSessionContinueTool: vi.fn(() => emptyStream()),
+    resetCaches: vi.fn(),
+  };
+  return model as unknown as CapturingModel;
+}
+
+// ---------------------------------------------------------------------------
+// Static preset-value assertions
+// ---------------------------------------------------------------------------
+
+const LOOSENED_CUTOFF = {
+  maxConsecutiveTokens: 256,
+  maxNgramRepeats: 8,
+  ngramSize: 64,
+} as const;
+
+describe('QWEN launch-preset anti-repetition cutoff', () => {
+  it('loosens the cutoff on every Qwen launch entry (qwen3 / qwen3_5 / qwen3_5_moe)', () => {
+    for (const key of ['qwen3', 'qwen3_5', 'qwen3_5_moe'] as const) {
+      const sampling = LAUNCH_PRESETS[key]!.sampling;
+      expect(sampling.maxConsecutiveTokens).toBe(256);
+      expect(sampling.maxNgramRepeats).toBe(8);
+      expect(sampling.ngramSize).toBe(64);
+    }
+  });
+
+  it('sets the loosened cutoff on all four QWEN_SAMPLING_DEFAULTS variants', () => {
+    for (const key of ['thinkingCoding', 'thinkingGeneral', 'instructGeneral', 'instructReasoning'] as const) {
+      const sampling = QWEN_SAMPLING_DEFAULTS[key];
+      expect(sampling.maxConsecutiveTokens).toBe(256);
+      expect(sampling.maxNgramRepeats).toBe(8);
+      expect(sampling.ngramSize).toBe(64);
+    }
+  });
+
+  it('does not disable the cutoff (runaway-loop protection must remain)', () => {
+    for (const key of ['thinkingCoding', 'thinkingGeneral', 'instructGeneral', 'instructReasoning'] as const) {
+      const sampling = QWEN_SAMPLING_DEFAULTS[key];
+      expect(sampling.maxConsecutiveTokens).not.toBe(0);
+      expect(sampling.maxNgramRepeats).not.toBe(0);
+    }
+  });
+
+  it('leaves the existing sampling knobs intact (thinkingCoding spec)', () => {
+    const s = QWEN_SAMPLING_DEFAULTS.thinkingCoding;
+    expect(s.temperature).toBe(0.6);
+    expect(s.topP).toBe(0.95);
+    expect(s.topK).toBe(20);
+    expect(s.minP).toBe(0);
+    expect(s.presencePenalty).toBe(0);
+    expect(s.repetitionPenalty).toBe(1);
+  });
+});
+
+describe('scope lock: non-Qwen presets unchanged', () => {
+  it('does not set the cutoff on the Gemma4 preset', () => {
+    expect(GEMMA4_SAMPLING_DEFAULTS.maxConsecutiveTokens).toBeUndefined();
+    expect(GEMMA4_SAMPLING_DEFAULTS.maxNgramRepeats).toBeUndefined();
+    expect(GEMMA4_SAMPLING_DEFAULTS.ngramSize).toBeUndefined();
+    expect(LAUNCH_PRESETS.gemma4!.sampling.maxConsecutiveTokens).toBeUndefined();
+  });
+
+  it('does not set the cutoff on the LFM2 preset', () => {
+    expect(LFM2_SAMPLING_DEFAULTS.maxConsecutiveTokens).toBeUndefined();
+    expect(LFM2_SAMPLING_DEFAULTS.maxNgramRepeats).toBeUndefined();
+    expect(LFM2_SAMPLING_DEFAULTS.ngramSize).toBeUndefined();
+    expect(LAUNCH_PRESETS.lfm2!.sampling.maxConsecutiveTokens).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Merge survival (real ChatSession.mergeConfig)
+// ---------------------------------------------------------------------------
+
+describe('cutoff survives ChatSession.mergeConfig', () => {
+  it('carries the loosened cutoff through when the per-request overlay omits it', async () => {
+    const registry = new ModelRegistry();
+    const model = createCapturingModel();
+    registry.register('qwen35moe', model, { samplingDefaults: LAUNCH_PRESETS.qwen3_5_moe!.sampling });
+
+    const sessionReg = registry.getSessionRegistry('qwen35moe')!;
+    const { session } = sessionReg.getOrCreate(null, null);
+
+    // Claude Code never sends these fields — overlay omits them.
+    await session.send('hi');
+
+    expect(model.lastStartConfig).toMatchObject(LOOSENED_CUTOFF);
+    // Full shape: defaults + reuseCache, nothing else injected.
+    expect(model.lastStartConfig).toEqual({
+      ...LAUNCH_PRESETS.qwen3_5_moe!.sampling,
+      reuseCache: true,
+    });
+  });
+
+  it('lets a per-request override win on maxConsecutiveTokens while the other cutoff fields survive', async () => {
+    const registry = new ModelRegistry();
+    const model = createCapturingModel();
+    registry.register('qwen35moe', model, { samplingDefaults: LAUNCH_PRESETS.qwen3_5_moe!.sampling });
+
+    const sessionReg = registry.getSessionRegistry('qwen35moe')!;
+    const { session } = sessionReg.getOrCreate(null, null);
+
+    await session.send('hi', { config: { maxConsecutiveTokens: 32 } });
+
+    expect(model.lastStartConfig!.maxConsecutiveTokens).toBe(32);
+    // Default n-gram fields still carried (overlay didn't touch them).
+    expect(model.lastStartConfig!.maxNgramRepeats).toBe(8);
+    expect(model.lastStartConfig!.ngramSize).toBe(64);
+  });
+});

--- a/__test__/server/stop-sequence-buffer.test.ts
+++ b/__test__/server/stop-sequence-buffer.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+import { StopSequenceBuffer } from '../../packages/server/src/stop-sequence-buffer.js';
+
+describe('StopSequenceBuffer', () => {
+  it('passes text through transparently when no stop sequences are configured', () => {
+    const buffer = new StopSequenceBuffer([]);
+
+    expect(buffer.push('abc')).toEqual({ safeText: 'abc', matched: null });
+    expect(buffer.push('def')).toEqual({ safeText: 'def', matched: null });
+    expect(buffer.flush()).toEqual({ safeText: '', matched: null });
+    expect(buffer.matched).toBeNull();
+  });
+
+  it('treats only-empty stop sequences as no configuration', () => {
+    const buffer = new StopSequenceBuffer(['', '']);
+
+    expect(buffer.push('anything')).toEqual({ safeText: 'anything', matched: null });
+    expect(buffer.flush()).toEqual({ safeText: '', matched: null });
+  });
+
+  it('detects a whole stop sequence within a single push and suppresses the rest', () => {
+    const buffer = new StopSequenceBuffer(['HALT']);
+
+    expect(buffer.push('abcHALTxyz')).toEqual({ safeText: 'abc', matched: 'HALT' });
+    expect(buffer.push('more')).toEqual({ safeText: '', matched: 'HALT' });
+    expect(buffer.matched).toBe('HALT');
+  });
+
+  it('detects a stop sequence split across two pushes', () => {
+    const buffer = new StopSequenceBuffer(['HALT']);
+
+    expect(buffer.push('abcHAL')).toEqual({ safeText: 'abc', matched: null });
+    expect(buffer.push('Tyz')).toEqual({ safeText: '', matched: 'HALT' });
+    expect(buffer.matched).toBe('HALT');
+  });
+
+  it('releases a false partial that never completes a stop sequence', () => {
+    const buffer = new StopSequenceBuffer(['HALT']);
+
+    expect(buffer.push('abHAL')).toEqual({ safeText: 'ab', matched: null });
+    expect(buffer.push('xz')).toEqual({ safeText: 'HALxz', matched: null });
+    expect(buffer.flush()).toEqual({ safeText: '', matched: null });
+    expect(buffer.matched).toBeNull();
+  });
+
+  it('detects a stop sequence at the very start of the text', () => {
+    const buffer = new StopSequenceBuffer(['STOP']);
+
+    expect(buffer.push('STOPnow')).toEqual({ safeText: '', matched: 'STOP' });
+  });
+
+  it('matches the earliest stop sequence when multiple are present', () => {
+    const buffer = new StopSequenceBuffer(['END', 'HALT']);
+
+    expect(buffer.push('aHALTbENDc')).toEqual({ safeText: 'a', matched: 'HALT' });
+  });
+
+  it('prefers the longest stop sequence on a tie at the same index', () => {
+    const buffer = new StopSequenceBuffer(['ab', 'abc']);
+
+    expect(buffer.push('xabc')).toEqual({ safeText: 'x', matched: 'abc' });
+  });
+
+  it('never emits a held-back partial suffix prematurely', () => {
+    const buffer = new StopSequenceBuffer(['STOP']);
+
+    // "ST" could begin "STOP", so it must be withheld, not emitted.
+    const first = buffer.push('abcST');
+    expect(first.safeText).toBe('abc');
+    expect(first.safeText).not.toContain('ST');
+    expect(first.matched).toBeNull();
+
+    // The withheld suffix is only released by flush when it cannot complete.
+    expect(buffer.flush()).toEqual({ safeText: 'ST', matched: null });
+  });
+});

--- a/__test__/server/stop-sequence-buffer.test.ts
+++ b/__test__/server/stop-sequence-buffer.test.ts
@@ -74,4 +74,41 @@ describe('StopSequenceBuffer', () => {
     // The withheld suffix is only released by flush when it cannot complete.
     expect(buffer.flush()).toEqual({ safeText: 'ST', matched: null });
   });
+
+  it('treats whitespace-only stop sequences as no configuration', () => {
+    const buffer = new StopSequenceBuffer([' ', '\n', '\t']);
+
+    expect(buffer.push('one two\nthree')).toEqual({ safeText: 'one two\nthree', matched: null });
+    expect(buffer.flush()).toEqual({ safeText: '', matched: null });
+    expect(buffer.matched).toBeNull();
+  });
+
+  it('holds a tail match when a longer same-index stop could still complete on a later push', () => {
+    const buffer = new StopSequenceBuffer(['ab', 'abc']);
+
+    // "ab" is complete at the tail, but "abc" (same start index) is still
+    // viable, so the match must be held rather than committed early.
+    expect(buffer.push('xab')).toEqual({ safeText: 'x', matched: null });
+    // The next push completes the longer stop, which wins on the tie.
+    expect(buffer.push('c tail')).toEqual({ safeText: '', matched: 'abc' });
+    expect(buffer.matched).toBe('abc');
+  });
+
+  it('commits the short stop when the longer same-index stop is broken on a later push', () => {
+    const buffer = new StopSequenceBuffer(['ab', 'abc']);
+
+    expect(buffer.push('xab')).toEqual({ safeText: 'x', matched: null });
+    // No "c" arrives, so the longer "abc" can never complete and "ab" wins.
+    expect(buffer.push(' x')).toEqual({ safeText: '', matched: 'ab' });
+    expect(buffer.matched).toBe('ab');
+  });
+
+  it('resolves a held tail match at flush when no longer stop completes', () => {
+    const buffer = new StopSequenceBuffer(['ab', 'abc']);
+
+    expect(buffer.push('xab')).toEqual({ safeText: 'x', matched: null });
+    // Stream ends with only "ab" present; the held match resolves to "ab".
+    expect(buffer.flush()).toEqual({ safeText: '', matched: 'ab' });
+    expect(buffer.matched).toBe('ab');
+  });
 });

--- a/__test__/server/stop-sequence-buffer.test.ts
+++ b/__test__/server/stop-sequence-buffer.test.ts
@@ -111,4 +111,34 @@ describe('StopSequenceBuffer', () => {
     expect(buffer.flush()).toEqual({ safeText: '', matched: 'ab' });
     expect(buffer.matched).toBe('ab');
   });
+
+  it('holds a short tail match while an EARLIER-index longer stop could still complete', () => {
+    // Finding A: "xab" contains the short stop "ab" at index 1, but it is also
+    // a viable prefix of the longer stop "xabc" beginning at the EARLIER index
+    // 0. Earliest-match-wins means the short "ab" must be HELD (not committed)
+    // until the earlier "xabc" either completes or is broken.
+    const buffer = new StopSequenceBuffer(['xabc', 'ab']);
+
+    expect(buffer.push('xab')).toEqual({ safeText: '', matched: null });
+    // The next char completes the earlier/longer "xabc", which wins.
+    expect(buffer.push('c')).toEqual({ safeText: '', matched: 'xabc' });
+    expect(buffer.matched).toBe('xabc');
+  });
+
+  it('commits the short stop when the earlier longer stop can no longer complete', () => {
+    const buffer = new StopSequenceBuffer(['xabc', 'ab']);
+
+    expect(buffer.push('xab')).toEqual({ safeText: '', matched: null });
+    // "z" breaks "xabc" (it needed "c"); the short "ab" at index 1 commits
+    // promptly, emitting the safe "x" before it — no hang, no dropped text.
+    expect(buffer.push('z')).toEqual({ safeText: 'x', matched: 'ab' });
+    expect(buffer.matched).toBe('ab');
+  });
+
+  it('matches the earlier longer stop in a single chunk', () => {
+    const buffer = new StopSequenceBuffer(['xabc', 'ab']);
+
+    expect(buffer.push('xabc')).toEqual({ safeText: '', matched: 'xabc' });
+    expect(buffer.matched).toBe('xabc');
+  });
 });

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -320,33 +320,12 @@ async function handleStreamingNative(
   // (`push` returns its input verbatim, `flush` returns ''), so the wire is
   // byte-identical to a request without `stop_sequences`. When a stop string
   // matches, `matchedStopSequence` is recorded, all later visible text is
-  // suppressed, and the text-recovery branches in the terminal block are
-  // gated off so the suppressed tail is never re-emitted.
+  // suppressed, and the done-path emits nothing past the stop. The done-path
+  // also scans the terminal / recovered visible text on this SAME buffer (with
+  // any held partial still in place), so a stop straddling the stream/terminal
+  // boundary is caught with buffer continuity.
   const stopBuffer = new StopSequenceBuffer(stopSequences);
   let matchedStopSequence: string | null = null;
-
-  // Route terminal / recovered visible text through the SAME stop-sequence
-  // detector that gated the streamed deltas. The done-path recovery branches
-  // can re-emit visible bytes the stream never surfaced — text the tag buffer
-  // suppressed after a structural marker, or native final / recovered text
-  // that diverges from what streamed — and a stop string living there would
-  // otherwise leak. The stream is ending, so push then flush: no later delta
-  // can complete a held partial. On a match `matchedStopSequence` is recorded
-  // (forcing the `stop_sequence` terminal) and only the safe prefix is
-  // returned, so the caller emits nothing past the stop. With an empty
-  // `stopSequences` the detector is a pass-through, returning the input
-  // verbatim.
-  const scanTerminalText = (candidate: string): string => {
-    const pushed = stopBuffer.push(candidate);
-    if (pushed.matched !== null) {
-      matchedStopSequence = pushed.matched;
-    }
-    const residue = stopBuffer.flush();
-    if (residue.matched !== null) {
-      matchedStopSequence = residue.matched;
-    }
-    return pushed.safeText + residue.safeText;
-  };
 
   // Terminal emission is deferred until after the loop drains so `wasCommitted()`
   // reads an authoritative `session.turns`. On a committed done chunk we emit
@@ -421,62 +400,14 @@ async function handleStreamingNative(
           break;
         }
 
-        // Run the tag-buffer's residual text through the stop-sequence
-        // detector (push any held-back tail, then flush the detector's own
-        // held-back suffix). When a stop string already matched (or matches
-        // here) both calls contribute empty `safeText`, so the suppressed
-        // tail never reaches the wire. With an empty `stopSequences` the
-        // buffer is a pass-through: `push` returns its input and `flush`
-        // returns '', so `remainingText === tagBuffer.flush()` as before.
-        const stopTail = stopBuffer.push(tagBuffer.flush());
-        if (stopTail.matched !== null) {
-          matchedStopSequence = stopTail.matched;
-        }
-        const stopResidue = stopBuffer.flush();
-        if (stopResidue.matched !== null) {
-          matchedStopSequence = stopResidue.matched;
-        }
-        const remainingText = stopTail.safeText + stopResidue.safeText;
-        if (!tagBuffer.suppressed && remainingText) {
-          // Flush any pending leading whitespace alongside the residual
-          // text — once a real text block opens, its declared content
-          // must be byte-accurate, so the buffered whitespace is
-          // promoted to the head of that block. If `remainingText`
-          // itself is whitespace-only and there is no buffered
-          // whitespace, `combined.trim()` is empty and we drop both.
-          const combined = pendingLeadingWhitespace + remainingText;
-          pendingLeadingWhitespace = '';
-          if (hasEmittedText || combined.trim().length > 0) {
-            if (!hasEmittedText) {
-              if (hasEmittedThinking) {
-                writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
-              }
-              hasEmittedText = true;
-              writeSSEEvent(
-                res,
-                'content_block_start',
-                buildContentBlockStart(contentBlockIndex, {
-                  type: 'text',
-                  text: '',
-                }),
-              );
-            }
-            emittedText += combined;
-            emittedTextLength += combined.length;
-            writeSSEEvent(
-              res,
-              'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, {
-                type: 'text_delta',
-                text: combined,
-              }),
-            );
-          }
-        }
-
-        if (hasEmittedThinking && !hasEmittedText) {
-          writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
-        }
+        // Flush the tag buffer's residual but keep the stop buffer intact: it
+        // may still hold a partial from the streamed deltas, and a stop can
+        // straddle the boundary between that held partial, the tag residue, and
+        // the native terminal/recovered text. All of it runs through the SAME
+        // buffer, in stream order, with a single flush, BEFORE the stop match,
+        // the emitted text, and the tool decision are finalized.
+        const tagResidual = tagBuffer.flush();
+        const heldPartial = stopBuffer.pending;
 
         const parsedToolCalls = event.toolCalls.filter((t) => t.status === 'ok');
         if (!allowToolUse && parsedToolCalls.length > 0) {
@@ -489,33 +420,96 @@ async function handleStreamingNative(
           containsToolCallMarkup(event.rawText)
             ? recoverSuppressedToolCallText(event.rawText)
             : event.text;
-        // A stop matched in the pre-tool visible text (the `tagFound`
-        // `cleanPrefix` path, or any streamed delta) halts generation at its
-        // position, so a tool call whose tag followed the stop boundary must
-        // not be emitted. `matchedStopSequence` here reflects only matches
-        // seen up to this point — the recovered-tail scan (below) runs after
-        // this gate, so a stop that lives only after a fully-formed tool call
-        // does not retroactively suppress that tool (tool-use precedence is
-        // left intact there).
-        const okToolCalls = allowToolUse && matchedStopSequence === null ? parsedToolCalls : [];
-        const hasToolCalls = okToolCalls.length > 0;
 
-        // Recovery: suppression triggered but no tool calls parsed — emit final text as a text block.
-        //
-        // All three recovery branches below reconcile `emittedText` against
-        // the model's final text and may RE-EMIT text the stream "missed".
-        // When a stop sequence matched, `emittedText` is intentionally a
-        // truncated prefix and `finalText` still carries the suppressed tail,
-        // so re-emitting would leak exactly what we suppressed. Gate every
-        // branch off in that case (`matchedStopSequence === null`) — the
-        // truncated `emittedText` is authoritative.
-        if (matchedStopSequence === null && tagBuffer.suppressed && !hasToolCalls && finalText && !hasEmittedText) {
-          // Route the recovered final text through the stop detector before
-          // emission so a stop string the tag buffer suppressed is honored,
-          // not leaked. `safe` is `finalText` verbatim when no stop matches.
-          const safe = scanTerminalText(finalText);
-          if (safe) {
-            // Thinking block (if any) was already closed above.
+        // The visible text the stream already RECEIVED through the stop buffer
+        // — what reached the wire, plus the still-held partial, plus the tag
+        // residue about to be scanned. Used as the overlap basis so the
+        // recovered terminal text is the suffix of `finalText` the stream has
+        // not already accounted for.
+        const streamedReceived = emittedText + heldPartial + tagResidual;
+        let recoveredTail = '';
+        if (finalText) {
+          if (!hasEmittedText && heldPartial.length === 0 && tagResidual.length === 0) {
+            // Nothing was streamed or held: the whole `finalText` is terminal.
+            recoveredTail = finalText;
+          } else if (!streamedReceived.includes(finalText)) {
+            // `finalText` extends past what the stream produced: recover the
+            // suffix beyond the longest overlap. The `includes` guard skips the
+            // duplicate-trim case where `finalText` is a substring of the
+            // received text (native `.trim()` / post-`</think>` shrinkage).
+            recoveredTail = finalText.slice(longestSuffixPrefixOverlap(streamedReceived, finalText));
+          }
+        }
+
+        // One continuous scan — held partial (already buffered) + tag residue +
+        // recovered tail, in stream order, with a single flush at the end. A
+        // stop matched anywhere here is caught with buffer continuity, and
+        // `matchedStopSequence` is finalized before tool emission and
+        // `stop_reason`. With an empty `stopSequences` the buffer is a
+        // pass-through, so `terminalVisible` equals the released text verbatim.
+        let terminalVisible = '';
+        for (const segment of [tagResidual, recoveredTail]) {
+          const pushed = stopBuffer.push(segment);
+          if (pushed.matched !== null) {
+            matchedStopSequence = pushed.matched;
+          }
+          terminalVisible += pushed.safeText;
+        }
+        const flushed = stopBuffer.flush();
+        if (flushed.matched !== null) {
+          matchedStopSequence = flushed.matched;
+        }
+        terminalVisible += flushed.safeText;
+
+        // Parked leading whitespace belongs in front of RELEASED held content
+        // (a stop-buffer partial or tag residue). When the terminal text is
+        // purely native `finalText` recovery, `finalText` already carries that
+        // whitespace, so prepending it would double those bytes.
+        const prependParked = heldPartial.length > 0 || tagResidual.length > 0;
+
+        // Close a dangling reasoning block before any terminal text block opens.
+        if (hasEmittedThinking && !hasEmittedText) {
+          writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
+        }
+
+        if (hasEmittedText) {
+          // A text block is already open from the streamed deltas: append the
+          // newly released terminal text (if any), then close the block.
+          if (terminalVisible) {
+            emittedText += terminalVisible;
+            emittedTextLength += terminalVisible.length;
+            writeSSEEvent(
+              res,
+              'content_block_delta',
+              buildContentBlockDelta(contentBlockIndex, {
+                type: 'text_delta',
+                text: terminalVisible,
+              }),
+            );
+          }
+          writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
+          contentBlockIndex++;
+          pendingLeadingWhitespace = '';
+        } else {
+          // No text block open yet. Build the block body from the terminal text
+          // (fronted by parked whitespace only when it precedes released held
+          // content), or from the parked whitespace alone when a stop truncated
+          // the turn right after it.
+          const body = terminalVisible
+            ? prependParked
+              ? pendingLeadingWhitespace + terminalVisible
+              : terminalVisible
+            : matchedStopSequence !== null
+              ? pendingLeadingWhitespace
+              : '';
+          pendingLeadingWhitespace = '';
+          // Open a text block for non-whitespace content, for a stop-truncated
+          // prefix (so the streamed body equals the non-streaming one), or for
+          // pure native `finalText` recovery (mirrors emitting recovered text
+          // verbatim). Whitespace-only released held content opens no block.
+          const openTextBlock =
+            body.length > 0 && (body.trim().length > 0 || matchedStopSequence !== null || !prependParked);
+          if (openTextBlock) {
             hasEmittedText = true;
             writeSSEEvent(
               res,
@@ -525,169 +519,29 @@ async function handleStreamingNative(
                 text: '',
               }),
             );
-            emittedText += safe;
-            emittedTextLength += safe.length;
+            emittedText += body;
+            emittedTextLength += body.length;
             writeSSEEvent(
               res,
               'content_block_delta',
               buildContentBlockDelta(contentBlockIndex, {
                 type: 'text_delta',
-                text: safe,
-              }),
-            );
-          }
-        } else if (
-          matchedStopSequence === null &&
-          tagBuffer.suppressed &&
-          !hasToolCalls &&
-          finalText &&
-          hasEmittedText &&
-          !emittedText.includes(finalText)
-        ) {
-          // Recovery: streaming text was cut off by a false-alarm `<tool_call>` tag.
-          //
-          // `emittedTextLength` is an index into the streamed chunks, NOT into
-          // `finalText`. The native side trims leading whitespace after
-          // `</think>` via `split_at_think_end`, so the prefixes can diverge:
-          // e.g. streamed=`"\n\n<tool_call>..."`, finalText=`"<tool_call>..."`.
-          // A naive `finalText.slice(emittedTextLength)` would chop `<t` off
-          // `<tool_call>` and emit `"ool_call>\n<function=..."`. Find the
-          // longest streamed-suffix == finalText-prefix overlap and emit
-          // whatever finalText has BEYOND that overlap.
-          //
-          // The `!emittedText.includes(finalText)` guard distinguishes:
-          //   (a) duplicate-trim case: streamed "Let me check. " + closed
-          //       non-ok tool_call → finalText="Let me check." (trimmed). The
-          //       trimmed text IS a substring of the streamed text → skip
-          //       (otherwise we'd duplicate "Let me check.").
-          //   (b) unclosed-tool case: streamed `\n\n` + unclosed
-          //       `<tool_call>...` → finalText=`<tool_call>...`. The malformed
-          //       tag is NOT a substring of the streamed whitespace → emit
-          //       (this is the original `<t`-strip bug we're fixing).
-          // Length-based guards (`finalText.length > emittedText.length`)
-          // misclassify case (b) when the streamed whitespace is long.
-          const overlap = longestSuffixPrefixOverlap(emittedText, finalText);
-          const unsent = finalText.slice(overlap);
-          // Route the recovered suffix through the stop detector so a stop
-          // string in the previously-suppressed tail is honored. `safe` is
-          // `unsent` verbatim when no stop matches.
-          const safe = scanTerminalText(unsent);
-          if (safe) {
-            emittedText += safe;
-            emittedTextLength += safe.length;
-            writeSSEEvent(
-              res,
-              'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, {
-                type: 'text_delta',
-                text: safe,
-              }),
-            );
-          }
-        } else if (matchedStopSequence === null && hasEmittedText && finalText && !emittedText.includes(finalText)) {
-          // Emit any unsent suffix when final text extends past what was
-          // streamed. Same divergence concern as above (post-</think> trim
-          // can leave `emittedText` longer than the matching prefix of
-          // `finalText`), so we use the same overlap-based slice instead of
-          // a length-based one. When the overlap covers all of `finalText`
-          // (i.e. nothing more to emit) `unsent` is empty and we skip.
-          //
-          // The `!emittedText.includes(finalText)` guard skips the
-          // duplicate-trim case where finalText is a substring of the
-          // streamed text (e.g. native `.trim()` shrinkage). See the
-          // companion comment above for the case-distinction rationale.
-          const overlap = longestSuffixPrefixOverlap(emittedText, finalText);
-          const unsent = finalText.slice(overlap);
-          // Route the unsent suffix through the stop detector before emission.
-          // `safe` is `unsent` verbatim when no stop matches.
-          const safe = scanTerminalText(unsent);
-          if (safe) {
-            emittedText += safe;
-            emittedTextLength += safe.length;
-            writeSSEEvent(
-              res,
-              'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, {
-                type: 'text_delta',
-                text: safe,
-              }),
-            );
-          }
-        }
-
-        if (hasEmittedText) {
-          writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
-          contentBlockIndex++;
-          pendingLeadingWhitespace = '';
-        } else if (matchedStopSequence !== null && pendingLeadingWhitespace) {
-          // The push that cleared this leading whitespace also matched the
-          // stop, so it is the entire safe truncated prefix: there is no later
-          // text delta to join it with, and no tool_use frame will follow (a
-          // match suppresses tools). Emit it as the turn's text block so the
-          // streamed body equals the non-streaming truncated prefix instead of
-          // dropping the parked whitespace.
-          writeSSEEvent(
-            res,
-            'content_block_start',
-            buildContentBlockStart(contentBlockIndex, {
-              type: 'text',
-              text: '',
-            }),
-          );
-          emittedText += pendingLeadingWhitespace;
-          emittedTextLength += pendingLeadingWhitespace.length;
-          writeSSEEvent(
-            res,
-            'content_block_delta',
-            buildContentBlockDelta(contentBlockIndex, {
-              type: 'text_delta',
-              text: pendingLeadingWhitespace,
-            }),
-          );
-          writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
-          contentBlockIndex++;
-          pendingLeadingWhitespace = '';
-        } else if (!finalText && hasToolCalls) {
-          // Pure tool-call turn — no text block. Drop any leading
-          // whitespace we had buffered before the `<tool_call>` tag.
-          pendingLeadingWhitespace = '';
-        } else if (finalText && matchedStopSequence === null) {
-          // All text arrived in the final event; emit it as a single
-          // block. `finalText` is the FULL accumulated text from the
-          // native side, NOT a delta — any whitespace we buffered in
-          // `pendingLeadingWhitespace` from intermediate whitespace-only
-          // deltas is already part of `finalText`, so prepending the
-          // buffer here would double-emit those bytes. Drop the buffer
-          // and emit the detector-safe `finalText` (a stop string present
-          // only in this final-event text is honored, not leaked).
-          pendingLeadingWhitespace = '';
-          const safe = scanTerminalText(finalText);
-          if (safe) {
-            writeSSEEvent(
-              res,
-              'content_block_start',
-              buildContentBlockStart(contentBlockIndex, {
-                type: 'text',
-                text: '',
-              }),
-            );
-            emittedText += safe;
-            emittedTextLength += safe.length;
-            writeSSEEvent(
-              res,
-              'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, {
-                type: 'text_delta',
-                text: safe,
+                text: body,
               }),
             );
             writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
             contentBlockIndex++;
           }
-        } else {
-          // No text emission at all this turn — drop the buffer.
-          pendingLeadingWhitespace = '';
         }
+
+        // Decide tool emission only AFTER the full terminal stop scan: when a
+        // stop matched ANYWHERE (the pre-tool visible text OR the
+        // terminal/recovered text) the tool calls are suppressed so a streamed
+        // turn never carries both a tool_use block and
+        // `stop_reason: 'stop_sequence'`. This keeps streaming in lockstep with
+        // the non-streaming path (`buildAnthropicResponse`).
+        const okToolCalls = allowToolUse && matchedStopSequence === null ? parsedToolCalls : [];
+        const hasToolCalls = okToolCalls.length > 0;
 
         for (const tc of okToolCalls) {
           // Translate native `call_<uuid>` ids (minted by the Rust parser,
@@ -771,38 +625,36 @@ async function handleStreamingNative(
           // text before it terminates here. Only `cleanPrefix` is fresh
           // model text — route it through the stop-sequence detector so a
           // configured stop string landing in it (e.g. "...HALT " right
-          // before a `<tool_call>`) is honored, not leaked. The tag
-          // suppresses everything after it, so no later delta can complete a
-          // held partial — flush the detector too so a benign partial it was
-          // holding (e.g. "H" of "HALT") is released as visible text instead
-          // of being stranded for the suppressed-terminal residue gate to
-          // drop. `pendingLeadingWhitespace` is whitespace the detector
-          // already cleared on an earlier delta (held back only because no
-          // text block was open yet), so it is prepended OUTSIDE the buffer:
-          // re-pushing it would double-scan it AND, because the buffer queues
-          // it after any partial it is still holding, invert stream order
-          // (e.g. held "H" + buffered " " emits as "H ") or even forge a
-          // false match (held "H" + " " -> "H " matching a "H " stop). On a
-          // match `matchedStopSequence` is recorded so the terminal reports
+          // before a `<tool_call>`) is honored, not leaked. Do NOT flush the
+          // detector here: a held partial (e.g. "HA" of "HALT") must stay
+          // buffered, because the native cleaned done text can reconstitute
+          // the bytes that followed the suppressed tag and complete the stop
+          // across that boundary. The done-path scans the held partial
+          // together with the terminal/recovered text and resolves it —
+          // releasing it as visible text if it cannot complete, or suppressing
+          // it if it does. `pendingLeadingWhitespace` is whitespace the
+          // detector already cleared on an earlier delta (held back only
+          // because no text block was open yet), so it is prepended OUTSIDE
+          // the buffer: re-pushing it would double-scan it AND, because the
+          // buffer queues it after any held partial, invert stream order
+          // (e.g. held "H" + buffered " " -> "H ") or forge a false match. On
+          // a match `matchedStopSequence` is recorded so the terminal reports
           // `stop_sequence`. With an empty `stopSequences` the detector is a
-          // pass-through (`push` returns its input, `flush` returns ''), so
-          // `visibleText === pendingLeadingWhitespace + cleanPrefix` and the
-          // wire is byte-identical to today.
+          // pass-through, so `visibleText === pendingLeadingWhitespace +
+          // cleanPrefix` and the wire is byte-identical to today.
           const stopPushed = stopBuffer.push(cleanPrefix);
           if (stopPushed.matched !== null) {
             matchedStopSequence = stopPushed.matched;
           }
-          const stopResidue = stopBuffer.flush();
-          if (stopResidue.matched !== null) {
-            matchedStopSequence = stopResidue.matched;
-          }
-          const visibleText = pendingLeadingWhitespace + stopPushed.safeText + stopResidue.safeText;
-          pendingLeadingWhitespace = '';
+          const visibleText = pendingLeadingWhitespace + stopPushed.safeText;
           // Mirror the original `cleanPrefix.trim()` gate, now on the
           // detector's safe text: emit only when there is non-whitespace to
-          // show, so a pure-whitespace prefix (or a stop match that leaves
-          // only whitespace) never ratifies a stray whitespace-only text
-          // block before the tool_use frame.
+          // show, so a pure-whitespace prefix never ratifies a stray
+          // whitespace-only text block before the tool_use frame. When the
+          // safe text is whitespace-only (e.g. the detector is still holding a
+          // partial), KEEP it parked so the done-path can join it with
+          // whatever the held partial releases — clearing it here would drop
+          // it before that text block opens.
           if (visibleText.trim().length > 0) {
             if (!hasEmittedText) {
               if (hasEmittedThinking) {
@@ -818,6 +670,7 @@ async function handleStreamingNative(
                 }),
               );
             }
+            pendingLeadingWhitespace = '';
             emittedText += visibleText;
             emittedTextLength += visibleText.length;
             writeSSEEvent(
@@ -828,6 +681,8 @@ async function handleStreamingNative(
                 text: visibleText,
               }),
             );
+          } else {
+            pendingLeadingWhitespace = hasEmittedText ? '' : visibleText;
           }
         } else if (safeText) {
           // Run the tag-buffer's visible text through the stop-sequence

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -529,9 +529,12 @@ async function handleStreamingNative(
           // Open a text block for non-whitespace content, for a stop-truncated
           // prefix (so the streamed body equals the non-streaming one), or for
           // pure native `finalText` recovery (mirrors emitting recovered text
-          // verbatim). Whitespace-only released held content opens no block.
+          // verbatim). A stop-matched turn always opens a text block — empty if
+          // the stop consumed all visible output — so the reconstructed content
+          // matches the non-streaming `[{type:'text', text:''}]`. Whitespace-only
+          // released held content opens no block.
           const openTextBlock =
-            body.length > 0 && (body.trim().length > 0 || matchedStopSequence !== null || !prependParked);
+            matchedStopSequence !== null || (body.length > 0 && (body.trim().length > 0 || !prependParked));
           if (openTextBlock) {
             hasEmittedText = true;
             writeSSEEvent(
@@ -542,16 +545,18 @@ async function handleStreamingNative(
                 text: '',
               }),
             );
-            emittedText += body;
-            emittedTextLength += body.length;
-            writeSSEEvent(
-              res,
-              'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, {
-                type: 'text_delta',
-                text: body,
-              }),
-            );
+            if (body.length > 0) {
+              emittedText += body;
+              emittedTextLength += body.length;
+              writeSSEEvent(
+                res,
+                'content_block_delta',
+                buildContentBlockDelta(contentBlockIndex, {
+                  type: 'text_delta',
+                  text: body,
+                }),
+              );
+            }
             writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
             contentBlockIndex++;
           }

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -692,24 +692,27 @@ async function handleStreamingNative(
         const { safeText, tagFound, cleanPrefix } = tagBuffer.push(event.text);
         if (tagFound) {
           // A structural tag (`<tool_call>` etc.) follows, so the visible
-          // text before it (`cleanPrefix`, plus any buffered leading
-          // whitespace that belongs to the same logical run) terminates
-          // here. Route that text through the stop-sequence detector before
-          // emitting: a configured stop string landing in `cleanPrefix`
-          // (e.g. "...HALT " right before a `<tool_call>`) must be honored,
-          // not leaked. The tag suppresses everything after it, so no later
-          // delta can complete a held partial — flush the detector too so a
-          // benign partial it was holding (e.g. "H" of "HALT") is released
-          // as visible text instead of being stranded for the
-          // suppressed-terminal residue gate to drop. Emit only the
-          // detector's safe text; on a match `matchedStopSequence` is
-          // recorded so the terminal reports `stop_sequence`. With an empty
-          // `stopSequences` the detector is a pass-through (`push` returns
-          // its input, `flush` returns ''), so `visibleText === combined`
-          // and the wire is byte-identical to today.
-          const combined = pendingLeadingWhitespace + cleanPrefix;
-          pendingLeadingWhitespace = '';
-          const stopPushed = stopBuffer.push(combined);
+          // text before it terminates here. Only `cleanPrefix` is fresh
+          // model text — route it through the stop-sequence detector so a
+          // configured stop string landing in it (e.g. "...HALT " right
+          // before a `<tool_call>`) is honored, not leaked. The tag
+          // suppresses everything after it, so no later delta can complete a
+          // held partial — flush the detector too so a benign partial it was
+          // holding (e.g. "H" of "HALT") is released as visible text instead
+          // of being stranded for the suppressed-terminal residue gate to
+          // drop. `pendingLeadingWhitespace` is whitespace the detector
+          // already cleared on an earlier delta (held back only because no
+          // text block was open yet), so it is prepended OUTSIDE the buffer:
+          // re-pushing it would double-scan it AND, because the buffer queues
+          // it after any partial it is still holding, invert stream order
+          // (e.g. held "H" + buffered " " emits as "H ") or even forge a
+          // false match (held "H" + " " -> "H " matching a "H " stop). On a
+          // match `matchedStopSequence` is recorded so the terminal reports
+          // `stop_sequence`. With an empty `stopSequences` the detector is a
+          // pass-through (`push` returns its input, `flush` returns ''), so
+          // `visibleText === pendingLeadingWhitespace + cleanPrefix` and the
+          // wire is byte-identical to today.
+          const stopPushed = stopBuffer.push(cleanPrefix);
           if (stopPushed.matched !== null) {
             matchedStopSequence = stopPushed.matched;
           }
@@ -717,7 +720,8 @@ async function handleStreamingNative(
           if (stopResidue.matched !== null) {
             matchedStopSequence = stopResidue.matched;
           }
-          const visibleText = stopPushed.safeText + stopResidue.safeText;
+          const visibleText = pendingLeadingWhitespace + stopPushed.safeText + stopResidue.safeText;
+          pendingLeadingWhitespace = '';
           // Mirror the original `cleanPrefix.trim()` gate, now on the
           // detector's safe text: emit only when there is non-whitespace to
           // show, so a pure-whitespace prefix (or a stop match that leaves

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -325,6 +325,29 @@ async function handleStreamingNative(
   const stopBuffer = new StopSequenceBuffer(stopSequences);
   let matchedStopSequence: string | null = null;
 
+  // Route terminal / recovered visible text through the SAME stop-sequence
+  // detector that gated the streamed deltas. The done-path recovery branches
+  // can re-emit visible bytes the stream never surfaced — text the tag buffer
+  // suppressed after a structural marker, or native final / recovered text
+  // that diverges from what streamed — and a stop string living there would
+  // otherwise leak. The stream is ending, so push then flush: no later delta
+  // can complete a held partial. On a match `matchedStopSequence` is recorded
+  // (forcing the `stop_sequence` terminal) and only the safe prefix is
+  // returned, so the caller emits nothing past the stop. With an empty
+  // `stopSequences` the detector is a pass-through, returning the input
+  // verbatim.
+  const scanTerminalText = (candidate: string): string => {
+    const pushed = stopBuffer.push(candidate);
+    if (pushed.matched !== null) {
+      matchedStopSequence = pushed.matched;
+    }
+    const residue = stopBuffer.flush();
+    if (residue.matched !== null) {
+      matchedStopSequence = residue.matched;
+    }
+    return pushed.safeText + residue.safeText;
+  };
+
   // Terminal emission is deferred until after the loop drains so `wasCommitted()`
   // reads an authoritative `session.turns`. On a committed done chunk we emit
   // `message_delta` + `message_stop`; on an uncommitted terminal (finishReason=error,
@@ -466,7 +489,15 @@ async function handleStreamingNative(
           containsToolCallMarkup(event.rawText)
             ? recoverSuppressedToolCallText(event.rawText)
             : event.text;
-        const okToolCalls = allowToolUse ? parsedToolCalls : [];
+        // A stop matched in the pre-tool visible text (the `tagFound`
+        // `cleanPrefix` path, or any streamed delta) halts generation at its
+        // position, so a tool call whose tag followed the stop boundary must
+        // not be emitted. `matchedStopSequence` here reflects only matches
+        // seen up to this point — the recovered-tail scan (below) runs after
+        // this gate, so a stop that lives only after a fully-formed tool call
+        // does not retroactively suppress that tool (tool-use precedence is
+        // left intact there).
+        const okToolCalls = allowToolUse && matchedStopSequence === null ? parsedToolCalls : [];
         const hasToolCalls = okToolCalls.length > 0;
 
         // Recovery: suppression triggered but no tool calls parsed — emit final text as a text block.
@@ -479,26 +510,32 @@ async function handleStreamingNative(
         // branch off in that case (`matchedStopSequence === null`) — the
         // truncated `emittedText` is authoritative.
         if (matchedStopSequence === null && tagBuffer.suppressed && !hasToolCalls && finalText && !hasEmittedText) {
-          // Thinking block (if any) was already closed above.
-          hasEmittedText = true;
-          writeSSEEvent(
-            res,
-            'content_block_start',
-            buildContentBlockStart(contentBlockIndex, {
-              type: 'text',
-              text: '',
-            }),
-          );
-          emittedText += finalText;
-          emittedTextLength += finalText.length;
-          writeSSEEvent(
-            res,
-            'content_block_delta',
-            buildContentBlockDelta(contentBlockIndex, {
-              type: 'text_delta',
-              text: finalText,
-            }),
-          );
+          // Route the recovered final text through the stop detector before
+          // emission so a stop string the tag buffer suppressed is honored,
+          // not leaked. `safe` is `finalText` verbatim when no stop matches.
+          const safe = scanTerminalText(finalText);
+          if (safe) {
+            // Thinking block (if any) was already closed above.
+            hasEmittedText = true;
+            writeSSEEvent(
+              res,
+              'content_block_start',
+              buildContentBlockStart(contentBlockIndex, {
+                type: 'text',
+                text: '',
+              }),
+            );
+            emittedText += safe;
+            emittedTextLength += safe.length;
+            writeSSEEvent(
+              res,
+              'content_block_delta',
+              buildContentBlockDelta(contentBlockIndex, {
+                type: 'text_delta',
+                text: safe,
+              }),
+            );
+          }
         } else if (
           matchedStopSequence === null &&
           tagBuffer.suppressed &&
@@ -531,15 +568,19 @@ async function handleStreamingNative(
           // misclassify case (b) when the streamed whitespace is long.
           const overlap = longestSuffixPrefixOverlap(emittedText, finalText);
           const unsent = finalText.slice(overlap);
-          if (unsent) {
-            emittedText += unsent;
-            emittedTextLength += unsent.length;
+          // Route the recovered suffix through the stop detector so a stop
+          // string in the previously-suppressed tail is honored. `safe` is
+          // `unsent` verbatim when no stop matches.
+          const safe = scanTerminalText(unsent);
+          if (safe) {
+            emittedText += safe;
+            emittedTextLength += safe.length;
             writeSSEEvent(
               res,
               'content_block_delta',
               buildContentBlockDelta(contentBlockIndex, {
                 type: 'text_delta',
-                text: unsent,
+                text: safe,
               }),
             );
           }
@@ -557,21 +598,52 @@ async function handleStreamingNative(
           // companion comment above for the case-distinction rationale.
           const overlap = longestSuffixPrefixOverlap(emittedText, finalText);
           const unsent = finalText.slice(overlap);
-          if (unsent) {
-            emittedText += unsent;
-            emittedTextLength += unsent.length;
+          // Route the unsent suffix through the stop detector before emission.
+          // `safe` is `unsent` verbatim when no stop matches.
+          const safe = scanTerminalText(unsent);
+          if (safe) {
+            emittedText += safe;
+            emittedTextLength += safe.length;
             writeSSEEvent(
               res,
               'content_block_delta',
               buildContentBlockDelta(contentBlockIndex, {
                 type: 'text_delta',
-                text: unsent,
+                text: safe,
               }),
             );
           }
         }
 
         if (hasEmittedText) {
+          writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
+          contentBlockIndex++;
+          pendingLeadingWhitespace = '';
+        } else if (matchedStopSequence !== null && pendingLeadingWhitespace) {
+          // The push that cleared this leading whitespace also matched the
+          // stop, so it is the entire safe truncated prefix: there is no later
+          // text delta to join it with, and no tool_use frame will follow (a
+          // match suppresses tools). Emit it as the turn's text block so the
+          // streamed body equals the non-streaming truncated prefix instead of
+          // dropping the parked whitespace.
+          writeSSEEvent(
+            res,
+            'content_block_start',
+            buildContentBlockStart(contentBlockIndex, {
+              type: 'text',
+              text: '',
+            }),
+          );
+          emittedText += pendingLeadingWhitespace;
+          emittedTextLength += pendingLeadingWhitespace.length;
+          writeSSEEvent(
+            res,
+            'content_block_delta',
+            buildContentBlockDelta(contentBlockIndex, {
+              type: 'text_delta',
+              text: pendingLeadingWhitespace,
+            }),
+          );
           writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
           contentBlockIndex++;
           pendingLeadingWhitespace = '';
@@ -586,28 +658,32 @@ async function handleStreamingNative(
           // `pendingLeadingWhitespace` from intermediate whitespace-only
           // deltas is already part of `finalText`, so prepending the
           // buffer here would double-emit those bytes. Drop the buffer
-          // and emit `finalText` verbatim.
+          // and emit the detector-safe `finalText` (a stop string present
+          // only in this final-event text is honored, not leaked).
           pendingLeadingWhitespace = '';
-          writeSSEEvent(
-            res,
-            'content_block_start',
-            buildContentBlockStart(contentBlockIndex, {
-              type: 'text',
-              text: '',
-            }),
-          );
-          emittedText += finalText;
-          emittedTextLength += finalText.length;
-          writeSSEEvent(
-            res,
-            'content_block_delta',
-            buildContentBlockDelta(contentBlockIndex, {
-              type: 'text_delta',
-              text: finalText,
-            }),
-          );
-          writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
-          contentBlockIndex++;
+          const safe = scanTerminalText(finalText);
+          if (safe) {
+            writeSSEEvent(
+              res,
+              'content_block_start',
+              buildContentBlockStart(contentBlockIndex, {
+                type: 'text',
+                text: '',
+              }),
+            );
+            emittedText += safe;
+            emittedTextLength += safe.length;
+            writeSSEEvent(
+              res,
+              'content_block_delta',
+              buildContentBlockDelta(contentBlockIndex, {
+                type: 'text_delta',
+                text: safe,
+              }),
+            );
+            writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex));
+            contentBlockIndex++;
+          }
         } else {
           // No text emission at all this turn — drop the buffer.
           pendingLeadingWhitespace = '';

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -88,6 +88,7 @@ import { genId } from '../mappers/response.js';
 import type { ModelWorkCoordinator } from '../model-work-coordinator.js';
 import type { ModelRegistry } from '../registry.js';
 import { QueueFullError, type SessionRegistry } from '../session-registry.js';
+import { StopSequenceBuffer } from '../stop-sequence-buffer.js';
 import { beginSSE, endSSE, writeSSEEvent } from '../streaming.js';
 import { longestSuffixPrefixOverlap } from '../text-recovery.js';
 import { resolveServerTuningForUsage, type ServerTimingForUsage } from '../timing.js';
@@ -206,9 +207,30 @@ async function handleNonStreaming(
   result: ChatResult,
   body: AnthropicMessagesRequest,
   visibility: TransportVisibility,
+  stopSequences: string[],
   serverTiming?: ServerTimingForUsage,
 ): Promise<void> {
   const messageId = genId('msg_');
+
+  // Honor client-supplied `stop_sequences`: scan the model's final text for
+  // the earliest configured stop string. On a match we truncate the text the
+  // response is built from at the match (dropping the stop string and
+  // everything after it) and report `stop_reason: 'stop_sequence'` +
+  // `stop_sequence: '<matched>'`. The native `ChatResult` is left untouched —
+  // only the response builder sees the truncated text. An empty
+  // `stopSequences` constructs a pass-through buffer that never matches, so
+  // behavior is byte-identical to a request without `stop_sequences`.
+  let matchedStopSequence: string | null = null;
+  let responseResult = result;
+  if (stopSequences.length > 0) {
+    const stopBuffer = new StopSequenceBuffer(stopSequences);
+    const { safeText, matched } = stopBuffer.push(result.text);
+    if (matched !== null) {
+      matchedStopSequence = matched;
+      responseResult = { ...result, text: safeText };
+    }
+  }
+
   // `result.performance` is only populated when `reportPerformance: true`
   // rides on the underlying `ChatConfig`; otherwise the field is
   // `undefined` and the mapper elides the wire-extension fields. The
@@ -216,12 +238,13 @@ async function handleNonStreaming(
   // by default, matching how `cachedTokens` is treated through
   // `buildAnthropicResponse`.
   const response = buildAnthropicResponse(
-    result,
+    responseResult,
     body,
     messageId,
     result.performance,
     requestAllowsToolUse(body),
     serverTiming,
+    matchedStopSequence,
   );
 
   // Native `chatSession*` has no AbortSignal surface yet, so a client that
@@ -256,6 +279,7 @@ async function handleStreamingNative(
   httpReq: IncomingMessage | undefined,
   visibility: TransportVisibility,
   emitReasoning: boolean,
+  stopSequences: string[],
   serverTiming?: ServerTimingForUsage,
 ): Promise<MessagesStreamingHandlerResult> {
   const messageId = genId('msg_');
@@ -290,6 +314,16 @@ async function handleStreamingNative(
   // suffix instead of a length-based slice that would chop characters.
   let emittedText = '';
   const tagBuffer = new ToolCallTagBuffer();
+  // Client-supplied `stop_sequences` detector. Feeds on the visible text that
+  // survives `tagBuffer` (structural-marker stripping) so it never sees tool
+  // markup. An empty `stopSequences` constructs a pass-through buffer
+  // (`push` returns its input verbatim, `flush` returns ''), so the wire is
+  // byte-identical to a request without `stop_sequences`. When a stop string
+  // matches, `matchedStopSequence` is recorded, all later visible text is
+  // suppressed, and the text-recovery branches in the terminal block are
+  // gated off so the suppressed tail is never re-emitted.
+  const stopBuffer = new StopSequenceBuffer(stopSequences);
+  let matchedStopSequence: string | null = null;
 
   // Terminal emission is deferred until after the loop drains so `wasCommitted()`
   // reads an authoritative `session.turns`. On a committed done chunk we emit
@@ -364,7 +398,22 @@ async function handleStreamingNative(
           break;
         }
 
-        const remainingText = tagBuffer.flush();
+        // Run the tag-buffer's residual text through the stop-sequence
+        // detector (push any held-back tail, then flush the detector's own
+        // held-back suffix). When a stop string already matched (or matches
+        // here) both calls contribute empty `safeText`, so the suppressed
+        // tail never reaches the wire. With an empty `stopSequences` the
+        // buffer is a pass-through: `push` returns its input and `flush`
+        // returns '', so `remainingText === tagBuffer.flush()` as before.
+        const stopTail = stopBuffer.push(tagBuffer.flush());
+        if (stopTail.matched !== null) {
+          matchedStopSequence = stopTail.matched;
+        }
+        const stopResidue = stopBuffer.flush();
+        if (stopResidue.matched !== null) {
+          matchedStopSequence = stopResidue.matched;
+        }
+        const remainingText = stopTail.safeText + stopResidue.safeText;
         if (!tagBuffer.suppressed && remainingText) {
           // Flush any pending leading whitespace alongside the residual
           // text — once a real text block opens, its declared content
@@ -421,7 +470,15 @@ async function handleStreamingNative(
         const hasToolCalls = okToolCalls.length > 0;
 
         // Recovery: suppression triggered but no tool calls parsed — emit final text as a text block.
-        if (tagBuffer.suppressed && !hasToolCalls && finalText && !hasEmittedText) {
+        //
+        // All three recovery branches below reconcile `emittedText` against
+        // the model's final text and may RE-EMIT text the stream "missed".
+        // When a stop sequence matched, `emittedText` is intentionally a
+        // truncated prefix and `finalText` still carries the suppressed tail,
+        // so re-emitting would leak exactly what we suppressed. Gate every
+        // branch off in that case (`matchedStopSequence === null`) — the
+        // truncated `emittedText` is authoritative.
+        if (matchedStopSequence === null && tagBuffer.suppressed && !hasToolCalls && finalText && !hasEmittedText) {
           // Thinking block (if any) was already closed above.
           hasEmittedText = true;
           writeSSEEvent(
@@ -443,6 +500,7 @@ async function handleStreamingNative(
             }),
           );
         } else if (
+          matchedStopSequence === null &&
           tagBuffer.suppressed &&
           !hasToolCalls &&
           finalText &&
@@ -485,7 +543,7 @@ async function handleStreamingNative(
               }),
             );
           }
-        } else if (hasEmittedText && finalText && !emittedText.includes(finalText)) {
+        } else if (matchedStopSequence === null && hasEmittedText && finalText && !emittedText.includes(finalText)) {
           // Emit any unsent suffix when final text extends past what was
           // streamed. Same divergence concern as above (post-</think> trim
           // can leave `emittedText` longer than the matching prefix of
@@ -521,7 +579,7 @@ async function handleStreamingNative(
           // Pure tool-call turn — no text block. Drop any leading
           // whitespace we had buffered before the `<tool_call>` tag.
           pendingLeadingWhitespace = '';
-        } else if (finalText) {
+        } else if (finalText && matchedStopSequence === null) {
           // All text arrived in the final event; emit it as a single
           // block. `finalText` is the FULL accumulated text from the
           // native side, NOT a delta — any whitespace we buffered in
@@ -593,7 +651,7 @@ async function handleStreamingNative(
         // Capture terminal state and break — actual `message_delta` / `message_stop` /
         // `error` emission is deferred until after the loop so `wasCommitted()` reads
         // an authoritative `session.turns` (the producer's finally runs on break).
-        terminalStopReason = mapStopReason(event.finishReason, hasToolCalls);
+        terminalStopReason = mapStopReason(event.finishReason, hasToolCalls, matchedStopSequence);
         terminalNumTokens = event.numTokens;
         terminalPromptTokens = event.promptTokens;
         terminalCachedTokens = event.cachedTokens;
@@ -675,55 +733,69 @@ async function handleStreamingNative(
             pendingLeadingWhitespace = '';
           }
         } else if (safeText) {
-          if (!hasEmittedText) {
-            // Hold back leading whitespace-only text so a `\n\n` emitted
-            // right before a `<tool_call>` tag never gets ratified into a
-            // standalone text content block. We can't open the block now
-            // because we don't yet know whether the next event is a real
-            // text delta (in which case the buffered prefix is flushed
-            // together with it) or a structural tag (in which case the
-            // buffer is dropped silently at tag-found / done time). When
-            // any non-whitespace arrives we ratify the block exactly
-            // once with `pendingLeadingWhitespace + safeText`.
-            const combined = pendingLeadingWhitespace + safeText;
-            if (combined.trim().length === 0) {
-              pendingLeadingWhitespace = combined;
-            } else {
-              if (hasEmittedThinking) {
-                writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
+          // Run the tag-buffer's visible text through the stop-sequence
+          // detector. `visibleText` is what survives suppression: the buffer
+          // holds back a trailing suffix that could be the start of a stop
+          // string (released on a later push or at flush), and once a full
+          // stop string matches it returns empty `safeText` for the rest of
+          // the stream. We record the match and keep consuming so the native
+          // `done` chunk still fires the commit gate and history commit.
+          const stopResult = stopBuffer.push(safeText);
+          if (stopResult.matched !== null) {
+            matchedStopSequence = stopResult.matched;
+          }
+          const visibleText = stopResult.safeText;
+          if (visibleText) {
+            if (!hasEmittedText) {
+              // Hold back leading whitespace-only text so a `\n\n` emitted
+              // right before a `<tool_call>` tag never gets ratified into a
+              // standalone text content block. We can't open the block now
+              // because we don't yet know whether the next event is a real
+              // text delta (in which case the buffered prefix is flushed
+              // together with it) or a structural tag (in which case the
+              // buffer is dropped silently at tag-found / done time). When
+              // any non-whitespace arrives we ratify the block exactly
+              // once with `pendingLeadingWhitespace + visibleText`.
+              const combined = pendingLeadingWhitespace + visibleText;
+              if (combined.trim().length === 0) {
+                pendingLeadingWhitespace = combined;
+              } else {
+                if (hasEmittedThinking) {
+                  writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
+                }
+                hasEmittedText = true;
+                writeSSEEvent(
+                  res,
+                  'content_block_start',
+                  buildContentBlockStart(contentBlockIndex, {
+                    type: 'text',
+                    text: '',
+                  }),
+                );
+                pendingLeadingWhitespace = '';
+                emittedText += combined;
+                emittedTextLength += combined.length;
+                writeSSEEvent(
+                  res,
+                  'content_block_delta',
+                  buildContentBlockDelta(contentBlockIndex, {
+                    type: 'text_delta',
+                    text: combined,
+                  }),
+                );
               }
-              hasEmittedText = true;
-              writeSSEEvent(
-                res,
-                'content_block_start',
-                buildContentBlockStart(contentBlockIndex, {
-                  type: 'text',
-                  text: '',
-                }),
-              );
-              pendingLeadingWhitespace = '';
-              emittedText += combined;
-              emittedTextLength += combined.length;
+            } else {
+              emittedText += visibleText;
+              emittedTextLength += visibleText.length;
               writeSSEEvent(
                 res,
                 'content_block_delta',
                 buildContentBlockDelta(contentBlockIndex, {
                   type: 'text_delta',
-                  text: combined,
+                  text: visibleText,
                 }),
               );
             }
-          } else {
-            emittedText += safeText;
-            emittedTextLength += safeText.length;
-            writeSSEEvent(
-              res,
-              'content_block_delta',
-              buildContentBlockDelta(contentBlockIndex, {
-                type: 'text_delta',
-                text: safeText,
-              }),
-            );
           }
         }
       }
@@ -765,6 +837,7 @@ async function handleStreamingNative(
         terminalCachedTokens,
         terminalPerformance,
         serverTiming,
+        matchedStopSequence,
       ),
     );
     // HTTP/1.1 chunked-encoding trailer: report the engine's cache-hit
@@ -984,8 +1057,17 @@ export async function handleCreateMessage(
   // resolveModel and use as a cheap pre-flight gate.
   let mappedMessages: ChatMessage[];
   let mappedConfig: ChatConfig;
+  // Client-supplied `stop_sequences`, normalized by the mapper (absent/empty
+  // dropped). Threaded into the streaming + non-streaming handlers, which own
+  // the detection/truncation. `ChatConfig` has no native stop field, so this
+  // rides alongside `config` from the mapper.
+  let mappedStopSequences: string[];
   try {
-    ({ messages: mappedMessages, config: mappedConfig } = mapAnthropicRequest(body));
+    ({
+      messages: mappedMessages,
+      config: mappedConfig,
+      stopSequences: mappedStopSequences,
+    } = mapAnthropicRequest(body));
   } catch (err) {
     sendAnthropicBadRequest(res, err instanceof Error ? err.message : 'Invalid request');
     return;
@@ -1123,6 +1205,7 @@ export async function handleCreateMessage(
     // trigger a multi-second model load just to 400 a moment later.
     const messages: ChatMessage[] = mappedMessages;
     const config: ChatConfig = mappedConfig;
+    const stopSequences: string[] = mappedStopSequences;
 
     // Canonicalize every assistant fan-out's trailing tool block against its
     // declared sibling order. Several native session backends pair tool results
@@ -1354,6 +1437,7 @@ export async function handleCreateMessage(
                 httpReq,
                 visibility,
                 config.includeReasoning !== false,
+                stopSequences,
                 serverTiming,
               );
               // Warm-slot adopt/drop only applies to the non-paged
@@ -1429,7 +1513,7 @@ export async function handleCreateMessage(
               if (result.cachedTokens > 0) {
                 res.setHeader('X-Cached-Tokens', String(result.cachedTokens));
               }
-              await handleNonStreaming(res, result, body, visibility, serverTiming);
+              await handleNonStreaming(res, result, body, visibility, stopSequences, serverTiming);
               // Non-paged success: adopt the warm slot only when the
               // dispatch actually committed. Mirrors the streaming-side
               // dual-gate at `streamResult.ok && outcome.wasCommitted()`

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -691,20 +691,39 @@ async function handleStreamingNative(
         // markers are transport structure, not user-visible text.
         const { safeText, tagFound, cleanPrefix } = tagBuffer.push(event.text);
         if (tagFound) {
-          // A structural tag (`<tool_call>` etc.) follows. When the
-          // chunk has visible text BEFORE the tag (`cleanPrefix.trim()`
-          // non-empty), the buffered leading whitespace semantically
-          // belongs to that visible text — they were one logical text
-          // run that just happened to land split across deltas. Combine
-          // them and emit as a single text_delta so the wire preserves
-          // exactly what the model produced. When the chunk is a pure
-          // tag transition (no visible prefix), the buffered whitespace
-          // is dropped so the wire never carries a stray
-          // whitespace-only `content_block_start`/`_stop` pair before
-          // the tool_use frame.
-          if (cleanPrefix.trim()) {
-            const combined = pendingLeadingWhitespace + cleanPrefix;
-            pendingLeadingWhitespace = '';
+          // A structural tag (`<tool_call>` etc.) follows, so the visible
+          // text before it (`cleanPrefix`, plus any buffered leading
+          // whitespace that belongs to the same logical run) terminates
+          // here. Route that text through the stop-sequence detector before
+          // emitting: a configured stop string landing in `cleanPrefix`
+          // (e.g. "...HALT " right before a `<tool_call>`) must be honored,
+          // not leaked. The tag suppresses everything after it, so no later
+          // delta can complete a held partial — flush the detector too so a
+          // benign partial it was holding (e.g. "H" of "HALT") is released
+          // as visible text instead of being stranded for the
+          // suppressed-terminal residue gate to drop. Emit only the
+          // detector's safe text; on a match `matchedStopSequence` is
+          // recorded so the terminal reports `stop_sequence`. With an empty
+          // `stopSequences` the detector is a pass-through (`push` returns
+          // its input, `flush` returns ''), so `visibleText === combined`
+          // and the wire is byte-identical to today.
+          const combined = pendingLeadingWhitespace + cleanPrefix;
+          pendingLeadingWhitespace = '';
+          const stopPushed = stopBuffer.push(combined);
+          if (stopPushed.matched !== null) {
+            matchedStopSequence = stopPushed.matched;
+          }
+          const stopResidue = stopBuffer.flush();
+          if (stopResidue.matched !== null) {
+            matchedStopSequence = stopResidue.matched;
+          }
+          const visibleText = stopPushed.safeText + stopResidue.safeText;
+          // Mirror the original `cleanPrefix.trim()` gate, now on the
+          // detector's safe text: emit only when there is non-whitespace to
+          // show, so a pure-whitespace prefix (or a stop match that leaves
+          // only whitespace) never ratifies a stray whitespace-only text
+          // block before the tool_use frame.
+          if (visibleText.trim().length > 0) {
             if (!hasEmittedText) {
               if (hasEmittedThinking) {
                 writeSSEEvent(res, 'content_block_stop', buildContentBlockStop(contentBlockIndex - 1));
@@ -719,18 +738,16 @@ async function handleStreamingNative(
                 }),
               );
             }
-            emittedText += combined;
-            emittedTextLength += combined.length;
+            emittedText += visibleText;
+            emittedTextLength += visibleText.length;
             writeSSEEvent(
               res,
               'content_block_delta',
               buildContentBlockDelta(contentBlockIndex, {
                 type: 'text_delta',
-                text: combined,
+                text: visibleText,
               }),
             );
-          } else {
-            pendingLeadingWhitespace = '';
           }
         } else if (safeText) {
           // Run the tag-buffer's visible text through the stop-sequence

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -212,22 +212,40 @@ async function handleNonStreaming(
 ): Promise<void> {
   const messageId = genId('msg_');
 
-  // Honor client-supplied `stop_sequences`: scan the model's final text for
-  // the earliest configured stop string. On a match we truncate the text the
-  // response is built from at the match (dropping the stop string and
-  // everything after it) and report `stop_reason: 'stop_sequence'` +
-  // `stop_sequence: '<matched>'`. The native `ChatResult` is left untouched —
-  // only the response builder sees the truncated text. An empty
-  // `stopSequences` constructs a pass-through buffer that never matches, so
-  // behavior is byte-identical to a request without `stop_sequences`.
+  // Honor client-supplied `stop_sequences`: scan the SAME visible text the
+  // response builder will emit for the earliest configured stop string. When
+  // the request disallows tools but the parser still produced a tool call and
+  // `result.text` is empty, `buildAnthropicContent` emits the recovered
+  // suppressed-tool text — so the scan must mirror that recovery gate and run
+  // over the recovered text, not the empty `result.text`. The scan does
+  // push+flush so a complete stop that `push()` held back (a longer
+  // overlapping stop was still viable) is resolved at end-of-text, matching
+  // the streaming done-path. On a match we truncate the text the response is
+  // built from at the match (dropping the stop string and everything after it)
+  // and report `stop_reason: 'stop_sequence'` + `stop_sequence: '<matched>'`;
+  // `buildAnthropicResponse` then suppresses tool calls and the recovery
+  // branch and emits the truncated text verbatim. The native `ChatResult` is
+  // left untouched. With no match `responseResult` stays `result` (full text
+  // retained — `flush()` releases any held incomplete partial as normal text),
+  // so behavior is byte-identical to a request without `stop_sequences`.
+  const visibleText =
+    !requestAllowsToolUse(body) &&
+    result.text.length === 0 &&
+    result.toolCalls.filter((t) => t.status === 'ok').length > 0 &&
+    containsToolCallMarkup(result.rawText)
+      ? recoverSuppressedToolCallText(result.rawText)
+      : result.text;
+
   let matchedStopSequence: string | null = null;
   let responseResult = result;
   if (stopSequences.length > 0) {
     const stopBuffer = new StopSequenceBuffer(stopSequences);
-    const { safeText, matched } = stopBuffer.push(result.text);
+    const pushed = stopBuffer.push(visibleText);
+    const flushed = stopBuffer.flush();
+    const matched = pushed.matched ?? flushed.matched;
     if (matched !== null) {
       matchedStopSequence = matched;
-      responseResult = { ...result, text: safeText };
+      responseResult = { ...result, text: pushed.safeText + flushed.safeText };
     }
   }
 

--- a/packages/server/src/endpoints/messages.ts
+++ b/packages/server/src/endpoints/messages.ts
@@ -421,12 +421,17 @@ async function handleStreamingNative(
             ? recoverSuppressedToolCallText(event.rawText)
             : event.text;
 
-        // The visible text the stream already RECEIVED through the stop buffer
-        // — what reached the wire, plus the still-held partial, plus the tag
-        // residue about to be scanned. Used as the overlap basis so the
-        // recovered terminal text is the suffix of `finalText` the stream has
-        // not already accounted for.
-        const streamedReceived = emittedText + heldPartial + tagResidual;
+        // The visible text the stream already RECEIVED, in stream order: what
+        // reached the wire (`emittedText`), the parked leading whitespace the
+        // detector already cleared but no block has shown yet
+        // (`pendingLeadingWhitespace`), the still-held detector partial
+        // (`heldPartial`), and the tag residue about to be scanned
+        // (`tagResidual`). Every parked/held byte is counted exactly once so the
+        // recovered terminal text is only the suffix of `finalText` the stream
+        // has not already accounted for — omitting the parked whitespace would
+        // make a full-text `finalText` look entirely unsent and replay the
+        // already-received prefix.
+        const streamedReceived = emittedText + pendingLeadingWhitespace + heldPartial + tagResidual;
         let recoveredTail = '';
         if (finalText) {
           if (!hasEmittedText && heldPartial.length === 0 && tagResidual.length === 0) {

--- a/packages/server/src/mappers/anthropic-request.ts
+++ b/packages/server/src/mappers/anthropic-request.ts
@@ -441,10 +441,13 @@ export function mapAnthropicRequest(
   }
 
   // `stop_sequences` has no `ChatConfig` field to map onto, so it rides out on
-  // the widened return instead. Normalize to drop absent/null entries and any
-  // empty strings (which would match at every position and stop generation
-  // immediately). A downstream consumer honours the result.
-  const stopSequences = (req.stop_sequences ?? []).filter((s) => typeof s === 'string' && s.length > 0);
+  // the widened return instead. Normalize to drop absent/null entries, empty
+  // strings (which would match at every position and stop generation
+  // immediately), and whitespace-only entries (which would truncate normal
+  // output at the first space/newline; the real Anthropic API rejects these
+  // with a 400, so making them a no-op is the lowest-risk resolution). A
+  // downstream consumer honours the result.
+  const stopSequences = (req.stop_sequences ?? []).filter((s) => typeof s === 'string' && s.trim().length > 0);
 
   if (req.tools && req.tools.length > 0) {
     const toolChoice = req.tool_choice;

--- a/packages/server/src/mappers/anthropic-request.ts
+++ b/packages/server/src/mappers/anthropic-request.ts
@@ -17,6 +17,13 @@ import { applyExtraBodyMtpOverrides } from './request.js';
 export interface MappedAnthropicRequest {
   messages: ChatMessage[];
   config: ChatConfig;
+  /**
+   * Client-supplied stop strings (Anthropic `stop_sequences`), normalized to
+   * drop absent/empty entries. Carried alongside `config` rather than on it
+   * because `ChatConfig` has no native stop field; a downstream consumer is
+   * responsible for honouring these.
+   */
+  stopSequences: string[];
 }
 
 /**
@@ -433,18 +440,11 @@ export function mapAnthropicRequest(
     config.topK = req.top_k;
   }
 
-  // `stop_sequences` is parsed into the request type but `ChatConfig` has no
-  // matching field, so wiring it through to the native model would require a
-  // Rust change (out of scope here). Reject explicitly with a 400 — silently
-  // dropping the field would let a client believe its custom stop strings are
-  // honoured when the model continues generating right past them. An empty
-  // array is treated as "not present" since it carries no semantics. Future
-  // Rust work can add `stopSequences` to `ChatConfig` and remove this guard.
-  if (req.stop_sequences != null && req.stop_sequences.length > 0) {
-    throw new Error(
-      'stop_sequences is not supported by this server. Remove the field or wait for a future release that supports it natively.',
-    );
-  }
+  // `stop_sequences` has no `ChatConfig` field to map onto, so it rides out on
+  // the widened return instead. Normalize to drop absent/null entries and any
+  // empty strings (which would match at every position and stop generation
+  // immediately). A downstream consumer honours the result.
+  const stopSequences = (req.stop_sequences ?? []).filter((s) => typeof s === 'string' && s.length > 0);
 
   if (req.tools && req.tools.length > 0) {
     const toolChoice = req.tool_choice;
@@ -474,5 +474,5 @@ export function mapAnthropicRequest(
 
   applyExtraBodyMtpOverrides(config, req.extra_body);
 
-  return { messages, config };
+  return { messages, config, stopSequences };
 }

--- a/packages/server/src/mappers/anthropic-response.ts
+++ b/packages/server/src/mappers/anthropic-response.ts
@@ -90,7 +90,11 @@ export function recoverSuppressedToolCallText(rawText: string): string {
     .replace(/<turn\|>/g, '');
 }
 
-export function buildAnthropicContent(result: ChatResult, allowToolUse = true): AnthropicResponseContent[] {
+export function buildAnthropicContent(
+  result: ChatResult,
+  allowToolUse = true,
+  stopMatched = false,
+): AnthropicResponseContent[] {
   const content: AnthropicResponseContent[] = [];
 
   if (result.thinking) {
@@ -98,9 +102,18 @@ export function buildAnthropicContent(result: ChatResult, allowToolUse = true): 
   }
 
   const parsedToolCalls = result.toolCalls.filter((t) => t.status === 'ok');
-  const okToolCalls = allowToolUse ? parsedToolCalls : [];
+  // A matched stop sequence halts generation at its position, so any tool call
+  // whose tag would have followed the stop boundary is dropped and the
+  // truncated visible text (`result.text`, already cut at the stop) is emitted
+  // verbatim — the suppressed-markup recovery is skipped because it would
+  // re-introduce text that lived after the stop.
+  const okToolCalls = stopMatched || !allowToolUse ? [] : parsedToolCalls;
   const text =
-    !allowToolUse && result.text.length === 0 && parsedToolCalls.length > 0 && containsToolCallMarkup(result.rawText)
+    !stopMatched &&
+    !allowToolUse &&
+    result.text.length === 0 &&
+    parsedToolCalls.length > 0 &&
+    containsToolCallMarkup(result.rawText)
       ? recoverSuppressedToolCallText(result.rawText)
       : result.text;
 
@@ -134,7 +147,11 @@ export function buildAnthropicResponse(
   serverTiming?: ServerTimingForUsage,
   matchedStopSequence?: string | null,
 ): AnthropicMessagesResponse {
-  const okToolCalls = allowToolUse ? result.toolCalls.filter((t) => t.status === 'ok') : [];
+  // A matched stop sequence takes precedence over tool_use: suppress the tool
+  // calls so `stop_reason: 'stop_sequence'` is never emitted alongside a
+  // tool_use block whose tag followed the stop boundary.
+  const stopMatched = Boolean(matchedStopSequence);
+  const okToolCalls = allowToolUse && !stopMatched ? result.toolCalls.filter((t) => t.status === 'ok') : [];
   const hasToolCalls = okToolCalls.length > 0;
 
   // Cache accounting (Anthropic Messages API spec):
@@ -181,7 +198,7 @@ export function buildAnthropicResponse(
     type: 'message',
     role: 'assistant',
     model: req.model,
-    content: buildAnthropicContent(result, allowToolUse),
+    content: buildAnthropicContent(result, allowToolUse, stopMatched),
     stop_reason: mapStopReason(result.finishReason, hasToolCalls, matchedStopSequence),
     stop_sequence: matchedStopSequence ?? null,
     usage,

--- a/packages/server/src/mappers/anthropic-response.ts
+++ b/packages/server/src/mappers/anthropic-response.ts
@@ -52,7 +52,14 @@ export function anthropicToolUseIdToInternal(id: string): string {
   return id.startsWith('toolu_') ? `call_${id.slice('toolu_'.length)}` : id;
 }
 
-export function mapStopReason(finishReason: string, hasToolCalls: boolean): 'end_turn' | 'max_tokens' | 'tool_use' {
+export function mapStopReason(
+  finishReason: string,
+  hasToolCalls: boolean,
+  matchedStopSequence?: string | null,
+): 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' {
+  if (matchedStopSequence) {
+    return 'stop_sequence';
+  }
   if (finishReason === 'length') {
     return 'max_tokens';
   }
@@ -125,6 +132,7 @@ export function buildAnthropicResponse(
   performance?: PerformanceMetricsForUsage,
   allowToolUse = true,
   serverTiming?: ServerTimingForUsage,
+  matchedStopSequence?: string | null,
 ): AnthropicMessagesResponse {
   const okToolCalls = allowToolUse ? result.toolCalls.filter((t) => t.status === 'ok') : [];
   const hasToolCalls = okToolCalls.length > 0;
@@ -174,8 +182,8 @@ export function buildAnthropicResponse(
     role: 'assistant',
     model: req.model,
     content: buildAnthropicContent(result, allowToolUse),
-    stop_reason: mapStopReason(result.finishReason, hasToolCalls),
-    stop_sequence: null,
+    stop_reason: mapStopReason(result.finishReason, hasToolCalls, matchedStopSequence),
+    stop_sequence: matchedStopSequence ?? null,
     usage,
   };
 }
@@ -239,6 +247,7 @@ export function buildMessageDelta(
   cachedTokens?: number,
   performance?: PerformanceMetricsForUsage,
   serverTiming?: ServerTimingForUsage,
+  stopSequence?: string | null,
 ): AnthropicMessageDeltaEvent {
   // Streaming `message_delta` mirrors the non-streaming response's
   // cache accounting: when `cachedTokens > 0` we emit
@@ -267,7 +276,7 @@ export function buildMessageDelta(
     type: 'message_delta',
     delta: {
       stop_reason: stopReason,
-      stop_sequence: null,
+      stop_sequence: stopSequence ?? null,
     },
     usage,
   };

--- a/packages/server/src/presets.ts
+++ b/packages/server/src/presets.ts
@@ -18,6 +18,16 @@ import type { ChatConfig } from '@mlx-node/core';
  *
  * All modes pin `top_k = 20` and `min_p = 0.0`; they differ in
  * `temperature`, `top_p`, and `presence_penalty`.
+ *
+ * Every mode also loosens the native anti-repetition cutoff
+ * (`maxConsecutiveTokens` / `maxNgramRepeats`, default 16 / 3). Coding
+ * answers legitimately contain long single-token runs — ASCII box
+ * borders (`────`), separators (`====`/`----`), table rules, repeated
+ * indentation — which the default cutoff treats as a stuck loop and
+ * truncates mid-diagram (finish_reason `"repetition"` → `end_turn`),
+ * silently cutting the answer. 256 / 8 lets a wide box or table survive
+ * while still bounding a true runaway loop; `ngramSize` is the default,
+ * kept explicit. Do not set 0 — that disables runaway protection.
  */
 export const QWEN_SAMPLING_DEFAULTS = {
   /** Thinking mode for precise coding tasks: temp=0.6, top_p=0.95, pp=0.0 */
@@ -28,6 +38,9 @@ export const QWEN_SAMPLING_DEFAULTS = {
     minP: 0.0,
     presencePenalty: 0.0,
     repetitionPenalty: 1.0,
+    maxConsecutiveTokens: 256,
+    maxNgramRepeats: 8,
+    ngramSize: 64,
   } satisfies ChatConfig,
 
   /** Thinking mode for general tasks: temp=1.0, top_p=0.95, pp=1.5 */
@@ -38,6 +51,9 @@ export const QWEN_SAMPLING_DEFAULTS = {
     minP: 0.0,
     presencePenalty: 1.5,
     repetitionPenalty: 1.0,
+    maxConsecutiveTokens: 256,
+    maxNgramRepeats: 8,
+    ngramSize: 64,
   } satisfies ChatConfig,
 
   /** Instruct (non-thinking) for general tasks: temp=0.7, top_p=0.8, pp=1.5 */
@@ -48,6 +64,9 @@ export const QWEN_SAMPLING_DEFAULTS = {
     minP: 0.0,
     presencePenalty: 1.5,
     repetitionPenalty: 1.0,
+    maxConsecutiveTokens: 256,
+    maxNgramRepeats: 8,
+    ngramSize: 64,
   } satisfies ChatConfig,
 
   /** Instruct (non-thinking) for reasoning tasks: temp=1.0, top_p=0.95, pp=1.5 */
@@ -58,6 +77,9 @@ export const QWEN_SAMPLING_DEFAULTS = {
     minP: 0.0,
     presencePenalty: 1.5,
     repetitionPenalty: 1.0,
+    maxConsecutiveTokens: 256,
+    maxNgramRepeats: 8,
+    ngramSize: 64,
   } satisfies ChatConfig,
 } as const;
 

--- a/packages/server/src/stop-sequence-buffer.ts
+++ b/packages/server/src/stop-sequence-buffer.ts
@@ -8,7 +8,7 @@
 export class StopSequenceBuffer {
   private readonly stopSequences: string[];
   private readonly maxLength: number;
-  private pending = '';
+  private pending_ = '';
   private _matched: string | null = null;
 
   constructor(stopSequences: string[]) {
@@ -29,7 +29,7 @@ export class StopSequenceBuffer {
     let matchIdx = -1;
     let matchSeq: string | null = null;
     for (const seq of this.stopSequences) {
-      const idx = this.pending.indexOf(seq);
+      const idx = this.pending_.indexOf(seq);
       if (idx < 0) {
         continue;
       }
@@ -47,6 +47,40 @@ export class StopSequenceBuffer {
   }
 
   /**
+   * The text currently held back (received but neither emitted nor matched).
+   * The streaming done-path reads this so it can scan the terminal/recovered
+   * text on the SAME buffer with the held partial still in place, and so it
+   * can reconstruct the full received-but-unemitted prefix for overlap math.
+   */
+  get pending(): string {
+    return this.pending_;
+  }
+
+  /**
+   * The earliest start index `j` in `[0, limit]` such that `pending.slice(j)`
+   * is a non-empty STRICT prefix of some configured stop — i.e. a partial that
+   * a later push could still grow into that stop. Returns -1 when no pending
+   * suffix at or before `limit` is viable. Scanning from the front yields the
+   * earliest start index, which is the one whose completed stop would win the
+   * earliest-index tiebreak. A suffix longer than `maxLength - 1` can never be
+   * a strict prefix of any stop, so the search starts no earlier than that.
+   */
+  private earliestViablePrefixIndex(limit: number): number {
+    if (this.pending_.length === 0) {
+      return -1;
+    }
+    const lowerBound = Math.max(0, this.pending_.length - (this.maxLength - 1));
+    const upper = Math.min(limit, this.pending_.length - 1);
+    for (let j = lowerBound; j <= upper; j++) {
+      const suffix = this.pending_.slice(j);
+      if (this.stopSequences.some((seq) => suffix.length < seq.length && seq.startsWith(suffix))) {
+        return j;
+      }
+    }
+    return -1;
+  }
+
+  /**
    * Feed text in. Returns `safeText` (emit as delta) and `matched` (the stop
    * sequence that has been matched, or `null`). After a match every push
    * returns empty `safeText` and keeps reporting the matched sequence.
@@ -61,46 +95,41 @@ export class StopSequenceBuffer {
       return { safeText: text, matched: null };
     }
 
-    this.pending += text;
+    this.pending_ += text;
 
     const { idx: matchIdx, seq: matchSeq } = this.findMatch();
+
+    // Earliest start index of a still-growable stop prefix. When a full match
+    // exists we only look at or before it (`limit = matchIdx`): a viable prefix
+    // beginning AFTER the match would complete at a later index and lose the
+    // earliest-index tiebreak, and the bytes from the match onward are
+    // suppressed anyway. A viable prefix at or before the match could still
+    // complete into a stop that WINS (earlier index, or longer at the same
+    // index), so the match must be held. With no full match we consider the
+    // whole pending text.
+    const limit = matchIdx >= 0 ? matchIdx : this.pending_.length - 1;
+    const holdIdx = this.earliestViablePrefixIndex(limit);
+
     if (matchIdx >= 0 && matchSeq !== null) {
-      // A full match sits at `matchIdx`. Commit it only when no LONGER stop
-      // sharing the same start index could still complete from a later push —
-      // otherwise longest-on-tie (C4) would pick that longer stop once it
-      // arrives. `fromMatch` is the text from the match index to the tail; if
-      // it is still a strict prefix of a longer stop, a future push could
-      // finish that stop, so we hold the match (emit only the safe text before
-      // `matchIdx`) and let a later push or `flush()` resolve the tie.
-      const fromMatch = this.pending.slice(matchIdx);
-      const longerStillViable = this.stopSequences.some(
-        (seq) => seq.length > fromMatch.length && seq.startsWith(fromMatch),
-      );
-      const safeText = this.pending.slice(0, matchIdx);
-      if (longerStillViable) {
-        this.pending = fromMatch;
+      if (holdIdx >= 0) {
+        // A longer/earlier stop could still complete from `holdIdx`; emit only
+        // the bytes before it and keep the rest pending for a later push or
+        // `flush()` to resolve.
+        const safeText = this.pending_.slice(0, holdIdx);
+        this.pending_ = this.pending_.slice(holdIdx);
         return { safeText, matched: null };
       }
+      const safeText = this.pending_.slice(0, matchIdx);
       this._matched = matchSeq;
-      this.pending = '';
+      this.pending_ = '';
       return { safeText, matched: matchSeq };
     }
 
-    // Hold back the longest suffix that is a proper prefix of any stop
-    // sequence, since a later push could complete it.
-    let holdLen = 0;
-    const maxHold = Math.min(this.pending.length, this.maxLength - 1);
-    for (let i = maxHold; i >= 1; i--) {
-      const suffix = this.pending.slice(-i);
-      if (this.stopSequences.some((seq) => suffix.length < seq.length && seq.startsWith(suffix))) {
-        holdLen = i;
-        break;
-      }
-    }
-
-    const safeLen = this.pending.length - holdLen;
-    const safeText = this.pending.slice(0, safeLen);
-    this.pending = this.pending.slice(safeLen);
+    // No full match: release everything before the earliest viable prefix and
+    // hold that suffix back, since a later push could complete it.
+    const safeLen = holdIdx >= 0 ? holdIdx : this.pending_.length;
+    const safeText = this.pending_.slice(0, safeLen);
+    this.pending_ = this.pending_.slice(safeLen);
     return { safeText, matched: null };
   }
 
@@ -120,13 +149,13 @@ export class StopSequenceBuffer {
     // released verbatim.
     const { idx: matchIdx, seq: matchSeq } = this.findMatch();
     if (matchIdx >= 0 && matchSeq !== null) {
-      const safeText = this.pending.slice(0, matchIdx);
+      const safeText = this.pending_.slice(0, matchIdx);
       this._matched = matchSeq;
-      this.pending = '';
+      this.pending_ = '';
       return { safeText, matched: matchSeq };
     }
-    const safeText = this.pending;
-    this.pending = '';
+    const safeText = this.pending_;
+    this.pending_ = '';
     return { safeText, matched: null };
   }
 }

--- a/packages/server/src/stop-sequence-buffer.ts
+++ b/packages/server/src/stop-sequence-buffer.ts
@@ -1,0 +1,92 @@
+/**
+ * Buffers streaming text to detect configured stop sequences. Text that
+ * cannot be part of a partial stop sequence is released immediately; a
+ * trailing suffix that could be the start of a stop sequence is held back
+ * until a later push resolves it or the stream is flushed. Once a full stop
+ * sequence is seen, everything after it is suppressed.
+ */
+export class StopSequenceBuffer {
+  private readonly stopSequences: string[];
+  private readonly maxLength: number;
+  private pending = '';
+  private _matched: string | null = null;
+
+  constructor(stopSequences: string[]) {
+    this.stopSequences = stopSequences.filter((s) => s.length > 0);
+    this.maxLength = this.stopSequences.reduce((max, s) => Math.max(max, s.length), 0);
+  }
+
+  /** The stop sequence that has matched so far, or `null` if none has. */
+  get matched(): string | null {
+    return this._matched;
+  }
+
+  /**
+   * Feed text in. Returns `safeText` (emit as delta) and `matched` (the stop
+   * sequence that has been matched, or `null`). After a match every push
+   * returns empty `safeText` and keeps reporting the matched sequence.
+   */
+  push(text: string): { safeText: string; matched: string | null } {
+    if (this._matched !== null) {
+      return { safeText: '', matched: this._matched };
+    }
+
+    // Transparent pass-through when there is nothing to detect.
+    if (this.stopSequences.length === 0) {
+      return { safeText: text, matched: null };
+    }
+
+    this.pending += text;
+
+    // Earliest index wins; on a tie at the same index the longest wins.
+    let matchIdx = -1;
+    let matchSeq: string | null = null;
+    for (const seq of this.stopSequences) {
+      const idx = this.pending.indexOf(seq);
+      if (idx < 0) {
+        continue;
+      }
+      if (matchIdx < 0 || idx < matchIdx || (idx === matchIdx && seq.length > (matchSeq?.length ?? 0))) {
+        matchIdx = idx;
+        matchSeq = seq;
+      }
+    }
+    if (matchIdx >= 0 && matchSeq !== null) {
+      const safeText = this.pending.slice(0, matchIdx);
+      this._matched = matchSeq;
+      this.pending = '';
+      return { safeText, matched: matchSeq };
+    }
+
+    // Hold back the longest suffix that is a proper prefix of any stop
+    // sequence, since a later push could complete it.
+    let holdLen = 0;
+    const maxHold = Math.min(this.pending.length, this.maxLength - 1);
+    for (let i = maxHold; i >= 1; i--) {
+      const suffix = this.pending.slice(-i);
+      if (this.stopSequences.some((seq) => suffix.length < seq.length && seq.startsWith(suffix))) {
+        holdLen = i;
+        break;
+      }
+    }
+
+    const safeLen = this.pending.length - holdLen;
+    const safeText = this.pending.slice(0, safeLen);
+    this.pending = this.pending.slice(safeLen);
+    return { safeText, matched: null };
+  }
+
+  /**
+   * Release any held-back text at stream end. If a stop sequence already
+   * matched, nothing more is emitted; otherwise the residue could not
+   * complete any sequence and is released.
+   */
+  flush(): { safeText: string; matched: string | null } {
+    if (this._matched !== null) {
+      return { safeText: '', matched: this._matched };
+    }
+    const safeText = this.pending;
+    this.pending = '';
+    return { safeText, matched: null };
+  }
+}

--- a/packages/server/src/stop-sequence-buffer.ts
+++ b/packages/server/src/stop-sequence-buffer.ts
@@ -12,8 +12,33 @@ export class StopSequenceBuffer {
   private _matched: string | null = null;
 
   constructor(stopSequences: string[]) {
-    this.stopSequences = stopSequences.filter((s) => s.length > 0);
+    // Drop empty AND whitespace-only entries: a whitespace-only stop would
+    // truncate normal output at the first space/newline, and the real
+    // Anthropic API rejects such stops outright. Mirrors the same trim filter
+    // in the request mapper so a whitespace-only configuration is a no-op.
+    this.stopSequences = stopSequences.filter((s) => s.trim().length > 0);
     this.maxLength = this.stopSequences.reduce((max, s) => Math.max(max, s.length), 0);
+  }
+
+  /**
+   * Earliest index wins; on a tie at the same index the longest wins. Returns
+   * `{ idx, seq }` for the winning stop, or `{ idx: -1, seq: null }` when none
+   * is present in `pending`.
+   */
+  private findMatch(): { idx: number; seq: string | null } {
+    let matchIdx = -1;
+    let matchSeq: string | null = null;
+    for (const seq of this.stopSequences) {
+      const idx = this.pending.indexOf(seq);
+      if (idx < 0) {
+        continue;
+      }
+      if (matchIdx < 0 || idx < matchIdx || (idx === matchIdx && seq.length > (matchSeq?.length ?? 0))) {
+        matchIdx = idx;
+        matchSeq = seq;
+      }
+    }
+    return { idx: matchIdx, seq: matchSeq };
   }
 
   /** The stop sequence that has matched so far, or `null` if none has. */
@@ -38,21 +63,24 @@ export class StopSequenceBuffer {
 
     this.pending += text;
 
-    // Earliest index wins; on a tie at the same index the longest wins.
-    let matchIdx = -1;
-    let matchSeq: string | null = null;
-    for (const seq of this.stopSequences) {
-      const idx = this.pending.indexOf(seq);
-      if (idx < 0) {
-        continue;
-      }
-      if (matchIdx < 0 || idx < matchIdx || (idx === matchIdx && seq.length > (matchSeq?.length ?? 0))) {
-        matchIdx = idx;
-        matchSeq = seq;
-      }
-    }
+    const { idx: matchIdx, seq: matchSeq } = this.findMatch();
     if (matchIdx >= 0 && matchSeq !== null) {
+      // A full match sits at `matchIdx`. Commit it only when no LONGER stop
+      // sharing the same start index could still complete from a later push —
+      // otherwise longest-on-tie (C4) would pick that longer stop once it
+      // arrives. `fromMatch` is the text from the match index to the tail; if
+      // it is still a strict prefix of a longer stop, a future push could
+      // finish that stop, so we hold the match (emit only the safe text before
+      // `matchIdx`) and let a later push or `flush()` resolve the tie.
+      const fromMatch = this.pending.slice(matchIdx);
+      const longerStillViable = this.stopSequences.some(
+        (seq) => seq.length > fromMatch.length && seq.startsWith(fromMatch),
+      );
       const safeText = this.pending.slice(0, matchIdx);
+      if (longerStillViable) {
+        this.pending = fromMatch;
+        return { safeText, matched: null };
+      }
       this._matched = matchSeq;
       this.pending = '';
       return { safeText, matched: matchSeq };
@@ -84,6 +112,18 @@ export class StopSequenceBuffer {
   flush(): { safeText: string; matched: string | null } {
     if (this._matched !== null) {
       return { safeText: '', matched: this._matched };
+    }
+    // The stream has ended, so any match `push()` held back for a possible
+    // longer same-index stop can no longer be extended — resolve it now.
+    // Re-scan `pending` for the earliest match (longest on tie) and commit it
+    // if present; otherwise the residue could not complete any sequence and is
+    // released verbatim.
+    const { idx: matchIdx, seq: matchSeq } = this.findMatch();
+    if (matchIdx >= 0 && matchSeq !== null) {
+      const safeText = this.pending.slice(0, matchIdx);
+      this._matched = matchSeq;
+      this.pending = '';
+      return { safeText, matched: matchSeq };
     }
     const safeText = this.pending;
     this.pending = '';


### PR DESCRIPTION
## Why

Running `mlx launch claude` against a local MLX model surfaced two server-side defects:

1. **Claude Code's auto-mode safety classifier always sends `stop_sequences`.** The
   `/v1/messages` mapper rejected any request carrying `stop_sequences` with a `400`, so the
   classifier failed with *"temporarily unavailable, cannot determine safety of Agent"* and the
   agent stalled.
2. **The native anti-repetition cutoff truncated legitimate output.** A wide ASCII box border
   (`────`), a separator (`====`/`----`), a table rule, or repeated indentation tripped the
   default cutoff (`maxConsecutiveTokens=16`, `maxNgramRepeats=3`), returning
   `finish_reason:"repetition"` → mapped to `end_turn` — so answers were silently cut off
   mid-diagram and looked like a clean finish.

## What

- **Honor `stop_sequences` end-to-end in `/v1/messages`** (streaming + non-streaming): detect,
  truncate exactly, and report `stop_reason:"stop_sequence"` + `stop_sequence`. Removes the 400.
- **Loosen the Qwen anti-repetition cutoff** in the launch presets (`256 / 8 / 64`) so wide
  boxes/tables/separators survive while a true runaway loop still stops.

TS-only in `packages/server` — **no native/Rust change**, `ChatConfig`/`packages/core` untouched.

## How

- `StopSequenceBuffer` (`packages/server/src/stop-sequence-buffer.ts`) — cross-delta detection
  mirroring `ToolCallTagBuffer`: partial-suffix holdback so a stop split across two streamed
  deltas is caught; earliest-match-wins, longest-on-tie (including a longer stop that begins at
  an earlier index); whitespace-only and empty stops filtered to a no-op.
- Request/response mappers thread `stopSequences` and can emit
  `stop_reason:"stop_sequence"` (precedence over `max_tokens`/`tool_use`/`end_turn`).
- Streaming done-path uses **suppress-then-natural-done**: it keeps consuming to the native
  `done` chunk (commit gate + history commit still fire), and finalizes the stop scan over one
  continuous buffer — streamed deltas, the held partial, tag residue, and the recovered terminal
  text — **before** emitting the safe prefix, deciding tool-call emission, or computing
  `stop_reason`. A matched stop suppresses any `tool_use` block so a response never carries both
  a tool call and `stop_reason:"stop_sequence"`. Empty/absent `stop_sequences` is a byte-identical
  no-op.
- Presets (`packages/server/src/presets.ts`): all four `QWEN_SAMPLING_DEFAULTS` variants get
  `maxConsecutiveTokens:256, maxNgramRepeats:8, ngramSize:64`. Gemma4/LFM2 unchanged.

## Testing

- `__test__/server/` — **24 files, 688 tests pass** (incl. new buffer, mapper, and handler
  coverage; the original 400-asserting tests replaced with honor-behavior tests).
- TDD throughout (failing test first), then 4 adversarial review rounds (Codex); every confirmed
  finding fixed and re-verified by execution. The one remaining review note (an overlap edge that
  would only bite if the native terminal chunk were *incremental*) was verified non-occurring —
  `backend.rs` `finish()` sends the full cumulative `result.text` (`clean_text`), which the
  overlap logic is built for.
- `vp lint --type-aware --type-check` and `yarn typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to Anthropic message streaming/non-streaming output shaping and stop/tool precedence; behavior is heavily tested but regressions could affect wire format or truncation edge cases.
> 
> **Overview**
> **`/v1/messages` now honors Anthropic `stop_sequences` instead of returning 400.** The request mapper normalizes stop strings (filters empty/whitespace-only) and returns them as `stopSequences` beside `ChatConfig`, which has no native stop field. A new **`StopSequenceBuffer`** detects matches across streamed deltas (partial holdback, earliest/longest tie-breaks) and drives truncation plus **`stop_reason: stop_sequence`** and **`stop_sequence`** on responses and SSE **`message_delta`**. Streaming and non-streaming paths wire the buffer through tool-tag buffering, terminal recovery, and flush-at-end; a matched stop **suppresses `tool_use`** blocks so stop wins over tools. Absent stops remain a pass-through no-op.
> 
> **Qwen launch presets** add loosened anti-repetition sampling (**`maxConsecutiveTokens: 256`**, **`maxNgramRepeats: 8`**, **`ngramSize: 64`**) on all four **`QWEN_SAMPLING_DEFAULTS`** variants; Gemma4/LFM2 unchanged. Tests cover buffer, mappers, handler edge cases, and preset merge survival.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee1e456937259ad9b763e6a8156dc17bf64548bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->