### PR TITLE
perf: inference perf polish + quality sweep (qwen3.5 RoPE axis fix, MLX NAX-fork bump, metallib packaging hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,15 @@ env:
   # off them. Set on the whole workflow so test jobs exercise the same
   # floor the publish artifacts ship with.
   MACOSX_DEPLOYMENT_TARGET: '26.0'
+  # Publish/release fail-closed switch for the metallib packaging gates in
+  # packages/core/build.ts. The `build` job's `yarn build` produces the .node +
+  # metallib artifacts the publish job ships, and every CI build can feed a
+  # release, so strictness is on for the whole workflow. With it set, a
+  # Metal-enabled darwin addon that bakes no METAL_PATH aborts the build instead
+  # of scanning possibly-stale mlx-sys-* dirs, and an unparseable metallib
+  # min-OS stamp aborts instead of silently skipping the deployment-floor check.
+  # Local `yarn build:native` leaves it unset and keeps the lenient dev behavior.
+  MLX_METALLIB_STRICT: '1'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,15 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 1
+  # Deployment floor of every macOS build product (metallib min-OS stamp,
+  # libmlx, .node). Without it the floor silently tracks the runner image's
+  # macOS version and ratchets with runner updates. 26.0 keeps published
+  # binaries loading on all macOS 26 releases; the vendored MLX fork still
+  # builds the NAX kernels at this floor (MLX_METAL_FORCE_NAX, see
+  # crates/mlx-sys/build.rs) and runtime dispatch keeps pre-26.2 machines
+  # off them. Set on the whole workflow so test jobs exercise the same
+  # floor the publish artifacts ship with.
+  MACOSX_DEPLOYMENT_TARGET: '26.0'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ MLX-Node brings Apple's [MLX](https://github.com/ml-explore/mlx) framework to Ja
 | macOS · Apple Silicon (M1–M5)    | Metal   | ✅ Fully supported (inference · training · VLM) |
 | Linux · aarch64 / glibc · NVIDIA | CUDA    | 🧪 Experimental — inference preview             |
 
+> **macOS version floor:** the prebuilt `darwin-arm64` binaries published to npm are
+> compiled on `macos-26` CI runners against the macOS 26 SDK, so their Metal library
+> targets MSL 4 and does not load on macOS 15 or older — **macOS 26+ is required for
+> the prebuilt binaries**. Building from source works on macOS ≥ 14 (MLX's floor); the
+> deployment floor then defaults to the build host's macOS version, and can be pinned
+> explicitly with `MACOSX_DEPLOYMENT_TARGET`. MLX's NAX kernels (M5-class GPUs) are
+> only compiled in when the floor is ≥ 26.2 and only dispatch on macOS 26.2+.
+
 ### NVIDIA CUDA (experimental preview)
 
 MLX-Node runs on NVIDIA GPUs through MLX's CUDA backend. This is an early
@@ -151,6 +159,7 @@ MLX_QWEN35_FORCE_EAGER=1 MLX_QWEN35_PAGED_OVERRIDE=0 \
 ### Prerequisites
 
 - macOS with Apple Silicon (M1–M5) and Metal — fully supported
+  - macOS 26+ for the prebuilt npm binaries; macOS ≥ 14 to build from source (see [Platform Support](#platform-support))
 - Node.js 18+
 - Rust 1.90
 

--- a/README.md
+++ b/README.md
@@ -121,12 +121,13 @@ MLX-Node brings Apple's [MLX](https://github.com/ml-explore/mlx) framework to Ja
 | Linux · aarch64 / glibc · NVIDIA | CUDA    | 🧪 Experimental — inference preview             |
 
 > **macOS version floor:** the prebuilt `darwin-arm64` binaries published to npm are
-> compiled on `macos-26` CI runners against the macOS 26 SDK, so their Metal library
-> targets MSL 4 and does not load on macOS 15 or older — **macOS 26+ is required for
-> the prebuilt binaries**. Building from source works on macOS ≥ 14 (MLX's floor); the
+> built with an explicit macOS 26.0 deployment floor (MSL 4) — they load on every
+> macOS 26 release and do not load on macOS 15 or older, so **macOS 26+ is required
+> for the prebuilt binaries**. They also carry MLX's NAX kernels (M5-class GPUs),
+> which activate only at runtime on macOS 26.2+ — on 26.0/26.1 the same binary runs
+> the standard kernels. Building from source works on macOS ≥ 14 (MLX's floor); the
 > deployment floor then defaults to the build host's macOS version, and can be pinned
-> explicitly with `MACOSX_DEPLOYMENT_TARGET`. MLX's NAX kernels (M5-class GPUs) are
-> only compiled in when the floor is ≥ 26.2 and only dispatch on macOS 26.2+.
+> explicitly with `MACOSX_DEPLOYMENT_TARGET`.
 
 ### NVIDIA CUDA (experimental preview)
 

--- a/__test__/core/metallib-select.test.ts
+++ b/__test__/core/metallib-select.test.ts
@@ -143,6 +143,32 @@ describe('collectMetallibCandidates', () => {
     expect(candidates).toHaveLength(1);
     expect(candidates[0]!.metallibPath).toBe(debug);
   });
+
+  it.skipIf(runningAsRoot)(
+    'THROWS when the newest candidate is untraversable (EACCES), instead of skipping it and picking an older one',
+    () => {
+      addOutDir(`${TRIPLE}/release/build/mlx-sys-aaaa1111`, 'older-readable', 7);
+      addOutDir(`${TRIPLE}/release/build/mlx-sys-ffff2222`, 'newest-unreadable', 0);
+      const newestLibDir = join(root, `${TRIPLE}/release/build/mlx-sys-ffff2222`, 'out', 'lib');
+      chmodSync(newestLibDir, 0o000); // stat on its metallib now fails EACCES, not ENOENT
+      try {
+        expect(() => collectMetallibCandidates(root, TRIPLE, 'release')).toThrow(/cannot stat/);
+      } finally {
+        chmodSync(newestLibDir, 0o755);
+      }
+    },
+  );
+
+  it.skipIf(runningAsRoot)('THROWS when a candidate build root exists but cannot be listed (EACCES)', () => {
+    addOutDir(`${TRIPLE}/release/build/mlx-sys-aaaa1111`, 'unreachable', 0);
+    const buildRoot = join(root, TRIPLE, 'release', 'build');
+    chmodSync(buildRoot, 0o000);
+    try {
+      expect(() => collectMetallibCandidates(root, TRIPLE, 'release')).toThrow(/cannot list/);
+    } finally {
+      chmodSync(buildRoot, 0o755);
+    }
+  });
 });
 
 describe('resolveTargetRoot', () => {

--- a/__test__/core/metallib-select.test.ts
+++ b/__test__/core/metallib-select.test.ts
@@ -6,9 +6,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
 
 import {
   BASE_KERNEL_MARKERS,
+  MIN_PAGED_METALLIB_BYTES,
   NAX_KERNEL_MARKERS,
   assertMetallibFloor,
   assertMetallibIntegrity,
+  assertPagedMetallibIntegrity,
   collectMetallibCandidates,
   compareVersions,
   extractBakedMetallibBinding,
@@ -17,6 +19,7 @@ import {
   profileDirName,
   resolveTargetRoot,
   selectMetallib,
+  selectPagedMetallib,
   shouldExpectNaxKernels,
 } from '../../packages/core/metallib-select';
 
@@ -350,6 +353,86 @@ describe('selectMetallib', () => {
         profile: 'release',
       }),
     ).toThrow(/mlx\.metallib not found under/);
+  });
+});
+
+describe('selectPagedMetallib / assertPagedMetallibIntegrity', () => {
+  let root: string;
+  let outDir: string;
+  let libDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'metallib-select-paged-'));
+    outDir = join(root, 'out');
+    libDir = join(outDir, 'lib');
+    mkdirSync(libDir, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function writeOrigin(content: string): string {
+    const p = join(outDir, 'paged_attn.metallib');
+    writeFileSync(p, content);
+    return p;
+  }
+  function writeInstallCopy(content: string): string {
+    const p = join(libDir, 'paged_attn.metallib');
+    writeFileSync(p, content);
+    return p;
+  }
+
+  it('ships the build.rs origin when both copies are byte-identical', () => {
+    const origin = writeOrigin('MTLB same-bytes');
+    writeInstallCopy('MTLB same-bytes');
+    const picked = selectPagedMetallib({ outDir, libDir });
+    expect(picked.path).toBe(origin);
+    expect(picked.contents.toString()).toBe('MTLB same-bytes');
+  });
+
+  it('REJECTS a both-present mismatch instead of silently preferring either copy', () => {
+    writeOrigin('MTLB origin-bytes');
+    writeInstallCopy('MTLB different-install-copy');
+    expect(() => selectPagedMetallib({ outDir, libDir })).toThrow(/not byte-identical/);
+  });
+
+  it('REJECTS loudly when the origin is truncated next to a good install copy (no silent fallback)', () => {
+    const good = 'MTLB ' + 'k'.repeat(64);
+    writeOrigin(good.slice(0, 7)); // interrupted write of the same build
+    writeInstallCopy(good);
+    expect(() => selectPagedMetallib({ outDir, libDir })).toThrow(/not byte-identical/);
+  });
+
+  it('ships the surviving copy (with a warning) when only one of the two exists', () => {
+    const origin = writeOrigin('MTLB origin-only');
+    let warnings: string[] = [];
+    const fromOrigin = selectPagedMetallib({ outDir, libDir, warn: (m) => warnings.push(m) });
+    expect(fromOrigin.path).toBe(origin);
+    expect(warnings.some((w) => w.includes('is missing'))).toBe(true);
+
+    rmSync(origin);
+    const installCopy = writeInstallCopy('MTLB install-copy-only');
+    warnings = [];
+    const fromCopy = selectPagedMetallib({ outDir, libDir, warn: (m) => warnings.push(m) });
+    expect(fromCopy.path).toBe(installCopy);
+    expect(fromCopy.contents.toString()).toBe('MTLB install-copy-only');
+    expect(warnings.some((w) => w.includes('is missing'))).toBe(true);
+  });
+
+  it('throws the loud not-found error when neither copy exists', () => {
+    expect(() => selectPagedMetallib({ outDir, libDir })).toThrow(/paged_attn\.metallib not found at/);
+  });
+
+  it('integrity gate: rejects truncation via the size floor and non-MTLB content via the magic', () => {
+    // An identically-truncated PAIR passes selection (byte-equal) — the
+    // integrity gate is what catches it.
+    expect(() => assertPagedMetallibIntegrity(Buffer.from('MTLB tiny'), { path: 'x' })).toThrow(
+      new RegExp(`below the ${MIN_PAGED_METALLIB_BYTES}-byte floor`),
+    );
+    expect(() => assertPagedMetallibIntegrity(Buffer.from('NOPE junk'), { path: 'x', minBytes: 1 })).toThrow(
+      /MTLB container magic/,
+    );
+    expect(() => assertPagedMetallibIntegrity(Buffer.from('MTLB healthy'), { path: 'x', minBytes: 1 })).not.toThrow();
   });
 });
 

--- a/__test__/core/metallib-select.test.ts
+++ b/__test__/core/metallib-select.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -24,6 +24,11 @@ import {
 } from '../../packages/core/metallib-select';
 
 const TRIPLE = 'aarch64-apple-darwin';
+
+// chmod-based unreadability tests are meaningless as root (root bypasses
+// permission bits); CI and dev both run unprivileged, so this only guards
+// exotic environments.
+const runningAsRoot = typeof process.getuid === 'function' && process.getuid() === 0;
 
 describe('compareVersions', () => {
   it('orders dotted versions numerically, not lexically', () => {
@@ -326,6 +331,30 @@ describe('selectMetallib', () => {
     ).toThrow(/neither that file nor its install copy .* exists/);
   });
 
+  it.skipIf(runningAsRoot)(
+    'THROWS when the baked file is uninspectable (EACCES), instead of treating it as absent and shipping the install copy',
+    () => {
+      const rel = `${TRIPLE}/release/build/mlx-sys-aaaa1111`;
+      addOutDir(rel, 'good-install-copy', 0);
+      addBakedFile(rel, 'origin-bytes');
+      const kernelsDir = join(root, rel, 'out', 'build', 'mlx', 'backend', 'metal', 'kernels');
+      chmodSync(kernelsDir, 0o000); // stat on the baked file now fails with EACCES, not ENOENT
+      try {
+        expect(() =>
+          selectMetallib({
+            addonBinary: fakeAddon([bakedPathFor(join(root, rel, 'out'))]),
+            addonPath: 'fake.node',
+            targetRoot: root,
+            triple: TRIPLE,
+            profile: 'release',
+          }),
+        ).toThrow(/cannot stat/);
+      } finally {
+        chmodSync(kernelsDir, 0o755);
+      }
+    },
+  );
+
   it('falls back to the mtime scan only when the addon bakes no METAL_PATH', () => {
     const newest = addOutDir(`${TRIPLE}/release/build/mlx-sys-ffff2222`, 'fresh', 0);
     addOutDir(`${TRIPLE}/release/build/mlx-sys-aaaa1111`, 'stale', 7);
@@ -422,6 +451,22 @@ describe('selectPagedMetallib / assertPagedMetallibIntegrity', () => {
   it('throws the loud not-found error when neither copy exists', () => {
     expect(() => selectPagedMetallib({ outDir, libDir })).toThrow(/paged_attn\.metallib not found at/);
   });
+
+  it.skipIf(runningAsRoot)(
+    'THROWS when the origin is present but unreadable (EACCES), instead of shipping the install copy uncompared',
+    () => {
+      const origin = writeOrigin('MTLB origin-bytes');
+      writeInstallCopy('MTLB good-install-copy');
+      chmodSync(origin, 0o000);
+      try {
+        const warnings: string[] = [];
+        expect(() => selectPagedMetallib({ outDir, libDir, warn: (m) => warnings.push(m) })).toThrow(/cannot read/);
+        expect(warnings).toHaveLength(0); // no warn-and-degrade
+      } finally {
+        chmodSync(origin, 0o644);
+      }
+    },
+  );
 
   it('integrity gate: rejects truncation via the size floor and non-MTLB content via the magic', () => {
     // An identically-truncated PAIR passes selection (byte-equal) — the

--- a/__test__/core/metallib-select.test.ts
+++ b/__test__/core/metallib-select.test.ts
@@ -186,7 +186,9 @@ describe('extractBakedMetallibBinding', () => {
     expect(binding).toBeDefined();
     expect(binding!.outDir).toBe(BAKED_DIR_A);
     expect(binding!.libDir).toBe(`${BAKED_DIR_A}/lib`);
-    expect(binding!.metallibPath).toBe(`${BAKED_DIR_A}/lib/mlx.metallib`);
+    expect(binding!.installCopyPath).toBe(`${BAKED_DIR_A}/lib/mlx.metallib`);
+    // the double slash in the baked string is normalized away
+    expect(binding!.bakedPath).toBe(`${BAKED_DIR_A}/build/mlx/backend/metal/kernels/mlx.metallib`);
   });
 
   it('accepts the single-slash kernels path form too', () => {
@@ -230,6 +232,15 @@ describe('selectMetallib', () => {
     return metallib;
   }
 
+  /** The cmake kernels build-tree file a baked METAL_PATH points at. */
+  function addBakedFile(rel: string, content: string): string {
+    const kernelsDir = join(root, rel, 'out', 'build', 'mlx', 'backend', 'metal', 'kernels');
+    mkdirSync(kernelsDir, { recursive: true });
+    const baked = join(kernelsDir, 'mlx.metallib');
+    writeFileSync(baked, content);
+    return baked;
+  }
+
   it('rejects a same-pin NEWER but unbound candidate: the baked METAL_PATH wins over mtime rank', () => {
     const boundRel = `${TRIPLE}/release/build/mlx-sys-aaaa1111`;
     const bound = addOutDir(boundRel, 'bound-build', 7);
@@ -251,7 +262,54 @@ describe('selectMetallib', () => {
     expect(picked.metallibPath).toBe(bound);
   });
 
-  it('throws (never falls back to another dir) when the bound metallib is missing on disk', () => {
+  it('ships the exact baked build-tree file when it matches its out/lib install copy', () => {
+    const rel = `${TRIPLE}/release/build/mlx-sys-aaaa1111`;
+    addOutDir(rel, 'same-bytes', 0);
+    const baked = addBakedFile(rel, 'same-bytes');
+    const picked = selectMetallib({
+      addonBinary: fakeAddon([bakedPathFor(join(root, rel, 'out'))]),
+      addonPath: 'fake.node',
+      targetRoot: root,
+      triple: TRIPLE,
+      profile: 'release',
+    });
+    expect(picked.source).toBe('baked');
+    expect(picked.metallibPath).toBe(baked);
+  });
+
+  it('REJECTS a diverged out/lib install copy: baked file and install copy must be byte-identical', () => {
+    const rel = `${TRIPLE}/release/build/mlx-sys-aaaa1111`;
+    addOutDir(rel, 'stale-install-copy', 0);
+    addBakedFile(rel, 'fresh-origin-bytes');
+    expect(() =>
+      selectMetallib({
+        addonBinary: fakeAddon([bakedPathFor(join(root, rel, 'out'))]),
+        addonPath: 'fake.node',
+        targetRoot: root,
+        triple: TRIPLE,
+        profile: 'release',
+      }),
+    ).toThrow(/not byte-identical/);
+  });
+
+  it('SUCCEEDS with the baked file when the out/lib install copy is missing entirely', () => {
+    const rel = `${TRIPLE}/release/build/mlx-sys-aaaa1111`;
+    const baked = addBakedFile(rel, 'origin-only');
+    const warnings: string[] = [];
+    const picked = selectMetallib({
+      addonBinary: fakeAddon([bakedPathFor(join(root, rel, 'out'))]),
+      addonPath: 'fake.node',
+      targetRoot: root,
+      triple: TRIPLE,
+      profile: 'release',
+      warn: (m) => warnings.push(m),
+    });
+    expect(picked.source).toBe('baked');
+    expect(picked.metallibPath).toBe(baked);
+    expect(warnings.some((w) => w.includes('is missing'))).toBe(true);
+  });
+
+  it('throws (never falls back to another dir) when the bound build has no metallib left on disk', () => {
     addOutDir(`${TRIPLE}/release/build/mlx-sys-ffff2222`, 'newer-unbound', 0);
     const addon = fakeAddon([bakedPathFor(join(root, `${TRIPLE}/release/build/mlx-sys-aaaa1111`, 'out'))]);
     expect(() =>
@@ -262,7 +320,7 @@ describe('selectMetallib', () => {
         triple: TRIPLE,
         profile: 'release',
       }),
-    ).toThrow(/does not exist/);
+    ).toThrow(/neither that file nor its install copy .* exists/);
   });
 
   it('falls back to the mtime scan only when the addon bakes no METAL_PATH', () => {
@@ -295,17 +353,31 @@ describe('selectMetallib', () => {
   });
 });
 
-/** MTLB container header with the given min-OS stamp (u16 LE major @12, minor @14). */
-function mtlbHeader(major: number, minor: number, magic = 'MTLB'): Buffer {
+/**
+ * MTLB container header with the given min-OS stamp (u16 LE major @12,
+ * minor @14) in the recognized layout: platform tag 0x8001 @4, container
+ * version 2 @6, library type 0x00 @10, macOS tag 0x81 @11. `opts` corrupts
+ * individual fields to model future/unknown container revisions.
+ */
+function mtlbHeader(
+  major: number,
+  minor: number,
+  opts?: { magic?: string; platform?: number; containerVersion?: number; libraryType?: number; osTag?: number },
+): Buffer {
   const header = Buffer.alloc(24);
-  header.write(magic, 0, 'latin1');
+  header.write(opts?.magic ?? 'MTLB', 0, 'latin1');
+  header.writeUInt16LE(opts?.platform ?? 0x8001, 4);
+  header.writeUInt16LE(opts?.containerVersion ?? 2, 6);
+  header.writeUInt16LE(9, 8); // container minor version — varies by toolchain, not validated
+  header[10] = opts?.libraryType ?? 0x00;
+  header[11] = opts?.osTag ?? 0x81;
   header.writeUInt16LE(major, 12);
   header.writeUInt16LE(minor, 14);
   return header;
 }
 
 describe('parseMetallibMinOs / assertMetallibFloor', () => {
-  it('parses the min-OS stamp out of the MTLB header', () => {
+  it('parses the min-OS stamp out of the recognized MTLB header layout', () => {
     expect(parseMetallibMinOs(mtlbHeader(26, 0))).toBe('26.0');
     expect(parseMetallibMinOs(mtlbHeader(26, 2))).toBe('26.2');
     expect(parseMetallibMinOs(mtlbHeader(15, 0))).toBe('15.0');
@@ -315,10 +387,29 @@ describe('parseMetallibMinOs / assertMetallibFloor', () => {
   });
 
   it('returns undefined on unknown layouts instead of guessing', () => {
-    expect(parseMetallibMinOs(mtlbHeader(26, 0, 'NOPE'))).toBeUndefined();
+    expect(parseMetallibMinOs(mtlbHeader(26, 0, { magic: 'NOPE' }))).toBeUndefined();
     expect(parseMetallibMinOs(Buffer.from('MTLB'))).toBeUndefined();
     expect(parseMetallibMinOs(mtlbHeader(0, 0))).toBeUndefined();
     expect(parseMetallibMinOs(mtlbHeader(4242, 0))).toBeUndefined();
+  });
+
+  it('a future container revision (version-like bytes at 12/14 but unrecognized layout) SKIPS with a warning, never hard-fails', () => {
+    // Each fixture stamps a would-fail min-OS 26.2 under floor 26.0, but a
+    // single unrecognized layout field must downgrade enforcement to a skip.
+    const futureLayouts = [
+      mtlbHeader(26, 2, { containerVersion: 3 }),
+      mtlbHeader(26, 2, { platform: 0x8002 }),
+      mtlbHeader(26, 2, { libraryType: 0x01 }),
+      mtlbHeader(26, 2, { osTag: 0x82 }),
+    ];
+    for (const fixture of futureLayouts) {
+      expect(parseMetallibMinOs(fixture)).toBeUndefined();
+      const warnings: string[] = [];
+      expect(() =>
+        assertMetallibFloor(fixture, { path: 'x', deploymentFloor: '26.0', warn: (m) => warnings.push(m) }),
+      ).not.toThrow();
+      expect(warnings.some((w) => w.includes('unrecognized MTLB header layout'))).toBe(true);
+    }
   });
 
   it('rejects a metallib stamped above the intended deployment floor', () => {
@@ -331,7 +422,9 @@ describe('parseMetallibMinOs / assertMetallibFloor', () => {
     expect(() => assertMetallibFloor(mtlbHeader(26, 0), { path: 'x', deploymentFloor: '26.0' })).not.toThrow();
     expect(() => assertMetallibFloor(mtlbHeader(15, 0), { path: 'x', deploymentFloor: '26.0' })).not.toThrow();
     expect(() => assertMetallibFloor(mtlbHeader(26, 0), { path: 'x', deploymentFloor: '26.5.2' })).not.toThrow();
-    expect(() => assertMetallibFloor(mtlbHeader(26, 2, 'NOPE'), { path: 'x', deploymentFloor: '26.0' })).not.toThrow();
+    expect(() =>
+      assertMetallibFloor(mtlbHeader(26, 2, { magic: 'NOPE' }), { path: 'x', deploymentFloor: '26.0' }),
+    ).not.toThrow();
   });
 });
 

--- a/__test__/core/metallib-select.test.ts
+++ b/__test__/core/metallib-select.test.ts
@@ -1,0 +1,157 @@
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
+
+import {
+  BASE_KERNEL_MARKERS,
+  NAX_KERNEL_MARKERS,
+  assertMetallibIntegrity,
+  collectMetallibCandidates,
+  compareVersions,
+  hostAppleTriple,
+  profileDirName,
+  shouldExpectNaxKernels,
+} from '../../packages/core/metallib-select';
+
+const TRIPLE = 'aarch64-apple-darwin';
+
+describe('compareVersions', () => {
+  it('orders dotted versions numerically, not lexically', () => {
+    expect(compareVersions('26.2', '26.10')).toBeLessThan(0);
+    expect(compareVersions('26.2', '26.2')).toBe(0);
+    expect(compareVersions('26.5.2', '26.2')).toBeGreaterThan(0);
+    expect(compareVersions('26', '26.0')).toBe(0);
+    expect(compareVersions('15.0', '26.2')).toBeLessThan(0);
+  });
+});
+
+describe('shouldExpectNaxKernels', () => {
+  it('mirrors the MLX cmake gate: SDK >= 26.2 AND effective deployment target >= 26.2', () => {
+    // deployment target defaults to the host version when the env is unset
+    expect(shouldExpectNaxKernels('26.5', '26.5.2', undefined)).toBe(true);
+    expect(shouldExpectNaxKernels('26.2', '26.2', undefined)).toBe(true);
+    // host below 26.2 -> defaulted deployment target too low
+    expect(shouldExpectNaxKernels('26.5', '26.1', undefined)).toBe(false);
+    // SDK too old builds no NAX regardless of target
+    expect(shouldExpectNaxKernels('15.5', '26.5', undefined)).toBe(false);
+    // explicit env pin overrides the host default in both directions
+    expect(shouldExpectNaxKernels('26.5', '26.5', '26.0')).toBe(false);
+    expect(shouldExpectNaxKernels('26.5', '26.5', '15.0')).toBe(false);
+    expect(shouldExpectNaxKernels('26.5', '26.1', '26.2')).toBe(true);
+    // empty env behaves like unset
+    expect(shouldExpectNaxKernels('26.5', '26.5', '')).toBe(true);
+  });
+});
+
+describe('profileDirName / hostAppleTriple', () => {
+  it('derives the cargo profile dir from napi build options', () => {
+    expect(profileDirName({ release: true })).toBe('release');
+    expect(profileDirName({})).toBe('debug');
+    expect(profileDirName({ profile: 'bench', release: true })).toBe('bench');
+  });
+  it('maps node arch to an apple triple', () => {
+    expect(hostAppleTriple('arm64')).toBe('aarch64-apple-darwin');
+    expect(hostAppleTriple('x64')).toBe('x86_64-apple-darwin');
+  });
+});
+
+describe('collectMetallibCandidates', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'metallib-select-'));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function addOutDir(rel: string, content: string, ageDays: number, withTimestamp = false): string {
+    const scriptDir = join(root, rel);
+    const libDir = join(scriptDir, 'out', 'lib');
+    mkdirSync(libDir, { recursive: true });
+    const metallib = join(libDir, 'mlx.metallib');
+    writeFileSync(metallib, content);
+    const when = new Date(Date.now() - ageDays * 86_400_000);
+    utimesSync(metallib, when, when);
+    if (withTimestamp) {
+      const stamp = join(scriptDir, 'invoked.timestamp');
+      writeFileSync(stamp, 'This file has an mtime of when this was started.');
+      utimesSync(stamp, when, when);
+    }
+    return metallib;
+  }
+
+  it('picks the most recently built mlx-sys dir, not the readdir-first one', () => {
+    // lexically-first dir is a week old (stale pin); lexically-last is fresh —
+    // the old first-match scan shipped the stale one.
+    addOutDir(`${TRIPLE}/release/build/mlx-sys-aaaa1111`, 'stale-pin', 7, true);
+    const fresh = addOutDir(`${TRIPLE}/release/build/mlx-sys-ffff2222`, 'fresh-pin', 0, true);
+
+    const candidates = collectMetallibCandidates(root, TRIPLE, 'release');
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]!.metallibPath).toBe(fresh);
+  });
+
+  it('ranks by cargo activity (invoked.timestamp) when the metallib itself was cache-reused', () => {
+    // dir A: metallib built recently but not used since (no fresh timestamp).
+    addOutDir(`${TRIPLE}/release/build/mlx-sys-aaaa1111`, 'other-toolchain', 2, true);
+    // dir B: metallib file is older, but cargo just re-used this dir — its
+    // invoked.timestamp is fresh.
+    const reused = addOutDir(`${TRIPLE}/release/build/mlx-sys-bbbb2222`, 'current-build', 5, true);
+    const stamp = join(root, `${TRIPLE}/release/build/mlx-sys-bbbb2222`, 'invoked.timestamp');
+    const now = new Date();
+    utimesSync(stamp, now, now);
+
+    const candidates = collectMetallibCandidates(root, TRIPLE, 'release');
+    expect(candidates[0]!.metallibPath).toBe(reused);
+  });
+
+  it('never mixes the plain-cargo layout into the triple tree, but falls back to it when the triple tree is empty', () => {
+    const plain = addOutDir('release/build/mlx-sys-cccc3333', 'plain-layout', 0);
+    expect(collectMetallibCandidates(root, TRIPLE, 'release')[0]!.metallibPath).toBe(plain);
+
+    const triple = addOutDir(`${TRIPLE}/release/build/mlx-sys-dddd4444`, 'triple-layout', 3);
+    const candidates = collectMetallibCandidates(root, TRIPLE, 'release');
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]!.metallibPath).toBe(triple);
+  });
+
+  it('scans the profile the build actually used and skips dirs without a metallib', () => {
+    mkdirSync(join(root, `${TRIPLE}/debug/build/mlx-sys-eeee5555/out/lib`), { recursive: true });
+    const debug = addOutDir(`${TRIPLE}/debug/build/mlx-sys-ffff6666`, 'debug-build', 0);
+
+    expect(collectMetallibCandidates(root, TRIPLE, 'release')).toHaveLength(0);
+    const candidates = collectMetallibCandidates(root, TRIPLE, 'debug');
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]!.metallibPath).toBe(debug);
+  });
+});
+
+describe('assertMetallibIntegrity', () => {
+  const healthy = Buffer.from(['MTLB', ...BASE_KERNEL_MARKERS, ...NAX_KERNEL_MARKERS].join('\0'));
+  const stalePin = Buffer.from(['MTLB', ...BASE_KERNEL_MARKERS].join('\0'));
+
+  it('rejects a truncated metallib via the minimum-size floor', () => {
+    expect(() => assertMetallibIntegrity(healthy, { path: 'x', expectNax: false })).toThrow(/below the .*-byte floor/);
+  });
+
+  it('rejects a metallib without the base kernel inventory', () => {
+    expect(() =>
+      assertMetallibIntegrity(Buffer.from('MTLB junk'), { path: 'x', expectNax: false, minBytes: 1 }),
+    ).toThrow(/missing expected kernel/);
+  });
+
+  it('rejects a previous-pin metallib when the host builds NAX kernels', () => {
+    expect(() => assertMetallibIntegrity(stalePin, { path: 'x', expectNax: true, minBytes: 1 })).toThrow(
+      /missing NAX kernel/,
+    );
+    // ...but accepts it when NAX is legitimately not built on this host.
+    expect(() => assertMetallibIntegrity(stalePin, { path: 'x', expectNax: false, minBytes: 1 })).not.toThrow();
+  });
+
+  it('accepts a current-pin metallib with NAX kernels', () => {
+    expect(() => assertMetallibIntegrity(healthy, { path: 'x', expectNax: true, minBytes: 1 })).not.toThrow();
+  });
+});

--- a/__test__/core/metallib-select.test.ts
+++ b/__test__/core/metallib-select.test.ts
@@ -28,16 +28,19 @@ describe('compareVersions', () => {
 });
 
 describe('shouldExpectNaxKernels', () => {
-  it('mirrors the MLX cmake gate: SDK >= 26.2 AND effective deployment target >= 26.2', () => {
+  it('mirrors the forced-NAX cmake gate: SDK >= 26.2 AND effective deployment target >= 26.0', () => {
     // deployment target defaults to the host version when the env is unset
     expect(shouldExpectNaxKernels('26.5', '26.5.2', undefined)).toBe(true);
     expect(shouldExpectNaxKernels('26.2', '26.2', undefined)).toBe(true);
-    // host below 26.2 -> defaulted deployment target too low
-    expect(shouldExpectNaxKernels('26.5', '26.1', undefined)).toBe(false);
+    // MLX_METAL_FORCE_NAX drops upstream's >= 26.2 floor clause: any
+    // macOS 26 target (MSL 4.0) builds the NAX kernels
+    expect(shouldExpectNaxKernels('26.5', '26.1', undefined)).toBe(true);
     // SDK too old builds no NAX regardless of target
     expect(shouldExpectNaxKernels('15.5', '26.5', undefined)).toBe(false);
-    // explicit env pin overrides the host default in both directions
-    expect(shouldExpectNaxKernels('26.5', '26.5', '26.0')).toBe(false);
+    // the published-artifact configuration: 26.0 floor still carries NAX
+    expect(shouldExpectNaxKernels('26.5', '26.5', '26.0')).toBe(true);
+    // a pre-26 floor drops MSL below 4.0, which fails the gate's
+    // MLX_METAL_VERSION >= 400 clause
     expect(shouldExpectNaxKernels('26.5', '26.5', '15.0')).toBe(false);
     expect(shouldExpectNaxKernels('26.5', '26.1', '26.2')).toBe(true);
     // empty env behaves like unset

--- a/__test__/core/metallib-select.test.ts
+++ b/__test__/core/metallib-select.test.ts
@@ -409,6 +409,42 @@ describe('selectMetallib', () => {
       }),
     ).toThrow(/mlx\.metallib not found under/);
   });
+
+  it('STRICT (publish): throws instead of scanning when the addon bakes no METAL_PATH', () => {
+    // A fresh, newest metallib is on disk — lenient mode would ship it — but a
+    // publish build must not pair an unbound scan result with the addon.
+    addOutDir(`${TRIPLE}/release/build/mlx-sys-ffff2222`, 'fresh', 0);
+    const warnings: string[] = [];
+    expect(() =>
+      selectMetallib({
+        addonBinary: fakeAddon(['no baked path here']),
+        addonPath: 'fake.node',
+        targetRoot: root,
+        triple: TRIPLE,
+        profile: 'release',
+        strict: true,
+        warn: (m) => warnings.push(m),
+      }),
+    ).toThrow(/MLX_METALLIB_STRICT/);
+    expect(warnings).toHaveLength(0); // fail closed — no scan warning, no scan
+  });
+
+  it('non-strict (local dev): still scans and warns when the addon bakes no METAL_PATH', () => {
+    const newest = addOutDir(`${TRIPLE}/release/build/mlx-sys-ffff2222`, 'fresh', 0);
+    const warnings: string[] = [];
+    const picked = selectMetallib({
+      addonBinary: fakeAddon(['no baked path here']),
+      addonPath: 'fake.node',
+      targetRoot: root,
+      triple: TRIPLE,
+      profile: 'release',
+      strict: false,
+      warn: (m) => warnings.push(m),
+    });
+    expect(picked.source).toBe('scan');
+    expect(picked.metallibPath).toBe(newest);
+    expect(warnings.some((w) => w.includes('No baked METAL_PATH'))).toBe(true);
+  });
 });
 
 describe('selectPagedMetallib / assertPagedMetallibIntegrity', () => {
@@ -579,6 +615,37 @@ describe('parseMetallibMinOs / assertMetallibFloor', () => {
     expect(() =>
       assertMetallibFloor(mtlbHeader(26, 2, { magic: 'NOPE' }), { path: 'x', deploymentFloor: '26.0' }),
     ).not.toThrow();
+  });
+
+  it('STRICT (publish): throws instead of warn-skip when the MTLB header layout is unrecognized', () => {
+    // A publish build must not ship a metallib whose floor cannot be verified.
+    const future = mtlbHeader(26, 2, { containerVersion: 3 }); // parses to undefined
+    expect(parseMetallibMinOs(future)).toBeUndefined();
+    const warnings: string[] = [];
+    expect(() =>
+      assertMetallibFloor(future, { path: 'x', deploymentFloor: '26.0', strict: true, warn: (m) => warnings.push(m) }),
+    ).toThrow(/MLX_METALLIB_STRICT/);
+    expect(warnings).toHaveLength(0); // fail closed — no warn-and-skip
+  });
+
+  it('non-strict (local dev): still warns and skips on an unrecognized MTLB header layout', () => {
+    const future = mtlbHeader(26, 2, { platform: 0x8002 });
+    const warnings: string[] = [];
+    expect(() =>
+      assertMetallibFloor(future, { path: 'x', deploymentFloor: '26.0', strict: false, warn: (m) => warnings.push(m) }),
+    ).not.toThrow();
+    expect(warnings.some((w) => w.includes('unrecognized MTLB header layout'))).toBe(true);
+  });
+
+  it('STRICT still accepts a recognized stamp at/below the floor and enforces above it', () => {
+    // Strict mode only changes the unparseable branch; a recognized stamp
+    // behaves exactly as before.
+    expect(() =>
+      assertMetallibFloor(mtlbHeader(26, 0), { path: 'x', deploymentFloor: '26.0', strict: true }),
+    ).not.toThrow();
+    expect(() => assertMetallibFloor(mtlbHeader(26, 2), { path: 'x', deploymentFloor: '26.0', strict: true })).toThrow(
+      /above the intended deployment floor/,
+    );
   });
 });
 

--- a/__test__/core/metallib-select.test.ts
+++ b/__test__/core/metallib-select.test.ts
@@ -7,11 +7,16 @@ import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
 import {
   BASE_KERNEL_MARKERS,
   NAX_KERNEL_MARKERS,
+  assertMetallibFloor,
   assertMetallibIntegrity,
   collectMetallibCandidates,
   compareVersions,
+  extractBakedMetallibBinding,
   hostAppleTriple,
+  parseMetallibMinOs,
   profileDirName,
+  resolveTargetRoot,
+  selectMetallib,
   shouldExpectNaxKernels,
 } from '../../packages/core/metallib-select';
 
@@ -129,6 +134,204 @@ describe('collectMetallibCandidates', () => {
     const candidates = collectMetallibCandidates(root, TRIPLE, 'debug');
     expect(candidates).toHaveLength(1);
     expect(candidates[0]!.metallibPath).toBe(debug);
+  });
+});
+
+describe('resolveTargetRoot', () => {
+  it('mirrors cargo precedence: --target-dir flag > CARGO_TARGET_DIR > CARGO_BUILD_TARGET_DIR > default', () => {
+    const env = { CARGO_TARGET_DIR: '/env/ct', CARGO_BUILD_TARGET_DIR: '/env/cbt' };
+    expect(resolveTargetRoot({ targetDir: '/flag', env, defaultRoot: '/repo/target' })).toBe('/flag');
+    expect(resolveTargetRoot({ targetDir: undefined, env, defaultRoot: '/repo/target' })).toBe('/env/ct');
+    expect(
+      resolveTargetRoot({
+        targetDir: undefined,
+        env: { CARGO_BUILD_TARGET_DIR: '/env/cbt' },
+        defaultRoot: '/repo/target',
+      }),
+    ).toBe('/env/cbt');
+    expect(resolveTargetRoot({ targetDir: undefined, env: {}, defaultRoot: '/repo/target' })).toBe('/repo/target');
+  });
+
+  it('treats empty env values as unset, like cargo', () => {
+    expect(
+      resolveTargetRoot({
+        targetDir: undefined,
+        env: { CARGO_TARGET_DIR: '', CARGO_BUILD_TARGET_DIR: '' },
+        defaultRoot: '/repo/target',
+      }),
+    ).toBe('/repo/target');
+  });
+});
+
+/** A synthetic addon binary: NUL-separated strings, like a real Mach-O string table. */
+function fakeAddon(strings: string[]): Buffer {
+  return Buffer.concat([Buffer.from([0x42, 0x00]), Buffer.from(strings.join('\0')), Buffer.from([0x00, 0x42])]);
+}
+
+const BAKED_DIR_A = `/repo/target/${TRIPLE}/release/build/mlx-sys-aaaa1111/out`;
+const bakedPathFor = (outDir: string, doubleSlash = true) =>
+  `${outDir}/build/mlx/backend/metal/kernels/${doubleSlash ? '/' : ''}mlx.metallib`;
+
+describe('extractBakedMetallibBinding', () => {
+  it('finds the baked METAL_PATH among decoy strings and derives the out/lib layout', () => {
+    const addon = fakeAddon([
+      'No Metal device found',
+      'mlx_paged_attn.metallibMTLB',
+      'Failed to load metallib: ',
+      bakedPathFor(BAKED_DIR_A),
+      '/some/unrelated/mlx.metallib',
+      '.metallib',
+    ]);
+    const binding = extractBakedMetallibBinding(addon);
+    expect(binding).toBeDefined();
+    expect(binding!.outDir).toBe(BAKED_DIR_A);
+    expect(binding!.libDir).toBe(`${BAKED_DIR_A}/lib`);
+    expect(binding!.metallibPath).toBe(`${BAKED_DIR_A}/lib/mlx.metallib`);
+  });
+
+  it('accepts the single-slash kernels path form too', () => {
+    const binding = extractBakedMetallibBinding(fakeAddon([bakedPathFor(BAKED_DIR_A, false)]));
+    expect(binding?.outDir).toBe(BAKED_DIR_A);
+  });
+
+  it('returns undefined when no METAL_PATH is baked (e.g. Metal-less build)', () => {
+    expect(extractBakedMetallibBinding(fakeAddon(['Failed to load metallib: ', '.metallib>']))).toBeUndefined();
+  });
+
+  it('dedupes repeated identical paths but rejects two distinct baked paths', () => {
+    const twice = fakeAddon([bakedPathFor(BAKED_DIR_A), 'x', bakedPathFor(BAKED_DIR_A)]);
+    expect(extractBakedMetallibBinding(twice)?.outDir).toBe(BAKED_DIR_A);
+
+    const conflicting = fakeAddon([
+      bakedPathFor(BAKED_DIR_A),
+      bakedPathFor(`/repo/target/${TRIPLE}/release/build/mlx-sys-bbbb2222/out`),
+    ]);
+    expect(() => extractBakedMetallibBinding(conflicting)).toThrow(/distinct METAL_PATH/);
+  });
+});
+
+describe('selectMetallib', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'metallib-select-'));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function addOutDir(rel: string, content: string, ageDays: number): string {
+    const libDir = join(root, rel, 'out', 'lib');
+    mkdirSync(libDir, { recursive: true });
+    const metallib = join(libDir, 'mlx.metallib');
+    writeFileSync(metallib, content);
+    const when = new Date(Date.now() - ageDays * 86_400_000);
+    utimesSync(metallib, when, when);
+    return metallib;
+  }
+
+  it('rejects a same-pin NEWER but unbound candidate: the baked METAL_PATH wins over mtime rank', () => {
+    const boundRel = `${TRIPLE}/release/build/mlx-sys-aaaa1111`;
+    const bound = addOutDir(boundRel, 'bound-build', 7);
+    const newerUnbound = addOutDir(`${TRIPLE}/release/build/mlx-sys-ffff2222`, 'newer-unbound', 0);
+
+    // The heuristic alone would ship the newer dir...
+    expect(collectMetallibCandidates(root, TRIPLE, 'release')[0]!.metallibPath).toBe(newerUnbound);
+
+    // ...but the addon linked the OLDER dir, and the binding overrides.
+    const addon = fakeAddon([bakedPathFor(join(root, boundRel, 'out'))]);
+    const picked = selectMetallib({
+      addonBinary: addon,
+      addonPath: 'fake.node',
+      targetRoot: root,
+      triple: TRIPLE,
+      profile: 'release',
+    });
+    expect(picked.source).toBe('baked');
+    expect(picked.metallibPath).toBe(bound);
+  });
+
+  it('throws (never falls back to another dir) when the bound metallib is missing on disk', () => {
+    addOutDir(`${TRIPLE}/release/build/mlx-sys-ffff2222`, 'newer-unbound', 0);
+    const addon = fakeAddon([bakedPathFor(join(root, `${TRIPLE}/release/build/mlx-sys-aaaa1111`, 'out'))]);
+    expect(() =>
+      selectMetallib({
+        addonBinary: addon,
+        addonPath: 'fake.node',
+        targetRoot: root,
+        triple: TRIPLE,
+        profile: 'release',
+      }),
+    ).toThrow(/does not exist/);
+  });
+
+  it('falls back to the mtime scan only when the addon bakes no METAL_PATH', () => {
+    const newest = addOutDir(`${TRIPLE}/release/build/mlx-sys-ffff2222`, 'fresh', 0);
+    addOutDir(`${TRIPLE}/release/build/mlx-sys-aaaa1111`, 'stale', 7);
+    const warnings: string[] = [];
+    const picked = selectMetallib({
+      addonBinary: fakeAddon(['no baked path here']),
+      addonPath: 'fake.node',
+      targetRoot: root,
+      triple: TRIPLE,
+      profile: 'release',
+      warn: (m) => warnings.push(m),
+    });
+    expect(picked.source).toBe('scan');
+    expect(picked.metallibPath).toBe(newest);
+    expect(warnings.some((w) => w.includes('No baked METAL_PATH'))).toBe(true);
+  });
+
+  it('keeps the loud not-found error when neither binding nor candidates exist', () => {
+    expect(() =>
+      selectMetallib({
+        addonBinary: fakeAddon(['nothing']),
+        addonPath: 'fake.node',
+        targetRoot: root,
+        triple: TRIPLE,
+        profile: 'release',
+      }),
+    ).toThrow(/mlx\.metallib not found under/);
+  });
+});
+
+/** MTLB container header with the given min-OS stamp (u16 LE major @12, minor @14). */
+function mtlbHeader(major: number, minor: number, magic = 'MTLB'): Buffer {
+  const header = Buffer.alloc(24);
+  header.write(magic, 0, 'latin1');
+  header.writeUInt16LE(major, 12);
+  header.writeUInt16LE(minor, 14);
+  return header;
+}
+
+describe('parseMetallibMinOs / assertMetallibFloor', () => {
+  it('parses the min-OS stamp out of the MTLB header', () => {
+    expect(parseMetallibMinOs(mtlbHeader(26, 0))).toBe('26.0');
+    expect(parseMetallibMinOs(mtlbHeader(26, 2))).toBe('26.2');
+    expect(parseMetallibMinOs(mtlbHeader(15, 0))).toBe('15.0');
+    // The exact header bytes of the shipped 26.0-floor artifacts.
+    const real = Buffer.from('4d544c420180020009000081' + '1a000000', 'hex');
+    expect(parseMetallibMinOs(real)).toBe('26.0');
+  });
+
+  it('returns undefined on unknown layouts instead of guessing', () => {
+    expect(parseMetallibMinOs(mtlbHeader(26, 0, 'NOPE'))).toBeUndefined();
+    expect(parseMetallibMinOs(Buffer.from('MTLB'))).toBeUndefined();
+    expect(parseMetallibMinOs(mtlbHeader(0, 0))).toBeUndefined();
+    expect(parseMetallibMinOs(mtlbHeader(4242, 0))).toBeUndefined();
+  });
+
+  it('rejects a metallib stamped above the intended deployment floor', () => {
+    expect(() => assertMetallibFloor(mtlbHeader(26, 2), { path: 'x', deploymentFloor: '26.0' })).toThrow(
+      /stamps min-OS 26\.2, above the intended deployment floor 26\.0/,
+    );
+  });
+
+  it('accepts stamps at or below the floor and skips unparseable headers', () => {
+    expect(() => assertMetallibFloor(mtlbHeader(26, 0), { path: 'x', deploymentFloor: '26.0' })).not.toThrow();
+    expect(() => assertMetallibFloor(mtlbHeader(15, 0), { path: 'x', deploymentFloor: '26.0' })).not.toThrow();
+    expect(() => assertMetallibFloor(mtlbHeader(26, 0), { path: 'x', deploymentFloor: '26.5.2' })).not.toThrow();
+    expect(() => assertMetallibFloor(mtlbHeader(26, 2, 'NOPE'), { path: 'x', deploymentFloor: '26.0' })).not.toThrow();
   });
 });
 

--- a/__test__/models/chat-session.test.ts
+++ b/__test__/models/chat-session.test.ts
@@ -466,6 +466,33 @@ describe('ChatSession', () => {
       expect(chatSessionContinue).toHaveBeenCalledTimes(1);
     });
 
+    it('large image buffers: identical bytes stay on delta path, single-byte-different bytes restart', async () => {
+      // The 3-byte imgA/imgB fixtures above never exceed a single
+      // hash chunk. This exercises the image-identity hash at the
+      // byte range the native-crypto perf fix targets (multi-MB
+      // buffers), guarding against regressions in the length-prefix
+      // framing across a large `hash.update()` call.
+      const bigA = new Uint8Array(2 * 1024 * 1024);
+      for (let i = 0; i < bigA.length; i++) bigA[i] = i & 0xff;
+      const bigACopy = Uint8Array.from(bigA);
+      const bigBLastByteFlipped = Uint8Array.from(bigA);
+      bigBLastByteFlipped[bigBLastByteFlipped.length - 1] ^= 0xff;
+
+      const { model, chatSessionStart, chatSessionContinue } = makeMockModel();
+      const session = new ChatSession(model);
+
+      await session.send('describe', { images: [bigA] });
+      // Same bytes via a distinct Uint8Array instance -> cheap delta path.
+      await session.send('describe-again', { images: [bigACopy] });
+      expect(chatSessionStart).toHaveBeenCalledTimes(1);
+      expect(chatSessionContinue).toHaveBeenCalledTimes(1);
+
+      // Flip only the trailing byte -> must be detected as a changed
+      // image set and trigger a full restart.
+      await session.send('describe-changed', { images: [bigBLastByteFlipped] });
+      expect(chatSessionStart).toHaveBeenCalledTimes(2);
+    });
+
     it('text-only follow-up after image turn stays on the delta path', async () => {
       // Semantic: omitting `images` means "keep the cache state as
       // is", not "clear images". This lets VLM users refer back to

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -2524,7 +2524,7 @@ export interface ConversionOptions {
   quantGroupSize?: number;
   /**
    * Quantization mode: "affine" (default), "mxfp4", "mxfp8", "nvfp4", or
-   * "sym8" (per-output-channel symmetric int8; dense qwen3_5 + lfm2/lfm2_moe + gemma4 in v1,
+   * "sym8" (per-output-channel symmetric int8; qwen3_5 + qwen3_5_moe + lfm2/lfm2_moe + gemma4,
    * implies bits=8, no group_size — consciously NOT mlx-lm-loadable)
    */
   quantMode?: string;

--- a/crates/mlx-core/src/array/banded_attention.rs
+++ b/crates/mlx-core/src/array/banded_attention.rs
@@ -724,8 +724,27 @@ mod tests {
     /// Same parity sweep as the bf16 test but in f32, where both paths use
     /// identical precision throughout. This catches algorithmic bugs that
     /// would be hidden under the bf16 magnitude-scaled tolerance.
+    ///
+    /// Skips on hosts where f32 GEMM/SDPA silently run in TF32 precision
+    /// (`test_support::f32_gemm_tf32_degraded`): the vendored MLX pin
+    /// defaults `MLX_ENABLE_TF32=1`, which on gen>=17 GPUs routes both this
+    /// test's fused f32 SDPA (q_len > 8) and the reference's f32 matmuls to
+    /// NAX kernels that truncate inputs to 11-bit mantissas. The two paths
+    /// then disagree at TF32 scale (measured max_abs_diff 9.35e-4 on the
+    /// t=64 case) instead of true-f32 scale, and the 5e-5 oracle bound is
+    /// unmeetable with no algorithmic bug present — the same binary passes
+    /// with `MLX_ENABLE_TF32=0` exported.
     #[test]
     fn banded_attention_matches_reference_f32() {
+        if crate::test_support::f32_gemm_tf32_degraded() {
+            eprintln!(
+                "skipping banded_attention_matches_reference_f32: this host runs \
+                 f32 GEMM/SDPA in TF32 precision (MLX_ENABLE_TF32 defaults to 1 \
+                 on NAX-capable GPUs), so the true-f32 5e-5 parity bound is not \
+                 meaningful; export MLX_ENABLE_TF32=0 to run it"
+            );
+            return;
+        }
         unsafe { sys::mlx_seed(0x6632_6e64) };
 
         let cases: &[(i64, i64, i64, i64, i64, i32)] = &[

--- a/crates/mlx-core/src/array/banded_attention.rs
+++ b/crates/mlx-core/src/array/banded_attention.rs
@@ -661,8 +661,31 @@ mod tests {
     /// Fast SDPA-based `banded_attention` should agree with the reference impl
     /// across the shapes used by the privacy-filter design (T=257, band=128)
     /// plus a couple of neighbours that stress GQA + multi-batch behaviour.
+    ///
+    /// Skips on hosts whose half-precision GEMM fails the
+    /// `test_support::half_gemm_untrustworthy` canary: BOTH sides of this
+    /// bf16 parity live inside the vendored-MLX NAX broken classes on
+    /// gen>=17 GPUs. The reference's `Q@K^T` and `attn@V` are bf16 GEMMs
+    /// with K = head_dim = 64 / K = T (unaligned-K garbage class), and the
+    /// fast path's fused bf16 full-SDPA (q_len > 8) is the kernel class the
+    /// item-G review measured 0.1-1.9 off per row. Probed on the t=64 case
+    /// against a host-f64 banded-attention truth built from the same
+    /// bf16-rounded inputs: fast err 2.22, reference err 2.05 (output
+    /// max_abs 0.96) — the observed parity failure (max_abs_diff 0.988 vs
+    /// tol 0.023) is garbage-vs-garbage, so the assertion is meaningless
+    /// here, not merely out of tolerance.
     #[test]
     fn banded_attention_matches_reference_on_random_inputs() {
+        if crate::test_support::half_gemm_untrustworthy() {
+            eprintln!(
+                "skipping banded_attention_matches_reference_on_random_inputs: \
+                 half-precision GEMM fails the K=64/N=64 canary on this host \
+                 (vendored-MLX NAX bug); both the bf16 reference matmuls and \
+                 the fused bf16 SDPA are untrustworthy, so bf16 parity is not \
+                 meaningful here"
+            );
+            return;
+        }
         // Seed for reproducibility — bf16 parity is intrinsically tight to
         // the magnitude-scaled tolerance, so we don't want a flaky test on
         // unlucky random draws.

--- a/crates/mlx-core/src/array/banded_attention.rs
+++ b/crates/mlx-core/src/array/banded_attention.rs
@@ -45,7 +45,19 @@ use napi::bindgen_prelude::*;
 ///
 /// Constructed as: `where(|q - k| <= band, 0, -inf)`. The caller is expected to
 /// reshape to `[1, 1, T, T]` and add to the (B, H, T, T) logits tensor.
-fn build_band_mask(t: i64, band: i32) -> Result<MxArray> {
+///
+/// `pub(crate)` because callers that run several layers sharing the same
+/// `(T, band)` pair (e.g. `privacy_filter::forward_logits`, which alternates
+/// between only 2 distinct bands across its transformer stack) build this
+/// once and reuse it across every such layer via [`banded_attention`],
+/// instead of paying the `arange`/`sub`/`abs`/`less_equal`/`where_` chain
+/// again on every layer.
+pub(crate) fn build_band_mask(t: i64, band: i32) -> Result<MxArray> {
+    if band < 0 {
+        return Err(Error::from_reason(format!(
+            "build_band_mask: band must be non-negative, got {band}"
+        )));
+    }
     if t <= 0 {
         return Err(Error::from_reason(format!(
             "build_band_mask: T must be positive, got {t}"
@@ -221,28 +233,32 @@ pub fn banded_attention_reference(
 /// Build the `[H_q, T, T+1]` augmented mask used by `banded_attention`.
 ///
 /// Layout:
-/// - `mask[h, q, k] = 0`         if `k < T && |q - k| <= band`
-/// - `mask[h, q, k] = -inf`      if `k < T && |q - k| >  band`
+/// - `mask[h, q, k] = 0`         if `k < T && band_mask[q, k] == 0` (in-band)
+/// - `mask[h, q, k] = -inf`      if `k < T && band_mask[q, k] == -inf` (out-of-band)
 /// - `mask[h, q, T] = sinks[h]`  for the appended virtual sink column
+///
+/// `band_mask` is the `[T, T]` band-only mask (see [`build_band_mask`]) —
+/// the caller supplies it rather than have this function rebuild it, so a
+/// stack of layers sharing the same `(T, band)` pair only pays for the
+/// `arange`/`sub`/`abs`/`less_equal`/`where_` chain once.
 ///
 /// `out_dtype` is the dtype the mask is cast to — must match the SDPA output
 /// dtype (`final_type` in MLX), otherwise SDPA rejects it because f32 does not
 /// promote to bf16/f16.
 fn build_band_plus_sink_mask(
-    t: i64,
-    band: i32,
+    band_mask: &MxArray,
     sinks: &MxArray,
     h_q: i64,
     out_dtype: DType,
 ) -> Result<MxArray> {
-    if t <= 0 {
+    let band_mask_shape = band_mask.shape()?;
+    let band_mask_shape = band_mask_shape.as_ref();
+    if band_mask_shape.len() != 2 || band_mask_shape[0] != band_mask_shape[1] {
         return Err(Error::from_reason(format!(
-            "build_band_plus_sink_mask: T must be positive, got {t}"
+            "build_band_plus_sink_mask: band_mask must be square [T, T], got {band_mask_shape:?}"
         )));
     }
-
-    // Band mask: [T, T] f32, 0 inside the band, -inf outside.
-    let band_mask = build_band_mask(t, band)?;
+    let t = band_mask_shape[0];
 
     // Broadcast to [H_q, T, T]. The band mask doesn't depend on the head index,
     // but the final mask does (sink column varies per head), so we materialise
@@ -287,20 +303,19 @@ fn build_band_plus_sink_mask(
 /// - `k`:  `[B, num_kv_heads, T, head_dim]`
 /// - `v`:  `[B, num_kv_heads, T, head_dim]`
 /// - `sinks`: `[num_q_heads]`
+/// - `band_mask`: `[T, T]` f32, `0` where `|q_pos - k_pos| <= band` else
+///   `-inf` (see [`build_band_mask`]). Callers running several layers that
+///   share the same `(T, band)` pair should build this once and reuse it
+///   across every such call instead of passing a raw `band: i32` and
+///   rebuilding the mask from scratch on every layer.
 /// - returns `[B, num_q_heads, T, head_dim]`
 pub fn banded_attention(
     q: &MxArray,
     k: &MxArray,
     v: &MxArray,
     sinks: &MxArray,
-    band: i32,
+    band_mask: &MxArray,
 ) -> Result<MxArray> {
-    if band < 0 {
-        return Err(Error::from_reason(format!(
-            "banded_attention: band must be non-negative, got {band}"
-        )));
-    }
-
     if q.ndim()? != 4 || k.ndim()? != 4 || v.ndim()? != 4 {
         return Err(Error::from_reason(
             "banded_attention: Q, K, V must be 4D [B, H, T, D]",
@@ -369,6 +384,18 @@ pub fn banded_attention(
     let t = t_q;
     let dtype = q.dtype()?;
 
+    // `band_mask` is caller-supplied (built once via `build_band_mask` and
+    // reused across every layer that shares the same `(T, band)` pair — see
+    // `privacy_filter::forward_logits`), so validate its shape against this
+    // call's Q/K sequence length instead of trusting the caller blindly.
+    let band_mask_shape = band_mask.shape()?;
+    let band_mask_shape = band_mask_shape.as_ref();
+    if band_mask_shape.len() != 2 || band_mask_shape[0] != t || band_mask_shape[1] != t {
+        return Err(Error::from_reason(format!(
+            "banded_attention: band_mask must be [T, T] with T={t}, got {band_mask_shape:?}"
+        )));
+    }
+
     // K_aug = concat([K, zeros[B, H_kv, 1, D]], axis=-2)  → [B, H_kv, T+1, D]
     // V_aug = concat([V, zeros[B, H_kv, 1, D]], axis=-2)  → [B, H_kv, T+1, D]
     //
@@ -382,7 +409,7 @@ pub fn banded_attention(
     let v_aug = MxArray::concatenate(v, &pad_v, -2)?;
 
     // Build [H_q, T, T+1] mask, cast to the SDPA output dtype (= q's dtype).
-    let mask = build_band_plus_sink_mask(t, band, sinks, h_q, dtype)?;
+    let mask = build_band_plus_sink_mask(band_mask, sinks, h_q, dtype)?;
 
     let scale = 1.0 / (d as f64).sqrt();
     scaled_dot_product_attention(q, &k_aug, &v_aug, scale, Some(&mask))
@@ -416,6 +443,18 @@ mod tests {
                 "{label}: divergence at {i}: actual={a}, expected={e}, diff={diff} > tol={tolerance}"
             );
         }
+    }
+
+    /// `build_band_mask` is the single mask-construction choke point that
+    /// callers (e.g. `privacy_filter::forward_logits`) route through with a
+    /// `band` derived from checkpoint config. A malformed config with a
+    /// negative `sliding_window` would otherwise build an all-`-inf` band mask
+    /// (sink-only attention → silently corrupted logits), so the function must
+    /// fail-fast on a negative band instead. No GPU dispatch is needed — the
+    /// guard returns before any MxArray op runs.
+    #[test]
+    fn build_band_mask_rejects_negative_band() {
+        assert!(build_band_mask(8, -1).is_err());
     }
 
     /// With `band >= T` every key is in-window, and with sinks set very
@@ -648,7 +687,8 @@ mod tests {
             // actually exercise softmax mixing, not the degenerate -inf case).
             let sinks = MxArray::random_normal(&[h_q], 0.0, 1.0, Some(DType::Float32)).unwrap();
 
-            let fast = banded_attention(&q, &k, &v, &sinks, band).unwrap();
+            let band_mask = build_band_mask(t, band).unwrap();
+            let fast = banded_attention(&q, &k, &v, &sinks, &band_mask).unwrap();
             let slow = banded_attention_reference(&q, &k, &v, &sinks, band).unwrap();
 
             let fast_shape = fast.shape().unwrap();
@@ -703,7 +743,8 @@ mod tests {
                 MxArray::random_normal(&[b, h_kv, t, d], 0.0, 1.0, Some(DType::Float32)).unwrap();
             let sinks = MxArray::random_normal(&[h_q], 0.0, 1.0, Some(DType::Float32)).unwrap();
 
-            let fast = banded_attention(&q, &k, &v, &sinks, band).unwrap();
+            let band_mask = build_band_mask(t, band).unwrap();
+            let fast = banded_attention(&q, &k, &v, &sinks, &band_mask).unwrap();
             let slow = banded_attention_reference(&q, &k, &v, &sinks, band).unwrap();
 
             let (diff, max_abs) = max_abs_diff_and_magnitude(&fast, &slow);
@@ -745,7 +786,8 @@ mod tests {
         .unwrap();
         let sinks = MxArray::from_float32(&[-1e9, -1e9], &[heads]).unwrap();
 
-        let banded = banded_attention(&q, &k, &v, &sinks, (t - 1) as i32).unwrap();
+        let band_mask = build_band_mask(t, (t - 1) as i32).unwrap();
+        let banded = banded_attention(&q, &k, &v, &sinks, &band_mask).unwrap();
 
         let scale = 1.0 / (head_dim as f64).sqrt();
         let full = crate::array::scaled_dot_product_attention(&q, &k, &v, scale, None).unwrap();
@@ -756,5 +798,90 @@ mod tests {
             1e-4,
             "banded_attention(band>=T, sinks=-inf) vs SDPA",
         );
+    }
+
+    /// Microbenchmark: rebuilding the `[T, T]` band mask on every layer vs
+    /// building it once per distinct band and reusing it — the exact win this
+    /// module's `band_mask` threading buys `privacy_filter::forward_logits`.
+    ///
+    /// Env-gated (`MLX_BENCH_BAND_MASK=1`) and `#[ignore]`d so it never runs in
+    /// the normal suite. Simulates the privacy-filter stack: 8 layers, GQA
+    /// shapes (H_q=14, H_kv=2, head_dim=64), T=2048, alternating 2 distinct
+    /// bands. Interleaves the two variants per iteration (A/B/A/B) and takes
+    /// medians to blunt M-series thermal skew; drops the first (cold) iteration.
+    #[test]
+    #[ignore = "microbenchmark — run with --ignored and MLX_BENCH_BAND_MASK=1"]
+    fn bench_band_mask_reuse_vs_rebuild() {
+        if std::env::var("MLX_BENCH_BAND_MASK").is_err() {
+            eprintln!("set MLX_BENCH_BAND_MASK=1 to run this microbenchmark");
+            return;
+        }
+        use std::time::Instant;
+
+        let (b, h_q, h_kv, d, t) = (1i64, 14i64, 2i64, 64i64, 2048i64);
+        // The two distinct bands `PrivacyFilterConfig::band_for_layer` returns:
+        // a sliding window and an effectively-unbounded full-attention band.
+        let bands = [128i32, i32::MAX / 2];
+        let layer_bands: Vec<i32> = (0..8).map(|i| bands[i % 2]).collect();
+
+        let q = MxArray::random_normal(&[b, h_q, t, d], 0.0, 1.0, Some(DType::BFloat16)).unwrap();
+        let k = MxArray::random_normal(&[b, h_kv, t, d], 0.0, 1.0, Some(DType::BFloat16)).unwrap();
+        let v = MxArray::random_normal(&[b, h_kv, t, d], 0.0, 1.0, Some(DType::BFloat16)).unwrap();
+        let sinks = MxArray::random_normal(&[h_q], 0.0, 1.0, Some(DType::Float32)).unwrap();
+
+        let iters = 12;
+        let mut rebuild_ms: Vec<f64> = Vec::with_capacity(iters);
+        let mut reuse_ms: Vec<f64> = Vec::with_capacity(iters);
+        // Also time the pure mask-construction cost the reuse path eliminates.
+        let mut build_ms: Vec<f64> = Vec::with_capacity(iters);
+
+        for _ in 0..iters {
+            // Variant A: rebuild the mask inside every one of the 8 layer calls.
+            let start = Instant::now();
+            for &band in &layer_bands {
+                let mask = build_band_mask(t, band).unwrap();
+                let out = banded_attention(&q, &k, &v, &sinks, &mask).unwrap();
+                out.eval();
+            }
+            rebuild_ms.push(start.elapsed().as_secs_f64() * 1e3);
+
+            // Variant B: build the 2 distinct masks once, reuse across layers.
+            let start = Instant::now();
+            let mask0 = build_band_mask(t, bands[0]).unwrap();
+            let mask1 = build_band_mask(t, bands[1]).unwrap();
+            for &band in &layer_bands {
+                let mask = if band == bands[0] { &mask0 } else { &mask1 };
+                let out = banded_attention(&q, &k, &v, &sinks, mask).unwrap();
+                out.eval();
+            }
+            reuse_ms.push(start.elapsed().as_secs_f64() * 1e3);
+
+            // Isolated: cost of a single build_band_mask (materialized).
+            let start = Instant::now();
+            let m = build_band_mask(t, bands[0]).unwrap();
+            m.eval();
+            build_ms.push(start.elapsed().as_secs_f64() * 1e3);
+        }
+
+        let median = |v: &[f64]| {
+            let mut s = v[1..].to_vec(); // drop first (cold) iteration
+            s.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            s[s.len() / 2]
+        };
+        let rb = median(&rebuild_ms);
+        let ru = median(&reuse_ms);
+        let bm = median(&build_ms);
+        println!(
+            "[bench band_mask] T={t}, 8-layer loop, medians over {} iters:",
+            iters - 1
+        );
+        println!("[bench band_mask]   rebuild-per-layer = {rb:.3} ms");
+        println!("[bench band_mask]   reuse-precomputed = {ru:.3} ms");
+        println!(
+            "[bench band_mask]   delta            = {:.3} ms ({:.1}%)",
+            rb - ru,
+            (rb - ru) / rb * 100.0
+        );
+        println!("[bench band_mask]   single build_band_mask = {bm:.3} ms (x6 saved per loop)");
     }
 }

--- a/crates/mlx-core/src/array/banded_attention.rs
+++ b/crates/mlx-core/src/array/banded_attention.rs
@@ -667,8 +667,8 @@ mod tests {
     /// bf16 parity live inside the vendored-MLX NAX broken classes on
     /// gen>=17 GPUs. The reference's `Q@K^T` and `attn@V` are bf16 GEMMs
     /// with K = head_dim = 64 / K = T (unaligned-K garbage class), and the
-    /// fast path's fused bf16 full-SDPA (q_len > 8) is the kernel class the
-    /// item-G review measured 0.1-1.9 off per row. Probed on the t=64 case
+    /// fast path's fused bf16 full-SDPA (q_len > 8) is a kernel class
+    /// measured 0.1-1.9 off per row vs host truth. Probed on the t=64 case
     /// against a host-f64 banded-attention truth built from the same
     /// bf16-rounded inputs: fast err 2.22, reference err 2.05 (output
     /// max_abs 0.96) — the observed parity failure (max_abs_diff 0.988 vs

--- a/crates/mlx-core/src/array/memory.rs
+++ b/crates/mlx-core/src/array/memory.rs
@@ -219,6 +219,95 @@ pub fn maybe_eval_clear_for_paged_prefill_layer(
     Ok(())
 }
 
+/// Default `PrivacyFilterModel::classify()` cache-clear cadence, in calls.
+///
+/// `classify()` is a single-shot (non-autoregressive) forward pass with no
+/// caller-supplied step counter, so unlike the paged-decode path this counts
+/// *calls* rather than *steps*. The old behavior called
+/// [`synchronize_and_clear_cache`] unconditionally after every call — a full
+/// GPU stall plus an allocator wipe on top of the actual forward pass, every
+/// single time `classify()` runs. For the module's stated use case
+/// (PII-scanning a stream of chat messages / document chunks) that tax is
+/// paid on every message.
+///
+/// Unlike the paged-decode / paged-prefill loops, `privacy_filter` model
+/// loads never register with [`crate::cache_limit::CacheLimitCoordinator`]
+/// (see `models/privacy_filter/persistence.rs::load_from_directory`), so
+/// MLX's caching allocator has no size cap of its own for this model — an
+/// aggressive cadence would let the cache grow without bound across a long
+/// classify stream. The default here is therefore deliberately far more
+/// conservative than [`PAGED_DECODE_CACHE_CLEAR_INTERVAL_DEFAULT`] (1024):
+/// 8 calls' worth of a small 8-layer/640-hidden forward pass's transients is
+/// a few tens of MB at most, while still cutting the number of forced
+/// stalls+wipes by 8× over an uninterrupted stream.
+///
+/// Override at runtime via `MLX_PRIVACY_FILTER_CACHE_CLEAR_INTERVAL`
+/// (positive integer). The env var is read once on first use and cached;
+/// invalid / non-positive values fall back to this default.
+pub const PRIVACY_FILTER_CACHE_CLEAR_INTERVAL_DEFAULT: i32 = 8;
+
+/// Effective cadence — `MLX_PRIVACY_FILTER_CACHE_CLEAR_INTERVAL` env override
+/// or [`PRIVACY_FILTER_CACHE_CLEAR_INTERVAL_DEFAULT`]. Read once on first
+/// call and cached; subsequent reads hit the OnceLock fast path.
+pub fn privacy_filter_cache_clear_interval() -> i32 {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<i32> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        parse_privacy_filter_cache_clear_interval(
+            std::env::var("MLX_PRIVACY_FILTER_CACHE_CLEAR_INTERVAL").ok(),
+        )
+    })
+}
+
+/// Pure parser for the privacy-filter cache-clear-interval env value.
+/// Extracted so it can be unit tested without touching process env state
+/// (which `privacy_filter_cache_clear_interval` reads exactly once via
+/// `OnceLock` per process).
+fn parse_privacy_filter_cache_clear_interval(env_value: Option<String>) -> i32 {
+    match env_value {
+        Some(s) => s
+            .trim()
+            .parse::<i32>()
+            .ok()
+            .filter(|&n| n > 0)
+            .unwrap_or(PRIVACY_FILTER_CACHE_CLEAR_INTERVAL_DEFAULT),
+        None => PRIVACY_FILTER_CACHE_CLEAR_INTERVAL_DEFAULT,
+    }
+}
+
+/// Pure predicate: should call number `call_number` (1-indexed count of
+/// `classify()` invocations since process start) trigger a cache clear at
+/// the given `interval`? Extracted so the cadence boundary logic is
+/// unit-testable without the process-wide atomic counter or a live MLX
+/// context.
+fn should_clear_for_privacy_filter_call(call_number: i64, interval: i32) -> bool {
+    interval > 0 && call_number % i64::from(interval) == 0
+}
+
+/// Helper: clear MLX's caching allocator on every Nth call to
+/// `PrivacyFilterModel::classify()`.
+///
+/// Unlike [`maybe_clear_cache_for_paged_step`], `classify()` has no
+/// caller-supplied step index — every call is an independent forward pass
+/// — so this keeps its own process-wide call counter (shared across every
+/// loaded `PrivacyFilterModel` instance, since MLX's caching allocator is
+/// itself process-wide).
+///
+/// Deliberately does **not** call [`synchronize`] first: `classify()`
+/// already forces the entire forward-pass graph to complete on the GPU via
+/// `probs.eval()` / `log_probs.eval()` before reaching this call (mirroring
+/// how [`maybe_clear_cache_for_paged_step`] relies on the paged loop's own
+/// per-step sync rather than synchronizing again here).
+#[inline]
+pub fn maybe_clear_cache_for_privacy_filter_call() {
+    use std::sync::atomic::{AtomicI64, Ordering};
+    static CALLS: AtomicI64 = AtomicI64::new(0);
+    let n = CALLS.fetch_add(1, Ordering::Relaxed) + 1;
+    if should_clear_for_privacy_filter_call(n, privacy_filter_cache_clear_interval()) {
+        clear_cache();
+    }
+}
+
 /// Get actively used memory in bytes (excludes cached memory).
 /// Internal Rust-only function — use memoryCleanupThreshold config for
 /// memory-based cleanup.
@@ -555,5 +644,84 @@ mod tests {
     #[test]
     fn parse_chunk_size_trims_whitespace() {
         assert_eq!(parse_chunk_size(Some("  512  ".to_string())), 512);
+    }
+
+    #[test]
+    fn parse_privacy_filter_cache_clear_interval_returns_default_when_env_unset() {
+        assert_eq!(
+            parse_privacy_filter_cache_clear_interval(None),
+            PRIVACY_FILTER_CACHE_CLEAR_INTERVAL_DEFAULT
+        );
+    }
+
+    #[test]
+    fn parse_privacy_filter_cache_clear_interval_returns_default_when_empty_string() {
+        assert_eq!(
+            parse_privacy_filter_cache_clear_interval(Some("".to_string())),
+            PRIVACY_FILTER_CACHE_CLEAR_INTERVAL_DEFAULT
+        );
+    }
+
+    #[test]
+    fn parse_privacy_filter_cache_clear_interval_returns_default_when_non_integer() {
+        assert_eq!(
+            parse_privacy_filter_cache_clear_interval(Some("abc".to_string())),
+            PRIVACY_FILTER_CACHE_CLEAR_INTERVAL_DEFAULT
+        );
+    }
+
+    #[test]
+    fn parse_privacy_filter_cache_clear_interval_returns_default_when_zero_or_negative() {
+        assert_eq!(
+            parse_privacy_filter_cache_clear_interval(Some("0".to_string())),
+            PRIVACY_FILTER_CACHE_CLEAR_INTERVAL_DEFAULT
+        );
+        assert_eq!(
+            parse_privacy_filter_cache_clear_interval(Some("-8".to_string())),
+            PRIVACY_FILTER_CACHE_CLEAR_INTERVAL_DEFAULT
+        );
+    }
+
+    #[test]
+    fn parse_privacy_filter_cache_clear_interval_positive_returns_value() {
+        assert_eq!(
+            parse_privacy_filter_cache_clear_interval(Some("32".to_string())),
+            32
+        );
+    }
+
+    #[test]
+    fn parse_privacy_filter_cache_clear_interval_trims_whitespace() {
+        assert_eq!(
+            parse_privacy_filter_cache_clear_interval(Some("  16  ".to_string())),
+            16
+        );
+    }
+
+    #[test]
+    fn should_clear_for_privacy_filter_call_fires_on_multiples_of_interval() {
+        let interval = 8;
+        for call in 1..8 {
+            assert!(
+                !should_clear_for_privacy_filter_call(call, interval),
+                "call {call} should not clear at interval {interval}"
+            );
+        }
+        assert!(should_clear_for_privacy_filter_call(8, interval));
+        for call in 9..16 {
+            assert!(
+                !should_clear_for_privacy_filter_call(call, interval),
+                "call {call} should not clear at interval {interval}"
+            );
+        }
+        assert!(should_clear_for_privacy_filter_call(16, interval));
+    }
+
+    #[test]
+    fn should_clear_for_privacy_filter_call_never_fires_for_nonpositive_interval() {
+        for call in 1..20 {
+            assert!(!should_clear_for_privacy_filter_call(call, 0));
+            assert!(!should_clear_for_privacy_filter_call(call, -1));
+        }
     }
 }

--- a/crates/mlx-core/src/array/memory.rs
+++ b/crates/mlx-core/src/array/memory.rs
@@ -23,10 +23,27 @@ impl std::fmt::Display for SetCacheLimitError {
 
 impl std::error::Error for SetCacheLimitError {}
 
+// Test-only call counters for `synchronize` / `clear_cache`, thread-local
+// so parallel `cargo test` threads never observe each other's counts —
+// `cargo test` runs each `#[test]` fn on its own thread, so resetting +
+// reading these from within a single test body is race-free without any
+// cross-test locking. Let `engine::decode`'s cache-cadence test assert on
+// WHICH of the two the FLAT `DecodeStep::maintain_cache` default actually
+// invokes, without adding a mockable trait seam to the FFI layer.
+#[cfg(test)]
+thread_local! {
+    /// Incremented once per [`synchronize`] call.
+    pub(crate) static TEST_SYNCHRONIZE_CALLS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    /// Incremented once per [`clear_cache`] call.
+    pub(crate) static TEST_CLEAR_CACHE_CALLS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
 /// Clear the MLX memory cache to prevent memory pressure buildup
 /// Should be called periodically during long-running operations
 /// Internal Rust-only function - memory management is handled automatically by the trainer
 pub fn clear_cache() {
+    #[cfg(test)]
+    TEST_CLEAR_CACHE_CALLS.with(|c| c.set(c.get() + 1));
     unsafe {
         sys::mlx_clear_cache();
     }
@@ -34,6 +51,8 @@ pub fn clear_cache() {
 
 /// Synchronize GPU — block until all pending GPU work completes
 pub fn synchronize() {
+    #[cfg(test)]
+    TEST_SYNCHRONIZE_CALLS.with(|c| c.set(c.get() + 1));
     unsafe {
         sys::mlx_synchronize();
     }

--- a/crates/mlx-core/src/cache_limit.rs
+++ b/crates/mlx-core/src/cache_limit.rs
@@ -4,8 +4,9 @@
 //! `mx.set_wired_limit(...)` at server startup and calls `mx.clear_cache()`
 //! every 256 decode steps. We already mirror both of those: `WiredLimitContext`
 //! (see `crates/mlx-core/src/stream.rs`) sets the wired limit at model load
-//! and `synchronize_and_clear_cache()` drains the pool every 256 decode steps
-//! inside each generative model. The piece that was still missing was an
+//! and the FLAT `DecodeStep::maintain_cache` default (`crates/mlx-core/src/
+//! engine/backend.rs`) drains the pool via `clear_cache()` every 256 decode
+//! steps inside each generative model. The piece that was still missing was an
 //! explicit ceiling on how large the MLX allocator's free-pool may grow
 //! between decode loops — on a 128GB M3 Max the default ceiling is the full
 //! `max_recommended_working_set_size` (~96GB), so the pool slowly climbs to
@@ -114,8 +115,8 @@
 //! model A discards reusable blocks belonging to model B's next turn.
 //! Between-turn draining now lives on the TS side (`@mlx-node/server`'s
 //! idle sweeper — drains only when the whole process is idle for
-//! `idleClearCacheMs`). The decode-loop `synchronize_and_clear_cache()`
-//! fired every 256 steps is untouched.
+//! `idleClearCacheMs`). The decode-loop `clear_cache()` fired every 256
+//! steps is untouched.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -10119,7 +10119,7 @@ mod tests {
             "{lm_head_key} mode must be 'affine'"
         );
 
-        // embed_tokens: 2-bit affine, group_size=64
+        // embed_tokens: 2-bit affine, group_size=128
         let et_key = "language_model.model.embed_tokens";
         let et = quant.get(et_key).unwrap_or_else(|| {
             panic!("quantization block must contain per-layer override for {et_key}")
@@ -10127,8 +10127,8 @@ mod tests {
         assert_eq!(et["bits"].as_i64(), Some(2), "{et_key} bits must be 2");
         assert_eq!(
             et["group_size"].as_i64(),
-            Some(64),
-            "{et_key} group_size must be 64"
+            Some(128),
+            "{et_key} group_size must be 128"
         );
         assert_eq!(
             et["mode"].as_str(),

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -2317,11 +2317,26 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
     // Apply quantization if requested
     let mut per_layer_overrides: HashMap<String, serde_json::Value> =
         gemma_pre_overrides.unwrap_or_default();
-    // Effective mode/group_size recorded in config.json. The no-recipe path
-    // updates these when --q-mxfp upgrades the global mode to mxfp4/mxfp8 so
-    // downstream loaders dispatch to the correct builder.
+    // Effective mode/group_size/bits recorded in config.json. The no-recipe
+    // path updates mode/group_size when --q-mxfp upgrades the global mode to
+    // mxfp4/mxfp8 so downstream loaders dispatch to the correct builder.
     let mut quant_mode_effective = quant_mode.clone();
     let mut quant_group_size_effective = quant_group_size;
+    let mut quant_bits_effective = quant_bits;
+    // The gemma-prequant path never runs the quantize block below (--quantize
+    // is rejected up front), so the effective values would otherwise stay at
+    // the generic CLI defaults (affine / 4-bit / group 64) — dishonest: every
+    // sidecar the importer emits is a 128-group affine repack. External
+    // loaders that trust the top-level default for tensors without a
+    // per-layer override would mis-dequantize, so derive the top-level block
+    // from the importer's own override map instead.
+    if is_gemma_prequantized {
+        let (bits, group_size, mode) =
+            crate::convert_gemma_import::top_level_quant_metadata(&per_layer_overrides)?;
+        quant_bits_effective = bits;
+        quant_group_size_effective = group_size;
+        quant_mode_effective = mode;
+    }
     // lfm2/lfm2_moe opt INTO quantizing the token embedding: their
     // `nn::Embedding` installs a PACKED-quantized backend (gather-dequant
     // lookup + quantized tied-head matmul), so the embedding table can be
@@ -2670,7 +2685,7 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
         };
         let mut quant_obj = serde_json::json!({
             "group_size": group_size_value,
-            "bits": quant_bits,
+            "bits": quant_bits_effective,
             "mode": quant_mode_effective,
         });
         if let Some(obj) = quant_obj.as_object_mut() {
@@ -10518,5 +10533,175 @@ mod tests {
         eprintln!("vision_tower tensors are dense (no .scales) ✓");
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Gemma-prequant conversions must write an HONEST top-level
+    /// `quantization` / `quantization_config` block. The importer repacks
+    /// every 2/4-bit module to MLX affine at group_size=128 (mode "affine",
+    /// bits per the E2B schedule) and records a complete per-layer override
+    /// for each — but the top-level values come from the `--quantize` CLI
+    /// defaults (group_size=64), which this path never uses. An external
+    /// mlx-lm-style loader that trusts the top-level default for any tensor
+    /// lacking an override would mis-dequantize at group 64.
+    ///
+    /// Fully synthetic (tiny tensors, no checkpoint needed): drives the real
+    /// `convert_model` pipeline end-to-end and asserts on the WRITTEN
+    /// config.json.
+    #[tokio::test]
+    async fn convert_model_gemma_prequant_top_level_block_is_honest() {
+        let base = std::env::temp_dir().join(format!(
+            "gemma_prequant_toplevel_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+        ));
+        let input = base.join("in");
+        let output = base.join("out");
+        std::fs::create_dir_all(&input).expect("create synthetic input dir");
+
+        // config.json: gemma quant_method + the exact E2B module_quant_configs
+        // schedule `validate_e2b_qat_schedule` pins.
+        let config = serde_json::json!({
+            "tie_word_embeddings": false,
+            "quantization_config": {
+                "quant_method": "gemma",
+                "module_quant_configs": {
+                    "^lm_head$": { "num_bits": 2 },
+                    "language_model\\.embed_tokens$": { "num_bits": 2 },
+                    "language_model\\.embed_tokens_per_layer$": { "num_bits": 4 },
+                    "language_model\\.layers\\.(\\d|1[0-4])\\.mlp\\.": { "num_bits": 4 },
+                    "language_model\\.layers\\.\\d+\\.mlp\\.": { "num_bits": 2 },
+                    "language_model\\.layers\\.\\d+\\.self_attn\\.": { "num_bits": 4 }
+                }
+            }
+        });
+        std::fs::write(
+            input.join("config.json"),
+            serde_json::to_string_pretty(&config).unwrap(),
+        )
+        .expect("write config.json");
+
+        // Synthetic source tensors in the wNa8o8 layout:
+        //  - 4-bit packed U8 `[out, in/2]` + per-row f32 scale `[out, 1]`
+        //  - 2-bit packed U8 `[out, in/4]` + per-row f32 scale
+        //  - I8 gate `[out, in]` + per-row f32 scale (dequants to dense bf16)
+        //  - float norm passthrough
+        // Two 4-bit modules vs one 2-bit module makes the modal bit-width an
+        // unambiguous 4, mirroring the real E2B checkpoint where 4-bit
+        // modules dominate.
+        let mut src: HashMap<String, MxArray> = HashMap::new();
+        let row_scales = [0.5f32, 0.25, 0.125, 0.0625];
+        for name in ["q_proj", "k_proj"] {
+            // 4-bit, in_features=128 → 64 packed bytes per row.
+            src.insert(
+                format!("model.language_model.layers.0.self_attn.{name}.weight"),
+                MxArray::from_uint8(&[0x88u8; 4 * 64], &[4, 64]).unwrap(),
+            );
+            src.insert(
+                format!("model.language_model.layers.0.self_attn.{name}.weight_scale"),
+                MxArray::from_float32(&row_scales, &[4, 1]).unwrap(),
+            );
+        }
+        // 2-bit MLP linear (layer 20 ≥ 15), in_features=128 → 32 bytes per row.
+        src.insert(
+            "model.language_model.layers.20.mlp.down_proj.weight".to_string(),
+            MxArray::from_uint8(&[0x66u8; 4 * 32], &[4, 32]).unwrap(),
+        );
+        src.insert(
+            "model.language_model.layers.20.mlp.down_proj.weight_scale".to_string(),
+            MxArray::from_float32(&row_scales, &[4, 1]).unwrap(),
+        );
+        // I8 per-layer gate → dense bf16 `.weight`, no `.scales`, no override.
+        src.insert(
+            "model.language_model.layers.0.per_layer_input_gate.weight".to_string(),
+            MxArray::from_int8(&[7i8; 4 * 16], &[4, 16]).unwrap(),
+        );
+        src.insert(
+            "model.language_model.layers.0.per_layer_input_gate.weight_scale".to_string(),
+            MxArray::from_float32(&row_scales, &[4, 1]).unwrap(),
+        );
+        // Float passthrough.
+        src.insert(
+            "model.language_model.layers.0.input_layernorm.weight".to_string(),
+            MxArray::from_float32(&[1.0f32; 16], &[16]).unwrap(),
+        );
+        crate::utils::safetensors::save_safetensors(
+            input.join("model.safetensors"),
+            &mut src,
+            None,
+        )
+        .expect("write synthetic model.safetensors");
+
+        let result = convert_model(ConversionOptions {
+            input_dir: input.to_string_lossy().to_string(),
+            output_dir: output.to_string_lossy().to_string(),
+            dtype: Some("bfloat16".to_string()),
+            verbose: Some(false),
+            model_type: Some("gemma4".to_string()),
+            quantize: None,
+            quant_bits: None,
+            quant_group_size: None,
+            quant_mode: None,
+            quant_recipe: None,
+            imatrix_path: None,
+            quant_mxfp: None,
+            quant_mtp: None,
+        })
+        .await
+        .expect("synthetic gemma-prequant conversion must succeed");
+        assert!(result.num_tensors > 0);
+
+        let config_str = std::fs::read_to_string(output.join("config.json"))
+            .expect("output config.json must exist");
+        let out_config: serde_json::Value =
+            serde_json::from_str(&config_str).expect("output config.json must be valid JSON");
+        for block_key in ["quantization", "quantization_config"] {
+            let block = out_config.get(block_key).unwrap_or_else(|| {
+                panic!("output config.json must carry a top-level `{block_key}` block")
+            });
+            assert_eq!(
+                block["group_size"].as_i64(),
+                Some(128),
+                "top-level {block_key}.group_size must match the 128-group affine \
+                 sidecars the importer writes, got {:?}",
+                block["group_size"]
+            );
+            assert_eq!(
+                block["bits"].as_i64(),
+                Some(4),
+                "top-level {block_key}.bits must be the modal sidecar bit-width (4), got {:?}",
+                block["bits"]
+            );
+            assert_eq!(
+                block["mode"].as_str(),
+                Some("affine"),
+                "top-level {block_key}.mode must be 'affine', got {:?}",
+                block["mode"]
+            );
+            // Per-layer overrides keep their true (schedule) values.
+            assert_eq!(
+                block["language_model.model.layers.0.self_attn.q_proj"]["group_size"].as_i64(),
+                Some(128)
+            );
+            assert_eq!(
+                block["language_model.model.layers.0.self_attn.q_proj"]["bits"].as_i64(),
+                Some(4)
+            );
+            assert_eq!(
+                block["language_model.model.layers.20.mlp.down_proj"]["bits"].as_i64(),
+                Some(2)
+            );
+            // The I8-dequant gate is dense: it must NOT get an override entry.
+            assert!(
+                block
+                    .get("language_model.model.layers.0.per_layer_input_gate")
+                    .is_none(),
+                "I8-dequant modules are dense bf16 and must not carry an override"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -922,8 +922,12 @@ pub(crate) mod recipe {
         }
 
         fn sym8_supported(&self) -> bool {
-            // Dense qwen3_5 has a sym8 dispatch; qwen3_5_moe does not.
-            !self.is_moe
+            // Both dense qwen3_5 and qwen3_5_moe dispatch sym8. The MoE loader
+            // covers its non-expert sublayers (attention, GDN, shared-expert
+            // MLP body); 3-D stacked switch_mlp experts are forced to an
+            // affine-8 per-layer override by `sym8_eligible`, so the emitted
+            // checkpoint always loads back.
+            true
         }
 
         fn has_mtp(&self) -> MtpPolicy {
@@ -1548,7 +1552,7 @@ pub struct ConversionOptions {
     pub quant_group_size: Option<i32>,
 
     /// Quantization mode: "affine" (default), "mxfp4", "mxfp8", "nvfp4", or
-    /// "sym8" (per-output-channel symmetric int8; dense qwen3_5 + lfm2/lfm2_moe + gemma4 in v1,
+    /// "sym8" (per-output-channel symmetric int8; qwen3_5 + qwen3_5_moe + lfm2/lfm2_moe + gemma4,
     /// implies bits=8, no group_size — consciously NOT mlx-lm-loadable)
     pub quant_mode: Option<String>,
 
@@ -1778,20 +1782,19 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
                     .to_string(),
             ));
         }
-        // sym8 v1 dispatch exists in the dense qwen3_5, lfm2/lfm2_moe, and
-        // gemma4 loaders (2D linears only — 3D stacked experts are auto-forced
-        // to affine-8 below). qwen3_5_moe still rejects sym8 up front (its
-        // per-expert SwitchMLP/gather path has no sym8 dispatch), so allowing
-        // it here would emit checkpoints this package cannot load back.
+        // sym8 dispatch exists in the qwen3_5 (dense + MoE non-expert
+        // sublayers), lfm2/lfm2_moe, and gemma4 loaders (2D linears only —
+        // 3D stacked experts are auto-forced to affine-8 below, so
+        // qwen3_5_moe's per-expert SwitchMLP/gather path never sees sym8).
         let sym8_supported = model_type
             .as_deref()
             .and_then(recipe::recipe_for)
             .is_some_and(|r| r.sym8_supported());
         if !sym8_supported {
             return Err(Error::from_reason(format!(
-                "sym8 is currently supported for model types qwen3_5 (dense), \
-                 lfm2, lfm2_moe, and gemma4 only (got {:?}); other families' \
-                 loaders have no sym8 dispatch",
+                "sym8 is currently supported for model types qwen3_5, \
+                 qwen3_5_moe, lfm2, lfm2_moe, and gemma4 only (got {:?}); \
+                 other families' loaders have no sym8 dispatch",
                 model_type.as_deref()
             )));
         }
@@ -5625,13 +5628,15 @@ mod tests {
                 "{mt}: embed_quantizable mismatch vs inline match"
             );
 
-            // sym8_supported == old sym8 allowlist (NOTE qwen3_5_moe excluded).
-            // gemma4_unified routes to Gemma4Recipe and supports sym8 like gemma4.
+            // sym8_supported allowlist: qwen3_5 (dense + MoE), lfm2/lfm2_moe,
+            // gemma4. gemma4_unified routes to Gemma4Recipe and supports sym8
+            // like gemma4. qwen3_5_moe dispatches sym8 on its non-expert
+            // sublayers (3-D stacked experts stay convert-forced affine-8).
             assert_eq!(
                 r.sym8_supported(),
                 matches!(
                     mt,
-                    "qwen3_5" | "lfm2" | "lfm2_moe" | "gemma4" | "gemma4_unified"
+                    "qwen3_5" | "qwen3_5_moe" | "lfm2" | "lfm2_moe" | "gemma4" | "gemma4_unified"
                 ),
                 "{mt}: sym8_supported mismatch vs inline sym8 allowlist"
             );
@@ -5668,10 +5673,11 @@ mod tests {
         // unrecognized model_type's flags as false then errors at dispatch).
         assert!(recipe::recipe_for("not-a-real-model").is_none());
 
-        // qwen3_5 vs qwen3_5_moe sym8 asymmetry is the subtle case: same recipe
-        // family, opposite sym8 support.
+        // qwen3_5 and qwen3_5_moe share the recipe family and BOTH support
+        // sym8: the MoE loader dispatches sym8 on its non-expert sublayers,
+        // while per-expert switch_mlp tensors stay convert-forced affine-8.
         assert!(recipe::recipe_for("qwen3_5").unwrap().sym8_supported());
-        assert!(!recipe::recipe_for("qwen3_5_moe").unwrap().sym8_supported());
+        assert!(recipe::recipe_for("qwen3_5_moe").unwrap().sym8_supported());
     }
 
     /// Byte-faithfulness gate for `Gemma4Recipe::sanitize`. Builds a tiny

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -4444,8 +4444,9 @@ fn quant_entry_emits(array: &MxArray, mode: &str, group_size: i32) -> Result<boo
 ///   AND shared_expert trio `{root}.mlp.shared_expert.{gate,up,down}_proj` —
 ///   `qwen3_5_moe/persistence.rs` builds each trio all-or-none (`if let
 ///   (Some(..), Some(..), Some(..))`); a partial trio drops ALL THREE members
-///   to the dense setters, sending the quantized members' packed payloads
-///   down the dense route. Reachable since qwen3_5_moe gained sym8 dispatch
+///   to the dense setters, where `ensure_dense_weight_floating` rejects the
+///   quantized members' packed non-float weights (matching the dense qwen3_5
+///   fallbacks). Reachable since qwen3_5_moe gained sym8 dispatch
 ///   for its non-expert sublayers (the old blanket fail-loud-on-any-sym8-
 ///   config guard is gone): under a sym8 default, 3-D switch_mlp experts and
 ///   2-D members with `K % 16 != 0` are both forced to affine-8

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -4422,8 +4422,9 @@ fn quant_entry_emits(array: &MxArray, mode: &str, group_size: i32) -> Result<boo
 /// Identify the CO-QUANTIZED group a weight base key (key minus `.weight`)
 /// belongs to, returning the full canonical member base list. Returns `None`
 /// for keys whose loaders resolve quantization per tensor (attention
-/// projections, GDN, embeddings, gemma4 MoE `experts.*`, qwen3_5_moe — the
-/// latter has no sym8 dispatch and fails loud up front on any sym8 config).
+/// projections, GDN, embeddings, gemma4 MoE `experts.*`, and qwen3_5_moe's
+/// router `.mlp.gate` / `.mlp.shared_expert_gate` — each of the latter builds
+/// through its own `try_build_ql` call with an independent dense fallback).
 ///
 /// These are the groups whose loaders are strict all-or-none:
 /// - dense MLP `{root}.mlp.{gate,up,down}_proj` — gemma4 (`gemma4/
@@ -4439,11 +4440,27 @@ fn quant_entry_emits(array: &MxArray, mode: &str, group_size: i32) -> Result<boo
 /// - lfm2 MoE quartet: router `{root}.feed_forward.gate` + 3D stacked
 ///   `{root}.feed_forward.switch_mlp.{gate,up,down}_proj` —
 ///   `moe_layer_is_quantized` couples all four (`moe_proj_bases`).
+/// - qwen3_5_moe switch_mlp trio `{root}.mlp.switch_mlp.{gate,up,down}_proj`
+///   AND shared_expert trio `{root}.mlp.shared_expert.{gate,up,down}_proj` —
+///   `qwen3_5_moe/persistence.rs` builds each trio all-or-none (`if let
+///   (Some(..), Some(..), Some(..))`); a partial trio drops ALL THREE members
+///   to the dense setters, sending the quantized members' packed payloads
+///   down the dense route. Reachable since qwen3_5_moe gained sym8 dispatch
+///   for its non-expert sublayers (the old blanket fail-loud-on-any-sym8-
+///   config guard is gone): under a sym8 default, 3-D switch_mlp experts and
+///   2-D members with `K % 16 != 0` are both forced to affine-8
+///   (`sym8_eligible`; a sym8 override reaching `try_build_qsl` fails loud at
+///   load), and a forced-affine member that ALSO fails the affine
+///   `K % group_size` alignment would silently stay dense next to quantized
+///   siblings without this table.
 ///
 /// `strip_suffix` is an exact tail match, so the tables cannot cross-match:
 /// `…switch_mlp.gate_proj` never strips as `.mlp.gate_proj` (the char before
-/// `mlp` is `_`, not `.`) and `…feed_forward.gate_proj` never strips as
-/// `.feed_forward.gate`.
+/// `mlp` is `_`, not `.`), `…feed_forward.gate_proj` never strips as
+/// `.feed_forward.gate`, qwen's `.mlp.switch_mlp.*` suffixes never match
+/// lfm2's `.feed_forward.switch_mlp.*` (different parent segment, both ways),
+/// and `….mlp.shared_expert.gate_proj` ends in `expert.gate_proj`, which no
+/// other table's suffix matches.
 fn coquant_group_members(base: &str) -> Option<Vec<String>> {
     const LFM2_MOE: [&str; 4] = [
         ".feed_forward.gate",
@@ -4456,8 +4473,24 @@ fn coquant_group_members(base: &str) -> Option<Vec<String>> {
         ".feed_forward.up_proj",
         ".feed_forward.down_proj",
     ];
+    const QWEN35_MOE_SWITCH: [&str; 3] = [
+        ".mlp.switch_mlp.gate_proj",
+        ".mlp.switch_mlp.up_proj",
+        ".mlp.switch_mlp.down_proj",
+    ];
+    const QWEN35_MOE_SHARED_EXPERT: [&str; 3] = [
+        ".mlp.shared_expert.gate_proj",
+        ".mlp.shared_expert.up_proj",
+        ".mlp.shared_expert.down_proj",
+    ];
     const DENSE_MLP: [&str; 3] = [".mlp.gate_proj", ".mlp.up_proj", ".mlp.down_proj"];
-    for table in [&LFM2_MOE[..], &LFM2_FFN[..], &DENSE_MLP[..]] {
+    for table in [
+        &LFM2_MOE[..],
+        &LFM2_FFN[..],
+        &QWEN35_MOE_SWITCH[..],
+        &QWEN35_MOE_SHARED_EXPERT[..],
+        &DENSE_MLP[..],
+    ] {
         for suffix in table {
             if let Some(root) = base.strip_suffix(suffix) {
                 return Some(table.iter().map(|s| format!("{root}{s}")).collect());
@@ -8348,6 +8381,189 @@ mod tests {
                 .expect("forced-affine member must carry a per-layer override");
             assert_eq!(ov["mode"], "affine");
             assert_eq!(ov["bits"], 8);
+        }
+    }
+
+    #[test]
+    fn sym8_group_coherence_covers_qwen35_moe_switch_and_shared_expert_groups() {
+        // qwen3_5_moe's loader builds the switch_mlp trio and the
+        // shared_expert trio all-or-none (`if let (Some, Some, Some)` in
+        // `qwen3_5_moe/persistence.rs`); a partial trio drops every member to
+        // the dense setters. One alignment-ineligible member must therefore
+        // force its whole trio dense. The router `.mlp.gate` and
+        // `.mlp.shared_expert_gate` resolve per tensor and must NOT be pulled
+        // dense by a sibling trio. Real MoE dims are 64-aligned, so only
+        // synthetic odd geometry exercises this.
+        let hidden = 64i64;
+        let odd = 24i64; // % 16 != 0 and % 64 != 0 → can never emit quantized
+
+        let w = |shape: &[i64]| {
+            let a = MxArray::random_normal(shape, 0.0, 0.02, Some(DType::Float32)).unwrap();
+            a.eval();
+            a
+        };
+
+        let mut weights: HashMap<String, MxArray> = HashMap::new();
+        // Layer 0 (incoherent switch trio): gate/up experts are 3-D with
+        // K=64 (forced affine-8, would emit); down has K=24 → forced affine
+        // then alignment-skipped → the whole trio must stay dense. The
+        // router gate in the same layer is per-tensor and must still emit.
+        weights.insert("model.layers.0.mlp.gate.weight".into(), w(&[4, hidden]));
+        weights.insert(
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight".into(),
+            w(&[2, 16, hidden]),
+        );
+        weights.insert(
+            "model.layers.0.mlp.switch_mlp.up_proj.weight".into(),
+            w(&[2, 16, hidden]),
+        );
+        weights.insert(
+            "model.layers.0.mlp.switch_mlp.down_proj.weight".into(),
+            w(&[2, hidden, odd]),
+        );
+        // Layer 1 (incoherent shared_expert trio): gate/up are sym8-eligible
+        // (K=64), down has K=24 (sym8-ineligible → forced affine-8 →
+        // alignment-skipped) → the whole trio must stay dense. The
+        // shared-expert output gate is per-tensor and must still emit.
+        weights.insert(
+            "model.layers.1.mlp.shared_expert.gate_proj.weight".into(),
+            w(&[32, hidden]),
+        );
+        weights.insert(
+            "model.layers.1.mlp.shared_expert.up_proj.weight".into(),
+            w(&[32, hidden]),
+        );
+        weights.insert(
+            "model.layers.1.mlp.shared_expert.down_proj.weight".into(),
+            w(&[hidden, odd]),
+        );
+        weights.insert(
+            "model.layers.1.mlp.shared_expert_gate.weight".into(),
+            w(&[1, hidden]),
+        );
+        // Layer 2 (control): both trios fully 64-aligned → switch experts
+        // emit forced affine-8, shared_expert members emit sym8.
+        weights.insert(
+            "model.layers.2.mlp.switch_mlp.gate_proj.weight".into(),
+            w(&[2, 16, hidden]),
+        );
+        weights.insert(
+            "model.layers.2.mlp.switch_mlp.up_proj.weight".into(),
+            w(&[2, 16, hidden]),
+        );
+        weights.insert(
+            "model.layers.2.mlp.switch_mlp.down_proj.weight".into(),
+            w(&[2, hidden, hidden]),
+        );
+        weights.insert(
+            "model.layers.2.mlp.shared_expert.gate_proj.weight".into(),
+            w(&[32, hidden]),
+        );
+        weights.insert(
+            "model.layers.2.mlp.shared_expert.up_proj.weight".into(),
+            w(&[32, hidden]),
+        );
+        weights.insert(
+            "model.layers.2.mlp.shared_expert.down_proj.weight".into(),
+            w(&[hidden, 32]),
+        );
+
+        let overrides = quantize_weights(&mut weights, 8, 64, "sym8", false)
+            .expect("sym8 quantize with coherence pass must succeed");
+
+        // Incoherent trios: every member dense float, no sidecars, no
+        // overrides.
+        for base in [
+            "model.layers.0.mlp.switch_mlp.gate_proj",
+            "model.layers.0.mlp.switch_mlp.up_proj",
+            "model.layers.0.mlp.switch_mlp.down_proj",
+            "model.layers.1.mlp.shared_expert.gate_proj",
+            "model.layers.1.mlp.shared_expert.up_proj",
+            "model.layers.1.mlp.shared_expert.down_proj",
+        ] {
+            let wt = weights
+                .get(&format!("{base}.weight"))
+                .expect("incoherent-trio member weight present");
+            assert_eq!(
+                wt.dtype().unwrap(),
+                DType::Float32,
+                "{base} must stay dense float (whole-trio coherence)"
+            );
+            assert!(
+                !weights.contains_key(&format!("{base}.scales")),
+                "{base} must not gain a scales sidecar"
+            );
+            assert!(
+                !overrides.contains_key(base),
+                "{base} must not carry a per-layer override"
+            );
+        }
+
+        // Per-tensor gates next to the incoherent trios must still emit
+        // (forced affine-8 via `is_router_gate`) — proves the drop is
+        // trio-scoped and the gates are not table members.
+        for base in [
+            "model.layers.0.mlp.gate",
+            "model.layers.1.mlp.shared_expert_gate",
+        ] {
+            let wt = weights
+                .get(&format!("{base}.weight"))
+                .expect("gate weight present");
+            assert_eq!(
+                wt.dtype().unwrap(),
+                DType::Uint32,
+                "{base} resolves per tensor and must still quantize affine-8"
+            );
+            assert!(weights.contains_key(&format!("{base}.scales")));
+            let ov = overrides
+                .get(base)
+                .expect("affine gate under a sym8 default must carry an override");
+            assert_eq!(ov["mode"], "affine");
+            assert_eq!(ov["bits"], 8);
+        }
+
+        // Control switch trio: forced affine-8 (packed Uint32 + override).
+        for base in [
+            "model.layers.2.mlp.switch_mlp.gate_proj",
+            "model.layers.2.mlp.switch_mlp.up_proj",
+            "model.layers.2.mlp.switch_mlp.down_proj",
+        ] {
+            let wt = weights
+                .get(&format!("{base}.weight"))
+                .expect("control switch member weight present");
+            assert_eq!(
+                wt.dtype().unwrap(),
+                DType::Uint32,
+                "{base} (aligned 3-D experts) must emit forced affine-8"
+            );
+            assert!(weights.contains_key(&format!("{base}.scales")));
+            let ov = overrides
+                .get(base)
+                .expect("forced-affine expert must carry a per-layer override");
+            assert_eq!(ov["mode"], "affine");
+            assert_eq!(ov["bits"], 8);
+        }
+
+        // Control shared_expert trio: genuine sym8 (int8 weight + f32
+        // scales, no override — sym8 IS the default here).
+        for base in [
+            "model.layers.2.mlp.shared_expert.gate_proj",
+            "model.layers.2.mlp.shared_expert.up_proj",
+            "model.layers.2.mlp.shared_expert.down_proj",
+        ] {
+            let wt = weights
+                .get(&format!("{base}.weight"))
+                .expect("control shared member weight present");
+            assert_eq!(
+                wt.dtype().unwrap(),
+                DType::Int8,
+                "{base} (aligned 2-D shared expert) must quantize sym8"
+            );
+            assert!(weights.contains_key(&format!("{base}.scales")));
+            assert!(
+                !overrides.contains_key(base),
+                "sym8-at-default member must not carry an override"
+            );
         }
     }
 

--- a/crates/mlx-core/src/convert_gemma_import.rs
+++ b/crates/mlx-core/src/convert_gemma_import.rs
@@ -53,8 +53,14 @@ use crate::utils::gemma_quant_repack::{
     repack_symmetric_per_group_to_mlx_affine, repack_symmetric_to_mlx_affine,
 };
 
-/// MLX affine group size for 2/4-bit linears and `embed_tokens`.
-const LINEAR_GROUP_SIZE: usize = 64;
+/// MLX affine group size for 2/4-bit linears and `embed_tokens`. 128 is the
+/// largest group size MLX affine quantization accepts (`affine_quantize`
+/// only allows 32/64/128). Every group in a row already carries the same
+/// per-row scale from the Google QAT source (see
+/// `repack_symmetric_to_mlx_affine`'s module doc), so there is zero
+/// numerical difference between group sizes here — the largest legal one
+/// halves the `.scales`/`.biases` table for free.
+const LINEAR_GROUP_SIZE: usize = 128;
 /// MLX affine group size for the PLE `embed_tokens_per_layer` embedding.
 const PLE_GROUP_SIZE: usize = 128;
 /// Width of a source scale block in the PLE embedding (`8960 / 35 = 256`).
@@ -719,7 +725,7 @@ mod tests {
         assert_eq!(s.dtype().unwrap(), DType::Float32);
         assert_eq!(b.dtype().unwrap(), DType::Float32);
 
-        let deq = affine_dequant(w, s, b, bits, 64);
+        let deq = affine_dequant(w, s, b, bits, 128);
         for o in 0..out_f {
             for c in 0..in_f {
                 let expected = q[o * in_f + c] as f32 * scales[o];
@@ -729,7 +735,7 @@ mod tests {
         // override keyed by post-sanitize prefix (bare module tail).
         let route = ov.get("layers.0.self_attn.q_proj").unwrap();
         assert_eq!(route["bits"], 4);
-        assert_eq!(route["group_size"], 64);
+        assert_eq!(route["group_size"], 128);
         assert_eq!(route["mode"], "affine");
     }
 
@@ -754,7 +760,7 @@ mod tests {
         let w = out.get(&format!("{base}.weight")).unwrap();
         let s = out.get(&format!("{base}.scales")).unwrap();
         let b = out.get(&format!("{base}.biases")).unwrap();
-        let deq = affine_dequant(w, s, b, bits, 64);
+        let deq = affine_dequant(w, s, b, bits, 128);
         for o in 0..out_f {
             for c in 0..in_f {
                 let expected = q[o * in_f + c] as f32 * scales[o];
@@ -767,7 +773,7 @@ mod tests {
     #[test]
     fn test_mlp_layer_schedule_4bit_below_15() {
         // mlp on layer 14 must be 4-bit (boundary).
-        let (out_f, in_f, bits) = (2usize, 64usize, 4u32);
+        let (out_f, in_f, bits) = (2usize, 128usize, 4u32);
         let q = make_q(out_f, in_f, bits);
         let scales = per_row_scales(out_f, 0.002);
         let mut raw = HashMap::new();
@@ -825,7 +831,7 @@ mod tests {
         let w = out.get(&format!("{base}.weight")).unwrap();
         let s = out.get(&format!("{base}.scales")).unwrap();
         let b = out.get(&format!("{base}.biases")).unwrap();
-        let deq = affine_dequant(w, s, b, bits, 64);
+        let deq = affine_dequant(w, s, b, bits, 128);
         for o in 0..vocab {
             for c in 0..dim {
                 let expected = q[o * dim + c] as f32 * scales[o];
@@ -833,7 +839,7 @@ mod tests {
             }
         }
         assert_eq!(ov["embed_tokens"]["bits"], 2);
-        assert_eq!(ov["embed_tokens"]["group_size"], 64);
+        assert_eq!(ov["embed_tokens"]["group_size"], 128);
     }
 
     #[test]
@@ -1101,7 +1107,7 @@ mod tests {
         let b = out.get(&format!("{base}.biases")).unwrap();
         assert_eq!(ov["layers.0.self_attn.q_proj"]["bits"], 4);
 
-        let deq = affine_dequant(w, s, b, 4, 64);
+        let deq = affine_dequant(w, s, b, 4, 128);
         let in_f = w_shape[1] * 2; // 4-bit → 2 vals/byte
         // Row-0 golden (first 16 vals), copied from the Task-1 numpy golden.
         let golden_row0: [f32; 16] = [
@@ -1135,7 +1141,7 @@ mod tests {
     #[test]
     fn test_key_namespace_full_prefix_stripped() {
         // Feed the longest HF wrapper prefix and assert the canonical output key.
-        let (out_f, in_f, bits) = (2usize, 64usize, 4u32);
+        let (out_f, in_f, bits) = (2usize, 128usize, 4u32);
         let q = make_q(out_f, in_f, bits);
         let scales = per_row_scales(out_f, 0.001);
         let mut raw = HashMap::new();

--- a/crates/mlx-core/src/convert_gemma_import.rs
+++ b/crates/mlx-core/src/convert_gemma_import.rs
@@ -249,6 +249,43 @@ fn is_skipped(stripped: &str) -> bool {
         || stripped.contains("rotary_emb")
 }
 
+/// Convert-time self-consistency tripwire for the gemma-prequant import:
+/// every `.scales`-bearing output tensor must carry a per-layer override,
+/// keyed by its pre-namespace (stripped) module prefix. The emitters uphold
+/// this by construction — `emit_affine_per_row` and the PLE arm insert the
+/// affine triplet and its override together, and the bf16-dequantized I8
+/// modules emit a dense `.weight` only (no `.scales`, so they need no
+/// exclusion here) — so a failure means a future emitter change decoupled
+/// tensor and override, which would silently make external loaders resolve
+/// the tensor through the top-level default and mis-dequantize it.
+///
+/// Deliberately scoped to the gemma-prequant import. The generic quantize
+/// paths cannot carry this guard: their override maps are intentionally
+/// sparse (only decisions that differ from the global defaults are recorded),
+/// so a `.scales` tensor without an override is the normal case there, and
+/// verifying it "matches the top-level default" would require re-deriving
+/// bits/group_size from mode-specific packed tensor layouts.
+fn verify_override_coverage(
+    weights: &HashMap<String, MxArray>,
+    overrides: &HashMap<String, serde_json::Value>,
+) -> Result<()> {
+    let covered: std::collections::HashSet<String> =
+        overrides.keys().map(|k| namespaced_key(k)).collect();
+    for key in weights.keys() {
+        let Some(prefix) = key.strip_suffix(".scales") else {
+            continue;
+        };
+        if !covered.contains(prefix) {
+            return Err(Error::from_reason(format!(
+                "gemma-QAT import: quantized tensor `{key}` has no per-layer quantization \
+                 override; the config.json `quantization` block would misrepresent it and \
+                 external loaders would dequantize it with the top-level defaults"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Bit-width for a 2/4-bit text linear, derived from the E2B layer schedule:
 /// `self_attn.*` is always 4-bit; `mlp.*` is 4-bit for layers 0–14 and 2-bit for
 /// layers ≥ 15. Returns `None` for keys this routing does not cover.
@@ -627,6 +664,8 @@ pub(crate) fn import_gemma_prequantized(
             LINEAR_GROUP_SIZE,
         )?;
     }
+
+    verify_override_coverage(&out, &overrides)?;
 
     Ok((out, overrides))
 }
@@ -1317,6 +1356,47 @@ mod tests {
         let err =
             top_level_quant_metadata(&ov).expect_err("mixed modes have no honest top-level value");
         assert!(err.to_string().contains("mix modes"));
+    }
+
+    #[test]
+    fn override_coverage_rejects_scales_without_override() {
+        // A `.scales`-bearing output tensor with no per-layer override would
+        // make external loaders fall back to the top-level default — the
+        // guard must fail the conversion instead.
+        let mut weights = HashMap::new();
+        weights.insert(
+            "language_model.model.layers.0.self_attn.q_proj.scales".to_string(),
+            f32_array(&[0.5], &[1, 1]),
+        );
+        let err = verify_override_coverage(&weights, &HashMap::new())
+            .expect_err("a .scales tensor without an override must fail the import");
+        assert!(
+            err.to_string()
+                .contains("language_model.model.layers.0.self_attn.q_proj.scales"),
+            "error must name the uncovered tensor: {err}"
+        );
+    }
+
+    #[test]
+    fn override_coverage_accepts_matching_override_and_dense_weights() {
+        let mut weights = HashMap::new();
+        weights.insert(
+            "language_model.model.layers.0.self_attn.q_proj.scales".to_string(),
+            f32_array(&[0.5], &[1, 1]),
+        );
+        // Dense (I8-dequant style) weights without `.scales` need no override.
+        weights.insert(
+            "language_model.model.layers.0.per_layer_input_gate.weight".to_string(),
+            f32_array(&[1.0], &[1, 1]),
+        );
+        // Overrides are keyed by the pre-namespace (stripped) module prefix.
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "layers.0.self_attn.q_proj".to_string(),
+            json!({ "bits": 4, "group_size": 128, "mode": "affine" }),
+        );
+        verify_override_coverage(&weights, &overrides)
+            .expect("covered .scales + dense weights must pass");
     }
 
     #[test]

--- a/crates/mlx-core/src/convert_gemma_import.rs
+++ b/crates/mlx-core/src/convert_gemma_import.rs
@@ -119,6 +119,91 @@ pub(crate) fn validate_e2b_qat_schedule(config: &serde_json::Value) -> Result<()
     Ok(())
 }
 
+/// Derive the honest top-level `quantization` block values from the per-layer
+/// overrides `import_gemma_prequantized` emitted — the import path's single
+/// source of truth for what was actually written to disk. Returns
+/// `(bits, group_size, mode)`.
+///
+/// `mode` and `group_size` are uniform across every override by construction
+/// (every 2/4-bit module is repacked to MLX affine at `LINEAR_GROUP_SIZE` /
+/// `PLE_GROUP_SIZE` = 128), so they are asserted uniform and returned
+/// directly; a divergence means the emitters changed and whoever changed them
+/// must decide what the top level should say. `bits` genuinely varies per
+/// module (the E2B schedule mixes 2- and 4-bit), so no single top-level value
+/// can describe every tensor: the modal (most common) bit-width is recorded,
+/// with ties broken toward the wider width. That is safe because every
+/// `.scales`-bearing output tensor carries its own complete
+/// `{bits, group_size, mode}` override — the top level only serves as the
+/// default for quantized tensors WITHOUT an override, and the importer emits
+/// none.
+pub(crate) fn top_level_quant_metadata(
+    overrides: &HashMap<String, serde_json::Value>,
+) -> Result<(i32, i32, String)> {
+    let mut mode: Option<String> = None;
+    let mut group_size: Option<i64> = None;
+    let mut bits_counts: HashMap<i64, usize> = HashMap::new();
+    for (key, ov) in overrides {
+        let read = |field: &str| {
+            ov.get(field).cloned().ok_or_else(|| {
+                Error::from_reason(format!(
+                    "gemma-QAT import: per-layer override `{key}` is missing `{field}`"
+                ))
+            })
+        };
+        let b = read("bits")?.as_i64().ok_or_else(|| {
+            Error::from_reason(format!(
+                "gemma-QAT import: per-layer override `{key}` has a non-integer `bits`"
+            ))
+        })?;
+        let gs = read("group_size")?.as_i64().ok_or_else(|| {
+            Error::from_reason(format!(
+                "gemma-QAT import: per-layer override `{key}` has a non-integer `group_size`"
+            ))
+        })?;
+        let m = read("mode")?.as_str().map(str::to_string).ok_or_else(|| {
+            Error::from_reason(format!(
+                "gemma-QAT import: per-layer override `{key}` has a non-string `mode`"
+            ))
+        })?;
+        match &mode {
+            None => mode = Some(m),
+            Some(prev) if *prev != m => {
+                return Err(Error::from_reason(format!(
+                    "gemma-QAT import: per-layer overrides mix modes ({prev} vs {m}); \
+                     no honest top-level `quantization.mode` exists — update \
+                     top_level_quant_metadata alongside the emitter change"
+                )));
+            }
+            _ => {}
+        }
+        match group_size {
+            None => group_size = Some(gs),
+            Some(prev) if prev != gs => {
+                return Err(Error::from_reason(format!(
+                    "gemma-QAT import: per-layer overrides mix group sizes ({prev} vs {gs}); \
+                     no honest top-level `quantization.group_size` exists — update \
+                     top_level_quant_metadata alongside the emitter change"
+                )));
+            }
+            _ => {}
+        }
+        *bits_counts.entry(b).or_default() += 1;
+    }
+    let (Some(mode), Some(group_size)) = (mode, group_size) else {
+        return Err(Error::from_reason(
+            "gemma-QAT import emitted no quantized modules; cannot derive an honest \
+             top-level `quantization` block"
+                .to_string(),
+        ));
+    };
+    let bits = bits_counts
+        .into_iter()
+        .max_by_key(|&(bits, count)| (count, bits))
+        .map(|(bits, _)| bits)
+        .expect("non-empty overrides imply at least one bits entry");
+    Ok((bits as i32, group_size as i32, mode))
+}
+
 /// Strip the HF wrapper prefix the same way `Gemma4Recipe::sanitize` does,
 /// returning the bare module key.
 fn strip_hf_prefix(key: &str) -> &str {
@@ -1155,5 +1240,111 @@ mod tests {
         );
         let (out, _ov) = import_gemma_prequantized(raw, &json!({}), DType::BFloat16).unwrap();
         assert!(out.contains_key("language_model.model.layers.0.self_attn.q_proj.weight"));
+    }
+
+    #[test]
+    fn top_level_metadata_uniform_gs_mode_modal_bits() {
+        // Mixed 2/4-bit overrides at uniform group 128 / affine → the top
+        // level records the modal bit-width (4: two modules vs one).
+        let mut ov = HashMap::new();
+        ov.insert(
+            "layers.0.self_attn.q_proj".to_string(),
+            json!({ "bits": 4, "group_size": 128, "mode": "affine" }),
+        );
+        ov.insert(
+            "layers.0.self_attn.k_proj".to_string(),
+            json!({ "bits": 4, "group_size": 128, "mode": "affine" }),
+        );
+        ov.insert(
+            "layers.20.mlp.down_proj".to_string(),
+            json!({ "bits": 2, "group_size": 128, "mode": "affine" }),
+        );
+        let (bits, group_size, mode) = top_level_quant_metadata(&ov).unwrap();
+        assert_eq!(bits, 4);
+        assert_eq!(group_size, 128);
+        assert_eq!(mode, "affine");
+    }
+
+    #[test]
+    fn top_level_metadata_bits_tie_breaks_wider() {
+        let mut ov = HashMap::new();
+        ov.insert(
+            "lm_head".to_string(),
+            json!({ "bits": 2, "group_size": 128, "mode": "affine" }),
+        );
+        ov.insert(
+            "layers.0.self_attn.q_proj".to_string(),
+            json!({ "bits": 4, "group_size": 128, "mode": "affine" }),
+        );
+        let (bits, _, _) = top_level_quant_metadata(&ov).unwrap();
+        assert_eq!(bits, 4, "a 2/4 tie must break toward the wider width");
+    }
+
+    #[test]
+    fn top_level_metadata_rejects_empty_overrides() {
+        let err = top_level_quant_metadata(&HashMap::new())
+            .expect_err("no quantized modules → no honest top-level block");
+        assert!(err.to_string().contains("no quantized modules"));
+    }
+
+    #[test]
+    fn top_level_metadata_rejects_mixed_group_size() {
+        let mut ov = HashMap::new();
+        ov.insert(
+            "layers.0.self_attn.q_proj".to_string(),
+            json!({ "bits": 4, "group_size": 128, "mode": "affine" }),
+        );
+        ov.insert(
+            "embed_tokens_per_layer".to_string(),
+            json!({ "bits": 4, "group_size": 64, "mode": "affine" }),
+        );
+        let err = top_level_quant_metadata(&ov)
+            .expect_err("mixed group sizes have no honest top-level value");
+        assert!(err.to_string().contains("mix group sizes"));
+    }
+
+    #[test]
+    fn top_level_metadata_rejects_mixed_mode() {
+        let mut ov = HashMap::new();
+        ov.insert(
+            "layers.0.self_attn.q_proj".to_string(),
+            json!({ "bits": 4, "group_size": 128, "mode": "affine" }),
+        );
+        ov.insert(
+            "lm_head".to_string(),
+            json!({ "bits": 8, "group_size": 128, "mode": "mxfp8" }),
+        );
+        let err =
+            top_level_quant_metadata(&ov).expect_err("mixed modes have no honest top-level value");
+        assert!(err.to_string().contains("mix modes"));
+    }
+
+    #[test]
+    fn top_level_metadata_from_real_import() {
+        // End-to-end over an actual import: a 4-bit q_proj + a 2-bit
+        // down_proj derive (bits=4 via tie-break, 128, affine).
+        let (out_f, in_f) = (4usize, 128usize);
+        let mut raw = HashMap::new();
+        raw.insert(
+            "model.language_model.layers.0.self_attn.q_proj.weight".to_string(),
+            packed_u8_array(&make_q(out_f, in_f, 4), out_f, in_f, 4),
+        );
+        raw.insert(
+            "model.language_model.layers.0.self_attn.q_proj.weight_scale".to_string(),
+            f32_array(&per_row_scales(out_f, 0.001), &[out_f as i64, 1]),
+        );
+        raw.insert(
+            "model.language_model.layers.20.mlp.down_proj.weight".to_string(),
+            packed_u8_array(&make_q(out_f, in_f, 2), out_f, in_f, 2),
+        );
+        raw.insert(
+            "model.language_model.layers.20.mlp.down_proj.weight_scale".to_string(),
+            f32_array(&per_row_scales(out_f, 0.01), &[out_f as i64, 1]),
+        );
+        let (_out, ov) = import_gemma_prequantized(raw, &json!({}), DType::BFloat16).unwrap();
+        let (bits, group_size, mode) = top_level_quant_metadata(&ov).unwrap();
+        assert_eq!(bits, 4);
+        assert_eq!(group_size, 128);
+        assert_eq!(mode, "affine");
     }
 }

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -128,12 +128,20 @@ pub(crate) trait DecodeStep {
     /// once per step at the END of the loop body, so the paged steppers
     /// can run their own cadence without forking the loop.
     ///
-    /// Default is the FLAT every-256-step `synchronize_and_clear_cache`.
-    /// Paged steppers override to
-    /// `crate::array::maybe_clear_cache_for_paged_step(step)`.
+    /// Default is the FLAT every-256-step `clear_cache` — no
+    /// `synchronize()`. mlx-lm's reference decode loop only calls
+    /// `mx.clear_cache()` on this cadence; a `synchronize()` here would
+    /// additionally target the WRONG stream (it blocks on the thread's
+    /// default stream, which sits idle — the actual forward runs on
+    /// `generation_stream`, only made default for the brief scope of
+    /// `StreamContext` in `crate::stream`, and restored before this call)
+    /// and would be redundant even if it targeted the right one (this
+    /// loop's own `y.eval()` at the top of every iteration already forces
+    /// full evaluation of everything scheduled so far). Paged steppers
+    /// override to `crate::array::maybe_clear_cache_for_paged_step(step)`.
     fn maintain_cache(&mut self, step: i32) {
         if (step + 1) % 256 == 0 {
-            crate::array::synchronize_and_clear_cache();
+            crate::array::clear_cache();
         }
     }
 

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -920,19 +920,23 @@ pub(crate) trait ChatBackend {
     where
         Self: 'a;
 
-    /// Set up the turn's decode path and return the stepper. == the
-    /// compiled-vs-eager dispatch blocks ahead of every `decode_loop!`
-    /// invocation (compiled lock acquisition + C++ seed-from-prefill on
-    /// the compiled path — `models/lfm2/model.rs` ~873-1100,
-    /// `models/qwen3_5/model.rs` compiled-init branches — or the
-    /// `DecodeOps` closure construction on the eager path). Turn-constant
-    /// captures (embedding weight, stream handles, the
-    /// `turn.params.reuse_cache` gate for [`DecodeStep::end_decode`])
-    /// move into the returned impl.
+    /// Set up the turn's decode stepper. Every family returns a pure-Rust
+    /// eager stepper; `turn` is consulted only for turn-constant setup:
     ///
-    /// lfm2 trap: the lfm2 impl must branch on `turn.is_delta` and return
-    /// the EAGER stepper for delta turns — its delta decode loop is always
-    /// eager, unlike the fresh flat path's compiled dispatch.
+    ///   * qwen3_5 dense reads `turn.params` / `turn.total_seq_len` /
+    ///     `turn.is_delta` / `turn.has_images` for its sync-path
+    ///     decode-entry trace (KV-capacity estimate via
+    ///     `engine::kv_capacity_round_up_saturating`) and, together with
+    ///     the recorded streaming-ness, picks the `chat*_rust` relabel.
+    ///   * qwen3 / MoE read only `turn.is_delta` for their profiler
+    ///     relabels (qwen3 additionally seeds `rope_offsets` from its
+    ///     post-prefill cursor — model state, not `turn`).
+    ///   * lfm2 / gemma4 ignore `turn` entirely and just wrap `self`.
+    ///
+    /// Turn-constant captures (the embedding weight and, for the qwen3.5
+    /// families, its transpose) move into the returned impl.
+    /// [`DecodeStep::end_decode`] is a default no-op that no family
+    /// overrides.
     fn begin_decode(&mut self, turn: &TurnSetup<'_>) -> Result<Self::Decode<'_>>;
 
     /// Decode the generated tokens and assemble the turn's
@@ -1105,7 +1109,7 @@ pub(crate) trait ChatBackend {
 
     /// Turn-level profiler label. Feeds
     /// `DecodeProfiler::new(label, family_name())`; the decode-path
-    /// relabel (compiled/eager) is [`DecodeStep::profiler_relabel`].
+    /// relabel is [`DecodeStep::profiler_relabel`].
     ///
     /// Default == the qwen3_5 dense labels (the de-facto engine
     /// reference): `"chat"` / `"chat_delta"` / `"chat_stream"` /
@@ -1298,10 +1302,11 @@ pub(crate) trait PagedBackend: ChatBackend {
     /// `[vocab]`.
     ///
     /// == the forked cores' `run_paged_prefill_chunk(suffix, prefix_len,
-    /// ..)` + last-token projection. MAY eval its input (compiled-paged
-    /// needs the concrete suffix); eager qwen3 does not. The engine fires
-    /// the post-prefill `synchronize_and_clear_cache` AFTER this returns
-    /// (it is NOT this method's job).
+    /// ..)` + last-token projection. MAY eval intermediates mid-prefill
+    /// (the chunked workers materialize each non-final chunk to bound the
+    /// lazy graph). The engine fires the post-prefill
+    /// `synchronize_and_clear_cache` AFTER this returns (it is NOT this
+    /// method's job).
     fn paged_prefill(
         &mut self,
         suffix_tokens: &[u32],
@@ -1310,9 +1315,10 @@ pub(crate) trait PagedBackend: ChatBackend {
     ) -> Result<MxArray>;
 
     /// Build the per-step paged decode stepper (the analog of
-    /// [`ChatBackend::begin_decode`]). Captures the turn constants
-    /// (`num_layers`, the dummy positions array, the compiled-paged
-    /// guards) into the returned stepper, which then drives
+    /// [`ChatBackend::begin_decode`]). Captures the turn constants into
+    /// the returned stepper (qwen3: `num_layers` + its dummy positions
+    /// array; gemma4 adds a diagnostic step counter; the rest just wrap
+    /// `self`), which then drives
     /// [`crate::engine::decode::run_decode_loop`].
     fn begin_paged_decode(&mut self, setup: &PagedTurnSetup<'_>) -> Result<Self::PagedDecode<'_>>;
 
@@ -1460,7 +1466,7 @@ pub(crate) trait PagedBackend: ChatBackend {
     /// Default — the dedicated `generation_stream`: a fresh Metal command
     /// queue that isolates decode work for the standard-KV families.
     ///
-    /// lfm2 OVERRIDES this to the canonical DEFAULT stream. Its compiled-paged
+    /// lfm2 OVERRIDES this to the canonical DEFAULT stream. Its paged
     /// forward holds persistent per-layer K/V pools across steps; running that
     /// forward on a queue SEPARATE from the shared loop's top-of-iteration
     /// `y.eval()` (which always runs on the default stream) forces a
@@ -1479,9 +1485,7 @@ pub(crate) trait PagedBackend: ChatBackend {
 /// MTP propose/verify loop needs to construct its per-turn stepper. The
 /// per-cycle scratch (snapshot / GDN tape / stashed replay error) does
 /// NOT live here: it becomes STRUCT FIELDS of the concrete
-/// [`MtpStepper`] (the analog of the compiled-paged guards on
-/// [`PagedBackend::PagedDecode`]), so the GDN tape never crosses the
-/// trait boundary.
+/// [`MtpStepper`], so the GDN tape never crosses the trait boundary.
 ///
 /// `depth` is the outer policy's requested draft depth (`params.mtp_depth`
 /// clamped to `[1, 5]`); the stepper still applies its own intra-cycle
@@ -1551,8 +1555,7 @@ pub(crate) trait MtpBackend: ChatBackend {
     /// Per-turn MTP propose/verify stepper. Borrows `&mut self` for the
     /// whole decode loop. The per-cycle GDN tape / linear-cache snapshot /
     /// stashed replay error live as STRUCT FIELDS of the concrete stepper
-    /// (declaration order == teardown order, like the compiled-paged
-    /// guards on [`PagedBackend::PagedDecode`]).
+    /// (declaration order == teardown order).
     type MtpDecode<'a>: MtpStepper
     where
         Self: 'a;

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -40,9 +40,10 @@ pub(crate) trait DecodeStep {
     /// Single-token forward pass. `input_ids` is the `[1, 1]` token the
     /// loop reshaped from the previous sample. Returns `(logits,
     /// needs_squeeze)` — `needs_squeeze == true` when the logits still
-    /// carry the sequence axis (`[1, 1, vocab]`, eager Rust forwards)
-    /// and the loop must `squeeze(&[1])` them; compiled C++ forwards
-    /// return `[1, vocab]` directly and pass `false`.
+    /// carry the sequence axis (`[1, 1, vocab]`)
+    /// and the loop must `squeeze(&[1])` them; steppers that already
+    /// collapse to `[1, vocab]` (e.g. the lfm2 and qwen3_5 paged
+    /// steppers) pass `false`.
     fn forward(&mut self, input_ids: &MxArray) -> Result<(MxArray, bool)>;
 
     /// Like [`DecodeStep::forward`], but the engine ALSO hands the
@@ -54,8 +55,8 @@ pub(crate) trait DecodeStep {
     /// `y.reshape([1, 1])` lazy node — calling `item_at_int32` on it
     /// forces a second per-step eval/sync that the loop already paid at
     /// the top. That extra synchronize is invisible on a slow eager
-    /// forward (qwen3 dense) but measurably regresses a FAST compiled-paged
-    /// decode (lfm2 / future qwen3_5* compiled paged) by several percent.
+    /// forward (qwen3 dense) but measurably regresses a FAST paged
+    /// decode (lfm2, qwen3_5 dense/MoE, gemma4) by several percent.
     /// Such steppers override this to consume the handed `token_id`
     /// directly. The default forwards to [`DecodeStep::forward`] (flat
     /// steppers embed `input_ids` and never need the scalar; qwen3 paged
@@ -456,45 +457,28 @@ pub(crate) enum ResetScope {
 
 /// Turn-constant inputs for [`ChatBackend::begin_decode`].
 ///
-/// Field set derived from what the compiled/eager decode-setup blocks
-/// read (`models/lfm2/model.rs` compiled seed block, `models/qwen3_5/
-/// model.rs` compiled-init branches):
+/// Field set derived from what the family `begin_decode` impls read:
 pub(crate) struct TurnSetup<'a> {
-    /// The turn's resolved [`ChatParams`]. Two consumers:
-    ///   * `params.reuse_cache` gates the compiled-cache export in
-    ///     [`DecodeStep::end_decode`] — the stepper captures it here at
-    ///     `begin_decode` time (qwen3_5 dense/MoE `if p.reuse_cache`
-    ///     export blocks, lfm2 `if use_compiled && reuse_cache`);
-    ///   * `params.enable_mtp` / `params.mtp_depth` /
-    ///     `params.max_new_tokens` feed the qwen3_5 decode-entry
-    ///     `info!` trace (`chat_with_caches_inner` "chat_decode entry"
-    ///     block).
-    ///
-    /// `params.max_new_tokens` is also the KV budget input: lfm2's
-    /// compiled seed sizes its fixed padded cache via
-    /// `kv_capacity_round_up(prefill_len, max_new_tokens)`; the qwen3.5
-    /// compiled init does the same. (There is deliberately no separate
-    /// `max_new_tokens` field so the two copies cannot drift.)
+    /// The turn's resolved [`ChatParams`]. `params.enable_mtp` /
+    /// `params.mtp_depth` / `params.max_new_tokens` feed the qwen3_5
+    /// dense decode-entry `info!` trace, whose `max_kv_len` estimate is
+    /// derived via `kv_capacity_round_up_saturating(total_seq_len,
+    /// max_new_tokens)`; the other families do not read `params` at
+    /// `begin_decode` time.
     pub params: &'a ChatParams,
     /// Delta-continuation flag (this turn appended a text delta on top of
     /// the live KV caches rather than running a fresh prefill). Read by
-    /// the qwen3.5 dense/MoE, qwen3, and lfm2 decode-setup blocks for
-    /// their session-continuation bookkeeping and entry traces.
+    /// the qwen3.5 dense/MoE and qwen3 `begin_decode` impls for their
+    /// profiler relabels and entry traces.
     pub is_delta: bool,
     /// Whether this turn carried image input. Read by the qwen3.5 dense
     /// decode-entry `info!` trace.
     pub has_images: bool,
     /// Total post-prefill sequence length: cached prefix + freshly
     /// prefilled tokens (i.e. the full prompt; the session-delta paths
-    /// pass `cached_history + delta`).
-    ///
-    /// The qwen3.5 compiled init sizes its fixed KV budget from `seq_len`
-    /// (`kv_capacity_round_up(seq_len, max_new_tokens)` in
-    /// `chat_with_caches_inner`), and `seq_len` there is the TOTAL prompt
-    /// length — not the prefilled tail. lfm2 deliberately ignores this
-    /// field and seeds from the live attention-KV offset instead (see the
-    /// "CRITICAL: seed the compiled decode position from the LIVE
-    /// attention KV offset" comment in `models/lfm2/model.rs`).
+    /// pass `cached_history + delta`). Read by the qwen3.5 dense
+    /// decode-entry trace (`prefill_seq_len` plus the `max_kv_len`
+    /// estimate above).
     pub total_seq_len: usize,
 }
 
@@ -1622,10 +1606,13 @@ pub(crate) trait MtpStepper {
     fn embedding_weight(&self) -> &MxArray;
 
     /// `true` when [`Self::commit_mtp`] runs the real committed-history
-    /// commit (and `run_mtp_cycle` uses the `chain_start = 0` draft mask) —
-    /// both the dense and MoE eager steppers report this whenever their
-    /// flag-gated `use_committed` gate holds; steppers with no
-    /// committed-history support return `false`.
+    /// commit. The engine ANDs it with `cycle_seed_was_chained` to pick
+    /// the chained-cycle commit anchor
+    /// (`MtpCommitAnchor::SkipAlreadyCommittedAnchor` instead of
+    /// `IncludeAnchor`) and the `chained_anchor` argument of
+    /// [`Self::begin_cycle`]. Both the dense and MoE eager steppers
+    /// report this whenever their flag-gated `use_committed` gate holds;
+    /// steppers with no committed-history support return `false`.
     /// == `MtpOps::committed_history_active`.
     fn committed_history_active(&self) -> bool;
 

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -1621,10 +1621,12 @@ pub(crate) trait MtpStepper {
     /// [`Self::restore_and_replay_main`] / [`Self::commit_mtp`]).
     fn embedding_weight(&self) -> &MxArray;
 
-    /// `true` on the dense path where [`Self::commit_mtp`] runs the real
-    /// committed-history commit (and `run_mtp_cycle` uses the
-    /// `chain_start = 0` draft mask). == `MtpOps::committed_history_active`.
-    /// MoE / cycle-history steppers return `false`.
+    /// `true` when [`Self::commit_mtp`] runs the real committed-history
+    /// commit (and `run_mtp_cycle` uses the `chain_start = 0` draft mask) —
+    /// both the dense and MoE eager steppers report this whenever their
+    /// flag-gated `use_committed` gate holds; steppers with no
+    /// committed-history support return `false`.
+    /// == `MtpOps::committed_history_active`.
     fn committed_history_active(&self) -> bool;
 
     /// Optional profiler relabel for the MTP path (e.g.
@@ -1709,8 +1711,9 @@ pub(crate) trait MtpStepper {
     /// Committed-history commit. Appends `K+2` exact committed K/V slots
     /// to the persistent MTP cache. The `anchor` selects the commit
     /// payload policy (engine-chosen [`MtpCommitAnchor`]); the model
-    /// consumes it. A no-op impl keeps the cycle-history policy (MoE /
-    /// tests). == `MtpOps::commit_mtp` (the `CM` closure) — `(anchor,
+    /// consumes it. A no-op impl keeps the cycle-history policy (tests, or
+    /// dense/MoE steppers whose flag-gated `use_committed` gate is off).
+    /// == `MtpOps::commit_mtp` (the `CM` closure) — `(anchor,
     /// prev_hidden [1,1,hidden], verify_hiddens [1,D+1,hidden],
     /// committed_ids [K+2], k_accepted, embedding_weight)`.
     fn commit_mtp(

--- a/crates/mlx-core/src/engine/decode.rs
+++ b/crates/mlx-core/src/engine/decode.rs
@@ -199,7 +199,8 @@ pub(crate) struct StreamingCtx<'s, 't> {
 ///
 ///   * (d) the per-step cache-maintenance cadence is routed through
 ///     [`DecodeStep::maintain_cache`] — the default is the every-256-step
-///     `synchronize_and_clear_cache`; paged steppers override to their
+///     `clear_cache` (no `synchronize()`, matching mlx-lm's reference
+///     cadence — see the trait doc); paged steppers override to their
 ///     own cadence (`maybe_clear_cache_for_paged_step`).
 pub(crate) fn run_decode_loop<S: DecodeStep>(
     step: &mut S,
@@ -255,9 +256,9 @@ pub(crate) fn run_decode_loop<S: DecodeStep>(
         // Cache-maintenance cadence runs EVERY committed step, here at the
         // loop TOP — including terminal/length-exit steps that break
         // before the forward. The default `maintain_cache` is the FLAT
-        // every-256-step `synchronize_and_clear_cache` (a cache clear
-        // changes timing, not values, and the 256-cadence keys off
-        // `step_idx`); paged steppers override to their own cadence
+        // every-256-step `clear_cache` (a cache clear changes timing, not
+        // values, and the 256-cadence keys off `step_idx`); paged
+        // steppers override to their own cadence
         // (`maybe_clear_cache_for_paged_step`).
         step.maintain_cache(step_idx);
 
@@ -724,9 +725,9 @@ mod run_decode_loop_tests {
 
     #[test]
     fn long_run_completes_through_cache_clear_cadence() {
-        // >300 steps so the every-256-step synchronize_and_clear_cache
-        // branch executes at least once. Cutoffs disabled so the
-        // constant script can't trip them.
+        // >300 steps so the every-256-step `clear_cache` branch (the
+        // FLAT `DecodeStep::maintain_cache` default) executes at least
+        // once. Cutoffs disabled so the constant script can't trip them.
         let params = greedy_params(|cfg| {
             cfg.max_consecutive_tokens = Some(0);
             cfg.max_ngram_repeats = Some(0);
@@ -742,6 +743,43 @@ mod run_decode_loop_tests {
         assert_eq!(out.finish_reason, "length");
         // Last iteration skips the pipelined forward (step+1 == max).
         assert_eq!(step.forward_calls, 399);
+    }
+
+    #[test]
+    fn maintain_cache_default_clears_without_synchronize() {
+        // Proves the FLAT `DecodeStep::maintain_cache` default cadence
+        // (crates/mlx-core/src/engine/backend.rs) fires `clear_cache`
+        // and NEVER `synchronize` — the redundant-stall this fix
+        // removes. Thread-local counters (`array::memory`) so this is
+        // race-free against other tests running concurrently.
+        use crate::array::memory::{TEST_CLEAR_CACHE_CALLS, TEST_SYNCHRONIZE_CALLS};
+
+        TEST_SYNCHRONIZE_CALLS.with(|c| c.set(0));
+        TEST_CLEAR_CACHE_CALLS.with(|c| c.set(0));
+
+        let params = greedy_params(|cfg| {
+            cfg.max_consecutive_tokens = Some(0);
+            cfg.max_ngram_repeats = Some(0);
+        });
+        let mut tracker = ReasoningTracker::new(false, None, None);
+        let mut step = MockStep::new(vec![1], 16);
+
+        // >256 steps so the cadence branch fires at least once.
+        drive(&mut step, 1, &params, &mut tracker, 300, 15, &[])
+            .unwrap_or_else(|e| panic!("loop failed: {}", e.reason));
+
+        assert_eq!(
+            TEST_SYNCHRONIZE_CALLS.with(|c| c.get()),
+            0,
+            "FLAT maintain_cache default must not call the stream-less \
+             mlx_synchronize — see crate::stream::StreamContext (the \
+             generation stream is not the default stream at this point)"
+        );
+        assert!(
+            TEST_CLEAR_CACHE_CALLS.with(|c| c.get()) >= 1,
+            "FLAT maintain_cache default should still drain the allocator \
+             cache on the 256-step cadence"
+        );
     }
 
     // ---- streaming ----

--- a/crates/mlx-core/src/engine/mtp_turn.rs
+++ b/crates/mlx-core/src/engine/mtp_turn.rs
@@ -239,7 +239,7 @@ pub(crate) fn run_mtp_cycle<S: MtpStepper>(
         // Keep the draft step's hidden/embedding handles alive even if the
         // EV gate stops here. The fixed-depth path always retains these
         // handles through the cycle tail; matching that lifetime matters
-        // for MLX's lazy compiled cache writes.
+        // for MLX's lazy cache writes.
         prev_hidden = h_next;
         let id_arr = A::from_int32(&[tok_id], &[1])?;
         let emb_2d = embedding_weight.take(&id_arr, 0)?; // [1, hidden]
@@ -299,8 +299,8 @@ pub(crate) fn run_mtp_cycle<S: MtpStepper>(
         "MTP verify input built"
     );
     // Snapshot the main path's GDN linear caches + offset BEFORE verify
-    // runs its D+1 sequential forwards. Verify mutates `g_compiled_caches`
-    // in place; on rejection we restore from this snapshot and replay only
+    // runs its D+1 sequential forwards. Verify mutates the main-path
+    // caches in place; on rejection we restore from this snapshot and replay only
     // the K accepted drafts so the linear recurrent state matches the
     // committed token stream. On full accept the snapshot is discarded —
     // verify already left the linear state correctly advanced.
@@ -457,7 +457,7 @@ pub(crate) fn run_mtp_cycle<S: MtpStepper>(
     } else {
         // We materialize logits now so per-position slicing reads
         // from a CPU-resident buffer for penalty application. The
-        // hiddens ride on the same compiled graph; we only eval the
+        // hiddens ride on the same lazy graph; we only eval the
         // K-th slice below.
         //
         // Note: the sparse-accept path also benefits from this eager
@@ -928,7 +928,8 @@ pub(crate) fn run_mtp_cycle<S: MtpStepper>(
     // Chained cycles skip Step A. Their `last_committed_id` is the prior
     // cycle's boundary token, already committed by that prior cycle. The
     // commit must therefore skip the anchor and append only
-    // `accepted_tokens`, advancing `g_mtp_committed_len` by the number of
+    // `accepted_tokens`, advancing the stepper's committed length by the
+    // number of
     // newly emitted tokens. Re-committing the anchor would drift the MTP
     // RoPE base by one slot per chained cycle.
     let committed_ids: Vec<u32> = match commit_anchor {
@@ -1685,7 +1686,7 @@ pub(crate) fn run_mtp_turn<B: MtpBackend, R: rand::Rng>(
         } else {
             depth
         };
-        // Near-tail budget cap. The compiled verify writes `depth+1`
+        // Near-tail budget cap. The verify writes `depth+1`
         // target-cache slots BEFORE the post-verify truncation to
         // `max_new_tokens`; when fewer than `depth+1` main-cache
         // slots remain near the tail the write can overrun the
@@ -1909,7 +1910,7 @@ pub(crate) fn run_mtp_turn<B: MtpBackend, R: rand::Rng>(
         // When chaining IS enabled, flush the main path's KV-cache
         // lazy graph BEFORE the next cycle starts AND fuse the
         // chained `verify_hidden[K]` slice into the SAME `async_eval`
-        // batch as `(token, g_compiled_caches)`.
+        // batch as `(token, main layer caches)`.
         //
         // A plain `eval_step(y, h, false)` here would leave the
         // chained hidden LAZY across the iteration boundary (that
@@ -1918,8 +1919,8 @@ pub(crate) fn run_mtp_turn<B: MtpBackend, R: rand::Rng>(
         // `prev_hidden = chained_hidden`, materializing the slice
         // forced a mid-cycle Metal command-buffer roundtrip that the
         // Step-A bypass doesn't pay (Step A's `forward_with_hidden`
-        // returns `(logits, hidden)` as siblings of the same compiled
-        // forward and `eval_step` co-schedules them via
+        // returns `(logits, hidden)` as siblings of the same forward
+        // graph and `eval_step` co-schedules them via
         // `next_token → logits → hidden`).
         //
         // `eval_step_with_chained_hidden` extends the same dispatch

--- a/crates/mlx-core/src/engine/persistence.rs
+++ b/crates/mlx-core/src/engine/persistence.rs
@@ -15,14 +15,18 @@ use crate::array::{DType, MxArray};
 use crate::engine::params::ModelGenerationDefaults;
 use crate::utils::safetensors::load_safetensors_lazy;
 
-/// Whether the compiled C++ forward path can run on this host.
+/// Whether the Metal-only native paths can run on this host.
 ///
-/// The compiled Qwen3.5 dense/MoE forward uses `fast::metal_kernel` (the GDN
-/// gating/recurrence kernels) and the block-paged custom primitives. Both
-/// require MLX's Metal backend and throw at runtime without it. On the
-/// CUDA/Linux build (`mlx_metal_is_available()` is false) the loaders must
-/// skip compiled-forward weight registration so `model_id` stays unset and
-/// every forward falls back to the device-agnostic eager Rust path.
+/// The block-paged custom primitives (`paged_kv_write` / `paged_attention`)
+/// and the GDN `fast::metal_kernel` kernels require MLX's Metal backend and
+/// throw at runtime without it. On the CUDA/Linux build
+/// (`mlx_metal_is_available()` is false) the model constructors leave the
+/// paged adapter unset and the GDN dispatch takes the ops path, so every
+/// forward falls back to the device-agnostic eager Rust path.
+///
+/// (The name is historical: this probe originally gated the deleted
+/// compiled-C++-forward weight registration; today it is a plain
+/// Metal-availability check.)
 ///
 /// The probe is cached: `mlx_metal_is_available()` is a constant per process.
 pub(crate) fn compiled_forward_backend_available() -> bool {

--- a/crates/mlx-core/src/engine/session.rs
+++ b/crates/mlx-core/src/engine/session.rs
@@ -732,7 +732,7 @@ fn chat_turn_core<B: ChatBackend>(
             total_seq_len: tokens.len(),
         };
         let mut step = backend.begin_decode(&turn_setup)?;
-        // Decode-path relabel (compiled/eager) — see
+        // Decode-path relabel — see
         // `DecodeStep::profiler_relabel`.
         if let Some(label) = step.profiler_relabel() {
             profiler.set_label(label);
@@ -787,10 +787,11 @@ fn chat_turn_core<B: ChatBackend>(
         {
             step.materialize_final(last_token)?;
         }
-        // Fallible post-loop hook (compiled-path export). Runs while the
-        // stepper (and its lock/reset guards) is still alive, BEFORE
+        // Fallible post-loop hook (currently a no-op for every family —
+        // see `DecodeStep::end_decode`). Runs while the
+        // stepper (and any guards it holds) is still alive, BEFORE
         // `save_cache_state` below. On Err the turn aborts here: the
-        // stepper drops (reset guards fire) and NO session state is
+        // stepper drops (its guards fire) and NO session state is
         // saved.
         step.end_decode()?;
     }

--- a/crates/mlx-core/src/engine/types.rs
+++ b/crates/mlx-core/src/engine/types.rs
@@ -86,8 +86,9 @@ pub struct ChatConfig {
     #[napi(ts_type = "boolean | undefined")]
     pub reuse_cache: Option<bool>,
     /// MTP: opt-in flag enabling the Multi-Token Prediction speculative decode
-    /// loop on the dense compiled path. Requires the model checkpoint to carry
-    /// an MTP head (otherwise silently ignored). Default: `false`.
+    /// loop (pure-Rust eager; qwen3.5 dense and MoE). Requires the model
+    /// checkpoint to carry an MTP head (otherwise silently ignored). Default:
+    /// `false`.
     #[napi(ts_type = "boolean | undefined")]
     pub enable_mtp: Option<bool>,
     /// MTP: number of draft tokens per speculative cycle. Clamped to `[1, 5]`

--- a/crates/mlx-core/src/lib.rs
+++ b/crates/mlx-core/src/lib.rs
@@ -29,6 +29,8 @@ pub mod sampling;
 pub mod sft;
 pub mod stream;
 pub mod tensor;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod tokenizer;
 pub mod tools;
 pub mod tracing;

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -404,6 +404,14 @@ pub(crate) struct Gemma4Inner {
     /// when the config flag is unset, in which case the model falls
     /// back to the flat `Gemma4LayerCache` path.
     pub(crate) paged_adapter: Option<PagedKVCacheAdapter>,
+    /// Cached result of `compute_layer_kinds_from_kv_cache_specs(&config)`,
+    /// computed once here in `Gemma4Inner::new` instead of re-derived
+    /// (BTreeMap/BTreeSet grouping + a sort) on every paged prefill-chunk /
+    /// decode-step call. Pure function of the immutable `config`, so it
+    /// never changes for the lifetime of this instance. Empty when
+    /// `paged_adapter` is `None`: every paged-only call site that reads it
+    /// errors out on a `None` adapter before consuming the value.
+    pub(crate) layer_kinds: Vec<Gemma4LayerKind>,
     sliding_prefix_checkpoints: VecDeque<Gemma4SlidingPrefixCheckpoint>,
     sliding_prompt_boundary_checkpoint: Option<Gemma4SlidingPrefixCheckpoint>,
     sliding_last_history_checkpoint: Option<Gemma4SlidingHistoryCheckpoint>,
@@ -971,6 +979,27 @@ impl Gemma4Inner {
             None
         };
 
+        // Derive the per-layer paged-routing classification once here
+        // instead of on every paged prefill-chunk / decode-step call (see
+        // `compute_layer_kinds_from_kv_cache_specs`'s BTreeMap/BTreeSet
+        // grouping + sort). It's a pure function of `config`, which is
+        // immutable for the lifetime of this `Gemma4Inner`. Only meaningful
+        // when `paged_adapter` is `Some` — every caller first errors out on
+        // a `None` adapter before reading the result, so `Vec::new()` below
+        // is never read in that case. Guaranteed to succeed whenever
+        // `paged_adapter` built above, since that already validated a
+        // strictly stronger constraint (a single full-attention group) over
+        // the same specs.
+        let layer_kinds = if paged_adapter.is_some() {
+            compute_layer_kinds_from_kv_cache_specs(&config).map_err(|e| {
+                Error::from_reason(format!(
+                    "Gemma4Inner::new: failed to derive cached layer-kind routes: {e}"
+                ))
+            })?
+        } else {
+            Vec::new()
+        };
+
         Ok(Self {
             config,
             embed_tokens,
@@ -990,6 +1019,7 @@ impl Gemma4Inner {
             cached_image_key: None,
             cached_audio_key: None,
             paged_adapter,
+            layer_kinds,
             sliding_prefix_checkpoints: VecDeque::new(),
             sliding_prompt_boundary_checkpoint: None,
             sliding_last_history_checkpoint: None,
@@ -1024,17 +1054,17 @@ impl Gemma4Inner {
         Ok(())
     }
 
-    /// Build the per-layer routing list for the paged dispatch.
+    /// Return the per-layer routing list for the paged dispatch.
     ///
-    /// See [`compute_layer_kinds`] (free helper) for full semantics.
-    /// This wrapper is the on-`Gemma4Inner` entry point used by the
-    /// chat-session forward dispatch.
+    /// Cheap clone of `self.layer_kinds`, cached once in `Gemma4Inner::new`
+    /// instead of being re-derived (BTreeMap/BTreeSet grouping + a sort —
+    /// see [`compute_layer_kinds`] (free helper) and
+    /// `compute_layer_kinds_from_kv_cache_specs`) on every call. It's a pure
+    /// function of the immutable `Gemma4Config`, so recomputing it from
+    /// scratch on every paged prefill-chunk / decode-step call was pure
+    /// waste.
     pub(crate) fn compute_layer_kinds(&self) -> Result<Vec<Gemma4LayerKind>> {
-        compute_layer_kinds_from_kv_cache_specs(&self.config).map_err(|e| {
-            Error::from_reason(format!(
-                "Gemma4 compute_layer_kinds: failed to derive KV routes: {e}"
-            ))
-        })
+        Ok(self.layer_kinds.clone())
     }
 
     /// Drop the live KV caches and clear reuse-tracking state.
@@ -8882,6 +8912,158 @@ mod tests {
             }
             ref other => panic!("layer 7: expected SharedOnGlobal, got {other:?}"),
         }
+    }
+
+    /// Element-wise comparison for `Gemma4LayerKind`, which intentionally
+    /// does not derive `PartialEq` (mirrors `Lfm2LayerKind`, which doesn't
+    /// either — this codebase's existing tests compare these routing enums
+    /// via `matches!`/`match`, not `assert_eq!`).
+    fn layer_kind_matches(a: &super::Gemma4LayerKind, b: &super::Gemma4LayerKind) -> bool {
+        use super::Gemma4LayerKind::*;
+        match (a, b) {
+            (Sliding, Sliding) => true,
+            (GlobalPaged { paged_idx: x }, GlobalPaged { paged_idx: y }) => x == y,
+            (
+                SharedOnGlobal {
+                    anchor_paged_idx: x,
+                },
+                SharedOnGlobal {
+                    anchor_paged_idx: y,
+                },
+            ) => x == y,
+            (
+                SharedOnSliding {
+                    anchor_layer_idx: x,
+                },
+                SharedOnSliding {
+                    anchor_layer_idx: y,
+                },
+            ) => x == y,
+            _ => false,
+        }
+    }
+
+    /// `Gemma4Inner::new` must cache `layer_kinds` once instead of
+    /// re-deriving it (BTreeMap/BTreeSet grouping + a sort, see
+    /// `compute_layer_kinds_from_kv_cache_specs`) on every paged
+    /// prefill-chunk / decode-step call. The cached field must always equal
+    /// a fresh from-scratch computation over the same config — covers
+    /// all-global, hybrid sliding+global, and KV-shared layouts (mirrors
+    /// the three `test_compute_layer_kinds_*` cases above).
+    #[test]
+    fn test_gemma4_inner_caches_layer_kinds_matching_fresh_compute() {
+        if !crate::engine::persistence::compiled_forward_backend_available() {
+            eprintln!("skipping (paged backend unavailable without Metal)");
+            return;
+        }
+
+        let all_global = super::Gemma4Config {
+            num_hidden_layers: 4,
+            layer_types: vec!["full_attention".to_string(); 4],
+            ..paged_tiny_config(Some(true))
+        };
+
+        let cycle = ["sliding_attention"; 4]
+            .iter()
+            .map(|s| s.to_string())
+            .chain(std::iter::once("full_attention".to_string()))
+            .collect::<Vec<_>>();
+        let hybrid = super::Gemma4Config {
+            num_hidden_layers: 10,
+            layer_types: (0..10).map(|i| cycle[i % 5].clone()).collect(),
+            ..paged_tiny_config(Some(true))
+        };
+
+        let shared_layer_types: Vec<String> = (0..8)
+            .map(|i| {
+                if i % 2 == 1 {
+                    "full_attention".to_string()
+                } else {
+                    "sliding_attention".to_string()
+                }
+            })
+            .collect();
+        let kv_shared = super::Gemma4Config {
+            num_hidden_layers: 8,
+            layer_types: shared_layer_types,
+            num_kv_shared_layers: Some(4),
+            ..paged_tiny_config(Some(true))
+        };
+
+        for cfg in [all_global, hybrid, kv_shared] {
+            let expected = super::compute_layer_kinds_from_kv_cache_specs(&cfg)
+                .expect("fresh layer-kind computation must succeed for a valid paged config");
+            let inner = match super::Gemma4Inner::new(cfg) {
+                Ok(inner) => inner,
+                Err(err) => {
+                    let msg = err.reason.to_string();
+                    if msg.contains("No Metal device found") {
+                        eprintln!("skipping (no Metal device): {msg}");
+                        return;
+                    }
+                    panic!("unexpected Gemma4Inner::new failure: {msg}");
+                }
+            };
+            assert!(
+                inner.paged_adapter.is_some(),
+                "test configs force use_block_paged_cache=true"
+            );
+            assert_eq!(
+                inner.layer_kinds.len(),
+                expected.len(),
+                "cached layer_kinds length must match a fresh compute"
+            );
+            for (i, (got, want)) in inner.layer_kinds.iter().zip(expected.iter()).enumerate() {
+                assert!(
+                    layer_kind_matches(got, want),
+                    "layer {i}: cached layer_kinds diverged from fresh compute: \
+                     got {got:?}, want {want:?}"
+                );
+            }
+        }
+    }
+
+    /// Manual timing probe (not a correctness gate — `#[ignore]`d so it
+    /// never runs in CI). Measures the per-call cost this task eliminates:
+    /// re-deriving the routing table from scratch (BTreeMap/BTreeSet + sort)
+    /// vs. the cached `Vec::clone`. Pure CPU, no GPU/model weights, immune
+    /// to thermal throttling. Run with:
+    /// `cargo test -p mlx-core --release --lib -- --ignored --nocapture \
+    ///  bench_layer_kinds_manual`
+    #[test]
+    #[ignore]
+    fn bench_layer_kinds_manual() {
+        // Scaled to ~48 layers with a realistic 5:1 sliding:global cycle
+        // and KV-sharing, so the BTreeMap/BTreeSet grouping + sort has a
+        // realistic amount of work to do.
+        let cycle = ["sliding_attention"; 4]
+            .iter()
+            .map(|s| s.to_string())
+            .chain(std::iter::once("full_attention".to_string()))
+            .collect::<Vec<_>>();
+        let cfg = super::Gemma4Config {
+            num_hidden_layers: 48,
+            layer_types: (0..48).map(|i| cycle[i % 5].clone()).collect(),
+            num_kv_shared_layers: Some(8),
+            ..paged_tiny_config(Some(true))
+        };
+
+        let n: u32 = 200_000;
+
+        let start = std::time::Instant::now();
+        for _ in 0..n {
+            std::hint::black_box(
+                super::compute_layer_kinds_from_kv_cache_specs(std::hint::black_box(&cfg)).unwrap(),
+            );
+        }
+        eprintln!("recompute: {:?}/call", start.elapsed() / n);
+
+        let cached = super::compute_layer_kinds_from_kv_cache_specs(&cfg).unwrap();
+        let start = std::time::Instant::now();
+        for _ in 0..n {
+            std::hint::black_box(std::hint::black_box(&cached).clone());
+        }
+        eprintln!("cached clone: {:?}/call", start.elapsed() / n);
     }
 
     #[test]

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -2101,7 +2101,8 @@ impl Gemma4Inner {
         // Gemma4's forward runs entirely through primitive-op FFI that takes
         // weight arrays by POINTER (from this Rust `inner`/`params`), so there
         // is no process-global weight table to populate and nothing to register
-        // here. `inner.model_id` (drawn from `QWEN35_MODEL_ID_COUNTER`) is a
+        // here. `inner.model_id` (drawn from gemma4's private `MODEL_ID_COUNTER`
+        // in `model.rs`) is a
         // purely local per-instance handle surfaced to NAPI; it is not a
         // routing key and never leaves this process state.
 

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -994,10 +994,12 @@ fn apply_weights(
     // int8 bytes as a dense weight, see `try_build_sym8_quantized_linear`).
     //
     // Paged KV stays the gemma4 default under sym8 (`use_block_paged_cache`
-    // defaults true in `model.rs`): gemma4 has NO compiled C++ forward path,
-    // and the eager paged loop drives the same `LinearProj::forward` sym8
-    // route as flat — qwen3_5's force-flat sym8 guard exists only because
-    // its compiled registry can't represent sym8, which does not transfer.
+    // defaults true in `model.rs`): gemma4's eager paged loop drives the
+    // same `LinearProj::forward` sym8 route as flat, and gemma4 ships sym8
+    // under paged decode. qwen3_5's force-flat sym8 pin is a conservative
+    // validation-scope choice on its own path (sym8 there is validated on
+    // the flat path only; paged is simply unvalidated) — a rationale that
+    // does not transfer here.
     let try_build_ql = |prefix: &str| -> Result<Option<super::quantized_linear::QuantizedLinear>> {
         let plq = per_layer_quant.get(prefix).copied().unwrap_or(default_plq);
         // int8 STORAGE with non-sym8 metadata = config drift — fail loud

--- a/crates/mlx-core/src/models/lfm2/attention.rs
+++ b/crates/mlx-core/src/models/lfm2/attention.rs
@@ -35,6 +35,41 @@ fn graph_decode_gather_enabled() -> bool {
     })
 }
 
+/// When enabled (opt-in; default OFF), cache-hit prefill (`cached_prefix_len > 0`,
+/// i.e. every multi-turn chat continuation) first tries the MLX graph-native
+/// paged-attention bridge (`PagedKVCacheAdapter::gather_kv_for_prefill_chunk`),
+/// which reads the K/V pool through MLX graph dependencies with no forced host
+/// sync. When disabled (the default), or when the bridge is unavailable for the
+/// inputs (non-Metal backend, batch > 1, an unsupported cache dtype, or an
+/// oversized auxiliary buffer), the synchronous `read_kv_range` path is used
+/// instead — a `[0, total_ctx)` host read that forces a per-layer pool eval via
+/// `eval_pending_pool_write_for_layer`.
+///
+/// The bridge reads the SAME physical KV bytes as `read_kv_range`; only the
+/// attention kernel differs (fused paged-attn vs explicit-mask SDPA), the
+/// accepted ~1-ULP class already shipped default-on for paged DECODE. It is held
+/// opt-in here — unlike `qwen3_5`/`gemma4`, which default it on — only because
+/// the divergence has no green automated parity gate on the one available LFM2
+/// checkpoint (greedy decode there is repeat-loop-degenerate, so byte-identical
+/// text parity is an unreliable oracle). Flip to default-on once a gemma4-style
+/// paged-vs-flat gate exists on a stable checkpoint.
+fn paged_prefill_paged_attention_enabled() -> bool {
+    // Without a Metal backend (CUDA/Linux build) the C++ paged-attention
+    // kernel throws, so a cache-hit prefill must NOT dispatch it. Hard-close
+    // the path here so reuse-turn prefills stay on the device-agnostic SDPA
+    // fallback (`read_kv_range` + explicit mask).
+    if !crate::engine::persistence::compiled_forward_backend_available() {
+        return false;
+    }
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        crate::inference_trace::env_flag_enabled_or_default(
+            "MLX_LFM2_PAGED_PREFILL_PAGED_ATTENTION",
+            false,
+        )
+    })
+}
+
 /// LFM2 multi-head attention with QK RMSNorm and RoPE.
 ///
 /// Follows `lfm2.py:53-109` (Attention class).
@@ -310,21 +345,63 @@ impl Lfm2Attention {
                     )?
                 }
             } else {
-                // Cache-hit prefill: read full [0, total_ctx) K/V back
-                // from the pool. The suffix was just written above.
+                // Cache-hit prefill: the suffix was just written above.
+                // Prefer the MLX graph-native paged-attention bridge (reads
+                // the pool through graph dependencies, no per-layer host
+                // sync) over `read_kv_range`, which forces
+                // `eval_pending_pool_write_for_layer` on every call. Mirrors
+                // the qwen3_5 / gemma4 `forward_paged` cache-hit branch.
                 let total_ctx = cached_prefix_len + (seq_len as u32);
-                let (k_full, v_full) = adapter
-                    .read_kv_range(attn_layer_idx, 0, total_ctx)
-                    .map_err(napi::Error::from_reason)?;
-                let mask =
-                    create_causal_mask(seq_len as i32, Some(cached_prefix_len as i32), None)?;
-                scaled_dot_product_attention(
-                    &queries_bhtd,
-                    &k_full,
-                    &v_full,
-                    self.scale,
-                    Some(&mask),
-                )?
+                let maybe_paged_attn = if batch == 1 && paged_prefill_paged_attention_enabled() {
+                    // [B, H, T, D] -> [H, T, D] -> [T, H, D], matching
+                    // `PagedKVCacheAdapter::gather_kv_for_prefill_chunk`.
+                    let queries_paged = queries_bhtd
+                        .squeeze(Some(&[0]))?
+                        .transpose(Some(&[1, 0, 2]))?;
+                    match adapter.gather_kv_for_prefill_chunk(
+                        attn_layer_idx,
+                        &queries_paged,
+                        cached_prefix_len,
+                        self.scale as f32,
+                    ) {
+                        Ok(attn_t_h_d) => {
+                            let target_dtype = x.dtype()?;
+                            let attn_t_h_d = attn_t_h_d.astype(target_dtype)?;
+                            // [T, H, D] -> [H, T, D] -> [B, H, T, D]
+                            let attn = attn_t_h_d.transpose(Some(&[1, 0, 2]))?.reshape(&[
+                                batch,
+                                self.num_heads as i64,
+                                seq_len,
+                                self.head_dim as i64,
+                            ])?;
+                            Some(attn)
+                        }
+                        Err(_) => None,
+                    }
+                } else {
+                    None
+                };
+
+                match maybe_paged_attn {
+                    Some(attn) => attn,
+                    None => {
+                        let (k_full, v_full) = adapter
+                            .read_kv_range(attn_layer_idx, 0, total_ctx)
+                            .map_err(napi::Error::from_reason)?;
+                        let mask = create_causal_mask(
+                            seq_len as i32,
+                            Some(cached_prefix_len as i32),
+                            None,
+                        )?;
+                        scaled_dot_product_attention(
+                            &queries_bhtd,
+                            &k_full,
+                            &v_full,
+                            self.scale,
+                            Some(&mask),
+                        )?
+                    }
+                }
             }
         } else {
             // Decode: gather full historical K/V via the paged kernel. Both

--- a/crates/mlx-core/src/models/lfm2/model.rs
+++ b/crates/mlx-core/src/models/lfm2/model.rs
@@ -41,6 +41,26 @@ fn last_token_slice_enabled() -> bool {
     *CACHED.get_or_init(|| std::env::var_os("MLX_LFM2_DISABLE_LAST_TOKEN_SLICE").is_none())
 }
 
+/// Whether the warm paged-turn conv-state reuse fast path is enabled.
+///
+/// OPT-IN, DEFAULT OFF. When ON, a qualifying warm continuation (see
+/// [`conv_state_reusable`]) reuses `self.caches`'s live incremental conv
+/// state instead of reconstructing it via a full re-embed + causal-SDPA pass
+/// over the whole cached prefix, skipping the redundant Pass 1. It ships
+/// opt-in because the reused incremental conv state differs MATERIALLY from
+/// the single-pass reconstruction it replaces (~40 ULP, enough to flip a
+/// near-tie argmax) — LFM2 ShortConv `in_proj` produces different bf16 for a
+/// T=1 incremental step vs the batched reconstruction input — so it is a real
+/// behavior change (arguably closer to flat continuous generation) that stays
+/// disabled until a conv oracle validates enabling it by default. Read once on
+/// first call and cached; subsequent reads hit the `OnceLock` fast path.
+fn conv_state_reuse_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        crate::inference_trace::env_flag_enabled_or_default("MLX_LFM2_CONV_STATE_REUSE", false)
+    })
+}
+
 /// Internal model state owned exclusively by the dedicated model thread.
 ///
 /// No `Arc<RwLock<>>` — the model thread has sole ownership.
@@ -81,6 +101,17 @@ pub(crate) struct Lfm2Inner {
     /// `config.eos_token_id` is derived separately in `persistence.rs`;
     /// this carries the FULL eos list plus sampling defaults on top.
     gen_defaults: crate::engine::ModelGenerationDefaults,
+    /// Whether the MOST RECENT `PagedBackend::prime_prefix_state` call
+    /// decided `self.caches`'s conv-layer state already reflected the
+    /// incoming prompt's cached prefix byte-for-byte (see
+    /// [`conv_state_reusable`]), letting `run_paged_prefill_chunk` skip
+    /// the full re-embed + causal-SDPA reconstruction pass
+    /// (`run_conv_only_prefill`) over the cached prefix. Read back by
+    /// `paged_perf_prefill_tokens` so `report_performance: true`
+    /// telemetry reports the SUFFIX-scale numerator (the work this turn
+    /// actually did) instead of the full-prompt-scale numerator that is
+    /// only honest when the reconstruction pass actually ran.
+    last_paged_prefill_reused_conv_state: bool,
 }
 
 /// Classification of the prefix-cache decision made from a
@@ -134,6 +165,50 @@ pub(crate) fn classify_prefix_cache_decision(
     } else {
         PrefixCacheDecision::Miss
     }
+}
+
+/// Decide whether `self.caches`'s conv-layer state ALREADY reflects the
+/// token prefix `plan[..cached_prefix_len]` byte-for-byte, so
+/// `run_paged_prefill_chunk`'s Pass 1 (`run_conv_only_prefill`) — a full
+/// re-embed + causal-SDPA reconstruction over the ENTIRE cached prefix
+/// through every layer, purely to rebuild conv state — can be skipped and
+/// the live caches carried straight into Pass 2 over just the suffix.
+///
+/// Returns `true` only for the standard "resend growing conversation"
+/// warm-continuation pattern: the new turn's paged-attention cache hit
+/// (`cached_prefix_len`, from the content-addressed KV-block pool, which
+/// may span foreign/cross-session blocks) EXACTLY equals the length AND
+/// content of `cached_token_history` — the token sequence
+/// `save_cache_state_internal` proved `self.caches`'s conv state was left
+/// at after the immediately preceding successful turn on THIS model
+/// instance. Any mismatch (first turn, a turn that aborted since the last
+/// save, a partial/foreign prefix hit shorter or longer than
+/// `cached_token_history`, or divergent content) safely returns `false`
+/// and falls back to the full reconstruction — conv state is a pure
+/// function of the token prefix, so this check is sufficient regardless
+/// of which logical chat session produced `cached_token_history`.
+///
+/// `cached_prefix_len == 0` and the degenerate identical-resend case
+/// (`cached_prefix_len` capped one below an exact match by
+/// `prime_prefix_state`'s `max_cache_hit_tokens`) both return `false` —
+/// mirrors [`classify_prefix_cache_decision`]'s exact-match-is-miss
+/// invariant: LFM2 has no safe "rewind by one" primitive.
+///
+/// This predicate only gates the fast path when [`conv_state_reuse_enabled`]
+/// is also true (opt-in via `MLX_LFM2_CONV_STATE_REUSE`, DEFAULT OFF): the
+/// reused live conv state differs materially (~40 ULP, near-tie argmax may
+/// flip) from the single-pass reconstruction it replaces, so it stays off
+/// until an oracle validates it.
+#[inline]
+fn conv_state_reusable(
+    plan: &[u32],
+    cached_token_history: &[u32],
+    cached_prefix_len: usize,
+) -> bool {
+    cached_prefix_len > 0
+        && cached_prefix_len == cached_token_history.len()
+        && plan.len() >= cached_prefix_len
+        && plan[..cached_prefix_len] == cached_token_history[..]
 }
 
 /// Build the LFM2 wire-format delta text for a tool-result turn.
@@ -297,6 +372,7 @@ impl Lfm2Inner {
             // Empty until the load path parses `generation_config.json`
             // (set via `set_gen_defaults` in `persistence.rs`).
             gen_defaults: crate::engine::ModelGenerationDefaults::default(),
+            last_paged_prefill_reused_conv_state: false,
         })
     }
 
@@ -437,10 +513,19 @@ impl Lfm2Inner {
     /// existing conv path (conv layers).
     ///
     /// `full_tokens` is the entire prompt (used for conv layers' prefill
-    /// from token 0). `suffix_tokens` is the new portion beyond the
-    /// paged prefix-cache hit (used by `record_tokens` +
-    /// `update_keys_values` for the attention layers).
-    /// `cached_prefix_len` is the paged-cache hit length.
+    /// from token 0, UNLESS `skip_conv_reconstruction` is set — see
+    /// below). `suffix_tokens` is the new portion beyond the paged
+    /// prefix-cache hit (used by `record_tokens` + `update_keys_values`
+    /// for the attention layers). `cached_prefix_len` is the paged-cache
+    /// hit length. `skip_conv_reconstruction` is
+    /// [`conv_state_reusable`]'s verdict from `prime_prefix_state`
+    /// (threaded through [`Lfm2PrefixState::conv_state_reusable`]),
+    /// and is only ever `true` when the opt-in `MLX_LFM2_CONV_STATE_REUSE`
+    /// flag is set ([`conv_state_reuse_enabled`], DEFAULT OFF): when `true`,
+    /// `self.caches`'s conv-layer state is already known to be at the
+    /// `cached_prefix_len` boundary, so Pass 1 is skipped entirely and Pass 2
+    /// runs directly on the live caches. Default-off ⇒ always `false` ⇒ Pass 1
+    /// reconstruction always runs (byte-identical to prior behavior).
     ///
     /// Returns the last position's logits squeezed to `[vocab]`.
     fn run_paged_prefill_chunk(
@@ -448,6 +533,7 @@ impl Lfm2Inner {
         full_tokens: &[u32],
         suffix_tokens: &[u32],
         cached_prefix_len: u32,
+        skip_conv_reconstruction: bool,
     ) -> Result<MxArray> {
         if suffix_tokens.is_empty() {
             return Err(Error::from_reason(
@@ -487,9 +573,16 @@ impl Lfm2Inner {
         //
         // For the no-cache case (cached_prefix_len == 0) the suffix IS
         // the full prompt, so pass 1 is skipped and pass 2 handles
-        // everything in one shot.
+        // everything in one shot. Pass 1 is ALSO skipped whenever
+        // `skip_conv_reconstruction` is set — `prime_prefix_state`
+        // already proved `self.caches`'s conv-layer state is at the
+        // `cached_prefix_len` boundary for THIS EXACT token prefix (the
+        // standard warm-continuation "resend growing conversation"
+        // pattern), so re-deriving it via a full re-embed + causal-SDPA
+        // reconstruction over the whole cached prefix would be
+        // redundant work with no observable effect on the result.
 
-        if cached_prefix_len > 0 {
+        if cached_prefix_len > 0 && !skip_conv_reconstruction {
             // Pass 1: conv-only prefill over the cached prefix. This
             // brings conv state up to position `cached_prefix_len` so
             // pass 2 can continue from there.
@@ -704,6 +797,13 @@ impl Lfm2Inner {
     /// downstream conv layers the correct residual, otherwise their state
     /// drifts and paged-CONTINUE diverges from flat. See
     /// `tests/lfm2_paged_vs_flat_parity.rs::lfm2_paged_budget_forced_warm_continue_parity`.
+    ///
+    /// `run_paged_prefill_chunk` skips calling this entirely when
+    /// [`conv_state_reusable`] already proved `self.caches` is at the
+    /// `cached_prefix_len` boundary for this exact token prefix (the
+    /// warm-continuation fast path) — this reconstruction is only needed to
+    /// derive that same state from scratch when the live caches are NOT
+    /// already known to hold it.
     fn run_conv_only_prefill(&mut self, prefix_tokens: &[u32]) -> Result<()> {
         if prefix_tokens.is_empty() {
             return Ok(());
@@ -1142,6 +1242,11 @@ pub(crate) struct Lfm2PrefixState {
     effective_cached_prefix_len: usize,
     suffix_len: usize,
     full_tokens: Vec<u32>,
+    /// [`conv_state_reusable`]'s verdict, computed once in
+    /// `prime_prefix_state` and consumed by `paged_prefill` to decide
+    /// whether `run_paged_prefill_chunk` may skip Pass 1
+    /// (`run_conv_only_prefill`) over the cached prefix.
+    conv_state_reusable: bool,
 }
 
 impl PagedPrefix for Lfm2PrefixState {
@@ -1203,20 +1308,38 @@ impl PagedBackend for Lfm2Inner {
             )
             .map_err(Error::from_reason)?;
 
-        // Reset conv-layer state for this turn. The paged path does not carry
-        // conv prefix state across turns; each turn reprefills from the start
-        // of the prompt over conv layers. `run_paged_turn` is family-neutral
-        // and will NOT do this — forget it and conv state goes stale across
-        // turns.
-        self.caches = init_caches(&self.config);
-        self.cached_token_history.clear();
-        self.cached_image_key = None;
+        let cached_prefix_len = turn_plan.cached_prefix_len as usize;
+
+        // Conv-state reuse fast path (see `conv_state_reusable`): when this
+        // turn strictly extends the immediately preceding successful turn's
+        // saved history byte-for-byte, `self.caches`'s conv-layer state is
+        // ALREADY at the `cached_prefix_len` boundary — keep it live instead
+        // of paying for a full re-embed + causal-SDPA reconstruction pass
+        // over the whole cached prefix (`run_paged_prefill_chunk` Pass 1).
+        // Any mismatch (first turn, aborted-since-last-save, or a
+        // foreign/partial prefix hit) falls through to the existing
+        // unconditional reset — `run_paged_turn` is family-neutral and will
+        // NOT do this for us; skip it and conv state goes stale across
+        // turns. Gated OFF by default (`conv_state_reuse_enabled`): reusing the
+        // live incremental conv state differs materially (~40 ULP, near-tie
+        // argmax may flip) from the reconstruction it replaces, so the flag
+        // stays off until an oracle validates it — flag off ⇒ `reused_conv_state
+        // == false` ⇒ the unconditional reset below always runs (pre-fix path).
+        let reused_conv_state = conv_state_reuse_enabled()
+            && conv_state_reusable(plan, &self.cached_token_history, cached_prefix_len);
+        if !reused_conv_state {
+            self.caches = init_caches(&self.config);
+            self.cached_token_history.clear();
+            self.cached_image_key = None;
+        }
+        self.last_paged_prefill_reused_conv_state = reused_conv_state;
 
         Ok(Lfm2PrefixState {
-            effective_cached_prefix_len: turn_plan.cached_prefix_len as usize,
+            effective_cached_prefix_len: cached_prefix_len,
             suffix_len: turn_plan.suffix_len as usize,
             // Conv Pass-1 needs the FULL prompt (not just the suffix).
             full_tokens: plan.to_vec(),
+            conv_state_reusable: reused_conv_state,
         })
     }
 
@@ -1227,14 +1350,17 @@ impl PagedBackend for Lfm2Inner {
         _stream: Stream,
     ) -> Result<MxArray> {
         // `run_paged_prefill_chunk` records the suffix in the adapter, runs
-        // conv Pass-1 over the cached prefix from `full_tokens`, then the
-        // full forward over the suffix, and folds in the last-token slice
-        // (returns `[vocab]`). The engine fires the post-prefill
-        // `synchronize_and_clear_cache` AFTER this returns (NOT here).
+        // conv Pass-1 over the cached prefix from `full_tokens` (unless
+        // `prefix.conv_state_reusable` says the live caches already cover
+        // it), then the full forward over the suffix, and folds in the
+        // last-token slice (returns `[vocab]`). The engine fires the
+        // post-prefill `synchronize_and_clear_cache` AFTER this returns
+        // (NOT here).
         self.run_paged_prefill_chunk(
             &prefix.full_tokens,
             suffix_tokens,
             prefix.effective_cached_prefix_len as u32,
+            prefix.conv_state_reusable,
         )
     }
 
@@ -1265,17 +1391,39 @@ impl PagedBackend for Lfm2Inner {
         if let Some(adapter) = self.paged_adapter.as_mut() {
             let _ = adapter.release_request();
         }
+        // Invalidate the conv-state-reuse invariant `conv_state_reusable`
+        // depends on: `self.caches`'s conv-layer state may now reflect a
+        // partially-executed (aborted) turn rather than the exact position
+        // `cached_token_history.len()` records (e.g. Pass 2 or a decode step
+        // ran partway before the error). Clearing `cached_token_history`
+        // forces the NEXT `prime_prefix_state` call's length/content check
+        // to fail closed (`> 0` guard), taking the unconditional
+        // `init_caches` reset — the same safe rebuild every paged turn got
+        // before this fast path existed.
+        self.cached_token_history.clear();
     }
 
-    fn paged_perf_prefill_tokens(&self, prompt_token_count: usize, _suffix_len: usize) -> usize {
-        // lfm2 reprefills the FULL prompt through conv layers EVERY turn
-        // (`run_paged_prefill_chunk` Pass-1) even on a warm attention-prefix
-        // hit, so ttft measures full-prompt work and the throughput numerator
-        // must be the FULL prompt — NOT the attention suffix (pinned by the
+    fn paged_perf_prefill_tokens(&self, prompt_token_count: usize, suffix_len: usize) -> usize {
+        // lfm2 reprefills the FULL prompt through conv layers on a normal
+        // warm attention-prefix hit (`run_paged_prefill_chunk` Pass-1), so
+        // ttft measures full-prompt work and the throughput numerator must
+        // be the FULL prompt — NOT the attention suffix (pinned by the
         // `lfm2_paged_prefill_tps_is_full_prompt_scale_on_warm_reuse` guard).
         // The default (`suffix_len`) is the standard-KV qwen behavior, which
         // would under-report lfm2's prefill tok/s by the cache-hit ratio.
-        prompt_token_count
+        //
+        // EXCEPTION: when `prime_prefix_state` took the conv-state-reuse
+        // fast path this turn (`last_paged_prefill_reused_conv_state`),
+        // Pass 1 never ran — the ACTUAL prefill work this turn was
+        // suffix-scale, so reporting the full-prompt count here would
+        // inflate `prefill_tokens_per_second` by the cache-hit ratio
+        // instead of under-reporting it. Report the honest numerator for
+        // whichever amount of work actually happened.
+        if self.last_paged_prefill_reused_conv_state {
+            suffix_len
+        } else {
+            prompt_token_count
+        }
     }
 
     fn paged_decode_stream(&self, _generation_stream: Stream) -> Stream {
@@ -1718,6 +1866,94 @@ mod prefix_cache_decision_tests {
 }
 
 #[cfg(test)]
+mod conv_state_reuse_tests {
+    //! Pure-logic coverage of [`conv_state_reusable`] — no model load
+    //! required. Guards the `prime_prefix_state` fast path that skips
+    //! `run_paged_prefill_chunk`'s Pass 1 (`run_conv_only_prefill`)
+    //! whenever `self.caches`'s conv-layer state is provably already at
+    //! the incoming cached-prefix boundary.
+
+    use super::conv_state_reusable;
+
+    #[test]
+    fn zero_cached_prefix_is_not_reusable() {
+        // First turn ever (or a cross-session/foreign miss the paged
+        // adapter itself already reported as 0): nothing to reuse.
+        assert!(!conv_state_reusable(&[1, 2, 3], &[], 0));
+    }
+
+    #[test]
+    fn strict_extension_of_saved_history_is_reusable() {
+        // The standard "resend growing conversation" pattern: the new
+        // prompt is `cached_token_history` plus new tail tokens, and the
+        // paged adapter's own hit length equals the saved history length
+        // exactly.
+        let history = vec![1u32, 2, 3, 4, 5];
+        let plan = vec![1u32, 2, 3, 4, 5, 6, 7];
+        assert!(conv_state_reusable(&plan, &history, history.len()));
+    }
+
+    #[test]
+    fn length_mismatch_is_not_reusable() {
+        // Paged-adapter hit length shorter than the saved history (a
+        // partial/foreign prefix hit, or a branched conversation that
+        // diverges before the end of the prior turn): the live caches
+        // are NOT known to be at this exact boundary.
+        let history = vec![1u32, 2, 3, 4, 5];
+        let plan = vec![1u32, 2, 3, 9, 9, 9];
+        assert!(!conv_state_reusable(&plan, &history, 3));
+
+        // Hit length longer than the saved history (foreign cross-session
+        // KV-block hit dwarfing this instance's own history): also unsafe.
+        assert!(!conv_state_reusable(&plan, &history, 6));
+    }
+
+    #[test]
+    fn content_divergence_is_not_reusable() {
+        // Same lengths, but the prefix bytes differ — a coincidental
+        // length match against an unrelated session's history.
+        let history = vec![1u32, 2, 3, 4, 5];
+        let plan = vec![1u32, 2, 9, 4, 5, 6];
+        assert!(!conv_state_reusable(&plan, &history, history.len()));
+    }
+
+    #[test]
+    fn exact_resend_capped_below_full_length_is_not_reusable() {
+        // `prime_prefix_state` caps the paged adapter's own hit at
+        // `plan.len() - 1` (never lets a cache hit consume the whole
+        // prompt), so an identical resend with zero new tokens reports
+        // `cached_prefix_len == history.len() - 1`, not `history.len()`.
+        // Mirrors `classify_prefix_cache_decision`'s exact-match-is-miss
+        // invariant.
+        let history = vec![1u32, 2, 3, 4, 5];
+        let plan = history.clone();
+        assert!(!conv_state_reusable(&plan, &history, history.len() - 1));
+    }
+
+    #[test]
+    fn chains_across_consecutive_growing_turns() {
+        // Turn 2 reuses against turn 1's saved history; turn 3 reuses
+        // against turn 2's (longer) saved history. Proves the invariant
+        // is not a one-shot check.
+        let history_after_turn1 = vec![1u32, 2, 3];
+        let plan_turn2 = vec![1u32, 2, 3, 4, 5];
+        assert!(conv_state_reusable(
+            &plan_turn2,
+            &history_after_turn1,
+            history_after_turn1.len()
+        ));
+
+        let history_after_turn2 = vec![1u32, 2, 3, 4, 5, 6];
+        let plan_turn3 = vec![1u32, 2, 3, 4, 5, 6, 7, 8];
+        assert!(conv_state_reusable(
+            &plan_turn3,
+            &history_after_turn2,
+            history_after_turn2.len()
+        ));
+    }
+}
+
+#[cfg(test)]
 mod tool_delta_marker_tests {
     //! Guard the structured `is_error` channel on LFM2's tool-result
     //! wire format. The shared
@@ -2088,7 +2324,7 @@ mod paged_adapter_construction_tests {
         }
 
         // Prefill the suffix == full prompt (cached_prefix_len = 0).
-        let logits = match inner.run_paged_prefill_chunk(&prompt, &prompt, 0) {
+        let logits = match inner.run_paged_prefill_chunk(&prompt, &prompt, 0, false) {
             Ok(l) => l,
             Err(e) => {
                 let msg = e.reason.to_string();

--- a/crates/mlx-core/src/models/lfm2/sparse_moe.rs
+++ b/crates/mlx-core/src/models/lfm2/sparse_moe.rs
@@ -476,8 +476,39 @@ mod tests {
         );
     }
 
+    /// Skips on hosts where either NAX half-precision kernel class this test
+    /// depends on is broken (gen>=17 GPUs on the current vendored-MLX pin):
+    ///
+    /// 1. `test_support::half_gemm_untrustworthy` — with 32 tokens the router
+    ///    gate projection is a bf16 `[32,4] @ [4,4]` GEMM (M>1, K=4), which
+    ///    the NAX unaligned-K bug turns into garbage (probed vs host truth:
+    ///    max_err 3.2; e.g. token-0 logit for expert 2 computes 0 where the
+    ///    true value is 1.0), corrupting every token's routing scores before
+    ///    the experts even run. The single-token sibling tests stay green
+    ///    because M=1 dispatches the correct GEMV.
+    /// 2. `test_support::sorted_gather_mm_untrustworthy` — the >= 64-index
+    ///    branch also switches expert dispatch to sorted `gather_mm`
+    ///    (`gather_mm_rhs_nax`), which is garbage at every K on such hosts.
+    ///
+    /// The gather-sort logic itself is NOT under suspicion: the identical
+    /// 32-token forward with f32 weights/input (same gather_sort /
+    /// scatter_unsort code, non-NAX kernels via MLX_ENABLE_TF32=0) matches
+    /// the per-token reference to 1.5e-8. Both canaries must be healthy
+    /// before the bf16 assertion means anything again, hence the OR.
     #[test]
     fn forward_64_index_gather_sort_branch() {
+        if crate::test_support::half_gemm_untrustworthy()
+            || crate::test_support::sorted_gather_mm_untrustworthy()
+        {
+            eprintln!(
+                "skipping forward_64_index_gather_sort_branch: this host's NAX \
+                 half-precision kernels are broken (plain unaligned-K GEMM \
+                 corrupts the [32,4]@[4,4] router gate, and/or sorted \
+                 gather_mm_rhs corrupts the expert matmuls), so the bf16 \
+                 gather-sort parity assertion is not meaningful here"
+            );
+            return;
+        }
         // 32 tokens x top_k=2 = 64 indices >= 64 → exercises the gather-sort
         // path in SwitchGLU::forward. Must equal the per-token reference.
         let bias = [0.0f32; N_EXP];

--- a/crates/mlx-core/src/models/paddleocr_vl/language.rs
+++ b/crates/mlx-core/src/models/paddleocr_vl/language.rs
@@ -315,6 +315,17 @@ pub fn apply_multimodal_rotary_pos_emb(
 /// head_dim` (the trailing `q_head_dim - head_dim` dims pass through unrotated,
 /// matching qwen3_5's partial-rotary factor).
 ///
+/// Split into [`select_interleaved_cos_sin`] (the `position_ids`/dtype-only
+/// half — independent of q/k) and [`apply_interleaved_rotary`] (the q/k
+/// half). Every full-attention layer in one Qwen3.5-VL forward pass shares
+/// byte-identical `position_ids`/`mrope_section`/dtype (`init_mrope_layers`
+/// seeds every layer from the same config), so a caller with multiple layers
+/// — e.g. `Qwen3_5Attention::forward_paged`'s per-forward-pass `mrope_cache`
+/// — computes `select_interleaved_cos_sin` ONCE and reuses it across layers
+/// instead of recomputing the cos/sin table + `take_along_axis` gather per
+/// layer. This wrapper stays byte-identical to the prior single-function
+/// implementation for callers that only ever see one (q, k) pair.
+///
 /// Note: Internal implementation detail, not exposed to TypeScript.
 pub fn apply_multimodal_rotary_pos_emb_interleaved(
     q: &MxArray,
@@ -322,6 +333,25 @@ pub fn apply_multimodal_rotary_pos_emb_interleaved(
     cos: &MxArray,
     sin: &MxArray,
     mrope_section: Vec<i32>,
+) -> Result<(MxArray, MxArray)> {
+    let (cos_final, sin_final) = select_interleaved_cos_sin(cos, sin, &mrope_section)?;
+    apply_interleaved_rotary(q, k, &cos_final, &sin_final)
+}
+
+/// Position-only half of [`apply_multimodal_rotary_pos_emb_interleaved`].
+///
+/// Builds the stride-3 per-frequency axis selector (mirroring mlx-vlm's
+/// `_interleaved_position_selector`) and gathers the selected
+/// `[batch, 1, seq_len, head_dim]` cos/sin rows out of the doubled
+/// `[3, batch, seq_len, head_dim]` cos/sin. Depends only on `cos`/`sin`
+/// (themselves a pure function of `position_ids` and dtype) and
+/// `mrope_section`/`head_dim` — NOT on q/k — so it is safe to compute ONCE
+/// per forward pass and reuse across every full-attention layer via
+/// [`apply_interleaved_rotary`].
+pub fn select_interleaved_cos_sin(
+    cos: &MxArray,
+    sin: &MxArray,
+    mrope_section: &[i32],
 ) -> Result<(MxArray, MxArray)> {
     let cos_shape = cos.shape()?; // 1 FFI call — cache and reuse below
     let batch_size = cos_shape[1];
@@ -358,9 +388,27 @@ pub fn apply_multimodal_rotary_pos_emb_interleaved(
     // [1, batch, seq, head_dim] -> [batch, 1, seq, head_dim] (flat order preserved).
     let cos_final = cos_sel.reshape(&[batch_size, 1, seq_len, head_dim])?;
     let sin_final = sin_sel.reshape(&[batch_size, 1, seq_len, head_dim])?;
+    Ok((cos_final, sin_final))
+}
 
+/// Q/K half of [`apply_multimodal_rotary_pos_emb_interleaved`]: applies
+/// `rotate_half` using an already-selected `(cos_final, sin_final)` pair from
+/// [`select_interleaved_cos_sin`]. Must be called once PER LAYER (q/k differ
+/// per layer) but does no cos/sin table build or gather work itself.
+///
+/// `cos_final`/`sin_final` shape: `[batch, 1, seq_len, head_dim]`.
+/// `q`/`k` shape: `[batch, heads, seq_len, q_head_dim]` where `q_head_dim >=
+/// head_dim` (the trailing `q_head_dim - head_dim` dims pass through
+/// unrotated, matching qwen3_5's partial-rotary factor).
+pub fn apply_interleaved_rotary(
+    q: &MxArray,
+    k: &MxArray,
+    cos_final: &MxArray,
+    sin_final: &MxArray,
+) -> Result<(MxArray, MxArray)> {
     // Standard rotate_half application (identical to the sectioned path tail).
-    let rotary_dim = head_dim;
+    let cos_shape = cos_final.shape()?; // 1 FFI call
+    let rotary_dim = cos_shape[3];
     let q_shape = q.shape()?; // 1 FFI call
     let q_dim = q_shape[3];
     let q_ndim = q_shape.len();
@@ -382,8 +430,8 @@ pub fn apply_multimodal_rotary_pos_emb_interleaved(
     let q_rotated = rotate_half(&q_rot, q_ndim, rotary_dim)?;
     let k_rotated = rotate_half(&k_rot, q_ndim, rotary_dim)?;
 
-    let q_embed = q_rot.mul(&cos_final)?.add(&q_rotated.mul(&sin_final)?)?;
-    let k_embed = k_rot.mul(&cos_final)?.add(&k_rotated.mul(&sin_final)?)?;
+    let q_embed = q_rot.mul(cos_final)?.add(&q_rotated.mul(sin_final)?)?;
+    let k_embed = k_rot.mul(cos_final)?.add(&k_rotated.mul(sin_final)?)?;
 
     let q_out = if let Some(q_pass) = q_pass {
         MxArray::concatenate_many(vec![&q_embed, &q_pass], Some(-1))?
@@ -1282,6 +1330,120 @@ mod tests {
             k_sec.to_float32().unwrap().as_ref(),
             k_int.to_float32().unwrap().as_ref(),
             "interleaved K must equal sectioned K for text tokens (t==h==w)"
+        );
+    }
+
+    #[test]
+    fn test_precomputed_cos_sin_reused_across_layers_matches_per_layer_recompute() {
+        // Regression for the M-RoPE precompute-once optimization: Qwen3.5-VL's
+        // paged prefill loop computes `select_interleaved_cos_sin` ONCE per
+        // forward pass via `Qwen3_5Attention::forward_paged`'s `mrope_cache`
+        // parameter and reuses the result across every full-attention layer,
+        // instead of recomputing the cos/sin table + axis-selector gather per
+        // layer (the pre-fix behaviour, still reachable through
+        // `apply_multimodal_rotary_pos_emb_interleaved`). This proves the
+        // precomputed pair is layer-invariant: applying it to TWO INDEPENDENT
+        // (q, k) pairs (simulating two different full-attention layers
+        // sharing one `position_ids`) must produce bit-identical results to
+        // calling the combined, per-layer-recompute wrapper independently for
+        // each layer.
+        let rope_dims = 64i32;
+        let mrope_section = vec![11i32, 11, 10];
+        let mrope =
+            MultimodalRoPE::new(rope_dims, 4096, Some(100_000.0), mrope_section.clone()).unwrap();
+
+        let seq_len = 5i64;
+        // Distinct per-axis positions (t != h != w) so this exercises genuine
+        // image-style M-RoPE, not just the text-invariant (t==h==w) case.
+        let mut pos_data = Vec::with_capacity(3 * seq_len as usize);
+        for axis in 0..3i64 {
+            for p in 0..seq_len {
+                pos_data.push((p + axis * 100) as f32);
+            }
+        }
+        let pos = MxArray::from_float32(&pos_data, &[3, 1, seq_len]).unwrap();
+        let x = MxArray::zeros(&[1, seq_len, rope_dims as i64], Some(DType::Float32)).unwrap();
+        let (cos, sin) = mrope.forward(&x, &pos).unwrap();
+
+        let head_dim = 96i64;
+        let heads = 2i64;
+        let q_layer1 = MxArray::random_uniform(
+            &[1, heads, seq_len, head_dim],
+            0.0,
+            1.0,
+            Some(DType::Float32),
+        )
+        .unwrap();
+        let k_layer1 = MxArray::random_uniform(
+            &[1, heads, seq_len, head_dim],
+            0.0,
+            1.0,
+            Some(DType::Float32),
+        )
+        .unwrap();
+        let q_layer2 = MxArray::random_uniform(
+            &[1, heads, seq_len, head_dim],
+            0.0,
+            1.0,
+            Some(DType::Float32),
+        )
+        .unwrap();
+        let k_layer2 = MxArray::random_uniform(
+            &[1, heads, seq_len, head_dim],
+            0.0,
+            1.0,
+            Some(DType::Float32),
+        )
+        .unwrap();
+
+        // Pre-fix behaviour: every "layer" independently recomputes the full
+        // selector + gather from `cos`/`sin`.
+        let (q1_ref, k1_ref) = apply_multimodal_rotary_pos_emb_interleaved(
+            &q_layer1,
+            &k_layer1,
+            &cos,
+            &sin,
+            mrope_section.clone(),
+        )
+        .unwrap();
+        let (q2_ref, k2_ref) = apply_multimodal_rotary_pos_emb_interleaved(
+            &q_layer2,
+            &k_layer2,
+            &cos,
+            &sin,
+            mrope_section.clone(),
+        )
+        .unwrap();
+
+        // Post-fix behaviour: compute the selected cos/sin ONCE, reuse for
+        // both "layers" (mirrors `Qwen3_5Attention::forward_paged`'s
+        // `mrope_cache` reuse).
+        let (cos_final, sin_final) =
+            select_interleaved_cos_sin(&cos, &sin, &mrope_section).unwrap();
+        let (q1_opt, k1_opt) =
+            apply_interleaved_rotary(&q_layer1, &k_layer1, &cos_final, &sin_final).unwrap();
+        let (q2_opt, k2_opt) =
+            apply_interleaved_rotary(&q_layer2, &k_layer2, &cos_final, &sin_final).unwrap();
+
+        assert_eq!(
+            q1_ref.to_float32().unwrap().as_ref(),
+            q1_opt.to_float32().unwrap().as_ref(),
+            "layer 1 Q must match the pre-fix per-layer recompute"
+        );
+        assert_eq!(
+            k1_ref.to_float32().unwrap().as_ref(),
+            k1_opt.to_float32().unwrap().as_ref(),
+            "layer 1 K must match the pre-fix per-layer recompute"
+        );
+        assert_eq!(
+            q2_ref.to_float32().unwrap().as_ref(),
+            q2_opt.to_float32().unwrap().as_ref(),
+            "layer 2 Q (reused cos/sin) must match the pre-fix per-layer recompute"
+        );
+        assert_eq!(
+            k2_ref.to_float32().unwrap().as_ref(),
+            k2_opt.to_float32().unwrap().as_ref(),
+            "layer 2 K (reused cos/sin) must match the pre-fix per-layer recompute"
         );
     }
 

--- a/crates/mlx-core/src/models/pp_doclayout_v3/model.rs
+++ b/crates/mlx-core/src/models/pp_doclayout_v3/model.rs
@@ -14,6 +14,8 @@
 //! 8. Decoder: iterative bbox refinement + class prediction + reading order
 //! 9. Post-processing: score thresholding + box decoding + reading order
 
+use std::sync::OnceLock;
+
 use crate::array::MxArray;
 use crate::nn::linear::Linear;
 use crate::nn::normalization::LayerNorm;
@@ -54,6 +56,12 @@ pub struct PPDocLayoutV3Model {
     mask_query_head: MLPPredictionHead,
     _denoising_class_embed: Option<MxArray>,
     image_processor: PPDocLayoutV3ImageProcessor,
+    /// Cached `(anchors, valid_mask)` from `generate_anchors`. `image_processor`
+    /// always resizes to a fixed 800x800 target (see processing.rs), so the
+    /// resulting `spatial_shapes_list` — and therefore the anchors/valid_mask —
+    /// is identical on every `detect()` call for this model instance. Computed
+    /// once on first use via `get_or_compute_anchors`.
+    anchor_cache: OnceLock<(MxArray, MxArray)>,
 }
 
 /// Generate anchor points for all feature levels.
@@ -132,6 +140,30 @@ fn generate_anchors(
     let inv_anchors = valid_mask.where_(&inv_anchors, &large_val)?;
 
     Ok((inv_anchors, valid_mask))
+}
+
+/// Return the cached `(anchors, valid_mask)` for `spatial_shapes_list`, computing
+/// and storing them on first use.
+///
+/// `generate_anchors` is a pure function of `(spatial_shapes_list, grid_size)` with
+/// no data dependence on image content, and `PPDocLayoutV3ImageProcessor` always
+/// resizes to a fixed 800x800 target, so `spatial_shapes_list` never changes across
+/// `detect()` calls for a given model instance. Caching removes ~30-40 redundant
+/// MLX op dispatches (arange/reshape/broadcast/concat/sigmoid) per call.
+fn get_or_compute_anchors(
+    cache: &OnceLock<(MxArray, MxArray)>,
+    spatial_shapes_list: &[(i64, i64)],
+    grid_size: f64,
+) -> Result<(MxArray, MxArray)> {
+    if let Some(cached) = cache.get() {
+        return Ok(cached.clone());
+    }
+    let computed = generate_anchors(spatial_shapes_list, grid_size)?;
+    // If another thread raced us here, `set` silently loses the race; both
+    // computations are equivalent since spatial_shapes_list is constant, so
+    // either value already stored is correct to keep using.
+    let _ = cache.set(computed.clone());
+    Ok(computed)
 }
 
 #[napi]
@@ -224,8 +256,9 @@ impl PPDocLayoutV3Model {
         }
         let level_start_index = MxArray::from_float32(&start_indices, &[num_levels as i64])?;
 
-        // 7. Generate anchors
-        let (anchors, valid_mask) = generate_anchors(&spatial_shapes_list, 0.05)?;
+        // 7. Generate anchors (cached across calls; see get_or_compute_anchors)
+        let (anchors, valid_mask) =
+            get_or_compute_anchors(&self.anchor_cache, &spatial_shapes_list, 0.05)?;
 
         // 8. Apply valid mask and compute encoder output
         let valid_mask_float = valid_mask.astype(crate::array::DType::Float32)?;
@@ -400,6 +433,7 @@ pub(super) fn create_model(
         mask_query_head,
         _denoising_class_embed: denoising_class_embed,
         image_processor: PPDocLayoutV3ImageProcessor::new(),
+        anchor_cache: OnceLock::new(),
     }
 }
 
@@ -418,5 +452,46 @@ mod tests {
 
         let v_shape: Vec<i64> = valid_mask.shape().unwrap().as_ref().to_vec();
         assert_eq!(v_shape, vec![1, total, 1]);
+    }
+
+    /// Regression test for the anchor cache: simulates two `detect()` calls (as
+    /// would happen for two different images, both resized to the fixed 800x800
+    /// target so `spatial_shapes_list` is identical) and asserts:
+    /// 1. The second call reuses the exact same cached MLX arrays (proving
+    ///    `generate_anchors` was not invoked again on cache hit), and
+    /// 2. The cached values are byte-for-byte identical to a fresh, uncached
+    ///    `generate_anchors` computation, so caching introduces no drift in the
+    ///    layout results.
+    #[test]
+    fn test_anchor_cache_reuses_across_calls_without_drift() {
+        let shapes = vec![(100, 100), (50, 50), (25, 25)];
+        let cache: OnceLock<(MxArray, MxArray)> = OnceLock::new();
+
+        // First "detect() call": cache is empty, computes and stores.
+        let (anchors1, valid1) = get_or_compute_anchors(&cache, &shapes, 0.05).unwrap();
+        // Second "detect() call" for a different image, same fixed target shapes.
+        let (anchors2, valid2) = get_or_compute_anchors(&cache, &shapes, 0.05).unwrap();
+
+        // Same underlying MLX array handle reused on cache hit.
+        assert_eq!(anchors1.as_raw_ptr(), anchors2.as_raw_ptr());
+        assert_eq!(valid1.as_raw_ptr(), valid2.as_raw_ptr());
+
+        // Cached values match a fresh, uncached computation exactly.
+        let (fresh_anchors, fresh_valid) = generate_anchors(&shapes, 0.05).unwrap();
+        assert_eq!(
+            anchors1.to_float32().unwrap().to_vec(),
+            fresh_anchors.to_float32().unwrap().to_vec()
+        );
+        let cached_valid_f32 = valid1
+            .astype(crate::array::DType::Float32)
+            .unwrap()
+            .to_float32()
+            .unwrap();
+        let fresh_valid_f32 = fresh_valid
+            .astype(crate::array::DType::Float32)
+            .unwrap()
+            .to_float32()
+            .unwrap();
+        assert_eq!(cached_valid_f32.to_vec(), fresh_valid_f32.to_vec());
     }
 }

--- a/crates/mlx-core/src/models/privacy_filter/attention.rs
+++ b/crates/mlx-core/src/models/privacy_filter/attention.rs
@@ -37,14 +37,16 @@ impl<'a> AttentionLayer<'a> {
     /// Input shape:  `[B, T, hidden_size]`
     /// Output shape: `[B, T, hidden_size]`
     ///
-    /// `band` is the bidirectional attention window in tokens —
-    /// `|q_pos - k_pos| <= band`. For `sliding_attention` layers pass
-    /// `config.sliding_window`; for `full_attention` layers pass an
-    /// effectively-unbounded value (use
-    /// [`PrivacyFilterConfig::band_for_layer`]). Per gpt-oss defaults,
-    /// half the layers alternate to full attention — applying the sliding
-    /// band to every layer cripples the bidirectional receptive field.
-    pub fn forward(&self, hidden: &MxArray, band: i32) -> Result<MxArray> {
+    /// `band_mask` is the precomputed `[T, T]` bidirectional band mask
+    /// (`0` where `|q_pos - k_pos| <= band`, `-inf` otherwise) for this
+    /// layer's attention window — built once via
+    /// `crate::array::banded_attention::build_band_mask` and shared by
+    /// every layer of the same type (`sliding_attention` vs
+    /// `full_attention`; see [`PrivacyFilterConfig::band_for_layer`]).
+    /// Building it once per distinct `(T, band)` pair instead of once per
+    /// layer matters here: gpt-oss alternates only 2 distinct bands
+    /// across the whole stack, so per-layer rebuilding is pure waste.
+    pub fn forward(&self, hidden: &MxArray, band_mask: &MxArray) -> Result<MxArray> {
         let batch = hidden.shape_at(0)?;
         let seq_len = hidden.shape_at(1)?;
 
@@ -130,15 +132,11 @@ impl<'a> AttentionLayer<'a> {
         let k = MxArray::from_handle(k, "privacy_filter yarn rope (k)")?;
 
         // 5. Banded attention with per-head sinks. Sliding window is
-        //    bidirectional: |q - k| <= band. `band` is supplied by the
-        //    caller because gpt-oss alternates sliding / full attention
-        //    per layer — see [`PrivacyFilterConfig::band_for_layer`].
-        if band < 0 {
-            return Err(Error::from_reason(format!(
-                "privacy_filter::AttentionLayer: band must be non-negative, got {band}",
-            )));
-        }
-        let attn = banded_attention(&q, &k, &v, &self.weights.sinks, band)?;
+        //    bidirectional: |q - k| <= band, already baked into
+        //    `band_mask` by the caller because gpt-oss alternates
+        //    sliding / full attention per layer — see
+        //    [`PrivacyFilterConfig::band_for_layer`].
+        let attn = banded_attention(&q, &k, &v, &self.weights.sinks, band_mask)?;
 
         // 6. Merge heads `[B, H, T, D]` → `[B, T, H*D]` and apply the output
         //    projection (`o_proj.weight` shape `[hidden_size, num_q_heads *
@@ -212,7 +210,12 @@ mod tests {
         .expect("random hidden");
 
         let band = loaded.config.band_for_layer(0);
-        let out = layer.forward(&hidden, band).expect("attention forward");
+        let seq_len = hidden.shape_at(1).expect("hidden seq_len");
+        let band_mask = crate::array::banded_attention::build_band_mask(seq_len, band)
+            .expect("build_band_mask");
+        let out = layer
+            .forward(&hidden, &band_mask)
+            .expect("attention forward");
 
         let shape = out.shape().unwrap().to_vec();
         assert_eq!(shape, vec![1, 8, loaded.config.hidden_size as i64]);
@@ -261,8 +264,11 @@ mod tests {
         .expect("random hidden");
 
         let band = loaded.config.band_for_layer(0);
-        let a = layer.forward(&hidden, band).expect("forward 1");
-        let b = layer.forward(&hidden, band).expect("forward 2");
+        let seq_len = hidden.shape_at(1).expect("hidden seq_len");
+        let band_mask = crate::array::banded_attention::build_band_mask(seq_len, band)
+            .expect("build_band_mask");
+        let a = layer.forward(&hidden, &band_mask).expect("forward 1");
+        let b = layer.forward(&hidden, &band_mask).expect("forward 2");
 
         let av = a.astype(DType::Float32).unwrap().to_float32().unwrap();
         let bv = b.astype(DType::Float32).unwrap().to_float32().unwrap();

--- a/crates/mlx-core/src/models/privacy_filter/forward.rs
+++ b/crates/mlx-core/src/models/privacy_filter/forward.rs
@@ -26,8 +26,11 @@
 //! of an LM head.
 
 use crate::array::MxArray;
+use crate::array::banded_attention::build_band_mask;
 use crate::nn::RMSNorm;
 use napi::bindgen_prelude::*;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::path::Path;
 
 use super::classifier::classifier_forward;
@@ -74,16 +77,31 @@ impl PrivacyFilterModel {
         //    produces `[B, T, hidden]`. Same pattern as
         //    `crate::nn::Embedding::forward`.
         let mut hidden = weights.embed_tokens.take(input_ids, 0)?;
+        let seq_len = hidden.shape_at(1)?;
 
-        // 2. Run all 8 transformer blocks. Each block needs its index to
-        //    decide whether to apply the sliding band or run full
-        //    bidirectional attention — gpt-oss alternates by default.
+        // 2. Run all 8 transformer blocks. Each block needs to know
+        //    whether to apply the sliding band or run full bidirectional
+        //    attention — gpt-oss alternates by default. `band_for_layer`
+        //    only ever returns a handful of distinct values (2 for the
+        //    default alternation), so the `[T, T]` band mask is built
+        //    once per distinct value here and reused across every layer
+        //    that shares it, instead of being rebuilt from scratch on
+        //    each of the 8 layers.
+        let mut band_mask_cache: HashMap<i32, MxArray> = HashMap::new();
         for (layer_idx, layer) in weights.layers.iter().enumerate() {
+            let band = cfg.band_for_layer(layer_idx);
+            if let Entry::Vacant(entry) = band_mask_cache.entry(band) {
+                entry.insert(build_band_mask(seq_len, band)?);
+            }
+            let band_mask = band_mask_cache
+                .get(&band)
+                .expect("band_mask inserted above");
+
             let block = Block {
                 weights: layer,
                 config: cfg,
                 yarn_freqs: &self.yarn_freqs,
-                layer_idx,
+                band_mask,
             };
             hidden = block.forward(&hidden)?;
         }

--- a/crates/mlx-core/src/models/privacy_filter/mod.rs
+++ b/crates/mlx-core/src/models/privacy_filter/mod.rs
@@ -215,17 +215,29 @@ impl PrivacyFilterModelJs {
         debug_assert_eq!(probs_flat.len(), n_tokens * num_classes);
         debug_assert_eq!(log_probs_flat.len(), n_tokens * num_classes);
 
-        // Drop GPU-side intermediates and reclaim MLX's buffer cache.
-        // Without this, repeated `classify` calls grow the cache
-        // unboundedly (one classify allocates ~per-layer hidden states,
-        // attention K/V, MLP gate/up/down for 8 layers + the [1, T, 33]
-        // logits + softmax/log-softmax tensors).
+        // Drop GPU-side intermediates. `probs.eval()` / `log_probs.eval()`
+        // above already forced the whole forward-pass graph to complete
+        // on the GPU before we pulled `probs_flat` / `log_probs_flat` to
+        // the host, so these drops just release refcounts.
         drop(probs);
         drop(log_probs);
         drop(logits_f32);
         drop(logits);
         drop(input_ids);
-        crate::array::memory::synchronize_and_clear_cache();
+
+        // Reclaim MLX's caching allocator — but on a cadence, not every
+        // call. Without *any* clearing, repeated `classify` calls grow
+        // the cache unboundedly (one classify allocates ~per-layer
+        // hidden states, attention K/V, MLP gate/up/down for 8 layers +
+        // the [1, T, 33] logits + softmax/log-softmax tensors). Clearing
+        // on *every* call pairs a full GPU stall with an allocator wipe
+        // on top of the actual forward pass, for every single
+        // invocation — worse than the paged-decode loop's old,
+        // already-rejected cadence=64 (see
+        // `crate::array::memory::PAGED_DECODE_CACHE_CLEAR_INTERVAL_DEFAULT`).
+        // See `maybe_clear_cache_for_privacy_filter_call`'s doc comment
+        // for why no extra `synchronize()` is needed at this call site.
+        crate::array::memory::maybe_clear_cache_for_privacy_filter_call();
 
         // ---- 4. Build the emission matrix [T, num_classes] from
         //         log-softmax. ----
@@ -405,5 +417,55 @@ mod tests {
         assert_eq!(merged.transition_bias_inside_to_end, -0.25);
         // Inherited zero-default:
         assert_eq!(merged.transition_bias_end_to_start, 0.0);
+    }
+
+    fn checkpoint_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join(".cache/models/privacy-filter")
+    }
+
+    /// Soak test for the cadence-gated cache clear in `classify()`
+    /// (`crate::array::memory::maybe_clear_cache_for_privacy_filter_call`).
+    ///
+    /// Runs `classify()` well past several cadence boundaries (default
+    /// interval is 8; 50 calls crosses it 6 times) and asserts MLX's
+    /// cache memory does not grow monotonically call-over-call — i.e.
+    /// gating the clear to every Nth call still bounds steady-state
+    /// footprint, it just amortizes the stall+wipe cost instead of
+    /// paying it on every single call.
+    #[test]
+    #[ignore = "requires .cache/models/privacy-filter — run with --ignored"]
+    fn classify_soak_cache_bounded() {
+        use crate::array::memory::get_cache_memory;
+
+        let inner = PrivacyFilterModel::load_from_dir(&checkpoint_dir()).expect("load model");
+        let model = PrivacyFilterModelJs { inner };
+
+        let text = "Hi I am Alice Smith, email alice@example.com";
+
+        // Warm up so first-call-only costs (e.g. any one-time kernel
+        // compilation) don't skew the "unbounded growth" comparison below.
+        model
+            .classify(text.to_string(), None)
+            .expect("warmup classify");
+        let cache_after_warmup = get_cache_memory();
+
+        for _ in 0..50 {
+            model.classify(text.to_string(), None).expect("classify");
+        }
+        let cache_after_soak = get_cache_memory();
+
+        // Bound rather than assert exact equality: allocator fragmentation
+        // can shift this a little run to run, but it must not scale with
+        // the number of calls (50 calls at unconditional-clear-per-call
+        // would stay ~flat too; this guards against a regression back to
+        // "never clear" rather than proving the OLD unconditional-clear
+        // behavior specifically).
+        assert!(
+            cache_after_soak <= cache_after_warmup * 3.0 + 16.0 * 1024.0 * 1024.0,
+            "cache memory grew unboundedly over 50 classify() calls: \
+             after_warmup={cache_after_warmup} after_soak={cache_after_soak}",
+        );
     }
 }

--- a/crates/mlx-core/src/models/privacy_filter/transformer.rs
+++ b/crates/mlx-core/src/models/privacy_filter/transformer.rs
@@ -42,11 +42,13 @@ pub struct Block<'a> {
     /// model load and threaded through every block — see
     /// [`super::yarn::compute_yarn_freqs`].
     pub yarn_freqs: &'a MxArray,
-    /// Index of this block within the stack (`0..num_hidden_layers`).
-    /// Drives the per-layer attention type (sliding vs full) via
-    /// [`PrivacyFilterConfig::band_for_layer`] — gpt-oss alternates
-    /// sliding/full attention by default.
-    pub layer_idx: usize,
+    /// Precomputed `[T, T]` band mask for this block's attention type
+    /// (sliding vs full — see [`PrivacyFilterConfig::band_for_layer`]).
+    /// Built once per distinct `(T, band)` pair by the caller
+    /// (`forward::PrivacyFilterModel::forward_logits`) and shared by
+    /// every layer of the same type, instead of being rebuilt here from
+    /// a raw `layer_idx` on every layer.
+    pub band_mask: &'a MxArray,
 }
 
 impl<'a> Block<'a> {
@@ -61,15 +63,14 @@ impl<'a> Block<'a> {
         let attn_in = pre_attn_norm.forward(hidden)?;
 
         // 2. Self-attention with banded mask + YaRN RoPE + sinks. The
-        //    band depends on whether this layer is `sliding_attention`
-        //    or `full_attention` per the gpt-oss default alternation.
+        //    band mask is precomputed by the caller and shared across
+        //    every layer of the same sliding/full type.
         let attn = AttentionLayer {
             weights: &self.weights.self_attn,
             config: self.config,
             yarn_freqs: self.yarn_freqs,
         };
-        let band = self.config.band_for_layer(self.layer_idx);
-        let attn_out = attn.forward(&attn_in, band)?;
+        let attn_out = attn.forward(&attn_in, self.band_mask)?;
 
         // 3. First residual.
         let hidden = hidden.add(&attn_out)?;

--- a/crates/mlx-core/src/models/quant_dispatch.rs
+++ b/crates/mlx-core/src/models/quant_dispatch.rs
@@ -36,8 +36,14 @@ pub enum PerLayerMode {
     /// `[N]` scales, no biases, group_size is null/meaningless). Consumed by
     /// the int8 kernels (`int8_w8a16_qmv` decode / `int8_w8a8_matmul`
     /// prefill), NEVER by `mlx_quantized_matmul` (there is no affine pack).
-    /// Dispatched by dense qwen3_5, lfm2/lfm2_moe, and gemma4 (all via the
-    /// shared `try_build_sym8_quantized_linear`); qwen3_5_moe still rejects.
+    /// Dispatched by dense qwen3_5, qwen3_5_moe (non-expert sublayers only —
+    /// attention q/k/v/o, GDN linear-attention, shared-expert MLP body; the
+    /// router gate and shared_expert_gate are accuracy-forced affine-8 by
+    /// `compute_moe_defaults` + convert's `is_router_gate`, so they never
+    /// dispatch sym8), lfm2/lfm2_moe, and gemma4 (all via the shared
+    /// `try_build_sym8_quantized_linear`). The per-expert `switch_mlp.*`
+    /// gather path (qwen3_5_moe, lfm2_moe) has no sym8 kernel and always
+    /// resolves to a forced-affine per-layer override instead.
     Sym8,
 }
 
@@ -72,14 +78,17 @@ pub fn parse_mode_str(s: Option<&str>) -> Option<PerLayerMode> {
 /// True when the resolved quantization settings reference sym8 anywhere
 /// (top-level default mode OR any per-layer override).
 ///
-/// Used by the loaders with sym8 dispatch (dense qwen3_5, lfm2/lfm2_moe,
-/// gemma4) to scope-gate the checkpoint: qwen3_5 pins flat KV + disables
-/// MTP/vision; lfm2 is eager-FLAT only v1, so it skips the C++
-/// compiled-forward registration (it stores 2-D `.weight` tensors in the
-/// [N,K] checkpoint orientation, which the shared `sym8_linear_proj`
-/// fail-loud rejects) and forces the flat decode shape; gemma4 has no
-/// compiled registry and keeps its eager paged default. qwen3_5_moe has no
-/// sym8 dispatch and uses this to fail loud up front.
+/// Used by the loaders with sym8 dispatch (dense qwen3_5, qwen3_5_moe,
+/// lfm2/lfm2_moe, gemma4) to scope-gate the checkpoint: qwen3_5 pins flat KV
+/// and disables MTP/vision; qwen3_5_moe disables its speculative MTP head and
+/// vision encoder the same way (the MTP module's own `try_build_ql`/
+/// `try_build_qsl` closures have unwired `Sym8 => None` arms, so a sym8 MTP
+/// head cannot load — the loader fail-softs to plain AR decode) while its
+/// AR-decode non-expert sublayers keep dispatching sym8; lfm2 is eager-FLAT
+/// only v1, so it skips the C++ compiled-forward registration (it stores 2-D
+/// `.weight` tensors in the [N,K] checkpoint orientation, which the shared
+/// `sym8_linear_proj` fail-loud rejects) and forces the flat decode shape;
+/// gemma4 has no compiled registry and keeps its eager paged default.
 pub fn has_sym8_mode(
     top_level_mode: Option<PerLayerMode>,
     per_layer: &HashMap<String, PerLayerQuant>,

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -4967,13 +4967,32 @@ mod tests {
     /// 97-token prompt. Tolerance budget mirrors the multi-chunk parity
     /// test (atol=rtol=5e-3 for bf16 + chunk-boundary fma reorderings).
     ///
-    /// Skips on no-Metal hosts.
+    /// Skips on no-Metal hosts, and on hosts whose half-precision GEMM
+    /// fails the `test_support::half_gemm_untrustworthy` canary: this
+    /// config's matmuls (K=64 projections, K=32 fallback-SDPA scores) sit
+    /// inside the vendored-MLX NAX unaligned-K broken regime on gen>=17
+    /// GPUs, and the 1-token tail chunk dispatches M=1 GEMV (correct)
+    /// where the single-shot rows go through the broken GEMM — so the two
+    /// paths deterministically diverge O(1) with no chunking bug present
+    /// (chunk-offset/mask/pool bookkeeping was verified independently:
+    /// the same comparison is byte-equal for 96/16 and 98/16 geometries,
+    /// and a patterned adapter write/read round-trip is exact for every
+    /// chunk geometry).
     #[test]
     fn test_chunked_prefill_uneven_tail_matches_single_shot() {
         // Block-paged needs the Metal backend; on a non-Metal build the
         // adapter is gated off (None) and there is nothing to exercise.
         if !crate::engine::persistence::compiled_forward_backend_available() {
             eprintln!("skipping (paged backend unavailable without Metal)");
+            return;
+        }
+        if crate::test_support::half_gemm_untrustworthy() {
+            eprintln!(
+                "skipping test_chunked_prefill_uneven_tail_matches_single_shot: \
+                 half-precision GEMM fails the K=64/N=64 canary on this host \
+                 (vendored-MLX NAX unaligned-K bug); tiny-config chunked-vs-\
+                 single-shot parity is not meaningful here"
+            );
             return;
         }
         let cfg = paged_tiny_config(Some(true));

--- a/crates/mlx-core/src/models/qwen3_5/adaptive_depth.rs
+++ b/crates/mlx-core/src/models/qwen3_5/adaptive_depth.rs
@@ -27,9 +27,9 @@
 //! drop-acceptance threshold (`0.75`) and probe-interval pattern are lifted
 //! directly.
 //!
-//! The compiled MTP verify graphs are pre-warmed at model load for every
-//! depth in `{1..=5}`, so switching depth between cycles is zero-cost from
-//! the compile side — the policy can swing freely.
+//! The MTP verify pass is pure-Rust eager — there are no per-depth
+//! compiled graphs to pre-warm, so switching depth between cycles carries
+//! no setup cost and the policy can swing freely.
 
 use std::time::Duration;
 

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -8,7 +8,8 @@ use crate::inference_trace::{
     elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
 };
 use crate::models::paddleocr_vl::language::{
-    MultimodalRoPE, apply_multimodal_rotary_pos_emb_interleaved,
+    MultimodalRoPE, apply_interleaved_rotary, apply_multimodal_rotary_pos_emb_interleaved,
+    select_interleaved_cos_sin,
 };
 use crate::nn::{Activations, Linear, RMSNorm, RoPE};
 use crate::transformer::KVCache;
@@ -351,6 +352,16 @@ impl Qwen3_5Attention {
     /// Returns `[B, T, hidden_size]` (post-output-projection,
     /// post-gate) so the layer's residual `h = x + r` matches the flat
     /// path.
+    /// `mrope_cache` is a per-forward-pass scratch slot for the M-RoPE arm:
+    /// every full-attention layer in one Qwen3.5-VL forward pass shares
+    /// byte-identical `position_ids`/`mrope_section`/dtype
+    /// (`init_mrope_layers` seeds every layer from the same config), so the
+    /// FIRST layer to see `Some(position_ids)` computes the selected cos/sin
+    /// and stores it here; every later layer in the same forward pass reuses
+    /// it instead of recomputing the cos/sin table + `take_along_axis`
+    /// gather. Callers outside the per-layer VLM prefill loop (decode / MTP
+    /// steps, which always pass `position_ids = None`) can pass `&mut None`
+    /// — it is never touched on that path.
     #[allow(clippy::too_many_arguments)]
     pub fn forward_paged(
         &self,
@@ -362,6 +373,7 @@ impl Qwen3_5Attention {
         is_prefill: bool,
         position_ids: Option<&MxArray>,
         rope_position_offset: i32,
+        mrope_cache: &mut Option<(MxArray, MxArray)>,
     ) -> Result<MxArray> {
         let batch = x.shape_at(0)?;
         let seq_len = x.shape_at(1)?;
@@ -399,16 +411,25 @@ impl Qwen3_5Attention {
         let (queries, keys) = if let (Some(pos_ids), Some(mrope)) = (position_ids, &self.mrope) {
             // Qwen3.5-VL uses the INTERLEAVED (stride-3) per-frequency axis
             // selector, NOT PaddleOCR-VL's contiguous-chunk (sectioned) one.
-            let (cos, sin) = mrope.forward(&queries, pos_ids)?;
+            //
+            // Every full-attention layer in one forward pass shares
+            // byte-identical `pos_ids`/`mrope_section`/dtype, so the cos/sin
+            // table build + axis-selector gather only needs to run once per
+            // forward pass (see `mrope_cache`'s doc comment above), not once
+            // per full-attention layer.
+            let (cos_final, sin_final) = match mrope_cache {
+                Some(cached) => cached.clone(),
+                None => {
+                    let (cos, sin) = mrope.forward(&queries, pos_ids)?;
+                    let selected =
+                        select_interleaved_cos_sin(&cos, &sin, mrope.mrope_section_arr())?;
+                    *mrope_cache = Some(selected.clone());
+                    selected
+                }
+            };
             let q_t = queries.transpose(Some(&[0, 2, 1, 3]))?;
             let k_t = keys.transpose(Some(&[0, 2, 1, 3]))?;
-            let (q_out, k_out) = apply_multimodal_rotary_pos_emb_interleaved(
-                &q_t,
-                &k_t,
-                &cos,
-                &sin,
-                mrope.mrope_section_arr().to_vec(),
-            )?;
+            let (q_out, k_out) = apply_interleaved_rotary(&q_t, &k_t, &cos_final, &sin_final)?;
             let q_out = q_out.transpose(Some(&[0, 2, 1, 3]))?;
             let k_out = k_out.transpose(Some(&[0, 2, 1, 3]))?;
             (q_out, k_out)

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -41,6 +41,28 @@ pub struct Qwen3_5Attention {
     num_kv_heads: i32,
     head_dim: i32,
     scale: f32,
+
+    /// Pre-transposed, OUTPUT-reordered `[hidden, 2*num_heads*head_dim]`
+    /// q_proj weight: block order `[Q_h0..Q_h{H-1}, G_h0..G_h{H-1}]` instead
+    /// of the checkpoint's per-head-interleaved order
+    /// `[Q_h0,G_h0,Q_h1,G_h1,...]`. Populated once by
+    /// `finalize_q_gate_block()` after `q_proj` is loaded; invalidated back
+    /// to `None` by any `q_proj` setter.
+    ///
+    /// When present, `project_q_gate` slices queries/gate as two flat,
+    /// row-contiguous halves of one matmul output instead of reshaping to
+    /// `[B,T,H,2D]` and slicing per head. The per-head split's `gate` slice
+    /// has a `2*head_dim` stride between heads, so `reshape([B,T,H*D])`
+    /// fails MLX's `prepare_reshape` free-view check and dispatches a real
+    /// strided `copy_gpu_inplace` (`CopyType::General`) Metal kernel on
+    /// every call — this cache makes that copy a one-time load-time cost
+    /// instead of a per-forward one. `None` (falls back to the unfused
+    /// per-head path) when `q_proj` is quantized, mirroring
+    /// `GatedDeltaNet::finalize_in_proj`.
+    q_gate_block_t: Option<MxArray>,
+    /// Reordered `[2*num_heads*head_dim]` q_proj bias matching
+    /// `q_gate_block_t`'s column order. `None` when q_proj has no bias.
+    q_gate_block_bias: Option<MxArray>,
 }
 
 fn paged_prefill_paged_attention_enabled() -> bool {
@@ -123,7 +145,65 @@ impl Qwen3_5Attention {
             num_kv_heads,
             head_dim,
             scale,
+            q_gate_block_t: None,
+            q_gate_block_bias: None,
         })
+    }
+
+    /// Project queries + gate, returning `(queries [B,T,H,D], gate
+    /// [B,T,H*D])`.
+    ///
+    /// Fast path (`q_gate_block_t` present, i.e. `q_proj` is non-quantized
+    /// and `finalize_q_gate_block()` has run): one matmul against the
+    /// block-ordered weight, then two flat `slice_axis` calls — both
+    /// already row-contiguous, so `queries`'s subsequent `[B,T,H,D]`
+    /// reshape is a free view and `gate` needs no reshape at all.
+    /// `MLX_DISABLE_QGATE_BLOCK_SPLIT=1` forces the fallback below (for
+    /// same-binary A/B benchmarking), mirroring
+    /// `MLX_DISABLE_E51_STACKED_GDN_IN_PROJ`.
+    ///
+    /// Fallback path (quantized `q_proj`, or the env override above):
+    /// the original per-head reshape+slice, unchanged from before this
+    /// split existed. `gate`'s reshape here pays a strided
+    /// `copy_gpu_inplace` every call — see `q_gate_block_t`'s doc comment.
+    fn project_q_gate(&self, x: &MxArray, batch: i64, seq_len: i64) -> Result<(MxArray, MxArray)> {
+        let hd = (self.num_heads * self.head_dim) as i64;
+        if let Some(w_block_t) = &self.q_gate_block_t
+            && std::env::var("MLX_DISABLE_QGATE_BLOCK_SPLIT").is_err()
+        {
+            let flat = match &self.q_gate_block_bias {
+                Some(bias) => x.addmm(bias, w_block_t, None, None)?,
+                None => x.matmul(w_block_t)?,
+            };
+            let queries_flat = flat.slice_axis(2, 0, hd)?;
+            let gate = flat.slice_axis(2, hd, 2 * hd)?;
+            let queries = queries_flat.reshape(&[
+                batch,
+                seq_len,
+                self.num_heads as i64,
+                self.head_dim as i64,
+            ])?;
+            Ok((queries, gate))
+        } else {
+            // Project queries (2x width for gating)
+            let q_proj_output = self.q_proj.forward(x)?;
+
+            // Split into queries and gate PER-HEAD (not flat):
+            //   reshape to [B, T, num_heads, head_dim*2]
+            //   split on last axis → queries [B,T,H,D] and gate [B,T,H,D]
+            let q_per_head = q_proj_output.reshape(&[
+                batch,
+                seq_len,
+                self.num_heads as i64,
+                (self.head_dim * 2) as i64,
+            ])?;
+            let queries = q_per_head.slice_axis(3, 0, self.head_dim as i64)?;
+            let gate =
+                q_per_head.slice_axis(3, self.head_dim as i64, (self.head_dim * 2) as i64)?;
+            // Flatten gate for later: [B, T, H, D] → [B, T, H*D]
+            let gate = gate.reshape(&[batch, seq_len, hd])?;
+            Ok((queries, gate))
+        }
     }
 
     /// Forward pass.
@@ -147,22 +227,9 @@ impl Qwen3_5Attention {
         let batch = x.shape_at(0)?;
         let seq_len = x.shape_at(1)?;
 
-        // Project queries (2x width for gating)
-        let q_proj_output = self.q_proj.forward(x)?;
-
-        // Split into queries and gate PER-HEAD (not flat):
-        //   reshape to [B, T, num_heads, head_dim*2]
-        //   split on last axis → queries [B,T,H,D] and gate [B,T,H,D]
-        let q_per_head = q_proj_output.reshape(&[
-            batch,
-            seq_len,
-            self.num_heads as i64,
-            (self.head_dim * 2) as i64,
-        ])?;
-        let queries = q_per_head.slice_axis(3, 0, self.head_dim as i64)?;
-        let gate = q_per_head.slice_axis(3, self.head_dim as i64, (self.head_dim * 2) as i64)?;
-        // Flatten gate for later: [B, T, H, D] → [B, T, H*D]
-        let gate = gate.reshape(&[batch, seq_len, (self.num_heads * self.head_dim) as i64])?;
+        // Project queries (2x width for gating), split into per-head
+        // queries [B,T,H,D] and flat gate [B,T,H*D]. See `project_q_gate`.
+        let (queries, gate) = self.project_q_gate(x, batch, seq_len)?;
 
         // Project keys and values
         let keys = self.k_proj.forward(x)?;
@@ -299,19 +366,9 @@ impl Qwen3_5Attention {
         let batch = x.shape_at(0)?;
         let seq_len = x.shape_at(1)?;
 
-        // Project queries (2x width for gating).
-        let q_proj_output = self.q_proj.forward(x)?;
-
-        // Per-head split of queries / gate (matches forward()).
-        let q_per_head = q_proj_output.reshape(&[
-            batch,
-            seq_len,
-            self.num_heads as i64,
-            (self.head_dim * 2) as i64,
-        ])?;
-        let queries = q_per_head.slice_axis(3, 0, self.head_dim as i64)?;
-        let gate = q_per_head.slice_axis(3, self.head_dim as i64, (self.head_dim * 2) as i64)?;
-        let gate = gate.reshape(&[batch, seq_len, (self.num_heads * self.head_dim) as i64])?;
+        // Project queries (2x width for gating), split into per-head
+        // queries / flat gate (matches forward(); see `project_q_gate`).
+        let (queries, gate) = self.project_q_gate(x, batch, seq_len)?;
 
         // K/V projections + reshape to per-head layout.
         let keys = self.k_proj.forward(x)?;
@@ -645,6 +702,8 @@ impl Qwen3_5Attention {
     // ========== Weight accessors (standard mode) ==========
 
     pub fn set_q_proj_weight(&mut self, w: &MxArray) -> Result<()> {
+        self.q_gate_block_t = None; // invalidate block-order cache
+        self.q_gate_block_bias = None;
         self.q_proj.set_weight(w, "q_proj")
     }
     pub fn set_k_proj_weight(&mut self, w: &MxArray) -> Result<()> {
@@ -657,6 +716,8 @@ impl Qwen3_5Attention {
         self.o_proj.set_weight(w, "o_proj")
     }
     pub fn set_q_proj_bias(&mut self, b: Option<&MxArray>) -> Result<()> {
+        self.q_gate_block_t = None;
+        self.q_gate_block_bias = None;
         self.q_proj.set_bias(b, "q_proj")
     }
     pub fn set_k_proj_bias(&mut self, b: Option<&MxArray>) -> Result<()> {
@@ -675,9 +736,53 @@ impl Qwen3_5Attention {
         self.k_norm.set_weight(w)
     }
 
+    /// Precompute the block-ordered `[hidden, 2*H*D]` q_proj weight (queries
+    /// flat | gate flat) so `project_q_gate` can split queries vs. gate as
+    /// two flat, row-contiguous slices instead of reshaping to
+    /// `[B,T,H,2D]` and slicing per head. See `q_gate_block_t`'s doc
+    /// comment for why the checkpoint's native per-head-interleaved column
+    /// order forces a strided copy on every call.
+    ///
+    /// Safe to call repeatedly (idempotent). No-op when `q_proj` is
+    /// quantized — mirrors `GatedDeltaNet::finalize_in_proj` (quantized
+    /// checkpoints stay on the unfused path).
+    pub fn finalize_q_gate_block(&mut self) -> Result<()> {
+        let LinearProj::Standard(q_lin) = &self.q_proj else {
+            return Ok(());
+        };
+        let h = self.num_heads as i64;
+        let d = self.head_dim as i64;
+
+        let weight = q_lin.get_weight(); // [2*H*D, hidden], per-head-interleaved
+        let hidden = weight.shape_at(1)?;
+        let w_per_head = weight.reshape(&[h, 2 * d, hidden])?;
+        let w_q = w_per_head.slice_axis(1, 0, d)?.reshape(&[h * d, hidden])?;
+        let w_g = w_per_head
+            .slice_axis(1, d, 2 * d)?
+            .reshape(&[h * d, hidden])?;
+        let w_block_t = MxArray::concatenate(&w_q, &w_g, 0)?.transpose(Some(&[1, 0]))?;
+        w_block_t.eval();
+        self.q_gate_block_t = Some(w_block_t);
+
+        self.q_gate_block_bias = match q_lin.get_bias() {
+            Some(b) => {
+                let b_per_head = b.reshape(&[h, 2 * d])?;
+                let b_q = b_per_head.slice_axis(1, 0, d)?.reshape(&[h * d])?;
+                let b_g = b_per_head.slice_axis(1, d, 2 * d)?.reshape(&[h * d])?;
+                let b_block = MxArray::concatenate(&b_q, &b_g, 0)?;
+                b_block.eval();
+                Some(b_block)
+            }
+            None => None,
+        };
+        Ok(())
+    }
+
     // ========== Quantized setters ==========
 
     pub fn set_quantized_q_proj(&mut self, ql: QuantizedLinear) {
+        self.q_gate_block_t = None;
+        self.q_gate_block_bias = None;
         self.q_proj.set_quantized(ql);
     }
     pub fn set_quantized_k_proj(&mut self, ql: QuantizedLinear) {
@@ -722,5 +827,202 @@ impl Qwen3_5Attention {
             || self.k_proj.is_quantized()
             || self.v_proj.is_quantized()
             || self.o_proj.is_quantized()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_cfg() -> Qwen3_5Config {
+        Qwen3_5Config {
+            vocab_size: 32,
+            hidden_size: 32,
+            num_layers: 1,
+            num_heads: 4,
+            num_kv_heads: 2,
+            intermediate_size: 64,
+            rms_norm_eps: 1e-6,
+            head_dim: 8,
+            tie_word_embeddings: true,
+            attention_bias: false,
+            max_position_embeddings: 128,
+            pad_token_id: 0,
+            eos_token_id: 0,
+            bos_token_id: 0,
+            linear_num_value_heads: 4,
+            linear_num_key_heads: 2,
+            linear_key_head_dim: 8,
+            linear_value_head_dim: 8,
+            linear_conv_kernel_dim: 4,
+            full_attention_interval: 4,
+            partial_rotary_factor: 0.5,
+            rope_theta: 100_000.0,
+            paged_cache_memory_mb: None,
+            paged_block_size: None,
+            use_block_paged_cache: None,
+            n_mtp_layers: 0,
+        }
+    }
+
+    /// Builds two `Qwen3_5Attention`s from byte-identical q/k/v/o weights:
+    /// one with `finalize_q_gate_block()` called (block-order fast path in
+    /// `project_q_gate`) and one without (the pre-fix per-head
+    /// reshape+slice fallback). Asserts `forward()` produces numerically
+    /// identical output on both — proving the q_proj row reorder is a pure
+    /// layout change with no effect on the computed queries/gate values.
+    #[test]
+    fn q_gate_block_split_matches_unfused_fallback() -> Result<()> {
+        let cfg = tiny_cfg();
+        let mut fast = Qwen3_5Attention::new(&cfg)?;
+        let mut slow = Qwen3_5Attention::new(&cfg)?;
+
+        let h = cfg.num_heads as i64;
+        let d = cfg.head_dim as i64;
+        let hidden = cfg.hidden_size as i64;
+        let kv = cfg.num_kv_heads as i64;
+
+        // Deterministic, distinct-per-element weights (iota-derived) so any
+        // column-reorder bug shows up as a numeric mismatch rather than
+        // hiding behind a symmetric weight matrix.
+        let q_w: Vec<f32> = (0..(2 * h * d * hidden))
+            .map(|i| (i as f32) * 0.001)
+            .collect();
+        let k_w: Vec<f32> = (0..(kv * d * hidden))
+            .map(|i| (i as f32) * 0.001 + 1.0)
+            .collect();
+        let v_w: Vec<f32> = (0..(kv * d * hidden))
+            .map(|i| (i as f32) * 0.001 + 2.0)
+            .collect();
+        let o_w: Vec<f32> = (0..(hidden * h * d))
+            .map(|i| (i as f32) * 0.001 + 3.0)
+            .collect();
+
+        let q_weight = MxArray::from_float32(&q_w, &[2 * h * d, hidden])?;
+        let k_weight = MxArray::from_float32(&k_w, &[kv * d, hidden])?;
+        let v_weight = MxArray::from_float32(&v_w, &[kv * d, hidden])?;
+        let o_weight = MxArray::from_float32(&o_w, &[hidden, h * d])?;
+
+        for attn in [&mut fast, &mut slow] {
+            attn.set_q_proj_weight(&q_weight)?;
+            attn.set_k_proj_weight(&k_weight)?;
+            attn.set_v_proj_weight(&v_weight)?;
+            attn.set_o_proj_weight(&o_weight)?;
+        }
+        fast.finalize_q_gate_block()?;
+        // `slow` intentionally left un-finalized: `q_gate_block_t` stays
+        // `None`, exercising the pre-fix per-head reshape+slice path.
+        assert!(slow.q_gate_block_t.is_none());
+        assert!(fast.q_gate_block_t.is_some());
+
+        let x_data: Vec<f32> = (0..(2 * hidden))
+            .map(|i| ((i as f32) * 0.01).sin())
+            .collect();
+        let x = MxArray::from_float32(&x_data, &[1, 2, hidden])?;
+
+        let out_fast = fast.forward(&x, None, None, None)?;
+        let out_slow = slow.forward(&x, None, None, None)?;
+
+        let got = out_fast.to_float32()?;
+        let want = out_slow.to_float32()?;
+        assert_eq!(got.len(), want.len());
+        // Empirically bit-identical (both paths compute the same per-column
+        // dot products, just via differently-ordered matmul calls); keep a
+        // tight-but-nonzero epsilon so the test isn't brittle to a future
+        // MLX GEMM version choosing different tiling.
+        for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+            assert!(
+                (g - w).abs() < 1e-6,
+                "mismatch at element {i}: fast={g} slow={w}"
+            );
+        }
+        Ok(())
+    }
+
+    /// Same parity check as `q_gate_block_split_matches_unfused_fallback`,
+    /// but WITH a q_proj bias loaded. This exercises the two bias-only
+    /// branches the no-bias test above never reaches: the
+    /// `q_lin.get_bias() => Some(b)` bias reorder in `finalize_q_gate_block`
+    /// and the `Some(bias) => x.addmm(bias, ...)` fast path in
+    /// `project_q_gate`. `Linear::set_bias` accepts a bias regardless of
+    /// `attention_bias`, so the same tiny config is reused.
+    #[test]
+    fn q_gate_block_split_matches_unfused_fallback_with_bias() -> Result<()> {
+        let cfg = tiny_cfg();
+        let mut fast = Qwen3_5Attention::new(&cfg)?;
+        let mut slow = Qwen3_5Attention::new(&cfg)?;
+
+        let h = cfg.num_heads as i64;
+        let d = cfg.head_dim as i64;
+        let hidden = cfg.hidden_size as i64;
+        let kv = cfg.num_kv_heads as i64;
+
+        // Byte-identical iota-derived weights, same as the no-bias test.
+        let q_w: Vec<f32> = (0..(2 * h * d * hidden))
+            .map(|i| (i as f32) * 0.001)
+            .collect();
+        let k_w: Vec<f32> = (0..(kv * d * hidden))
+            .map(|i| (i as f32) * 0.001 + 1.0)
+            .collect();
+        let v_w: Vec<f32> = (0..(kv * d * hidden))
+            .map(|i| (i as f32) * 0.001 + 2.0)
+            .collect();
+        let o_w: Vec<f32> = (0..(hidden * h * d))
+            .map(|i| (i as f32) * 0.001 + 3.0)
+            .collect();
+        // Distinct iota-derived q_proj bias, per-head-interleaved `[2*H*D]`
+        // to match the checkpoint column order `finalize_q_gate_block`
+        // reorders. Nonzero + distinct-per-element so a bias-reorder bug
+        // surfaces as a numeric mismatch.
+        let q_b: Vec<f32> = (0..(2 * h * d)).map(|i| (i as f32) * 0.01 + 4.0).collect();
+
+        let q_weight = MxArray::from_float32(&q_w, &[2 * h * d, hidden])?;
+        let k_weight = MxArray::from_float32(&k_w, &[kv * d, hidden])?;
+        let v_weight = MxArray::from_float32(&v_w, &[kv * d, hidden])?;
+        let o_weight = MxArray::from_float32(&o_w, &[hidden, h * d])?;
+        let q_bias = MxArray::from_float32(&q_b, &[2 * h * d])?;
+
+        for attn in [&mut fast, &mut slow] {
+            attn.set_q_proj_weight(&q_weight)?;
+            attn.set_k_proj_weight(&k_weight)?;
+            attn.set_v_proj_weight(&v_weight)?;
+            attn.set_o_proj_weight(&o_weight)?;
+            // Load the q_proj bias BEFORE finalize: every q_proj setter
+            // invalidates the block cache to `None`, so `finalize` must run
+            // last to snapshot both the weight and the bias (matches the
+            // production load order).
+            attn.set_q_proj_bias(Some(&q_bias))?;
+        }
+        fast.finalize_q_gate_block()?;
+        // `slow` intentionally left un-finalized: exercises the per-head
+        // reshape+slice fallback (with `Linear::forward`'s own bias add).
+        assert!(slow.q_gate_block_t.is_none());
+        assert!(fast.q_gate_block_t.is_some());
+        // Proves the bias-reorder branch actually ran (vs. silently taking
+        // the `None` arm): `q_gate_block_bias` is populated only when
+        // `q_proj` has a bias to reorder.
+        assert!(
+            fast.q_gate_block_bias.is_some(),
+            "finalize_q_gate_block should have reordered the q_proj bias"
+        );
+
+        let x_data: Vec<f32> = (0..(2 * hidden))
+            .map(|i| ((i as f32) * 0.01).sin())
+            .collect();
+        let x = MxArray::from_float32(&x_data, &[1, 2, hidden])?;
+
+        let out_fast = fast.forward(&x, None, None, None)?;
+        let out_slow = slow.forward(&x, None, None, None)?;
+
+        let got = out_fast.to_float32()?;
+        let want = out_slow.to_float32()?;
+        assert_eq!(got.len(), want.len());
+        for (i, (g, w)) in got.iter().zip(want.iter()).enumerate() {
+            assert!(
+                (g - w).abs() < 1e-6,
+                "mismatch at element {i}: fast={g} slow={w}"
+            );
+        }
+        Ok(())
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -276,11 +276,26 @@ impl Qwen3_5Attention {
             let k_out = k_out.transpose(Some(&[0, 2, 1, 3]))?;
             (q_out, k_out)
         } else {
-            // Standard scalar offset RoPE (text-only path, existing behavior)
+            // Standard scalar-offset RoPE (text-only path).
+            //
+            // `fast::rope` varies the rotation position along axis -2 of its
+            // input, so it must see the [B, H, T, D] layout (token axis at
+            // -2) — matching mlx-lm's `self.rope(x.transpose(0, 2, 1, 3),
+            // offset)`. Applying it on [B, T, H, D] rotates along the HEAD
+            // axis instead: every token in a multi-token forward gets the
+            // same angle (offset + head_index), collapsing per-token
+            // positions. Transpose in, rotate, transpose back (the extra
+            // transposes are views; the rope Metal kernel handles the
+            // transposed stride pattern without a copy).
             let offset = cache.as_ref().map_or(0, |c| c.get_offset());
-            let queries = self.rope.forward(&queries, Some(offset))?;
-            let keys = self.rope.forward(&keys, Some(offset))?;
-            (queries, keys)
+            let q_t = queries.transpose(Some(&[0, 2, 1, 3]))?;
+            let k_t = keys.transpose(Some(&[0, 2, 1, 3]))?;
+            let q_rot = self.rope.forward(&q_t, Some(offset))?;
+            let k_rot = self.rope.forward(&k_t, Some(offset))?;
+            (
+                q_rot.transpose(Some(&[0, 2, 1, 3]))?,
+                k_rot.transpose(Some(&[0, 2, 1, 3]))?,
+            )
         };
 
         // Transpose to [B, H, T, D] for KVCache and SDPA
@@ -439,12 +454,22 @@ impl Qwen3_5Attention {
             // warm-continues an image prefill rotates at the compressed
             // M-RoPE position (physical slot + a negative cross-turn delta)
             // while K/V still writes at the physical slot below. Text turns
-            // pass `rope_position_offset == first_logical_position as i32`,
-            // so this stays byte-identical to the prior behaviour.
+            // pass `rope_position_offset == first_logical_position as i32`.
+            //
+            // `fast::rope` varies the rotation position along axis -2 of its
+            // input, so it must see the [B, H, T, D] layout (token axis at
+            // -2) — matching mlx-lm and the flat `forward` above. Applying
+            // it on [B, T, H, D] rotates along the HEAD axis, collapsing
+            // per-token positions within any multi-token chunk.
             let rope_offset = rope_position_offset;
-            let queries = self.rope.forward(&queries, Some(rope_offset))?;
-            let keys = self.rope.forward(&keys, Some(rope_offset))?;
-            (queries, keys)
+            let q_t = queries.transpose(Some(&[0, 2, 1, 3]))?;
+            let k_t = keys.transpose(Some(&[0, 2, 1, 3]))?;
+            let q_rot = self.rope.forward(&q_t, Some(rope_offset))?;
+            let k_rot = self.rope.forward(&k_t, Some(rope_offset))?;
+            (
+                q_rot.transpose(Some(&[0, 2, 1, 3]))?,
+                k_rot.transpose(Some(&[0, 2, 1, 3]))?,
+            )
         };
 
         // Transpose to [B, H, T, D] for SDPA.
@@ -884,6 +909,102 @@ mod tests {
             use_block_paged_cache: None,
             n_mtp_layers: 0,
         }
+    }
+
+    /// RoPE token-axis regression test. Prefills one KV cache with a single
+    /// 4-token forward (chunk) and another with 4 single-token forwards
+    /// (stepwise), then runs the same probe token through both caches and
+    /// compares the outputs.
+    ///
+    /// `fast::rope` varies the rotation position along axis -2 of its
+    /// input. The scalar-offset arm used to rope on `[B, T, H, D]`, which
+    /// rotates along the HEAD axis: in the 4-token chunk every token got
+    /// the same angle (`offset + head_index`), while the stepwise path got
+    /// per-token angles — so the two caches held O(1)-different keys and
+    /// the probe outputs diverged (observed max_abs_diff 0.053 with this
+    /// setup, vs 1.4e-4 with the fix). With the rotation on `[B, H, T, D]`
+    /// the caches agree and the probe outputs match to f32-kernel noise.
+    ///
+    /// Everything is f32 on purpose: f32 matmuls take the non-NAX Metal
+    /// path on gen-17 GPUs, so this test isolates rope-layout semantics
+    /// from the half-precision NAX GEMM issues that poison bf16
+    /// chunk-vs-stepwise comparisons on M5 hosts (see cleanup-G report).
+    #[test]
+    fn scalar_rope_rotates_along_token_axis() -> Result<()> {
+        let cfg = tiny_cfg();
+        let mut attn = Qwen3_5Attention::new(&cfg)?;
+
+        let h = cfg.num_heads as i64;
+        let d = cfg.head_dim as i64;
+        let hidden = cfg.hidden_size as i64;
+        let kv = cfg.num_kv_heads as i64;
+
+        // Deterministic weights, scaled small so multi-layer products stay
+        // O(1) in f32.
+        let q_w: Vec<f32> = (0..(2 * h * d * hidden))
+            .map(|i| ((i as f32) * 0.7391).sin() * 0.2)
+            .collect();
+        let k_w: Vec<f32> = (0..(kv * d * hidden))
+            .map(|i| ((i as f32) * 0.5711 + 1.0).sin() * 0.2)
+            .collect();
+        let v_w: Vec<f32> = (0..(kv * d * hidden))
+            .map(|i| ((i as f32) * 0.9173 + 2.0).sin() * 0.2)
+            .collect();
+        let o_w: Vec<f32> = (0..(hidden * h * d))
+            .map(|i| ((i as f32) * 0.6133 + 3.0).sin() * 0.2)
+            .collect();
+        attn.set_q_proj_weight(&MxArray::from_float32(&q_w, &[2 * h * d, hidden])?)?;
+        attn.set_k_proj_weight(&MxArray::from_float32(&k_w, &[kv * d, hidden])?)?;
+        attn.set_v_proj_weight(&MxArray::from_float32(&v_w, &[kv * d, hidden])?)?;
+        attn.set_o_proj_weight(&MxArray::from_float32(&o_w, &[hidden, h * d])?)?;
+
+        let x_vals: Vec<f32> = (0..(4 * hidden))
+            .map(|i| ((i as f32) * 0.8317).sin())
+            .collect();
+        let probe_vals: Vec<f32> = (0..hidden)
+            .map(|i| ((i as f32) * 0.3719 + 5.0).sin())
+            .collect();
+        let probe = MxArray::from_float32(&probe_vals, &[1, 1, hidden])?;
+
+        // Chunk prefill: one 4-token forward.
+        let mut cache_chunk = KVCache::new();
+        let x_full = MxArray::from_float32(&x_vals, &[1, 4, hidden])?;
+        let _ = attn.forward(&x_full, None, Some(&mut cache_chunk), None)?;
+        assert_eq!(cache_chunk.get_offset(), 4);
+
+        // Stepwise prefill: four 1-token forwards.
+        let mut cache_step = KVCache::new();
+        for t in 0..4usize {
+            let x_t = MxArray::from_float32(
+                &x_vals[t * hidden as usize..(t + 1) * hidden as usize],
+                &[1, 1, hidden],
+            )?;
+            let _ = attn.forward(&x_t, None, Some(&mut cache_step), None)?;
+        }
+        assert_eq!(cache_step.get_offset(), 4);
+
+        // Same probe token through both caches.
+        let out_chunk = attn.forward(&probe, None, Some(&mut cache_chunk), None)?;
+        let out_step = attn.forward(&probe, None, Some(&mut cache_step), None)?;
+
+        let a = out_chunk.to_float32()?;
+        let b = out_step.to_float32()?;
+        assert_eq!(a.len(), b.len());
+        let mut max_diff = 0.0f32;
+        for (x, y) in a.iter().zip(b.iter()) {
+            max_diff = max_diff.max((x - y).abs());
+        }
+        // Observed ~1.4e-4 with the fix (chunk vs stepwise runs different
+        // f32 GEMM/GEMV kernels and softmax reduction orders); the broken
+        // head-axis rotation produced ~0.9. 1e-3 sits three orders of
+        // magnitude below the failure signal.
+        assert!(
+            max_diff < 1e-3,
+            "chunk-prefilled and stepwise-prefilled caches disagree \
+             (max_abs_diff={max_diff}); scalar RoPE is not rotating along \
+             the token axis"
+        );
+        Ok(())
     }
 
     /// Builds two `Qwen3_5Attention`s from byte-identical q/k/v/o weights:

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -285,8 +285,10 @@ impl Qwen3_5Attention {
             // axis instead: every token in a multi-token forward gets the
             // same angle (offset + head_index), collapsing per-token
             // positions. Transpose in, rotate, transpose back (the extra
-            // transposes are views; the rope Metal kernel handles the
-            // transposed stride pattern without a copy).
+            // transposes are views; qwen3.5's partial rotary
+            // (rope_dims < head_dim) takes the rope kernel's copying
+            // `dims_ < D` branch either way, so the transposed input costs a
+            // strided rather than vector copy — the same price mlx-lm pays).
             let offset = cache.as_ref().map_or(0, |c| c.get_offset());
             let q_t = queries.transpose(Some(&[0, 2, 1, 3]))?;
             let k_t = keys.transpose(Some(&[0, 2, 1, 3]))?;

--- a/crates/mlx-core/src/models/qwen3_5/decoder_layer.rs
+++ b/crates/mlx-core/src/models/qwen3_5/decoder_layer.rs
@@ -276,6 +276,7 @@ impl DecoderLayer {
         position_ids: Option<&MxArray>,
         use_kernel: bool,
         rope_position_offset: i32,
+        mrope_cache: &mut Option<(MxArray, MxArray)>,
     ) -> Result<MxArray> {
         match kind {
             Qwen3_5LayerKind::Linear => {
@@ -319,6 +320,7 @@ impl DecoderLayer {
                     is_prefill,
                     position_ids,
                     rope_position_offset,
+                    mrope_cache,
                 )?;
                 // Residual.
                 let h = x.add(&attn_out)?;
@@ -400,6 +402,7 @@ impl DecoderLayer {
                     is_prefill,
                     None,
                     rope_position_offset,
+                    &mut None,
                 )?;
                 let h = x.add(&attn_out)?;
                 let normed = self.post_attention_layernorm.forward(&h)?;

--- a/crates/mlx-core/src/models/qwen3_5/gated_delta.rs
+++ b/crates/mlx-core/src/models/qwen3_5/gated_delta.rs
@@ -25,8 +25,8 @@ const CHUNK_THRESHOLD: i64 = 64;
 /// chunked Metal kernel (`gated_delta_chunked.metal.inc`) is pure scalar-FMA + `simd_sum`
 /// reductions with ZERO `simdgroup_matrix` / NAX matmul, so it never had a tensor-core
 /// advantage. The gen gate was a stale inversion of an old M3 result that was never A/B'd on
-/// M5; it is removed. Per-step is already the canonical path on M1–M4, for all `seq < 64`, all
-/// masked GDN calls, and every compiled-C++ prefill path — so per-step is the de-facto
+/// M5; it is removed. Per-step is already the canonical path on M1–M4, for all `seq < 64`, and
+/// all masked GDN calls — so per-step is the de-facto
 /// reference everywhere.
 ///
 /// Chunked is retained behind `MLX_GDN_KERNEL=chunked` for A/B and bring-up only. NOTE: the two

--- a/crates/mlx-core/src/models/qwen3_5/int8_gemm.rs
+++ b/crates/mlx-core/src/models/qwen3_5/int8_gemm.rs
@@ -185,8 +185,8 @@ pub fn int8_w8a8_qmv(x: &MxArray, w_i8: &MxArray, s_w: &MxArray) -> Result<MxArr
 /// streams `[N,K]` row-major like MLX's affine qmv; the eager layer passes
 /// its stored checkpoint weight, so this is buffer-shared, not a copy);
 /// `s_w` f32 `[N]`. The result is **lazy** and narrowed to bf16 inside the
-/// kernel. `INT8_QMV_W8A16=0` (read inside the shared C++ builder, so eager
-/// and compiled stay byte-identical) reroutes back to the W8A8 qmv for
+/// kernel. `INT8_QMV_W8A16=0` (read inside the shared C++ builder, so every
+/// caller sees one dispatch rule) reroutes back to the W8A8 qmv for
 /// same-binary A/B. Returns `Err` when unsupported (gen < 17 or
 /// `K % 16 != 0`) or on a kernel/FFI failure.
 pub fn int8_w8a16_qmv(

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -4293,8 +4293,8 @@ impl Qwen35Inner {
         // prior NON-streaming paged turn (`send()` → `chat_tokens_delta_sync`
         // → `paged_turn_sync_core`) therefore leaves `self.caches`'
         // full-attention slots EMPTY/STALE for the prior turn's tokens.
-        // Delta-prefilling only `delta_tokens` on top of that and exporting
-        // `self.caches` into the compiled/MTP graph would decode from an
+        // Delta-prefilling only `delta_tokens` on top of that and running
+        // the eager MTP decode against `self.caches` would decode from an
         // incomplete flat prefix (missing the prior turn's attention KV).
         //
         // Fix: when taking this dense fallback AND the flat caches are dirty
@@ -4306,7 +4306,7 @@ impl Qwen35Inner {
         // cache-prefix miss (full reset + full re-prefill). The GDN recurrent
         // state cannot be rewound mid-sequence, so a full reset + full
         // prefill is the only coherent way to seed both the GDN linear and
-        // full-attention flat caches for the compiled/MTP decode.
+        // full-attention flat caches for the eager MTP decode.
         //
         // The dirty gate keeps this a ONE-TIME cost on the paged→dense
         // transition: the flag is cleared once at end-of-turn success (atomic
@@ -8523,9 +8523,10 @@ fn chunked_prefill_with_size(
 /// state for the prompt tail needed by MTP, concatenated along the time axis
 /// -> `[1, kept_len, hidden]`.
 ///
-/// Used only when MTP is active for the turn: the prompt hiddens are
-/// needed to commit the prompt prefix into the MTP committed-history
-/// cache (`prefill_mtp_commit`). Logits-only callers keep the cheaper
+/// Used only when MTP is active for the turn: the prompt hiddens flow
+/// through `ChatDecodeInputs::prompt_hidden` into `begin_mtp_decode`'s
+/// prompt-prefix seed, which commits the prompt prefix into the MTP
+/// committed-history caches. Logits-only callers keep the cheaper
 /// `chunked_prefill`. The per-chunk forward op sequence is identical for
 /// chunks whose hidden is kept; chunks before the requested tail use the
 /// logits-only path and discard hidden to avoid materializing prompt history

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -1246,6 +1246,17 @@ impl Qwen35Inner {
         })?;
         if let serde_json::Value::Object(ref mut map) = config_value {
             map.insert("model_type".to_string(), serde_json::json!("qwen3_5"));
+            // `parse_config` reads the MTP layer count ONLY from the
+            // HF-convention keys `mtp_num_hidden_layers` /
+            // `num_nextn_predict_layers`; the serde field name
+            // `n_mtp_layers` is ignored on load. Without this, a saved MTP
+            // checkpoint reloads with `n_mtp_layers = 0` and its head is
+            // silently dropped. Mirrors the MoE saver
+            // (`qwen3_5_moe::model::Qwen35MoeInner::save_model_sync`).
+            map.insert(
+                "mtp_num_hidden_layers".to_string(),
+                serde_json::json!(self.config.n_mtp_layers),
+            );
         }
 
         let weights_json = serde_json::json!({

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -55,14 +55,12 @@ pub(crate) struct VisionCacheInner {
 
 pub(crate) type VisionCache = Arc<Mutex<VisionCacheInner>>;
 
-// The shared model-id counter lives in `crate::engine::compiled_lock` (the
-// family-neutral home for the C++ compiled-registry contract). Re-exported here
-// for unqualified internal use across the dense + MoE forward code.
+// The shared model-id counter lives in `crate::engine::compiled_lock` so the
+// dense + MoE families draw from one id space (per-instance ids never
+// overlap). Re-exported here for unqualified use by this module's
+// `Qwen35Inner::new`; MoE imports it from `crate::engine::compiled_lock`
+// directly.
 pub(crate) use crate::engine::compiled_lock::QWEN35_MODEL_ID_COUNTER;
-
-// The process-wide compiled-path locks live in `crate::engine::compiled_lock`;
-// imported here for unqualified internal use (no re-export — external consumers
-// import them from `crate::engine::compiled_lock`).
 
 fn fresh_dense_layer_caches(config: &Qwen3_5Config) -> Vec<Qwen3_5LayerCache> {
     (0..config.num_layers as usize)
@@ -268,8 +266,8 @@ pub(crate) struct Qwen35Inner {
     /// `Some(...)`, full-attention layers route through this adapter
     /// while linear-attention (GDN) layers stay on
     /// `Qwen3_5LayerCache::Linear` with no cross-request prefix reuse.
-    /// The compiled C++ forward path is bypassed entirely on the paged
-    /// path.
+    /// Paged turns run the pure-Rust eager paged forward
+    /// (`paged_forward::run_paged_prefill_chunk` / `run_paged_decode_step`).
     pub(crate) paged_adapter: Option<PagedKVCacheAdapter>,
     /// True when a paged-core turn has populated
     /// the paged adapter's `LayerKVPool` since the last flat full-attention
@@ -304,7 +302,7 @@ pub(crate) struct Qwen35Inner {
     /// Whether the CURRENT generic-flow turn is streaming. Set by the
     /// [`ChatBackend::profiler_label`] hook (the session core calls it
     /// exactly once per generic-flow turn, before `begin_decode`);
-    /// consumed by [`ChatBackend::begin_decode`]'s compiled/eager
+    /// consumed by [`ChatBackend::begin_decode`]'s
     /// profiler relabel, which must pick the `chat_*` vs `chat_stream_*`
     /// label family (`TurnSetup` does not carry streaming-ness).
     /// Whole-turn override paths (vision/paged/MTP) never consult it.
@@ -532,8 +530,8 @@ pub(crate) struct ChatDecodeInputs {
     /// `[1, prefill_len, hidden]`. `Some` only when MTP is active for this
     /// turn (`params.enable_mtp && has_mtp_weights`) and the prefill ran
     /// the hidden-emitting `chunked_prefill_with_hidden`. Consumed once,
-    /// after `init_mtp_compiled_from_main`, to commit the prompt prefix
-    /// into the MTP committed-history cache via `prefill_mtp_commit`.
+    /// by `begin_mtp_decode`'s prompt-prefix seed, to commit the prompt
+    /// prefix into the MTP committed-history cache.
     /// `None` for non-MTP turns and for the streaming/delta paths.
     pub prompt_hidden: Option<MxArray>,
     /// The exact prompt token ids whose hiddens `prompt_hidden` holds —
@@ -1873,8 +1871,8 @@ impl Qwen35Inner {
         })
     }
 
-    /// Shared post-prefill pipeline: penalty → sample → compiled init (if needed)
-    /// → decode loop → cache export → save cache state → finalize result.
+    /// Shared post-prefill pipeline: penalty → sample → decode loop (eager
+    /// MTP or AR) → save cache state → finalize result.
     ///
     /// Extracted from `vision_mtp_whole_turn_core` so it can also be driven by the text-only
     /// session path (`chat_tokens_delta_sync`). Preserves the exact semantics
@@ -2290,8 +2288,8 @@ impl Qwen35Inner {
     ///   fall back to GDN replay from token 0.
     /// * Pure-cache prompt (every prompt token already in the paged
     ///   pool) is rejected — same caveat as LFM2 / Qwen3 paged paths.
-    /// * The compiled C++ forward path is bypassed — paged turns run
-    ///   the pure-Rust `DecoderLayer::forward_paged_or_flat`.
+    /// * Paged turns run the pure-Rust
+    ///   `DecoderLayer::forward_paged_or_flat`.
     fn paged_turn_sync_core(
         &mut self,
         tokens: Vec<u32>,
@@ -2585,8 +2583,9 @@ impl Qwen35Inner {
 
         // Paged prompt-prefix MTP prefill. Mirrors the dense gate's
         // `want_prompt_hidden` predicate. Capturing the post-`final_norm`
-        // hidden for every prompt token lets the paged-MTP gate seed
-        // `g_mtp_committed_len = N` via `prefill_mtp_commit` before cycle 1, so
+        // hidden for every prompt token lets `begin_mtp_decode`'s
+        // prompt-prefix seed commit the full prompt (advancing the stepper's
+        // `committed_len` to N) before cycle 1, so
         // MTP drafts attend over the prompt (matches the dense MTP path). The
         // `cached_prefix_len == 0` clause matches dense: on a cache-reuse turn
         // the suffix-only prefill cannot produce the full prompt's hidden
@@ -2754,7 +2753,7 @@ impl Qwen35Inner {
             let _ = outcome.last_in_cache;
 
             // `self.caches` already holds the live GDN state (the eager paged
-            // forwards wrote it directly) — no compiled cache export needed.
+            // forwards wrote it directly) — nothing to export.
             return Ok((generated_tokens, finish_reason, Some(profiler)));
         }
 
@@ -3887,10 +3886,11 @@ impl Qwen35Inner {
     /// [`Self::paged_turn_stream_core`]. Mirrors LFM2's
     /// `paged_turn_stream_core_inner`.
     ///
-    /// Uses a C++ compiled paged decode dispatcher when
-    /// `use_cpp_paged` is true. See the sync sibling
-    /// `paged_turn_sync_core_inner` for the cpp_session_ready gate
-    /// rationale.
+    /// Runs the pure-Rust paged path — same dispatch as the sync sibling
+    /// `paged_turn_sync_core_inner`: prefill populates the GDN linear
+    /// caches and writes K/V into the adapter pool, then decode steps run
+    /// through `paged_forward::run_paged_decode_step` (or the eager paged
+    /// MTP arm when the MTP gate holds).
     #[allow(clippy::too_many_arguments)]
     fn paged_turn_stream_core_inner<'a>(
         &mut self,
@@ -4241,9 +4241,8 @@ impl Qwen35Inner {
         };
         let mut first_token_instant: Option<std::time::Instant> = None;
 
-        // Paged streaming path does not carry an MTP gate;
-        // MTP-on-paged streams continue to fall through to the dense
-        // compiled streaming path. Non-MTP paged streams take the paged
+        // MTP-on-paged delta streams fall through to the dense (flat)
+        // streaming path; non-MTP paged streams take the paged
         // streaming core.
         let mtp_takes_dense_path =
             p.enable_mtp && self.has_mtp_weights() && self.paged_adapter.is_some();
@@ -6522,15 +6521,13 @@ impl StreamSender<'_> {
     }
 }
 
-/// Paged decode stepper for qwen3_5 dense (compiled-paged hybrid — the paged
-/// analog of the FLAT [`Qwen35Decode`]). Drives
+/// Paged decode stepper for qwen3_5 dense (the paged analog of the FLAT
+/// [`Qwen35Decode`]). Drives
 /// [`crate::engine::decode::run_decode_loop`] through the generic
 /// [`crate::engine::paged_turn::run_paged_turn`]: each `forward` runs the
-/// compiled C++ paged step when seeded, else the pure-Rust eager paged step.
-/// Created by `<Qwen35Inner as PagedBackend>::begin_paged_decode` (which armed
-/// the guards + seeded the C++ paged session), consumed across the whole decode
-/// loop, dropped at loop exit (the `CompiledResetGuard` resets the C++ paged
-/// globals on EVERY exit path).
+/// pure-Rust eager paged step against the live post-prefill adapter pools +
+/// GDN caches. Created by `<Qwen35Inner as PagedBackend>::begin_paged_decode`,
+/// consumed across the whole decode loop.
 pub(crate) struct Qwen35PagedDecode<'a> {
     inner: &'a mut Qwen35Inner,
 }
@@ -6590,7 +6587,7 @@ impl DecodeStep for Qwen35PagedDecode<'_> {
     }
 
     fn eval_step(&mut self, next_token: &MxArray, _logits: &MxArray, _budget_forced: bool) {
-        // Single SYNCHRONOUS eval of `next_token`: the compiled-paged forward
+        // Single SYNCHRONOUS eval of `next_token`: the paged forward
         // is bandwidth-bound, so an async two-wait (bottom `async_eval` +
         // loop-top `y.eval`) would buy ZERO overlap. One `y.eval()` per sample
         // is the cheapest correct cadence.
@@ -6858,8 +6855,8 @@ impl PagedBackend for Qwen35Inner {
     }
 
     fn paged_decode_stream(&self, _generation_stream: Stream) -> Stream {
-        // Run the compiled-paged DECODE on the canonical DEFAULT stream, NOT the
-        // per-turn `generation_stream`. dense's compiled forward + every
+        // Run the paged DECODE on the canonical DEFAULT stream, NOT the
+        // per-turn `generation_stream`. dense's paged forward + every
         // `y.eval()` run on the MLX DEFAULT stream; running the forward on a
         // queue separate from the shared loop's top-of-iteration `y.eval()`
         // (always on the default stream) would force a cross-queue
@@ -6975,9 +6972,10 @@ impl Qwen35Inner {
     /// [`Self::chat_stream_sync_inner`], delta streaming →
     /// [`Self::chat_stream_tokens_delta_sync_inner`]. These cores own
     /// every dense-path subtlety the generic flow does not model: VLM
-    /// prefill + M-RoPE deltas, the MTP gate (compiled-init fallback to
-    /// AR), the MTP-on-paged `mtp_takes_dense_path` release/rebuild
-    /// dance, and the paged-text-only rejection for image turns.
+    /// prefill + M-RoPE deltas, the MTP gate (eager MTP, falling back to
+    /// AR when ineligible), the MTP-on-paged `mtp_takes_dense_path`
+    /// release/rebuild dance, and the paged-text-only rejection for
+    /// image turns.
     ///
     /// Delta turns recover the raw delta from the engine-composed
     /// `args.tokens` (`cached_history + delta` by construction — the
@@ -7043,8 +7041,8 @@ impl Qwen35Inner {
     ///   * MTP turns (`enable_mtp && has_mtp_weights`) take the native
     ///     paged-MTP path. The streaming-MTP probe declined earlier
     ///     (routed to `mtp_turn` → `dense_whole_turn`), so only SYNC reaches
-    ///     here with MTP on; `paged_turn_sync_core` self-handles the
-    ///     compiled-availability check + MTP gate + silent AR fallback. The
+    ///     here with MTP on; `paged_turn_sync_core` self-handles the MTP
+    ///     gate (the eager paged MTP arm, with AR fallback). The
     ///     `(sink, cancelled)` match is preserved so any future MTP-stream
     ///     entry still finds its dispatch target.
     ///   * NON-MTP turns (sync or stream) → the new generic AR+paged path via
@@ -7109,10 +7107,7 @@ impl Qwen35Inner {
 /// non-paged, non-MTP) flow on Qwen3.5 dense
 /// ([`ChatBackend::begin_decode`]).
 ///
-/// Carries the compiled-vs-eager dispatch: the compiled arm drives
-/// `forward_compiled` against the C++ graph seeded by `begin_decode`,
-/// the eager arm drives the pure-Rust `forward_inner` over the flat
-/// caches.
+/// Drives the pure-Rust eager `forward_inner` over the flat caches.
 pub(crate) struct Qwen35Decode<'a> {
     inner: &'a mut Qwen35Inner,
     embedding_weight: MxArray,
@@ -7260,8 +7255,8 @@ impl MtpStepper for DenseMtpStepper<'_> {
 
     // Step A main forward: eager pre-norm + final-norm + project. Returns
     // `hidden` shaped `[1, hidden]` (squeeze the time axis) to match the
-    // compiled contract; `logits` stays `[1, 1, vocab]` with
-    // `needs_squeeze = true`.
+    // [`MtpStepper::forward_with_hidden`] contract; `logits` stays
+    // `[1, 1, vocab]` with `needs_squeeze = true`.
     fn forward_with_hidden(
         &mut self,
         ids: &MxArray,
@@ -7761,8 +7756,8 @@ impl MtpBackend for Qwen35Inner {
             layer_kinds,
         };
 
-        // Prompt-prefix seed (v2 committed-history only). Mirror the compiled
-        // `prefill_mtp_commit`: commit the contiguous run
+        // Prompt-prefix seed (v2 committed-history only): commit the
+        // contiguous run
         // `[prompt_hidden_ids[1..], y]` (length P, token 0 skipped, the first
         // sampled token `y` appended) into the persistent MTP cache so the
         // drafter attends the prompt from cycle 1. Each committed token `x` is
@@ -8114,8 +8109,9 @@ impl ChatBackend for Qwen35Inner {
 
     fn mtp_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Option<Result<TurnOutput>> {
         // `p.enable_mtp && has_mtp_weights` turns run the dense cores whose
-        // internal MTP gate does the compiled-availability check,
-        // `init_mtp_compiled…`, and the silent AR fallback on init failure.
+        // internal MTP gate drives the eager MTP turn
+        // (`engine::mtp_turn::run_mtp_turn`) and falls back to plain AR
+        // decode when MTP is ineligible for the turn shape.
         // Everything beyond this entry condition stays inside those cores.
         if !(args.params.enable_mtp && self.has_mtp_weights()) {
             return None;
@@ -8795,7 +8791,7 @@ fn project_logits_from_hidden(
 
 /// Eager (pure-Rust) MTP verify step.
 ///
-/// Translation of the compiled `forward_mtp_verify_compiled_with_hidden`
+/// Translation of the deleted compiled `forward_mtp_verify_compiled_with_hidden`
 /// FFI: runs the `verify_ids` (`[1, K+1]` int32) through the SAME main-model
 /// stack the AR path uses (`forward_pre_norm_inner` + `final_norm` +
 /// `project_logits_from_hidden`), advancing `inner.caches` by `K+1` positions.

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -8850,7 +8850,11 @@ fn project_last_logits_from_pre_norm_hidden(
 ///
 /// Precondition: `total >= 1`. For `total in {1..7}` the single chunk is
 /// `total` itself.
-fn partition_prefill_chunks(total: usize) -> Vec<usize> {
+///
+/// `pub(crate)`: also used by `MoeMtpStepper::begin_mtp_decode`'s
+/// committed-history v2 prompt-prefix seed
+/// (`crate::models::qwen3_5_moe::model`), which mirrors this dense chunking.
+pub(crate) fn partition_prefill_chunks(total: usize) -> Vec<usize> {
     debug_assert!(total >= 1, "partition_prefill_chunks: total must be >= 1");
     const CHUNK: usize = 6;
     if total == 1 {

--- a/crates/mlx-core/src/models/qwen3_5/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5/mtp.rs
@@ -237,8 +237,8 @@ impl Qwen3_5MTPModule {
                     try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
                 }
                 // Unreachable in practice: `apply_weights_inner` skips the MTP
-                // load entirely for sym8 checkpoints (MTP needs the compiled
-                // verify path, which sym8 disables). `None` here keeps the
+                // load entirely for sym8 checkpoints (the dense loader
+                // disables speculative MTP under sym8). `None` here keeps the
                 // exhaustive match honest without silently mis-packing.
                 PerLayerMode::Sym8 => None,
             }

--- a/crates/mlx-core/src/models/qwen3_5/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5/mtp.rs
@@ -354,6 +354,10 @@ impl Qwen3_5MTPModule {
             if let Some(w) = params.get(&format!("{}.self_attn.o_proj.bias", prefix)) {
                 attn.set_o_proj_bias(Some(w))?;
             }
+            // Precompute the block-ordered q_proj weight so forward()/
+            // forward_paged() split queries/gate without a strided
+            // reshape-copy. No-op for quantized q_proj.
+            attn.finalize_q_gate_block()?;
 
             // MLP — dense or per-mode quantized via the same swap as
             // the main loop. The MTP MLP is always a `Standard` MLP at

--- a/crates/mlx-core/src/models/qwen3_5/mtp_decode.rs
+++ b/crates/mlx-core/src/models/qwen3_5/mtp_decode.rs
@@ -154,7 +154,7 @@ const CHAINED_CYCLES_MIN_GPU_GEN: i32 = 17;
 // Once MTP caches use committed-history and the verifier exports
 // `verify_hidden[K]`, chaining avoids paying the Step-A target forward at the
 // start of every speculative cycle. That hidden slice is fused into the same
-// `async_eval` batch as `(token, g_compiled_caches)` at end-of-iteration (see
+// `async_eval` batch as `(token, main layer caches)` at end-of-iteration (see
 // the `eval_step_with_chained_hidden` stepper hook) so the slice becomes a sibling
 // of the next-cycle draft's first inputs rather than a late dependency
 // materialized inside the draft graph build.
@@ -426,11 +426,13 @@ pub(crate) fn mtp_batch_target_arrays_enabled() -> bool {
 
 // Native stochastic verifier sparse-target output.
 //
-// This is an opt-out gate for the dense Qwen compiled path. When the sampler is
-// in MTPLX parity mode, the verifier can return compact
-// `[depth+1, top_k]` target ids/probabilities directly from the native graph
-// instead of surfacing full `[1, depth+1, vocab]` logits and rebuilding the same
-// sparse rows on the Rust side.
+// This is an opt-out gate for the native sparse-verify fast path
+// (`MtpStepper::verify_step_sparse`). When the sampler is in MTPLX parity
+// mode, such a verifier can return compact `[depth+1, top_k]` target
+// ids/probabilities directly from the native graph instead of surfacing full
+// `[1, depth+1, vocab]` logits and rebuilding the same sparse rows on the
+// Rust side. No eager stepper implements `verify_step_sparse` today, so the
+// gate is currently inert; kept for a future native sparse verifier.
 pub(crate) fn mtp_native_sparse_verify_enabled() -> bool {
     static CACHE: OnceLock<bool> = OnceLock::new();
     *CACHE.get_or_init(|| match std::env::var("MLX_MTP_NATIVE_SPARSE_VERIFY") {
@@ -727,8 +729,8 @@ pub(crate) fn trace_acceptance_dense(
 // The qwen3_5 dense/MoE whole-turn cores behind the engine's `mtp_turn` /
 // `vision_turn` probes (`vision_mtp_whole_turn_core` and the delta/streaming
 // twins in `models/qwen3_5/model.rs` and `models/qwen3_5_moe/model.rs`) invoke
-// `decode_loop!` for their AR arms (MTP compiled-init failure → AR decode;
-// vision turns; the MTP-ineligible delta shapes). The MTP propose/verify loop
+// `decode_loop!` for their AR arms (plain AR turns; vision turns;
+// the MTP-ineligible delta shapes). The MTP propose/verify loop
 // those cores interleave with now lives in `crate::engine::mtp_turn`, so the
 // AR macro lives HERE next to the MTP draft/verify helpers it shares.
 // =============================================================================

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -456,14 +456,15 @@ pub(crate) fn run_paged_vlm_prefill(
 ///
 /// Mirror of `chunked_prefill_with_hidden` (dense / flat path). The
 /// paged-MTP gate inside `paged_turn_sync_core_inner` consumes this so
-/// `prefill_mtp_commit` can seed `g_mtp_committed_len = N` before the
+/// `begin_mtp_decode`'s prompt-prefix seed can commit the full prompt
+/// (advancing the stepper's `committed_len` to N) before the
 /// first MTP cycle — without it the MTP draft attends over a
 /// prompt-less context and parity vs the AR run breaks.
 ///
 /// Caller MUST gate on `cached_prefix_len == 0` (the dense gate uses
 /// the same `want_prompt_hidden` predicate). On a cache-reuse turn the
 /// prefill only processes the suffix, so the captured hidden would not
-/// cover the full prompt and `prefill_mtp_commit` cannot use it.
+/// cover the full prompt and the prompt-prefix seed cannot use it.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn run_paged_prefill_chunk_with_hidden(
     full_tokens: &[u32],
@@ -939,9 +940,9 @@ pub(crate) fn run_paged_decode_step(
 /// Routes full-attention layers through the paged adapter (writing one new K/V
 /// slot into the pool, attending over `read_kv_range(0, total_ctx)`) and GDN
 /// layers through the flat `Qwen3_5LayerCache::Linear` slots in `caches`, the
-/// same split `run_paged_decode_step` uses. The eager analogue of the compiled
-/// `forward_with_hidden` closure that calls `forward_dense_cpp_paged` +
-/// `export_last_hidden_paged`.
+/// same split `run_paged_decode_step` uses. The eager analogue of the deleted
+/// compiled `forward_with_hidden` closure that called `forward_dense_cpp_paged`
+/// + `export_last_hidden_paged`.
 ///
 /// Returns `(logits [1, 1, vocab], hidden [1, hidden])`. The hidden is squeezed
 /// on the time axis to match the eager-flat MTP `forward_with_hidden` contract
@@ -1025,7 +1026,7 @@ pub(crate) fn run_paged_step_with_hidden(
 /// at every verify position, recording the per-layer GDN tape for the rollback
 /// replay.
 ///
-/// The eager analogue of the compiled `forward_mtp_verify_paged` FFI. The
+/// The eager analogue of the deleted compiled `forward_mtp_verify_paged` FFI. The
 /// `verify_ids` (`[1, K+1]` int32) are recorded into the adapter in ONE
 /// `record_tokens` call (so the new K/V land at logical positions
 /// `[ctx, ctx+K]`), then run through every layer: full-attention via the paged

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -819,9 +819,9 @@ fn project_last_token_logits(
 /// head, returning `(last_token_logits[vocab], full_chunk_hidden[1, T, hidden])`.
 ///
 /// The paged prefill variant needs every chunk's post-`final_norm` hidden so
-/// the MTP committed-history prefill seed (`prefill_mtp_commit`) gets a
-/// contiguous `[1, prompt_len, hidden]` tensor — mirrors
-/// `chunked_prefill_with_hidden` on the dense path.
+/// the MTP committed-history prompt seed (`prompt_hidden`, consumed by
+/// `begin_mtp_decode`) gets a contiguous `[1, prompt_len, hidden]` tensor —
+/// mirrors `chunked_prefill_with_hidden` on the dense path.
 fn project_last_token_logits_with_full_hidden(
     hidden_states: &MxArray,
     final_norm: &RMSNorm,
@@ -852,9 +852,10 @@ fn project_last_token_logits_with_full_hidden(
         full_hidden
     };
 
-    // The caller runs `synchronize_and_clear_cache()` before
-    // `prefill_mtp_commit`, which would otherwise free the lazy graph nodes
-    // backing the kept hidden. Materialise before return.
+    // The caller runs `synchronize_and_clear_cache()` after prefill, before
+    // `begin_mtp_decode` consumes the kept hidden as its prompt-prefix seed
+    // — that sweep would otherwise free the lazy graph nodes backing the
+    // kept hidden. Materialise before return.
     kept_hidden.eval();
     debug_assert_eq!(kept_hidden.shape_at(0)?, 1);
     debug_assert!(kept_hidden.shape_at(1)? >= 1);

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -743,6 +743,15 @@ fn run_paged_prefill_one_chunk(
     // and image prefill uses the M-RoPE arm so this is ignored there.
     let rope_position_offset = paged_rope_offset(chunk_first_position, cached_rope_deltas);
 
+    // Shared per-forward-pass scratch slot for the M-RoPE cos/sin precompute
+    // (see `Qwen3_5Attention::forward_paged`'s `mrope_cache` doc comment).
+    // Every `FullAttentionPaged` layer in this loop shares one `position_ids`
+    // array, so the first such layer computes the selected cos/sin and every
+    // later one reuses it instead of recomputing the cos/sin table +
+    // `take_along_axis` gather. Stays `None` (untouched) on the text-only
+    // path where `position_ids` is `None`.
+    let mut mrope_cache: Option<(MxArray, MxArray)> = None;
+
     for (layer_idx, ((layer, cache_slot), kind)) in layers
         .iter_mut()
         .zip(caches.iter_mut())
@@ -767,6 +776,7 @@ fn run_paged_prefill_one_chunk(
             layer_positions,
             /* use_kernel */ true,
             rope_position_offset,
+            &mut mrope_cache,
         )?;
         crate::array::maybe_eval_clear_for_paged_prefill_layer(layer_idx, &hidden_states)?;
     }
@@ -893,6 +903,7 @@ pub(crate) fn run_paged_decode_step(
             /* position_ids */ None,
             /* use_kernel */ true,
             rope_position_offset,
+            &mut None,
         )?;
     }
 
@@ -971,6 +982,7 @@ pub(crate) fn run_paged_step_with_hidden(
             /* position_ids */ None,
             /* use_kernel */ true,
             rope_position_offset,
+            &mut None,
         )?;
     }
 

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -292,6 +292,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
                 &hidden_states,
                 final_norm,
                 lm_head,
+                embed,
                 embedding_weight,
             )?);
             if let Some(start) = chunk_trace_start {
@@ -389,7 +390,7 @@ fn run_paged_prefill_single_shot(
         cached_rope_deltas,
     )?;
 
-    project_last_token_logits(&hidden_states, final_norm, lm_head, embedding_weight)
+    project_last_token_logits(&hidden_states, final_norm, lm_head, embed, embedding_weight)
 }
 
 /// Single-turn image-bearing paged prefill.
@@ -446,7 +447,7 @@ pub(crate) fn run_paged_vlm_prefill(
         0,
     )?;
 
-    project_last_token_logits(&hidden_states, final_norm, lm_head, embedding_weight)
+    project_last_token_logits(&hidden_states, final_norm, lm_head, embed, embedding_weight)
 }
 
 /// Paged prefill variant that ALSO returns the post-`final_norm` hidden
@@ -600,6 +601,8 @@ fn run_paged_prefill_chunk_with_hidden_with_size(
             let last_hidden = chunk_hidden.slice_axis(1, chunk_len - 1, chunk_len)?;
             let logits = if let Some(head) = lm_head {
                 head.forward(&last_hidden)?
+            } else if embed.is_packed_quantized() {
+                embed.as_linear(&last_hidden)?
             } else {
                 let weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
                 last_hidden.matmul(&weight_t)?
@@ -697,6 +700,7 @@ fn run_paged_prefill_single_shot_with_hidden(
         &hidden_states,
         final_norm,
         lm_head,
+        embed,
         embedding_weight,
         keep_last_hidden,
     )
@@ -787,6 +791,7 @@ fn project_last_token_logits(
     hidden_states: &MxArray,
     final_norm: &RMSNorm,
     lm_head: &Option<Linear>,
+    embed: &Embedding,
     embedding_weight: &MxArray,
 ) -> Result<MxArray> {
     let seq_len = hidden_states.shape_at(1)?;
@@ -795,6 +800,12 @@ fn project_last_token_logits(
     let h = final_norm.forward(&last_hidden)?;
     let logits = if let Some(head) = lm_head {
         head.forward(&h)?
+    } else if embed.is_packed_quantized() {
+        // Tied + packed-quantized embedding: route through the packed
+        // `quantized_matmul` instead of a dense `[vocab, hidden]` transpose
+        // + matmul (the `embedding_weight` fallback below reads a fully
+        // pre-dequantized/on-demand-dequantized dense copy).
+        embed.as_linear(&h)?
     } else {
         let weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
         h.matmul(&weight_t)?
@@ -814,6 +825,7 @@ fn project_last_token_logits_with_full_hidden(
     hidden_states: &MxArray,
     final_norm: &RMSNorm,
     lm_head: &Option<Linear>,
+    embed: &Embedding,
     embedding_weight: &MxArray,
     keep_last_hidden: Option<usize>,
 ) -> Result<(MxArray, MxArray)> {
@@ -823,6 +835,8 @@ fn project_last_token_logits_with_full_hidden(
     let last_hidden = full_hidden.slice_axis(1, prompt_len - 1, prompt_len)?;
     let logits = if let Some(head) = lm_head {
         head.forward(&last_hidden)?
+    } else if embed.is_packed_quantized() {
+        embed.as_linear(&last_hidden)?
     } else {
         let weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
         last_hidden.matmul(&weight_t)?
@@ -910,6 +924,8 @@ pub(crate) fn run_paged_decode_step(
     let h = final_norm.forward(&hidden_states)?;
     let logits = if let Some(head) = lm_head {
         head.forward(&h)?
+    } else if embed.is_packed_quantized() {
+        embed.as_linear(&h)?
     } else {
         let weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
         h.matmul(&weight_t)?
@@ -987,12 +1003,17 @@ pub(crate) fn run_paged_step_with_hidden(
     }
 
     let h3 = final_norm.forward(&hidden_states)?;
-    let logits = match (lm_head, embedding_weight_t) {
-        (Some(head), _) => head.forward(&h3)?,
-        (None, Some(wt)) => h3.matmul(wt)?,
-        (None, None) => {
-            let wt = embedding_weight.transpose(Some(&[1, 0]))?;
-            h3.matmul(&wt)?
+    let logits = if let Some(head) = lm_head {
+        head.forward(&h3)?
+    } else if embed.is_packed_quantized() {
+        embed.as_linear(&h3)?
+    } else {
+        match embedding_weight_t {
+            Some(wt) => h3.matmul(wt)?,
+            None => {
+                let wt = embedding_weight.transpose(Some(&[1, 0]))?;
+                h3.matmul(&wt)?
+            }
         }
     };
     let hidden = h3.squeeze(Some(&[1]))?;
@@ -1092,12 +1113,17 @@ pub(crate) fn run_paged_verify_step(
     }
 
     let hiddens = final_norm.forward(&hidden_states)?;
-    let logits = match (lm_head, embedding_weight_t) {
-        (Some(head), _) => head.forward(&hiddens)?,
-        (None, Some(wt)) => hiddens.matmul(wt)?,
-        (None, None) => {
-            let wt = embedding_weight.transpose(Some(&[1, 0]))?;
-            hiddens.matmul(&wt)?
+    let logits = if let Some(head) = lm_head {
+        head.forward(&hiddens)?
+    } else if embed.is_packed_quantized() {
+        embed.as_linear(&hiddens)?
+    } else {
+        match embedding_weight_t {
+            Some(wt) => hiddens.matmul(wt)?,
+            None => {
+                let wt = embedding_weight.transpose(Some(&[1, 0]))?;
+                hiddens.matmul(&wt)?
+            }
         }
     };
     Ok(super::mtp_decode::MtpVerifyOutput::logits_only(

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -1380,11 +1380,9 @@ fn apply_weights_inner(
     // `mtp.forward`; the module sits next to the main model and reads from
     // the same params HashMap.
     if let Some(mtp) = inner.mtp.as_mut() {
-        // sym8 v1 scope: MTP is OUT. The sym8 compiled coverage is the FLAT
-        // decode only (`qwen35_decode_fn`, atomic eager C++); the MTP
-        // draft/verify graphs are `mlx::core::compile`d and the sym8 custom
-        // Metal kernels are unproven inside a compile trace. Loading the MTP
-        // head through the affine builders would also mis-pack int8 tensors —
+        // sym8 v1 scope: MTP is OUT. The MTP quant builders carry no sym8 arm
+        // (`mtp.rs` maps `PerLayerMode::Sym8 => None`), and loading the MTP
+        // head through the affine builders would mis-pack int8 tensors —
         // skip the load and fail soft into plain AR decode, mirroring the
         // missing-weights branch.
         if has_sym8_mode(top_level_mode, per_layer_quant) {
@@ -1646,20 +1644,21 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
                     parse_quant_block(quant_cfg, quant_group_size);
                 augment_mtplx_mtp_quantization(&raw, config.n_mtp_layers, &mut per_layer_quant);
 
-                // sym8 v1 scope: the compiled C++ path covers the FLAT decode
-                // only (`qwen35_decode_fn` — atomic eager C++, no
-                // `mlx::core::compile`). The block-paged decode graph IS
-                // `mlx::core::compile`d, and the sym8 custom Metal kernels are
-                // unproven inside a compile trace — force the flat path so a
+                // sym8 v1 scope: sym8 is only validated on the dense FLAT
+                // (eager int8) decode path. Dense paged decode is pure-Rust
+                // eager too, but sym8 under it is simply UNVALIDATED — the pin
+                // is retained conservatively, forcing the flat path so a
                 // paged-opt-in config (or MLX_QWEN35_PAGED_OVERRIDE=1) cannot
-                // route sym8 through it.
+                // route sym8 through it. (MoE and gemma4 already ship sym8
+                // under paged decode, so lifting this pin is a plausible
+                // follow-up — a behavior decision, not made here.)
                 if has_sym8_mode(top_level_mode, &per_layer_quant)
                     && config.use_block_paged_cache == Some(true)
                 {
                     warn!(
                         "Qwen3.5: sym8 checkpoint requested block-paged KV cache; \
-                         the sym8 compiled path is flat-only — forcing \
-                         use_block_paged_cache=false."
+                         sym8 is validated on the flat (eager int8) path only — \
+                         forcing use_block_paged_cache=false."
                     );
                     config.use_block_paged_cache = Some(false);
                 }
@@ -1974,8 +1973,8 @@ fn parse_config(raw: &Value) -> Result<Qwen3_5Config> {
             .map(|v| v as u32),
         // Stage 1 (MTP-paged enablement): we do NOT auto-flip
         // `use_block_paged_cache` based on `n_mtp_layers > 0`. The
-        // Stage 1 hot path still runs the dense compiled MTP cycle
-        // (verify reads from `g_compiled_caches`, not the paged pool),
+        // default MTP hot path still runs the FLAT eager MTP cycle
+        // (verify reads the flat Rust layer caches, not the paged pool),
         // so eagerly constructing the paged adapter on every MTP-
         // capable checkpoint adds ~256 MB of unused GPU memory pressure
         // AND (more importantly) silently routes pure-AR turns on the

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -1254,6 +1254,10 @@ fn apply_weights_inner(
                 if let Some(w) = params.get(&format!("{}.self_attn.o_proj.bias", prefix)) {
                     attn.set_o_proj_bias(Some(w))?;
                 }
+                // Precompute the block-ordered q_proj weight so forward()/
+                // forward_paged() split queries/gate without a strided
+                // reshape-copy. No-op for quantized q_proj.
+                attn.finalize_q_gate_block()?;
             }
         }
 

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -2458,6 +2458,79 @@ mod tests {
         }
     }
 
+    /// A saved dense-MTP checkpoint must round-trip its MTP layer count.
+    /// `parse_config` reads the count ONLY from the HF-convention keys
+    /// (`mtp_num_hidden_layers` / `num_nextn_predict_layers`) and ignores the
+    /// serde field name `n_mtp_layers`, so `save_model_sync` must inject the
+    /// HF key into config.json (mirroring the MoE saver) — without it a
+    /// reloaded checkpoint comes back with `n_mtp_layers = 0` and its MTP
+    /// head is silently dropped.
+    #[test]
+    fn save_model_sync_round_trips_mtp_layer_count() {
+        let label = "save_model_sync_round_trips_mtp_layer_count";
+        let cfg = Qwen3_5Config {
+            n_mtp_layers: 1,
+            ..no_mtp_layer_cfg()
+        };
+
+        let mut inner = match Qwen35Inner::new(cfg) {
+            Ok(inner) => inner,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                // Random-init construction needs MLX ops; skip cleanly when
+                // the GPU/device is unavailable (CI without Metal).
+                if msg.contains("Metal") || msg.contains("device") {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {msg}");
+                    return;
+                }
+                panic!("unexpected Qwen35Inner::new failure in {label}: {msg}");
+            }
+        };
+        // A random-init MTP head's weights ARE its loaded weights (same
+        // rationale as `create_random_qwen35_moe_checkpoint_sync`); the saver
+        // only serializes the `mtp.*` tensors when this flag is set.
+        inner.mtp_weights_loaded = true;
+
+        let ckpt_dir = std::env::temp_dir().join(format!(
+            "mlx-qwen35-dense-mtp-roundtrip-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock before UNIX_EPOCH")
+                .as_nanos()
+        ));
+        struct DirCleanup(std::path::PathBuf);
+        impl Drop for DirCleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        let _cleanup = DirCleanup(ckpt_dir.clone());
+        let ckpt_path = ckpt_dir
+            .to_str()
+            .expect("temp checkpoint path is not valid UTF-8")
+            .to_string();
+
+        inner
+            .save_model_sync(&ckpt_path)
+            .unwrap_or_else(|err| panic!("save_model_sync failed in {label}: {}", err.reason));
+
+        let config_json = std::fs::read_to_string(ckpt_dir.join("config.json"))
+            .expect("saved config.json must be readable");
+        let raw: Value = serde_json::from_str(&config_json).expect("saved config.json is JSON");
+        assert_eq!(
+            raw.get("mtp_num_hidden_layers").and_then(|v| v.as_i64()),
+            Some(1),
+            "saved config.json must carry the HF-convention MTP key"
+        );
+
+        let reparsed = parse_config(&raw).expect("saved config.json must re-parse");
+        assert_eq!(
+            reparsed.n_mtp_layers, 1,
+            "reloaded config must reconstruct the MTP module (n_mtp_layers)"
+        );
+    }
+
     /// Persistence-level regression for the tied+quantized lm_head packed
     /// fast-path (paged, non-MTP, non-VLM): a quantized `embedding.*` sidecar
     /// on a paged config must load via `Embedding::load_quantized_packed`

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -910,6 +910,7 @@ fn apply_weights_inner(
     quant_group_size: i32,
     top_level_mode: Option<PerLayerMode>,
     per_layer_quant: &HashMap<String, PerLayerQuant>,
+    has_vision: bool,
 ) -> Result<()> {
     let is_quantized = is_quantized_checkpoint(params);
     let is_mxfp8 = is_mxfp8_checkpoint(params);
@@ -971,13 +972,54 @@ fn apply_weights_inner(
             .get("embed_tokens")
             .copied()
             .unwrap_or(default_plq);
-        inner
-            .embedding
-            .load_quantized(weight, scales, biases, plq.group_size, plq.bits)?;
-        info!(
-            "Loaded quantized embedding ({}-bit, quantized_matmul on forward)",
-            plq.bits
-        );
+        // Packed-resident load (`quantized_matmul` on the tied lm_head via
+        // `Embedding::as_linear` on the paged path) is a WIN only where every
+        // per-turn `get_weight()` consumer is packed-aware. That holds for the
+        // paged, non-MTP, non-VLM turn path (input lookup already uses
+        // `embed.forward`; the only eval'd `get_weight()` was the tied-head
+        // matmul, now routed through `as_linear`). It REGRESSES under packed on:
+        // the flat/eager path (`use_block_paged_cache != Some(true)`, incl. sym8
+        // + the non-Metal preview — re-dequants input lookup AND head per turn),
+        // MTP draft (`n_mtp_layers > 0` — per-draft dequant), and VLM image turns
+        // (`has_vision` — the vision-merge text-embed re-dequants). Gate the
+        // packed load to the proven-clean case; everything else keeps the legacy
+        // full-pre-dequant load (unchanged behavior). Coverage of MTP / VLM /
+        // flat is a follow-up.
+        //
+        // `use_block_paged_cache == Some(true)` is config INTENT; the paged
+        // adapter is only created when `compiled_forward_backend_available()`
+        // is ALSO true (`Qwen35Inner::new`), so a non-Metal/CUDA build with a
+        // paged config still runs flat — the added predicate keeps those on the
+        // legacy load (no per-turn dequant regression).
+        let prefer_packed = config.use_block_paged_cache == Some(true)
+            && crate::engine::persistence::compiled_forward_backend_available()
+            && config.n_mtp_layers == 0
+            && !has_vision;
+        if prefer_packed {
+            // Mode hardcoded "affine": embed_tokens/lm_head sidecars are always
+            // affine-quantized in every checkpoint format this loader accepts,
+            // matching what `Embedding::load_quantized` already hardcodes.
+            inner.embedding.load_quantized_packed(
+                weight,
+                scales,
+                biases,
+                plq.group_size,
+                plq.bits,
+                "affine",
+            )?;
+            info!(
+                "Loaded packed-quantized embedding ({}-bit, quantized_matmul on forward + tied lm_head)",
+                plq.bits
+            );
+        } else {
+            inner
+                .embedding
+                .load_quantized(weight, scales, biases, plq.group_size, plq.bits)?;
+            info!(
+                "Loaded quantized embedding ({}-bit, quantized_matmul on forward)",
+                plq.bits
+            );
+        }
     } else if let Some(w) = params.get("embedding.weight") {
         // Dense fallback (no `.scales`): a stripped quant group must never
         // reach the dense lookup / tied-lm_head matmul.
@@ -1670,6 +1712,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
                     quant_group_size,
                     top_level_mode,
                     &per_layer_quant,
+                    has_vision,
                 )?;
 
                 // Materialize mmap-backed weights. Pages were pre-warmed above, so
@@ -2413,6 +2456,139 @@ mod tests {
             use_block_paged_cache: None,
             n_mtp_layers: 0,
         }
+    }
+
+    /// Persistence-level regression for the tied+quantized lm_head packed
+    /// fast-path (paged, non-MTP, non-VLM): a quantized `embedding.*` sidecar
+    /// on a paged config must load via `Embedding::load_quantized_packed`
+    /// (packed-resident: `forward()` gather-then-dequants, `as_linear()` runs
+    /// `quantized_matmul`) — NOT the legacy `Embedding::load_quantized` (eager
+    /// full-table pre-dequant into a dense bf16 `[vocab, hidden]` array). Guards
+    /// the gated `apply_weights_inner` load branch directly; the packed-vs-dense
+    /// forward/as_linear numerical equivalence itself is already covered by
+    /// `crate::nn::embedding::tests::packed_affine_2bit_lookup_byte_identical_to_legacy_dense`
+    /// and `packed_affine_as_linear_matches_dense_matmul`.
+    #[test]
+    fn tied_quantized_embedding_loads_via_packed_path() {
+        let label = "tied_quantized_embedding_loads_via_packed_path";
+        // Satisfy the packed-load gate: paged, non-MTP, non-VLM.
+        // `no_mtp_layer_cfg()` already sets `n_mtp_layers = 0` but leaves
+        // `use_block_paged_cache = None`, so opt the fixture into paged here.
+        // The block-paged `LayerKVPool` only accepts head sizes in a fixed set
+        // (`no_mtp_layer_cfg`'s `head_dim = 16` is rejected), so bump the tied
+        // head/attention dim to the smallest valid pool size (32).
+        let mut cfg = no_mtp_layer_cfg(); // tie_word_embeddings: true, vocab 1024
+        cfg.use_block_paged_cache = Some(true);
+        cfg.head_dim = 32;
+
+        let mut inner = match Qwen35Inner::new(cfg.clone()) {
+            Ok(inner) => inner,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                // Pool allocation (`LayerKVPool`) requires Metal; skip cleanly
+                // when the GPU/device is unavailable (CI without Metal).
+                if msg.contains("Metal") || msg.contains("device") || msg.contains("LayerKVPool") {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {msg}");
+                    return;
+                }
+                panic!("unexpected Qwen35Inner::new failure in {label}: {msg}");
+            }
+        };
+
+        // Affine-quantize a synthetic [vocab, hidden] table exactly like a
+        // tied checkpoint's `embedding.{weight,scales,biases}` sidecar
+        // (group_size 32, 4-bit — this repo's embed_tokens/lm_head sidecars
+        // are always affine regardless of the body recipe).
+        let vocab = cfg.vocab_size as i64;
+        let hidden = cfg.hidden_size as i64;
+        let n = (vocab * hidden) as usize;
+        let data: Vec<f32> = (0..n).map(|i| ((i % 13) as f32 - 6.0) * 0.01).collect();
+        let dense = match MxArray::from_float32(&data, &[vocab, hidden]) {
+            Ok(a) => match a.astype(DType::BFloat16) {
+                Ok(a) => a,
+                Err(err) => panic!("unexpected astype failure in {label}: {}", err.reason),
+            },
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("Metal") || msg.contains("device") {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {msg}");
+                    return;
+                }
+                panic!("unexpected MxArray::from_float32 failure in {label}: {msg}");
+            }
+        };
+
+        let group_size = 32;
+        let bits = 4;
+        let mut out_q: *mut mlx_sys::mlx_array = std::ptr::null_mut();
+        let mut out_s: *mut mlx_sys::mlx_array = std::ptr::null_mut();
+        let mut out_b: *mut mlx_sys::mlx_array = std::ptr::null_mut();
+        let ok = unsafe {
+            mlx_sys::mlx_quantize(
+                dense.as_raw_ptr(),
+                group_size,
+                bits,
+                c"affine".as_ptr(),
+                &mut out_q,
+                &mut out_s,
+                &mut out_b,
+            )
+        };
+        assert!(ok, "mlx_quantize affine failed");
+        let qw = MxArray::from_handle(out_q, "qw").expect("qw");
+        let qs = MxArray::from_handle(out_s, "qs").expect("qs");
+        let qb = MxArray::from_handle(out_b, "qb").expect("qb");
+
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert("embedding.weight".to_string(), qw);
+        params.insert("embedding.scales".to_string(), qs);
+        params.insert("embedding.biases".to_string(), qb);
+
+        // Explicit per-layer override so the loader's group_size/bits exactly
+        // match how this test quantized the tensor above (the DEFAULT_QUANT_*
+        // fallback used when no override is present may not match).
+        let mut per_layer_quant: HashMap<String, PerLayerQuant> = HashMap::new();
+        per_layer_quant.insert(
+            "embed_tokens".to_string(),
+            PerLayerQuant {
+                bits,
+                group_size,
+                mode: PerLayerMode::Affine,
+            },
+        );
+
+        // The embedding sidecar is the ONLY tensor this fixture provides.
+        // `apply_weights_inner` loads the embedding UP FRONT, then runs an
+        // end-of-function completeness gate that rejects this deliberately
+        // partial checkpoint (no final_norm / attn / mlp). That Err is expected
+        // and fires strictly AFTER the embedding backend is installed on
+        // `inner`, so the packed-load assertion below still observes the real
+        // load decision. Only tolerate that specific completeness error — any
+        // other failure means the embedding load path itself broke.
+        match apply_weights_inner(
+            &mut inner,
+            &params,
+            &cfg,
+            DEFAULT_QUANT_BITS,
+            DEFAULT_QUANT_GROUP_SIZE,
+            None,
+            &per_layer_quant,
+            /* has_vision */ false,
+        ) {
+            Ok(()) => {}
+            Err(err) => {
+                let msg = err.reason.to_string();
+                assert!(
+                    msg.contains("missing mandatory weights"),
+                    "unexpected apply_weights_inner error in {label}: {msg}"
+                );
+            }
+        }
+
+        assert!(
+            inner.embedding.is_packed_quantized(),
+            "tied+quantized embedding.* on the paged path must load via load_quantized_packed, not the legacy dense load_quantized"
+        );
     }
 
     /// Build the three (never-quantized) MTP norms as bf16. Returns `None`

--- a/crates/mlx-core/src/models/qwen3_5/quantized_linear.rs
+++ b/crates/mlx-core/src/models/qwen3_5/quantized_linear.rs
@@ -486,7 +486,7 @@ impl QuantizedLinear {
     /// `M >= 3` → [`int8_gemm::int8_w8a8_matmul`] (the W8A8 prefill GEMM —
     /// act quant amortizes at prefill M). The only env gate is the
     /// same-binary A/B escape hatch `INT8_QMV_W8A16=0` (read inside the
-    /// shared C++ builder, so eager and compiled stay byte-identical) which
+    /// shared C++ builder, so every caller sees one dispatch rule) which
     /// reroutes decode back to the W8A8 qmv. Fail-loud on kernel error
     /// (there is no affine pack to fall back to).
     fn forward_sym8(&self, x: &MxArray) -> Result<MxArray> {

--- a/crates/mlx-core/src/models/qwen3_5/vision.rs
+++ b/crates/mlx-core/src/models/qwen3_5/vision.rs
@@ -7,7 +7,7 @@
 /// Architecture: patch_embed → + pos_embed → 27 blocks with 2D RoPE → merger
 use crate::array::MxArray;
 use crate::vision::embeddings::PatchEmbedding;
-use crate::vision::encoder::VisionEncoderLayer;
+use crate::vision::encoder::{VisionAttention, VisionEncoderLayer};
 use crate::vision::projector::SpatialProjector;
 use crate::vision::rope_vision::VisionRotaryEmbedding;
 use napi::bindgen_prelude::*;
@@ -346,9 +346,18 @@ impl Qwen3_5VisionEncoder {
         }
         let cu_seqlens_arr = MxArray::from_int32(&cu_seqlens, &[cu_seqlens.len() as i64])?;
 
+        // Build the additive attention mask once for this forward pass and
+        // reuse it across all encoder layers: it is a pure function of
+        // cu_seqlens/seq_len/dtype, which are identical for every layer
+        // (LayerNorm preserves dtype, and no layer changes the token count).
+        let total_seq_len = h.shape()?[0];
+        let mask_dtype = h.dtype()?;
+        let attention_mask =
+            VisionAttention::build_attention_mask(&cu_seqlens_arr, total_seq_len, mask_dtype)?;
+
         // Forward through encoder layers
         for layer in &self.layers {
-            h = layer.forward(&h, &cu_seqlens_arr, Some(&rotary_pos_emb))?;
+            h = layer.forward_with_mask(&h, Some(&attention_mask), Some(&rotary_pos_emb))?;
         }
 
         // Spatial projector (reduces token count by merge_size^2)
@@ -401,5 +410,98 @@ impl Clone for Qwen3_5VisionEncoder {
             rotary_pos_emb: self.rotary_pos_emb.clone(),
             merger: self.merger.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nn::LayerNorm;
+    use crate::vision::encoder::{BUILD_ATTENTION_MASK_CALLS, VisionMLP};
+
+    fn random_array(shape: &[i64]) -> MxArray {
+        let size: usize = shape.iter().map(|&s| s as usize).product();
+        let data: Vec<f32> = (0..size)
+            .map(|i| ((i % 100) as f32 - 50.0) / 100.0)
+            .collect();
+        MxArray::from_float32(&data, shape).unwrap()
+    }
+
+    /// Build a tiny encoder (small dims, `num_layers` transformer blocks, no
+    /// spatial merge) sufficient to exercise a full `forward()` call.
+    fn tiny_encoder(num_layers: usize) -> Qwen3_5VisionEncoder {
+        let hidden = 8i64;
+        let heads = 2u32;
+        let patch = 2i64;
+        let intermediate = 16i64;
+
+        let config = Qwen3_5VisionConfig {
+            hidden_size: hidden as i32,
+            intermediate_size: intermediate as i32,
+            num_heads: heads as i32,
+            num_layers: num_layers as i32,
+            patch_size: patch as i32,
+            spatial_merge_size: 1,
+            image_size: 4,
+            out_hidden_size: hidden as i32,
+        };
+
+        let mut encoder = Qwen3_5VisionEncoder::new(config).unwrap();
+
+        let patch_weight = random_array(&[hidden, patch, patch, 3]);
+        encoder.set_patch_embed(&patch_weight, None).unwrap();
+
+        for _ in 0..num_layers {
+            let ln1 = LayerNorm::new(hidden as u32, None).unwrap();
+            let ln2 = LayerNorm::new(hidden as u32, None).unwrap();
+            let qkv_weight = random_array(&[hidden * 3, hidden]);
+            let out_weight = random_array(&[hidden, hidden]);
+            let attn =
+                VisionAttention::new(hidden as u32, heads, &qkv_weight, None, &out_weight, None)
+                    .unwrap();
+            let fc1_weight = random_array(&[intermediate, hidden]);
+            let fc2_weight = random_array(&[hidden, intermediate]);
+            let mlp = VisionMLP::new(&fc1_weight, None, &fc2_weight, None).unwrap();
+            let layer = VisionEncoderLayer::new(&ln1, &ln2, &attn, &mlp);
+            encoder.add_layer(&layer);
+        }
+
+        let merger = SpatialProjector::new(
+            1,
+            &random_array(&[hidden]),
+            &random_array(&[hidden]),
+            &random_array(&[hidden, hidden]),
+            &random_array(&[hidden]),
+            &random_array(&[hidden, hidden]),
+            &random_array(&[hidden]),
+        )
+        .unwrap();
+        encoder.set_merger(merger);
+
+        encoder
+    }
+
+    #[test]
+    fn test_forward_builds_attention_mask_once_per_call() {
+        let num_layers = 3;
+        let encoder = tiny_encoder(num_layers);
+
+        // Single image, 1x2x2 patch grid = 4 patches, each patch_size x
+        // patch_size x 3 (channels) raw pixels.
+        let hidden_states = random_array(&[1, 4, 3, 2, 2]);
+        let grid_thw = MxArray::from_int32(&[1, 2, 2], &[1, 3]).unwrap();
+
+        BUILD_ATTENTION_MASK_CALLS.with(|c| c.set(0));
+        let output = encoder.forward(&hidden_states, &grid_thw).unwrap();
+        let calls = BUILD_ATTENTION_MASK_CALLS.with(|c| c.get());
+
+        assert_eq!(
+            calls, 1,
+            "build_attention_mask should be built once per forward call and reused \
+             across all {num_layers} encoder layers, not rebuilt once per layer"
+        );
+
+        let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
+        assert_eq!(shape, vec![4, 8]);
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5_moe/decoder_layer.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/decoder_layer.rs
@@ -173,6 +173,7 @@ impl DecoderLayer {
         position_ids: Option<&MxArray>,
         use_kernel: bool,
         rope_position_offset: i32,
+        mrope_cache: &mut Option<(MxArray, MxArray)>,
     ) -> Result<MxArray> {
         match kind {
             Qwen3_5LayerKind::Linear => {
@@ -214,6 +215,7 @@ impl DecoderLayer {
                     is_prefill,
                     position_ids,
                     rope_position_offset,
+                    mrope_cache,
                 )?;
                 let h = x.add(&attn_out)?;
                 let normed = self.post_attention_layernorm.forward(&h)?;

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -22,7 +22,8 @@ use crate::inference_trace::{
 use crate::model_thread::ResponseTx;
 use crate::models::qwen3_5::model::{
     VisionCache, VisionCacheInner, async_eval_layer_caches, compute_image_token_counts_per_image,
-    eval_layer_caches, inject_image_placeholders, vlm_prepare_vision_features,
+    eval_layer_caches, inject_image_placeholders, partition_prefill_chunks,
+    vlm_prepare_vision_features,
 };
 use crate::models::qwen3_5::processing::Qwen35VLImageProcessor;
 use crate::models::qwen3_5::vision::Qwen3_5VisionEncoder;
@@ -1307,9 +1308,12 @@ impl Qwen35MoeInner {
         if eager_mtp {
             // Pure-Rust eager MoE MTP — the propose/verify whole-turn loop is
             // engine-owned (`engine::run_mtp_turn`) and drives the
-            // `MoeMtpStepper` (`MtpBackend::begin_mtp_decode`). Cycle-history
-            // v1: no prompt-prefix seed, so the `prompt_hidden*` setup fields
-            // are `None`/`0`. The `profiler.set_label("moe_mtp_eager")` relabel
+            // `MoeMtpStepper` (`MtpBackend::begin_mtp_decode`). Committed-
+            // history v2 activates within-turn (persistent drafter cache
+            // across cycles) when its opt-in flag is on; the prompt-prefix seed
+            // itself stays inert here because this call site has no MoE
+            // hidden-emitting prefill yet, so `prompt_hidden`/`prompt_hidden_ids`
+            // stay `None`. The `profiler.set_label("moe_mtp_eager")` relabel
             // moved into `MoeMtpStepper::profiler_relabel`.
             let mut rng = rand::rng();
             MxArray::async_eval_arrays(&[&y]);
@@ -3767,7 +3771,9 @@ impl Qwen35MoeInner {
         if eager_mtp {
             // Delta-continuation eager MoE MTP — same engine-owned
             // `run_mtp_turn` loop + `MoeMtpStepper` as the fresh-prefill sync
-            // site (cycle-history v1: no prompt-prefix seed).
+            // site (committed-history v2 within-turn when its opt-in flag is on;
+            // prompt-prefix seed inert here — see the `MoeMtpStepper` struct
+            // doc).
             let mut rng = rand::rng();
             MxArray::async_eval_arrays(&[&y]);
 
@@ -4043,7 +4049,9 @@ impl Qwen35MoeInner {
         if eager_mtp {
             // Streaming delta-continuation eager MoE MTP — same engine-owned
             // `run_mtp_turn` loop + `MoeMtpStepper` + `StreamingCtx` as the
-            // fresh-prefill stream site (cycle-history v1: no prompt seed).
+            // fresh-prefill stream site (committed-history v2 within-turn when
+            // its opt-in flag is on; prompt-prefix seed inert here — see the
+            // `MoeMtpStepper` struct doc).
             let mut rng = rand::rng();
             MxArray::async_eval_arrays(&[&y]);
 
@@ -4589,6 +4597,16 @@ impl Qwen35MoeInner {
         })?;
         if let serde_json::Value::Object(ref mut map) = config_value {
             map.insert("model_type".to_string(), serde_json::json!("qwen3_5_moe"));
+            // `parse_config` reads the MTP layer count ONLY from the
+            // HF-convention keys `mtp_num_hidden_layers` /
+            // `num_nextn_predict_layers`; the serde field name
+            // `n_mtp_layers` is ignored on load. Without this, a saved MTP
+            // checkpoint reloads with `n_mtp_layers = 0` and its head is
+            // silently dropped.
+            map.insert(
+                "mtp_num_hidden_layers".to_string(),
+                serde_json::json!(self.config.n_mtp_layers),
+            );
         }
 
         let weights_json = serde_json::json!({
@@ -6827,22 +6845,60 @@ impl ChatBackend for Qwen35MoeInner {
     }
 }
 
+/// Opt-in gate for the MoE MTP committed-history v2 path. Default OFF: the
+/// drafter cache retention policy is an unvalidated perf change (v2 adds
+/// per-cycle commit work whose accept-rate payoff is unmeasured), so it ships
+/// behind this flag until a same-checkpoint A/B confirms the win. When off,
+/// `MoeMtpStepper::use_committed` is `false` at every site and the stepper is
+/// byte-for-byte the prior cycle-history v1. Read once on first call and
+/// cached; subsequent reads hit the `OnceLock` fast path.
+fn moe_mtp_committed_history_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        crate::inference_trace::env_flag_enabled_or_default(
+            "MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY",
+            false,
+        )
+    })
+}
+
 /// Per-turn MTP propose/verify stepper for the MoE family's FLAT eager path
 /// that [`crate::engine::mtp_turn::run_mtp_turn`] drives.
 ///
-/// CYCLE-HISTORY v1: the drafter cache is reset fresh by [`Self::begin_cycle`]
-/// every cycle and [`Self::commit_mtp`] is a no-op, so the stepper carries no
-/// persistent committed prefix and no committed-length cursor — the simpler
-/// policy the MoE eager MTP path has always run. FLAT-ONLY: the main forward,
-/// verify, and rollback all act on `inner.caches`; there is no paged routing,
-/// adapter, or `MtpStepMode` here.
+/// COMMITTED-HISTORY v2 (mirrors dense's `DenseMtpStepper`): when
+/// `use_committed` holds, [`Self::begin_cycle`] only truncates the prior
+/// cycle's speculative draft tail back to `committed_len` (never rebuilding a
+/// fresh cache) and [`Self::commit_mtp`] appends each cycle's newly committed
+/// tokens' exact K/V, so the drafter's cache persists across cycles within a
+/// turn. `use_committed` is opt-in: it requires the
+/// `MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY` flag AND
+/// `setup.prompt_hidden_position_base == 0`. With the flag off (the default)
+/// `use_committed` is `false`, so this stepper falls back to CYCLE-HISTORY v1
+/// (fresh drafter cache each cycle, no-op commit) — byte-for-byte the prior
+/// behavior. The prompt-prefix seed in [`MtpBackend::begin_mtp_decode`]
+/// mirrors dense's byte-for-byte but is currently INERT: no MoE call site
+/// populates a real `prompt_hidden`/`prompt_hidden_ids` yet (there is no MoE
+/// hidden-emitting prefill), so even with the flag on, cycle 1 of every turn
+/// still starts the drafter from an empty cache — only cycles 2+ within the
+/// SAME turn benefit today. FLAT-ONLY: the main forward, verify, and rollback
+/// all act on `inner.caches`; there is no paged routing, adapter, or
+/// `MtpStepMode` here.
 pub(crate) struct MoeMtpStepper<'a> {
     /// The model — owns layers / caches / mtp / final_norm / lm_head and the
     /// `flat_mtp_caches_desynced` latch.
     inner: &'a mut Qwen35MoeInner,
-    /// Drafter K/V caches, reset fresh each cycle by [`Self::begin_cycle`]
-    /// (cycle-history v1).
+    /// Drafter K/V caches. v2 committed-history mode (`use_committed`) holds
+    /// the persistent committed prefix; v1 cycle-history mode (the flag-off
+    /// default, or the `position_base != 0` fallback) is reset fresh by
+    /// [`Self::begin_cycle`].
     mtp_caches: Vec<Qwen3_5LayerCache>,
+    /// Eager analogue of dense's committed-length cursor: committed tokens
+    /// whose exact K/V live in `mtp_caches`.
+    committed_len: i32,
+    /// Committed-history active iff the opt-in flag is on AND the prompt tail's
+    /// hiddens start at absolute position 0 — mirrors
+    /// `DenseMtpStepper::use_committed`.
+    use_committed: bool,
     /// Pre-verify snapshot of the main caches, taken in
     /// [`Self::snapshot_main_linear`], consumed by [`Self::rollback`].
     snap: Option<Result<Vec<super::layer_cache::Qwen3_5LayerSnapshot>>>,
@@ -6872,7 +6928,7 @@ impl MtpStepper for MoeMtpStepper<'_> {
     }
 
     fn committed_history_active(&self) -> bool {
-        false
+        self.use_committed
     }
 
     fn profiler_relabel(&self) -> Option<&'static str> {
@@ -7079,23 +7135,95 @@ impl MtpStepper for MoeMtpStepper<'_> {
         Ok(())
     }
 
-    // Cycle-history v1: no committed-history commit.
+    // Committed-history commit. Mirrors `DenseMtpStepper::commit_mtp`.
+    //
+    // v1 (`!use_committed`): no-op.
+    //
+    // v2 (`use_committed`): append the M newly committed tokens' EXACT K/V to
+    // the persistent MTP cache via one multi-token drafter forward.
     fn commit_mtp(
         &mut self,
-        _anchor: mtp_decode::MtpCommitAnchor,
-        _seed_hidden: &MxArray,
-        _verify_hiddens: &MxArray,
-        _committed_ids: &[u32],
+        anchor: mtp_decode::MtpCommitAnchor,
+        seed_hidden: &MxArray,
+        verify_hiddens: &MxArray,
+        committed_ids: &[u32],
         _k_accepted: usize,
-        _emb: &MxArray,
+        emb: &MxArray,
     ) -> Result<()> {
+        if !self.use_committed {
+            return Ok(());
+        }
+        let m = committed_ids.len();
+        if m == 0 {
+            return Ok(());
+        }
+        let hidden_dim = verify_hiddens.shape_at(2)?;
+
+        // Assemble hidden_seq [1, M, hidden] per anchor.
+        let hidden_seq = match anchor {
+            mtp_decode::MtpCommitAnchor::IncludeAnchor => {
+                // seed_hidden ++ verify_hiddens[:, 0..M-1, :].
+                let vh_prefix =
+                    verify_hiddens.slice(&[0, 0, 0], &[1, (m - 1) as i64, hidden_dim])?;
+                MxArray::concatenate(seed_hidden, &vh_prefix, 1)?
+            }
+            mtp_decode::MtpCommitAnchor::SkipAlreadyCommittedAnchor => {
+                // verify_hiddens[:, 0..M, :].
+                verify_hiddens.slice(&[0, 0, 0], &[1, m as i64, hidden_dim])?
+            }
+        };
+
+        // Gather the M committed-token input embeddings → [1, M, hidden].
+        let ids_i32: Vec<i32> = committed_ids.iter().map(|&v| v as i32).collect();
+        let ids_arr = MxArray::from_int32(&ids_i32, &[m as i64])?;
+        let gathered = emb.take(&ids_arr, 0)?;
+        let emb_seq = gathered.reshape(&[1, m as i64, hidden_dim])?;
+
+        // Drop this cycle's draft K/V (written past committed_len by the draft
+        // steps), then write the exact committed K/V via one multi-token
+        // forward.
+        let inner = &mut *self.inner;
+        let mtp = inner.mtp.as_mut().ok_or_else(|| {
+            Error::from_reason(
+                "eager MoE MTP commit_mtp: inner.mtp is None despite \
+                 has_mtp_weights() gate",
+            )
+        })?;
+        let caches = &mut self.mtp_caches;
+        for c in caches.iter_mut() {
+            if let Some(kv) = c.as_kv_cache_mut() {
+                kv.trim(self.committed_len);
+            }
+        }
+        let _ = mtp.forward(&hidden_seq, &emb_seq, Some(caches))?;
+        self.committed_len += m as i32;
         Ok(())
     }
 
-    // Cycle-history v1: reset the drafter cache to a fresh cache each cycle
-    // (the `chained_anchor` re-anchor is dense committed-history only).
-    fn begin_cycle(&mut self, _chained_anchor: bool) {
-        self.mtp_caches = Qwen3_5MoeMTPModule::fresh_caches(&self.config);
+    // Re-anchor the drafter cache at the start of each cycle. Mirrors
+    // `DenseMtpStepper::begin_cycle`.
+    //
+    // v1 (`!use_committed`): reset to a fresh cache.
+    //
+    // v2 (`use_committed`): the cache is PERSISTENT; truncate the prior
+    // cycle's draft tail back to the re-anchor target. `chained_anchor`
+    // cycles anchor one slot earlier (`committed_len - 1`); Step-A cycles at
+    // `committed_len`.
+    fn begin_cycle(&mut self, chained_anchor: bool) {
+        if !self.use_committed {
+            self.mtp_caches = Qwen3_5MoeMTPModule::fresh_caches(&self.config);
+            return;
+        }
+        let target = if chained_anchor {
+            (self.committed_len - 1).max(0)
+        } else {
+            self.committed_len
+        };
+        for c in self.mtp_caches.iter_mut() {
+            if let Some(kv) = c.as_kv_cache_mut() {
+                kv.trim(target);
+            }
+        }
     }
 
     // Bound the lazy graph: materialize the token plus the main GDN/full-attn
@@ -7138,17 +7266,27 @@ impl MtpBackend for Qwen35MoeInner {
         Self: 'a;
 
     fn begin_mtp_decode(&mut self, setup: &MtpTurnSetup<'_>) -> Result<Self::MtpDecode<'_>> {
-        // Cycle-history v1 ignores the prompt-prefix seed (the dense
-        // committed-history v2 prompt commit has no analog here).
-        let _ = setup;
         let embedding_weight = self.embedding.get_weight();
         let embedding_weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
         let config = self.config.clone();
-        let mtp_caches = Qwen3_5MoeMTPModule::fresh_caches(&config);
         let fa_idx = self.fa_idx;
-        Ok(MoeMtpStepper {
+
+        // Committed-history is opt-in (default off) and only correct when the
+        // prompt tail's hiddens start at absolute position 0 (the eager
+        // drafter derives RoPE purely from the local cache offset) — mirrors
+        // `DenseMtpStepper::begin_mtp_decode`'s gate, plus the
+        // `MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY` flag. No MoE call site
+        // populates a real `prompt_hidden_position_base` yet (see the struct
+        // doc), so the position gate is always satisfied today; the flag is
+        // what makes this `true`.
+        let use_committed =
+            moe_mtp_committed_history_enabled() && setup.prompt_hidden_position_base == 0;
+
+        let mut stepper = MoeMtpStepper {
             inner: self,
-            mtp_caches,
+            mtp_caches: Qwen3_5MoeMTPModule::fresh_caches(&config),
+            committed_len: 0,
+            use_committed,
             snap: None,
             tape: Vec::new(),
             replay_err: None,
@@ -7157,7 +7295,65 @@ impl MtpBackend for Qwen35MoeInner {
             embedding_weight_t,
             config,
             fa_idx,
-        })
+        };
+
+        // Prompt-prefix seed (v2 committed-history only). Mirrors
+        // `DenseMtpStepper::begin_mtp_decode`'s prompt-prefix seed block
+        // byte-for-byte. Currently INERT: no MoE call site populates
+        // `setup.prompt_hidden` / `setup.prompt_hidden_ids` yet (there is no
+        // MoE hidden-emitting prefill), so this block never runs until a
+        // follow-up wires that capture through — see the struct doc on
+        // [`MoeMtpStepper`].
+        if use_committed
+            && let (Some(ph), Some(ph_ids)) = (setup.prompt_hidden, setup.prompt_hidden_ids)
+            && !ph_ids.is_empty()
+        {
+            let prompt_len = ph_ids.len();
+            let hidden_dim = ph.shape_at(2)?;
+            let hidden_len = ph.shape_at(1)? as usize;
+            if hidden_len != prompt_len {
+                return Err(Error::from_reason(format!(
+                    "eager MoE MTP prompt-seed: prompt_hidden length {hidden_len} \
+                     does not match prompt_hidden_ids length {prompt_len}"
+                )));
+            }
+            // The first sampled token `y` is supplied by the engine via the
+            // setup so the prompt seed can commit `[prompt_ids[1..], y]`.
+            let y_id = setup.first_sampled_token;
+
+            // Committed run = [prompt_ids[1..prompt_len], y] (length P).
+            let mut committed_ids: Vec<i32> = Vec::with_capacity(prompt_len);
+            committed_ids.extend(ph_ids[1..prompt_len].iter().map(|&v| v as i32));
+            committed_ids.push(y_id as i32);
+
+            let chunk_sizes = partition_prefill_chunks(prompt_len);
+            let mut cursor: usize = 0;
+            for &chunk in &chunk_sizes {
+                let chunk_i64 = chunk as i64;
+                let start = cursor as i64;
+                // hidden_seq = prompt_hidden[:, cursor..cursor+chunk, :].
+                let hidden_seq = ph.slice(&[0, start, 0], &[1, start + chunk_i64, hidden_dim])?;
+                // emb_seq = gather embedding rows for the chunk's ids.
+                let ids_arr =
+                    MxArray::from_int32(&committed_ids[cursor..cursor + chunk], &[chunk_i64])?;
+                let gathered = stepper.embedding_weight.take(&ids_arr, 0)?;
+                let emb_seq = gathered.reshape(&[1, chunk_i64, hidden_dim])?;
+
+                let inner = &mut *stepper.inner;
+                let mtp = inner.mtp.as_mut().ok_or_else(|| {
+                    Error::from_reason(
+                        "eager MoE MTP prompt-seed: inner.mtp is None despite \
+                         has_mtp_weights() gate",
+                    )
+                })?;
+                let caches = &mut stepper.mtp_caches;
+                let _ = mtp.forward(&hidden_seq, &emb_seq, Some(caches))?;
+                stepper.committed_len += chunk as i32;
+                cursor += chunk;
+            }
+        }
+
+        Ok(stepper)
     }
 }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -34,7 +34,6 @@ use super::mtp::Qwen3_5MoeMTPModule;
 use super::persistence;
 use super::quantized_linear::LinearProj;
 use crate::array::MxArray;
-use crate::array::mask::create_causal_mask;
 use crate::engine;
 use crate::engine::backend::{MtpBackend, MtpStepper, MtpTurnSetup};
 use crate::engine::{
@@ -7424,39 +7423,26 @@ crate::models::chat_napi::chat_napi_surface! {
 /// This is the shared eager-MTP primitive: it advances `caches` (the flat
 /// per-layer caches: `Linear` GDN slots + `FullAttention` KV slots) by `T`
 /// and returns the full per-position hidden, exactly mirroring the dense
-/// `forward_pre_norm_inner`. Linear (GDN) layers run mask-free; full-attention
-/// layers get a causal mask sized from the `fa_idx` cache offset.
+/// `forward_pre_norm_inner`. No explicit mask is ever built: `Linear` (GDN)
+/// layers run mask-free, and full-attention layers pass `mask: None` too, so
+/// `Qwen3_5Attention::forward` picks its fused "causal" SDPA kernel whenever
+/// `seq_len > 1` — covering both prefill and the `[1, K+1]` eager-MTP verify
+/// shape this helper backs.
 fn forward_pre_norm_inner(
     input_ids: &MxArray,
     embedding_weight: &MxArray,
     layers: &mut [DecoderLayer],
     caches: &mut Option<Vec<Qwen3_5LayerCache>>,
-    fa_idx: usize,
+    _fa_idx: usize,
 ) -> Result<MxArray> {
     let embedding = Embedding::from_weight(embedding_weight)?;
     let hidden_states = embedding.forward(input_ids)?;
     let mut h = hidden_states.clone();
 
-    let seq_len = hidden_states.shape_at(1)?;
-    let fa_mask = {
-        let has_cache = caches.is_some();
-        if seq_len <= 1 && has_cache {
-            None
-        } else {
-            let offset = caches.as_ref().map(|c| c[fa_idx].offset()).unwrap_or(0);
-            Some(create_causal_mask(seq_len as i32, Some(offset), None)?)
-        }
-    };
-
     let num_layers = layers.len();
     for i in 0..num_layers {
-        let mask = if layers[i].is_linear() {
-            None
-        } else {
-            fa_mask.as_ref()
-        };
         let cache = caches.as_mut().map(|c| &mut c[i]);
-        h = layers[i].forward(&h, mask, cache, None, true)?;
+        h = layers[i].forward(&h, None, cache, None, true)?;
     }
     Ok(h)
 }
@@ -7466,29 +7452,19 @@ fn forward_pre_norm_inner(
 /// each GDN (`Linear`) layer writes `Some(GdnLayerTape)` into its slot and
 /// full-attention layers leave it `None` — the exact indexing the rollback
 /// replay relies on. The forward output is byte-identical to the non-tape
-/// variant (the tape is a side-channel clone of the kernel inputs).
+/// variant (the tape is a side-channel clone of the kernel inputs). No
+/// explicit mask is built here either — see `forward_pre_norm_inner`.
 fn forward_pre_norm_inner_with_tape(
     input_ids: &MxArray,
     embedding_weight: &MxArray,
     layers: &mut [DecoderLayer],
     caches: &mut Option<Vec<Qwen3_5LayerCache>>,
-    fa_idx: usize,
+    _fa_idx: usize,
     tape: &mut [Option<super::gated_delta_net::GdnLayerTape>],
 ) -> Result<MxArray> {
     let embedding = Embedding::from_weight(embedding_weight)?;
     let hidden_states = embedding.forward(input_ids)?;
     let mut h = hidden_states.clone();
-
-    let seq_len = hidden_states.shape_at(1)?;
-    let fa_mask = {
-        let has_cache = caches.is_some();
-        if seq_len <= 1 && has_cache {
-            None
-        } else {
-            let offset = caches.as_ref().map(|c| c[fa_idx].offset()).unwrap_or(0);
-            Some(create_causal_mask(seq_len as i32, Some(offset), None)?)
-        }
-    };
 
     let num_layers = layers.len();
     debug_assert_eq!(
@@ -7497,14 +7473,9 @@ fn forward_pre_norm_inner_with_tape(
         "forward_pre_norm_inner_with_tape: tape length must equal layer count"
     );
     for i in 0..num_layers {
-        let mask = if layers[i].is_linear() {
-            None
-        } else {
-            fa_mask.as_ref()
-        };
         let cache = caches.as_mut().map(|c| &mut c[i]);
         let mut slot: Option<super::gated_delta_net::GdnLayerTape> = None;
-        h = layers[i].forward_with_tape(&h, mask, cache, None, true, Some(&mut slot))?;
+        h = layers[i].forward_with_tape(&h, None, cache, None, true, Some(&mut slot))?;
         tape[i] = slot;
     }
     Ok(h)
@@ -7572,36 +7543,25 @@ fn forward_inner(
     caches: &mut Option<Vec<Qwen3_5LayerCache>>,
     final_norm: &RMSNorm,
     lm_head: &Option<LinearProj>,
-    fa_idx: usize,
+    _fa_idx: usize,
     embedding_weight_t: Option<&MxArray>,
 ) -> Result<MxArray> {
     let embedding = Embedding::from_weight(embedding_weight)?;
     let hidden_states = embedding.forward(input_ids)?;
     let mut h = hidden_states.clone();
 
-    let seq_len = hidden_states.shape_at(1)?;
-    let fa_mask = {
-        let has_cache = caches.is_some();
-        if seq_len <= 1 && has_cache {
-            None
-        } else {
-            let offset = caches.as_ref().map(|c| c[fa_idx].offset()).unwrap_or(0);
-            Some(create_causal_mask(seq_len as i32, Some(offset), None)?)
-        }
-    };
-
-    // SSM mask is always None — mlx-vlm never creates one for ArraysCache.
-    // An all-ones mask is a no-op that adds unnecessary graph nodes and Metal overhead.
-
+    // No explicit mask is ever built. Full-attention layers pass `mask:
+    // None`, so `Qwen3_5Attention::forward` picks its fused "causal" SDPA
+    // kernel whenever `seq_len > 1` (prefill and the `[1, K+1]` eager-MTP
+    // verify shape alike) instead of a materialized boolean-mask array.
+    // Linear (GDN) layers already ran mask-free — mlx-vlm never creates one
+    // for `ArraysCache`, and an all-ones mask would just be a no-op that
+    // adds graph nodes and Metal overhead. Mirrors the dense
+    // `forward_pre_norm_inner`.
     let num_layers = layers.len();
     for i in 0..num_layers {
-        let mask = if layers[i].is_linear() {
-            None
-        } else {
-            fa_mask.as_ref()
-        };
         let cache = caches.as_mut().map(|c| &mut c[i]);
-        h = layers[i].forward(&h, mask, cache, None, true)?;
+        h = layers[i].forward(&h, None, cache, None, true)?;
     }
 
     let h = final_norm.forward(&h)?;
@@ -7968,5 +7928,174 @@ mod paged_construction_tests {
             "Qwen35MoeInner::new with use_block_paged_cache=true must succeed on Metal host",
         );
         assert!(inner.paged_adapter.is_some());
+    }
+}
+
+#[cfg(test)]
+mod mask_free_full_attention_parity_tests {
+    //! Locks in that `forward_pre_norm_inner`'s mask-free full-attention
+    //! forward (the shared attention module's fused "causal" SDPA fast
+    //! path, selected whenever `mask` is `None` and `seq_len > 1`) is
+    //! numerically transparent versus the explicit `create_causal_mask`
+    //! array it replaced, for a PRIMED cache (nonzero KV offset) — the
+    //! exact shape of the eager-MTP verify call (`[1, K+1]` ids over an
+    //! already-decoded prefix). Mirrors
+    //! `causal_attention_matches_explicit_offset_mask_when_kv_is_longer` in
+    //! `crate::array::attention::tests`, one layer stack up.
+
+    use super::*;
+    use crate::array::mask::create_causal_mask;
+    use crate::models::qwen3_5_moe::config::Qwen3_5MoeConfig;
+
+    fn tiny_moe_cfg() -> Qwen3_5MoeConfig {
+        Qwen3_5MoeConfig {
+            vocab_size: 1024,
+            hidden_size: 64,
+            num_layers: 8,
+            num_heads: 4,
+            num_kv_heads: 2,
+            intermediate_size: 128,
+            rms_norm_eps: 1e-6,
+            head_dim: 16,
+            tie_word_embeddings: true,
+            attention_bias: false,
+            max_position_embeddings: 1024,
+            pad_token_id: 0,
+            eos_token_id: 0,
+            bos_token_id: 0,
+            linear_num_value_heads: 4,
+            linear_num_key_heads: 2,
+            linear_key_head_dim: 16,
+            linear_value_head_dim: 16,
+            linear_conv_kernel_dim: 4,
+            full_attention_interval: 4,
+            partial_rotary_factor: 0.25,
+            rope_theta: 100_000.0,
+            num_experts: 4,
+            num_experts_per_tok: 2,
+            decoder_sparse_step: 1,
+            shared_expert_intermediate_size: None,
+            moe_intermediate_size: None,
+            norm_topk_prob: true,
+            mlp_only_layers: None,
+            paged_cache_memory_mb: Some(64),
+            paged_block_size: Some(16),
+            use_block_paged_cache: None,
+            n_mtp_layers: 0,
+        }
+    }
+
+    /// Pre-fix mask construction, kept here ONLY as a reference oracle —
+    /// byte-for-byte the code this fix deletes from `forward_pre_norm_inner`.
+    /// Builds an explicit causal mask sized from `caches[fa_idx]`'s offset
+    /// and hands it to every full-attention layer.
+    fn forward_with_explicit_causal_mask(
+        input_ids: &MxArray,
+        embedding_weight: &MxArray,
+        layers: &mut [DecoderLayer],
+        caches: &mut Option<Vec<Qwen3_5LayerCache>>,
+        fa_idx: usize,
+    ) -> Result<MxArray> {
+        let embedding = Embedding::from_weight(embedding_weight)?;
+        let hidden_states = embedding.forward(input_ids)?;
+        let mut h = hidden_states.clone();
+
+        let seq_len = hidden_states.shape_at(1)?;
+        let fa_mask = {
+            let has_cache = caches.is_some();
+            if seq_len <= 1 && has_cache {
+                None
+            } else {
+                let offset = caches.as_ref().map(|c| c[fa_idx].offset()).unwrap_or(0);
+                Some(create_causal_mask(seq_len as i32, Some(offset), None)?)
+            }
+        };
+
+        let num_layers = layers.len();
+        for i in 0..num_layers {
+            let mask = if layers[i].is_linear() {
+                None
+            } else {
+                fa_mask.as_ref()
+            };
+            let cache = caches.as_mut().map(|c| &mut c[i]);
+            h = layers[i].forward(&h, mask, cache, None, true)?;
+        }
+        Ok(h)
+    }
+
+    #[test]
+    fn mask_free_forward_matches_explicit_offset_mask_after_priming() {
+        let cfg = tiny_moe_cfg();
+        let mut layers = (0..cfg.num_layers as usize)
+            .map(|i| DecoderLayer::new(&cfg, i))
+            .collect::<Result<Vec<_>>>()
+            .expect("layer construction must succeed");
+        let embedding = Embedding::new(cfg.vocab_size as u32, cfg.hidden_size as u32)
+            .expect("embedding construction must succeed");
+        let embedding_weight = embedding.weight();
+
+        let fa_idx = (0..cfg.num_layers as usize)
+            .find(|&i| !cfg.is_linear_layer(i))
+            .expect("tiny_moe_cfg must contain at least one full-attention layer");
+
+        let mut caches_old = Some(fresh_moe_layer_caches(&cfg));
+        let mut caches_new = Some(fresh_moe_layer_caches(&cfg));
+
+        // Prime both cache sets identically with a few single-token decode
+        // steps so the eventual multi-token forward runs against a nonzero
+        // KV offset — an empty cache is the degenerate offset=0 case both
+        // code paths already handled identically, so it wouldn't exercise
+        // the fix.
+        for tok in [5u32, 9, 13] {
+            let ids = MxArray::from_uint32(&[tok], &[1, 1]).expect("prime ids");
+            forward_pre_norm_inner(
+                &ids,
+                &embedding_weight,
+                &mut layers,
+                &mut caches_old,
+                fa_idx,
+            )
+            .expect("priming forward (old-path cache) must succeed");
+            forward_pre_norm_inner(
+                &ids,
+                &embedding_weight,
+                &mut layers,
+                &mut caches_new,
+                fa_idx,
+            )
+            .expect("priming forward (new-path cache) must succeed");
+        }
+
+        // The eager-MTP verify shape: `[1, K+1]` ids over the primed prefix.
+        let verify_ids = MxArray::from_uint32(&[21u32, 22, 23, 24], &[1, 4]).expect("verify ids");
+
+        let old_out = forward_with_explicit_causal_mask(
+            &verify_ids,
+            &embedding_weight,
+            &mut layers,
+            &mut caches_old,
+            fa_idx,
+        )
+        .expect("explicit-mask forward must succeed");
+        let new_out = forward_pre_norm_inner(
+            &verify_ids,
+            &embedding_weight,
+            &mut layers,
+            &mut caches_new,
+            fa_idx,
+        )
+        .expect("mask-free forward must succeed");
+
+        let old_vals = old_out.to_float32().expect("old output to_float32");
+        let new_vals = new_out.to_float32().expect("new output to_float32");
+        assert_eq!(old_vals.len(), new_vals.len());
+        for (idx, (a, b)) in old_vals.iter().zip(new_vals.iter()).enumerate() {
+            let diff = (a - b).abs();
+            assert!(
+                diff <= 1e-4,
+                "mask-free forward diverged from explicit-mask forward at {idx}: {a} vs {b} (diff {diff})"
+            );
+        }
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -2400,7 +2400,8 @@ impl Qwen35MoeInner {
         // `update_keys_values` per layer (Metal kernel dispatch — direct
         // buffer mutation, NOT MLX graph) and populates the GDN linear
         // caches in `Qwen3_5LayerCache::Linear(ArraysCache)`. Both are
-        // exactly what the C++ compiled paged decode reads as inputs.
+        // exactly what the pure-Rust paged decode steps
+        // (`paged_forward::run_paged_decode_step`) read as inputs.
         let last_logits = {
             let embed = self.embedding.clone();
             let embedding_weight = embed.get_weight();
@@ -2517,8 +2518,9 @@ impl Qwen35MoeInner {
 
     /// Block-paged streaming variant for MoE — mirrors dense
     /// `paged_turn_stream_core`. See [`Self::paged_turn_sync_core`]
-    /// for the C++ compiled paged dispatch rationale; the streaming path
-    /// uses the same lock acquisition + fall-back semantics.
+    /// for the paged dispatch rationale (pure-Rust paged prefill + decode
+    /// against the adapter pool); the streaming path uses the same
+    /// adapter lifecycle + prefix-reuse semantics.
     #[allow(clippy::too_many_arguments)]
     fn paged_turn_stream_core(
         &mut self,

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -279,7 +279,7 @@ pub(crate) struct Qwen35MoeInner {
     /// Whether the CURRENT generic-flow turn is streaming. Set by the
     /// [`ChatBackend::profiler_label`] hook (the session core calls it
     /// exactly once per generic-flow turn, before `begin_decode`);
-    /// consumed by [`ChatBackend::begin_decode`]'s compiled/eager
+    /// consumed by [`ChatBackend::begin_decode`]'s
     /// profiler relabel, which must pick the `moe_chat_*` vs
     /// `moe_chat_stream_*` label family (`TurnSetup` does not carry
     /// streaming-ness). Whole-turn override paths (vision/paged/MTP)
@@ -2396,11 +2396,12 @@ impl Qwen35MoeInner {
             |i| self.config.is_linear_layer(i),
         );
 
-        // Pure-Rust paged prefill: writes K/V into the adapter pool via
-        // `update_keys_values` per layer (Metal kernel dispatch — direct
-        // buffer mutation, NOT MLX graph) and populates the GDN linear
-        // caches in `Qwen3_5LayerCache::Linear(ArraysCache)`. Both are
-        // exactly what the pure-Rust paged decode steps
+        // Pure-Rust paged prefill: writes K/V into the adapter pool per
+        // layer via `update_keys_values_native` (graph-native `PagedKVWrite`
+        // primitive — the default; the synchronous raw-Metal
+        // `update_keys_values` is the error/opt-out fallback) and populates
+        // the GDN linear caches in `Qwen3_5LayerCache::Linear(ArraysCache)`.
+        // Both are exactly what the pure-Rust paged decode steps
         // (`paged_forward::run_paged_decode_step`) read as inputs.
         let last_logits = {
             let embed = self.embedding.clone();
@@ -6004,8 +6005,8 @@ impl Qwen35MoeInner {
     /// [`Self::vision_mtp_whole_turn_stream_core`], delta streaming →
     /// [`Self::chat_stream_tokens_delta_sync_inner`]. These cores own
     /// every MoE-path subtlety the generic flow does not model: VLM
-    /// prefill + M-RoPE deltas, the MTP gate (compiled-init fallback to
-    /// AR), the paged-always-wins dispatch (including the
+    /// prefill + M-RoPE deltas, the MTP gate (eager MTP, falling back
+    /// to AR when ineligible), the paged-always-wins dispatch (including the
     /// paged-text-only rejection for image turns — unlike dense, MoE
     /// has NO `mtp_takes_dense_path` exception: its paged early-return
     /// runs before any MTP consideration on every path).

--- a/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
@@ -463,6 +463,10 @@ impl Qwen3_5MoeMTPModule {
             if let Some(w) = params.get(&format!("{}.self_attn.o_proj.bias", prefix)) {
                 attn.set_o_proj_bias(Some(w))?;
             }
+            // Precompute the block-ordered q_proj weight so forward()/
+            // forward_paged() split queries/gate without a strided
+            // reshape-copy. No-op for quantized q_proj.
+            attn.finalize_q_gate_block()?;
 
             // MLP — dense MLP, MoE switch_mlp + router gate +
             // shared_expert, or already-quantized (no-op). Mirrors the

--- a/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
@@ -337,8 +337,10 @@ impl Qwen3_5MoeMTPModule {
                 PerLayerMode::Affine => {
                     try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
                 }
-                // Unreachable: `apply_weights_moe_inner` rejects sym8
-                // checkpoints before the MTP load runs.
+                // Unreachable: `apply_weights_moe_inner` disables the MTP
+                // head load for sym8 checkpoints (`mtp_weights_loaded =
+                // false`, warn) before this `apply_weights` can run, so no
+                // sym8 PLQ ever reaches these builders.
                 PerLayerMode::Sym8 => None,
             }
         };

--- a/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
@@ -1002,14 +1002,36 @@ mod tests {
     ///
     /// `mlx_sys::mlx_seed(0xC0DEC0DE)` pins MLX's random init so the
     /// chunked-vs-single-shot drift is reproducible across runs;
-    /// observed `max_abs_diff = 0.0693`, argmax stable at idx=69.
+    /// observed `max_abs_diff = 0.0693`, argmax stable at idx=69 (M3,
+    /// pre scalar-RoPE-axis fix — the magnitude will differ after that
+    /// fix since both paths' rotation angles changed; the 0.25 budget
+    /// rationale below is unchanged).
     /// Requires Metal GPU; run with `--ignored`.
+    ///
+    /// Skips on hosts whose half-precision GEMM fails the
+    /// `test_support::half_gemm_untrustworthy` canary: this config's
+    /// q_proj (K=128, N=256) and fallback-SDPA matmuls (K=32 scores)
+    /// sit inside the vendored-MLX NAX unaligned-K broken regime on
+    /// gen>=17 GPUs, where chunk length changes which kernel class each
+    /// token's math takes and parity deterministically breaks O(1)
+    /// (observed 0.86-0.91 with argmax flips on M5 Max) with no chunking
+    /// bug present.
+    ///
     /// `Qwen35MoeInner::new` can throw a foreign C++ exception on
     /// machines without Metal, which aborts the test process before
     /// Rust can catch the failure.
     #[test]
     #[ignore = "requires Metal GPU; run with --ignored"]
     fn test_chunked_prefill_qwen3_5_moe_matches_single_shot_logits() {
+        if crate::test_support::half_gemm_untrustworthy() {
+            eprintln!(
+                "skipping test_chunked_prefill_qwen3_5_moe_matches_single_shot_logits: \
+                 half-precision GEMM fails the K=64/N=64 canary on this host \
+                 (vendored-MLX NAX unaligned-K bug); tiny-config chunked-vs-\
+                 single-shot parity is not meaningful here"
+            );
+            return;
+        }
         unsafe {
             mlx_sys::mlx_seed(0xC0DEC0DE);
         }
@@ -1079,14 +1101,32 @@ mod tests {
     ///
     /// `mlx_sys::mlx_seed(0xC0DEC0DE)` pins MLX's random init so the
     /// chunked-vs-single-shot drift is reproducible across runs;
-    /// observed `max_abs_diff = 0.1199`, argmax stable at idx=80.
+    /// observed `max_abs_diff = 0.1199`, argmax stable at idx=80 (M3,
+    /// pre scalar-RoPE-axis fix — the magnitude will differ after that
+    /// fix since both paths' rotation angles changed; the 0.25 budget
+    /// rationale is unchanged).
     /// Requires Metal GPU; run with `--ignored`.
+    ///
+    /// Skips on hosts whose half-precision GEMM fails the
+    /// `test_support::half_gemm_untrustworthy` canary — same rationale
+    /// as `test_chunked_prefill_qwen3_5_moe_matches_single_shot_logits`
+    /// above (observed 0.73-0.91 on M5 Max with no chunking bug).
+    ///
     /// `Qwen35MoeInner::new` can throw a foreign C++ exception on
     /// machines without Metal, which aborts the test process before
     /// Rust can catch the failure.
     #[test]
     #[ignore = "requires Metal GPU; run with --ignored"]
     fn test_chunked_prefill_qwen3_5_moe_uneven_tail() {
+        if crate::test_support::half_gemm_untrustworthy() {
+            eprintln!(
+                "skipping test_chunked_prefill_qwen3_5_moe_uneven_tail: \
+                 half-precision GEMM fails the K=64/N=64 canary on this host \
+                 (vendored-MLX NAX unaligned-K bug); tiny-config chunked-vs-\
+                 single-shot parity is not meaningful here"
+            );
+            return;
+        }
         unsafe {
             mlx_sys::mlx_seed(0xC0DEC0DE);
         }

--- a/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
@@ -513,6 +513,15 @@ fn run_paged_prefill_one_chunk_moe(
         cached_rope_deltas,
     );
 
+    // Shared per-forward-pass scratch slot for the M-RoPE cos/sin precompute
+    // (see `Qwen3_5Attention::forward_paged`'s `mrope_cache` doc comment).
+    // Every `FullAttentionPaged` layer in this loop shares one `position_ids`
+    // array, so the first such layer computes the selected cos/sin and every
+    // later one reuses it instead of recomputing the cos/sin table +
+    // `take_along_axis` gather. Stays `None` (untouched) on the text-only
+    // path where `position_ids` is `None`.
+    let mut mrope_cache: Option<(MxArray, MxArray)> = None;
+
     // Layer loop. Safe-by-construction via `iter_mut().zip(...)` —
     // each iteration takes disjoint `&mut DecoderLayer` and `&mut
     // Qwen3_5LayerCache` references, with `kind` consumed by-value
@@ -541,6 +550,7 @@ fn run_paged_prefill_one_chunk_moe(
             layer_positions,
             true,
             rope_position_offset,
+            &mut mrope_cache,
         )?;
         // Smooth the prefill memory peak: every K layers, materialize the
         // residual stream so MLX can release the upstream graph nodes
@@ -635,6 +645,7 @@ pub(crate) fn run_paged_decode_step(
             None,
             true,
             rope_position_offset,
+            &mut None,
         )?;
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
@@ -264,6 +264,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
                 &hidden,
                 final_norm,
                 lm_head,
+                embed,
                 embedding_weight,
             )?);
             if let Some(start) = chunk_trace_start {
@@ -381,7 +382,7 @@ pub(crate) fn run_paged_prefill_single_shot(
         /* position_ids */ None,
         cached_rope_deltas,
     )?;
-    project_last_token_logits_moe(&hidden_states, final_norm, lm_head, embedding_weight)
+    project_last_token_logits_moe(&hidden_states, final_norm, lm_head, embed, embedding_weight)
 }
 
 /// Single-turn image-bearing paged prefill for the MoE stack.
@@ -441,7 +442,7 @@ pub(crate) fn run_paged_vlm_prefill_moe(
         0,
     )?;
 
-    project_last_token_logits_moe(&hidden_states, final_norm, lm_head, embedding_weight)
+    project_last_token_logits_moe(&hidden_states, final_norm, lm_head, embed, embedding_weight)
 }
 
 /// Run a single prefill chunk through `embed → layer loop`. Returns
@@ -576,11 +577,16 @@ fn project_last_token_logits_moe(
     hidden_states: &MxArray,
     final_norm: &RMSNorm,
     lm_head: &Option<LinearProj>,
+    embed: &Embedding,
     embedding_weight: &MxArray,
 ) -> Result<MxArray> {
     let h = final_norm.forward(hidden_states)?;
     let logits = if let Some(head) = lm_head {
         head.forward(&h)?
+    } else if embed.is_packed_quantized() {
+        // Tied + packed-quantized embedding: route through the packed
+        // `quantized_matmul` instead of dequantizing the full dense table.
+        embed.as_linear(&h)?
     } else {
         let weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
         h.matmul(&weight_t)?
@@ -652,6 +658,8 @@ pub(crate) fn run_paged_decode_step(
     let h = final_norm.forward(&hidden_states)?;
     let logits = if let Some(head) = lm_head {
         head.forward(&h)?
+    } else if embed.is_packed_quantized() {
+        embed.as_linear(&h)?
     } else {
         let weight_t = embedding_weight.transpose(Some(&[1, 0]))?;
         h.matmul(&weight_t)?

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -1318,6 +1318,34 @@ fn load_vision_encoder_moe(
     Ok(vision_params)
 }
 
+/// Pin a sym8 checkpoint to the flat (eager int8) KV path, mirroring the
+/// dense loader's sym8 pin (`qwen3_5/persistence.rs`).
+///
+/// A sym8 MoE checkpoint on the block-paged path fails its FIRST paged KV
+/// write: sym8 convert stores norm weights as f32 (the affine twin stores
+/// bf16), and `fast::rms_norm` promotes its output to
+/// `result_type(x, weight)`, so K leaves `k_norm` as f32 while V — which has
+/// no norm and comes straight out of the bf16-emitting int8 kernels — stays
+/// bf16. The paged pool's `update_keys_values` hard-rejects mixed K/V dtypes
+/// (its kernel templates on a single 2-byte KV element type), aborting the
+/// generation with "keys/values dtype mismatch (Float32 vs BFloat16)". The
+/// flat `KVCache` has no such gate, so the flat path is the validated one.
+fn pin_sym8_to_flat_kv_cache(
+    config: &mut Qwen3_5MoeConfig,
+    top_level_mode: Option<PerLayerMode>,
+    per_layer_quant: &HashMap<String, PerLayerQuant>,
+) {
+    if has_sym8_mode(top_level_mode, per_layer_quant) && config.use_block_paged_cache == Some(true)
+    {
+        warn!(
+            "Qwen3.5-MoE: sym8 checkpoint requested block-paged KV cache; \
+             sym8 is validated on the flat (eager int8) path only — \
+             forcing use_block_paged_cache=false."
+        );
+        config.use_block_paged_cache = Some(false);
+    }
+}
+
 /// Load a pretrained Qwen3.5 MoE model into a dedicated model thread.
 ///
 /// All model state lives on the spawned thread. Returns a thin NAPI shell
@@ -1356,7 +1384,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5MoeModel> {
                         Error::from_reason(format!("Failed to parse config: {}", e))
                     })?;
 
-                    let config = parse_config(&raw)?;
+                    let mut config = parse_config(&raw)?;
 
                     info!(
                         "Qwen3.5 MoE config: {} layers, hidden={}, experts={}x{}",
@@ -1507,6 +1535,12 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5MoeModel> {
                         mtp_linear_suffixes,
                         &mut per_layer_quant,
                     );
+
+                    // sym8 emits mixed-dtype K/V (f32 K after the f32-weight
+                    // k_norm, bf16 V) which the block-paged pool hard-rejects;
+                    // force the flat path before `Qwen35MoeInner::new` builds
+                    // the paged adapter. See `pin_sym8_to_flat_kv_cache`.
+                    pin_sym8_to_flat_kv_cache(&mut config, top_level_mode, &per_layer_quant);
 
                     if quant_cfg.is_some() {
                         info!(
@@ -1851,7 +1885,7 @@ mod tests {
     use super::{
         AttentionType, DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, DType, MLPType, MxArray,
         PerLayerMode, PerLayerQuant, Qwen3_5MoeConfig, Qwen35MoeInner, apply_weights_moe_inner,
-        default_per_layer_quant, load_vision_encoder_moe,
+        default_per_layer_quant, load_vision_encoder_moe, pin_sym8_to_flat_kv_cache,
     };
     use std::collections::HashMap;
 
@@ -2493,6 +2527,63 @@ mod tests {
             inner.image_processor.is_none(),
             "sym8 checkpoint must NOT install the image processor"
         );
+    }
+
+    /// A sym8 checkpoint that requests the block-paged KV cache must be
+    /// pinned to the flat path (see `pin_sym8_to_flat_kv_cache`): sym8's f32
+    /// norm weights promote K to f32 after `k_norm` while V stays bf16, and
+    /// the paged pool's `update_keys_values` hard-rejects mixed K/V dtypes —
+    /// the first paged generation would abort. Asserts the EFFECTIVE cache
+    /// mode (`paged_adapter` presence), not just the config bit, for both the
+    /// pinned sym8 config and an affine control.
+    #[test]
+    fn sym8_checkpoint_pins_flat_kv_cache() {
+        // Top-level sym8 mode: the pin fires and the built model is flat.
+        let mut cfg = moe_paged_tiny_cfg();
+        assert_eq!(cfg.use_block_paged_cache, Some(true));
+        pin_sym8_to_flat_kv_cache(&mut cfg, Some(PerLayerMode::Sym8), &HashMap::new());
+        assert_eq!(
+            cfg.use_block_paged_cache,
+            Some(false),
+            "sym8 top-level mode must force use_block_paged_cache=false"
+        );
+        let inner = Qwen35MoeInner::new(cfg).expect("Qwen35MoeInner::new must succeed");
+        assert!(
+            inner.paged_adapter.is_none(),
+            "pinned sym8 model must run the flat KV path (no paged adapter)"
+        );
+
+        // Per-layer-only sym8 (no top-level mode) must pin too — has_sym8_mode
+        // covers both shapes.
+        let mut cfg = moe_paged_tiny_cfg();
+        let mut per_layer_quant = HashMap::new();
+        per_layer_quant.insert(
+            "layers.0.self_attn.q_proj".to_string(),
+            default_per_layer_quant(8, -1, PerLayerMode::Sym8),
+        );
+        pin_sym8_to_flat_kv_cache(&mut cfg, None, &per_layer_quant);
+        assert_eq!(
+            cfg.use_block_paged_cache,
+            Some(false),
+            "a per-layer sym8 override must force use_block_paged_cache=false"
+        );
+
+        // Affine control: the paged request survives and the adapter builds
+        // (on hosts with the paged backend available).
+        let mut cfg = moe_paged_tiny_cfg();
+        pin_sym8_to_flat_kv_cache(&mut cfg, Some(PerLayerMode::Affine), &HashMap::new());
+        assert_eq!(
+            cfg.use_block_paged_cache,
+            Some(true),
+            "affine checkpoints must keep their block-paged request"
+        );
+        if crate::engine::persistence::compiled_forward_backend_available() {
+            let inner = Qwen35MoeInner::new(cfg).expect("Qwen35MoeInner::new must succeed");
+            assert!(
+                inner.paged_adapter.is_some(),
+                "affine paged config must build the paged adapter"
+            );
+        }
     }
 
     /// A packed (non-float) member of a PARTIAL quant group must fail loud

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -1518,13 +1518,35 @@ fn parse_config(raw: &Value) -> Result<Qwen3_5MoeConfig> {
     })
 }
 
+/// Create a random-init Qwen3.5 MoE model and save it to `save_path`,
+/// synchronously on the calling thread.
+///
+/// Shared core of the NAPI `create_random_qwen35_moe_checkpoint` wrapper
+/// (which runs it on a dedicated model thread) and the pure-Rust synthetic
+/// MTP integration tests (which call it directly; MLX ops are fine on a test
+/// thread). A random-init MTP head's weights ARE its loaded weights, so
+/// `mtp_weights_loaded` is set whenever the config declares MTP layers —
+/// without it `save_model_sync` would drop the `mtp.*` tensors and the
+/// reloaded checkpoint could never engage speculative decode. The in-memory
+/// model is released when this returns.
+pub fn create_random_qwen35_moe_checkpoint_sync(
+    config: Qwen3_5MoeConfig,
+    save_path: &str,
+) -> Result<()> {
+    let mut inner = Qwen35MoeInner::new(config)?;
+    if inner.config.n_mtp_layers > 0 {
+        inner.mtp_weights_loaded = true;
+    }
+    inner.save_model_sync(save_path)
+}
+
 /// Create a random-init Qwen3.5 MoE model and save it to disk.
 ///
-/// Spawns a dedicated `ModelThread<Qwen35MoeCmd>` whose init builds a fresh
-/// random-weight `Qwen35MoeInner` directly, then dispatches
-/// `Qwen35MoeCmd::SaveModel` on that thread. The thread is dropped at the end
-/// of the promise, so the in-memory model is released once the checkpoint has
-/// been written. Used by TypeScript test fixtures that need an on-disk
+/// Spawns a dedicated model thread whose init runs
+/// [`create_random_qwen35_moe_checkpoint_sync`] (random-init inner + save);
+/// the thread holds no state and is dropped once the promise resolves, so
+/// the in-memory model is released as soon as the checkpoint has been
+/// written. Used by TypeScript test fixtures that need an on-disk
 /// checkpoint without keeping a NAPI model instance alive.
 #[napi]
 pub fn create_random_qwen35_moe_checkpoint<'env>(
@@ -1532,28 +1554,18 @@ pub fn create_random_qwen35_moe_checkpoint<'env>(
     config: Qwen3_5MoeConfig,
     save_path: String,
 ) -> Result<PromiseRaw<'env, ()>> {
-    use super::model::Qwen35MoeCmd;
-
-    let (thread, init_rx) = crate::model_thread::ModelThread::spawn_with_init(
+    let (thread, init_rx) = crate::model_thread::ModelThread::<()>::spawn_with_init(
         move || {
-            let inner = Qwen35MoeInner::new(config)?;
-            Ok((inner, ()))
+            create_random_qwen35_moe_checkpoint_sync(config, &save_path)?;
+            Ok(((), ()))
         },
-        handle_qwen35_moe_cmd,
+        |_state, _cmd| {},
     );
 
     env.spawn_future(async move {
         init_rx
             .await
             .map_err(|_| napi::Error::from_reason("Model thread exited during init"))??;
-
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        thread.send(Qwen35MoeCmd::SaveModel {
-            save_path,
-            reply: tx,
-        })?;
-        rx.await
-            .map_err(|_| napi::Error::from_reason("Model thread exited unexpectedly"))??;
 
         // Drop the thread explicitly so the dedicated OS thread shuts down
         // now that the checkpoint has been written.

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -15,8 +15,8 @@ use crate::engine::persistence::{
 };
 use crate::models::mtp_drafter::{DrafterBodyVariant, MTP_MOE_LAYER_LINEAR_SUFFIXES};
 use crate::models::quant_dispatch::{
-    default_per_layer_quant, effective_plq_for, ensure_int8_storage_resolves_sym8, has_sym8_mode,
-    parse_quant_block, resolve_default_mode,
+    default_per_layer_quant, effective_plq_for, ensure_dense_weight_floating,
+    ensure_int8_storage_resolves_sym8, has_sym8_mode, parse_quant_block, resolve_default_mode,
 };
 use crate::models::qwen3_5::persistence::{
     MTP_LAYER_LINEAR_SUFFIXES, augment_mtplx_mtp_quantization_with_suffixes, load_vision_weights,
@@ -601,6 +601,9 @@ fn apply_weights_moe_inner(
             info!("Loaded quantized embedding ({}-bit)", plq.bits);
         }
     } else if let Some(w) = params.get("embedding.weight") {
+        // Dense fallback (no `.scales`): a stripped quant group must never
+        // reach the dense lookup / tied-lm_head matmul.
+        ensure_dense_weight_floating("embedding.weight", w)?;
         inner.embedding.set_weight(w)?;
     }
 
@@ -616,11 +619,15 @@ fn apply_weights_moe_inner(
         } else if let Some(ref mut head) = inner.lm_head
             && let Some(w) = params.get("lm_head.weight")
         {
+            // Dense fallback (no `.scales`) — same stripped-quant-group
+            // dtype guard as the embedding above.
+            ensure_dense_weight_floating("lm_head.weight", w)?;
             head.set_weight(w, "lm_head")?;
         }
     } else if let Some(ref mut head) = inner.lm_head
         && let Some(w) = params.get("lm_head.weight")
     {
+        ensure_dense_weight_floating("lm_head.weight", w)?;
         head.set_weight(w, "lm_head")?;
     }
 
@@ -632,6 +639,11 @@ fn apply_weights_moe_inner(
         match &mut layer.attn {
             AttentionType::Linear(gdn) => {
                 if is_quantized {
+                    // Dense fallbacks below are dtype-guarded, mirroring the
+                    // dense qwen3_5 loader: a truncated quant group (packed
+                    // `.weight` whose `.scales` was stripped) makes
+                    // `try_build_ql` return `Ok(None)`, and the packed bytes
+                    // must NEVER reach the dense bf16 route.
                     if let Some(ql) =
                         try_build_ql(params, &format!("{}.linear_attn.in_proj_qkvz", prefix))?
                     {
@@ -639,6 +651,10 @@ fn apply_weights_moe_inner(
                     } else if let Some(w) =
                         params.get(&format!("{}.linear_attn.in_proj_qkvz.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.linear_attn.in_proj_qkvz.weight", prefix),
+                            w,
+                        )?;
                         gdn.set_in_proj_qkvz_weight(w)?;
                     }
 
@@ -649,6 +665,10 @@ fn apply_weights_moe_inner(
                     } else if let Some(w) =
                         params.get(&format!("{}.linear_attn.in_proj_ba.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.linear_attn.in_proj_ba.weight", prefix),
+                            w,
+                        )?;
                         gdn.set_in_proj_ba_weight(w)?;
                     }
 
@@ -659,12 +679,25 @@ fn apply_weights_moe_inner(
                     } else if let Some(w) =
                         params.get(&format!("{}.linear_attn.out_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.linear_attn.out_proj.weight", prefix),
+                            w,
+                        )?;
                         gdn.set_out_proj_weight(w)?;
                     }
                 } else {
+                    // Unquantized-checkpoint arm. Still dtype-guarded: a
+                    // FULLY-stripped quant checkpoint (every `.scales`
+                    // removed) flips `is_quantized` false and lands here, so
+                    // packed/int8 storage must fail loud before any dense
+                    // setter.
                     if let Some(w) =
                         params.get(&format!("{}.linear_attn.in_proj_qkvz.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.linear_attn.in_proj_qkvz.weight", prefix),
+                            w,
+                        )?;
                         gdn.set_in_proj_qkvz_weight(w)?;
                     }
                     if let Some(w) =
@@ -673,6 +706,14 @@ fn apply_weights_moe_inner(
                         if let Some(z) =
                             params.get(&format!("{}.linear_attn.in_proj_z.weight", prefix))
                         {
+                            ensure_dense_weight_floating(
+                                &format!("{}.linear_attn.in_proj_qkv.weight", prefix),
+                                w,
+                            )?;
+                            ensure_dense_weight_floating(
+                                &format!("{}.linear_attn.in_proj_z.weight", prefix),
+                                z,
+                            )?;
                             let combined = MxArray::concatenate(w, z, 0)?;
                             gdn.set_in_proj_qkvz_weight(&combined)?;
                         } else {
@@ -685,17 +726,33 @@ fn apply_weights_moe_inner(
                     if let Some(w) =
                         params.get(&format!("{}.linear_attn.in_proj_ba.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.linear_attn.in_proj_ba.weight", prefix),
+                            w,
+                        )?;
                         gdn.set_in_proj_ba_weight(w)?;
                     }
                     if let Some(b) = params.get(&format!("{}.linear_attn.in_proj_b.weight", prefix))
                         && let Some(a) =
                             params.get(&format!("{}.linear_attn.in_proj_a.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.linear_attn.in_proj_b.weight", prefix),
+                            b,
+                        )?;
+                        ensure_dense_weight_floating(
+                            &format!("{}.linear_attn.in_proj_a.weight", prefix),
+                            a,
+                        )?;
                         let combined = MxArray::concatenate(b, a, 0)?;
                         gdn.set_in_proj_ba_weight(&combined)?;
                     }
                     if let Some(w) = params.get(&format!("{}.linear_attn.out_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.linear_attn.out_proj.weight", prefix),
+                            w,
+                        )?;
                         gdn.set_out_proj_weight(w)?;
                     }
                 }
@@ -714,12 +771,18 @@ fn apply_weights_moe_inner(
             }
             AttentionType::Full(attn) => {
                 if is_quantized {
+                    // Dense fallbacks below are dtype-guarded (see the GDN
+                    // branch above): truncated quant groups must fail loud.
                     if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.q_proj", prefix))?
                     {
                         attn.set_quantized_q_proj(ql);
                     } else if let Some(w) =
                         params.get(&format!("{}.self_attn.q_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.self_attn.q_proj.weight", prefix),
+                            w,
+                        )?;
                         attn.set_q_proj_weight(w)?;
                     }
                     if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.k_proj", prefix))?
@@ -728,6 +791,10 @@ fn apply_weights_moe_inner(
                     } else if let Some(w) =
                         params.get(&format!("{}.self_attn.k_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.self_attn.k_proj.weight", prefix),
+                            w,
+                        )?;
                         attn.set_k_proj_weight(w)?;
                     }
                     if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.v_proj", prefix))?
@@ -736,6 +803,10 @@ fn apply_weights_moe_inner(
                     } else if let Some(w) =
                         params.get(&format!("{}.self_attn.v_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.self_attn.v_proj.weight", prefix),
+                            w,
+                        )?;
                         attn.set_v_proj_weight(w)?;
                     }
                     if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.o_proj", prefix))?
@@ -744,19 +815,41 @@ fn apply_weights_moe_inner(
                     } else if let Some(w) =
                         params.get(&format!("{}.self_attn.o_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.self_attn.o_proj.weight", prefix),
+                            w,
+                        )?;
                         attn.set_o_proj_weight(w)?;
                     }
                 } else {
+                    // Unquantized-checkpoint arm — dtype-guarded like the GDN
+                    // branch above.
                     if let Some(w) = params.get(&format!("{}.self_attn.q_proj.weight", prefix)) {
+                        ensure_dense_weight_floating(
+                            &format!("{}.self_attn.q_proj.weight", prefix),
+                            w,
+                        )?;
                         attn.set_q_proj_weight(w)?;
                     }
                     if let Some(w) = params.get(&format!("{}.self_attn.k_proj.weight", prefix)) {
+                        ensure_dense_weight_floating(
+                            &format!("{}.self_attn.k_proj.weight", prefix),
+                            w,
+                        )?;
                         attn.set_k_proj_weight(w)?;
                     }
                     if let Some(w) = params.get(&format!("{}.self_attn.v_proj.weight", prefix)) {
+                        ensure_dense_weight_floating(
+                            &format!("{}.self_attn.v_proj.weight", prefix),
+                            w,
+                        )?;
                         attn.set_v_proj_weight(w)?;
                     }
                     if let Some(w) = params.get(&format!("{}.self_attn.o_proj.weight", prefix)) {
+                        ensure_dense_weight_floating(
+                            &format!("{}.self_attn.o_proj.weight", prefix),
+                            w,
+                        )?;
                         attn.set_o_proj_weight(w)?;
                     }
                 }
@@ -800,24 +893,39 @@ fn apply_weights_moe_inner(
                     if let (Some(qg), Some(qu), Some(qd)) = (q_gate, q_up, q_down) {
                         layer.set_quantized_dense_mlp(qg, qu, qd);
                     } else {
+                        // Partial trio: ALL THREE fall back to the dense
+                        // setters, so any quantized member's packed payload
+                        // must fail loud here instead of entering dense math.
                         if let Some(w) = params.get(&format!("{}.weight", gate_key)) {
+                            ensure_dense_weight_floating(&format!("{}.weight", gate_key), w)?;
                             mlp.set_gate_proj_weight(w)?;
                         }
                         if let Some(w) = params.get(&format!("{}.weight", up_key)) {
+                            ensure_dense_weight_floating(&format!("{}.weight", up_key), w)?;
                             mlp.set_up_proj_weight(w)?;
                         }
                         if let Some(w) = params.get(&format!("{}.weight", down_key)) {
+                            ensure_dense_weight_floating(&format!("{}.weight", down_key), w)?;
                             mlp.set_down_proj_weight(w)?;
                         }
                     }
                 } else {
                     if let Some(w) = params.get(&format!("{}.mlp.gate_proj.weight", prefix)) {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.gate_proj.weight", prefix),
+                            w,
+                        )?;
                         mlp.set_gate_proj_weight(w)?;
                     }
                     if let Some(w) = params.get(&format!("{}.mlp.up_proj.weight", prefix)) {
+                        ensure_dense_weight_floating(&format!("{}.mlp.up_proj.weight", prefix), w)?;
                         mlp.set_up_proj_weight(w)?;
                     }
                     if let Some(w) = params.get(&format!("{}.mlp.down_proj.weight", prefix)) {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.down_proj.weight", prefix),
+                            w,
+                        )?;
                         mlp.set_down_proj_weight(w)?;
                     }
                 }
@@ -825,9 +933,15 @@ fn apply_weights_moe_inner(
             MLPType::Dense(MLPVariant::Quantized { .. }) => {}
             MLPType::MoE(moe) => {
                 if is_quantized {
+                    // Dense fallbacks below are dtype-guarded, mirroring the
+                    // dense qwen3_5 loader. This matters most for the
+                    // switch_mlp trio, whose dense setters are infallible: a
+                    // packed member of a partial trio would otherwise enter
+                    // dense expert math silently (garbage logits, no error).
                     if let Some(ql) = try_build_ql(params, &format!("{}.mlp.gate", prefix))? {
                         moe.set_quantized_gate(ql);
                     } else if let Some(w) = params.get(&format!("{}.mlp.gate.weight", prefix)) {
+                        ensure_dense_weight_floating(&format!("{}.mlp.gate.weight", prefix), w)?;
                         moe.set_gate_weight(w)?;
                     }
 
@@ -844,12 +958,15 @@ fn apply_weights_moe_inner(
                         moe.set_switch_mlp(quantized_switch);
                     } else {
                         if let Some(w) = params.get(&format!("{}.weight", gate_proj_key)) {
+                            ensure_dense_weight_floating(&format!("{}.weight", gate_proj_key), w)?;
                             moe.set_switch_mlp_gate_proj_weight(w);
                         }
                         if let Some(w) = params.get(&format!("{}.weight", up_proj_key)) {
+                            ensure_dense_weight_floating(&format!("{}.weight", up_proj_key), w)?;
                             moe.set_switch_mlp_up_proj_weight(w);
                         }
                         if let Some(w) = params.get(&format!("{}.weight", down_proj_key)) {
+                            ensure_dense_weight_floating(&format!("{}.weight", down_proj_key), w)?;
                             moe.set_switch_mlp_down_proj_weight(w);
                         }
                     }
@@ -866,12 +983,15 @@ fn apply_weights_moe_inner(
                         moe.set_quantized_shared_expert(qg, qu, qd);
                     } else {
                         if let Some(w) = params.get(&format!("{}.weight", se_gate_key)) {
+                            ensure_dense_weight_floating(&format!("{}.weight", se_gate_key), w)?;
                             moe.set_shared_expert_gate_proj_weight(w)?;
                         }
                         if let Some(w) = params.get(&format!("{}.weight", se_up_key)) {
+                            ensure_dense_weight_floating(&format!("{}.weight", se_up_key), w)?;
                             moe.set_shared_expert_up_proj_weight(w)?;
                         }
                         if let Some(w) = params.get(&format!("{}.weight", se_down_key)) {
+                            ensure_dense_weight_floating(&format!("{}.weight", se_down_key), w)?;
                             moe.set_shared_expert_down_proj_weight(w)?;
                         }
                     }
@@ -883,45 +1003,80 @@ fn apply_weights_moe_inner(
                     } else if let Some(w) =
                         params.get(&format!("{}.mlp.shared_expert_gate.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.shared_expert_gate.weight", prefix),
+                            w,
+                        )?;
                         moe.set_shared_expert_gate_weight(w)?;
                     }
                 } else {
+                    // Unquantized-checkpoint arm — dtype-guarded like the GDN
+                    // branch above.
                     if let Some(w) = params.get(&format!("{}.mlp.gate.weight", prefix)) {
+                        ensure_dense_weight_floating(&format!("{}.mlp.gate.weight", prefix), w)?;
                         moe.set_gate_weight(w)?;
                     }
                     if let Some(w) =
                         params.get(&format!("{}.mlp.switch_mlp.gate_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.switch_mlp.gate_proj.weight", prefix),
+                            w,
+                        )?;
                         moe.set_switch_mlp_gate_proj_weight(w);
                     }
                     if let Some(w) =
                         params.get(&format!("{}.mlp.switch_mlp.up_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.switch_mlp.up_proj.weight", prefix),
+                            w,
+                        )?;
                         moe.set_switch_mlp_up_proj_weight(w);
                     }
                     if let Some(w) =
                         params.get(&format!("{}.mlp.switch_mlp.down_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.switch_mlp.down_proj.weight", prefix),
+                            w,
+                        )?;
                         moe.set_switch_mlp_down_proj_weight(w);
                     }
                     if let Some(w) =
                         params.get(&format!("{}.mlp.shared_expert.gate_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.shared_expert.gate_proj.weight", prefix),
+                            w,
+                        )?;
                         moe.set_shared_expert_gate_proj_weight(w)?;
                     }
                     if let Some(w) =
                         params.get(&format!("{}.mlp.shared_expert.up_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.shared_expert.up_proj.weight", prefix),
+                            w,
+                        )?;
                         moe.set_shared_expert_up_proj_weight(w)?;
                     }
                     if let Some(w) =
                         params.get(&format!("{}.mlp.shared_expert.down_proj.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.shared_expert.down_proj.weight", prefix),
+                            w,
+                        )?;
                         moe.set_shared_expert_down_proj_weight(w)?;
                     }
                     if let Some(w) =
                         params.get(&format!("{}.mlp.shared_expert_gate.weight", prefix))
                     {
+                        ensure_dense_weight_floating(
+                            &format!("{}.mlp.shared_expert_gate.weight", prefix),
+                            w,
+                        )?;
                         moe.set_shared_expert_gate_weight(w)?;
                     }
                 }
@@ -2157,6 +2312,84 @@ mod tests {
         assert!(
             inner.image_processor.is_none(),
             "sym8 checkpoint must NOT install the image processor"
+        );
+    }
+
+    /// A packed (non-float) member of a PARTIAL quant group must fail loud
+    /// on the dense fallback, never silently install. When a `.scales`
+    /// sidecar is missing, `try_build_ql`/`try_build_qsl` return `Ok(None)`
+    /// and the whole trio drops to the dense setters — the switch_mlp
+    /// setters are infallible, so without the dtype guard a packed Uint32
+    /// payload would enter dense expert math (garbage logits, no error).
+    /// Mirrors dense qwen3_5's `ensure_dense_weight_floating` fallback
+    /// contract.
+    #[test]
+    fn packed_weight_without_sidecars_fails_loud_on_dense_fallback() {
+        let config = tiny_sym8_moe_cfg();
+        let scales_placeholder = || {
+            // Lone `.scales` on an unrelated projection flips
+            // `is_quantized_checkpoint` true without forming any buildable
+            // quant group (same trick as the sym8 fail-loud test above).
+            MxArray::from_float32(&[0.0f32], &[1]).expect("scales placeholder")
+        };
+
+        // (a) switch_mlp trio member: packed Uint32 `.weight`, no sidecars.
+        let mut inner =
+            Qwen35MoeInner::new(config.clone()).expect("Qwen35MoeInner::new must succeed");
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert(
+            "layers.0.self_attn.q_proj.scales".to_string(),
+            scales_placeholder(),
+        );
+        params.insert(
+            "layers.0.mlp.switch_mlp.gate_proj.weight".to_string(),
+            MxArray::from_uint32(&vec![0u32; 2 * 16 * 8], &[2, 16, 8]).expect("packed uint32"),
+        );
+        let per_layer_quant: HashMap<String, PerLayerQuant> = HashMap::new();
+        let err = apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &config,
+            4,
+            32,
+            None,
+            &per_layer_quant,
+            /* has_vision */ false,
+        )
+        .expect_err("packed switch_mlp member without sidecars must fail loud");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("layers.0.mlp.switch_mlp.gate_proj.weight") && msg.contains("non-float"),
+            "error must name the key and the dtype problem, got: {msg}"
+        );
+
+        // (b) shared_expert trio member: same stripped-sidecar shape.
+        let mut inner =
+            Qwen35MoeInner::new(config.clone()).expect("Qwen35MoeInner::new must succeed");
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert(
+            "layers.0.self_attn.q_proj.scales".to_string(),
+            scales_placeholder(),
+        );
+        params.insert(
+            "layers.0.mlp.shared_expert.up_proj.weight".to_string(),
+            MxArray::from_uint32(&vec![0u32; 8 * 8], &[8, 8]).expect("packed uint32"),
+        );
+        let err = apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &config,
+            4,
+            32,
+            None,
+            &per_layer_quant,
+            /* has_vision */ false,
+        )
+        .expect_err("packed shared_expert member without sidecars must fail loud");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("layers.0.mlp.shared_expert.up_proj.weight") && msg.contains("non-float"),
+            "error must name the key and the dtype problem, got: {msg}"
         );
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -475,6 +475,7 @@ fn apply_weights_moe_inner(
     quant_group_size: i32,
     top_level_mode: Option<PerLayerMode>,
     per_layer_quant: &HashMap<String, PerLayerQuant>,
+    has_vision: bool,
 ) -> Result<()> {
     // sym8 is consumed by the DENSE Qwen3.5 loader only (eager int8 W8A8
     // path). The MoE loader has no sym8 dispatch — fail loud instead of
@@ -538,10 +539,46 @@ fn apply_weights_moe_inner(
             .get("embed_tokens")
             .copied()
             .unwrap_or(default_plq);
-        inner
-            .embedding
-            .load_quantized(weight, scales, biases, plq.group_size, plq.bits)?;
-        info!("Loaded quantized embedding ({}-bit)", plq.bits);
+        // Gate the packed-resident load exactly like the dense loader
+        // (`qwen3_5/persistence.rs`): packed is a WIN only on the paged,
+        // non-MTP, non-VLM turn path, where the tied lm_head routes through
+        // `Embedding::as_linear` (packed `quantized_matmul`) in
+        // `paged_forward.rs`. The flat/eager path, MTP draft, and VLM image
+        // turns still eval a per-turn `get_weight()` — they keep the legacy
+        // full-pre-dequant load (unchanged behavior); extending the win to
+        // them is a follow-up.
+        //
+        // `use_block_paged_cache == Some(true)` is config INTENT; the paged
+        // adapter is only created when `compiled_forward_backend_available()`
+        // is ALSO true (`Qwen35MoeInner::new`), so a non-Metal/CUDA build with
+        // a paged config still runs flat — the added predicate keeps those on
+        // the legacy load (no per-turn dequant regression).
+        let prefer_packed = config.use_block_paged_cache == Some(true)
+            && crate::engine::persistence::compiled_forward_backend_available()
+            && config.n_mtp_layers == 0
+            && !has_vision;
+        if prefer_packed {
+            // Mode hardcoded "affine": embed_tokens/lm_head sidecars are always
+            // affine-quantized, matching what `Embedding::load_quantized`
+            // already hardcodes.
+            inner.embedding.load_quantized_packed(
+                weight,
+                scales,
+                biases,
+                plq.group_size,
+                plq.bits,
+                "affine",
+            )?;
+            info!(
+                "Loaded packed-quantized embedding ({}-bit, quantized_matmul on forward + tied lm_head)",
+                plq.bits
+            );
+        } else {
+            inner
+                .embedding
+                .load_quantized(weight, scales, biases, plq.group_size, plq.bits)?;
+            info!("Loaded quantized embedding ({}-bit)", plq.bits);
+        }
     } else if let Some(w) = params.get("embedding.weight") {
         inner.embedding.set_weight(w)?;
     }
@@ -1236,6 +1273,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5MoeModel> {
                         quant_group_size,
                         top_level_mode,
                         &per_layer_quant,
+                        has_vision,
                     )?;
 
                     // Materialize mmap-backed weights
@@ -1539,6 +1577,165 @@ mod tests {
         assert_eq!(
             strip_wrapper_prefix("model.language_model.model.mtp.layers.0.input_layernorm.weight"),
             "mtp.layers.0.input_layernorm.weight"
+        );
+    }
+
+    use super::{
+        DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, DType, MxArray, PerLayerMode, PerLayerQuant,
+        Qwen3_5MoeConfig, Qwen35MoeInner, apply_weights_moe_inner,
+    };
+    use std::collections::HashMap;
+
+    /// Paged, tied, non-MTP, non-VLM `Qwen3_5MoeConfig` fixture. `head_dim = 32`
+    /// (smallest valid block-paged pool head size); `hidden_size = num_heads *
+    /// head_dim = 128`. Mirrors `paged_forward::tests::moe_paged_tiny_config`.
+    fn moe_paged_tiny_cfg() -> Qwen3_5MoeConfig {
+        Qwen3_5MoeConfig {
+            vocab_size: 128,
+            hidden_size: 128,
+            num_layers: 8,
+            num_heads: 4,
+            num_kv_heads: 2,
+            intermediate_size: 128,
+            rms_norm_eps: 1e-6,
+            head_dim: 32,
+            tie_word_embeddings: true,
+            attention_bias: false,
+            max_position_embeddings: 256,
+            pad_token_id: 0,
+            eos_token_id: 0,
+            bos_token_id: 0,
+            linear_num_value_heads: 4,
+            linear_num_key_heads: 2,
+            linear_key_head_dim: 32,
+            linear_value_head_dim: 32,
+            linear_conv_kernel_dim: 4,
+            full_attention_interval: 4,
+            partial_rotary_factor: 0.25,
+            rope_theta: 100_000.0,
+            num_experts: 4,
+            num_experts_per_tok: 2,
+            decoder_sparse_step: 1,
+            shared_expert_intermediate_size: None,
+            moe_intermediate_size: None,
+            norm_topk_prob: true,
+            mlp_only_layers: None,
+            paged_cache_memory_mb: Some(256),
+            paged_block_size: Some(16),
+            use_block_paged_cache: Some(true),
+            n_mtp_layers: 0,
+        }
+    }
+
+    /// MoE mirror of the dense `tied_quantized_embedding_loads_via_packed_path`:
+    /// a quantized `embedding.*` sidecar on a paged, non-MTP, non-VLM
+    /// `Qwen3_5MoeConfig` must load via `Embedding::load_quantized_packed`
+    /// (packed-resident, so the tied lm_head runs `quantized_matmul` via
+    /// `as_linear` on the paged path) — NOT the legacy full-table pre-dequant
+    /// `Embedding::load_quantized`. Guards `apply_weights_moe_inner`'s gated
+    /// load branch directly.
+    #[test]
+    fn tied_quantized_embedding_loads_via_packed_path_moe() {
+        let label = "tied_quantized_embedding_loads_via_packed_path_moe";
+        let cfg = moe_paged_tiny_cfg();
+
+        let mut inner = match Qwen35MoeInner::new(cfg.clone()) {
+            Ok(inner) => inner,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                // Pool allocation (`LayerKVPool`) requires Metal; skip cleanly
+                // when the GPU/device is unavailable (CI without Metal).
+                if msg.contains("Metal") || msg.contains("device") || msg.contains("LayerKVPool") {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {msg}");
+                    return;
+                }
+                panic!("unexpected Qwen35MoeInner::new failure in {label}: {msg}");
+            }
+        };
+
+        let vocab = cfg.vocab_size as i64;
+        let hidden = cfg.hidden_size as i64;
+        let n = (vocab * hidden) as usize;
+        let data: Vec<f32> = (0..n).map(|i| ((i % 13) as f32 - 6.0) * 0.01).collect();
+        let dense = match MxArray::from_float32(&data, &[vocab, hidden]) {
+            Ok(a) => match a.astype(DType::BFloat16) {
+                Ok(a) => a,
+                Err(err) => panic!("unexpected astype failure in {label}: {}", err.reason),
+            },
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("Metal") || msg.contains("device") {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {msg}");
+                    return;
+                }
+                panic!("unexpected MxArray::from_float32 failure in {label}: {msg}");
+            }
+        };
+
+        let group_size = 32;
+        let bits = 4;
+        let mut out_q: *mut mlx_sys::mlx_array = std::ptr::null_mut();
+        let mut out_s: *mut mlx_sys::mlx_array = std::ptr::null_mut();
+        let mut out_b: *mut mlx_sys::mlx_array = std::ptr::null_mut();
+        let ok = unsafe {
+            mlx_sys::mlx_quantize(
+                dense.as_raw_ptr(),
+                group_size,
+                bits,
+                c"affine".as_ptr(),
+                &mut out_q,
+                &mut out_s,
+                &mut out_b,
+            )
+        };
+        assert!(ok, "mlx_quantize affine failed");
+        let qw = MxArray::from_handle(out_q, "qw").expect("qw");
+        let qs = MxArray::from_handle(out_s, "qs").expect("qs");
+        let qb = MxArray::from_handle(out_b, "qb").expect("qb");
+
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert("embedding.weight".to_string(), qw);
+        params.insert("embedding.scales".to_string(), qs);
+        params.insert("embedding.biases".to_string(), qb);
+
+        let mut per_layer_quant: HashMap<String, PerLayerQuant> = HashMap::new();
+        per_layer_quant.insert(
+            "embed_tokens".to_string(),
+            PerLayerQuant {
+                bits,
+                group_size,
+                mode: PerLayerMode::Affine,
+            },
+        );
+
+        // Same tolerate-completeness rationale as the dense mirror: the
+        // embedding loads UP FRONT, then `apply_weights_moe_inner`'s end-of-
+        // function completeness gate rejects this embedding-only fixture. The
+        // Err fires after the embedding backend is installed, so the packed
+        // assertion below still observes the real load decision.
+        match apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &cfg,
+            DEFAULT_QUANT_BITS,
+            DEFAULT_QUANT_GROUP_SIZE,
+            None,
+            &per_layer_quant,
+            /* has_vision */ false,
+        ) {
+            Ok(()) => {}
+            Err(err) => {
+                let msg = err.reason.to_string();
+                assert!(
+                    msg.contains("missing mandatory weights"),
+                    "unexpected apply_weights_moe_inner error in {label}: {msg}"
+                );
+            }
+        }
+
+        assert!(
+            inner.embedding.is_packed_quantized(),
+            "tied+quantized MoE embedding.* on the paged path must load via load_quantized_packed, not the legacy dense load_quantized"
         );
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -15,8 +15,8 @@ use crate::engine::persistence::{
 };
 use crate::models::mtp_drafter::{DrafterBodyVariant, MTP_MOE_LAYER_LINEAR_SUFFIXES};
 use crate::models::quant_dispatch::{
-    default_per_layer_quant, effective_plq_for, has_sym8_mode, parse_quant_block,
-    resolve_default_mode,
+    default_per_layer_quant, effective_plq_for, ensure_int8_storage_resolves_sym8, has_sym8_mode,
+    parse_quant_block, resolve_default_mode,
 };
 use crate::models::qwen3_5::persistence::{
     MTP_LAYER_LINEAR_SUFFIXES, augment_mtplx_mtp_quantization_with_suffixes, load_vision_weights,
@@ -31,11 +31,12 @@ use super::decoder_layer::{AttentionType, MLPType};
 use super::model::{Qwen3_5MoeModel, Qwen35MoeInner, handle_qwen35_moe_cmd};
 use super::quantized_linear::{
     DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, GATE_QUANT_BITS, GATE_QUANT_GROUP_SIZE,
-    MLPVariant, PerLayerMode, PerLayerQuant, QuantizedSwitchLinear, is_mxfp8_checkpoint,
-    is_quantized_checkpoint, try_build_mxfp4_quantized_linear,
+    MLPVariant, PerLayerMode, PerLayerQuant, QuantizedLinear, QuantizedSwitchLinear,
+    is_mxfp8_checkpoint, is_quantized_checkpoint, try_build_mxfp4_quantized_linear,
     try_build_mxfp4_quantized_switch_linear, try_build_mxfp8_quantized_linear,
     try_build_mxfp8_quantized_switch_linear, try_build_nvfp4_quantized_linear,
     try_build_nvfp4_quantized_switch_linear, try_build_quantized_linear,
+    try_build_sym8_quantized_linear,
 };
 use super::switch_glu::SwitchGLU;
 
@@ -477,21 +478,21 @@ fn apply_weights_moe_inner(
     per_layer_quant: &HashMap<String, PerLayerQuant>,
     has_vision: bool,
 ) -> Result<()> {
-    // sym8 is consumed by the DENSE Qwen3.5 loader only (eager int8 W8A8
-    // path). The MoE loader has no sym8 dispatch — fail loud instead of
-    // letting the Sym8 match arms below silently fall back to dense weights
-    // (an int8 [N,K] tensor through `set_weight` would be garbage).
-    if has_sym8_mode(top_level_mode, per_layer_quant) {
-        return Err(Error::from_reason(
-            "sym8 checkpoints are not supported by the qwen3_5_moe loader yet \
-             (sym8 v1 is dense Qwen3.5 only). Re-convert with an affine quant mode.",
-        ));
-    }
+    // sym8 dispatch covers the NON-EXPERT sublayers (attention q/k/v/o, GDN
+    // in_proj_qkvz/in_proj_ba/out_proj, shared-expert MLP body) through the
+    // same shared `QuantizedLinear` machinery as the dense qwen3_5 loader.
+    // The per-expert `switch_mlp.*` gather path has no sym8 kernel — convert
+    // forces those 3-D tensors to an explicit affine-8 per-layer override
+    // (`sym8_eligible` rejects ndim != 2), and `try_build_qsl` below fails
+    // loud if a sym8 override ever reaches it. The speculative MTP head is
+    // disabled under sym8 (see the MTP branch below), mirroring dense.
+    let checkpoint_has_sym8 = has_sym8_mode(top_level_mode, per_layer_quant);
     let is_quantized = is_quantized_checkpoint(params);
     let (default_plq, default_gate_plq) =
         compute_moe_defaults(params, top_level_mode, quant_bits, quant_group_size);
 
-    // Helper: dispatch by per-layer mode (mxfp4 / mxfp8 / nvfp4 / affine).
+    // Helper: dispatch by per-layer mode (mxfp4 / mxfp8 / nvfp4 / affine /
+    // sym8).
     //
     // Per-projection PLQ resolution (override lookup, merged GDN fallback,
     // and gate-prefix routing) is delegated to `effective_plq_for`. That
@@ -499,34 +500,54 @@ fn apply_weights_moe_inner(
     // `*.mlp.shared_expert_gate`) by routing them to `default_gate_plq`
     // when no per-layer override is recorded — the historical
     // `try_build_ql_gate` closure is therefore subsumed and removed.
-    let try_build_ql = |params: &HashMap<String, MxArray>, prefix: &str| {
+    //
+    // Result<Option<..>>: `Ok(None)` = "prefix not quantized, fall back to
+    // the dense-weight branch"; `Err` = fail-loud (a malformed sym8 group
+    // must never silently fall back, see `try_build_sym8_quantized_linear`).
+    let try_build_ql = |params: &HashMap<String, MxArray>,
+                        prefix: &str|
+     -> Result<Option<QuantizedLinear>> {
         let plq = effective_plq_for(prefix, per_layer_quant, default_plq, Some(default_gate_plq));
-        match plq.mode {
+        // int8 STORAGE with non-sym8 metadata = config drift — fail loud
+        // before the int8 tensor can flow into the affine/mxfp builders.
+        ensure_int8_storage_resolves_sym8(params, prefix, plq.mode, "qwen3_5_moe")?;
+        Ok(match plq.mode {
             PerLayerMode::Mxfp4 => try_build_mxfp4_quantized_linear(params, prefix),
             PerLayerMode::Mxfp8 => try_build_mxfp8_quantized_linear(params, prefix),
             PerLayerMode::Nvfp4 => try_build_nvfp4_quantized_linear(params, prefix),
             PerLayerMode::Affine => {
                 try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
             }
-            // Unreachable: the sym8 guard at the top of this function
-            // rejects sym8 checkpoints before any builder runs.
-            PerLayerMode::Sym8 => None,
-        }
+            PerLayerMode::Sym8 => try_build_sym8_quantized_linear(params, prefix)?,
+        })
     };
 
-    let try_build_qsl = |params: &HashMap<String, MxArray>, prefix: &str| {
+    let try_build_qsl = |params: &HashMap<String, MxArray>,
+                         prefix: &str|
+     -> Result<Option<QuantizedSwitchLinear>> {
         let plq = effective_plq_for(prefix, per_layer_quant, default_plq, Some(default_gate_plq));
-        match plq.mode {
+        ensure_int8_storage_resolves_sym8(params, prefix, plq.mode, "qwen3_5_moe")?;
+        Ok(match plq.mode {
             PerLayerMode::Mxfp4 => try_build_mxfp4_quantized_switch_linear(params, prefix),
             PerLayerMode::Mxfp8 => try_build_mxfp8_quantized_switch_linear(params, prefix),
             PerLayerMode::Nvfp4 => try_build_nvfp4_quantized_switch_linear(params, prefix),
             PerLayerMode::Affine => {
                 try_build_quantized_switch_linear(params, prefix, plq.group_size, plq.bits)
             }
-            // Unreachable: the sym8 guard at the top of this function
-            // rejects sym8 checkpoints before any builder runs.
-            PerLayerMode::Sym8 => None,
-        }
+            // Per-expert 3-D stacked projections route through gather_qmm,
+            // which has no sym8 pack. Convert's `sym8_eligible` forces every
+            // switch_mlp.* tensor to an explicit affine-8 per-layer override,
+            // so a sym8 PLQ reaching this arm means corrupt/hand-edited quant
+            // metadata — fail loud, never fall back to a silent affine/dense
+            // read of int8 bytes.
+            PerLayerMode::Sym8 => {
+                return Err(Error::from_reason(format!(
+                    "sym8 layer '{prefix}': per-expert switch_mlp projections (3-D stacked \
+                     experts) have no sym8 kernel; convert forces these to an affine-8 \
+                     per-layer override — re-convert the checkpoint"
+                )));
+            }
+        })
     };
 
     // Embedding — supports both dense and quantized weights
@@ -590,7 +611,7 @@ fn apply_weights_moe_inner(
 
     // lm_head — direct access, no lock
     if is_quantized {
-        if let Some(ql) = try_build_ql(params, "lm_head") {
+        if let Some(ql) = try_build_ql(params, "lm_head")? {
             inner.lm_head = Some(super::quantized_linear::LinearProj::Quantized(ql));
         } else if let Some(ref mut head) = inner.lm_head
             && let Some(w) = params.get("lm_head.weight")
@@ -612,7 +633,7 @@ fn apply_weights_moe_inner(
             AttentionType::Linear(gdn) => {
                 if is_quantized {
                     if let Some(ql) =
-                        try_build_ql(params, &format!("{}.linear_attn.in_proj_qkvz", prefix))
+                        try_build_ql(params, &format!("{}.linear_attn.in_proj_qkvz", prefix))?
                     {
                         gdn.set_quantized_in_proj_qkvz(ql);
                     } else if let Some(w) =
@@ -622,7 +643,7 @@ fn apply_weights_moe_inner(
                     }
 
                     if let Some(ql) =
-                        try_build_ql(params, &format!("{}.linear_attn.in_proj_ba", prefix))
+                        try_build_ql(params, &format!("{}.linear_attn.in_proj_ba", prefix))?
                     {
                         gdn.set_quantized_in_proj_ba(ql);
                     } else if let Some(w) =
@@ -632,7 +653,7 @@ fn apply_weights_moe_inner(
                     }
 
                     if let Some(ql) =
-                        try_build_ql(params, &format!("{}.linear_attn.out_proj", prefix))
+                        try_build_ql(params, &format!("{}.linear_attn.out_proj", prefix))?
                     {
                         gdn.set_quantized_out_proj(ql);
                     } else if let Some(w) =
@@ -693,7 +714,7 @@ fn apply_weights_moe_inner(
             }
             AttentionType::Full(attn) => {
                 if is_quantized {
-                    if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.q_proj", prefix))
+                    if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.q_proj", prefix))?
                     {
                         attn.set_quantized_q_proj(ql);
                     } else if let Some(w) =
@@ -701,7 +722,7 @@ fn apply_weights_moe_inner(
                     {
                         attn.set_q_proj_weight(w)?;
                     }
-                    if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.k_proj", prefix))
+                    if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.k_proj", prefix))?
                     {
                         attn.set_quantized_k_proj(ql);
                     } else if let Some(w) =
@@ -709,7 +730,7 @@ fn apply_weights_moe_inner(
                     {
                         attn.set_k_proj_weight(w)?;
                     }
-                    if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.v_proj", prefix))
+                    if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.v_proj", prefix))?
                     {
                         attn.set_quantized_v_proj(ql);
                     } else if let Some(w) =
@@ -717,7 +738,7 @@ fn apply_weights_moe_inner(
                     {
                         attn.set_v_proj_weight(w)?;
                     }
-                    if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.o_proj", prefix))
+                    if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.o_proj", prefix))?
                     {
                         attn.set_quantized_o_proj(ql);
                     } else if let Some(w) =
@@ -772,9 +793,9 @@ fn apply_weights_moe_inner(
                     let up_key = format!("{}.mlp.up_proj", prefix);
                     let down_key = format!("{}.mlp.down_proj", prefix);
 
-                    let q_gate = try_build_ql(params, &gate_key);
-                    let q_up = try_build_ql(params, &up_key);
-                    let q_down = try_build_ql(params, &down_key);
+                    let q_gate = try_build_ql(params, &gate_key)?;
+                    let q_up = try_build_ql(params, &up_key)?;
+                    let q_down = try_build_ql(params, &down_key)?;
 
                     if let (Some(qg), Some(qu), Some(qd)) = (q_gate, q_up, q_down) {
                         layer.set_quantized_dense_mlp(qg, qu, qd);
@@ -804,7 +825,7 @@ fn apply_weights_moe_inner(
             MLPType::Dense(MLPVariant::Quantized { .. }) => {}
             MLPType::MoE(moe) => {
                 if is_quantized {
-                    if let Some(ql) = try_build_ql(params, &format!("{}.mlp.gate", prefix)) {
+                    if let Some(ql) = try_build_ql(params, &format!("{}.mlp.gate", prefix))? {
                         moe.set_quantized_gate(ql);
                     } else if let Some(w) = params.get(&format!("{}.mlp.gate.weight", prefix)) {
                         moe.set_gate_weight(w)?;
@@ -814,9 +835,9 @@ fn apply_weights_moe_inner(
                     let up_proj_key = format!("{}.mlp.switch_mlp.up_proj", prefix);
                     let down_proj_key = format!("{}.mlp.switch_mlp.down_proj", prefix);
 
-                    let q_gate = try_build_qsl(params, &gate_proj_key);
-                    let q_up = try_build_qsl(params, &up_proj_key);
-                    let q_down = try_build_qsl(params, &down_proj_key);
+                    let q_gate = try_build_qsl(params, &gate_proj_key)?;
+                    let q_up = try_build_qsl(params, &up_proj_key)?;
+                    let q_down = try_build_qsl(params, &down_proj_key)?;
 
                     if let (Some(qg), Some(qu), Some(qd)) = (q_gate, q_up, q_down) {
                         let quantized_switch = SwitchGLU::new_quantized(qg, qu, qd);
@@ -837,9 +858,9 @@ fn apply_weights_moe_inner(
                     let se_up_key = format!("{}.mlp.shared_expert.up_proj", prefix);
                     let se_down_key = format!("{}.mlp.shared_expert.down_proj", prefix);
 
-                    let q_se_gate = try_build_ql(params, &se_gate_key);
-                    let q_se_up = try_build_ql(params, &se_up_key);
-                    let q_se_down = try_build_ql(params, &se_down_key);
+                    let q_se_gate = try_build_ql(params, &se_gate_key)?;
+                    let q_se_up = try_build_ql(params, &se_up_key)?;
+                    let q_se_down = try_build_ql(params, &se_down_key)?;
 
                     if let (Some(qg), Some(qu), Some(qd)) = (q_se_gate, q_se_up, q_se_down) {
                         moe.set_quantized_shared_expert(qg, qu, qd);
@@ -856,7 +877,7 @@ fn apply_weights_moe_inner(
                     }
 
                     if let Some(ql) =
-                        try_build_ql(params, &format!("{}.mlp.shared_expert_gate", prefix))
+                        try_build_ql(params, &format!("{}.mlp.shared_expert_gate", prefix))?
                     {
                         moe.set_quantized_shared_expert_gate(ql);
                     } else if let Some(w) =
@@ -932,36 +953,50 @@ fn apply_weights_moe_inner(
     // decode. On an incomplete set, warn + disable MTP (leave
     // `mtp_weights_loaded = false`) rather than feeding garbage to the head.
     if inner.mtp.is_some() {
-        // Derive the expected MLP-key schema from the SAME flavor decision
-        // `Qwen3_5MoeMTPModule::new` uses (`is_moe_layer(fa_idx)`), NOT a
-        // hardcoded `Moe`. The MTP layer mirrors the main decoder at
-        // `fa_idx = full_attention_interval - 1`, so a dense-flavored MoE-MTP
-        // layer (sparse step not dividing the interval, or `fa_idx ∈
-        // mlp_only_layers`) emits dense `mlp.{gate,up,down}_proj` keys via
-        // `get_parameters`/`apply_weights`. Hardcoding `Moe` would demand
-        // `switch_mlp.* + mlp.gate`, flag the complete dense-flavored
-        // checkpoint as incomplete, and silently disable speculative MTP even
-        // though the flavor-aware `apply_weights` would have loaded it fine.
-        let body = super::mtp::Qwen3_5MoeMTPModule::mtp_mlp_variant(config);
-        let missing = crate::models::mtp_drafter::missing_required_mtp_keys(
-            params,
-            body,
-            config.n_mtp_layers,
-        );
-        if missing.is_empty() {
-            if let Some(mtp) = inner.mtp.as_mut() {
-                mtp.apply_weights(params, default_plq, default_gate_plq, per_layer_quant)?;
-            }
-            inner.mtp_weights_loaded = true;
-        } else {
+        if checkpoint_has_sym8 {
+            // sym8 scope: MTP is OUT, mirroring the dense loader. mtp.rs's
+            // own `try_build_ql`/`try_build_qsl` closures have unwired
+            // `Sym8 => None` arms, so a sym8 MTP head cannot build — loading
+            // it would silently install nothing. Fail soft into plain AR
+            // decode, mirroring the missing-weights branch below.
             inner.mtp_weights_loaded = false;
             warn!(
-                "Qwen3.5-MoE config declares {} MTP layer(s), but MTP weights are incomplete; \
-                 disabling speculative MTP. Missing first entries: {:?} ({} total)",
-                config.n_mtp_layers,
-                &missing[..missing.len().min(12)],
-                missing.len()
+                "Qwen3.5-MoE: sym8 checkpoint with config.n_mtp_layers={} — MTP is not \
+                 supported on the sym8 (eager int8) path; disabling speculative MTP.",
+                config.n_mtp_layers
             );
+        } else {
+            // Derive the expected MLP-key schema from the SAME flavor decision
+            // `Qwen3_5MoeMTPModule::new` uses (`is_moe_layer(fa_idx)`), NOT a
+            // hardcoded `Moe`. The MTP layer mirrors the main decoder at
+            // `fa_idx = full_attention_interval - 1`, so a dense-flavored MoE-MTP
+            // layer (sparse step not dividing the interval, or `fa_idx ∈
+            // mlp_only_layers`) emits dense `mlp.{gate,up,down}_proj` keys via
+            // `get_parameters`/`apply_weights`. Hardcoding `Moe` would demand
+            // `switch_mlp.* + mlp.gate`, flag the complete dense-flavored
+            // checkpoint as incomplete, and silently disable speculative MTP even
+            // though the flavor-aware `apply_weights` would have loaded it fine.
+            let body = super::mtp::Qwen3_5MoeMTPModule::mtp_mlp_variant(config);
+            let missing = crate::models::mtp_drafter::missing_required_mtp_keys(
+                params,
+                body,
+                config.n_mtp_layers,
+            );
+            if missing.is_empty() {
+                if let Some(mtp) = inner.mtp.as_mut() {
+                    mtp.apply_weights(params, default_plq, default_gate_plq, per_layer_quant)?;
+                }
+                inner.mtp_weights_loaded = true;
+            } else {
+                inner.mtp_weights_loaded = false;
+                warn!(
+                    "Qwen3.5-MoE config declares {} MTP layer(s), but MTP weights are incomplete; \
+                     disabling speculative MTP. Missing first entries: {:?} ({} total)",
+                    config.n_mtp_layers,
+                    &missing[..missing.len().min(12)],
+                    missing.len()
+                );
+            }
         }
     }
 
@@ -1043,6 +1078,72 @@ fn apply_weights_moe_inner(
         total_weights
     );
     Ok(())
+}
+
+/// Load the vision encoder onto `inner` when the checkpoint ships one —
+/// unless the checkpoint is sym8.
+///
+/// sym8 v1 scope is TEXT-ONLY, mirroring the dense loader
+/// (`qwen3_5/persistence.rs`): the eager VLM prefill path is not wired for
+/// sym8 int8 operands, so an image turn would run bf16-shaped matmuls
+/// against the [N,K] int8 kernel weights and emit garbage. Under sym8
+/// (top-level default OR any per-layer override — the same trigger as the
+/// MTP-disable gate in `apply_weights_moe_inner`) the vision tower is
+/// stripped with a loud warn so image turns fail loud ("vision
+/// encoder/processor not loaded") instead.
+///
+/// Returns the retained `vision_params` (`None` under sym8) so the caller's
+/// weight-byte accounting only counts tensors that were actually installed.
+fn load_vision_encoder_moe(
+    inner: &mut Qwen35MoeInner,
+    vision_params: Option<HashMap<String, MxArray>>,
+    raw: &Value,
+    config: &Qwen3_5MoeConfig,
+    top_level_mode: Option<PerLayerMode>,
+    per_layer_quant: &HashMap<String, PerLayerQuant>,
+) -> Result<Option<HashMap<String, MxArray>>> {
+    let vision_params = if has_sym8_mode(top_level_mode, per_layer_quant) {
+        if vision_params.is_some() {
+            warn!(
+                "Qwen3.5-MoE: sym8 checkpoint ships a vision tower, but sym8 \
+                 v1 is text-only — skipping vision encoder load (image turns \
+                 will be rejected)."
+            );
+        }
+        None
+    } else {
+        vision_params
+    };
+
+    if let Some(ref vparams) = vision_params {
+        let vision_config = parse_vision_config(raw);
+        info!(
+            "Vision config: {} layers, hidden={}, heads={}, patch={}",
+            vision_config.num_layers,
+            vision_config.hidden_size,
+            vision_config.num_heads,
+            vision_config.patch_size,
+        );
+
+        let mut vision_encoder = Qwen3_5VisionEncoder::new(vision_config.clone())?;
+        load_vision_weights(&mut vision_encoder, vparams, &vision_config)?;
+
+        inner.init_mrope_layers(
+            vec![11, 11, 10],
+            config.rope_theta,
+            config.max_position_embeddings,
+        )?;
+
+        inner.set_vision_encoder(vision_encoder)?;
+        inner.set_image_processor(Qwen35VLImageProcessor::new(None));
+        inner.set_spatial_merge_size(vision_config.spatial_merge_size);
+
+        info!("Qwen3.5 MoE-VL model loaded successfully (with vision encoder)");
+    } else {
+        info!("Qwen3.5 MoE model loaded successfully");
+    }
+
+    Ok(vision_params)
 }
 
 /// Load a pretrained Qwen3.5 MoE model into a dedicated model thread.
@@ -1287,34 +1388,17 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5MoeModel> {
                         inner.set_tokenizer(Arc::new(tok));
                     }
 
-                    // Load vision encoder if present
-                    if let Some(ref vparams) = vision_params {
-                        let vision_config = parse_vision_config(&raw);
-                        info!(
-                            "Vision config: {} layers, hidden={}, heads={}, patch={}",
-                            vision_config.num_layers,
-                            vision_config.hidden_size,
-                            vision_config.num_heads,
-                            vision_config.patch_size,
-                        );
-
-                        let mut vision_encoder = Qwen3_5VisionEncoder::new(vision_config.clone())?;
-                        load_vision_weights(&mut vision_encoder, vparams, &vision_config)?;
-
-                        inner.init_mrope_layers(
-                            vec![11, 11, 10],
-                            config.rope_theta,
-                            config.max_position_embeddings,
-                        )?;
-
-                        inner.set_vision_encoder(vision_encoder)?;
-                        inner.set_image_processor(Qwen35VLImageProcessor::new(None));
-                        inner.set_spatial_merge_size(vision_config.spatial_merge_size);
-
-                        info!("Qwen3.5 MoE-VL model loaded successfully (with vision encoder)");
-                    } else {
-                        info!("Qwen3.5 MoE model loaded successfully");
-                    }
+                    // Load vision encoder if present. Under sym8 the vision
+                    // tower is stripped (loud warn) — sym8 v1 is text-only,
+                    // mirroring the dense loader.
+                    let vision_params = load_vision_encoder_moe(
+                        &mut inner,
+                        vision_params,
+                        &raw,
+                        &config,
+                        top_level_mode,
+                        &per_layer_quant,
+                    )?;
 
                     // Deterministic weight-byte total for the cache-limit
                     // coordinator. Includes text + vision weights when a
@@ -1593,8 +1677,9 @@ mod tests {
     }
 
     use super::{
-        DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, DType, MxArray, PerLayerMode, PerLayerQuant,
-        Qwen3_5MoeConfig, Qwen35MoeInner, apply_weights_moe_inner,
+        AttentionType, DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, DType, MxArray, PerLayerMode,
+        PerLayerQuant, Qwen3_5MoeConfig, Qwen35MoeInner, apply_weights_moe_inner,
+        default_per_layer_quant, load_vision_encoder_moe,
     };
     use std::collections::HashMap;
 
@@ -1748,6 +1833,330 @@ mod tests {
         assert!(
             inner.embedding.is_packed_quantized(),
             "tied+quantized MoE embedding.* on the paged path must load via load_quantized_packed, not the legacy dense load_quantized"
+        );
+    }
+
+    // ===== sym8 (per-output-channel symmetric int8) loader dispatch =====
+    //
+    // qwen3_5_moe's non-expert sublayers (attention q/k/v/o, GDN
+    // in_proj_qkvz/in_proj_ba/out_proj, shared-expert MLP body) reuse dense
+    // qwen3_5's LinearProj/QuantizedLinear machinery, so the sym8 int8 W8A8
+    // backend is family-agnostic. These tests pin the LOADER seam: a
+    // sym8-default checkpoint must install the raw int8 backend on non-expert
+    // linears, the per-expert switch_mlp gather path (no sym8 kernel) must
+    // fail loud on a sym8 override, and an MTP-capable sym8 checkpoint must
+    // load with the speculative MTP head disabled.
+
+    /// Flat (non-paged), tied, non-MTP tiny MoE config for the sym8 loader
+    /// tests. `full_attention_interval = 1` makes layer 0 Full attention and
+    /// `decoder_sparse_step = 1` makes it MoE; `hidden_size = num_heads *
+    /// head_dim = 64`, so q_proj's K = 64 satisfies the sym8 kernel's
+    /// K % 16 == 0 contract.
+    fn tiny_sym8_moe_cfg() -> Qwen3_5MoeConfig {
+        Qwen3_5MoeConfig {
+            vocab_size: 8,
+            hidden_size: 64,
+            num_layers: 1,
+            num_heads: 4,
+            num_kv_heads: 2,
+            intermediate_size: 64,
+            rms_norm_eps: 1e-6,
+            head_dim: 16,
+            tie_word_embeddings: true,
+            attention_bias: false,
+            max_position_embeddings: 256,
+            pad_token_id: 0,
+            eos_token_id: 0,
+            bos_token_id: 0,
+            linear_num_value_heads: 4,
+            linear_num_key_heads: 2,
+            linear_key_head_dim: 32,
+            linear_value_head_dim: 32,
+            linear_conv_kernel_dim: 4,
+            full_attention_interval: 1,
+            partial_rotary_factor: 0.25,
+            rope_theta: 100_000.0,
+            num_experts: 4,
+            num_experts_per_tok: 2,
+            decoder_sparse_step: 1,
+            shared_expert_intermediate_size: None,
+            moe_intermediate_size: None,
+            norm_topk_prob: true,
+            mlp_only_layers: None,
+            paged_cache_memory_mb: None,
+            paged_block_size: None,
+            use_block_paged_cache: None,
+            n_mtp_layers: 0,
+        }
+    }
+
+    /// Synthesize a well-formed sym8 group under `{base}.*`: int8 `[n,k]`
+    /// weight (values in [-127,127]) + positive f32 `[n]` scales. Mirrors the
+    /// dense/lfm2 sym8 test helper of the same name.
+    fn synth_sym8_group(p: &mut HashMap<String, MxArray>, base: &str, n: i64, k: i64) {
+        let q: Vec<f32> = (0..n * k).map(|i| ((i % 255) - 127) as f32).collect();
+        let w = MxArray::from_float32(&q, &[n, k])
+            .expect("from_float32")
+            .astype(DType::Int8)
+            .expect("astype int8");
+        let s: Vec<f32> = (0..n).map(|i| 0.001 + (i as f32) * 1e-4).collect();
+        p.insert(format!("{base}.weight"), w);
+        p.insert(
+            format!("{base}.scales"),
+            MxArray::from_float32(&s, &[n]).expect("scales"),
+        );
+    }
+
+    #[test]
+    fn sym8_default_installs_int8_backend_on_attention_q_proj() {
+        if unsafe { mlx_sys::mlx_gpu_architecture_gen() } < 17 {
+            eprintln!("[skip] sym8 MoE loader test: int8 kernels need an M5+ GPU (gen >= 17)");
+            return;
+        }
+        let config = tiny_sym8_moe_cfg();
+        let mut inner =
+            Qwen35MoeInner::new(config.clone()).expect("Qwen35MoeInner::new must succeed");
+
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert(
+            "embedding.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 8 * 64], &[8, 64]).expect("embedding"),
+        );
+        params.insert(
+            "final_norm.weight".to_string(),
+            MxArray::from_float32(&vec![1.0f32; 64], &[64]).expect("final_norm"),
+        );
+        // hidden_size=64, num_heads=4, head_dim=16 -> q_proj is [64, 64]; K=64
+        // satisfies the sym8 kernel's K % 16 == 0 contract.
+        synth_sym8_group(&mut params, "layers.0.self_attn.q_proj", 64, 64);
+        params.insert(
+            "layers.0.mlp.gate.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 4 * 64], &[4, 64]).expect("gate"),
+        );
+
+        // Mirrors what convert.rs actually emits for a real sym8 checkpoint:
+        // 3-D switch_mlp.* experts always get a forced affine-8 override.
+        let mut per_layer_quant = HashMap::new();
+        for suffix in ["gate_proj", "up_proj", "down_proj"] {
+            per_layer_quant.insert(
+                format!("layers.0.mlp.switch_mlp.{suffix}"),
+                default_per_layer_quant(8, 64, PerLayerMode::Affine),
+            );
+        }
+
+        apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &config,
+            4,
+            32,
+            Some(PerLayerMode::Sym8),
+            &per_layer_quant,
+            /* has_vision */ false,
+        )
+        .expect("sym8-default checkpoint must load: attention is a non-expert sublayer");
+
+        match &inner.layers[0].attn {
+            AttentionType::Full(attn) => {
+                assert_eq!(
+                    attn.get_q_proj_weight().dtype().unwrap(),
+                    DType::Int8,
+                    "q_proj must install the raw int8 sym8 backend, not affine-packed Uint32"
+                );
+            }
+            AttentionType::Linear(_) => {
+                panic!("tiny_sym8_moe_cfg (full_attention_interval=1) must assign Full attention")
+            }
+        }
+    }
+
+    #[test]
+    fn sym8_switch_mlp_expert_projection_fails_loud_never_silently_affine() {
+        let config = tiny_sym8_moe_cfg();
+        let mut inner =
+            Qwen35MoeInner::new(config.clone()).expect("Qwen35MoeInner::new must succeed");
+
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert(
+            "layers.0.mlp.switch_mlp.gate_proj.scales".to_string(),
+            MxArray::from_float32(&[0.0f32], &[1]).expect("scales placeholder"),
+        );
+
+        let mut per_layer_quant = HashMap::new();
+        per_layer_quant.insert(
+            "layers.0.mlp.switch_mlp.gate_proj".to_string(),
+            default_per_layer_quant(8, -1, PerLayerMode::Sym8),
+        );
+
+        let err = apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &config,
+            4,
+            32,
+            None,
+            &per_layer_quant,
+            /* has_vision */ false,
+        )
+        .expect_err("3-D stacked experts have no sym8 kernel; must fail loud");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("switch_mlp.gate_proj") && msg.contains("sym8"),
+            "error must name the expert projection and mention sym8, got: {msg}"
+        );
+    }
+
+    /// A sym8 checkpoint on an MTP-capable config must LOAD (the non-expert
+    /// sublayers dispatch sym8) but leave the speculative MTP head DISABLED:
+    /// mtp.rs's own builder closures have no sym8 wiring (`Sym8 => None`), so
+    /// without the call-site gate the head would silently install nothing.
+    /// Mirrors dense qwen3_5's MTP-disable-under-sym8 branch.
+    #[test]
+    fn sym8_checkpoint_disables_mtp_head_load() {
+        if unsafe { mlx_sys::mlx_gpu_architecture_gen() } < 17 {
+            eprintln!("[skip] sym8 MoE MTP-disable test: int8 kernels need an M5+ GPU (gen >= 17)");
+            return;
+        }
+        let config = Qwen3_5MoeConfig {
+            n_mtp_layers: 1,
+            ..tiny_sym8_moe_cfg()
+        };
+        let mut inner =
+            Qwen35MoeInner::new(config.clone()).expect("Qwen35MoeInner::new must succeed");
+        assert!(
+            inner.mtp.is_some(),
+            "config with n_mtp_layers=1 must construct the MTP module"
+        );
+
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert(
+            "embedding.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 8 * 64], &[8, 64]).expect("embedding"),
+        );
+        params.insert(
+            "final_norm.weight".to_string(),
+            MxArray::from_float32(&vec![1.0f32; 64], &[64]).expect("final_norm"),
+        );
+        synth_sym8_group(&mut params, "layers.0.self_attn.q_proj", 64, 64);
+        params.insert(
+            "layers.0.mlp.gate.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 4 * 64], &[4, 64]).expect("gate"),
+        );
+
+        let mut per_layer_quant = HashMap::new();
+        for suffix in ["gate_proj", "up_proj", "down_proj"] {
+            per_layer_quant.insert(
+                format!("layers.0.mlp.switch_mlp.{suffix}"),
+                default_per_layer_quant(8, 64, PerLayerMode::Affine),
+            );
+        }
+
+        apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &config,
+            4,
+            32,
+            Some(PerLayerMode::Sym8),
+            &per_layer_quant,
+            /* has_vision */ false,
+        )
+        .expect("sym8 MTP-capable checkpoint must still load (plain AR decode)");
+
+        assert!(
+            !inner.mtp_weights_loaded,
+            "sym8 checkpoint must disable the speculative MTP head load"
+        );
+        assert!(
+            !inner.has_mtp_weights(),
+            "has_mtp_weights() must report inactive under sym8"
+        );
+    }
+
+    /// A sym8 checkpoint that ships a vision tower must LOAD (text-only)
+    /// with the vision encoder NOT installed: the eager VLM prefill path is
+    /// not wired for sym8 int8 operands, so `load_vision_encoder_moe` strips
+    /// the vision params under sym8 (loud warn, image turns then fail loud
+    /// with "vision encoder/processor not loaded"). Mirrors dense qwen3_5's
+    /// vision-gate-under-sym8 branch.
+    #[test]
+    fn sym8_checkpoint_skips_vision_encoder_load() {
+        if unsafe { mlx_sys::mlx_gpu_architecture_gen() } < 17 {
+            eprintln!("[skip] sym8 MoE vision-gate test: int8 kernels need an M5+ GPU (gen >= 17)");
+            return;
+        }
+        let config = tiny_sym8_moe_cfg();
+        let mut inner =
+            Qwen35MoeInner::new(config.clone()).expect("Qwen35MoeInner::new must succeed");
+
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert(
+            "embedding.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 8 * 64], &[8, 64]).expect("embedding"),
+        );
+        params.insert(
+            "final_norm.weight".to_string(),
+            MxArray::from_float32(&vec![1.0f32; 64], &[64]).expect("final_norm"),
+        );
+        synth_sym8_group(&mut params, "layers.0.self_attn.q_proj", 64, 64);
+        params.insert(
+            "layers.0.mlp.gate.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 4 * 64], &[4, 64]).expect("gate"),
+        );
+
+        let mut per_layer_quant = HashMap::new();
+        for suffix in ["gate_proj", "up_proj", "down_proj"] {
+            per_layer_quant.insert(
+                format!("layers.0.mlp.switch_mlp.{suffix}"),
+                default_per_layer_quant(8, 64, PerLayerMode::Affine),
+            );
+        }
+
+        // Text load succeeds under sym8 (has_vision mirrors the real loader,
+        // which passes true when the checkpoint ships vision tensors).
+        apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &config,
+            4,
+            32,
+            Some(PerLayerMode::Sym8),
+            &per_layer_quant,
+            /* has_vision */ true,
+        )
+        .expect("sym8 checkpoint with a vision tower must still load (text-only)");
+
+        // The checkpoint ships vision tensors; under sym8 the vision step
+        // must strip them WITHOUT erroring and WITHOUT installing the
+        // encoder (a real tower would need real weights — the gate must
+        // reject BEFORE any vision weight is read).
+        let mut vision_params: HashMap<String, MxArray> = HashMap::new();
+        vision_params.insert(
+            "patch_embed.proj.weight".to_string(),
+            MxArray::from_float32(&[0.0f32], &[1]).expect("vision placeholder"),
+        );
+        let raw = serde_json::json!({});
+        let retained = load_vision_encoder_moe(
+            &mut inner,
+            Some(vision_params),
+            &raw,
+            &config,
+            Some(PerLayerMode::Sym8),
+            &per_layer_quant,
+        )
+        .expect("sym8 vision gate must fail soft (strip + warn), not error");
+
+        assert!(
+            retained.is_none(),
+            "sym8 must strip the vision params (weight-byte accounting must not count them)"
+        );
+        assert!(
+            inner.vision_encoder.is_none(),
+            "sym8 checkpoint must NOT install the vision encoder"
+        );
+        assert!(
+            inner.image_processor.is_none(),
+            "sym8 checkpoint must NOT install the image processor"
         );
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -535,22 +535,27 @@ fn apply_weights_moe_inner(
                 try_build_quantized_switch_linear(params, prefix, plq.group_size, plq.bits)
             }
             // Per-expert 3-D stacked projections route through gather_qmm,
-            // which has no sym8 pack. Two cases, keyed on the `.scales`
-            // sidecar — the shared "is this prefix quantized?" signal
-            // (`try_build_sym8_quantized_linear`'s documented contract):
-            //   * `.scales` ABSENT — the trio was emitted dense (convert's
-            //     group-coherence pass forces the whole trio dense when any
-            //     member is unquantizable), so a sym8 top-level DEFAULT
-            //     legitimately resolves here with no override. `Ok(None)`
+            // which has no sym8 pack. Sym8 reaches a switch prefix two ways
+            // (`effective_plq_for`: direct per-layer entry, else the
+            // top-level default — the gate/GDN-merge fallbacks never key on
+            // switch prefixes), and only the DEFAULT falling through has a
+            // legitimate dense reading:
+            //   * `.scales` ABSENT with NO explicit entry for this prefix —
+            //     the trio was emitted dense (convert's group-coherence pass
+            //     forces the whole trio dense when any member is
+            //     unquantizable, recording no override), so the sym8
+            //     top-level DEFAULT legitimately resolves here. `Ok(None)`
             //     hands the prefix to the dtype-guarded dense fallback below.
-            //   * `.scales` PRESENT — quantized bytes under a sym8 PLQ means
+            //   * `.scales` PRESENT, or an EXPLICIT sym8 per-layer entry —
             //     corrupt/hand-edited quant metadata (convert's
             //     `sym8_eligible` forces every quantized switch_mlp.* tensor
-            //     to an explicit affine-8 per-layer override) — fail loud,
-            //     never fall back to a silent affine/dense read of int8
-            //     bytes.
+            //     to an explicit affine-8 per-layer override and never emits
+            //     sym8 ones) — fail loud, never install the prefix through a
+            //     silent affine/dense fallback.
             PerLayerMode::Sym8 => {
-                if !params.contains_key(&format!("{prefix}.scales")) {
+                if !params.contains_key(&format!("{prefix}.scales"))
+                    && !per_layer_quant.contains_key(prefix)
+                {
                     return Ok(None);
                 }
                 return Err(Error::from_reason(format!(
@@ -2166,6 +2171,85 @@ mod tests {
             /* has_vision */ false,
         )
         .expect_err("3-D stacked experts have no sym8 kernel; must fail loud");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("switch_mlp.gate_proj") && msg.contains("sym8"),
+            "error must name the expert projection and mention sym8, got: {msg}"
+        );
+    }
+
+    /// An EXPLICIT per-layer sym8 override on a switch_mlp expert projection
+    /// is lying metadata: convert never emits one (`sym8_eligible` forces
+    /// every quantized switch_mlp.* tensor to an affine-8 override, and the
+    /// group-coherence pass emits forced-dense trios with NO override — a
+    /// sym8 entry can only come from hand-edited/stale config.json). Even
+    /// when the trio carries float weights with no `.scales` sidecar, the
+    /// load must fail loud on the explicit override rather than silently
+    /// installing the weights dense — only the top-level sym8 DEFAULT
+    /// falling through (no explicit entry) may take the forced-dense
+    /// `Ok(None)` hand-off.
+    #[test]
+    fn sym8_explicit_switch_mlp_override_without_scales_fails_loud() {
+        let config = tiny_sym8_moe_cfg();
+        let mut inner =
+            Qwen35MoeInner::new(config.clone()).expect("Qwen35MoeInner::new must succeed");
+
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert(
+            "embedding.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 8 * 64], &[8, 64]).expect("embedding"),
+        );
+        params.insert(
+            "final_norm.weight".to_string(),
+            MxArray::from_float32(&vec![1.0f32; 64], &[64]).expect("final_norm"),
+        );
+        // One OTHER genuinely-quantized tensor (affine pack; never forwarded,
+        // so the pack contents are irrelevant): makes `is_quantized_checkpoint`
+        // true so the loader takes the quantized MoE arm — the path that calls
+        // `try_build_qsl`.
+        params.insert(
+            "layers.0.self_attn.q_proj.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 64 * 8], &[64, 8])
+                .expect("q_proj pack")
+                .astype(DType::Uint32)
+                .expect("astype uint32"),
+        );
+        params.insert(
+            "layers.0.self_attn.q_proj.scales".to_string(),
+            MxArray::from_float32(&vec![1.0f32; 64 * 2], &[64, 2]).expect("q_proj scales"),
+        );
+        params.insert(
+            "layers.0.self_attn.q_proj.biases".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 64 * 2], &[64, 2]).expect("q_proj biases"),
+        );
+        // The lying trio: float 3-D expert weights, NO `.scales`, but an
+        // explicit sym8 per-layer override for gate_proj.
+        for suffix in ["gate_proj", "up_proj", "down_proj"] {
+            params.insert(
+                format!("layers.0.mlp.switch_mlp.{suffix}.weight"),
+                MxArray::from_float32(&vec![0.5f32; 4 * 8 * 64], &[4, 8, 64]).expect("trio"),
+            );
+        }
+
+        let mut per_layer_quant = HashMap::new();
+        per_layer_quant.insert(
+            "layers.0.mlp.switch_mlp.gate_proj".to_string(),
+            default_per_layer_quant(8, -1, PerLayerMode::Sym8),
+        );
+
+        let err = apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &config,
+            4,
+            32,
+            None,
+            &per_layer_quant,
+            /* has_vision */ false,
+        )
+        .expect_err(
+            "an explicit sym8 override on a switch_mlp projection must fail loud even without .scales",
+        );
         let msg = format!("{err}");
         assert!(
             msg.contains("switch_mlp.gate_proj") && msg.contains("sym8"),

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -535,12 +535,24 @@ fn apply_weights_moe_inner(
                 try_build_quantized_switch_linear(params, prefix, plq.group_size, plq.bits)
             }
             // Per-expert 3-D stacked projections route through gather_qmm,
-            // which has no sym8 pack. Convert's `sym8_eligible` forces every
-            // switch_mlp.* tensor to an explicit affine-8 per-layer override,
-            // so a sym8 PLQ reaching this arm means corrupt/hand-edited quant
-            // metadata — fail loud, never fall back to a silent affine/dense
-            // read of int8 bytes.
+            // which has no sym8 pack. Two cases, keyed on the `.scales`
+            // sidecar — the shared "is this prefix quantized?" signal
+            // (`try_build_sym8_quantized_linear`'s documented contract):
+            //   * `.scales` ABSENT — the trio was emitted dense (convert's
+            //     group-coherence pass forces the whole trio dense when any
+            //     member is unquantizable), so a sym8 top-level DEFAULT
+            //     legitimately resolves here with no override. `Ok(None)`
+            //     hands the prefix to the dtype-guarded dense fallback below.
+            //   * `.scales` PRESENT — quantized bytes under a sym8 PLQ means
+            //     corrupt/hand-edited quant metadata (convert's
+            //     `sym8_eligible` forces every quantized switch_mlp.* tensor
+            //     to an explicit affine-8 per-layer override) — fail loud,
+            //     never fall back to a silent affine/dense read of int8
+            //     bytes.
             PerLayerMode::Sym8 => {
+                if !params.contains_key(&format!("{prefix}.scales")) {
+                    return Ok(None);
+                }
                 return Err(Error::from_reason(format!(
                     "sym8 layer '{prefix}': per-expert switch_mlp projections (3-D stacked \
                      experts) have no sym8 kernel; convert forces these to an affine-8 \
@@ -1832,8 +1844,8 @@ mod tests {
     }
 
     use super::{
-        AttentionType, DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, DType, MxArray, PerLayerMode,
-        PerLayerQuant, Qwen3_5MoeConfig, Qwen35MoeInner, apply_weights_moe_inner,
+        AttentionType, DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, DType, MLPType, MxArray,
+        PerLayerMode, PerLayerQuant, Qwen3_5MoeConfig, Qwen35MoeInner, apply_weights_moe_inner,
         default_per_layer_quant, load_vision_encoder_moe,
     };
     use std::collections::HashMap;
@@ -2159,6 +2171,90 @@ mod tests {
             msg.contains("switch_mlp.gate_proj") && msg.contains("sym8"),
             "error must name the expert projection and mention sym8, got: {msg}"
         );
+    }
+
+    /// A checkpoint whose top-level mode is sym8 can legitimately carry a
+    /// DENSE switch_mlp trio: convert's group-coherence pass forces the whole
+    /// trio dense when any member is unquantizable (e.g. K not divisible by
+    /// the affine group size), emitting f32 weights with NO `.scales` sidecar
+    /// and NO per-layer override. The prefix then resolves to the sym8
+    /// DEFAULT PLQ, and `try_build_qsl` must treat the absent `.scales` as
+    /// "this layer is not quantized" (`Ok(None)`, the contract shared with
+    /// `try_build_sym8_quantized_linear` and the 2-D `try_build_ql`) so the
+    /// dtype-guarded dense fallback installs the weights — NOT fail the whole
+    /// load with the re-convert error.
+    #[test]
+    fn sym8_default_loads_forced_dense_switch_mlp_trio() {
+        if unsafe { mlx_sys::mlx_gpu_architecture_gen() } < 17 {
+            eprintln!(
+                "[skip] sym8 MoE forced-dense trio test: int8 kernels need an M5+ GPU (gen >= 17)"
+            );
+            return;
+        }
+        let config = tiny_sym8_moe_cfg();
+        let mut inner =
+            Qwen35MoeInner::new(config.clone()).expect("Qwen35MoeInner::new must succeed");
+
+        let mut params: HashMap<String, MxArray> = HashMap::new();
+        params.insert(
+            "embedding.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 8 * 64], &[8, 64]).expect("embedding"),
+        );
+        params.insert(
+            "final_norm.weight".to_string(),
+            MxArray::from_float32(&vec![1.0f32; 64], &[64]).expect("final_norm"),
+        );
+        // One OTHER tensor genuinely sym8-quantized: makes
+        // `is_quantized_checkpoint` true so the loader takes the quantized
+        // MoE arm (the path that calls `try_build_qsl`).
+        synth_sym8_group(&mut params, "layers.0.self_attn.q_proj", 64, 64);
+        params.insert(
+            "layers.0.mlp.gate.weight".to_string(),
+            MxArray::from_float32(&vec![0.0f32; 4 * 64], &[4, 64]).expect("gate"),
+        );
+        // The forced-dense trio: 3-D f32 [experts, N, K] with K = 60 (fails
+        // the affine group gate, so convert's coherence pass emitted the
+        // whole trio dense), no .scales, no per-layer override.
+        for suffix in ["gate_proj", "up_proj", "down_proj"] {
+            params.insert(
+                format!("layers.0.mlp.switch_mlp.{suffix}.weight"),
+                MxArray::from_float32(&vec![0.5f32; 4 * 8 * 60], &[4, 8, 60]).expect("trio"),
+            );
+        }
+
+        apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &config,
+            4,
+            32,
+            Some(PerLayerMode::Sym8),
+            &HashMap::new(),
+            /* has_vision */ false,
+        )
+        .expect("forced-dense switch_mlp trio under a sym8 default must load dense");
+
+        match &inner.layers[0].mlp {
+            MLPType::MoE(moe) => {
+                let switch = moe.get_switch_mlp();
+                assert!(
+                    !switch.is_quantized(),
+                    "trio must land on the dense SwitchGLU path"
+                );
+                let w = switch.get_gate_proj_weight();
+                assert_eq!(
+                    w.dtype().unwrap(),
+                    DType::Float32,
+                    "dense fallback must keep the f32 checkpoint dtype"
+                );
+                assert_eq!(
+                    &w.shape().unwrap()[..],
+                    &[4i64, 8, 60],
+                    "dense fallback must install the checkpoint tensor, not the ctor placeholder"
+                );
+            }
+            _ => panic!("layer 0 must be MoE (decoder_sparse_step = 1)"),
+        }
     }
 
     /// A sym8 checkpoint on an MTP-capable config must LOAD (the non-expert

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -178,19 +178,19 @@ fn sanitize_weights(
 
         // MTP *non-expert* weights bypass the +1.0 norm shift and stay in final
         // MTPLX form (norms, fc, attn, shared-expert, router gate are consumed
-        // as-is by both the MTP module and the compiled MTP graph). MTP
+        // as-is by the MTP module). MTP
         // *expert* weights (`mtp.*.mlp.experts.*`), however, must be normalized
         // identically to the main namespace — fused gate_up split, experts ->
-        // switch_mlp rename, per-expert stacking — so the compiled MoE-MTP path's
-        // `switch_mlp.*` 3D-transpose lookups resolve (they otherwise throw
-        // "MTP 3D transpose not found"). Those weights fall through to the shared
+        // switch_mlp rename, per-expert stacking — so the MoE-MTP head's
+        // `switch_mlp.*` stacked-expert lookups resolve like the main
+        // namespace's. Those weights fall through to the shared
         // expert-normalization paths below, which are prefix-safe. Only the
         // conv1d transpose still applies to the bypassed weights — defensive,
         // MTP layers reuse the main DecoderLayer architecture which includes
         // conv1d.
         //
         // MoE-MTP IS functional once the MTP norms are in final (+1.0-shifted)
-        // form: on a `mlx convert`-ed checkpoint the compiled draft head drafts
+        // form: on a `mlx convert`-ed checkpoint the MTP draft head drafts
         // ~2-2.25 tokens/cycle and is a ~1.25x win at the default depth 1 (proven
         // 2026-06-01, byte-identical to AR). The earlier "0-accept draft-head bug"
         // was REFUTED — it was a raw-checkpoint artifact: the loader shifts MAIN
@@ -1340,9 +1340,9 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5MoeModel> {
             // deterministic weight-byte footprint for the cache-limit
             // coordinator. No process-wide active-memory sampling —
             // the sum of `params.values().nbytes()` is race-free and
-            // deterministic. Caveat: the MoE transpose cache
-            // `g_weight_transposes_3d` is built lazily on the FIRST
-            // compiled prefill, not at load time — the coordinator's
+            // deterministic. Caveat: post-load lazy growth (the warmup
+            // forward pass and any lazy scratch) lands after this
+            // measurement — the coordinator's
             // 1.75x multiplier adds ~75% slack to cover that post-load
             // growth without needing runtime measurements. See
             // `cache_limit.rs` module docs.

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -720,6 +720,10 @@ fn apply_weights_moe_inner(
                 if let Some(w) = params.get(&format!("{}.self_attn.o_proj.bias", prefix)) {
                     attn.set_o_proj_bias(Some(w))?;
                 }
+                // Precompute the block-ordered q_proj weight so forward()/
+                // forward_paged() split queries/gate without a strided
+                // reshape-copy. No-op for quantized q_proj.
+                attn.finalize_q_gate_block()?;
             }
         }
 

--- a/crates/mlx-core/src/nn/embedding.rs
+++ b/crates/mlx-core/src/nn/embedding.rs
@@ -761,8 +761,30 @@ mod tests {
 
     /// PACKED affine embedding: `as_linear(x)` must match `x @ dequant(table)^T`
     /// within quantized_matmul tolerance (the tied-head path).
+    ///
+    /// Skips on hosts whose half-precision GEMM fails the
+    /// `test_support::half_gemm_untrustworthy` canary: the REFERENCE side of
+    /// this parity — `x @ dequant(table)^T`, a bf16 `[2,64] @ [64,8]` GEMM
+    /// with K=64 — is exactly the NAX unaligned-K garbage class on gen>=17
+    /// GPUs. Probed against a host-f64 truth built from the dequantized
+    /// table and bf16-rounded x: the bf16 GEMM reference errs 0.0825 (the
+    /// entire observed test failure of max_err=0.08248; truth max |logit| is
+    /// only 0.024) while `as_linear`'s quantized_matmul errs 1.6e-4. The
+    /// packed as_linear path under test is CORRECT here — the oracle it is
+    /// compared against is the broken side — so skipping is honest and the
+    /// tied-head guarantee is unaffected.
     #[test]
     fn packed_affine_as_linear_matches_dense_matmul() {
+        if crate::test_support::half_gemm_untrustworthy() {
+            eprintln!(
+                "skipping packed_affine_as_linear_matches_dense_matmul: \
+                 half-precision GEMM fails the K=64/N=64 canary on this host \
+                 (vendored-MLX NAX unaligned-K bug); the bf16 dense-matmul \
+                 REFERENCE side of this parity is garbage here while \
+                 as_linear itself matches a host-f64 truth to 1.6e-4"
+            );
+            return;
+        }
         let vocab = 8i64;
         let hidden = 64i64;
         let n = (vocab * hidden) as usize;

--- a/crates/mlx-core/src/test_support.rs
+++ b/crates/mlx-core/src/test_support.rs
@@ -1,0 +1,103 @@
+//! Test-only helpers for detecting host-level numeric-environment issues
+//! that make certain assertions meaningless.
+
+use std::sync::OnceLock;
+
+use crate::array::{DType, MxArray};
+
+/// Returns `true` when this host's half-precision GEMM produces results
+/// that deviate from an f32 host reference by more than `0.1` on a small
+/// `[8, 64] x [64, 64]` bf16 canary.
+///
+/// The vendored MLX pin's NAX steel GEMM (dispatched for every non-f32
+/// matmul on gen>=17 GPUs under macOS 26.2+, see
+/// `mlx/backend/metal/matmul.cpp::steel_matmul_regular_axpby`) mishandles
+/// unaligned-K tiles: K < 128 produces garbage for every output element,
+/// and K remainders in `[128, 256)` corrupt N-tiles past the first. The
+/// wrong results are deterministic functions of the inputs (padding the
+/// operands does not change them) and are NOT reproduced by the f32 path,
+/// by the M=1 GEMV path, or by stock pre-NAX MLX wheels on the same
+/// hardware.
+///
+/// Tiny-config chunked-vs-single-shot parity tests (hidden 64-128,
+/// head_dim 32) compute almost entirely inside that broken regime, and
+/// chunking changes which kernel class each token's math takes (a 1-token
+/// tail chunk dispatches the CORRECT GEMV while the single-shot rows go
+/// through the broken GEMM; per-chunk context lengths change the
+/// score/out matmul shapes) — so the two paths deterministically diverge
+/// O(1) without any chunk-bookkeeping bug. Parity assertions are gated on
+/// this canary so they resume automatically once an MLX bump repairs the
+/// kernel.
+///
+/// Returns `false` (trustworthy) if the canary cannot run at all (e.g. no
+/// Metal device) — callers are expected to have their own
+/// Metal-availability skips.
+///
+/// Set `MLX_TEST_FORCE_HALF_PARITY=1` to bypass the canary and force the
+/// gated assertions to run anyway (for measuring the divergence on a
+/// broken host, or for re-validating after an MLX pin bump before the
+/// canary is removed).
+pub(crate) fn half_gemm_untrustworthy() -> bool {
+    static RESULT: OnceLock<bool> = OnceLock::new();
+    *RESULT.get_or_init(|| {
+        if std::env::var_os("MLX_TEST_FORCE_HALF_PARITY").is_some_and(|v| v == "1") {
+            eprintln!(
+                "half_gemm_untrustworthy: MLX_TEST_FORCE_HALF_PARITY=1 — bypassing \
+                 the canary; gated parity assertions will run even if this host's \
+                 half-precision GEMM is broken"
+            );
+            return false;
+        }
+        let run = || -> Result<bool, napi::Error> {
+            let m = 8usize;
+            let k_dim = 64usize;
+            let n_dim = 64usize;
+            let x_vals: Vec<f32> = (0..(m * k_dim))
+                .map(|i| ((i as f32 * 0.9173 + 0.37).sin()) * 1.5)
+                .collect();
+            let w_vals: Vec<f32> = (0..(k_dim * n_dim))
+                .map(|i| ((i as f32 * 0.5711 + 0.71).sin()) * 0.5)
+                .collect();
+            let x = MxArray::from_float32(&x_vals, &[m as i64, k_dim as i64])?
+                .astype(DType::BFloat16)?;
+            let w = MxArray::from_float32(&w_vals, &[k_dim as i64, n_dim as i64])?
+                .astype(DType::BFloat16)?;
+
+            let flat = |a: &MxArray| -> Result<Vec<f32>, napi::Error> {
+                let n: i64 = a.shape()?.iter().product();
+                let f = a.reshape(&[n])?.astype(DType::Float32)?;
+                f.eval();
+                (0..n as usize).map(|i| f.item_at_float32(i)).collect()
+            };
+
+            let y = flat(&x.matmul(&w)?)?;
+            let xb = flat(&x)?;
+            let wb = flat(&w)?;
+            let mut max_err = 0.0f32;
+            for r in 0..m {
+                for n in 0..n_dim {
+                    let mut acc = 0.0f32;
+                    for k in 0..k_dim {
+                        acc += xb[r * k_dim + k] * wb[k * n_dim + n];
+                    }
+                    max_err = max_err.max((y[r * n_dim + n] - acc).abs());
+                }
+            }
+            Ok(max_err > 0.1)
+        };
+        match run() {
+            Ok(untrustworthy) => {
+                if untrustworthy {
+                    eprintln!(
+                        "half_gemm_untrustworthy: this host's bf16 GEMM fails the \
+                         K=64/N=64 canary (vendored-MLX NAX unaligned-K bug on \
+                         gen>=17 GPUs); half-precision parity assertions on tiny \
+                         configs are gated off"
+                    );
+                }
+                untrustworthy
+            }
+            Err(_) => false,
+        }
+    })
+}

--- a/crates/mlx-core/src/test_support.rs
+++ b/crates/mlx-core/src/test_support.rs
@@ -3,6 +3,8 @@
 
 use std::sync::OnceLock;
 
+use mlx_sys as sys;
+
 use crate::array::{DType, MxArray};
 
 /// Returns `true` when this host's half-precision GEMM produces results
@@ -37,6 +39,71 @@ use crate::array::{DType, MxArray};
 /// gated assertions to run anyway (for measuring the divergence on a
 /// broken host, or for re-validating after an MLX pin bump before the
 /// canary is removed).
+pub(crate) fn half_gemm_untrustworthy() -> bool {
+    static RESULT: OnceLock<bool> = OnceLock::new();
+    *RESULT.get_or_init(|| {
+        if std::env::var_os("MLX_TEST_FORCE_HALF_PARITY").is_some_and(|v| v == "1") {
+            eprintln!(
+                "half_gemm_untrustworthy: MLX_TEST_FORCE_HALF_PARITY=1 — bypassing \
+                 the canary; gated parity assertions will run even if this host's \
+                 half-precision GEMM is broken"
+            );
+            return false;
+        }
+        let run = || -> Result<bool, napi::Error> {
+            let m = 8usize;
+            let k_dim = 64usize;
+            let n_dim = 64usize;
+            let x_vals: Vec<f32> = (0..(m * k_dim))
+                .map(|i| ((i as f32 * 0.9173 + 0.37).sin()) * 1.5)
+                .collect();
+            let w_vals: Vec<f32> = (0..(k_dim * n_dim))
+                .map(|i| ((i as f32 * 0.5711 + 0.71).sin()) * 0.5)
+                .collect();
+            let x = MxArray::from_float32(&x_vals, &[m as i64, k_dim as i64])?
+                .astype(DType::BFloat16)?;
+            let w = MxArray::from_float32(&w_vals, &[k_dim as i64, n_dim as i64])?
+                .astype(DType::BFloat16)?;
+
+            let flat = |a: &MxArray| -> Result<Vec<f32>, napi::Error> {
+                let n: i64 = a.shape()?.iter().product();
+                let f = a.reshape(&[n])?.astype(DType::Float32)?;
+                f.eval();
+                (0..n as usize).map(|i| f.item_at_float32(i)).collect()
+            };
+
+            let y = flat(&x.matmul(&w)?)?;
+            let xb = flat(&x)?;
+            let wb = flat(&w)?;
+            let mut max_err = 0.0f32;
+            for r in 0..m {
+                for n in 0..n_dim {
+                    let mut acc = 0.0f32;
+                    for k in 0..k_dim {
+                        acc += xb[r * k_dim + k] * wb[k * n_dim + n];
+                    }
+                    max_err = max_err.max((y[r * n_dim + n] - acc).abs());
+                }
+            }
+            Ok(max_err > 0.1)
+        };
+        match run() {
+            Ok(untrustworthy) => {
+                if untrustworthy {
+                    eprintln!(
+                        "half_gemm_untrustworthy: this host's bf16 GEMM fails the \
+                         K=64/N=64 canary (vendored-MLX NAX unaligned-K bug on \
+                         gen>=17 GPUs); half-precision parity assertions on tiny \
+                         configs are gated off"
+                    );
+                }
+                untrustworthy
+            }
+            Err(_) => false,
+        }
+    })
+}
+
 /// Returns `true` when this host silently computes f32 GEMM in reduced
 /// (TF32-class) precision instead of true f32.
 ///
@@ -119,50 +186,95 @@ pub(crate) fn f32_gemm_tf32_degraded() -> bool {
     })
 }
 
-pub(crate) fn half_gemm_untrustworthy() -> bool {
+/// Returns `true` when this host's half-precision **sorted** `gather_mm`
+/// (the `right_sorted` M=1-rows fast path MoE expert dispatch uses once a
+/// forward carries >= 64 token-expert indices) produces garbage.
+///
+/// This is a distinct broken kernel from the plain-GEMM canary above: on
+/// gen>=17 GPUs + macOS 26.2+ the vendored pin routes bf16/f16 sorted
+/// gather_mm to `gather_mm_rhs_nax` (`matmul.cpp:2408`), which against a
+/// host-f64 reference errs O(1) at EVERY K probed — K=4: 2.7, K=64: 5.0,
+/// K=128: 3.7, K=256: 3.9, K=2048: 2.9 — including block-aligned and
+/// production-scale K, unlike the plain NAX GEMM whose damage is confined
+/// to unaligned K. The same call with f32 operands and `MLX_ENABLE_TF32=0`
+/// (dispatching the non-NAX `gather_mm_rhs`) matches the host reference to
+/// ~1e-8, and the UNSORTED m=1 path (`gather_mv`) is correct in bf16 — so
+/// an MLX pin bump can fix the plain GEMM and this kernel independently,
+/// which is why they get separate probes.
+///
+/// (Also documented here because it is test-adjacent: with the pin's
+/// `MLX_ENABLE_TF32=1` default, f32 sorted gather_mm ABORTS the process —
+/// dispatch enters `gather_mm_rhs_nax`, whose JIT template instantiation
+/// for float32 throws an uncatchable foreign exception through the FFI
+/// boundary.)
+///
+/// Same contract as `half_gemm_untrustworthy`: `false` when the probe
+/// cannot run, and `MLX_TEST_FORCE_HALF_PARITY=1` bypasses it.
+pub(crate) fn sorted_gather_mm_untrustworthy() -> bool {
     static RESULT: OnceLock<bool> = OnceLock::new();
     *RESULT.get_or_init(|| {
         if std::env::var_os("MLX_TEST_FORCE_HALF_PARITY").is_some_and(|v| v == "1") {
             eprintln!(
-                "half_gemm_untrustworthy: MLX_TEST_FORCE_HALF_PARITY=1 — bypassing \
-                 the canary; gated parity assertions will run even if this host's \
-                 half-precision GEMM is broken"
+                "sorted_gather_mm_untrustworthy: MLX_TEST_FORCE_HALF_PARITY=1 — \
+                 bypassing the canary; gated parity assertions will run even if \
+                 this host's sorted half-precision gather_mm is broken"
             );
             return false;
         }
         let run = || -> Result<bool, napi::Error> {
-            let m = 8usize;
+            let rows = 64usize;
+            let n_exp = 4usize;
             let k_dim = 64usize;
             let n_dim = 64usize;
-            let x_vals: Vec<f32> = (0..(m * k_dim))
+            // x: [rows, 1, 1, K] bf16 — each row is one M=1 matmul, matching
+            // the SwitchGLU gather-sort layout.
+            let x_vals: Vec<f32> = (0..(rows * k_dim))
                 .map(|i| ((i as f32 * 0.9173 + 0.37).sin()) * 1.5)
                 .collect();
-            let w_vals: Vec<f32> = (0..(k_dim * n_dim))
+            let x = MxArray::from_float32(&x_vals, &[rows as i64, 1, 1, k_dim as i64])?
+                .astype(DType::BFloat16)?;
+            // b: [E, K, N] bf16 expert stack.
+            let w_vals: Vec<f32> = (0..(n_exp * k_dim * n_dim))
                 .map(|i| ((i as f32 * 0.5711 + 0.71).sin()) * 0.5)
                 .collect();
-            let x = MxArray::from_float32(&x_vals, &[m as i64, k_dim as i64])?
+            let w = MxArray::from_float32(&w_vals, &[n_exp as i64, k_dim as i64, n_dim as i64])?
                 .astype(DType::BFloat16)?;
-            let w = MxArray::from_float32(&w_vals, &[k_dim as i64, n_dim as i64])?
-                .astype(DType::BFloat16)?;
+            // Sorted expert ids, rows/n_exp rows per expert.
+            let per = rows / n_exp;
+            let ids: Vec<i32> = (0..rows).map(|r| (r / per) as i32).collect();
+            let idx = MxArray::from_int32(&ids, &[rows as i64, 1])?;
 
+            let out = MxArray::from_handle(
+                unsafe {
+                    sys::mlx_gather_mm(
+                        x.handle.0,
+                        w.handle.0,
+                        std::ptr::null_mut(),
+                        idx.handle.0,
+                        true,
+                    )
+                },
+                "sorted_gather_mm_canary",
+            )?;
             let flat = |a: &MxArray| -> Result<Vec<f32>, napi::Error> {
                 let n: i64 = a.shape()?.iter().product();
                 let f = a.reshape(&[n])?.astype(DType::Float32)?;
                 f.eval();
-                (0..n as usize).map(|i| f.item_at_float32(i)).collect()
+                Ok(f.to_float32()?.to_vec())
             };
-
-            let y = flat(&x.matmul(&w)?)?;
+            let got = flat(&out)?;
             let xb = flat(&x)?;
             let wb = flat(&w)?;
             let mut max_err = 0.0f32;
-            for r in 0..m {
+            for r in 0..rows {
+                let e = ids[r] as usize;
                 for n in 0..n_dim {
-                    let mut acc = 0.0f32;
+                    let mut acc = 0.0f64;
                     for k in 0..k_dim {
-                        acc += xb[r * k_dim + k] * wb[k * n_dim + n];
+                        acc +=
+                            xb[r * k_dim + k] as f64 * wb[e * k_dim * n_dim + k * n_dim + n] as f64;
                     }
-                    max_err = max_err.max((y[r * n_dim + n] - acc).abs());
+                    max_err = max_err.max((got[r * n_dim + n] - acc as f32).abs());
                 }
             }
             Ok(max_err > 0.1)
@@ -171,10 +283,11 @@ pub(crate) fn half_gemm_untrustworthy() -> bool {
             Ok(untrustworthy) => {
                 if untrustworthy {
                     eprintln!(
-                        "half_gemm_untrustworthy: this host's bf16 GEMM fails the \
-                         K=64/N=64 canary (vendored-MLX NAX unaligned-K bug on \
-                         gen>=17 GPUs); half-precision parity assertions on tiny \
-                         configs are gated off"
+                        "sorted_gather_mm_untrustworthy: this host's bf16 sorted \
+                         gather_mm fails the K=64/N=64 canary (vendored-MLX \
+                         gather_mm_rhs_nax bug on gen>=17 GPUs, broken at every \
+                         probed K incl. 2048); half-precision MoE gather-sort \
+                         parity assertions are gated off"
                     );
                 }
                 untrustworthy

--- a/crates/mlx-core/src/test_support.rs
+++ b/crates/mlx-core/src/test_support.rs
@@ -37,6 +37,88 @@ use crate::array::{DType, MxArray};
 /// gated assertions to run anyway (for measuring the divergence on a
 /// broken host, or for re-validating after an MLX pin bump before the
 /// canary is removed).
+/// Returns `true` when this host silently computes f32 GEMM in reduced
+/// (TF32-class) precision instead of true f32.
+///
+/// The vendored MLX pin defaults `MLX_ENABLE_TF32` to **1**
+/// (`mlx/utils.h::enable_tf32`), and on gen>=17 GPUs under macOS 26.2+
+/// (`metal::is_nax_available()`) that default routes every f32 GEMM with
+/// M > 1 (`matmul.cpp:367`) and every f32 fused full-SDPA with q_len > 8
+/// (`scaled_dot_product_attention.cpp:178`) to the NAX kernels, which
+/// accumulate from TF32-truncated (11-bit-mantissa) inputs. Measured on the
+/// `[8,64] x [64,64]` canary against a host-f64 reference: max_err 3.1e-3
+/// with the default, 9.5e-7 with `MLX_ENABLE_TF32=0` — a ~3000x precision
+/// loss that is invisible to dtype inspection (arrays still report f32).
+///
+/// f32 parity/finite-difference tests calibrated for true-f32 accumulation
+/// (tolerances 5e-5, or central differences whose loss-delta signal is
+/// ~1e-6) are meaningless in that regime, so they gate on this probe. The
+/// probe self-adapts: exporting `MLX_ENABLE_TF32=0` restores true f32, the
+/// probe then reports trustworthy, and the gated tests run (and pass) again
+/// — same for pre-gen-17 hosts and for a future MLX pin that flips the
+/// default.
+///
+/// Returns `false` if the probe cannot run (no Metal device) — callers keep
+/// their own Metal-availability skips. `MLX_TEST_FORCE_HALF_PARITY=1`
+/// bypasses this canary too (one override for every numeric-environment
+/// gate), forcing the gated assertions to run for re-measurement.
+pub(crate) fn f32_gemm_tf32_degraded() -> bool {
+    static RESULT: OnceLock<bool> = OnceLock::new();
+    *RESULT.get_or_init(|| {
+        if std::env::var_os("MLX_TEST_FORCE_HALF_PARITY").is_some_and(|v| v == "1") {
+            eprintln!(
+                "f32_gemm_tf32_degraded: MLX_TEST_FORCE_HALF_PARITY=1 — bypassing \
+                 the canary; gated f32 parity assertions will run even if this \
+                 host computes f32 GEMM in TF32 precision"
+            );
+            return false;
+        }
+        let run = || -> Result<bool, napi::Error> {
+            let m = 8usize;
+            let k_dim = 64usize;
+            let n_dim = 64usize;
+            let x_vals: Vec<f32> = (0..(m * k_dim))
+                .map(|i| ((i as f32 * 0.9173 + 0.37).sin()) * 1.5)
+                .collect();
+            let w_vals: Vec<f32> = (0..(k_dim * n_dim))
+                .map(|i| ((i as f32 * 0.5711 + 0.71).sin()) * 0.5)
+                .collect();
+            let x = MxArray::from_float32(&x_vals, &[m as i64, k_dim as i64])?;
+            let w = MxArray::from_float32(&w_vals, &[k_dim as i64, n_dim as i64])?;
+            let y = x.matmul(&w)?;
+            y.eval();
+            let yv = y.to_float32()?;
+            let mut max_err = 0.0f32;
+            for r in 0..m {
+                for n in 0..n_dim {
+                    let mut acc = 0.0f64;
+                    for k in 0..k_dim {
+                        acc += x_vals[r * k_dim + k] as f64 * w_vals[k * n_dim + n] as f64;
+                    }
+                    max_err = max_err.max((yv[r * n_dim + n] - acc as f32).abs());
+                }
+            }
+            // True f32 measures ~1e-6 on this shape; TF32 measures ~3e-3.
+            Ok(max_err > 1e-4)
+        };
+        match run() {
+            Ok(degraded) => {
+                if degraded {
+                    eprintln!(
+                        "f32_gemm_tf32_degraded: this host computes f32 GEMM in \
+                         TF32 precision (vendored-MLX MLX_ENABLE_TF32 defaults \
+                         to 1 and routes f32 to NAX kernels on gen>=17 GPUs); \
+                         f32 parity assertions are gated off — export \
+                         MLX_ENABLE_TF32=0 to restore true f32 and re-enable them"
+                    );
+                }
+                degraded
+            }
+            Err(_) => false,
+        }
+    })
+}
+
 pub(crate) fn half_gemm_untrustworthy() -> bool {
     static RESULT: OnceLock<bool> = OnceLock::new();
     *RESULT.get_or_init(|| {

--- a/crates/mlx-core/src/transformer/attention_vjp_test.rs
+++ b/crates/mlx-core/src/transformer/attention_vjp_test.rs
@@ -923,8 +923,27 @@ mod tests {
     /// Test gradient correctness for float32 without masking
     /// Note: This is a spot-check test that verifies gradients are in the right ballpark.
     /// Due to numerical precision issues with finite differences, we use a lenient tolerance.
+    ///
+    /// Skips on hosts where f32 GEMM/SDPA silently run in TF32 precision
+    /// (`test_support::f32_gemm_tf32_degraded`): the central-difference signal
+    /// here is `2 * epsilon * grad` ~ 1e-6 on a loss of ~0.5 (inputs are
+    /// N(0, 0.02), so dQ/dK are ~1e-5..1e-4), which true-f32 forward noise
+    /// (~1e-7) resolves but TF32-truncated forwards (~1e-4 loss error) drown
+    /// completely — observed numerical estimates then include exact 0.0
+    /// (f(x+e) and f(x-e) round to the same value) and noise-dominated
+    /// garbage, failing 6/9 samples. The same binary passes 9/9 with
+    /// `MLX_ENABLE_TF32=0` exported.
     #[test]
     fn test_attention_vjp_finite_diff_f32_no_mask() {
+        if crate::test_support::f32_gemm_tf32_degraded() {
+            eprintln!(
+                "skipping test_attention_vjp_finite_diff_f32_no_mask: this host \
+                 runs f32 GEMM/SDPA in TF32 precision (MLX_ENABLE_TF32 defaults \
+                 to 1 on NAX-capable GPUs), which drowns the finite-difference \
+                 signal; export MLX_ENABLE_TF32=0 to run it"
+            );
+            return;
+        }
         let batch = 1;
         let heads = 2;
         let seq_len = 16;
@@ -1000,9 +1019,26 @@ mod tests {
 
     /// Test gradient correctness for float32 with causal masking
     /// Note: This is a spot-check test that verifies gradients are in the right ballpark.
+    ///
+    /// Skips on TF32-degraded hosts for the same reason as
+    /// `test_attention_vjp_finite_diff_f32_no_mask` (see its docstring):
+    /// the finite-difference signal (~1e-6 loss delta) needs true-f32
+    /// forwards; with the vendored pin's `MLX_ENABLE_TF32=1` default on
+    /// NAX GPUs this test fails 6/9 samples, and passes 9/9 with
+    /// `MLX_ENABLE_TF32=0` exported.
     #[test]
     fn test_attention_vjp_finite_diff_f32_causal() {
         use crate::array::scaled_dot_product_attention_causal;
+
+        if crate::test_support::f32_gemm_tf32_degraded() {
+            eprintln!(
+                "skipping test_attention_vjp_finite_diff_f32_causal: this host \
+                 runs f32 GEMM/SDPA in TF32 precision (MLX_ENABLE_TF32 defaults \
+                 to 1 on NAX-capable GPUs), which drowns the finite-difference \
+                 signal; export MLX_ENABLE_TF32=0 to run it"
+            );
+            return;
+        }
 
         let batch = 1;
         let heads = 2;

--- a/crates/mlx-core/src/transformer/block.rs
+++ b/crates/mlx-core/src/transformer/block.rs
@@ -1,5 +1,8 @@
 use crate::array::mask::create_causal_mask;
 use crate::array::{MxArray, scaled_dot_product_attention, scaled_dot_product_attention_causal};
+use crate::inference_trace::{
+    elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
+};
 use crate::nn::RMSNorm;
 use crate::transformer::attention::Attention;
 use crate::transformer::kv_cache::KVCache;
@@ -8,6 +11,27 @@ use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
 use mlx_sys as sys;
 use napi::bindgen_prelude::*;
 use std::ptr;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+/// When enabled (default), Qwen3's paged decode path writes K/V into the
+/// pool with the graph-native, lazily-scheduled `update_keys_values_native`
+/// (see [`PagedKVCacheAdapter::update_keys_values_native`]) so the write
+/// feeds the same-step attention read through MLX graph dependencies
+/// instead of forcing a blocking `mlx_metal_synchronize()` + command-buffer
+/// host wait on every layer/token (see
+/// [`PagedKVCacheAdapter::update_keys_values`] /
+/// `LayerKVPool::write_kv`). Falls back to the synchronous
+/// `update_keys_values` automatically when disabled (via
+/// `MLX_QWEN3_NATIVE_KV_WRITE=0`) or when the native write errors. Mirrors
+/// the default-on migration already shipped for Gemma4 / Qwen3.5 / LFM2
+/// (PR #56).
+fn native_kv_write_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        crate::inference_trace::env_flag_enabled_or_default("MLX_QWEN3_NATIVE_KV_WRITE", true)
+    })
+}
 
 /// Transformer block combining self-attention and MLP with pre-normalization.
 ///
@@ -239,11 +263,19 @@ impl TransformerBlock {
     ///   The on-device zero-copy fast-path (TODO in the adapter) will replace
     ///   the read with a Metal kernel that attends in-place against the paged
     ///   buffers.
-    /// - **Decode output dtype.** `gather_kv_for_decode` currently returns
-    ///   Float32 (host-roundtrip). We `astype` it back to `x`'s dtype
-    ///   before output projection / residual so the rest of the block stays
-    ///   in BF16. The on-device zero-copy fast-path (TODO in the adapter)
-    ///   will remove this cast.
+    /// - **K/V write and decode gather default to graph-native.** The write
+    ///   prefers `update_keys_values_native` and the decode read prefers
+    ///   `gather_kv_for_decode_graph`, both falling back to their
+    ///   synchronous counterparts on error or when disabled via
+    ///   `MLX_QWEN3_NATIVE_KV_WRITE=0`. This removes the per-layer,
+    ///   per-decode-token blocking `mlx_metal_synchronize()` +
+    ///   command-buffer host wait that the synchronous path forces,
+    ///   mirroring the default-on migration already shipped for Gemma4 /
+    ///   Qwen3.5 / LFM2 (PR #56).
+    /// - **Decode output dtype.** The decode gather returns the query/pool
+    ///   dtype (BF16 for Qwen3's non-FP8 cache). We `astype` it back to
+    ///   `x`'s dtype defensively before output projection / residual so the
+    ///   rest of the block stays homogeneous.
     #[allow(clippy::too_many_arguments)]
     pub fn forward_paged_adapter(
         &self,
@@ -282,9 +314,58 @@ impl TransformerBlock {
         //    read them back via gather. Note: the adapter's
         //    `record_tokens` MUST already have advanced the cursor by the
         //    chunk size before this call (see method docstring).
-        adapter
-            .update_keys_values(layer_idx, &qkv.keys, &qkv.values, first_logical_position)
-            .map_err(napi::Error::from_reason)?;
+        //
+        //    Prefer the graph-native, lazily-scheduled
+        //    `update_keys_values_native` so the same-step attention read
+        //    stays inside MLX's dependency graph instead of forcing a
+        //    blocking `mlx_metal_synchronize()` + command-buffer host wait
+        //    on every layer/token (see
+        //    `PagedKVCacheAdapter::update_keys_values`). Falls back to the
+        //    synchronous write automatically when
+        //    `MLX_QWEN3_NATIVE_KV_WRITE=0` or when the native write errors.
+        let trace_enabled = inference_trace_enabled();
+        let write_trace_start = trace_enabled.then(Instant::now);
+        let write_path = if native_kv_write_enabled() {
+            match adapter.update_keys_values_native(
+                layer_idx,
+                &qkv.keys,
+                &qkv.values,
+                first_logical_position,
+            ) {
+                Ok(()) => "native",
+                Err(err) => {
+                    if trace_enabled {
+                        write_inference_trace(format_args!(
+                            "[MLX_TRACE] qwen3 paged_kv_write_fallback layer={} first_position={} error={}",
+                            layer_idx, first_logical_position, err
+                        ));
+                    }
+                    adapter
+                        .update_keys_values(
+                            layer_idx,
+                            &qkv.keys,
+                            &qkv.values,
+                            first_logical_position,
+                        )
+                        .map_err(napi::Error::from_reason)?;
+                    "legacy"
+                }
+            }
+        } else {
+            adapter
+                .update_keys_values(layer_idx, &qkv.keys, &qkv.values, first_logical_position)
+                .map_err(napi::Error::from_reason)?;
+            "legacy"
+        };
+        if trace_enabled {
+            write_inference_trace(format_args!(
+                "[MLX_TRACE] qwen3 paged_kv_write_done layer={} first_position={} path={} elapsed_ms={:.1}",
+                layer_idx,
+                first_logical_position,
+                write_path,
+                write_trace_start.map(elapsed_ms).unwrap_or(0.0)
+            ));
+        }
 
         // 4. Compute attention output.
         let attn_out_paged = if is_prefill {
@@ -351,36 +432,86 @@ impl TransformerBlock {
                 .reshape(&[num_tokens, n_heads, head_dim])?
         } else {
             // Decode: K/V at the new position has just been written to the
-            // pool by `update_keys_values` above. Dispatch the
-            // `gather_kv_for_decode` Metal kernel directly against the
-            // on-GPU paged buffers — avoids the per-step host roundtrip
-            // (~57 MB per layer per K/V on long contexts) that
-            // `read_kv_range` performs and that drives a ~40 GB memory
-            // regression in long-context decode.
+            // pool by the write step above. When that write went native,
+            // use the graph-native `gather_kv_for_decode_graph` so the
+            // native paged-kv-write output and the attention read stay in
+            // one MLX dependency graph — no per-layer host sync — falling
+            // back to the synchronous `gather_kv_for_decode` kernel only if
+            // the graph gather errors. When the write landed on the legacy
+            // branch (flag off or native-write error), use the synchronous
+            // `gather_kv_for_decode` directly so `MLX_QWEN3_NATIVE_KV_WRITE=0`
+            // fully reverts BOTH the write and the decode read.
             //
-            // The kernel returns the query/io dtype. Cast back to x's dtype
+            // Both kernels return the query/io dtype. Cast back to x's dtype
             // so the rest of the block stays homogeneous. This is a
             // zero-extra-host-buffer path — the K/V are not materialized as
             // MxArrays at all.
             //
-            // `gather_kv_for_decode` expects queries shape
-            // `[1, num_query_heads, head_size]` (3-D). `qkv.queries` from
-            // `compute_qkv` is already `[num_tokens=1, n_heads, head_dim]`
-            // for the single-token decode chunk, so it's a direct fit.
+            // Both expect queries shape `[1, num_query_heads, head_size]`
+            // (3-D). `qkv.queries` from `compute_qkv` is already
+            // `[num_tokens=1, n_heads, head_dim]` for the single-token
+            // decode chunk, so it's a direct fit.
             let scale = self.self_attn.get_scale();
 
-            let attn_3d = adapter
-                .gather_kv_for_decode(
+            let gather_trace_start = trace_enabled.then(Instant::now);
+            let attn_3d = if write_path == "native" {
+                match adapter.gather_kv_for_decode_graph(
                     layer_idx,
                     &qkv.queries,
                     scale as f32,
                     /* softcap */ 1.0,
-                )
-                .map_err(napi::Error::from_reason)?;
+                ) {
+                    Ok(attn_3d) => {
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] qwen3 decode_gather_done layer={} path=graph elapsed_ms={:.1}",
+                                layer_idx,
+                                gather_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                            ));
+                        }
+                        attn_3d
+                    }
+                    Err(err) => {
+                        if trace_enabled {
+                            write_inference_trace(format_args!(
+                                "[MLX_TRACE] qwen3 decode_gather_fallback layer={} path=raw error={}",
+                                layer_idx, err
+                            ));
+                        }
+                        adapter
+                            .gather_kv_for_decode(
+                                layer_idx,
+                                &qkv.queries,
+                                scale as f32,
+                                /* softcap */ 1.0,
+                            )
+                            .map_err(napi::Error::from_reason)?
+                    }
+                }
+            } else {
+                // Flag off (or the native write above errored): take the
+                // synchronous gather directly, matching the legacy write.
+                let attn_3d = adapter
+                    .gather_kv_for_decode(
+                        layer_idx,
+                        &qkv.queries,
+                        scale as f32,
+                        /* softcap */ 1.0,
+                    )
+                    .map_err(napi::Error::from_reason)?;
+                if trace_enabled {
+                    write_inference_trace(format_args!(
+                        "[MLX_TRACE] qwen3 decode_gather_done layer={} path=legacy elapsed_ms={:.1}",
+                        layer_idx,
+                        gather_trace_start.map(elapsed_ms).unwrap_or(0.0)
+                    ));
+                }
+                attn_3d
+            };
 
             // Cast back to x's dtype.
-            // `gather_kv_for_decode` returns `[1, n_heads, head_dim]`, which
-            // is exactly the layout `output_projection` expects for
+            // Both gathers return `[1, n_heads, head_dim]`, which is
+            // exactly the layout `output_projection` expects for
             // `batch * seq_len = 1`.
             let target_dtype = x.dtype()?;
             attn_3d.astype(target_dtype)?

--- a/crates/mlx-core/src/utils/gemma_quant_repack.rs
+++ b/crates/mlx-core/src/utils/gemma_quant_repack.rs
@@ -42,7 +42,9 @@
 /// * `out_features` — number of output channels (rows)
 /// * `in_features` — number of input channels (logical columns per row)
 /// * `bits` — 2 or 4
-/// * `group_size` — MLX affine group size (e.g. 64 for linear projections)
+/// * `group_size` — MLX affine group size (e.g. 128 for linear projections;
+///   MLX affine only accepts 32/64/128, and since every group in a row
+///   carries the same source per-row scale, 128 is always optimal here)
 ///
 /// # Returns
 /// `(weight, scales, biases)` as raw Vecs:

--- a/crates/mlx-core/src/vision/encoder.rs
+++ b/crates/mlx-core/src/vision/encoder.rs
@@ -12,6 +12,17 @@ use crate::vision::rope_vision::apply_rotary_pos_emb_vision;
 use napi::bindgen_prelude::*;
 use std::sync::Arc;
 
+#[cfg(test)]
+thread_local! {
+    /// Test-only call counter for [`VisionAttention::build_attention_mask`],
+    /// used to assert that callers hoist mask construction once per forward
+    /// pass instead of rebuilding it on every transformer layer.
+    /// Thread-local so concurrently-running unrelated tests (which also
+    /// exercise vision attention) can't interfere with a given test's count.
+    pub(crate) static BUILD_ATTENTION_MASK_CALLS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 /// Vision Attention (internal)
 ///
 /// Self-attention for vision transformers with fused QKV projection.
@@ -102,15 +113,25 @@ impl VisionAttention {
     /// to each other (mask=0) and positions in different sub-sequences are
     /// penalized (mask=1). This matches the Python mlx-vlm implementation.
     ///
+    /// This is a pure function of `cu_seqlens`/`seq_len`/`dtype`. Callers that
+    /// run multiple transformer layers per forward pass (e.g. a full vision
+    /// encoder stack) share one `cu_seqlens` across all layers -- build the
+    /// mask once via this function and reuse it (see
+    /// [`Self::forward_with_mask`]) instead of calling [`Self::forward`]
+    /// once per layer, which would rebuild an identical mask every time.
+    ///
     /// # Arguments
     /// * `cu_seqlens` - Cumulative sequence lengths, e.g. [0, 196, 392]
     /// * `seq_len` - Total sequence length
     /// * `dtype` - Output dtype for the mask
-    fn build_attention_mask(
+    pub(crate) fn build_attention_mask(
         cu_seqlens: &MxArray,
         seq_len: i64,
         dtype: crate::array::DType,
     ) -> Result<MxArray> {
+        #[cfg(test)]
+        BUILD_ATTENTION_MASK_CALLS.with(|c| c.set(c.get() + 1));
+
         // Eval cu_seqlens so we can read values
         cu_seqlens.eval();
         let num_boundaries = cu_seqlens.size()? as usize;
@@ -154,19 +175,25 @@ impl VisionAttention {
         mask.reshape(&[1, seq_len, seq_len])
     }
 
-    /// Forward pass
+    /// Forward pass using a pre-built additive attention mask.
+    ///
+    /// Prefer this over [`Self::forward`] when calling it once per layer
+    /// across multiple layers in the same forward pass with the same
+    /// `cu_seqlens`/`seq_len`/`dtype`: build the mask once with
+    /// [`Self::build_attention_mask`] and reuse it here instead of
+    /// rebuilding an identical mask on every call.
     ///
     /// # Arguments
     /// * `x` - Input tensor [seq_len, dim]
-    /// * `cu_seqlens` - Cumulative sequence lengths for variable-length batching
+    /// * `attention_mask` - Pre-built additive mask [1, seq_len, seq_len] (or `None` for full attention)
     /// * `rotary_pos_emb` - Rotary position embeddings [seq_len, head_dim/2]
     ///
     /// # Returns
     /// * Output tensor [seq_len, dim]
-    pub fn forward(
+    pub fn forward_with_mask(
         &self,
         x: &MxArray,
-        cu_seqlens: &MxArray,
+        attention_mask: Option<&MxArray>,
         rotary_pos_emb: Option<&MxArray>,
     ) -> Result<MxArray> {
         let shape = x.shape()?;
@@ -216,14 +243,9 @@ impl VisionAttention {
             .reshape(&[1, seq_len, self.num_heads as i64, self.head_dim as i64])?
             .transpose(Some(&[0, 2, 1, 3]))?;
 
-        // Build attention mask from cu_seqlens
-        let input_dtype = x.dtype()?;
-        let attention_mask = Self::build_attention_mask(cu_seqlens, seq_len, input_dtype)?;
-
         // Use fused scaled dot-product attention (Metal kernel)
         // mask shape [1, seq_len, seq_len] broadcasts to [1, num_heads, seq_len, seq_len]
-        let output =
-            scaled_dot_product_attention(&q, &k, &v, self.scale as f64, Some(&attention_mask))?;
+        let output = scaled_dot_product_attention(&q, &k, &v, self.scale as f64, attention_mask)?;
 
         // Transpose back: [1, num_heads, seq_len, head_dim] -> [1, seq_len, num_heads, head_dim]
         let output = output.transpose(Some(&[0, 2, 1, 3]))?;
@@ -233,6 +255,32 @@ impl VisionAttention {
 
         // Output projection
         self.out_proj.forward(&output)
+    }
+
+    /// Forward pass, building the attention mask from `cu_seqlens` internally.
+    ///
+    /// Prefer [`Self::forward_with_mask`] when calling this repeatedly with
+    /// the same `cu_seqlens`/`seq_len`/`dtype` across multiple layers in one
+    /// forward pass (e.g. a transformer stack): build the mask once and
+    /// reuse it, instead of rebuilding an identical mask on every call.
+    ///
+    /// # Arguments
+    /// * `x` - Input tensor [seq_len, dim]
+    /// * `cu_seqlens` - Cumulative sequence lengths for variable-length batching
+    /// * `rotary_pos_emb` - Rotary position embeddings [seq_len, head_dim/2]
+    ///
+    /// # Returns
+    /// * Output tensor [seq_len, dim]
+    pub fn forward(
+        &self,
+        x: &MxArray,
+        cu_seqlens: &MxArray,
+        rotary_pos_emb: Option<&MxArray>,
+    ) -> Result<MxArray> {
+        let seq_len = x.shape()?[0];
+        let input_dtype = x.dtype()?;
+        let attention_mask = Self::build_attention_mask(cu_seqlens, seq_len, input_dtype)?;
+        self.forward_with_mask(x, Some(&attention_mask), rotary_pos_emb)
     }
 }
 
@@ -363,7 +411,44 @@ impl VisionEncoderLayer {
         &self.layer_norm2
     }
 
-    /// Forward pass
+    /// Forward pass using a pre-built additive attention mask.
+    ///
+    /// Prefer this over [`Self::forward`] when a caller runs multiple layers
+    /// per forward pass with the same `cu_seqlens` (e.g. a full encoder
+    /// stack): build the mask once (see
+    /// [`VisionAttention::build_attention_mask`]) and reuse it across all
+    /// layers instead of rebuilding an identical mask per layer.
+    ///
+    /// # Arguments
+    /// * `hidden_states` - Input tensor [seq_len, dim]
+    /// * `attention_mask` - Pre-built additive mask [1, seq_len, seq_len] (or `None` for full attention)
+    /// * `rotary_pos_emb` - Rotary position embeddings
+    ///
+    /// # Returns
+    /// * Output tensor [seq_len, dim]
+    pub fn forward_with_mask(
+        &self,
+        hidden_states: &MxArray,
+        attention_mask: Option<&MxArray>,
+        rotary_pos_emb: Option<&MxArray>,
+    ) -> Result<MxArray> {
+        // Self-attention with residual
+        let normed = self.layer_norm1.forward(hidden_states)?;
+        let attn_output =
+            self.self_attn
+                .forward_with_mask(&normed, attention_mask, rotary_pos_emb)?;
+        let hidden_states = hidden_states.add(&attn_output)?;
+
+        // MLP with residual
+        let normed = self.layer_norm2.forward(&hidden_states)?;
+        let mlp_output = self.mlp.forward(&normed)?;
+        hidden_states.add(&mlp_output)
+    }
+
+    /// Forward pass, building the attention mask from `cu_seqlens` internally.
+    ///
+    /// Prefer [`Self::forward_with_mask`] when calling this repeatedly with
+    /// the same `cu_seqlens` across multiple layers in one forward pass.
     ///
     /// # Arguments
     /// * `hidden_states` - Input tensor [seq_len, dim]
@@ -461,5 +546,77 @@ mod tests {
 
         let shape: Vec<i64> = output.shape().unwrap().as_ref().to_vec();
         assert_eq!(shape, vec![seq_len, dim as i64]);
+    }
+
+    /// Throwaway microbenchmark (not part of the fix) isolating the exact
+    /// cost this task removes: rebuilding `build_attention_mask` once per
+    /// transformer layer (27x, old behavior) vs building it once and reusing
+    /// the handle (1x, new behavior), at realistic Qwen3.5-VL document-OCR
+    /// patch counts. Run manually:
+    /// `cargo test -p mlx-core --lib vision::encoder::tests::bench_build_attention_mask_27x_vs_1x -- --ignored --nocapture`
+    #[test]
+    #[ignore]
+    fn bench_build_attention_mask_27x_vs_1x() {
+        use crate::array::DType;
+        use std::time::Instant;
+
+        const NUM_LAYERS: usize = 27;
+        const WARMUP: usize = 3;
+        const ITERS: usize = 20;
+
+        for &seq_len in &[2048i64, 4096i64] {
+            // Single-image cu_seqlens: one segment spanning the whole image.
+            let cu_seqlens = MxArray::from_int32(&[0, seq_len as i32], &[2]).unwrap();
+
+            // Warmup both variants.
+            for _ in 0..WARMUP {
+                for _ in 0..NUM_LAYERS {
+                    let m = VisionAttention::build_attention_mask(
+                        &cu_seqlens,
+                        seq_len,
+                        DType::BFloat16,
+                    )
+                    .unwrap();
+                    m.eval();
+                }
+                let m =
+                    VisionAttention::build_attention_mask(&cu_seqlens, seq_len, DType::BFloat16)
+                        .unwrap();
+                m.eval();
+            }
+
+            // Old-shape cost: rebuild the mask once per layer (27x).
+            let start = Instant::now();
+            for _ in 0..ITERS {
+                for _ in 0..NUM_LAYERS {
+                    let m = VisionAttention::build_attention_mask(
+                        &cu_seqlens,
+                        seq_len,
+                        DType::BFloat16,
+                    )
+                    .unwrap();
+                    m.eval();
+                }
+            }
+            let old_elapsed = start.elapsed();
+
+            // New-shape cost: build once, reuse the handle 27x (the mask
+            // itself isn't rebuilt; this measures only the one build call).
+            let start = Instant::now();
+            for _ in 0..ITERS {
+                let m =
+                    VisionAttention::build_attention_mask(&cu_seqlens, seq_len, DType::BFloat16)
+                        .unwrap();
+                m.eval();
+            }
+            let new_elapsed = start.elapsed();
+
+            let old_avg_us = old_elapsed.as_micros() as f64 / ITERS as f64;
+            let new_avg_us = new_elapsed.as_micros() as f64 / ITERS as f64;
+            println!(
+                "seq_len={seq_len}: old(27x)={old_avg_us:.1}us/iter new(1x)={new_avg_us:.1}us/iter ratio={:.2}x",
+                old_avg_us / new_avg_us
+            );
+        }
     }
 }

--- a/crates/mlx-core/tests/common/mod.rs
+++ b/crates/mlx-core/tests/common/mod.rs
@@ -1,0 +1,345 @@
+//! Shared harness for the synthetic MoE MTP integration tests
+//! (`qwen3_5_moe_mtp_synthetic_v1.rs` / `qwen3_5_moe_mtp_synthetic_v2.rs`).
+//!
+//! Those are two SEPARATE test binaries on purpose: the MoE stepper reads
+//! `MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY` exactly once per process (via
+//! `OnceLock`), so each binary pins one flag state — v1 leaves the flag
+//! unset (cycle-history default), v2 sets it before any model work
+//! (committed-history).
+//!
+//! The harness builds a TINY random-init MoE checkpoint that ships a real
+//! MTP head, reloads it, and decodes the same prompt with MTP off (plain AR
+//! reference) and on. Every local real MoE-MTP checkpoint is a VLM export
+//! whose config forces the block-paged KV backend — where the eager MoE MTP
+//! stepper is unreachable — so this synthetic checkpoint is the only
+//! always-on end-to-end route through `MoeMtpStepper`.
+//!
+//! What each test asserts — all four are deterministic on random weights:
+//! 1. `has_mtp_weights()` is true after reload (gates the random-save
+//!    `mtp.*` emission and the `mtp_num_hidden_layers` config round-trip).
+//! 2. The plain AR baseline decodes exactly `max_new_tokens` tokens (EOS is
+//!    unreachable by construction — see the prompt comment below).
+//! 3. The MTP decode completes crash-free across every draft/verify (and,
+//!    under v2, trim/commit) cycle with the same full token budget,
+//!    `mtp_cycles > 1`, and a populated `mtp_mean_accepted_tokens`.
+//! 4. Within-mode determinism: a second MTP decode of the same prompt on the
+//!    same loaded model is byte-identical to the first. This catches
+//!    allocator-dependent garbage (e.g. an out-of-bounds gather); the repeat
+//!    run executes identical kernel shapes, so it must be deterministic.
+//!
+//! MTP==AR byte-identity is deliberately NOT asserted here. Measured on this
+//! host: on random weights `mtp.text == ar.text` flips on ~10-15% of fresh
+//! checkpoint draws — greedy argmax near-ties (random logits over a 250k
+//! vocab have tiny top-2 gaps, and MTP's batched verify kernels round
+//! differently from AR's single-token decode kernels, well above 1 ULP).
+//! Exoneration of the v2 port: the flag-OFF v1 path (byte-for-byte the
+//! pre-existing cycle-history code) fails at the SAME rate as v2, depth-1
+//! and depth-4 MTP outputs are byte-identical to each other, and the flips
+//! are late single tokens after dozens of byte-clean cycles — so the assert
+//! measures kernel rounding, not port correctness (verify re-derives every
+//! emitted token from the MAIN model at T=0, so the drafter's cache policy
+//! cannot change which tokens are emitted). The MTP==AR byte-identity gate
+//! lives in the real-weights deep test
+//! (`qwen3_5_moe_mtp_committed_history.rs`), where bf16 real-distribution
+//! logits keep top-2 gaps far above kernel rounding.
+
+use std::path::{Path, PathBuf};
+
+use mlx_core::engine::types::ChatConfig;
+use mlx_core::models::qwen3_5_moe::Qwen3_5MoeConfig;
+use mlx_core::models::qwen3_5_moe::model::Qwen3_5MoeModel;
+use mlx_core::models::qwen3_5_moe::persistence::create_random_qwen35_moe_checkpoint_sync;
+use mlx_core::tokenizer::ChatMessage;
+
+/// Tiny MoE config with one MTP layer. `full_attention_interval: 1` makes
+/// the single decoder layer (and the MTP layer pinned at
+/// `fa_idx = interval - 1 = 0`) full-attention, so no GDN state is involved;
+/// `decoder_sparse_step: 1` makes layer 0 MoE-flavored, which is the flavor
+/// the MTP loader gate expects for this config. `use_block_paged_cache` is
+/// left unset so the reloaded model has no paged adapter and the eager MTP
+/// arm is reachable.
+///
+/// `vocab_size` MUST cover every id the real Qwen tokenizer can emit
+/// (chat-template special tokens reach id ~248076 on the Qwen3.5 tokenizer):
+/// the prompt always contains `<|im_start|>`/`<|im_end|>`, and an id past the
+/// embedding table turns the prompt embedding `take()` into an out-of-bounds
+/// GPU gather — undefined values that shift with allocator state, which
+/// manifested as nondeterministic output for BOTH plain AR and MTP decodes
+/// on an earlier `vocab_size: 1000` draft of this config.
+fn tiny_mtp_config() -> Qwen3_5MoeConfig {
+    Qwen3_5MoeConfig {
+        vocab_size: 250_000,
+        hidden_size: 64,
+        num_layers: 1,
+        num_heads: 4,
+        num_kv_heads: 2,
+        intermediate_size: 128,
+        rms_norm_eps: 1e-6,
+        head_dim: 16,
+        tie_word_embeddings: true,
+        attention_bias: false,
+        max_position_embeddings: 512,
+        pad_token_id: 0,
+        eos_token_id: 1,
+        bos_token_id: 0,
+        linear_num_value_heads: 4,
+        linear_num_key_heads: 2,
+        linear_key_head_dim: 16,
+        linear_value_head_dim: 16,
+        linear_conv_kernel_dim: 4,
+        full_attention_interval: 1,
+        partial_rotary_factor: 0.25,
+        rope_theta: 100_000.0,
+        num_experts: 4,
+        num_experts_per_tok: 2,
+        decoder_sparse_step: 1,
+        shared_expert_intermediate_size: Some(64),
+        moe_intermediate_size: Some(64),
+        norm_topk_prob: true,
+        mlp_only_layers: None,
+        paged_cache_memory_mb: None,
+        paged_block_size: None,
+        use_block_paged_cache: None,
+        n_mtp_layers: 1,
+    }
+}
+
+/// Locate a real Qwen tokenizer directory under the repo's `.cache/models`.
+/// The random checkpoint save writes no tokenizer, but the session chat path
+/// requires one with an `<|im_end|>` special token. Mirrors the candidate
+/// list in `__test__/test-model-utils.ts::findTokenizerPath`.
+fn find_tokenizer_dir() -> Option<PathBuf> {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    [
+        ".cache/models/qwen3.5-0.8b-mlx-bf16",
+        ".cache/models/qwen3.5-0.8b",
+        ".cache/models/qwen3-0.6b-mlx-bf16",
+        ".cache/models/qwen3-0.6b",
+    ]
+    .iter()
+    .map(|c| repo_root.join(c))
+    .find(|d| d.join("tokenizer.json").exists())
+}
+
+/// Best-effort removal of the temp checkpoint dir, including on panic
+/// (assert failures unwind through the test body).
+struct DirCleanup(PathBuf);
+
+impl Drop for DirCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn chat_config(max_new_tokens: i32, enable_mtp: bool) -> ChatConfig {
+    ChatConfig {
+        max_new_tokens: Some(max_new_tokens),
+        temperature: Some(0.0),
+        top_k: None,
+        top_p: None,
+        min_p: None,
+        repetition_penalty: None,
+        repetition_context_size: None,
+        presence_penalty: None,
+        presence_context_size: None,
+        frequency_penalty: None,
+        frequency_context_size: None,
+        max_consecutive_tokens: None,
+        max_ngram_repeats: None,
+        ngram_size: None,
+        tools: None,
+        reasoning_effort: None,
+        thinking_token_budget: Some(0),
+        include_reasoning: Some(false),
+        report_performance: Some(true),
+        reuse_cache: Some(true),
+        enable_mtp: Some(enable_mtp),
+        mtp_depth: Some(4),
+        mtp_adaptive_depth: Some(false),
+    }
+}
+
+fn user_message(content: &str) -> ChatMessage {
+    ChatMessage {
+        role: "user".to_string(),
+        content: content.to_string(),
+        tool_calls: None,
+        tool_call_id: None,
+        is_error: None,
+        reasoning_content: None,
+        images: None,
+        audio: None,
+    }
+}
+
+/// Build the tiny random MoE+MTP checkpoint, load it, and run the four
+/// deterministic assertions documented in the module header: the MTP head
+/// engages after reload, the AR baseline and the MTP decode both complete
+/// the full token budget, the MTP run reports cycles/acceptance metrics,
+/// and a repeat MTP decode is byte-identical to the first. `mode_label`
+/// only labels messages (v1 vs v2 — the flag itself is process state owned
+/// by the calling test binary).
+///
+/// Graceful skips (eprintln + return) ONLY for environment gaps: non-macOS
+/// (no Metal) or no local Qwen tokenizer. Everything else is a hard failure —
+/// in particular `has_mtp_weights() == false` after reload means the
+/// random-save `mtp.*` emission or the `mtp_num_hidden_layers` config
+/// round-trip regressed.
+pub async fn run_synthetic_mtp_gate(mode_label: &str) {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skipping: synthetic MoE MTP test requires Metal (macOS)");
+        return;
+    }
+    let Some(tokenizer_dir) = find_tokenizer_dir() else {
+        eprintln!(
+            "skipping: no Qwen tokenizer.json found under .cache/models (download one first, \
+             e.g. `yarn mlx download model -m Qwen/Qwen3-0.6B -o .cache/models/qwen3-0.6b`)"
+        );
+        return;
+    };
+
+    let ckpt_dir = std::env::temp_dir().join(format!(
+        "mlx-moe-mtp-synth-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before UNIX_EPOCH")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&ckpt_dir).expect("failed to create temp checkpoint dir");
+    let _cleanup = DirCleanup(ckpt_dir.clone());
+    let ckpt_path = ckpt_dir
+        .to_str()
+        .expect("temp checkpoint path is not valid UTF-8")
+        .to_string();
+
+    create_random_qwen35_moe_checkpoint_sync(tiny_mtp_config(), &ckpt_path)
+        .expect("failed to create random MoE+MTP checkpoint");
+    // The chat template lives in tokenizer_config.json next to
+    // tokenizer.json; copy both (plus a standalone template if the source
+    // checkpoint ships one).
+    for file in [
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "chat_template.jinja",
+    ] {
+        let src = tokenizer_dir.join(file);
+        if src.exists() {
+            std::fs::copy(&src, ckpt_dir.join(file))
+                .unwrap_or_else(|e| panic!("failed to copy {file}: {e}"));
+        }
+    }
+    println!("synthetic MoE+MTP checkpoint created at {ckpt_path}");
+
+    let mtp_model = Qwen3_5MoeModel::load(ckpt_path.clone())
+        .await
+        .expect("failed to load synthetic checkpoint (MTP run)");
+    assert!(
+        mtp_model.has_mtp_weights(),
+        "synthetic checkpoint did not engage the MTP head after reload \
+         (has_mtp_weights() == false) — the random-save mtp.* emission \
+         (`create_random_qwen35_moe_checkpoint_sync`) or the \
+         `mtp_num_hidden_layers` config round-trip (`save_model_sync`) regressed"
+    );
+    let ar_model = Qwen3_5MoeModel::load(ckpt_path)
+        .await
+        .expect("failed to load synthetic checkpoint (AR reference)");
+
+    // Random weights make the CONTENT meaningless; only crash-freedom and
+    // determinism matter. The vocab covers the tokenizer's <|im_end|> id (a
+    // smaller vocab would make the prompt's special tokens out-of-bounds
+    // embedding gathers — UB), but greedy argmax over ~250k random logits
+    // virtually never lands on the one EOS id, so both runs decode exactly
+    // `max_new_tokens` tokens — enough for several depth-4 MTP cycles.
+    const PROMPT_TEXT: &str = "Write one short sentence about the weather.";
+    const MAX_NEW_TOKENS: i32 = 32;
+
+    // Assert 2: the plain AR baseline completes the full token budget.
+    let ar_result = ar_model
+        .chat_session_start(
+            vec![user_message(PROMPT_TEXT)],
+            Some(chat_config(MAX_NEW_TOKENS, false)),
+        )
+        .await
+        .expect("AR reference chat_session_start failed");
+    assert_eq!(
+        ar_result.num_tokens, MAX_NEW_TOKENS as u32,
+        "AR baseline stopped early ({mode_label}): finish_reason={} — EOS should \
+         be unreachable on random logits over a 250k vocab",
+        ar_result.finish_reason
+    );
+
+    // Assert 3: the MTP decode completes crash-free with the same budget and
+    // reports cycle/acceptance metrics (proving the eager MTP arm engaged
+    // and, under v2, that commit_mtp's forward + begin_cycle's trim ran every
+    // cycle without a shape/length failure).
+    let mtp_result = mtp_model
+        .chat_session_start(
+            vec![user_message(PROMPT_TEXT)],
+            Some(chat_config(MAX_NEW_TOKENS, true)),
+        )
+        .await
+        .expect("MTP chat_session_start failed");
+    assert_eq!(
+        mtp_result.num_tokens, MAX_NEW_TOKENS as u32,
+        "MTP decode stopped early ({mode_label}): finish_reason={}",
+        mtp_result.finish_reason
+    );
+
+    let perf = mtp_result
+        .performance
+        .as_ref()
+        .expect("MTP performance metrics missing (reportPerformance: true)");
+    assert!(
+        perf.mtp_mean_accepted_tokens.is_some(),
+        "has_mtp_weights() was true but no MTP cycle ran \
+         (mtp_mean_accepted_tokens is None) — the eager MTP arm did not engage \
+         ({mode_label})"
+    );
+    let cycles = perf.mtp_cycles.unwrap_or(0);
+    assert!(
+        cycles > 1,
+        "expected multiple MTP cycles, got {cycles} ({mode_label})"
+    );
+
+    // Assert 4: within-mode determinism. A same-prompt `chat_session_start`
+    // on the same model takes the engine's exact-match-as-miss route (the
+    // zero-delta guard in `engine/session.rs`: full cache reset + full
+    // re-prefill), so this repeat run executes the identical kernel shapes
+    // as the first — cold-equivalent, hence bitwise-deterministic. Any
+    // divergence here is real (allocator-dependent UB such as an
+    // out-of-bounds gather), never an argmax near-tie.
+    let mtp_repeat = mtp_model
+        .chat_session_start(
+            vec![user_message(PROMPT_TEXT)],
+            Some(chat_config(MAX_NEW_TOKENS, true)),
+        )
+        .await
+        .expect("repeat MTP chat_session_start failed");
+    assert_eq!(
+        mtp_repeat.text, mtp_result.text,
+        "repeat MTP decode diverged from the first MTP run ({mode_label}) — \
+         identical kernel shapes must be deterministic; suspect \
+         allocator-dependent UB (e.g. an out-of-bounds gather)"
+    );
+    assert_eq!(
+        mtp_repeat.num_tokens, mtp_result.num_tokens,
+        "repeat MTP decode token count diverged ({mode_label})"
+    );
+    let repeat_cycles = mtp_repeat
+        .performance
+        .as_ref()
+        .and_then(|p| p.mtp_cycles)
+        .unwrap_or(0);
+
+    println!(
+        "synthetic moe mtp ({mode_label}): cycles={} mean_accepted_tokens={:?} \
+         num_tokens={} finish_reason={} repeat_cycles={repeat_cycles} \
+         repeat_byte_identical=true ar_num_tokens={}",
+        cycles,
+        perf.mtp_mean_accepted_tokens,
+        mtp_result.num_tokens,
+        mtp_result.finish_reason,
+        ar_result.num_tokens
+    );
+}

--- a/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
@@ -823,6 +823,77 @@ async fn lfm2_paged_prefill_tps_is_full_prompt_scale_on_warm_reuse() {
 }
 
 // ---------------------------------------------------------------------------
+// A/B probe: cache-hit prefill actually reaches `forward_paged`'s
+// `cached_prefix_len > 0` branch (the graph-native paged-attention bridge this
+// change adds). Paired-process: run TWICE with
+// MLX_LFM2_PAGED_PREFILL_PAGED_ATTENTION=1 (bridge on; default is OFF) and =0 and
+// diff the printed raw_text (a single process cannot toggle the OnceLock-cached
+// env var mid-run). Text is intentionally NOT asserted byte-identical — see below.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "needs MLX_TEST_MODEL_PATH pointing to a real LFM2 checkpoint; run TWICE with \
+            MLX_LFM2_PAGED_PREFILL_PAGED_ATTENTION=1 and =0 and diff the printed raw_text \
+            (a single process cannot toggle the OnceLock-cached env var mid-run)"]
+async fn lfm2_paged_prefill_bridge_cache_hit_ab_probe() {
+    let Some(src) = resolve_source_model() else {
+        return;
+    };
+    let dir = match clone_model_dir(&src, "lfm2-bridge-ab-probe", true) {
+        Ok(p) => p,
+        Err(e) => panic!("failed to clone model dir: {e}"),
+    };
+    let model = Lfm2Model::load_from_dir(&dir.to_string_lossy())
+        .await
+        .expect("failed to load LFM2 model");
+
+    let user1 = "Name the five largest planets in our solar system, in order.";
+    let r1 = model
+        .chat_session_start(vec![user_message(user1)], Some(parity_chat_config(32)))
+        .await
+        .expect("turn 1 chat_session_start failed");
+    eprintln!(
+        "[bridge-ab] turn1: num_tokens={} finish={} raw_text={:?}",
+        r1.num_tokens, r1.finish_reason, r1.raw_text
+    );
+
+    // Turn 2: a FRESH chat_session_start (NOT chat_session_continue -- LFM2
+    // declines the delta path, see model.rs ~1041) re-submitting the growing
+    // history. The content-addressed prefix cache hits (cached_tokens>0),
+    // driving run_paged_prefill_chunk's Pass 2 through forward_paged with
+    // cached_prefix_len>0 -- the EXACT branch this fix changes.
+    let user2 = "Which of those is the closest to the sun?";
+    let r2 = model
+        .chat_session_start(
+            vec![
+                user_message(user1),
+                assistant_message(&r1.raw_text),
+                user_message(user2),
+            ],
+            Some(parity_chat_config(32)),
+        )
+        .await
+        .expect("turn 2 chat_session_start failed");
+    eprintln!(
+        "[bridge-ab] turn2: num_tokens={} cached_tokens={} finish={} raw_text={:?}",
+        r2.num_tokens, r2.cached_tokens, r2.finish_reason, r2.raw_text
+    );
+
+    // Reachability gate only -- text is intentionally NOT asserted
+    // byte-identical here. On the one checkpoint available
+    // (lfm2.5-1.2b-thinking-mlx), greedy decode falls into degenerate repeat
+    // loops that make text-level comparison unreliable; the bridge ON vs OFF
+    // agree on the first handful of generated tokens then diverge (a small
+    // kernel-level numerical difference cascading under greedy decode on a
+    // near-tied logit distribution -- the accepted ~1-ULP paged-vs-flat class,
+    // NOT a bug). `cached_tokens > 0` proves turn 2 reused a content-addressed
+    // prefix and thus drove forward_paged's cached_prefix_len>0 branch.
+    assert!(
+        r2.cached_tokens > 0,
+        "probe precondition: turn 2 must reuse a content-addressed prefix (cached_tokens=0)"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Regression: a quantized LFM2 checkpoint loaded with NO config override must
 // default to the FLAT decode path.
 //

--- a/crates/mlx-core/tests/qwen3_5_moe_mtp_committed_history.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_mtp_committed_history.rs
@@ -1,0 +1,222 @@
+//! Gated integration test for Qwen3.5-MoE's MTP committed-history v2
+//! within-turn persistence (the `MoeMtpStepper::use_committed` /
+//! `commit_mtp` / `begin_cycle` port — see the `MoeMtpStepper` struct doc in
+//! `crates/mlx-core/src/models/qwen3_5_moe/model.rs`).
+//!
+//! v2 is opt-in behind `MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY` (default off).
+//! This test does NOT force the flag — it inherits it from the process env, so
+//! the SAME test binary runs as v1 (flag unset) or v2 (flag=1) depending on how
+//! it is launched. That makes it the same-binary A/B correctness harness:
+//!   - flag unset → v1 (fresh drafter cache each cycle)
+//!   - flag=1     → v2 (persistent drafter cache across cycles)
+//!
+//! Both modes MUST produce output byte-identical to a plain AR decode.
+//!
+//! Speculative decoding's accept/reject verification always re-derives ground
+//! truth from the MAIN model's own forward pass, so the emitted token SEQUENCE
+//! at T=0 is invariant to the drafter's cache-retention policy: a broken
+//! `commit_mtp` / `begin_cycle` port can only crash (a drafter-cache
+//! shape/length mismatch) or silently degrade the drafter's OWN proposals
+//! (worse accept rate) — never change which tokens get emitted. This test
+//! therefore gates crash/shape/corruption, NOT accept-rate; the perf win is
+//! validated separately by a flag-off/flag-on same-checkpoint A/B (deferred to
+//! the consolidated cooled-GPU bench).
+//!
+//! It requires a checkpoint that actually ENGAGES the MoE MTP drafter — i.e.
+//! `has_mtp_weights()` is true (config declares `mtp_num_hidden_layers`/
+//! `num_nextn_predict_layers` > 0 AND the `mtp.*` head tensors load, including
+//! `.scales` siblings for any packed head) AND the turn runs the eager MTP
+//! arm. If the checkpoint at `MLX_TEST_MOE_MTP_MODEL_PATH` does not engage
+//! MTP, the test SKIPS (mirrors the dense reference `qwen3_5_delta_chat.rs`)
+//! rather than asserting on a silently-AR run. In particular, VLM MoE-MTP
+//! checkpoints force the block-paged backend, where the eager MTP stepper is
+//! unreachable — the head loads but never engages, so the test skips there.
+//!
+//! This is the opt-in DEEP gate for a future text MoE-MTP checkpoint; the
+//! always-on gates for the eager MoE MTP path (both flag states) are the
+//! synthetic random-checkpoint pair `qwen3_5_moe_mtp_synthetic_v1.rs` /
+//! `qwen3_5_moe_mtp_synthetic_v2.rs`.
+//!
+//! Run it manually with:
+//!
+//! ```shell
+//! # v2 (committed-history on):
+//! MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY=1 \
+//! MLX_TEST_MOE_MTP_MODEL_PATH=/absolute/path/to/moe-mtp-checkpoint \
+//!     cargo test -p mlx-core --test qwen3_5_moe_mtp_committed_history \
+//!     -- --ignored --nocapture --test-threads=1
+//! # v1 (baseline): same command without MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY.
+//! ```
+//!
+//! Without `MLX_TEST_MOE_MTP_MODEL_PATH` the test early-returns and passes
+//! trivially so it still compiles as part of `cargo test`.
+
+use std::path::Path;
+
+use mlx_core::engine::types::ChatConfig;
+use mlx_core::models::qwen3_5_moe::model::Qwen3_5MoeModel;
+use mlx_core::tokenizer::ChatMessage;
+
+fn chat_config(max_new_tokens: i32, enable_mtp: bool) -> ChatConfig {
+    ChatConfig {
+        max_new_tokens: Some(max_new_tokens),
+        temperature: Some(0.0),
+        top_k: None,
+        top_p: None,
+        min_p: None,
+        repetition_penalty: None,
+        repetition_context_size: None,
+        presence_penalty: None,
+        presence_context_size: None,
+        frequency_penalty: None,
+        frequency_context_size: None,
+        max_consecutive_tokens: None,
+        max_ngram_repeats: None,
+        ngram_size: None,
+        tools: None,
+        reasoning_effort: None,
+        thinking_token_budget: Some(0),
+        include_reasoning: Some(false),
+        report_performance: Some(true),
+        reuse_cache: Some(true),
+        enable_mtp: Some(enable_mtp),
+        mtp_depth: Some(4),
+        mtp_adaptive_depth: Some(false),
+    }
+}
+
+fn user_message(content: &str) -> ChatMessage {
+    ChatMessage {
+        role: "user".to_string(),
+        content: content.to_string(),
+        tool_calls: None,
+        tool_call_id: None,
+        is_error: None,
+        reasoning_content: None,
+        images: None,
+        audio: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_MOE_MTP_MODEL_PATH pointing to a real Qwen3.5-MoE-A3B MTP checkpoint"]
+async fn mtp_matches_ar_after_multi_cycle_decode() {
+    let Ok(model_path) = std::env::var("MLX_TEST_MOE_MTP_MODEL_PATH") else {
+        eprintln!(
+            "skipping: MLX_TEST_MOE_MTP_MODEL_PATH unset (point it at an ABSOLUTE path to a \
+             Qwen3.5-MoE-A3B checkpoint that ships an MTP head, e.g. \
+             /abs/path/to/qwen3.6-35b-a3b-mxfp8-mtp)"
+        );
+        return;
+    };
+    assert!(
+        Path::new(&model_path).exists(),
+        "MLX_TEST_MOE_MTP_MODEL_PATH does not exist: {model_path}"
+    );
+    println!("MLX_TEST_MOE_MTP_MODEL_PATH resolved to: {model_path}");
+
+    // v2 is read from the env (default off) by the model itself — we do NOT set
+    // it here, so the same binary is the v1/v2 A/B harness. Report which mode
+    // this run exercises.
+    let v2_on = std::env::var("MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY")
+        .ok()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    println!(
+        "committed-history mode: {}",
+        if v2_on {
+            "v2 (flag on)"
+        } else {
+            "v1 (flag off / default)"
+        }
+    );
+
+    const PROMPT_TEXT: &str = "Write a short numbered list (6 items) of steps to plan a \
+         weekend hiking trip. Keep each step to one sentence.";
+
+    // Load the MTP model first and check it actually engages the MoE MTP
+    // drafter. If not (config declares no mtp layers, or the mtp.* head — incl.
+    // its .scales for a packed head — did not load), SKIP rather than assert on
+    // a silently-AR decode. Mirrors the dense reference guard in
+    // `qwen3_5_delta_chat.rs`.
+    let mtp_model = Qwen3_5MoeModel::load(model_path.clone())
+        .await
+        .expect("failed to load Qwen3.5 MoE model (MTP)");
+    println!(
+        "MTP model loaded; has_mtp_weights() = {}",
+        mtp_model.has_mtp_weights()
+    );
+    if !mtp_model.has_mtp_weights() {
+        eprintln!(
+            "skipping MTP assertions: checkpoint at {model_path} does not engage the MoE MTP \
+             drafter (has_mtp_weights() == false — its config declares no mtp layer count, or the \
+             mtp.* head tensors / their .scales siblings did not load). Point \
+             MLX_TEST_MOE_MTP_MODEL_PATH at a checkpoint whose MTP head loads."
+        );
+        return;
+    }
+
+    // Reference: plain autoregressive decode (MTP disabled).
+    let ar_model = Qwen3_5MoeModel::load(model_path)
+        .await
+        .expect("failed to load Qwen3.5 MoE model (AR reference)");
+    println!("AR reference model loaded");
+    let ar_result = ar_model
+        .chat_session_start(
+            vec![user_message(PROMPT_TEXT)],
+            Some(chat_config(200, false)),
+        )
+        .await
+        .expect("AR reference chat_session_start failed");
+
+    // MTP-enabled decode over the SAME prompt/params — 200 tokens at depth 4
+    // runs many `begin_cycle` / `commit_mtp` cycles, exactly the path this
+    // fix changes.
+    let mtp_result = mtp_model
+        .chat_session_start(
+            vec![user_message(PROMPT_TEXT)],
+            Some(chat_config(200, true)),
+        )
+        .await
+        .expect("MTP chat_session_start failed");
+
+    let perf = mtp_result
+        .performance
+        .as_ref()
+        .expect("MTP performance metrics missing (reportPerformance: true)");
+
+    // MTP actually ran (not a silent AR fallback): the acceptance summary is
+    // only populated when at least one MTP cycle was recorded. This is a
+    // graceful skip, not a failure: every local MoE-MTP checkpoint is a VLM
+    // export whose config forces the block-paged KV backend, and the paged
+    // MoE core has no MTP stepper — the eager MTP arm this test targets is
+    // unreachable there, so the head loads but never engages.
+    if perf.mtp_mean_accepted_tokens.is_none() {
+        eprintln!(
+            "skipping MTP assertions: the MTP head loaded but no MTP cycle ran on this turn \
+             (mtp_mean_accepted_tokens is None). This is expected for VLM MoE-MTP checkpoints \
+             (vision_config forces the block-paged backend, where the eager MoE MTP stepper is \
+             unreachable). Point MLX_TEST_MOE_MTP_MODEL_PATH at a TEXT MoE-MTP checkpoint (no \
+             vision_config, use_block_paged_cache unset/false) to exercise this deep gate; the \
+             always-on gate is the synthetic pair qwen3_5_moe_mtp_synthetic_v1/_v2."
+        );
+        return;
+    }
+
+    assert_eq!(
+        mtp_result.text, ar_result.text,
+        "MTP-enabled decode diverged from the AR reference at T=0 — the \
+         committed-history port likely corrupted `mtp_caches` (check \
+         `MoeMtpStepper::commit_mtp` / `begin_cycle` trim targets)"
+    );
+    assert_eq!(mtp_result.num_tokens, ar_result.num_tokens);
+    let cycles = perf.mtp_cycles.unwrap_or(0);
+    assert!(cycles > 1, "expected multiple MTP cycles, got {cycles}");
+    println!(
+        "moe mtp ({}): cycles={} mean_accepted_tokens_total={:?} mean_depth={:?}",
+        if v2_on { "v2" } else { "v1" },
+        cycles,
+        perf.mtp_mean_accepted_tokens_total,
+        perf.mtp_mean_depth
+    );
+}

--- a/crates/mlx-core/tests/qwen3_5_moe_mtp_synthetic_v1.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_mtp_synthetic_v1.rs
@@ -1,0 +1,28 @@
+//! Synthetic end-to-end gate for the eager MoE MTP path in its DEFAULT
+//! (flag-off, cycle-history v1) state.
+//!
+//! Deliberately does NOT touch `MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY`: the
+//! stepper reads it once per process, so this binary pins the default-off
+//! path. Its sibling `qwen3_5_moe_mtp_synthetic_v2.rs` pins the flag-on
+//! path. See `tests/common/mod.rs` for the shared harness and the rationale
+//! (all local real MoE-MTP checkpoints are VLM → forced block-paged → the
+//! eager stepper is unreachable, so a tiny random checkpoint is the only
+//! always-on route through it).
+//!
+//! Asserts the four deterministic conditions documented in the harness
+//! header: MTP head engages after reload, AR baseline and MTP decode both
+//! complete the full token budget crash-free with `mtp_cycles > 1` and
+//! populated acceptance metrics, and a repeat MTP decode is byte-identical
+//! to the first. MTP==AR byte-identity is NOT asserted on random weights —
+//! measured ~10-15% of fresh checkpoint draws flip a late token via greedy
+//! argmax near-ties, at the SAME rate in this flag-off (pre-existing v1)
+//! binary as in the v2 sibling, so the flakiness is kernel rounding, not the
+//! committed-history port. That byte-identity gate lives in the real-weights
+//! deep test `qwen3_5_moe_mtp_committed_history.rs`.
+
+mod common;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn synthetic_moe_mtp_gate_v1_cycle_history() {
+    common::run_synthetic_mtp_gate("v1 cycle-history, flag off/default").await;
+}

--- a/crates/mlx-core/tests/qwen3_5_moe_mtp_synthetic_v1.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_mtp_synthetic_v1.rs
@@ -1,9 +1,11 @@
 //! Synthetic end-to-end gate for the eager MoE MTP path in its DEFAULT
 //! (flag-off, cycle-history v1) state.
 //!
-//! Deliberately does NOT touch `MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY`: the
-//! stepper reads it once per process, so this binary pins the default-off
-//! path. Its sibling `qwen3_5_moe_mtp_synthetic_v2.rs` pins the flag-on
+//! Pins the flag-OFF path: `MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY` is
+//! defensively REMOVED at startup — the stepper reads it once per process,
+//! and an inherited environment (e.g. a shell that exported the flag for a
+//! committed-history run) must not flip the v1 baseline ON. Its sibling
+//! `qwen3_5_moe_mtp_synthetic_v2.rs` pins the flag-on
 //! path. See `tests/common/mod.rs` for the shared harness and the rationale
 //! (all local real MoE-MTP checkpoints are VLM → forced block-paged → the
 //! eager stepper is unreachable, so a tiny random checkpoint is the only
@@ -22,7 +24,24 @@
 
 mod common;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn synthetic_moe_mtp_gate_v1_cycle_history() {
-    common::run_synthetic_mtp_gate("v1 cycle-history, flag off/default").await;
+#[test]
+fn synthetic_moe_mtp_gate_v1_cycle_history() {
+    // Defensively strip the committed-history flag before building the
+    // runtime: this binary pins the DEFAULT (flag-off) path and the stepper
+    // reads the flag once per process, so an inherited environment must not
+    // flip it ON for the v1 baseline.
+    // SAFETY: `remove_var` requires no concurrent access to the process
+    // environment. This is the binary's only `#[test]`, so libtest runs just
+    // this one test thread; the tokio workers and model threads — the only
+    // in-process readers of this flag — are spawned below, after the remove.
+    unsafe { std::env::remove_var("MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY") };
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime")
+        .block_on(common::run_synthetic_mtp_gate(
+            "v1 cycle-history, flag off/default",
+        ));
 }

--- a/crates/mlx-core/tests/qwen3_5_moe_mtp_synthetic_v2.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_mtp_synthetic_v2.rs
@@ -1,0 +1,42 @@
+//! Synthetic end-to-end gate for the eager MoE MTP path with
+//! COMMITTED-HISTORY v2 forced ON (`MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY=1`).
+//!
+//! This exercises the persistent-drafter-cache mechanics every cycle —
+//! `commit_mtp`'s multi-token drafter forward and `begin_cycle`'s trim back
+//! to the committed cursor. Separate binary from the v1 sibling because the
+//! stepper reads the flag once per process (`OnceLock`); the env var is set
+//! before the tokio runtime (and thus any model work) starts. See
+//! `tests/common/mod.rs` for the shared harness.
+//!
+//! Asserts the four deterministic conditions documented in the harness
+//! header: MTP head engages after reload, AR baseline and MTP decode both
+//! complete the full token budget crash-free with `mtp_cycles > 1` and
+//! populated acceptance metrics, and a repeat MTP decode is byte-identical
+//! to the first — every cycle runs the v2 trim/commit path, so a shape or
+//! cache-length bug in the port fails here loudly. MTP==AR byte-identity is
+//! NOT asserted on random weights — measured ~10-15% of fresh checkpoint
+//! draws flip a late token via greedy argmax near-ties, at the SAME rate as
+//! the flag-off v1 sibling (pre-existing code), so the flakiness is kernel
+//! rounding, not the committed-history port. That byte-identity gate lives
+//! in the real-weights deep test `qwen3_5_moe_mtp_committed_history.rs`.
+
+mod common;
+
+#[test]
+fn synthetic_moe_mtp_gate_v2_committed_history() {
+    // Set the flag before building the runtime so no other thread exists yet
+    // when the environment is mutated, and before any model code can hit the
+    // stepper's once-per-process flag read.
+    // SAFETY: single-threaded at this point — the tokio workers and model
+    // threads that later read the environment are spawned below.
+    unsafe { std::env::set_var("MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY", "1") };
+
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime")
+        .block_on(common::run_synthetic_mtp_gate(
+            "v2 committed-history, flag on",
+        ));
+}

--- a/crates/mlx-core/tests/qwen3_5_moe_mtp_synthetic_v2.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_mtp_synthetic_v2.rs
@@ -24,11 +24,12 @@ mod common;
 
 #[test]
 fn synthetic_moe_mtp_gate_v2_committed_history() {
-    // Set the flag before building the runtime so no other thread exists yet
-    // when the environment is mutated, and before any model code can hit the
-    // stepper's once-per-process flag read.
-    // SAFETY: single-threaded at this point — the tokio workers and model
-    // threads that later read the environment are spawned below.
+    // Set the flag before building the runtime, and before any model code can
+    // hit the stepper's once-per-process flag read.
+    // SAFETY: `set_var` requires no concurrent access to the process
+    // environment. This is the binary's only `#[test]`, so libtest runs just
+    // this one test thread; the tokio workers and model threads — the only
+    // in-process readers of this flag — are spawned below, after the set.
     unsafe { std::env::set_var("MLX_QWEN35_MOE_MTP_COMMITTED_HISTORY", "1") };
 
     tokio::runtime::Builder::new_multi_thread()

--- a/crates/mlx-core/tests/qwen3_5_moe_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/qwen3_5_moe_paged_vs_flat_parity.rs
@@ -2,9 +2,8 @@
 //! MoE.
 //!
 //! Mirrors `qwen3_5_paged_vs_flat_parity.rs` but loads the MoE
-//! checkpoint. Same caveats apply — the compiled C++ MoE forward path
-//! is bypassed when the paged adapter is enabled, so this gate is a
-//! Rust-paged-vs-Rust-flat comparison.
+//! checkpoint. Same caveats apply — both sides are pure-Rust eager
+//! forwards, so this gate is a Rust-paged-vs-Rust-flat comparison.
 //!
 //! Gated on `MLX_TEST_MODEL_PATH`. Run with:
 //!

--- a/crates/mlx-core/tests/qwen3_5_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/qwen3_5_paged_vs_flat_parity.rs
@@ -3,16 +3,11 @@
 //!
 //! Mirrors `lfm2_paged_vs_flat_parity.rs`. Qwen3.5's hybrid layer mix
 //! (GDN linear-attention + full-attention) means only the
-//! full-attention layers route through the paged adapter. The compiled
-//! C++ forward is bypassed entirely on the paged path; this gate
-//! verifies that the pure-Rust paged forward is byte-equal to the
-//! pure-Rust flat forward (for greedy decoding) on real weights.
-//!
-//! ⚠️ The compiled C++ forward path is the production fast path on
-//! flat (≈6.4 tok/s on M3 Max). When the paged adapter is enabled the
-//! Rust fallback runs instead — so the parity comparison is between
-//! two Rust forward paths, NOT between Rust paged and compiled C++
-//! flat. This is the same trade-off LFM2 makes with the conv operator.
+//! full-attention layers route through the paged adapter. Both sides of
+//! the comparison are pure-Rust eager forwards (the compiled C++
+//! qwen3.5 forward no longer exists): this gate verifies that the paged
+//! forward is byte-equal to the flat forward (for greedy decoding) on
+//! real weights.
 //!
 //! Gated on `MLX_TEST_MODEL_PATH` so a plain `cargo test --ignored`
 //! without the env var still passes (the early-return short-circuits

--- a/crates/mlx-paged-attn/Cargo.toml
+++ b/crates/mlx-paged-attn/Cargo.toml
@@ -11,8 +11,16 @@ crate-type = ["rlib"]
 
 [dependencies]
 mlx-sys.workspace = true
+hashlink = "0.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = "0.33"
 objc = "0.2"
 block = "0.1"
+
+[dev-dependencies]
+criterion = { workspace = true }
+
+[[bench]]
+name = "prefix_cache_lru_bench"
+harness = false

--- a/crates/mlx-paged-attn/benches/prefix_cache_lru_bench.rs
+++ b/crates/mlx-paged-attn/benches/prefix_cache_lru_bench.rs
@@ -1,0 +1,105 @@
+//! Prefix-cache LRU touch benchmark.
+//!
+//! Reproduces the scenario from the "BlockAllocator LRU order O(n) touch"
+//! perf backlog item: a long shared prefix (e.g. a 4096-token system prompt
+//! at block_size=16 -> 256 blocks) re-touched by every new request that
+//! shares it, while `num_blocks` background entries (other concurrent
+//! requests' cached blocks) occupy the rest of the prefix cache.
+//!
+//! Before the fix, `lookup_prefix`'s LRU touch was `VecDeque::retain()` +
+//! `push_back()` -- O(current lru_order length) per touched block, so one
+//! 256-block cache-hit walk costs O(256 * num_blocks). After the fix it's
+//! an O(1)-amortized `LinkedHashSet::insert()` per touched block, so the
+//! per-walk cost should stop scaling with `num_blocks`.
+//!
+//! Run with: cargo bench --package mlx-paged-attn --bench prefix_cache_lru_bench
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use mlx_paged_attn::BlockAllocator;
+use std::hint::black_box;
+
+const BLOCK_SIZE: u32 = 16;
+/// 4096 tokens at block_size=16, matching the backlog item's example.
+const PREFIX_BLOCKS: usize = 256;
+
+/// Build a `BlockAllocator` whose prefix cache holds exactly `num_blocks`
+/// entries: `PREFIX_BLOCKS` of them belonging to one long shared prefix
+/// (registered last, so it's the most-recently-touched segment of LRU
+/// order at the start of the benchmark), and the rest distinct
+/// single-block "background" prefixes standing in for other concurrent
+/// requests' cached blocks.
+///
+/// Returns the allocator and the shared prefix's token_ids so the
+/// benchmark closure can re-walk it via `find_longest_cache_hit`.
+fn build_populated_allocator(num_blocks: usize) -> (BlockAllocator, Vec<u32>) {
+    assert!(
+        num_blocks > PREFIX_BLOCKS,
+        "num_blocks must exceed the shared-prefix block count"
+    );
+    let mut allocator = BlockAllocator::new(num_blocks as u32, BLOCK_SIZE);
+
+    let filler_count = num_blocks - PREFIX_BLOCKS;
+    for i in 0..filler_count {
+        let block = allocator.allocate().expect("pool sized for num_blocks");
+        // Distinct single-block token content per filler entry so its hash
+        // can't collide with the shared prefix or with other fillers.
+        let tokens: Vec<u32> = (0..BLOCK_SIZE)
+            .map(|t| {
+                0x1000_0000u32
+                    .wrapping_add((i as u32).wrapping_mul(1000))
+                    .wrapping_add(t)
+            })
+            .collect();
+        allocator
+            .cache_full_blocks(&tokens, std::slice::from_ref(&block), BLOCK_SIZE, &[], 0)
+            .expect("filler registration must succeed");
+    }
+
+    // The long shared prefix: PREFIX_BLOCKS blocks of small, distinct
+    // token content (disjoint range from the filler tokens above).
+    let prefix_tokens: Vec<u32> = (0..(PREFIX_BLOCKS as u32 * BLOCK_SIZE)).collect();
+    let prefix_blocks: Vec<_> = (0..PREFIX_BLOCKS)
+        .map(|_| allocator.allocate().expect("pool sized for num_blocks"))
+        .collect();
+    let registered = allocator
+        .cache_full_blocks(&prefix_tokens, &prefix_blocks, BLOCK_SIZE, &[], 0)
+        .expect("shared-prefix registration must succeed");
+    assert_eq!(
+        registered, PREFIX_BLOCKS,
+        "whole shared prefix must register"
+    );
+
+    (allocator, prefix_tokens)
+}
+
+/// Simulates one new request walking in and hitting the full shared
+/// prefix: `find_longest_cache_hit` looks up all `PREFIX_BLOCKS` blocks in
+/// order, LRU-touching every one of them. `num_blocks` (500/2000/8000)
+/// stands in for realistic prefix-cache population sizes (bigger
+/// `gpu_memory_mb`, or FP8 cache doubling block count).
+fn shared_prefix_cache_hit_walk(c: &mut Criterion) {
+    let mut group = c.benchmark_group("prefix_cache_lru_touch");
+    for &num_blocks in &[500usize, 2000, 8000] {
+        let (mut allocator, prefix_tokens) = build_populated_allocator(num_blocks);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_blocks),
+            &num_blocks,
+            |b, _| {
+                b.iter(|| {
+                    let (blocks, cached_tokens) = allocator.find_longest_cache_hit(
+                        black_box(&prefix_tokens),
+                        BLOCK_SIZE,
+                        &[],
+                        0,
+                    );
+                    assert_eq!(cached_tokens, prefix_tokens.len());
+                    black_box(blocks);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, shared_prefix_cache_hit_walk);
+criterion_main!(benches);

--- a/crates/mlx-paged-attn/src/block_allocator.rs
+++ b/crates/mlx-paged-attn/src/block_allocator.rs
@@ -61,6 +61,8 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
+use hashlink::LinkedHashSet;
+
 /// A physical block in GPU memory
 #[derive(Debug)]
 pub struct PhysicalBlock {
@@ -139,8 +141,15 @@ pub struct BlockAllocator {
     /// Reverse mapping: block_id -> hash (for cleanup during free)
     block_hashes: HashMap<u32, u64>,
 
-    /// LRU order for prefix cache eviction (oldest first)
-    lru_order: VecDeque<u64>,
+    /// LRU order for prefix cache eviction (oldest first).
+    ///
+    /// Backed by an intrusive doubly-linked hash set (`hashlink`) rather
+    /// than a `VecDeque` so that "touch" (move-to-back on cache hit) and
+    /// single-entry removal are O(1) amortized instead of an O(n)
+    /// `retain()` over the whole order. Mirrors vLLM's
+    /// `FreeKVCacheBlockQueue` / `BlockPool.touch()` intent, without a
+    /// hand-rolled unsafe intrusive list.
+    lru_order: LinkedHashSet<u64>,
 
     /// Maximum entries in prefix cache
     max_prefix_cache_entries: usize,
@@ -205,7 +214,7 @@ impl BlockAllocator {
             prefix_cache: HashMap::new(),
             prefix_cache_identities: HashMap::new(),
             block_hashes: HashMap::new(),
-            lru_order: VecDeque::new(),
+            lru_order: LinkedHashSet::new(),
             // Scale the prefix-cache capacity to `num_blocks` so the cache
             // can accommodate the full live block set. `num_blocks` is the
             // natural upper bound — no more than that many blocks can ever
@@ -253,31 +262,43 @@ impl BlockAllocator {
     /// logical ref). The block_id is NOT pushed onto `free_blocks` —
     /// `allocate` will reuse it directly via the returned id.
     fn try_evict_lru_for_allocation(&mut self) -> Option<u32> {
-        // Snapshot the LRU order so we can mutate `prefix_cache` /
-        // `block_hashes` / `allocated` without invalidating iteration.
-        let candidates: Vec<u64> = self.lru_order.iter().copied().collect();
-        for hash in candidates {
-            let Some(block) = self.prefix_cache.get(&hash) else {
-                // Desync (shouldn't happen, but defensive): entry in
-                // lru_order has no matching prefix_cache record. Skip.
-                continue;
-            };
-            if block.get_ref_count() != 1 {
-                // In use by a live request — skip and try the next.
-                continue;
+        // Scan the LRU order oldest-first for the first cache-only entry.
+        // Unlike the old approach (cloning the ENTIRE `lru_order` into a
+        // fresh `Vec` on every call), this only visits entries up to the
+        // match and remembers a single `u64` — no whole-list allocation.
+        // The scan itself still has to walk past any entries that are
+        // in-use (ref_count > 1); that's inherent to "oldest cache-only
+        // wins" eviction, not an artifact of the container type.
+        let mut evict_hash = None;
+        for &hash in self.lru_order.iter() {
+            match self.prefix_cache.get(&hash) {
+                Some(block) if block.get_ref_count() == 1 => {
+                    evict_hash = Some(hash);
+                    break;
+                }
+                // ref_count > 1: in use by a live request — keep scanning.
+                // None: desync (shouldn't happen, but defensive) — keep scanning.
+                _ => continue,
             }
-            let block_id = block.block_id;
-            // Release the cache's logical ref (1 → 0).
-            let _ = block.decref();
-            // Remove all bookkeeping for this entry.
-            self.prefix_cache.remove(&hash);
-            self.prefix_cache_identities.remove(&hash);
-            self.block_hashes.remove(&block_id);
-            self.lru_order.retain(|&h| h != hash);
-            self.allocated.remove(&block_id);
-            return Some(block_id);
         }
-        None
+        let hash = evict_hash?;
+
+        // Re-borrow now that the scan's immutable borrow of `lru_order` has
+        // ended, so we're free to mutate `prefix_cache` / `lru_order` below.
+        let block = self
+            .prefix_cache
+            .get(&hash)
+            .expect("hash found during the scan above; no mutation happened in between");
+        let block_id = block.block_id;
+        // Release the cache's logical ref (1 → 0).
+        let _ = block.decref();
+        // Remove all bookkeeping for this entry.
+        self.prefix_cache.remove(&hash);
+        self.prefix_cache_identities.remove(&hash);
+        self.block_hashes.remove(&block_id);
+        self.lru_order.remove(&hash);
+        self.allocated.remove(&block_id);
+        Some(block_id)
     }
 
     /// Free a block
@@ -461,7 +482,7 @@ impl BlockAllocator {
                 // is safe and avoids a free→re-allocate flap.
                 let _ = block.decref();
             }
-            self.lru_order.retain(|&h| h != existing_hash);
+            self.lru_order.remove(&existing_hash);
         }
 
         // Step 3 (capacity eviction, only on genuine insertion): if this
@@ -498,12 +519,14 @@ impl BlockAllocator {
             }
         }
 
-        // Step 4: LRU refresh (remove if exists, add to end) + insert.
-        // Take the cache's logical reference iff this is a genuine new
-        // insertion. An idempotent refresh leaves ref_count unchanged so
-        // the cache continues to hold exactly ONE logical ref per entry.
-        self.lru_order.retain(|&h| h != hash);
-        self.lru_order.push_back(hash);
+        // Step 4: LRU refresh (move to back if present, insert if not) +
+        // insert into `prefix_cache`. Take the cache's logical reference
+        // iff this is a genuine new insertion. An idempotent refresh leaves
+        // ref_count unchanged so the cache continues to hold exactly ONE
+        // logical ref per entry. `LinkedHashSet::insert` is an O(1)
+        // amortized move-to-back when `hash` is already present, replacing
+        // the old O(n) retain()+push_back() pair.
+        self.lru_order.insert(hash);
 
         // Track the hash for this block (for cleanup during free)
         self.block_hashes.insert(block.block_id, hash);
@@ -527,9 +550,12 @@ impl BlockAllocator {
     /// Returns the cached block if found, incrementing its ref count
     pub(crate) fn lookup_prefix(&mut self, hash: u64) -> Option<Arc<PhysicalBlock>> {
         if let Some(block) = self.prefix_cache.get(&hash) {
-            // Update LRU order
-            self.lru_order.retain(|&h| h != hash);
-            self.lru_order.push_back(hash);
+            // Update LRU order: O(1) amortized move-to-back (insert is a
+            // no-op re-link when `hash` is already present), replacing the
+            // old O(n) retain()+push_back() pair. This runs once per
+            // matched block on every prefix-cache hit, so it's the hottest
+            // of the four LRU-touch sites in this file.
+            self.lru_order.insert(hash);
 
             // Increment ref count and return
             block.incref();
@@ -2041,6 +2067,68 @@ mod tests {
         assert!(allocator.lookup_prefix(h2).is_some());
         assert!(allocator.lookup_prefix(h3).is_some());
         assert!(allocator.lookup_prefix(h4).is_some());
+    }
+
+    #[test]
+    fn test_register_prefix_refresh_moves_hash_to_mru() {
+        // Discriminating regression test for the core Task-13 semantic:
+        // `LinkedHashSet::insert` of an ALREADY-PRESENT key must move it to
+        // the back (MRU), exactly like the old `retain(..); push_back(..)`.
+        // A hypothetical broken swap (e.g. `replace`, which does NOT reposition
+        // an existing entry) would leave the refreshed hash at the front and
+        // get it wrongly evicted. This test fails under that broken variant.
+        //
+        // Unlike `test_register_prefix_idempotent_at_capacity`, this test
+        // never calls `lookup_prefix` before the final assertions (lookup also
+        // bumps LRU order and would confound the outcome). It refreshes the
+        // OLDEST entry via `register_prefix` and checks membership through the
+        // non-bumping `prefix_cache.contains_key`.
+        let mut allocator = BlockAllocator::new(8, 4);
+        allocator.max_prefix_cache_entries = 3;
+
+        let block_1 = allocator.allocate().unwrap();
+        let block_2 = allocator.allocate().unwrap();
+        let block_3 = allocator.allocate().unwrap();
+
+        let h1 = 0x1111_1111_1111_1111;
+        let h2 = 0x2222_2222_2222_2222;
+        let h3 = 0x3333_3333_3333_3333;
+
+        // Insertion order → lru_order front..back = [h1, h2, h3]. h1 is oldest.
+        allocator.register_prefix(Arc::clone(&block_1), h1);
+        allocator.register_prefix(Arc::clone(&block_2), h2);
+        allocator.register_prefix(Arc::clone(&block_3), h3);
+        assert_eq!(allocator.prefix_cache.len(), 3);
+
+        // Idempotent refresh of the OLDEST entry (block_1 under h1). Correct
+        // move-to-back → order becomes [h2, h3, h1], making h2 the new LRU.
+        // (Broken no-reposition → order stays [h1, h2, h3], h1 still LRU.)
+        allocator.register_prefix(Arc::clone(&block_1), h1);
+
+        // Force exactly one capacity eviction with a genuinely new hash.
+        let block_4 = allocator.allocate().unwrap();
+        let h4 = 0x4444_4444_4444_4444;
+        allocator.register_prefix(Arc::clone(&block_4), h4);
+
+        // Correct move-to-back: h2 (new LRU after the refresh) is evicted;
+        // the refreshed h1 survives. Under a broken swap, h1 would be gone.
+        assert!(
+            allocator.prefix_cache.contains_key(&h1),
+            "refreshing h1 must move it to MRU so it survives the next eviction"
+        );
+        assert!(
+            !allocator.prefix_cache.contains_key(&h2),
+            "h2 became the LRU after h1's refresh and must be the evicted entry"
+        );
+        assert!(
+            allocator.prefix_cache.contains_key(&h3),
+            "h3 was newer than the evicted LRU and must survive"
+        );
+        assert!(
+            allocator.prefix_cache.contains_key(&h4),
+            "h4 is the freshly inserted entry"
+        );
+        assert_eq!(allocator.prefix_cache.len(), 3);
     }
 
     #[test]

--- a/crates/mlx-sys/build.rs
+++ b/crates/mlx-sys/build.rs
@@ -287,11 +287,25 @@ fn main() {
         // recorded in CMakeCache.txt (e.g. a CI-restored cargo cache),
         // which the environment variable alone cannot. When unset, MLX's
         // CMakeLists defaults the floor to the build host's macOS version.
-        // Note MLX only builds the NAX (M5 tensor-core) kernels when this
-        // floor is >= 26.2 — pinning lower silently drops them.
         if let Some(deployment_target) = macos_deployment_target() {
             cfg.define("CMAKE_OSX_DEPLOYMENT_TARGET", &deployment_target);
         }
+        // Upstream MLX only builds the NAX (gen-17 tensor-core) kernels when
+        // the deployment floor is >= 26.2 and otherwise compiles the dispatch
+        // out via MLX_METAL_NO_NAX. The vendored fork branch
+        // (mlx-node/mlx#nax-macos-26-0-floor) adds MLX_METAL_FORCE_NAX to
+        // decouple kernel presence from the floor, so one published artifact
+        // can keep a macOS 26.0 floor AND carry the NAX kernels. The NAX
+        // kernels themselves still compile at -mmacosx-version-min=26.2 —
+        // they need the 26.2 tensor-ops ABI (lower targets select MPP's
+        // pre-26.2 compatibility intrinsics, which miscompute) — while the
+        // metallib links at the floor, so it loads on all of macOS 26.
+        // Runtime dispatch (`is_nax_available`: gpu gen >= 17 && macOS >=
+        // 26.2) keeps pre-26.2 machines from ever instantiating the
+        // 26.2-targeted functions. The option is inert when the floor is
+        // already >= 26.2 and when the SDK cannot build NAX (SDK < 26.2 or
+        // MSL < 4.0).
+        cfg.define("MLX_METAL_FORCE_NAX", "ON");
     }
 
     if target_os == "macos" {

--- a/crates/mlx-sys/build.rs
+++ b/crates/mlx-sys/build.rs
@@ -10,6 +10,19 @@ fn metal_toolchain_available() -> bool {
         .unwrap_or(false)
 }
 
+/// Explicit deployment-target floor for the macOS build products. When unset,
+/// every toolchain stamps its own default and the artifact floor silently
+/// tracks the build machine: the metal compiler uses the SDK's default min-OS
+/// and MLX's CMake defaults `CMAKE_OSX_DEPLOYMENT_TARGET` to the build host's
+/// macOS version. Setting `MACOSX_DEPLOYMENT_TARGET` (already honored by
+/// rustc and cc for the Rust side) makes the floor deliberate for the CMake
+/// and metallib products too.
+fn macos_deployment_target() -> Option<String> {
+    env::var("MACOSX_DEPLOYMENT_TARGET")
+        .ok()
+        .filter(|v| !v.is_empty())
+}
+
 /// Compile the paged-attention `.metal` sources into
 /// `<out_dir>/paged_attn.metallib`. The kernels live in
 /// `crates/mlx-paged-attn/metal/`. mlx-sys's own
@@ -51,22 +64,28 @@ fn compile_paged_attn_metallib(manifest_dir: &Path, out_dir: &Path) -> PathBuf {
         let air_name = file.replace('/', "_").replace(".metal", ".air");
         let air_path = out_dir.join(&air_name);
 
-        let status = Command::new("xcrun")
-            .args([
-                "-sdk",
-                "macosx",
-                "metal",
-                "-c",
-                src_path.to_str().unwrap(),
-                "-o",
-                air_path.to_str().unwrap(),
-                "-I",
-                metal_src_dir.to_str().unwrap(),
-                "-O3",
-                "-ffast-math",
-            ])
-            .status()
-            .expect("Failed to execute xcrun metal");
+        let mut compile_cmd = Command::new("xcrun");
+        compile_cmd.args([
+            "-sdk",
+            "macosx",
+            "metal",
+            "-c",
+            src_path.to_str().unwrap(),
+            "-o",
+            air_path.to_str().unwrap(),
+            "-I",
+            metal_src_dir.to_str().unwrap(),
+            "-O3",
+            "-ffast-math",
+        ]);
+        // Pin the metallib's min-OS stamp when a floor is requested, matching
+        // what MLX's kernel CMake does for mlx.metallib. The metal driver
+        // reads MACOSX_DEPLOYMENT_TARGET from the environment too, but the
+        // explicit flag keeps the floor visible in the command line.
+        if let Some(target) = macos_deployment_target() {
+            compile_cmd.arg(format!("-mmacosx-version-min={target}"));
+        }
+        let status = compile_cmd.status().expect("Failed to execute xcrun metal");
         if !status.success() {
             panic!(
                 "Metal compilation failed for {}: exit code {:?}",
@@ -177,6 +196,10 @@ fn xcrun_find(tool: &str) -> Option<String> {
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=mlx");
+    // The deployment-target floor participates in both the CMake configure
+    // and the paged-attn metallib compile; changing it must re-run this
+    // script or the caches keep the old floor.
+    println!("cargo:rerun-if-env-changed=MACOSX_DEPLOYMENT_TARGET");
     // Watch all C++ source files, headers, and Metal kernel includes
     let src_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("src");
     if let Ok(entries) = std::fs::read_dir(&src_dir) {
@@ -259,6 +282,16 @@ fn main() {
                 "x86_64"
             },
         );
+        // Forward an explicit deployment-target floor as a -D define: a
+        // define overrides a stale CMAKE_OSX_DEPLOYMENT_TARGET already
+        // recorded in CMakeCache.txt (e.g. a CI-restored cargo cache),
+        // which the environment variable alone cannot. When unset, MLX's
+        // CMakeLists defaults the floor to the build host's macOS version.
+        // Note MLX only builds the NAX (M5 tensor-core) kernels when this
+        // floor is >= 26.2 — pinning lower silently drops them.
+        if let Some(deployment_target) = macos_deployment_target() {
+            cfg.define("CMAKE_OSX_DEPLOYMENT_TARGET", &deployment_target);
+        }
     }
 
     if target_os == "macos" {

--- a/crates/mlx-sys/src/mlx_common.h
+++ b/crates/mlx-sys/src/mlx_common.h
@@ -89,11 +89,10 @@ struct PagedAttentionInputs {
 // NA int8 W8A8 lazy graph builders (defined in mlx_na_int8.cpp).
 //
 // External-linkage C++ entry points for the sym8 (per-output-channel symmetric
-// int8) linear path, so the compiled C++ forwards (mlx_qwen35_common.h
-// `linear_proj`) can emit the SAME graph nodes the eager Rust
-// `QuantizedLinear::forward_sym8` emits via the `mlx_w8a8_linear` /
-// `mlx_int8_qmv` FFI wrappers (the wrappers now delegate to these). Keeping a
-// single definition is what makes compiled-vs-eager sym8 decode byte-identical.
+// int8) linear path. The eager Rust `QuantizedLinear::forward_sym8` emits
+// these graphs via the `mlx_w8a8_linear` / `mlx_int8_qmv` FFI wrappers, which
+// delegate to these builders. Keeping the math in ONE definition means every
+// consumer emits byte-identical graph nodes for the same inputs.
 //
 // Contract (both):
 //   x    : [M,K] activations (bf16; non-bf16 defensively cast)
@@ -111,7 +110,7 @@ struct PagedAttentionInputs {
 // qmv_w8a16_lazy takes BOTH weight orientations: w_kn [K,N] (the GEMM operand,
 // consumed by the 2D-block fallback under INT8_QMV16_SG=0 and the W8A8
 // reroute) and w_nk [N,K] (the CHECKPOINT orientation, consumed by the default
-// simd_sum-style kernel — buffer-shared with the registry/params tensor).
+// simd_sum-style kernel — buffer-shared with the params tensor).
 // =============================================================================
 namespace na_int8 {
 mlx::core::array w8a8_linear_lazy(const mlx::core::array& x,

--- a/crates/mlx-sys/src/mlx_na_int8.cpp
+++ b/crates/mlx-sys/src/mlx_na_int8.cpp
@@ -765,10 +765,9 @@ mlx::core::array int8_weight_to_kn(const mlx::core::array& w_i8) {
 // External-linkage lazy graph builders (declared in mlx_common.h).
 //
 // SINGLE SOURCE OF TRUTH for the sym8 W8A8 linear math: the extern "C" FFI
-// wrappers below (`mlx_w8a8_linear`, `mlx_int8_qmv` — the eager Rust path) and
-// the compiled C++ forward (`linear_proj` sym8 dispatch in
-// mlx_qwen35_common.h) both call these, so the two paths emit byte-identical
-// graphs for the same inputs. Contract checks THROW here; the FFI wrappers
+// wrappers below (`mlx_w8a8_linear`, `mlx_int8_qmv` — the eager Rust path)
+// delegate to these builders, so every consumer emits byte-identical graphs
+// for the same inputs. Contract checks THROW here; the FFI wrappers
 // translate to cerr + false.
 // =============================================================================
 namespace na_int8 {

--- a/crates/mlx-sys/src/mlx_paged_dispatch.cpp
+++ b/crates/mlx-sys/src/mlx_paged_dispatch.cpp
@@ -17,10 +17,12 @@
 #include <dlfcn.h>
 #include <filesystem>
 #include <limits>
+#include <map>
 #include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "mlx/allocator.h"
@@ -170,103 +172,198 @@ size_t dtype_byte_size(KvDtype d) {
   return 2;
 }
 
-std::string reshape_and_cache_kernel_name(
+// -----------------------------------------------------------------------
+// Kernel-name memoization.
+//
+// Every name-builder function below runs on every PagedKVWrite /
+// PagedAttention dispatch (per attention layer, per decode token /
+// prefill chunk) purely to look the resulting string up in MLX's own
+// `Device::get_kernel` cache (see `load_pipeline` below). The name is
+// fully determined by a handful of compile-time-fixed-per-model
+// parameters (dtype, head_size, block_size, alibi flag) that never
+// change between calls for a loaded model, so re-running the
+// `std::ostringstream` formatting on every call is pure repeated work.
+// Memoize on those parameters instead — same idea as the
+// `get_or_create_kernel` cache in `mlx_gated_delta.cpp`.
+//
+// The cache key is a `std::tuple` of the exact parameter values, so
+// each field is compared independently at its full width via
+// `std::tuple`'s built-in `operator<`. Distinct parameter tuples can
+// therefore never alias onto the same key regardless of magnitude —
+// there is no bit-packing, so an out-of-range field can never overflow
+// into a neighbouring field and collide with another valid key. Using
+// `std::map` gives us this field-wise ordering for free (no custom hash
+// or comparator needed); its O(log n) lookup is irrelevant here since
+// each cache holds only a handful of entries and is touched on the
+// cold, first-per-tuple path only.
+template <typename Key, typename Builder>
+const std::string& memoized_kernel_name(
+    std::map<Key, std::string>& cache,
+    std::mutex& mutex,
+    const Key& key,
+    Builder&& build) {
+  std::lock_guard<std::mutex> lock(mutex);
+  auto it = cache.find(key);
+  if (it != cache.end()) {
+    return it->second;
+  }
+  // `std::map`, like `std::unordered_map`, is node-based and never
+  // invalidates references to existing elements on insertion (only
+  // iterators), so returning a reference into the map after `mutex` is
+  // released below is safe.
+  return cache.emplace(key, build()).first->second;
+}
+
+const std::string& reshape_and_cache_kernel_name(
     KvDtype input_dtype,
     KvDtype cache_dtype,
     bool use_fp8) {
-  std::ostringstream os;
-  os << "reshape_and_cache_kv_" << dtype_string(input_dtype) << "_cache_"
-     << dtype_string(cache_dtype);
-  if (use_fp8) {
-    os << "_fp8";
-  }
-  return os.str();
+  static std::mutex mutex;
+  static std::map<std::tuple<KvDtype, KvDtype, bool>, std::string> cache;
+  return memoized_kernel_name(
+      cache, mutex, std::make_tuple(input_dtype, cache_dtype, use_fp8), [&] {
+    std::ostringstream os;
+    os << "reshape_and_cache_kv_" << dtype_string(input_dtype) << "_cache_"
+       << dtype_string(cache_dtype);
+    if (use_fp8) {
+      os << "_fp8";
+    }
+    return os.str();
+  });
 }
 
-std::string paged_attention_v1_kernel_name(
+const std::string& paged_attention_v1_kernel_name(
     KvDtype io_dtype,
     KvDtype cache_dtype,
     int head_size,
     int block_size,
     bool use_alibi) {
-  std::ostringstream os;
-  os << "paged_attention_" << dtype_string(io_dtype) << "_cache_"
-     << dtype_string(cache_dtype) << "_hs" << head_size << "_bs" << block_size
-     << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes << "_ps0";
-  if (use_alibi) {
-    os << "_alibi";
-  }
-  return os.str();
+  static std::mutex mutex;
+  static std::map<std::tuple<KvDtype, KvDtype, int, int, bool>, std::string>
+      cache;
+  return memoized_kernel_name(
+      cache,
+      mutex,
+      std::make_tuple(io_dtype, cache_dtype, head_size, block_size, use_alibi),
+      [&] {
+    std::ostringstream os;
+    os << "paged_attention_" << dtype_string(io_dtype) << "_cache_"
+       << dtype_string(cache_dtype) << "_hs" << head_size << "_bs"
+       << block_size << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes
+       << "_ps0";
+    if (use_alibi) {
+      os << "_alibi";
+    }
+    return os.str();
+  });
 }
 
-std::string paged_attention_v2_kernel_name(
+const std::string& paged_attention_v2_kernel_name(
     KvDtype io_dtype,
     KvDtype cache_dtype,
     int head_size,
     int block_size,
     bool use_alibi) {
-  std::ostringstream os;
-  os << "paged_attention_" << dtype_string(io_dtype) << "_cache_"
-     << dtype_string(cache_dtype) << "_hs" << head_size << "_bs" << block_size
-     << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes << "_ps"
-     << kPartitionSize;
-  if (use_alibi) {
-    os << "_alibi";
-  }
-  return os.str();
+  static std::mutex mutex;
+  static std::map<std::tuple<KvDtype, KvDtype, int, int, bool>, std::string>
+      cache;
+  return memoized_kernel_name(
+      cache,
+      mutex,
+      std::make_tuple(io_dtype, cache_dtype, head_size, block_size, use_alibi),
+      [&] {
+    std::ostringstream os;
+    os << "paged_attention_" << dtype_string(io_dtype) << "_cache_"
+       << dtype_string(cache_dtype) << "_hs" << head_size << "_bs"
+       << block_size << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes
+       << "_ps" << kPartitionSize;
+    if (use_alibi) {
+      os << "_alibi";
+    }
+    return os.str();
+  });
 }
 
-std::string paged_attention_v2_reduce_kernel_name(
+const std::string& paged_attention_v2_reduce_kernel_name(
     KvDtype io_dtype,
     int head_size) {
-  std::ostringstream os;
-  os << "paged_attention_v2_reduce_" << dtype_string(io_dtype) << "_hs"
-     << head_size << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes << "_ps"
-     << kPartitionSize;
-  return os.str();
+  static std::mutex mutex;
+  static std::map<std::tuple<KvDtype, int>, std::string> cache;
+  return memoized_kernel_name(
+      cache, mutex, std::make_tuple(io_dtype, head_size), [&] {
+    std::ostringstream os;
+    os << "paged_attention_v2_reduce_" << dtype_string(io_dtype) << "_hs"
+       << head_size << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes
+       << "_ps" << kPartitionSize;
+    return os.str();
+  });
 }
 
-std::string paged_attention_varlen_v1_kernel_name(
+const std::string& paged_attention_varlen_v1_kernel_name(
     KvDtype io_dtype,
     KvDtype cache_dtype,
     int head_size,
     int block_size,
     bool use_alibi) {
-  std::ostringstream os;
-  os << "paged_attention_varlen_" << dtype_string(io_dtype) << "_cache_"
-     << dtype_string(cache_dtype) << "_hs" << head_size << "_bs" << block_size
-     << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes << "_ps0";
-  if (use_alibi) {
-    os << "_alibi";
-  }
-  return os.str();
+  static std::mutex mutex;
+  static std::map<std::tuple<KvDtype, KvDtype, int, int, bool>, std::string>
+      cache;
+  return memoized_kernel_name(
+      cache,
+      mutex,
+      std::make_tuple(io_dtype, cache_dtype, head_size, block_size, use_alibi),
+      [&] {
+    std::ostringstream os;
+    os << "paged_attention_varlen_" << dtype_string(io_dtype) << "_cache_"
+       << dtype_string(cache_dtype) << "_hs" << head_size << "_bs"
+       << block_size << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes
+       << "_ps0";
+    if (use_alibi) {
+      os << "_alibi";
+    }
+    return os.str();
+  });
 }
 
-std::string paged_attention_varlen_v2_kernel_name(
+const std::string& paged_attention_varlen_v2_kernel_name(
     KvDtype io_dtype,
     KvDtype cache_dtype,
     int head_size,
     int block_size,
     bool use_alibi) {
-  std::ostringstream os;
-  os << "paged_attention_varlen_" << dtype_string(io_dtype) << "_cache_"
-     << dtype_string(cache_dtype) << "_hs" << head_size << "_bs" << block_size
-     << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes << "_ps"
-     << kPartitionSize;
-  if (use_alibi) {
-    os << "_alibi";
-  }
-  return os.str();
+  static std::mutex mutex;
+  static std::map<std::tuple<KvDtype, KvDtype, int, int, bool>, std::string>
+      cache;
+  return memoized_kernel_name(
+      cache,
+      mutex,
+      std::make_tuple(io_dtype, cache_dtype, head_size, block_size, use_alibi),
+      [&] {
+    std::ostringstream os;
+    os << "paged_attention_varlen_" << dtype_string(io_dtype) << "_cache_"
+       << dtype_string(cache_dtype) << "_hs" << head_size << "_bs"
+       << block_size << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes
+       << "_ps" << kPartitionSize;
+    if (use_alibi) {
+      os << "_alibi";
+    }
+    return os.str();
+  });
 }
 
-std::string paged_attention_varlen_v2_reduce_kernel_name(
+const std::string& paged_attention_varlen_v2_reduce_kernel_name(
     KvDtype io_dtype,
     int head_size) {
-  std::ostringstream os;
-  os << "paged_attention_varlen_v2_reduce_" << dtype_string(io_dtype) << "_hs"
-     << head_size << "_nt" << kNumThreads << "_nsl" << kNumSimdLanes << "_ps"
-     << kPartitionSize;
-  return os.str();
+  static std::mutex mutex;
+  static std::map<std::tuple<KvDtype, int>, std::string> cache;
+  return memoized_kernel_name(
+      cache, mutex, std::make_tuple(io_dtype, head_size), [&] {
+    std::ostringstream os;
+    os << "paged_attention_varlen_v2_reduce_" << dtype_string(io_dtype)
+       << "_hs" << head_size << "_nt" << kNumThreads << "_nsl"
+       << kNumSimdLanes << "_ps" << kPartitionSize;
+    return os.str();
+  });
 }
 
 // =============================================================================
@@ -319,7 +416,7 @@ void dispatch_reshape_and_cache(
       cache_dtype == KvDtype::Fp8 ? KvDtype::Bf16 : cache_dtype;
   const bool use_fp8 = cache_dtype == KvDtype::Fp8;
 
-  std::string kernel_name =
+  const std::string& kernel_name =
       reshape_and_cache_kernel_name(input_dtype, cache_dtype, use_fp8);
   MTL::ComputePipelineState* pipeline = load_pipeline(device, kernel_name);
   encoder.set_compute_pipeline_state(pipeline);
@@ -391,7 +488,7 @@ void dispatch_paged_attention_v1_inner(
     int sliding_window,
     KvDtype io_dtype,
     KvDtype cache_dtype) {
-  std::string kernel_name = paged_attention_v1_kernel_name(
+  const std::string& kernel_name = paged_attention_v1_kernel_name(
       io_dtype, cache_dtype, head_size, block_size, /*use_alibi=*/false);
   MTL::ComputePipelineState* pipeline = load_pipeline(device, kernel_name);
   encoder.set_compute_pipeline_state(pipeline);
@@ -560,7 +657,7 @@ void dispatch_paged_attention_v2_inner(
 
   // Stage 1: partitioned attention.
   {
-    std::string kernel_name = paged_attention_v2_kernel_name(
+    const std::string& kernel_name = paged_attention_v2_kernel_name(
         io_dtype, cache_dtype, head_size, block_size, /*use_alibi=*/false);
     MTL::ComputePipelineState* pipeline = load_pipeline(device, kernel_name);
     encoder.set_compute_pipeline_state(pipeline);
@@ -621,7 +718,7 @@ void dispatch_paged_attention_v2_inner(
   // via `set_output_array` in stage 1 and re-set as `set_input_array`
   // here, so MLX's dependency tracking fences via `prev_outputs_`.
   {
-    std::string kernel_name =
+    const std::string& kernel_name =
         paged_attention_v2_reduce_kernel_name(io_dtype, head_size);
     MTL::ComputePipelineState* pipeline = load_pipeline(device, kernel_name);
     encoder.set_compute_pipeline_state(pipeline);
@@ -798,7 +895,7 @@ void dispatch_paged_attention_varlen_v1_inner(
     int sliding_window,
     KvDtype io_dtype,
     KvDtype cache_dtype) {
-  std::string kernel_name = paged_attention_varlen_v1_kernel_name(
+  const std::string& kernel_name = paged_attention_varlen_v1_kernel_name(
       io_dtype, cache_dtype, head_size, block_size, /*use_alibi=*/false);
   MTL::ComputePipelineState* pipeline = load_pipeline(device, kernel_name);
   encoder.set_compute_pipeline_state(pipeline);
@@ -921,7 +1018,7 @@ void dispatch_paged_attention_varlen_v2_inner(
 
   // Stage 1: partitioned varlen attention.
   {
-    std::string kernel_name = paged_attention_varlen_v2_kernel_name(
+    const std::string& kernel_name = paged_attention_varlen_v2_kernel_name(
         io_dtype, cache_dtype, head_size, block_size, /*use_alibi=*/false);
     MTL::ComputePipelineState* pipeline = load_pipeline(device, kernel_name);
     encoder.set_compute_pipeline_state(pipeline);
@@ -976,7 +1073,7 @@ void dispatch_paged_attention_varlen_v2_inner(
 
   // Stage 2: reduce partitions.
   {
-    std::string kernel_name =
+    const std::string& kernel_name =
         paged_attention_varlen_v2_reduce_kernel_name(io_dtype, head_size);
     MTL::ComputePipelineState* pipeline = load_pipeline(device, kernel_name);
     encoder.set_compute_pipeline_state(pipeline);

--- a/crates/mlx-sys/src/mlx_paged_dispatch.h
+++ b/crates/mlx-sys/src/mlx_paged_dispatch.h
@@ -12,7 +12,8 @@
 // primitives dispatched here are the graph-native default: every paged
 // family's pure-Rust forward (qwen3, qwen3.5 dense/MoE, lfm2, gemma4)
 // emits them via `PagedKVCacheAdapter::update_keys_values_native` /
-// `gather_kv_for_decode_graph` / `gather_kv_for_prefill_chunk`, so the
+// `gather_kv_for_decode_graph` (`gather_kv_for_prefill_chunk` is
+// family-dependent: opt-in default-OFF on lfm2, absent on qwen3), so the
 // K/V write and attention read ride MLX's lazy graph with no per-layer
 // host sync. They also stay compile-traceable (usable inside
 // `mlx::core::compile`), covered by the compile-trace smoke tests in

--- a/crates/mlx-sys/src/mlx_paged_dispatch.h
+++ b/crates/mlx-sys/src/mlx_paged_dispatch.h
@@ -6,12 +6,17 @@
 // Kernel names + threadgroup-memory math + V1/V2 selection mirror the
 // Rust dispatcher in `crates/mlx-paged-attn/src/metal/{state,
 // reshape_and_cache, paged_attention}.rs`. The Rust dispatcher remains
-// in place: it is the active production paged path for Qwen3, LFM2, and
-// Gemma4 (whose paged forward goes through `PagedKVCacheAdapter` →
-// `LayerKVPool` → Rust `dispatch_*`, NOT these C++ Custom primitives).
-// The C++ port here is exclusively for the compile-traceable primitives
-// used inside the Qwen3.5 dense / MoE C++ compile graphs
-// (`mlx_qwen35_init_paged` / `mlx_qwen35_moe_init_paged`).
+// in place as the synchronous fallback path: the adapter's raw-Metal
+// `PagedKVCacheAdapter::update_keys_values` goes through `LayerKVPool` →
+// Rust `dispatch_*`, outside MLX's graph scheduler. The `Custom`
+// primitives dispatched here are the graph-native default: every paged
+// family's pure-Rust forward (qwen3, qwen3.5 dense/MoE, lfm2, gemma4)
+// emits them via `PagedKVCacheAdapter::update_keys_values_native` /
+// `gather_kv_for_decode_graph` / `gather_kv_for_prefill_chunk`, so the
+// K/V write and attention read ride MLX's lazy graph with no per-layer
+// host sync. They also stay compile-traceable (usable inside
+// `mlx::core::compile`), covered by the compile-trace smoke tests in
+// `mlx_paged_ops.cpp`.
 //
 // Notes:
 //   - The .metallib for these kernels is compiled by `mlx-sys/build.rs`

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -40,6 +40,7 @@ The per-generation profiler (`crates/mlx-core/src/decode_profiler.rs`) records:
 | `MLX_NO_COMPILE=1`                                   | Disable compiled C++ forward path (Qwen3.5)                                                                                                                                          |
 | `MLX_EVAL_ALL_CACHES=1`                              | Revert to eval-all-caches (default is token-only)                                                                                                                                    |
 | `MLX_QWEN35_NATIVE_KV_WRITE` / `MLX_NATIVE_KV_WRITE` | Toggle native KV-write optimization on Qwen3.5 attention                                                                                                                             |
+| `MLX_QWEN3_NATIVE_KV_WRITE`                          | Toggle graph-native paged KV write/decode-gather on Qwen3 (plain) dense; default on, falls back to the legacy synchronous path on error                                             |
 | `MLX_WEIGHT_MATERIALIZE_CHUNK_MB`                    | Weight-loading chunk size                                                                                                                                                            |
 | `MLX_GDN_KERNEL=perstep\|chunked`                    | Force GDN recurrence kernel (default per-step on all archs; `chunked` is A/B-only and changes generated tokens by 1–2 bf16 ULP → different greedy continuation on some long prompts) |
 

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -44,6 +44,7 @@ The per-generation profiler (`crates/mlx-core/src/decode_profiler.rs`) records:
 | `MLX_WEIGHT_MATERIALIZE_CHUNK_MB`                    | Weight-loading chunk size                                                                                                                                                            |
 | `MLX_GDN_KERNEL=perstep\|chunked`                    | Force GDN recurrence kernel (default per-step on all archs; `chunked` is A/B-only and changes generated tokens by 1–2 bf16 ULP → different greedy continuation on some long prompts) |
 | `MLX_LFM2_CONV_STATE_REUSE`                          | Opt-in (default off): reuse live conv state on warm LFM2 paged continuation instead of reconstructing it, skipping the redundant Pass-1 over the cached prefix. Materially changes warm-turn output (~40 ULP, near-tie argmax may flip); off until oracle-validated |
+| `MLX_LFM2_PAGED_PREFILL_PAGED_ATTENTION`             | Opt-in (default off): multi-turn LFM2 cache-hit prefill tries the graph-native paged-attention bridge (gather_kv_for_prefill_chunk) before read_kv_range, skipping the forced per-layer pool sync. Held opt-in pending a stable-checkpoint paged-vs-flat gate (fused-vs-masked-SDPA ~1-ULP divergence) |
 
 ### Paged-attention
 

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -43,6 +43,7 @@ The per-generation profiler (`crates/mlx-core/src/decode_profiler.rs`) records:
 | `MLX_QWEN3_NATIVE_KV_WRITE`                          | Toggle graph-native paged KV write/decode-gather on Qwen3 (plain) dense; default on, falls back to the legacy synchronous path on error                                             |
 | `MLX_WEIGHT_MATERIALIZE_CHUNK_MB`                    | Weight-loading chunk size                                                                                                                                                            |
 | `MLX_GDN_KERNEL=perstep\|chunked`                    | Force GDN recurrence kernel (default per-step on all archs; `chunked` is A/B-only and changes generated tokens by 1–2 bf16 ULP → different greedy continuation on some long prompts) |
+| `MLX_LFM2_CONV_STATE_REUSE`                          | Opt-in (default off): reuse live conv state on warm LFM2 paged continuation instead of reconstructing it, skipping the redundant Pass-1 over the cached prefix. Materially changes warm-turn output (~40 ULP, near-tie argmax may flip); off until oracle-validated |
 
 ### Paged-attention
 

--- a/docs/privacy-filter.md
+++ b/docs/privacy-filter.md
@@ -221,7 +221,7 @@ Quality on long-form text was validated only on a 5-fixture short-input parity s
 
 ## Memory on Apple Silicon
 
-`process.memoryUsage().rss` undercounts Metal buffer allocations because Apple's unified memory architecture charges GPU buffers to the process's **`phys_footprint`** (what Activity Monitor's "Memory" column displays) rather than the resident set. For accurate measurements use `vmmap -summary <pid> | grep "Physical footprint"` or the `footprint` CLI. Each `classify()` call clears the MLX buffer cache before returning, so steady-state footprint stays bounded; transient peaks between calls scale with input length.
+`process.memoryUsage().rss` undercounts Metal buffer allocations because Apple's unified memory architecture charges GPU buffers to the process's **`phys_footprint`** (what Activity Monitor's "Memory" column displays) rather than the resident set. For accurate measurements use `vmmap -summary <pid> | grep "Physical footprint"` or the `footprint` CLI. Every `PRIVACY_FILTER_CACHE_CLEAR_INTERVAL`-th `classify()` call (default 8; override via `MLX_PRIVACY_FILTER_CACHE_CLEAR_INTERVAL`) clears the MLX buffer cache, so steady-state footprint stays bounded across a cadence window rather than after every single call; transient peaks between clears scale with both input length and the configured cadence.
 
 ## Internals
 

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile, copyFile, readdir, stat, mkdir } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { readFile, writeFile, copyFile, stat, mkdir } from 'node:fs/promises';
 import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -6,6 +7,13 @@ import { NapiCli, createBuildCommand } from '@napi-rs/cli';
 import { format } from 'vite-plus/fmt';
 
 import viteConfig from '../../vite.config';
+import {
+  assertMetallibIntegrity,
+  collectMetallibCandidates,
+  hostAppleTriple,
+  profileDirName,
+  shouldExpectNaxKernels,
+} from './metallib-select';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const buildCommand = createBuildCommand(process.argv.slice(2));
@@ -109,66 +117,85 @@ async function copyNativeAddon(outputs: Awaited<typeof task>) {
   console.log(`Copied ${expectedName} -> ${dst}`);
 }
 
+// Probe the same inputs MLX's kernel CMake uses to decide whether the NAX
+// (M5 tensor-core) kernels are compiled on this host; the metallib gate then
+// requires them to be present. Any probe failure downgrades to the base gate
+// only — a broken Metal toolchain already fails the native build itself.
+function detectExpectNax(): boolean {
+  try {
+    const sdkVersion = execFileSync('xcrun', ['-sdk', 'macosx', '--show-sdk-version'], { encoding: 'utf-8' }).trim();
+    const hostVersion = execFileSync('sw_vers', ['-productVersion'], { encoding: 'utf-8' }).trim();
+    return shouldExpectNaxKernels(sdkVersion, hostVersion, process.env.MACOSX_DEPLOYMENT_TARGET);
+  } catch {
+    return false;
+  }
+}
+
 async function copyMetallibs() {
   const npmDarwinDir = join(__dirname, 'npm', 'darwin-arm64');
   const destDirs = [__dirname, npmDarwinDir];
 
-  const targetDir = join(__dirname, '../../target');
-  // Find mlx.metallib in the build directory.
-  // Pattern: target/*/release/build/mlx-sys-*/out/lib/mlx.metallib
-  const archDirs = await readdir(targetDir);
-  for (const arch of archDirs) {
-    const releaseDir = join(targetDir, arch, 'release', 'build');
-    let buildDirs: string[];
-    try {
-      buildDirs = await readdir(releaseDir);
-    } catch {
-      // release/build dir doesn't exist for this arch
-      continue;
-    }
-    for (const dir of buildDirs) {
-      if (!dir.startsWith('mlx-sys-')) continue;
-      const libDir = join(releaseDir, dir, 'out', 'lib');
-      const mlxPath = join(libDir, 'mlx.metallib');
-      try {
-        await stat(mlxPath);
-      } catch {
-        // metallib not at this path, continue searching
-        continue;
-      }
-      // mlx.metallib is required: copy to all destinations or fail.
-      for (const dest of destDirs) {
-        const dst = join(dest, 'mlx.metallib');
-        await copyFile(mlxPath, dst);
-        console.log(`Copied mlx.metallib -> ${dst}`);
-      }
-      // paged_attn.metallib is also required for darwin.
-      // It lives next to mlx.metallib in the same lib dir.
-      const pagedPath = join(libDir, 'paged_attn.metallib');
-      try {
-        await stat(pagedPath);
-      } catch {
-        throw new Error(
-          `paged_attn.metallib not found at ${pagedPath}. The paged-attention ` +
-            `compile path (mlx_paged_dispatch.cpp) loads this metallib via dladdr ` +
-            `at runtime; without it, the addon throws on first paged-attention use. ` +
-            `Check that mlx-sys/build.rs ran compile_paged_attn_metallib successfully.`,
-        );
-      }
-      for (const dest of destDirs) {
-        const dst = join(dest, 'paged_attn.metallib');
-        await copyFile(pagedPath, dst);
-        console.log(`Copied paged_attn.metallib -> ${dst}`);
-      }
-      // Final sanity-check: every destination must have BOTH files.
-      // This catches a copy that silently overwrote or partially
-      // failed; cheaper to fail the build than to publish a broken
-      // optional package.
-      await assertMetallibPresence(destDirs);
-      return;
-    }
+  // Bind the search to the build napi just ran: same target dir, same
+  // triple (napi always passes `--target`, defaulting to the host triple),
+  // same profile. See metallib-select.ts for why a loose "first directory
+  // that has a metallib" scan is unsafe.
+  const targetRoot = buildOptions.targetDir ?? process.env.CARGO_BUILD_TARGET_DIR ?? join(__dirname, '../../target');
+  const triple = buildOptions.target ?? process.env.CARGO_BUILD_TARGET ?? hostAppleTriple();
+  const profile = profileDirName(buildOptions);
+  const candidates = collectMetallibCandidates(targetRoot, triple, profile);
+  if (candidates.length === 0) {
+    throw new Error(
+      `mlx.metallib not found under ${join(targetRoot, triple, profile, 'build')}/mlx-sys-*/out/lib/ ` +
+        `(nor the plain ${join(targetRoot, profile, 'build')} layout).`,
+    );
   }
-  throw new Error('mlx.metallib not found under any target/<arch>/release/build/mlx-sys-*/out/lib/');
+  const picked = candidates[0]!;
+  if (candidates.length > 1) {
+    console.warn(
+      `Multiple mlx-sys metallib dirs found; using the most recently built one:\n` +
+        candidates
+          .map(
+            (c, i) =>
+              `  ${i === 0 ? '->' : '  '} ${c.metallibPath} (${c.size} bytes, ${new Date(c.rankMtimeMs).toISOString()})`,
+          )
+          .join('\n'),
+    );
+  }
+
+  // Hard gate: never ship a truncated or stale-pin metallib. A mismatch here
+  // pairs wrong kernels with the freshly built addon and produces garbage
+  // inference output with no error at load time.
+  const metallib = await readFile(picked.metallibPath);
+  assertMetallibIntegrity(metallib, { path: picked.metallibPath, expectNax: detectExpectNax() });
+
+  for (const dest of destDirs) {
+    const dst = join(dest, 'mlx.metallib');
+    await copyFile(picked.metallibPath, dst);
+    console.log(`Copied mlx.metallib -> ${dst}`);
+  }
+  // paged_attn.metallib is also required for darwin.
+  // It lives next to mlx.metallib in the same lib dir.
+  const pagedPath = join(picked.libDir, 'paged_attn.metallib');
+  try {
+    await stat(pagedPath);
+  } catch {
+    throw new Error(
+      `paged_attn.metallib not found at ${pagedPath}. The paged-attention ` +
+        `compile path (mlx_paged_dispatch.cpp) loads this metallib via dladdr ` +
+        `at runtime; without it, the addon throws on first paged-attention use. ` +
+        `Check that mlx-sys/build.rs ran compile_paged_attn_metallib successfully.`,
+    );
+  }
+  for (const dest of destDirs) {
+    const dst = join(dest, 'paged_attn.metallib');
+    await copyFile(pagedPath, dst);
+    console.log(`Copied paged_attn.metallib -> ${dst}`);
+  }
+  // Final sanity-check: every destination must have BOTH files.
+  // This catches a copy that silently overwrote or partially
+  // failed; cheaper to fail the build than to publish a broken
+  // optional package.
+  await assertMetallibPresence(destDirs);
 }
 
 async function assertMetallibPresence(destDirs: string[]) {

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -189,7 +189,7 @@ async function copyMetallibs(outputs: Awaited<typeof task>) {
   const metallib = await readFile(picked.metallibPath);
   assertMetallibIntegrity(metallib, { path: picked.metallibPath, expectNax: detectExpectNax() });
   if (deploymentFloor !== undefined) {
-    assertMetallibFloor(metallib, { path: picked.metallibPath, deploymentFloor });
+    assertMetallibFloor(metallib, { path: picked.metallibPath, deploymentFloor, warn: (msg) => console.warn(msg) });
   }
 
   for (const dest of destDirs) {
@@ -197,22 +197,32 @@ async function copyMetallibs(outputs: Awaited<typeof task>) {
     await copyFile(picked.metallibPath, dst);
     console.log(`Copied mlx.metallib -> ${dst}`);
   }
-  // paged_attn.metallib is also required for darwin.
-  // It lives next to mlx.metallib in the same lib dir.
-  const pagedPath = join(picked.libDir, 'paged_attn.metallib');
-  let pagedMetallib: Buffer;
-  try {
-    pagedMetallib = await readFile(pagedPath);
-  } catch {
+  // paged_attn.metallib is also required for darwin. build.rs writes it to
+  // the OUT_DIR root and copies it into out/lib; prefer the origin file and
+  // accept the copy when the origin is gone — both live in the selected
+  // build's out dir, so the binding still holds.
+  const pagedCandidates = [join(picked.outDir, 'paged_attn.metallib'), join(picked.libDir, 'paged_attn.metallib')];
+  let pagedPath: string | undefined;
+  let pagedMetallib: Buffer | undefined;
+  for (const candidate of pagedCandidates) {
+    try {
+      pagedMetallib = await readFile(candidate);
+      pagedPath = candidate;
+      break;
+    } catch {
+      // absent here — try the next location
+    }
+  }
+  if (pagedPath === undefined || pagedMetallib === undefined) {
     throw new Error(
-      `paged_attn.metallib not found at ${pagedPath}. The paged-attention ` +
+      `paged_attn.metallib not found at ${pagedCandidates.join(' nor at ')}. The paged-attention ` +
         `compile path (mlx_paged_dispatch.cpp) loads this metallib via dladdr ` +
         `at runtime; without it, the addon throws on first paged-attention use. ` +
         `Check that mlx-sys/build.rs ran compile_paged_attn_metallib successfully.`,
     );
   }
   if (deploymentFloor !== undefined) {
-    assertMetallibFloor(pagedMetallib, { path: pagedPath, deploymentFloor });
+    assertMetallibFloor(pagedMetallib, { path: pagedPath, deploymentFloor, warn: (msg) => console.warn(msg) });
   }
   for (const dest of destDirs) {
     const dst = join(dest, 'paged_attn.metallib');

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -8,10 +8,12 @@ import { format } from 'vite-plus/fmt';
 
 import viteConfig from '../../vite.config';
 import {
+  assertMetallibFloor,
   assertMetallibIntegrity,
-  collectMetallibCandidates,
   hostAppleTriple,
   profileDirName,
+  resolveTargetRoot,
+  selectMetallib,
   shouldExpectNaxKernels,
 } from './metallib-select';
 
@@ -74,7 +76,7 @@ await copyNativeAddon(outputs);
 // build there is no Metal toolchain and no metallib to copy, so skip the
 // whole step (and its presence assert) on non-darwin platforms.
 if (process.platform === 'darwin') {
-  await copyMetallibs();
+  await copyMetallibs(outputs);
 }
 
 // Derive the napi addon file name + the matching `npm/<triple>/` directory
@@ -131,42 +133,64 @@ function detectExpectNax(): boolean {
   }
 }
 
-async function copyMetallibs() {
+// The intended min-OS load floor for the artifacts we ship: an explicit
+// MACOSX_DEPLOYMENT_TARGET (what build.rs forwards to the MLX cmake build and
+// the paged-attn metal link), else the build host's macOS version (MLX's
+// cmake default). Undefined skips the floor gate — a broken sw_vers probe
+// must not fail an otherwise healthy build.
+function detectDeploymentFloor(): string | undefined {
+  const env = process.env.MACOSX_DEPLOYMENT_TARGET;
+  if (env !== undefined && env !== '') return env;
+  try {
+    return execFileSync('sw_vers', ['-productVersion'], { encoding: 'utf-8' }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+async function copyMetallibs(outputs: Awaited<typeof task>) {
   const npmDarwinDir = join(__dirname, 'npm', 'darwin-arm64');
   const destDirs = [__dirname, npmDarwinDir];
 
-  // Bind the search to the build napi just ran: same target dir, same
-  // triple (napi always passes `--target`, defaulting to the host triple),
-  // same profile. See metallib-select.ts for why a loose "first directory
-  // that has a metallib" scan is unsafe.
-  const targetRoot = buildOptions.targetDir ?? process.env.CARGO_BUILD_TARGET_DIR ?? join(__dirname, '../../target');
+  // Authoritative binding: the freshly built addon bakes the METAL_PATH of
+  // the exact mlx-sys build it linked against; ship that build's metallibs.
+  // The target-dir/triple/profile derivation only feeds the heuristic scan
+  // used when no path is baked (see metallib-select.ts).
+  const nodeOutput = outputs.find((output) => output.kind === 'node');
+  if (!nodeOutput) {
+    throw new Error('[build.ts smoke check] native addon output missing from napi build');
+  }
+  const targetRoot = resolveTargetRoot({
+    targetDir: buildOptions.targetDir,
+    env: process.env,
+    defaultRoot: join(__dirname, '../../target'),
+  });
   const triple = buildOptions.target ?? process.env.CARGO_BUILD_TARGET ?? hostAppleTriple();
   const profile = profileDirName(buildOptions);
-  const candidates = collectMetallibCandidates(targetRoot, triple, profile);
-  if (candidates.length === 0) {
-    throw new Error(
-      `mlx.metallib not found under ${join(targetRoot, triple, profile, 'build')}/mlx-sys-*/out/lib/ ` +
-        `(nor the plain ${join(targetRoot, profile, 'build')} layout).`,
-    );
-  }
-  const picked = candidates[0]!;
-  if (candidates.length > 1) {
-    console.warn(
-      `Multiple mlx-sys metallib dirs found; using the most recently built one:\n` +
-        candidates
-          .map(
-            (c, i) =>
-              `  ${i === 0 ? '->' : '  '} ${c.metallibPath} (${c.size} bytes, ${new Date(c.rankMtimeMs).toISOString()})`,
-          )
-          .join('\n'),
-    );
-  }
+  const picked = selectMetallib({
+    addonBinary: await readFile(nodeOutput.path),
+    addonPath: nodeOutput.path,
+    targetRoot,
+    triple,
+    profile,
+    warn: (msg) => console.warn(msg),
+  });
+  console.log(
+    picked.source === 'baked'
+      ? `Metallib bound via the addon's baked METAL_PATH: ${picked.metallibPath}`
+      : `Metallib selected by directory scan (no baked METAL_PATH): ${picked.metallibPath}`,
+  );
 
-  // Hard gate: never ship a truncated or stale-pin metallib. A mismatch here
-  // pairs wrong kernels with the freshly built addon and produces garbage
-  // inference output with no error at load time.
+  // Hard gates: never ship a truncated or stale-pin metallib (wrong kernels
+  // paired with the fresh addon produce garbage inference with no error at
+  // load time), nor one stamped above the intended deployment floor (it
+  // would refuse to load on floor machines).
+  const deploymentFloor = detectDeploymentFloor();
   const metallib = await readFile(picked.metallibPath);
   assertMetallibIntegrity(metallib, { path: picked.metallibPath, expectNax: detectExpectNax() });
+  if (deploymentFloor !== undefined) {
+    assertMetallibFloor(metallib, { path: picked.metallibPath, deploymentFloor });
+  }
 
   for (const dest of destDirs) {
     const dst = join(dest, 'mlx.metallib');
@@ -176,8 +200,9 @@ async function copyMetallibs() {
   // paged_attn.metallib is also required for darwin.
   // It lives next to mlx.metallib in the same lib dir.
   const pagedPath = join(picked.libDir, 'paged_attn.metallib');
+  let pagedMetallib: Buffer;
   try {
-    await stat(pagedPath);
+    pagedMetallib = await readFile(pagedPath);
   } catch {
     throw new Error(
       `paged_attn.metallib not found at ${pagedPath}. The paged-attention ` +
@@ -185,6 +210,9 @@ async function copyMetallibs() {
         `at runtime; without it, the addon throws on first paged-attention use. ` +
         `Check that mlx-sys/build.rs ran compile_paged_attn_metallib successfully.`,
     );
+  }
+  if (deploymentFloor !== undefined) {
+    assertMetallibFloor(pagedMetallib, { path: pagedPath, deploymentFloor });
   }
   for (const dest of destDirs) {
     const dst = join(dest, 'paged_attn.metallib');

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -10,10 +10,12 @@ import viteConfig from '../../vite.config';
 import {
   assertMetallibFloor,
   assertMetallibIntegrity,
+  assertPagedMetallibIntegrity,
   hostAppleTriple,
   profileDirName,
   resolveTargetRoot,
   selectMetallib,
+  selectPagedMetallib,
   shouldExpectNaxKernels,
 } from './metallib-select';
 
@@ -197,36 +199,23 @@ async function copyMetallibs(outputs: Awaited<typeof task>) {
     await copyFile(picked.metallibPath, dst);
     console.log(`Copied mlx.metallib -> ${dst}`);
   }
-  // paged_attn.metallib is also required for darwin. build.rs writes it to
-  // the OUT_DIR root and copies it into out/lib; prefer the origin file and
-  // accept the copy when the origin is gone — both live in the selected
-  // build's out dir, so the binding still holds.
-  const pagedCandidates = [join(picked.outDir, 'paged_attn.metallib'), join(picked.libDir, 'paged_attn.metallib')];
-  let pagedPath: string | undefined;
-  let pagedMetallib: Buffer | undefined;
-  for (const candidate of pagedCandidates) {
-    try {
-      pagedMetallib = await readFile(candidate);
-      pagedPath = candidate;
-      break;
-    } catch {
-      // absent here — try the next location
-    }
-  }
-  if (pagedPath === undefined || pagedMetallib === undefined) {
-    throw new Error(
-      `paged_attn.metallib not found at ${pagedCandidates.join(' nor at ')}. The paged-attention ` +
-        `compile path (mlx_paged_dispatch.cpp) loads this metallib via dladdr ` +
-        `at runtime; without it, the addon throws on first paged-attention use. ` +
-        `Check that mlx-sys/build.rs ran compile_paged_attn_metallib successfully.`,
-    );
-  }
+  // paged_attn.metallib is also required for darwin, under the same
+  // contract as mlx.metallib: build.rs writes the origin to the OUT_DIR
+  // root and copies it into out/lib; both-present pairs must be
+  // byte-identical, and the shipped file passes size/magic + floor gates
+  // before any copy.
+  const paged = selectPagedMetallib({
+    outDir: picked.outDir,
+    libDir: picked.libDir,
+    warn: (msg) => console.warn(msg),
+  });
+  assertPagedMetallibIntegrity(paged.contents, { path: paged.path });
   if (deploymentFloor !== undefined) {
-    assertMetallibFloor(pagedMetallib, { path: pagedPath, deploymentFloor, warn: (msg) => console.warn(msg) });
+    assertMetallibFloor(paged.contents, { path: paged.path, deploymentFloor, warn: (msg) => console.warn(msg) });
   }
   for (const dest of destDirs) {
     const dst = join(dest, 'paged_attn.metallib');
-    await copyFile(pagedPath, dst);
+    await copyFile(paged.path, dst);
     console.log(`Copied paged_attn.metallib -> ${dst}`);
   }
   // Final sanity-check: every destination must have BOTH files.

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -135,6 +135,18 @@ function detectExpectNax(): boolean {
   }
 }
 
+// Publish/release fail-closed switch (set as `MLX_METALLIB_STRICT=1` in the
+// CI workflow env — see .github/workflows/ci.yml). In strict mode the metallib
+// gates FAIL CLOSED: a Metal-enabled addon that bakes no METAL_PATH aborts the
+// build instead of scanning possibly-stale mlx-sys-* dirs, and a min-OS stamp
+// that cannot be parsed aborts instead of skipping the deployment-floor check.
+// Local `yarn build:native` leaves it unset and keeps the lenient
+// warn-and-continue behavior so a CPU-only / exotic dev build still works.
+function metallibStrictMode(): boolean {
+  const v = process.env.MLX_METALLIB_STRICT;
+  return v === '1' || v === 'true';
+}
+
 // The intended min-OS load floor for the artifacts we ship: an explicit
 // MACOSX_DEPLOYMENT_TARGET (what build.rs forwards to the MLX cmake build and
 // the paged-attn metal link), else the build host's macOS version (MLX's
@@ -169,12 +181,14 @@ async function copyMetallibs(outputs: Awaited<typeof task>) {
   });
   const triple = buildOptions.target ?? process.env.CARGO_BUILD_TARGET ?? hostAppleTriple();
   const profile = profileDirName(buildOptions);
+  const strict = metallibStrictMode();
   const picked = selectMetallib({
     addonBinary: await readFile(nodeOutput.path),
     addonPath: nodeOutput.path,
     targetRoot,
     triple,
     profile,
+    strict,
     warn: (msg) => console.warn(msg),
   });
   console.log(
@@ -191,7 +205,12 @@ async function copyMetallibs(outputs: Awaited<typeof task>) {
   const metallib = await readFile(picked.metallibPath);
   assertMetallibIntegrity(metallib, { path: picked.metallibPath, expectNax: detectExpectNax() });
   if (deploymentFloor !== undefined) {
-    assertMetallibFloor(metallib, { path: picked.metallibPath, deploymentFloor, warn: (msg) => console.warn(msg) });
+    assertMetallibFloor(metallib, {
+      path: picked.metallibPath,
+      deploymentFloor,
+      strict,
+      warn: (msg) => console.warn(msg),
+    });
   }
 
   for (const dest of destDirs) {
@@ -211,7 +230,12 @@ async function copyMetallibs(outputs: Awaited<typeof task>) {
   });
   assertPagedMetallibIntegrity(paged.contents, { path: paged.path });
   if (deploymentFloor !== undefined) {
-    assertMetallibFloor(paged.contents, { path: paged.path, deploymentFloor, warn: (msg) => console.warn(msg) });
+    assertMetallibFloor(paged.contents, {
+      path: paged.path,
+      deploymentFloor,
+      strict,
+      warn: (msg) => console.warn(msg),
+    });
   }
   for (const dest of destDirs) {
     const dst = join(dest, 'paged_attn.metallib');

--- a/packages/core/metallib-select.ts
+++ b/packages/core/metallib-select.ts
@@ -49,6 +49,15 @@ export interface MetallibCandidate {
 /** Smallest healthy mlx.metallib observed is ~154 MB; anything far below is truncated. */
 export const MIN_METALLIB_BYTES = 100 * 1024 * 1024;
 
+/**
+ * Every healthy paged_attn.metallib observed to date (8 samples across
+ * debug/release profiles and old/new MLX pins) is exactly 19,490,342 bytes
+ * (~19.5 MB) — the kernel set is ours (crates/mlx-paged-attn) and stable.
+ * A 4 MiB floor keeps generous headroom for future kernel trimming while
+ * still catching a truncated or interrupted write.
+ */
+export const MIN_PAGED_METALLIB_BYTES = 4 * 1024 * 1024;
+
 /** Kernel names present in every healthy mlx.metallib from the vendored MLX. */
 export const BASE_KERNEL_MARKERS = ['steel_attention', 'sdpa_vector'] as const;
 
@@ -262,6 +271,89 @@ export function selectMetallib(opts: {
     );
   }
   return { outDir: dirname(picked.libDir), libDir: picked.libDir, metallibPath: picked.metallibPath, source: 'scan' };
+}
+
+export interface SelectedPagedMetallib {
+  path: string;
+  contents: Buffer;
+}
+
+function readIfExists(path: string): Buffer | undefined {
+  try {
+    return readFileSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve paged_attn.metallib inside the selected mlx-sys build dir, under
+ * the same contract as the mlx.metallib binding: build.rs writes the origin
+ * to the OUT_DIR root and copies it into `out/lib`, so when BOTH exist they
+ * must be byte-identical (a mismatch means one of them is stale or
+ * truncated — fail loudly, never silently prefer either); a single
+ * surviving copy ships with a warning; neither existing throws.
+ */
+export function selectPagedMetallib(opts: {
+  outDir: string;
+  libDir: string;
+  warn?: (msg: string) => void;
+}): SelectedPagedMetallib {
+  const warn = opts.warn ?? (() => {});
+  const originPath = join(opts.outDir, 'paged_attn.metallib');
+  const installCopyPath = join(opts.libDir, 'paged_attn.metallib');
+  const origin = readIfExists(originPath);
+  const installCopy = readIfExists(installCopyPath);
+  if (origin === undefined && installCopy === undefined) {
+    throw new Error(
+      `paged_attn.metallib not found at ${originPath} nor at ${installCopyPath}. The paged-attention ` +
+        `compile path (mlx_paged_dispatch.cpp) loads this metallib via dladdr ` +
+        `at runtime; without it, the addon throws on first paged-attention use. ` +
+        `Check that mlx-sys/build.rs ran compile_paged_attn_metallib successfully.`,
+    );
+  }
+  if (origin !== undefined && installCopy !== undefined) {
+    if (!origin.equals(installCopy)) {
+      throw new Error(
+        `[build.ts metallib gate] ${originPath} (the file build.rs produced) and its install copy ` +
+          `${installCopyPath} are not byte-identical — one of them is stale or truncated. Re-run ` +
+          `the native build; if it persists, remove ${opts.outDir} to force a clean build.`,
+      );
+    }
+    return { path: originPath, contents: origin };
+  }
+  if (origin !== undefined) {
+    warn(`${installCopyPath} is missing; shipping the build.rs origin ${originPath} directly.`);
+    return { path: originPath, contents: origin };
+  }
+  warn(`${originPath} is missing; shipping its install copy ${installCopyPath} from the same build dir.`);
+  return { path: installCopyPath, contents: installCopy! };
+}
+
+/**
+ * Hard gate before paged_attn.metallib is copied anywhere, mirroring
+ * `assertMetallibIntegrity`: a truncated file or a non-metallib container
+ * must fail the build loudly. There is no kernel-name inventory here — the
+ * paged-attn kernel set is small and ours — so the gate is the size floor
+ * plus the MTLB container magic.
+ */
+export function assertPagedMetallibIntegrity(metallib: Buffer, opts: { path: string; minBytes?: number }): void {
+  const minBytes = opts.minBytes ?? MIN_PAGED_METALLIB_BYTES;
+  if (metallib.byteLength < minBytes) {
+    throw new Error(
+      `[build.ts metallib gate] ${opts.path} is ${metallib.byteLength} bytes, below the ` +
+        `${minBytes}-byte floor of a healthy paged_attn.metallib (every observed healthy ` +
+        `build is ~19.5 MB) — the file is truncated or the build was interrupted. Re-run ` +
+        `the native build; if it persists, remove the containing mlx-sys-*/out dir.`,
+    );
+  }
+  if (metallib.toString('latin1', 0, 4) !== 'MTLB') {
+    throw new Error(
+      `[build.ts metallib gate] ${opts.path} does not start with the MTLB container magic — ` +
+        `this is not a Metal library. Re-run the native build; if it persists, remove the ` +
+        `containing mlx-sys-*/out dir.`,
+    );
+  }
 }
 
 export function profileDirName(opts: { profile?: string | undefined; release?: boolean | undefined }): string {

--- a/packages/core/metallib-select.ts
+++ b/packages/core/metallib-select.ts
@@ -14,10 +14,11 @@
 //      (`mlx/backend/metal/device.cpp` `default_mtllib_path`). That string
 //      names the exact `mlx-sys-<hash>/out` dir the addon linked against, so
 //      `extractBakedMetallibBinding` reads it out of the freshly built .node
-//      and the copy step ships `<that out dir>/lib/mlx.metallib` — no
-//      heuristics, immune to newer same-pin dirs left by other cargo
-//      invocations (different feature unification, clippy/test builds,
-//      rust-cache restores) that a recency ranking could wrongly prefer.
+//      and the copy step ships that exact file (with its `out/lib` install
+//      copy required to be byte-identical when both exist) — no heuristics,
+//      immune to newer same-pin dirs left by other cargo invocations
+//      (different feature unification, clippy/test builds, rust-cache
+//      restores) that a recency ranking could wrongly prefer.
 //   2. Heuristic fallback (only when no METAL_PATH is baked, e.g. a
 //      Metal-less addon): scan the tree the napi build used —
 //      `<targetRoot>/<triple>/<profile>/build` (napi always passes
@@ -33,8 +34,8 @@
 //
 // Stale dirs are deliberately NOT deleted: they are live cargo cache for
 // other toolchains/branches, and deleting them forces a full MLX rebuild.
-import { readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, normalize } from 'node:path';
 
 export interface MetallibCandidate {
   /** `.../mlx-sys-<hash>/out/lib` — also holds paged_attn.metallib. */
@@ -85,14 +86,18 @@ export function resolveTargetRoot(opts: {
 
 /** The exact mlx-sys build a native addon linked against, read from the addon itself. */
 export interface MetallibBinding {
-  /** The METAL_PATH string baked into the binary (cmake kernels build-tree path). */
+  /**
+   * The METAL_PATH the addon references at runtime (cmake kernels build-tree
+   * file, path normalized). This is the origin file; `installCopyPath` is a
+   * cmake-install duplicate of it.
+   */
   bakedPath: string;
   /** `.../mlx-sys-<hash>/out` — OUT_DIR of the bound mlx-sys build. */
   outDir: string;
-  /** `.../out/lib` — install dir holding mlx.metallib + paged_attn.metallib. */
+  /** `.../out/lib` — install dir holding copies of both metallibs. */
   libDir: string;
-  /** `.../out/lib/mlx.metallib`. */
-  metallibPath: string;
+  /** `.../out/lib/mlx.metallib` — cmake-install copy of `bakedPath`. */
+  installCopyPath: string;
 }
 
 /**
@@ -131,7 +136,13 @@ export function extractBakedMetallibBinding(addonBinary: Buffer): MetallibBindin
     if (match) {
       const outDir = match[1]!;
       const libDir = join(outDir, 'lib');
-      bindings.set(candidate, { bakedPath: candidate, outDir, libDir, metallibPath: join(libDir, 'mlx.metallib') });
+      bindings.set(candidate, {
+        // normalize() collapses the `kernels//mlx.metallib` double slash
+        bakedPath: normalize(candidate),
+        outDir,
+        libDir,
+        installCopyPath: join(libDir, 'mlx.metallib'),
+      });
     }
     at = addonBinary.indexOf(needle, at + needle.length);
   }
@@ -147,19 +158,32 @@ export function extractBakedMetallibBinding(addonBinary: Buffer): MetallibBindin
 }
 
 export interface SelectedMetallib {
+  /** `.../mlx-sys-<hash>/out` of the selected build. */
+  outDir: string;
   libDir: string;
   metallibPath: string;
   /** 'baked' = authoritative binding from the addon binary; 'scan' = heuristic fallback. */
   source: 'baked' | 'scan';
 }
 
+function statSize(path: string): number | undefined {
+  try {
+    return statSync(path).size;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Pick the metallib to ship with a freshly built addon. The baked METAL_PATH
- * inside the addon is authoritative; the mtime-ranked directory scan runs
- * only when the addon carries no baked path at all. When the baked dir has
- * lost its metallib this throws instead of falling back — shipping a
- * different build's metallib is exactly the pairing hazard this exists to
- * prevent.
+ * inside the addon is authoritative: ship exactly the file the addon
+ * references. Its `out/lib` cmake-install copy is accepted only when the
+ * baked file is gone (e.g. a pruned build tree) — and when BOTH exist they
+ * must be byte-identical, otherwise the install copy is stale and the build
+ * fails loudly. The mtime-ranked directory scan runs only when the addon
+ * carries no baked path at all; a bound build with no metallib left throws
+ * instead of falling back — shipping a different build's metallib is exactly
+ * the pairing hazard this exists to prevent.
  */
 export function selectMetallib(opts: {
   addonBinary: Buffer;
@@ -172,17 +196,47 @@ export function selectMetallib(opts: {
   const warn = opts.warn ?? (() => {});
   const binding = extractBakedMetallibBinding(opts.addonBinary);
   if (binding) {
-    try {
-      statSync(binding.metallibPath);
-    } catch {
+    const bakedSize = statSize(binding.bakedPath);
+    const installSize = statSize(binding.installCopyPath);
+    if (bakedSize === undefined && installSize === undefined) {
       throw new Error(
         `[build.ts metallib gate] ${opts.addonPath} was linked against the mlx-sys build at ` +
-          `${binding.outDir} (baked METAL_PATH: ${binding.bakedPath}), but ${binding.metallibPath} ` +
-          `does not exist. That build dir was deleted or moved after linking; re-run the native ` +
-          `build so the addon and metallib come out of the same mlx-sys build.`,
+          `${binding.outDir} (baked METAL_PATH: ${binding.bakedPath}), but neither that file nor ` +
+          `its install copy ${binding.installCopyPath} exists. That build dir was deleted or ` +
+          `moved after linking; re-run the native build so the addon and metallib come out of ` +
+          `the same mlx-sys build.`,
       );
     }
-    return { libDir: binding.libDir, metallibPath: binding.metallibPath, source: 'baked' };
+    const selected = (metallibPath: string): SelectedMetallib => ({
+      outDir: binding.outDir,
+      libDir: binding.libDir,
+      metallibPath,
+      source: 'baked',
+    });
+    if (bakedSize !== undefined && installSize !== undefined) {
+      const identical =
+        bakedSize === installSize && readFileSync(binding.bakedPath).equals(readFileSync(binding.installCopyPath));
+      if (!identical) {
+        throw new Error(
+          `[build.ts metallib gate] ${binding.bakedPath} (the file the addon references) and its ` +
+            `install copy ${binding.installCopyPath} are not byte-identical — the install copy is ` +
+            `stale or partially restored. Re-run the native build; if it persists, remove ` +
+            `${binding.outDir} to force a clean MLX kernel build.`,
+        );
+      }
+      return selected(binding.bakedPath);
+    }
+    if (bakedSize !== undefined) {
+      warn(
+        `${binding.installCopyPath} is missing; shipping the baked build-tree file ` + `${binding.bakedPath} directly.`,
+      );
+      return selected(binding.bakedPath);
+    }
+    warn(
+      `${binding.bakedPath} is missing (build tree pruned?); shipping its cmake-install copy ` +
+        `${binding.installCopyPath} from the same bound build dir.`,
+    );
+    return selected(binding.installCopyPath);
   }
   warn(
     `No baked METAL_PATH found in ${opts.addonPath}; falling back to scanning ` +
@@ -207,7 +261,7 @@ export function selectMetallib(opts: {
           .join('\n'),
     );
   }
-  return { libDir: picked.libDir, metallibPath: picked.metallibPath, source: 'scan' };
+  return { outDir: dirname(picked.libDir), libDir: picked.libDir, metallibPath: picked.metallibPath, source: 'scan' };
 }
 
 export function profileDirName(opts: { profile?: string | undefined; release?: boolean | undefined }): string {
@@ -337,17 +391,29 @@ export function assertMetallibIntegrity(
 }
 
 /**
- * Read the min-OS stamp from a metallib's MTLB container header: magic
- * `MTLB` at offset 0, min-OS major as u16 LE at offset 12, minor at 14.
- * Verified against `xcrun metal -mmacosx-version-min=15.0/26.0/26.2` output
- * (`0f00 0000` / `1a00 0000` / `1a00 0200`) and cross-checked with
- * `xcrun air-vtool -show` on the shipped artifacts. Returns undefined when
- * the header does not look like this layout — the floor gate is
- * best-effort and must not fail on a future container revision.
+ * Read the min-OS stamp from a metallib's MTLB container header. The floor
+ * gate only ENFORCES on a fully recognized layout; any deviation returns
+ * undefined so a future container revision degrades to a warn+skip, never a
+ * hard failure on a good build. Recognized layout — every field validated
+ * against `xcrun metal -mmacosx-version-min=15.0/26.0/26.2` scratch builds
+ * plus the shipped artifacts (min-OS cross-checked with
+ * `xcrun air-vtool -show`):
+ *
+ *   offset  0: magic `MTLB`
+ *   offset  4: u16 LE platform tag, 0x8001 on all macOS outputs
+ *   offset  6: u16 LE container version major, 2 (minor at 8 varies with
+ *              the tools — 8 for a 15.0 target, 9 for 26.x — not pinned)
+ *   offset 10: u8 library type, 0x00 (executable)
+ *   offset 11: u8 target-OS tag, 0x81 (macOS)
+ *   offset 12: u16 LE min-OS major, offset 14: u16 LE min-OS minor
+ *              (`0f00 0000` / `1a00 0000` / `1a00 0200` for 15.0/26.0/26.2)
  */
 export function parseMetallibMinOs(metallib: Buffer): string | undefined {
   if (metallib.byteLength < 16) return undefined;
   if (metallib.toString('latin1', 0, 4) !== 'MTLB') return undefined;
+  if (metallib.readUInt16LE(4) !== 0x8001) return undefined;
+  if (metallib.readUInt16LE(6) !== 2) return undefined;
+  if (metallib[10] !== 0x00 || metallib[11] !== 0x81) return undefined;
   const major = metallib.readUInt16LE(12);
   const minor = metallib.readUInt16LE(14);
   // macOS majors run 10 (Yosemite era) through the year-based 26+; anything
@@ -360,12 +426,21 @@ export function parseMetallibMinOs(metallib: Buffer): string | undefined {
  * Deployment-floor gate: a metallib whose container min-OS stamp is ABOVE
  * the intended floor refuses to load on floor machines, and the kernel-name
  * inventory cannot tell floors apart. A stamp below the floor is harmless
- * (it loads on the floor and older). Skips silently when the header cannot
- * be parsed.
+ * (it loads on the floor and older). Warns and skips when the header layout
+ * is not recognized — this gate is best-effort by design.
  */
-export function assertMetallibFloor(metallib: Buffer, opts: { path: string; deploymentFloor: string }): void {
+export function assertMetallibFloor(
+  metallib: Buffer,
+  opts: { path: string; deploymentFloor: string; warn?: (msg: string) => void },
+): void {
   const stamped = parseMetallibMinOs(metallib);
-  if (stamped === undefined) return;
+  if (stamped === undefined) {
+    opts.warn?.(
+      `[build.ts metallib gate] ${opts.path}: unrecognized MTLB header layout; ` +
+        `skipping the deployment-floor check (min-OS stamp not verifiable).`,
+    );
+    return;
+  }
   if (compareVersions(stamped, opts.deploymentFloor) > 0) {
     throw new Error(
       `[build.ts metallib gate] ${opts.path} stamps min-OS ${stamped}, above the intended ` +

--- a/packages/core/metallib-select.ts
+++ b/packages/core/metallib-select.ts
@@ -67,11 +67,20 @@ export function compareVersions(a: string, b: string): number {
 }
 
 /**
- * Mirror of the NAX condition in MLX's
- * `mlx/backend/metal/kernels/CMakeLists.txt`: NAX kernels are compiled iff
- * the macOS SDK is >= 26.2 AND the effective `CMAKE_OSX_DEPLOYMENT_TARGET`
- * is >= 26.2, where the deployment target defaults to the build host's
- * macOS version when `MACOSX_DEPLOYMENT_TARGET` is not set.
+ * Mirror of the NAX condition in the vendored MLX's
+ * `mlx/backend/metal/kernels/CMakeLists.txt` as configured by
+ * `crates/mlx-sys/build.rs`. mlx-sys always passes `-DMLX_METAL_FORCE_NAX=ON`
+ * (fork branch `nax-macos-26-0-floor`), which drops upstream's
+ * deployment-target >= 26.2 clause, so NAX kernels are compiled iff the macOS
+ * SDK is >= 26.2 AND the effective `CMAKE_OSX_DEPLOYMENT_TARGET` is >= 26.0
+ * (below 26.0 the Metal language version falls under MSL 4.0 and the gate's
+ * `MLX_METAL_VERSION GREATER_EQUAL 400` clause fails). The deployment target
+ * defaults to the build host's macOS version when `MACOSX_DEPLOYMENT_TARGET`
+ * is not set. The force-built NAX kernels internally compile against the
+ * macOS 26.2 tensor-ops ABI while the metallib links (and load-gates) at the
+ * floor; runtime dispatch still requires macOS 26.2 — kernel presence and
+ * dispatch are deliberately decoupled so one 26.0-floor artifact serves
+ * every macOS 26 host.
  */
 export function shouldExpectNaxKernels(
   sdkVersion: string,
@@ -79,7 +88,7 @@ export function shouldExpectNaxKernels(
   deploymentTargetEnv: string | undefined,
 ): boolean {
   const effectiveTarget = deploymentTargetEnv && deploymentTargetEnv !== '' ? deploymentTargetEnv : hostVersion;
-  return compareVersions(sdkVersion, '26.2') >= 0 && compareVersions(effectiveTarget, '26.2') >= 0;
+  return compareVersions(sdkVersion, '26.2') >= 0 && compareVersions(effectiveTarget, '26.0') >= 0;
 }
 
 /**

--- a/packages/core/metallib-select.ts
+++ b/packages/core/metallib-select.ts
@@ -175,11 +175,23 @@ export interface SelectedMetallib {
   source: 'baked' | 'scan';
 }
 
+/**
+ * Only ENOENT/ENOTDIR mean "the artifact is not there". Anything else
+ * (EACCES, EPERM, EISDIR, EIO, ...) means the artifact may well exist but
+ * cannot be inspected — treating that as absence would silently skip the
+ * byte-identity comparison and ship the other copy unverified.
+ */
+function isAbsenceError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | null)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
 function statSize(path: string): number | undefined {
   try {
     return statSync(path).size;
-  } catch {
-    return undefined;
+  } catch (err) {
+    if (isAbsenceError(err)) return undefined;
+    throw new Error(`[build.ts metallib gate] cannot stat ${path}: ${(err as Error).message}`);
   }
 }
 
@@ -281,8 +293,9 @@ export interface SelectedPagedMetallib {
 function readIfExists(path: string): Buffer | undefined {
   try {
     return readFileSync(path);
-  } catch {
-    return undefined;
+  } catch (err) {
+    if (isAbsenceError(err)) return undefined;
+    throw new Error(`[build.ts metallib gate] cannot read ${path}: ${(err as Error).message}`);
   }
 }
 

--- a/packages/core/metallib-select.ts
+++ b/packages/core/metallib-select.ts
@@ -34,7 +34,7 @@
 //
 // Stale dirs are deliberately NOT deleted: they are live cargo cache for
 // other toolchains/branches, and deleting them forces a full MLX rebuild.
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync, type Stats } from 'node:fs';
 import { dirname, join, normalize } from 'node:path';
 
 export interface MetallibCandidate {
@@ -179,20 +179,26 @@ export interface SelectedMetallib {
  * Only ENOENT/ENOTDIR mean "the artifact is not there". Anything else
  * (EACCES, EPERM, EISDIR, EIO, ...) means the artifact may well exist but
  * cannot be inspected — treating that as absence would silently skip the
- * byte-identity comparison and ship the other copy unverified.
+ * byte-identity comparison (or, in the fallback scan, skip the current
+ * candidate and select an older one). Every fs probe in this module routes
+ * through this policy: absence continues, everything else fails loudly.
  */
 function isAbsenceError(err: unknown): boolean {
   const code = (err as NodeJS.ErrnoException | null)?.code;
   return code === 'ENOENT' || code === 'ENOTDIR';
 }
 
-function statSize(path: string): number | undefined {
+function statIfExists(path: string): Stats | undefined {
   try {
-    return statSync(path).size;
+    return statSync(path);
   } catch (err) {
     if (isAbsenceError(err)) return undefined;
     throw new Error(`[build.ts metallib gate] cannot stat ${path}: ${(err as Error).message}`);
   }
+}
+
+function statSize(path: string): number | undefined {
+  return statIfExists(path)?.size;
 }
 
 /**
@@ -422,8 +428,12 @@ export function collectMetallibCandidates(targetRoot: string, triple: string, pr
     let entries: string[];
     try {
       entries = readdirSync(buildRoot);
-    } catch {
-      continue;
+    } catch (err) {
+      // A missing tree just means the build used the other layout; anything
+      // else (EACCES, ...) would silently hide the current candidates and
+      // let an older readable one win — fail loudly instead.
+      if (isAbsenceError(err)) continue;
+      throw new Error(`[build.ts metallib gate] cannot list ${buildRoot}: ${(err as Error).message}`);
     }
     const candidates: MetallibCandidate[] = [];
     for (const dir of entries) {
@@ -431,20 +441,19 @@ export function collectMetallibCandidates(targetRoot: string, triple: string, pr
       const scriptDir = join(buildRoot, dir);
       const libDir = join(scriptDir, 'out', 'lib');
       const metallibPath = join(libDir, 'mlx.metallib');
-      let metallibStat;
-      try {
-        metallibStat = statSync(metallibPath);
-      } catch {
-        continue;
-      }
+      // Dirs without a metallib are skipped; an uninspectable one throws
+      // (via statIfExists) rather than being mistaken for absent.
+      const metallibStat = statIfExists(metallibPath);
+      if (metallibStat === undefined) continue;
       // `invoked.timestamp` is rewritten when cargo (re)runs the build
       // script; the metallib/`output` mtimes cover reused cached outputs.
       let rankMtimeMs = metallibStat.mtimeMs;
       for (const probe of ['invoked.timestamp', 'output']) {
-        try {
-          rankMtimeMs = Math.max(rankMtimeMs, statSync(join(scriptDir, probe)).mtimeMs);
-        } catch {
-          // probe file absent — fall back to the mtimes we have
+        // Probe files are optional; when absent the mtimes we have rank the
+        // dir. Unreadable probes throw — they would corrupt the ranking.
+        const probeStat = statIfExists(join(scriptDir, probe));
+        if (probeStat !== undefined) {
+          rankMtimeMs = Math.max(rankMtimeMs, probeStat.mtimeMs);
         }
       }
       candidates.push({ libDir, metallibPath, size: metallibStat.size, rankMtimeMs });

--- a/packages/core/metallib-select.ts
+++ b/packages/core/metallib-select.ts
@@ -1,0 +1,168 @@
+// Deterministic selection of the mlx.metallib produced by the mlx-sys build
+// that the just-built native addon actually linked against.
+//
+// Background: cargo keeps one `mlx-sys-<hash>/out` dir per (target, profile,
+// compiler-metadata) fingerprint, and stale hash dirs from earlier toolchains
+// or earlier MLX submodule pins survive next to the current one (locally and
+// in CI-restored cargo caches). A naive "first directory that contains
+// mlx.metallib" scan can therefore pair a stale metallib with a fresh .node —
+// the kernels then mismatch the compiled C++ and inference produces garbage
+// without any error. Selection here is bound to the build that just ran:
+//
+//   1. Only the tree the napi build used is scanned:
+//      `<targetRoot>/<triple>/<profile>/build` (napi always passes
+//      `--target`); the plain `<targetRoot>/<profile>/build` layout is a
+//      fallback for napi-less flows, never mixed with the primary tree.
+//   2. Among candidate `mlx-sys-*` dirs, the one cargo touched most recently
+//      wins (`invoked.timestamp` / build-script `output` / metallib mtime).
+//   3. The chosen metallib must pass a content gate (minimum size + expected
+//      kernel names, including the current pin's NAX kernels on hosts where
+//      MLX builds them) or the build fails loudly instead of shipping it.
+//
+// Stale dirs are deliberately NOT deleted: they are live cargo cache for
+// other toolchains/branches, and deleting them forces a full MLX rebuild.
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface MetallibCandidate {
+  /** `.../mlx-sys-<hash>/out/lib` — also holds paged_attn.metallib. */
+  libDir: string;
+  metallibPath: string;
+  size: number;
+  /** Newest cargo activity observed for this build-script dir (ms). */
+  rankMtimeMs: number;
+}
+
+/** Smallest healthy mlx.metallib observed is ~154 MB; anything far below is truncated. */
+export const MIN_METALLIB_BYTES = 100 * 1024 * 1024;
+
+/** Kernel names present in every healthy mlx.metallib from the vendored MLX. */
+export const BASE_KERNEL_MARKERS = ['steel_attention', 'sdpa_vector'] as const;
+
+/**
+ * Kernel names introduced by the current MLX pin (e9463bbf): the NAX gen-17
+ * family. Absent from the previous pin (a8776b7b), so their absence on a
+ * NAX-building host means a stale metallib was selected.
+ */
+export const NAX_KERNEL_MARKERS = ['affine_qmv_wide', 'steel_gemm_segmented_nax'] as const;
+
+export function hostAppleTriple(arch: string = process.arch): string {
+  return arch === 'arm64' ? 'aarch64-apple-darwin' : 'x86_64-apple-darwin';
+}
+
+export function profileDirName(opts: { profile?: string | undefined; release?: boolean | undefined }): string {
+  return opts.profile ?? (opts.release ? 'release' : 'debug');
+}
+
+/** Numeric dotted-version compare: negative if a < b, 0 if equal, positive if a > b. */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map((p) => Number.parseInt(p, 10) || 0);
+  const pb = b.split('.').map((p) => Number.parseInt(p, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Mirror of the NAX condition in MLX's
+ * `mlx/backend/metal/kernels/CMakeLists.txt`: NAX kernels are compiled iff
+ * the macOS SDK is >= 26.2 AND the effective `CMAKE_OSX_DEPLOYMENT_TARGET`
+ * is >= 26.2, where the deployment target defaults to the build host's
+ * macOS version when `MACOSX_DEPLOYMENT_TARGET` is not set.
+ */
+export function shouldExpectNaxKernels(
+  sdkVersion: string,
+  hostVersion: string,
+  deploymentTargetEnv: string | undefined,
+): boolean {
+  const effectiveTarget = deploymentTargetEnv && deploymentTargetEnv !== '' ? deploymentTargetEnv : hostVersion;
+  return compareVersions(sdkVersion, '26.2') >= 0 && compareVersions(effectiveTarget, '26.2') >= 0;
+}
+
+/**
+ * Enumerate mlx-sys metallib output dirs for the build that just ran,
+ * newest cargo activity first. The `<triple>` tree is authoritative (napi
+ * always builds with `--target`); the plain `<profile>` tree is only used
+ * when the triple tree has no candidates at all.
+ */
+export function collectMetallibCandidates(targetRoot: string, triple: string, profile: string): MetallibCandidate[] {
+  const roots = [join(targetRoot, triple, profile, 'build'), join(targetRoot, profile, 'build')];
+  for (const buildRoot of roots) {
+    let entries: string[];
+    try {
+      entries = readdirSync(buildRoot);
+    } catch {
+      continue;
+    }
+    const candidates: MetallibCandidate[] = [];
+    for (const dir of entries) {
+      if (!dir.startsWith('mlx-sys-')) continue;
+      const scriptDir = join(buildRoot, dir);
+      const libDir = join(scriptDir, 'out', 'lib');
+      const metallibPath = join(libDir, 'mlx.metallib');
+      let metallibStat;
+      try {
+        metallibStat = statSync(metallibPath);
+      } catch {
+        continue;
+      }
+      // `invoked.timestamp` is rewritten when cargo (re)runs the build
+      // script; the metallib/`output` mtimes cover reused cached outputs.
+      let rankMtimeMs = metallibStat.mtimeMs;
+      for (const probe of ['invoked.timestamp', 'output']) {
+        try {
+          rankMtimeMs = Math.max(rankMtimeMs, statSync(join(scriptDir, probe)).mtimeMs);
+        } catch {
+          // probe file absent — fall back to the mtimes we have
+        }
+      }
+      candidates.push({ libDir, metallibPath, size: metallibStat.size, rankMtimeMs });
+    }
+    if (candidates.length > 0) {
+      return candidates.sort((a, b) => b.rankMtimeMs - a.rankMtimeMs);
+    }
+  }
+  return [];
+}
+
+/**
+ * Hard gate before the metallib is copied anywhere: a truncated file or a
+ * stale-pin kernel inventory must fail the build loudly, not ship to npm.
+ */
+export function assertMetallibIntegrity(
+  metallib: Buffer,
+  opts: { path: string; expectNax: boolean; minBytes?: number },
+): void {
+  const minBytes = opts.minBytes ?? MIN_METALLIB_BYTES;
+  if (metallib.byteLength < minBytes) {
+    throw new Error(
+      `[build.ts metallib gate] ${opts.path} is ${metallib.byteLength} bytes, below the ` +
+        `${minBytes}-byte floor of a healthy mlx.metallib — the file is truncated or the ` +
+        `build was interrupted. Re-run the native build; if it persists, remove the ` +
+        `containing mlx-sys-*/out dir to force a clean MLX kernel build.`,
+    );
+  }
+  const missing = (markers: readonly string[]) => markers.filter((name) => !metallib.includes(name));
+  const missingBase = missing(BASE_KERNEL_MARKERS);
+  if (missingBase.length > 0) {
+    throw new Error(
+      `[build.ts metallib gate] ${opts.path} is missing expected kernel(s) ${missingBase.join(', ')} — ` +
+        `this is not a healthy MLX kernel library for the vendored pin.`,
+    );
+  }
+  if (opts.expectNax) {
+    const missingNax = missing(NAX_KERNEL_MARKERS);
+    if (missingNax.length > 0) {
+      throw new Error(
+        `[build.ts metallib gate] ${opts.path} is missing NAX kernel(s) ${missingNax.join(', ')} ` +
+          `although this host builds them (SDK and deployment target >= 26.2). The metallib is ` +
+          `stale — most likely from an out-of-date mlx-sys-*/out dir of a previous MLX pin. ` +
+          `Re-run the native build; if it persists, remove the stale mlx-sys-* dirs under ` +
+          `target/*/release/build/.`,
+      );
+    }
+  }
+}

--- a/packages/core/metallib-select.ts
+++ b/packages/core/metallib-select.ts
@@ -218,6 +218,15 @@ export function selectMetallib(opts: {
   targetRoot: string;
   triple: string;
   profile: string;
+  /**
+   * Publish/release mode (set from `MLX_METALLIB_STRICT` in CI). A
+   * Metal-enabled darwin addon always bakes its METAL_PATH, so a missing
+   * binding on a publish build means Metal was disabled or the addon is
+   * broken — fail closed instead of scanning possibly-stale mlx-sys-* dirs
+   * for a metallib that may not be this addon's kernels. Local dev leaves it
+   * off and keeps the lenient scan.
+   */
+  strict?: boolean;
   warn?: (msg: string) => void;
 }): SelectedMetallib {
   const warn = opts.warn ?? (() => {});
@@ -264,6 +273,17 @@ export function selectMetallib(opts: {
         `${binding.installCopyPath} from the same bound build dir.`,
     );
     return selected(binding.installCopyPath);
+  }
+  if (opts.strict) {
+    throw new Error(
+      `[build.ts metallib gate] no baked METAL_PATH in ${opts.addonPath} while MLX_METALLIB_STRICT ` +
+        `is set (publish/release build). A Metal-enabled darwin addon always bakes the METAL_PATH ` +
+        `of the mlx-sys build it linked against; its absence means Metal was disabled for this ` +
+        `build (MLX_DISABLE_METAL) or the addon is broken. Refusing to scan stale mlx-sys-* dirs — ` +
+        `a same-pin metallib from an unrelated build passes the size/marker gates yet may not be ` +
+        `the kernels this addon links. Build with Metal enabled (never set MLX_DISABLE_METAL for a ` +
+        `published artifact), or skip metallib packaging for a CPU-only build.`,
+    );
   }
   warn(
     `No baked METAL_PATH found in ${opts.addonPath}; falling back to scanning ` +
@@ -540,15 +560,27 @@ export function parseMetallibMinOs(metallib: Buffer): string | undefined {
  * Deployment-floor gate: a metallib whose container min-OS stamp is ABOVE
  * the intended floor refuses to load on floor machines, and the kernel-name
  * inventory cannot tell floors apart. A stamp below the floor is harmless
- * (it loads on the floor and older). Warns and skips when the header layout
- * is not recognized — this gate is best-effort by design.
+ * (it loads on the floor and older). When the header layout is not
+ * recognized the gate is best-effort: local dev warns and skips, but a
+ * publish/release build (`strict`, from `MLX_METALLIB_STRICT`) fails closed —
+ * shipping a metallib whose floor cannot be verified could publish a package
+ * that fails to load on the floor OS.
  */
 export function assertMetallibFloor(
   metallib: Buffer,
-  opts: { path: string; deploymentFloor: string; warn?: (msg: string) => void },
+  opts: { path: string; deploymentFloor: string; strict?: boolean; warn?: (msg: string) => void },
 ): void {
   const stamped = parseMetallibMinOs(metallib);
   if (stamped === undefined) {
+    if (opts.strict) {
+      throw new Error(
+        `[build.ts metallib gate] ${opts.path}: unrecognized MTLB header layout while ` +
+          `MLX_METALLIB_STRICT is set (publish/release build) — the min-OS floor cannot be ` +
+          `verified against ${opts.deploymentFloor}, and shipping an unverifiable metallib risks ` +
+          `an artifact that fails to load on macOS ${opts.deploymentFloor}. The container header ` +
+          `format changed (new toolchain?); update parseMetallibMinOs to recognize the new layout.`,
+      );
+    }
     opts.warn?.(
       `[build.ts metallib gate] ${opts.path}: unrecognized MTLB header layout; ` +
         `skipping the deployment-floor check (min-OS stamp not verifiable).`,

--- a/packages/core/metallib-select.ts
+++ b/packages/core/metallib-select.ts
@@ -7,17 +7,29 @@
 // in CI-restored cargo caches). A naive "first directory that contains
 // mlx.metallib" scan can therefore pair a stale metallib with a fresh .node —
 // the kernels then mismatch the compiled C++ and inference produces garbage
-// without any error. Selection here is bound to the build that just ran:
+// without any error. Selection is bound to the build that just ran:
 //
-//   1. Only the tree the napi build used is scanned:
+//   1. AUTHORITATIVE binding: MLX bakes the absolute path of its cmake
+//      kernels output into the addon as the `METAL_PATH` compile definition
+//      (`mlx/backend/metal/device.cpp` `default_mtllib_path`). That string
+//      names the exact `mlx-sys-<hash>/out` dir the addon linked against, so
+//      `extractBakedMetallibBinding` reads it out of the freshly built .node
+//      and the copy step ships `<that out dir>/lib/mlx.metallib` — no
+//      heuristics, immune to newer same-pin dirs left by other cargo
+//      invocations (different feature unification, clippy/test builds,
+//      rust-cache restores) that a recency ranking could wrongly prefer.
+//   2. Heuristic fallback (only when no METAL_PATH is baked, e.g. a
+//      Metal-less addon): scan the tree the napi build used —
 //      `<targetRoot>/<triple>/<profile>/build` (napi always passes
-//      `--target`); the plain `<targetRoot>/<profile>/build` layout is a
-//      fallback for napi-less flows, never mixed with the primary tree.
-//   2. Among candidate `mlx-sys-*` dirs, the one cargo touched most recently
-//      wins (`invoked.timestamp` / build-script `output` / metallib mtime).
-//   3. The chosen metallib must pass a content gate (minimum size + expected
-//      kernel names, including the current pin's NAX kernels on hosts where
-//      MLX builds them) or the build fails loudly instead of shipping it.
+//      `--target`), with the plain `<targetRoot>/<profile>/build` layout as
+//      a napi-less fallback — and pick the `mlx-sys-*` dir cargo touched
+//      most recently (`invoked.timestamp` / build-script `output` /
+//      metallib mtime).
+//   3. Content gates run on the chosen metallib either way: minimum size +
+//      expected kernel names (including the current pin's NAX kernels on
+//      hosts where MLX builds them), plus a min-OS stamp check against the
+//      intended deployment floor. Failures abort the build loudly instead
+//      of shipping a broken pairing.
 //
 // Stale dirs are deliberately NOT deleted: they are live cargo cache for
 // other toolchains/branches, and deleting them forces a full MLX rebuild.
@@ -48,6 +60,154 @@ export const NAX_KERNEL_MARKERS = ['affine_qmv_wide', 'steel_gemm_segmented_nax'
 
 export function hostAppleTriple(arch: string = process.arch): string {
   return arch === 'arm64' ? 'aarch64-apple-darwin' : 'x86_64-apple-darwin';
+}
+
+/**
+ * Cargo target-dir resolution for the fallback scan, mirroring cargo's own
+ * precedence: `--target-dir` flag > `CARGO_TARGET_DIR` env >
+ * `CARGO_BUILD_TARGET_DIR` env (the `build.target-dir` config form) > the
+ * repo default. Empty env values behave like unset, matching cargo.
+ */
+export function resolveTargetRoot(opts: {
+  /** `--target-dir` as parsed by the napi CLI (its flag is forwarded to cargo). */
+  targetDir: string | undefined;
+  env: Record<string, string | undefined>;
+  defaultRoot: string;
+}): string {
+  const nonEmpty = (v: string | undefined): string | undefined => (v !== undefined && v !== '' ? v : undefined);
+  return (
+    nonEmpty(opts.targetDir) ??
+    nonEmpty(opts.env['CARGO_TARGET_DIR']) ??
+    nonEmpty(opts.env['CARGO_BUILD_TARGET_DIR']) ??
+    opts.defaultRoot
+  );
+}
+
+/** The exact mlx-sys build a native addon linked against, read from the addon itself. */
+export interface MetallibBinding {
+  /** The METAL_PATH string baked into the binary (cmake kernels build-tree path). */
+  bakedPath: string;
+  /** `.../mlx-sys-<hash>/out` — OUT_DIR of the bound mlx-sys build. */
+  outDir: string;
+  /** `.../out/lib` — install dir holding mlx.metallib + paged_attn.metallib. */
+  libDir: string;
+  /** `.../out/lib/mlx.metallib`. */
+  metallibPath: string;
+}
+
+/**
+ * MLX compiles `device.cpp` with `-DMETAL_PATH="<kernels build dir>/mlx.metallib"`
+ * (see `mlx/backend/metal/CMakeLists.txt`), so every Metal-enabled addon carries
+ * the absolute path of the kernels dir it linked against. The trailing
+ * `kernels//` double slash comes from CMake joining a dir that already ends in
+ * `/`; accept both forms.
+ */
+const BAKED_METAL_PATH_RE = /^(\/.+\/mlx-sys-[0-9a-f]+\/out)\/build\/mlx\/backend\/metal\/kernels\/{1,2}mlx\.metallib$/;
+
+/** Longest plausible baked path; bounds the NUL-terminated-string expansion. */
+const MAX_BAKED_PATH_BYTES = 4096;
+
+/**
+ * Extract the baked METAL_PATH from an addon binary. Returns undefined when
+ * the binary carries no baked path (Metal not built in); throws when it
+ * carries more than one distinct path — that would mean two different MLX
+ * builds were linked and no single metallib can be authoritative.
+ */
+export function extractBakedMetallibBinding(addonBinary: Buffer): MetallibBinding | undefined {
+  const needle = Buffer.from('mlx.metallib');
+  const bindings = new Map<string, MetallibBinding>();
+  let at = addonBinary.indexOf(needle);
+  while (at !== -1) {
+    // Expand the hit to its enclosing NUL-terminated C string (bounded: a
+    // hit inside non-string data must not walk megabytes backwards).
+    let start = at;
+    const startFloor = Math.max(0, at - MAX_BAKED_PATH_BYTES);
+    while (start > startFloor && addonBinary[start - 1] !== 0) start--;
+    let end = at + needle.length;
+    const endCap = Math.min(addonBinary.length, end + MAX_BAKED_PATH_BYTES);
+    while (end < endCap && addonBinary[end] !== 0) end++;
+    const candidate = addonBinary.subarray(start, end).toString('utf-8');
+    const match = BAKED_METAL_PATH_RE.exec(candidate);
+    if (match) {
+      const outDir = match[1]!;
+      const libDir = join(outDir, 'lib');
+      bindings.set(candidate, { bakedPath: candidate, outDir, libDir, metallibPath: join(libDir, 'mlx.metallib') });
+    }
+    at = addonBinary.indexOf(needle, at + needle.length);
+  }
+  if (bindings.size === 0) return undefined;
+  if (bindings.size > 1) {
+    throw new Error(
+      `[build.ts metallib gate] the addon bakes ${bindings.size} distinct METAL_PATH strings — ` +
+        `cannot bind a single metallib to it:\n` +
+        [...bindings.keys()].map((p) => `  ${p}`).join('\n'),
+    );
+  }
+  return bindings.values().next().value;
+}
+
+export interface SelectedMetallib {
+  libDir: string;
+  metallibPath: string;
+  /** 'baked' = authoritative binding from the addon binary; 'scan' = heuristic fallback. */
+  source: 'baked' | 'scan';
+}
+
+/**
+ * Pick the metallib to ship with a freshly built addon. The baked METAL_PATH
+ * inside the addon is authoritative; the mtime-ranked directory scan runs
+ * only when the addon carries no baked path at all. When the baked dir has
+ * lost its metallib this throws instead of falling back — shipping a
+ * different build's metallib is exactly the pairing hazard this exists to
+ * prevent.
+ */
+export function selectMetallib(opts: {
+  addonBinary: Buffer;
+  addonPath: string;
+  targetRoot: string;
+  triple: string;
+  profile: string;
+  warn?: (msg: string) => void;
+}): SelectedMetallib {
+  const warn = opts.warn ?? (() => {});
+  const binding = extractBakedMetallibBinding(opts.addonBinary);
+  if (binding) {
+    try {
+      statSync(binding.metallibPath);
+    } catch {
+      throw new Error(
+        `[build.ts metallib gate] ${opts.addonPath} was linked against the mlx-sys build at ` +
+          `${binding.outDir} (baked METAL_PATH: ${binding.bakedPath}), but ${binding.metallibPath} ` +
+          `does not exist. That build dir was deleted or moved after linking; re-run the native ` +
+          `build so the addon and metallib come out of the same mlx-sys build.`,
+      );
+    }
+    return { libDir: binding.libDir, metallibPath: binding.metallibPath, source: 'baked' };
+  }
+  warn(
+    `No baked METAL_PATH found in ${opts.addonPath}; falling back to scanning ` +
+      `${opts.targetRoot} for the most recent mlx-sys build.`,
+  );
+  const candidates = collectMetallibCandidates(opts.targetRoot, opts.triple, opts.profile);
+  if (candidates.length === 0) {
+    throw new Error(
+      `mlx.metallib not found under ${join(opts.targetRoot, opts.triple, opts.profile, 'build')}/mlx-sys-*/out/lib/ ` +
+        `(nor the plain ${join(opts.targetRoot, opts.profile, 'build')} layout).`,
+    );
+  }
+  const picked = candidates[0]!;
+  if (candidates.length > 1) {
+    warn(
+      `Multiple mlx-sys metallib dirs found; using the most recently built one:\n` +
+        candidates
+          .map(
+            (c, i) =>
+              `  ${i === 0 ? '->' : '  '} ${c.metallibPath} (${c.size} bytes, ${new Date(c.rankMtimeMs).toISOString()})`,
+          )
+          .join('\n'),
+    );
+  }
+  return { libDir: picked.libDir, metallibPath: picked.metallibPath, source: 'scan' };
 }
 
 export function profileDirName(opts: { profile?: string | undefined; release?: boolean | undefined }): string {
@@ -173,5 +333,46 @@ export function assertMetallibIntegrity(
           `target/*/release/build/.`,
       );
     }
+  }
+}
+
+/**
+ * Read the min-OS stamp from a metallib's MTLB container header: magic
+ * `MTLB` at offset 0, min-OS major as u16 LE at offset 12, minor at 14.
+ * Verified against `xcrun metal -mmacosx-version-min=15.0/26.0/26.2` output
+ * (`0f00 0000` / `1a00 0000` / `1a00 0200`) and cross-checked with
+ * `xcrun air-vtool -show` on the shipped artifacts. Returns undefined when
+ * the header does not look like this layout — the floor gate is
+ * best-effort and must not fail on a future container revision.
+ */
+export function parseMetallibMinOs(metallib: Buffer): string | undefined {
+  if (metallib.byteLength < 16) return undefined;
+  if (metallib.toString('latin1', 0, 4) !== 'MTLB') return undefined;
+  const major = metallib.readUInt16LE(12);
+  const minor = metallib.readUInt16LE(14);
+  // macOS majors run 10 (Yosemite era) through the year-based 26+; anything
+  // outside a generous bound means the offset no longer holds a version.
+  if (major < 10 || major > 99) return undefined;
+  return `${major}.${minor}`;
+}
+
+/**
+ * Deployment-floor gate: a metallib whose container min-OS stamp is ABOVE
+ * the intended floor refuses to load on floor machines, and the kernel-name
+ * inventory cannot tell floors apart. A stamp below the floor is harmless
+ * (it loads on the floor and older). Skips silently when the header cannot
+ * be parsed.
+ */
+export function assertMetallibFloor(metallib: Buffer, opts: { path: string; deploymentFloor: string }): void {
+  const stamped = parseMetallibMinOs(metallib);
+  if (stamped === undefined) return;
+  if (compareVersions(stamped, opts.deploymentFloor) > 0) {
+    throw new Error(
+      `[build.ts metallib gate] ${opts.path} stamps min-OS ${stamped}, above the intended ` +
+        `deployment floor ${opts.deploymentFloor} — it would fail to load on macOS ` +
+        `${opts.deploymentFloor} hosts. It was linked under a different ` +
+        `MACOSX_DEPLOYMENT_TARGET; re-run the native build with the intended floor ` +
+        `(if it persists, purge the containing mlx-sys-*/out dir).`,
+    );
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,5 +7,5 @@
     "types": ["node"]
   },
   "include": ["."],
-  "exclude": ["build.ts"]
+  "exclude": ["build.ts", "dist"]
 }

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -83,6 +83,8 @@
  * await session.reset();
  * ```
  */
+import { createHash } from 'node:crypto';
+
 import type { ChatConfig, ChatMessage, ChatResult, ToolCall, ToolCallResult, ToolDefinition } from '@mlx-node/core';
 
 import type { ChatStreamEvent } from './stream.js';
@@ -432,15 +434,15 @@ export interface ChatSessionOptions {
  * template.
  *
  * This is a byte-identity check — callers use the key solely to
- * decide whether to restart the server-side session, so a
- * non-cryptographic hash is sufficient. We use FNV-1a 64-bit with a
- * length-prefixed framing so different image counts and different
- * byte lengths cannot collide by accident.
+ * decide whether to restart the server-side session, so any
+ * collision-resistant digest is sufficient. We use SHA-256 (native
+ * `node:crypto`) with a length-prefixed framing so different image
+ * counts and different byte lengths cannot collide by accident.
  *
  * Implementation note: kept fully sync + self-contained so
- * `send()` can stay synchronous in its routing decision and so the
- * module has no external runtime dependencies beyond `@mlx-node/core`
- * and the existing stream bridge.
+ * `send()` can stay synchronous in its routing decision. `node:crypto`
+ * is a Node built-in, so this adds no external runtime dependency
+ * beyond `@mlx-node/core` and the existing stream bridge.
  */
 function computeImagesKey(images: Uint8Array[] | undefined): string | null {
   return computeByteListKey(images);
@@ -450,83 +452,41 @@ function computeImagesKey(images: Uint8Array[] | undefined): string | null {
  * Audio counterpart of {@link computeImagesKey}: a stable, order-sensitive
  * byte-identity key for a list of encoded audio buffers. Used by `send()` /
  * `sendStream()` to decide whether a new audio set must cold-restart the
- * server-side session. Shares the exact FNV-1a framing as the image key.
+ * server-side session. Shares the exact SHA-256 framing as the image key.
  */
 function computeAudioKey(audio: Uint8Array[] | undefined): string | null {
   return computeByteListKey(audio);
 }
 
 /**
- * FNV-1a 64-bit byte-identity key for a length-framed list of byte buffers.
+ * SHA-256 byte-identity key for a length-framed list of byte buffers.
  * Returns `null` for an empty/absent list so callers can distinguish
  * "no media" from "media changed". Shared by the image and audio keys.
+ *
+ * Uses `node:crypto`'s native SHA-256 rather than a hand-rolled JS hash
+ * loop: hashing large image/audio buffers byte-at-a-time in JS is
+ * 25-60x slower than the native digest (measured: 5MB ~105ms JS loop
+ * vs ~1.8ms native) and this runs synchronously on the event loop
+ * before any `await` in `send()`/`sendStream()`, so the JS loop's cost
+ * was a real head-of-line-blocking stall for every other request
+ * handled by the same process.
  */
 function computeByteListKey(buffers: Uint8Array[] | undefined): string | null {
-  const images = buffers;
-  if (!images || images.length === 0) return null;
-  // FNV-1a 64-bit. Split into two 32-bit halves because JavaScript
-  // doesn't have a native 64-bit integer type and BigInt ops are
-  // slow on large byte streams. This emulates 64-bit FNV-1a using
-  // paired 32-bit lo/hi halves — the standard JS idiom.
-  const FNV_OFFSET_LO = 0x84222325 >>> 0;
-  const FNV_OFFSET_HI = 0xcbf29ce4 >>> 0;
-  const FNV_PRIME_LO = 0x000001b3 >>> 0;
-  const FNV_PRIME_HI = 0x00000100 >>> 0;
-
-  let lo = FNV_OFFSET_LO;
-  let hi = FNV_OFFSET_HI;
-
-  function mix(byte: number): void {
-    lo = (lo ^ byte) >>> 0;
-    // Multiply (hi:lo) by (FNV_PRIME_HI:FNV_PRIME_LO) mod 2^64.
-    // Break 32-bit halves into 16-bit quarters to keep intermediate
-    // products inside the safe-integer range.
-    const loLo = lo & 0xffff;
-    const loHi = lo >>> 16;
-    const hiLo = hi & 0xffff;
-    const hiHi = hi >>> 16;
-
-    const pLo = FNV_PRIME_LO & 0xffff;
-    const pLoH = FNV_PRIME_LO >>> 16;
-    const pHi = FNV_PRIME_HI & 0xffff;
-    const pHiH = FNV_PRIME_HI >>> 16;
-
-    const r0 = loLo * pLo;
-    const r1 = loLo * pLoH + loHi * pLo;
-    const r2 = loLo * pHi + loHi * pLoH + hiLo * pLo;
-    const r3 = loLo * pHiH + loHi * pHi + hiLo * pLoH + hiHi * pLo;
-
-    const newLo0 = r0 & 0xffff;
-    const carry1 = r0 >>> 16;
-    const sum1 = r1 + carry1;
-    const newLo1 = sum1 & 0xffff;
-    const carry2 = Math.floor(sum1 / 0x10000);
-    const sum2 = r2 + carry2;
-    const newHi0 = sum2 & 0xffff;
-    const carry3 = Math.floor(sum2 / 0x10000);
-    const sum3 = r3 + carry3;
-    const newHi1 = sum3 & 0xffff;
-
-    lo = ((newLo1 << 16) | newLo0) >>> 0;
-    hi = ((newHi1 << 16) | newHi0) >>> 0;
+  if (!buffers || buffers.length === 0) return null;
+  const hash = createHash('sha256');
+  // Frame each buffer with a 4-byte little-endian length prefix (and a
+  // leading count prefix) so `[ab, c]` and `[a, bc]` — and different
+  // buffer counts — hash to distinct values.
+  const prefix = new Uint8Array(4);
+  const prefixView = new DataView(prefix.buffer);
+  prefixView.setUint32(0, buffers.length, true);
+  hash.update(prefix);
+  for (const buf of buffers) {
+    prefixView.setUint32(0, buf.byteLength, true);
+    hash.update(prefix);
+    hash.update(buf);
   }
-
-  // Frame each image with a 4-byte little-endian length prefix so
-  // `[ab, c]` and `[a, bc]` hash to distinct values.
-  mix(images.length & 0xff);
-  mix((images.length >>> 8) & 0xff);
-  mix((images.length >>> 16) & 0xff);
-  mix((images.length >>> 24) & 0xff);
-  for (const img of images) {
-    mix(img.byteLength & 0xff);
-    mix((img.byteLength >>> 8) & 0xff);
-    mix((img.byteLength >>> 16) & 0xff);
-    mix((img.byteLength >>> 24) & 0xff);
-    for (let i = 0; i < img.byteLength; i++) {
-      mix(img[i]!);
-    }
-  }
-  return hi.toString(16).padStart(8, '0') + lo.toString(16).padStart(8, '0');
+  return hash.digest('hex');
 }
 
 /**
@@ -552,7 +512,7 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
 
   /**
    * Hex-encoded byte-identity key of the image set currently bound
-   * to the server's KV cache (FNV-1a 64-bit; see `computeImagesKey`).
+   * to the server's KV cache (SHA-256; see `computeImagesKey`).
    * `null` when no images are cached. A `send()` whose new key
    * differs triggers a full `chatSessionStart` restart.
    */
@@ -1566,7 +1526,7 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
 
   /**
    * Walk the history backward to find the most recent user message
-   * with images and return its FNV-1a key. Used by
+   * with images and return its SHA-256 key. Used by
    * {@link startFromHistory} and {@link startFromHistoryStream} to
    * hydrate `lastImagesKey` after a cold replay, so subsequent delta
    * continues correctly detect image changes.
@@ -1584,7 +1544,7 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
   /**
    * Audio counterpart of {@link computeTrailingImagesKey}: walk history
    * backward to the most recent user message carrying audio and return its
-   * FNV-1a key, so a cold replay hydrates `lastAudioKey` correctly.
+   * SHA-256 key, so a cold replay hydrates `lastAudioKey` correctly.
    */
   private computeTrailingAudioKey(): string | null {
     for (let i = this.history.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## What & why

Implements the *inference perf polish + quality sweep* design spec: a correctness pass over the shared inference paths, a vendored-MLX bump that fixes broken Apple-Silicon (gen-17 / M5) kernels, and a code/comment cleanup sweep. 48 commits on top of `main` (`f65104aa`).

## Highlights

**Correctness**
- **qwen3.5 scalar RoPE axis fix** — the scalar RoPE arm fed `[B,T,H,D]` to `fast::rope`, rotating along the **head** axis instead of the **token** axis (rotation angle was constant across tokens). This is the *production* path (dense / MoE / MTP / VLM-text, flat + paged), so every qwen3.5 output changed. Fixed by transposing to `[B,H,T,D]` → rope → back, matching mlx-lm. Self-referential gates never caught it; added an absolute regression test.
- **sym8 flat-KV pins (dense + MoE)** — a sym8 checkpoint emits mixed-dtype K/V (f32 K after the f32-weight `k_norm`, bf16 V) which the block-paged pool rejects on the first write. Both loaders now pin sym8 to the validated flat path.
- gemma4-prequant `group_size` metadata honesty; qwen3.5-MoE loader `ensure_dense_weight_floating` guards so packed weights with missing sidecars fail loud.

**Vendored MLX bump** (`crates/mlx-sys/mlx`)
- Bumped to a **fork branch** `nax-macos-26-0-floor` @ `de7e3429` = upstream `ml-explore/mlx` `e9463bbfc` + one cmake patch. The old pin's NAX kernels were **broken on gen-17 / macOS ≥ 26.2** (bf16 unaligned-K GEMM, bf16 causal full-SDPA, sorted `gather_mm` all producing garbage; f32 sorted `gather_mm` SIGABRT). Three of four classes are fixed and probe-verified; the fourth (f32 TF32 degradation) is upstream's deliberate `MLX_ENABLE_TF32=1` default, kept as-is with a documented escape hatch.
- The one fork patch adds `option(MLX_METAL_FORCE_NAX)` so npm artifacts keep a **macOS 26.0** load floor while still shipping the NAX kernels (compiled at their required 26.2 ABI; runtime `is_nax_available()` gates dispatch at 26.2+). Upstream's 26.2 gate turned out to be a *correctness* gate — building NAX at a uniform 26.0 target miscompiles.
- Submodule URL is the public HTTPS fork; the pinned commit is on a pushed branch, so CI submodule checkout works.

**Packaging hardening** (`packages/core`)
- metallib selection is now bound to the built `.node`'s baked `METAL_PATH` (authoritative, not an mtime heuristic), byte-compared to the install copy, deployment-floor-gated, and **fails closed in publish/release mode** (`MLX_METALLIB_STRICT=1` in CI). Closes a long-standing "stale/incomplete metallib" hazard (root-caused to stale-dir first-match pairing, not a corrupt build).

**Cleanup** — retired dead compiled-C++ comments/docs across qwen3.5 dense+MoE, canary-gated the tests that depend on the (now-fixed) NAX kernels, plus assorted comment/hygiene fixes.

## Testing

- Rust: `mlx-core` lib **1930/0** (46 ignored), `mlx-paged-attn` **220/0**, clippy `-D warnings` clean, `cargo fmt` clean.
- TS: `yarn typecheck` clean, metallib-select **45/45**, full Vitest suite green apart from a missing gitignored GSM8K fixture and 4 gemma4 real-model E2E tests (see caveat).
- Every high-risk area passed an independent adversarial review pass; the packaging series went through several review rounds.

## Perf — new-pin decode (no regression; modest gains)

Full cooled re-bench on **M5 Max (gen-17)** through a fresh new-pin binary — both published 35B `qwen3_5_moe` series, every quant, median of 3×512-token greedy decodes with a 60-second GPU cooldown after every generation. tok/s, vs each model's previously-published (old-pin) number:

| quant | Ornith-1.0-35B old→new (Δ) | Qwen-AgentWorld-35B-A3B old→new (Δ) |
|---|---|---|
| UD-Q3 | 103.8 → **111.6** (+7.5%) | 105.8 → **112.3** (+6.1%) |
| UD-Q4 | 87.0 → **102.3** (+17.6%) | 94.5 → **99.8** (+5.6%) |
| UD-Q5 | 91.2 → **95.4** (+4.6%) | 90.8 → **95.4** (+5.1%) |
| UD-Q6 | 87.1 → **93.1** (+6.9%) | 88.2 → **92.7** (+5.1%) |
| UD-Q8 | 84.2 → **91.5** (+8.7%) | 64.3 → **91.1** (+41.7%)\* |
| MXFP4 | 90.1 → **107.8** (+19.6%) | 85.7 → **102.6** (+19.7%) |
| NVFP4 | 87.8 → **94.6** (+7.7%) | 77.1 → **94.1** (+22.0%) |
| MXFP8 | 80.0 → **84.8** (+6.0%) | 62.4 → **91.0** (+45.8%)\* |
| BF16 | 56.5 → **62.8** (+11.2%) | 41.8 → **60.8** (+45.5%)\* |

All 18 models coherent (per-model warm-up read). **No quant regressed** — the RoPE fix's added transposes cost no measurable decode throughput. The reliable branch signal is roughly **+5–22%** across the cool-baseline quants.

`*` The three outsized AgentWorld deltas are dominated by **old-pin thermal crush** — those prior numbers were measured hot at a sequence tail (~62–64 tok/s) — not a genuine pin speedup. The new cooled numbers restore correct size ordering and match Ornith's siblings. Separately, **Gemma-4-26B-A4B** (gemma4, bump-only) landed ~55–60% above its M3-Max baseline in an earlier sanity bench (host-mismatched, directional only).

Both collections' published HuggingFace model cards were regenerated with these numbers.

## Caveat for the first build

The branch's packaging changes are TS-only and did not rebuild the native addon, so the checked-in dev artifacts are still the old pin. The **first `yarn build:native`** (locally or in CI) deploys a fresh new-pin addon + metallib — the 4 gemma4 E2E tests fail only because they currently run against that stale old-pin addon and go green once it's refreshed. Validate that first build against the metallib integrity gate (now enforced by strict mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect published macOS binary compatibility (26.0 floor), release metallib fail-closed behavior, and several inference/quant paths (sym8 MoE, decode cache cadence, privacy-filter memory); mitigated by extensive new tests but release impact is real.
> 
> **Overview**
> CI and docs now **pin `MACOSX_DEPLOYMENT_TARGET=26.0`** and **`MLX_METALLIB_STRICT=1`** for the whole workflow so builds and tests match published npm darwin-arm64 artifacts (26+ load floor, fail-closed metallib gates). **README** states prebuilt binaries require macOS 26+ and explains NAX kernel runtime gating.
> 
> **Metallib packaging** gains a large **`metallib-select` Vitest suite** (bound to baked `METAL_PATH`, byte-identity checks, deployment-floor parsing, strict vs dev scan behavior) aligned with **`packages/core/build.ts`** selection logic referenced in CI comments.
> 
> **Decode cache cadence:** flat **`DecodeStep::maintain_cache`** now calls **`clear_cache` only** (no `synchronize`), with a unit test using thread-local counters; docs/comments updated across engine and cache-limit modules.
> 
> **Privacy filter:** **`classify()`** uses **`maybe_clear_cache_for_privacy_filter_call`** (default every 8 calls, env override) instead of clearing after every call.
> 
> **Banded attention** takes a caller-supplied **`band_mask`** (build once per `(T, band)`), rejects negative bands, and **skips bf16/f32 parity tests** when **`test_support`** detects broken half GEMM or TF32-degraded f32.
> 
> **Quant/convert:** **sym8** extended to **`qwen3_5_moe`** with co-quant coherence for switch/shared expert trios; **gemma prequant import** uses **group_size 128**, derives honest top-level **`quantization` metadata**, and verifies override coverage; related **convert tests** added.
> 
> **Gemma4** caches **`layer_kinds`** at model init. **LFM2** adds opt-in **`MLX_LFM2_PAGED_PREFILL_PAGED_ATTENTION`** for graph-native cache-hit prefill (default off). **Chat session** tests cover multi-MB image identity hashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2190e36f0f886b5c9e6d732f254ea614cee04ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
