### PR TITLE
fix: align repetition handling with vLLM (cutoff off by default)

### DIFF
--- a/__test__/server/presets.test.ts
+++ b/__test__/server/presets.test.ts
@@ -125,7 +125,7 @@ describe('scope lock: non-Qwen presets unchanged', () => {
 // Merge survival (real ChatSession.mergeConfig)
 // ---------------------------------------------------------------------------
 
-describe('cutoff survives ChatSession.mergeConfig', () => {
+describe('repetition-cutoff handling through ChatSession.mergeConfig', () => {
   it('injects no repetition-cutoff fields when the per-request overlay omits them', async () => {
     const registry = new ModelRegistry();
     const model = createCapturingModel();

--- a/__test__/server/presets.test.ts
+++ b/__test__/server/presets.test.ts
@@ -1,13 +1,13 @@
 /**
- * Coverage for the launch-preset anti-repetition cutoff values.
+ * Coverage for the launch-preset repetition handling.
  *
- * A live Claude Code session on Ornith (qwen3_5_moe) truncated an
- * ASCII box mid-diagram: a run of repeated `─` tripped the native
- * sampler's consecutive-token cutoff (`max_consecutive_tokens`
- * default 16) → finish_reason `"repetition"` → `stop_reason:"end_turn"`.
- * The Qwen launch presets loosen the cutoff so legit repeated content
- * (box borders, separators, tables) survives while a true runaway loop
- * still stops.
+ * The native anti-repetition cutoff is now disabled by default
+ * (vLLM-aligned — vLLM ships no repetition-stop heuristic), so the Qwen
+ * launch presets no longer pin `maxConsecutiveTokens` / `maxNgramRepeats`
+ * / `ngramSize`. Repetition is shaped by the sampling penalties and
+ * bounded by the per-model `maxOutputTokens`. An operator or client can
+ * still opt in by setting those fields explicitly; a per-request config
+ * value wins via `ChatSession.mergeConfig`.
  *
  * The merge-survival tests drive the REAL `ChatSession.mergeConfig`
  * through `ModelRegistry.register({ samplingDefaults }) → getOrCreate →
@@ -75,36 +75,22 @@ function createCapturingModel(): CapturingModel {
 // Static preset-value assertions
 // ---------------------------------------------------------------------------
 
-const LOOSENED_CUTOFF = {
-  maxConsecutiveTokens: 256,
-  maxNgramRepeats: 8,
-  ngramSize: 64,
-} as const;
-
-describe('QWEN launch-preset anti-repetition cutoff', () => {
-  it('loosens the cutoff on every Qwen launch entry (qwen3 / qwen3_5 / qwen3_5_moe)', () => {
+describe('QWEN launch-preset repetition cutoff is default-off', () => {
+  it('injects no cutoff fields on every Qwen launch entry (qwen3 / qwen3_5 / qwen3_5_moe)', () => {
     for (const key of ['qwen3', 'qwen3_5', 'qwen3_5_moe'] as const) {
       const sampling = LAUNCH_PRESETS[key]!.sampling;
-      expect(sampling.maxConsecutiveTokens).toBe(256);
-      expect(sampling.maxNgramRepeats).toBe(8);
-      expect(sampling.ngramSize).toBe(64);
+      expect(sampling.maxConsecutiveTokens).toBeUndefined();
+      expect(sampling.maxNgramRepeats).toBeUndefined();
+      expect(sampling.ngramSize).toBeUndefined();
     }
   });
 
-  it('sets the loosened cutoff on all four QWEN_SAMPLING_DEFAULTS variants', () => {
+  it('injects no cutoff fields on any of the four QWEN_SAMPLING_DEFAULTS variants', () => {
     for (const key of ['thinkingCoding', 'thinkingGeneral', 'instructGeneral', 'instructReasoning'] as const) {
       const sampling = QWEN_SAMPLING_DEFAULTS[key];
-      expect(sampling.maxConsecutiveTokens).toBe(256);
-      expect(sampling.maxNgramRepeats).toBe(8);
-      expect(sampling.ngramSize).toBe(64);
-    }
-  });
-
-  it('does not disable the cutoff (runaway-loop protection must remain)', () => {
-    for (const key of ['thinkingCoding', 'thinkingGeneral', 'instructGeneral', 'instructReasoning'] as const) {
-      const sampling = QWEN_SAMPLING_DEFAULTS[key];
-      expect(sampling.maxConsecutiveTokens).not.toBe(0);
-      expect(sampling.maxNgramRepeats).not.toBe(0);
+      expect(sampling.maxConsecutiveTokens).toBeUndefined();
+      expect(sampling.maxNgramRepeats).toBeUndefined();
+      expect(sampling.ngramSize).toBeUndefined();
     }
   });
 
@@ -140,7 +126,7 @@ describe('scope lock: non-Qwen presets unchanged', () => {
 // ---------------------------------------------------------------------------
 
 describe('cutoff survives ChatSession.mergeConfig', () => {
-  it('carries the loosened cutoff through when the per-request overlay omits it', async () => {
+  it('injects no repetition-cutoff fields when the per-request overlay omits them', async () => {
     const registry = new ModelRegistry();
     const model = createCapturingModel();
     registry.register('qwen35moe', model, { samplingDefaults: LAUNCH_PRESETS.qwen3_5_moe!.sampling });
@@ -151,15 +137,18 @@ describe('cutoff survives ChatSession.mergeConfig', () => {
     // Claude Code never sends these fields — overlay omits them.
     await session.send('hi');
 
-    expect(model.lastStartConfig).toMatchObject(LOOSENED_CUTOFF);
-    // Full shape: defaults + reuseCache, nothing else injected.
+    // Full shape: defaults + reuseCache, nothing else injected. The
+    // preset carries no cutoff fields, so none appear here.
     expect(model.lastStartConfig).toEqual({
       ...LAUNCH_PRESETS.qwen3_5_moe!.sampling,
       reuseCache: true,
     });
+    expect(model.lastStartConfig!.maxConsecutiveTokens).toBeUndefined();
+    expect(model.lastStartConfig!.maxNgramRepeats).toBeUndefined();
+    expect(model.lastStartConfig!.ngramSize).toBeUndefined();
   });
 
-  it('lets a per-request override win on maxConsecutiveTokens while the other cutoff fields survive', async () => {
+  it('lets a per-request override reach the model on maxConsecutiveTokens (opt-in)', async () => {
     const registry = new ModelRegistry();
     const model = createCapturingModel();
     registry.register('qwen35moe', model, { samplingDefaults: LAUNCH_PRESETS.qwen3_5_moe!.sampling });
@@ -170,8 +159,8 @@ describe('cutoff survives ChatSession.mergeConfig', () => {
     await session.send('hi', { config: { maxConsecutiveTokens: 32 } });
 
     expect(model.lastStartConfig!.maxConsecutiveTokens).toBe(32);
-    // Default n-gram fields still carried (overlay didn't touch them).
-    expect(model.lastStartConfig!.maxNgramRepeats).toBe(8);
-    expect(model.lastStartConfig!.ngramSize).toBe(64);
+    // The preset contributes no n-gram fields, so they stay undefined.
+    expect(model.lastStartConfig!.maxNgramRepeats).toBeUndefined();
+    expect(model.lastStartConfig!.ngramSize).toBeUndefined();
   });
 });

--- a/__test__/server/presets.test.ts
+++ b/__test__/server/presets.test.ts
@@ -87,7 +87,9 @@ describe('QWEN launch-preset repetition cutoff is default-off', () => {
 
   it('injects no cutoff fields on any of the four QWEN_SAMPLING_DEFAULTS variants', () => {
     for (const key of ['thinkingCoding', 'thinkingGeneral', 'instructGeneral', 'instructReasoning'] as const) {
-      const sampling = QWEN_SAMPLING_DEFAULTS[key];
+      // Widen from the `as const` literal to ChatConfig so the now-removed
+      // cutoff fields are optional-undefined accesses, not TS2339 errors.
+      const sampling: ChatConfig = QWEN_SAMPLING_DEFAULTS[key];
       expect(sampling.maxConsecutiveTokens).toBeUndefined();
       expect(sampling.maxNgramRepeats).toBeUndefined();
       expect(sampling.ngramSize).toBeUndefined();

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -2288,11 +2288,11 @@ export interface ChatConfig {
   frequencyPenalty?: number | undefined;
   /** Number of recent tokens to consider for frequency penalty (default: 20) */
   frequencyContextSize?: number | undefined;
-  /** Max consecutive identical tokens before stopping (default: 16, 0 = disabled) */
+  /** Max consecutive identical tokens before stopping (default: 0 = disabled; opt in with a positive value) */
   maxConsecutiveTokens?: number | undefined;
-  /** Max n-gram repetitions before stopping (default: 3, 0 = disabled) */
+  /** Max n-gram repetitions before stopping (default: 0 = disabled; opt in with a positive value) */
   maxNgramRepeats?: number | undefined;
-  /** Max pattern size for n-gram repetition detection (default: 64) */
+  /** Max pattern size for n-gram repetition detection (default: 0 = disabled; opt in with a positive value) */
   ngramSize?: number | undefined;
   tools?: Array<ToolDefinition>;
   /**
@@ -2988,19 +2988,19 @@ export interface GenerationConfig {
   /** Number of recent tokens to consider for frequency penalty (default: 20) */
   frequencyContextSize?: number;
   /**
-   * Stop if same token repeats this many times consecutively (default: 16)
-   * Set to 0 to disable. Prevents OOM from degenerate repetitive generation.
+   * Stop if same token repeats this many times consecutively (default: 0 = disabled).
+   * Opt in by setting a positive value to guard against degenerate repetitive generation.
    */
   maxConsecutiveTokens?: number;
   /**
-   * Stop if a pattern repeats this many times consecutively (default: 3)
-   * Set to 0 to disable. Detects patterns like "A B A B A B".
+   * Stop if a pattern repeats this many times consecutively (default: 0 = disabled).
+   * Opt in with a positive value to detect patterns like "A B A B A B".
    * Uses range-based detection: checks all pattern sizes from 2 to ngram_size.
    */
   maxNgramRepeats?: number;
   /**
-   * Maximum pattern size for repetition detection (default: 64)
-   * All pattern sizes from 2 up to this value are checked each decode step.
+   * Maximum pattern size for repetition detection (default: 0 = disabled).
+   * When enabled, all pattern sizes from 2 up to this value are checked each decode step.
    * Larger values catch long phrase-level repetition common in small models.
    */
   ngramSize?: number;

--- a/crates/mlx-core/src/engine/params.rs
+++ b/crates/mlx-core/src/engine/params.rs
@@ -390,9 +390,15 @@ pub(crate) fn extract_chat_params(config: &ChatConfig) -> ChatParams {
         presence_context_size: config.presence_context_size.unwrap_or(20),
         frequency_penalty: config.frequency_penalty.unwrap_or(0.0),
         frequency_context_size: config.frequency_context_size.unwrap_or(20),
-        max_consecutive_tokens: config.max_consecutive_tokens.unwrap_or(16),
-        max_ngram_repeats: config.max_ngram_repeats.unwrap_or(3),
-        ngram_size: config.ngram_size.unwrap_or(64),
+        max_consecutive_tokens: config
+            .max_consecutive_tokens
+            .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS),
+        max_ngram_repeats: config
+            .max_ngram_repeats
+            .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS),
+        ngram_size: config
+            .ngram_size
+            .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE),
         sampling_config: Some(SamplingConfig {
             temperature: config.temperature,
             top_k: config.top_k,
@@ -601,6 +607,41 @@ mod mtp_params_tests {
         let p = extract_chat_params(&cfg);
         assert!(!p.mtp_adaptive_depth);
         assert_eq!(p.mtp_depth, 1);
+    }
+
+    /// Repetition cutoff is OFF by default: with all three knobs unset the
+    /// resolved params are zero, which the `check_consecutive` / `check_ngram`
+    /// guards treat as disabled. This matches vLLM, which ships no
+    /// repetition-stop heuristic out of the box.
+    #[test]
+    fn repetition_cutoff_disabled_by_default() {
+        let cfg = base_config();
+        let p = extract_chat_params(&cfg);
+        assert_eq!(
+            p.max_consecutive_tokens, 0,
+            "max_consecutive_tokens must default to 0 (disabled)"
+        );
+        assert_eq!(
+            p.max_ngram_repeats, 0,
+            "max_ngram_repeats must default to 0 (disabled)"
+        );
+        assert_eq!(p.ngram_size, 0, "ngram_size must default to 0 (disabled)");
+    }
+
+    /// Opt-in still works: a positive value re-enables detection and the
+    /// per-request override wins over the disabled default.
+    #[test]
+    fn repetition_cutoff_opt_in_overrides_default() {
+        let mut cfg = base_config();
+        cfg.max_consecutive_tokens = Some(16);
+        let p = extract_chat_params(&cfg);
+        assert_eq!(
+            p.max_consecutive_tokens, 16,
+            "explicit max_consecutive_tokens must pass through"
+        );
+        // Knobs left unset stay at the disabled default.
+        assert_eq!(p.max_ngram_repeats, 0);
+        assert_eq!(p.ngram_size, 0);
     }
 }
 

--- a/crates/mlx-core/src/engine/types.rs
+++ b/crates/mlx-core/src/engine/types.rs
@@ -47,13 +47,13 @@ pub struct ChatConfig {
     /// Number of recent tokens to consider for frequency penalty (default: 20)
     #[napi(ts_type = "number | undefined")]
     pub frequency_context_size: Option<i32>,
-    /// Max consecutive identical tokens before stopping (default: 16, 0 = disabled)
+    /// Max consecutive identical tokens before stopping (default: 0 = disabled; opt in with a positive value)
     #[napi(ts_type = "number | undefined")]
     pub max_consecutive_tokens: Option<i32>,
-    /// Max n-gram repetitions before stopping (default: 3, 0 = disabled)
+    /// Max n-gram repetitions before stopping (default: 0 = disabled; opt in with a positive value)
     #[napi(ts_type = "number | undefined")]
     pub max_ngram_repeats: Option<i32>,
-    /// Max pattern size for n-gram repetition detection (default: 64)
+    /// Max pattern size for n-gram repetition detection (default: 0 = disabled; opt in with a positive value)
     #[napi(ts_type = "number | undefined")]
     pub ngram_size: Option<i32>,
     #[napi(ts_type = "Array<ToolDefinition>")]

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -5650,9 +5650,15 @@ struct Gemma4RepetitionCutoff {
 
 fn repetition_cutoff_from_config(config: &ChatConfig) -> Gemma4RepetitionCutoff {
     Gemma4RepetitionCutoff {
-        max_consecutive_tokens: config.max_consecutive_tokens.unwrap_or(16),
-        max_ngram_repeats: config.max_ngram_repeats.unwrap_or(3),
-        ngram_size: config.ngram_size.unwrap_or(64),
+        max_consecutive_tokens: config
+            .max_consecutive_tokens
+            .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS),
+        max_ngram_repeats: config
+            .max_ngram_repeats
+            .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS),
+        ngram_size: config
+            .ngram_size
+            .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE),
     }
 }
 

--- a/crates/mlx-core/src/models/qianfan_ocr/model.rs
+++ b/crates/mlx-core/src/models/qianfan_ocr/model.rs
@@ -386,9 +386,15 @@ impl QianfanOCRInner {
         let presence_context_size = config.presence_context_size.unwrap_or(20);
         let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
         let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-        let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-        let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-        let ngram_size = config.ngram_size.unwrap_or(64);
+        let max_consecutive_tokens = config
+            .max_consecutive_tokens
+            .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS);
+        let max_ngram_repeats = config
+            .max_ngram_repeats
+            .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS);
+        let ngram_size = config
+            .ngram_size
+            .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE);
         let enable_thinking = crate::engine::resolve_enable_thinking(&config).unwrap_or(false);
         let reuse_cache = config.reuse_cache.unwrap_or(true);
         let report_perf = config.report_performance.unwrap_or(false);
@@ -784,9 +790,15 @@ impl QianfanOCRInner {
             let presence_context_size = config.presence_context_size.unwrap_or(20);
             let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
             let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-            let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-            let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-            let ngram_size = config.ngram_size.unwrap_or(64);
+            let max_consecutive_tokens = config
+                .max_consecutive_tokens
+                .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS);
+            let max_ngram_repeats = config
+                .max_ngram_repeats
+                .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS);
+            let ngram_size = config
+                .ngram_size
+                .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE);
             let enable_thinking = crate::engine::resolve_enable_thinking(&config).unwrap_or(false);
             let reuse_cache = config.reuse_cache.unwrap_or(true);
             let report_perf = config.report_performance.unwrap_or(false);
@@ -1367,9 +1379,15 @@ impl QianfanOCRInner {
         let presence_context_size = config.presence_context_size.unwrap_or(20);
         let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
         let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-        let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-        let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-        let ngram_size = config.ngram_size.unwrap_or(64);
+        let max_consecutive_tokens = config
+            .max_consecutive_tokens
+            .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS);
+        let max_ngram_repeats = config
+            .max_ngram_repeats
+            .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS);
+        let ngram_size = config
+            .ngram_size
+            .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE);
         let report_perf = config.report_performance.unwrap_or(false);
 
         let generation_start = if report_perf {
@@ -1844,9 +1862,15 @@ impl QianfanOCRInner {
         let presence_context_size = config.presence_context_size.unwrap_or(20);
         let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
         let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-        let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-        let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-        let ngram_size = config.ngram_size.unwrap_or(64);
+        let max_consecutive_tokens = config
+            .max_consecutive_tokens
+            .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS);
+        let max_ngram_repeats = config
+            .max_ngram_repeats
+            .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS);
+        let ngram_size = config
+            .ngram_size
+            .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE);
         let report_perf = config.report_performance.unwrap_or(false);
 
         let generation_start = if report_perf {

--- a/crates/mlx-core/src/models/qwen3/generation.rs
+++ b/crates/mlx-core/src/models/qwen3/generation.rs
@@ -47,17 +47,17 @@ pub struct GenerationConfig {
     /// Number of recent tokens to consider for frequency penalty (default: 20)
     pub frequency_context_size: Option<i32>,
 
-    /// Stop if same token repeats this many times consecutively (default: 16)
-    /// Set to 0 to disable. Prevents OOM from degenerate repetitive generation.
+    /// Stop if same token repeats this many times consecutively (default: 0 = disabled).
+    /// Opt in by setting a positive value to guard against degenerate repetitive generation.
     pub max_consecutive_tokens: Option<i32>,
 
-    /// Stop if a pattern repeats this many times consecutively (default: 3)
-    /// Set to 0 to disable. Detects patterns like "A B A B A B".
+    /// Stop if a pattern repeats this many times consecutively (default: 0 = disabled).
+    /// Opt in with a positive value to detect patterns like "A B A B A B".
     /// Uses range-based detection: checks all pattern sizes from 2 to ngram_size.
     pub max_ngram_repeats: Option<i32>,
 
-    /// Maximum pattern size for repetition detection (default: 64)
-    /// All pattern sizes from 2 up to this value are checked each decode step.
+    /// Maximum pattern size for repetition detection (default: 0 = disabled).
+    /// When enabled, all pattern sizes from 2 up to this value are checked each decode step.
     /// Larger values catch long phrase-level repetition common in small models.
     pub ngram_size: Option<i32>,
 
@@ -94,9 +94,9 @@ impl Default for GenerationConfig {
             presence_context_size: None,
             frequency_penalty: None,
             frequency_context_size: None,
-            max_consecutive_tokens: Some(16),
-            max_ngram_repeats: Some(3),
-            ngram_size: Some(64),
+            max_consecutive_tokens: Some(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS),
+            max_ngram_repeats: Some(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS),
+            ngram_size: Some(crate::sampling::DEFAULT_NGRAM_SIZE),
             eos_token_id: None,
             return_logprobs: Some(true),
             prefill_step_size: Some(2048),

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -820,9 +820,15 @@ impl Qwen3Inner {
         let presence_context_size = config.presence_context_size.unwrap_or(20);
         let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
         let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-        let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-        let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-        let ngram_size = config.ngram_size.unwrap_or(64);
+        let max_consecutive_tokens = config
+            .max_consecutive_tokens
+            .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS);
+        let max_ngram_repeats = config
+            .max_ngram_repeats
+            .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS);
+        let ngram_size = config
+            .ngram_size
+            .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE);
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
         let return_logprobs = config.return_logprobs.unwrap_or(true);
         let prefill_step_size = config.prefill_step_size.unwrap_or(2048) as usize;
@@ -1538,9 +1544,15 @@ impl Qwen3Inner {
         let presence_context_size = config.presence_context_size.unwrap_or(20);
         let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
         let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-        let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-        let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-        let ngram_size = config.ngram_size.unwrap_or(64);
+        let max_consecutive_tokens = config
+            .max_consecutive_tokens
+            .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS);
+        let max_ngram_repeats = config
+            .max_ngram_repeats
+            .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS);
+        let ngram_size = config
+            .ngram_size
+            .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE);
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
         let return_logprobs = config.return_logprobs.unwrap_or(true);
         let prefill_step_size = config.prefill_step_size.unwrap_or(2048) as usize;

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -5401,9 +5401,15 @@ impl Qwen35Inner {
         let presence_context_size = config.presence_context_size.unwrap_or(20);
         let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
         let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-        let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-        let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-        let ngram_size = config.ngram_size.unwrap_or(64);
+        let max_consecutive_tokens = config
+            .max_consecutive_tokens
+            .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS);
+        let max_ngram_repeats = config
+            .max_ngram_repeats
+            .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS);
+        let ngram_size = config
+            .ngram_size
+            .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE);
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
         let return_logprobs = config.return_logprobs.unwrap_or(true);
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -4816,9 +4816,15 @@ impl Qwen35MoeInner {
         let presence_context_size = config.presence_context_size.unwrap_or(20);
         let frequency_penalty = config.frequency_penalty.unwrap_or(0.0);
         let frequency_context_size = config.frequency_context_size.unwrap_or(20);
-        let max_consecutive_tokens = config.max_consecutive_tokens.unwrap_or(16);
-        let max_ngram_repeats = config.max_ngram_repeats.unwrap_or(3);
-        let ngram_size = config.ngram_size.unwrap_or(64);
+        let max_consecutive_tokens = config
+            .max_consecutive_tokens
+            .unwrap_or(crate::sampling::DEFAULT_MAX_CONSECUTIVE_TOKENS);
+        let max_ngram_repeats = config
+            .max_ngram_repeats
+            .unwrap_or(crate::sampling::DEFAULT_MAX_NGRAM_REPEATS);
+        let ngram_size = config
+            .ngram_size
+            .unwrap_or(crate::sampling::DEFAULT_NGRAM_SIZE);
         let eos_token_id = config.eos_token_id.or(Some(self.config.eos_token_id));
         let return_logprobs = config.return_logprobs.unwrap_or(true);
 

--- a/crates/mlx-core/src/sampling.rs
+++ b/crates/mlx-core/src/sampling.rs
@@ -1406,6 +1406,16 @@ pub(crate) fn apply_frequency_penalty(
     logits.put_along_axis(&indices, &penalized, ctx.last_axis)
 }
 
+/// Default repetition-cutoff parameters. All-zero = DISABLED, matching vLLM,
+/// which ships no repetition-stop heuristic out of the box and relies on
+/// `max_tokens` plus logit penalties (repetition / frequency / presence) to
+/// shape repetition. Callers opt in by setting positive `ChatConfig` /
+/// `GenerationConfig` values, which re-enable the `check_consecutive` /
+/// `check_ngram` guards in [`check_repetition_cutoff`].
+pub(crate) const DEFAULT_MAX_CONSECUTIVE_TOKENS: i32 = 0;
+pub(crate) const DEFAULT_MAX_NGRAM_REPEATS: i32 = 0;
+pub(crate) const DEFAULT_NGRAM_SIZE: i32 = 0;
+
 /// Check if generation has fallen into a repetitive loop.
 ///
 /// Detect degenerate repetitive generation and signal early termination.

--- a/crates/mlx-core/tests/lfm2_session.rs
+++ b/crates/mlx-core/tests/lfm2_session.rs
@@ -593,12 +593,12 @@ async fn lfm2_session_continue_tool_round_trips() {
     // tool_call_id (its template identifies tool responses positionally), so a
     // minimal tool-continue on the "thinking" checkpoint enters a think block
     // immediately and, under the 32-token budget here, legitimately bottoms out
-    // via any cutoff: EOS ("stop"), the budget cap ("length"), or the
-    // repetition guard ("repetition", which is active by default —
-    // params.rs defaults max_consecutive_tokens=16 / max_ngram_repeats=3 /
-    // ngram_size=64 when the config leaves them unset). All three are valid
-    // non-cancelled terminal states. Forward correctness is covered separately
-    // by lfm2_paged_vs_flat_parity (6/6 byte-identical).
+    // via EOS ("stop") or the budget cap ("length"). The repetition guard is
+    // OFF by default (params.rs resolves max_consecutive_tokens / max_ngram_repeats
+    // / ngram_size to 0 when the config leaves them unset), so "repetition" only
+    // fires if a caller opts in; it stays an accepted terminal state here for that
+    // case. All are valid non-cancelled terminal states. Forward correctness is
+    // covered separately by lfm2_paged_vs_flat_parity (6/6 byte-identical).
     assert!(
         matches!(
             result.finish_reason.as_str(),

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -2288,11 +2288,11 @@ export interface ChatConfig {
   frequencyPenalty?: number | undefined;
   /** Number of recent tokens to consider for frequency penalty (default: 20) */
   frequencyContextSize?: number | undefined;
-  /** Max consecutive identical tokens before stopping (default: 16, 0 = disabled) */
+  /** Max consecutive identical tokens before stopping (default: 0 = disabled; opt in with a positive value) */
   maxConsecutiveTokens?: number | undefined;
-  /** Max n-gram repetitions before stopping (default: 3, 0 = disabled) */
+  /** Max n-gram repetitions before stopping (default: 0 = disabled; opt in with a positive value) */
   maxNgramRepeats?: number | undefined;
-  /** Max pattern size for n-gram repetition detection (default: 64) */
+  /** Max pattern size for n-gram repetition detection (default: 0 = disabled; opt in with a positive value) */
   ngramSize?: number | undefined;
   tools?: Array<ToolDefinition>;
   /**
@@ -2988,19 +2988,19 @@ export interface GenerationConfig {
   /** Number of recent tokens to consider for frequency penalty (default: 20) */
   frequencyContextSize?: number;
   /**
-   * Stop if same token repeats this many times consecutively (default: 16)
-   * Set to 0 to disable. Prevents OOM from degenerate repetitive generation.
+   * Stop if same token repeats this many times consecutively (default: 0 = disabled).
+   * Opt in by setting a positive value to guard against degenerate repetitive generation.
    */
   maxConsecutiveTokens?: number;
   /**
-   * Stop if a pattern repeats this many times consecutively (default: 3)
-   * Set to 0 to disable. Detects patterns like "A B A B A B".
+   * Stop if a pattern repeats this many times consecutively (default: 0 = disabled).
+   * Opt in with a positive value to detect patterns like "A B A B A B".
    * Uses range-based detection: checks all pattern sizes from 2 to ngram_size.
    */
   maxNgramRepeats?: number;
   /**
-   * Maximum pattern size for repetition detection (default: 64)
-   * All pattern sizes from 2 up to this value are checked each decode step.
+   * Maximum pattern size for repetition detection (default: 0 = disabled).
+   * When enabled, all pattern sizes from 2 up to this value are checked each decode step.
    * Larger values catch long phrase-level repetition common in small models.
    */
   ngramSize?: number;

--- a/packages/server/src/presets.ts
+++ b/packages/server/src/presets.ts
@@ -19,15 +19,13 @@ import type { ChatConfig } from '@mlx-node/core';
  * All modes pin `top_k = 20` and `min_p = 0.0`; they differ in
  * `temperature`, `top_p`, and `presence_penalty`.
  *
- * Every mode also loosens the native anti-repetition cutoff
- * (`maxConsecutiveTokens` / `maxNgramRepeats`, default 16 / 3). Coding
- * answers legitimately contain long single-token runs — ASCII box
- * borders (`────`), separators (`====`/`----`), table rules, repeated
- * indentation — which the default cutoff treats as a stuck loop and
- * truncates mid-diagram (finish_reason `"repetition"` → `end_turn`),
- * silently cutting the answer. 256 / 8 lets a wide box or table survive
- * while still bounding a true runaway loop; `ngramSize` is the default,
- * kept explicit. Do not set 0 — that disables runaway protection.
+ * The native anti-repetition cutoff is now disabled by default
+ * (vLLM-aligned — vLLM ships no repetition-stop heuristic), so these
+ * presets no longer pin `maxConsecutiveTokens` / `maxNgramRepeats` /
+ * `ngramSize`. Repetition is shaped by the sampling penalties above and
+ * bounded by the per-model `maxOutputTokens`. An operator or client can
+ * still opt in by setting those fields explicitly — a per-request config
+ * value wins via `ChatSession.mergeConfig`.
  */
 export const QWEN_SAMPLING_DEFAULTS = {
   /** Thinking mode for precise coding tasks: temp=0.6, top_p=0.95, pp=0.0 */
@@ -38,9 +36,6 @@ export const QWEN_SAMPLING_DEFAULTS = {
     minP: 0.0,
     presencePenalty: 0.0,
     repetitionPenalty: 1.0,
-    maxConsecutiveTokens: 256,
-    maxNgramRepeats: 8,
-    ngramSize: 64,
   } satisfies ChatConfig,
 
   /** Thinking mode for general tasks: temp=1.0, top_p=0.95, pp=1.5 */
@@ -51,9 +46,6 @@ export const QWEN_SAMPLING_DEFAULTS = {
     minP: 0.0,
     presencePenalty: 1.5,
     repetitionPenalty: 1.0,
-    maxConsecutiveTokens: 256,
-    maxNgramRepeats: 8,
-    ngramSize: 64,
   } satisfies ChatConfig,
 
   /** Instruct (non-thinking) for general tasks: temp=0.7, top_p=0.8, pp=1.5 */
@@ -64,9 +56,6 @@ export const QWEN_SAMPLING_DEFAULTS = {
     minP: 0.0,
     presencePenalty: 1.5,
     repetitionPenalty: 1.0,
-    maxConsecutiveTokens: 256,
-    maxNgramRepeats: 8,
-    ngramSize: 64,
   } satisfies ChatConfig,
 
   /** Instruct (non-thinking) for reasoning tasks: temp=1.0, top_p=0.95, pp=1.5 */
@@ -77,9 +66,6 @@ export const QWEN_SAMPLING_DEFAULTS = {
     minP: 0.0,
     presencePenalty: 1.5,
     repetitionPenalty: 1.0,
-    maxConsecutiveTokens: 256,
-    maxNgramRepeats: 8,
-    ngramSize: 64,
   } satisfies ChatConfig,
 } as const;
 


### PR DESCRIPTION
## Problem

Qwen models generating large markdown tables (a `|----------------------------------|` rule, or many byte-identical rows) get **silently truncated**. The native `check_repetition_cutoff` runs every decode step and stops generation on N identical tokens in a row (Tier 1) or a repeating n-gram block (Tier 2). It fires on legitimate repeated structure — table rules, ASCII boxes, separators, repeated rows — and the `"repetition"` finish reason is then mapped to a clean `end_turn`, so the cut looks like a normal answer.

PR #81 only loosened the **TS Qwen launch preset** (256/8/64). Every other path — non-launch servers, Gemma4/LFM2, per-request configs that omit the fields, and the napi `GenerationConfig::default()` — still fell back to the tight native defaults (16/3/64), so as few as ~6 repeated tokens still truncated tables.

## How vLLM handles it (the model for this change)

vLLM ships **no** repetition-stop heuristic by default. It shapes repetition only with logit-level penalties (`repetition_penalty` 1.0, `frequency_penalty`/`presence_penalty` 0.0 — all no-ops by default) and stops generation only on real conditions (EOS, stop tokens, stop strings, `max_tokens`). Its opt-in loop detector (`repetition_detection`, recent main) defaults to `None`, and when enabled surfaces its own distinct `FINISHED_REPETITION` finish reason rather than disguising the cut.

## Change: fully align with vLLM — cutoff OFF by default, opt-in

- **`fix(sampling)`** — Introduce three named constants (all `0`) in `sampling.rs` and route **every** former 16/3/64 default-fallback site through them (`params.rs`, qwen3 / qwen3.5 / qwen3.5-MoE / gemma4 / qianfan_ocr model files, and the napi `GenerationConfig::default()`). With the knobs unset the detectors resolve to disabled (`0` already trips the existing `check_consecutive` / `check_ngram` guards). The detection **algorithm is unchanged**; GRPO training (`grpo/engine.rs`) and paddleocr keep their explicit values. New unit tests lock default-off and prove a positive value still re-enables detection (opt-in).
- **`fix(server)`** — Remove the now-unnecessary loosened cutoff (256/8/64) from all four Qwen launch presets; repetition is now shaped by the sampling penalties and bounded by `maxOutputTokens`, with per-request opt-in still winning via `ChatSession.mergeConfig`. Presets test flipped to assert the fields are absent while keeping the opt-in/override coverage.
- **`fix(types)`** — Sync the build-generated `packages/core/index.d.cts` cutoff doc comments to match the hand-synced `crates/mlx-core/index.d.cts` (both now say `default: 0 = disabled`), and rename a stale test `describe` block.

### Behavior change / migration

A degenerate small model now runs to `max_tokens` (default `max_new_tokens` = 2048) instead of stopping at ~16 tokens. This is intended and vLLM-aligned — `max_tokens` is the backstop. Operators who want the old early repetition-stop must now set `maxConsecutiveTokens` / `maxNgramRepeats` / `ngramSize` explicitly (per-request or via registered `samplingDefaults`).

## Testing

- Rust: `cargo test -p mlx-core --lib repetition` → 28 passing (TDD RED→GREEN; algorithm tests unchanged). Full lib suite 1878 pass; the 7 failures are pre-existing flaky f32/Metal numerical tests (banded-attn, attention-vjp, packed-affine embedding, sparse-moe gather, chunked-prefill parity) — verified to fail identically on base `73f4a89e`, no path to this change.
- TS: `vp test __test__/server/presets.test.ts` → 7/7.

## Out of scope (noted, not fixed here)

An adversarial review flagged that `/v1/responses` never clamps `max_output_tokens` against the registry's per-model `outputTokenLimit` (unlike `/v1/messages`). Independently verified as **pre-existing** (byte-identical at base `73f4a89e`; this branch doesn't touch `responses.ts`/`messages.ts`) and **not** a regression of this change (the cutoff only ever caught exact-repeat loops, never bounded long coherent output). Worth a separate server-hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default generation stopping behavior across all chat paths: legitimate long repeats no longer truncate early, but runaway loops rely on `max_new_tokens` unless operators opt back in via config.
> 
> **Overview**
> **Native repetition-stop heuristics are off by default**, matching vLLM: unset `maxConsecutiveTokens`, `maxNgramRepeats`, and `ngramSize` now resolve to **0** (disabled) instead of 16/3/64. Shared `DEFAULT_*` constants in `sampling.rs` replace scattered literal fallbacks across chat param extraction and Qwen/Gemma/Qianfan generation paths; the detection logic is unchanged and **positive per-request values still opt in**.
> 
> **Qwen launch presets** drop the previous 256/8/64 “loosened” cutoff pins—repetition is left to sampling penalties and `maxOutputTokens`, with `ChatSession.mergeConfig` still letting clients override. **API docs** (`ChatConfig` / `GenerationConfig`) and **tests** (presets, `params.rs` unit tests, LFM2 session comment) are updated for default-off behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5686106532760b9c7d8d20d9d63d4998f8cc893b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->