### PR TITLE
fix(qwen3.5): allow non-affine (nvfp4/mxfp8) quantized lm_head + MTP fc via LinearProj

### DIFF
--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -8,6 +8,7 @@ use napi::threadsafe_function::ThreadsafeFunctionCallMode;
 use napi_derive::napi;
 use tracing::{debug, info, warn};
 
+use super::quantized_linear::LinearProj;
 use crate::array::MxArray;
 use crate::engine::backend::{
     ChatBackend, ChunkSink, DecodeStep, MtpBackend, MtpStepper, MtpTurnSetup, PagedBackend,
@@ -245,7 +246,7 @@ pub(crate) struct Qwen35Inner {
     pub(crate) embedding: Embedding,
     pub(crate) layers: Vec<DecoderLayer>,
     pub(crate) final_norm: RMSNorm,
-    pub(crate) lm_head: Option<Linear>,
+    pub(crate) lm_head: Option<LinearProj>,
     pub(crate) caches: Option<Vec<Qwen3_5LayerCache>>,
     pub(crate) tokenizer: Option<Arc<Qwen3Tokenizer>>,
     pub(crate) vision_encoder: Option<Arc<Qwen3_5VisionEncoder>>,
@@ -600,11 +601,11 @@ impl Qwen35Inner {
         let lm_head = if config.tie_word_embeddings {
             None
         } else {
-            Some(Linear::new(
+            Some(LinearProj::Standard(Linear::new(
                 config.hidden_size as u32,
                 config.vocab_size as u32,
                 Some(false),
-            )?)
+            )?))
         };
 
         let model_id = QWEN35_MODEL_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -6361,7 +6362,7 @@ impl Qwen35Inner {
         for (name, updated_param) in updated_params.iter() {
             if name == "lm_head.weight" {
                 if let Some(ref mut lm) = self.lm_head {
-                    lm.set_weight(updated_param)?;
+                    lm.set_weight(updated_param, "lm_head")?;
                 }
             } else if name == "final_norm.weight" {
                 self.final_norm.set_weight(updated_param)?;
@@ -8523,7 +8524,7 @@ fn chunked_prefill(
     layers: &mut [DecoderLayer],
     caches: &mut Option<Vec<Qwen3_5LayerCache>>,
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight_t: Option<&MxArray>,
     generation_stream: crate::stream::Stream,
 ) -> Result<MxArray> {
@@ -8546,7 +8547,7 @@ fn chunked_prefill_with_size(
     layers: &mut [DecoderLayer],
     caches: &mut Option<Vec<Qwen3_5LayerCache>>,
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight_t: Option<&MxArray>,
     generation_stream: crate::stream::Stream,
     chunk_size: i64,
@@ -8613,7 +8614,7 @@ fn chunked_prefill_with_hidden(
     layers: &mut [DecoderLayer],
     caches: &mut Option<Vec<Qwen3_5LayerCache>>,
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight_t: Option<&MxArray>,
     generation_stream: crate::stream::Stream,
     keep_last_hidden: Option<usize>,
@@ -8638,7 +8639,7 @@ fn chunked_prefill_with_hidden_with_size(
     layers: &mut [DecoderLayer],
     caches: &mut Option<Vec<Qwen3_5LayerCache>>,
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight_t: Option<&MxArray>,
     generation_stream: crate::stream::Stream,
     keep_last_hidden: Option<usize>,
@@ -8755,7 +8756,7 @@ fn forward_inner(
     layers: &mut [DecoderLayer],
     caches: &mut Option<Vec<Qwen3_5LayerCache>>,
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight_t: Option<&MxArray>,
 ) -> Result<MxArray> {
     let hidden = forward_pre_norm_inner(input_ids, embedding_weight, layers, caches)?;
@@ -8850,7 +8851,7 @@ fn forward_pre_norm_inner_with_tape(
 
 fn project_logits_from_hidden(
     hidden: &MxArray,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     embedding_weight_t: Option<&MxArray>,
 ) -> Result<MxArray> {
@@ -8887,7 +8888,7 @@ fn eager_verify_step(
     layers: &mut [DecoderLayer],
     caches: &mut Option<Vec<Qwen3_5LayerCache>>,
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     verify_ids: &MxArray,
     emb: &MxArray,
     emb_t: Option<&MxArray>,
@@ -8911,7 +8912,7 @@ fn eager_verify_step(
 fn project_last_logits_from_pre_norm_hidden(
     hidden: &MxArray,
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     embedding_weight_t: Option<&MxArray>,
 ) -> Result<MxArray> {
@@ -10036,7 +10037,7 @@ mod paged_construction_tests {
 
         if let Some(head) = inner.lm_head.as_mut() {
             let w = head.get_weight();
-            head.set_weight(&cast(&w)).expect("set lm_head");
+            head.set_weight(&cast(&w), "lm_head").expect("set lm_head");
         }
 
         for layer in inner.layers.iter_mut() {

--- a/crates/mlx-core/src/models/qwen3_5/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5/mtp.rs
@@ -46,7 +46,7 @@ use super::config::Qwen3_5Config;
 use super::decoder_layer::{AttentionType, DecoderLayer};
 use super::layer_cache::Qwen3_5LayerCache;
 use super::quantized_linear::{
-    MLPVariant, PerLayerMode, PerLayerQuant, is_quantized_checkpoint,
+    LinearProj, MLPVariant, PerLayerMode, PerLayerQuant, is_quantized_checkpoint,
     try_build_mxfp4_quantized_linear, try_build_mxfp8_quantized_linear,
     try_build_nvfp4_quantized_linear, try_build_quantized_linear,
 };
@@ -59,7 +59,7 @@ use super::quantized_linear::{
 pub struct Qwen3_5MTPModule {
     pre_fc_norm_hidden: RMSNorm,
     pre_fc_norm_embedding: RMSNorm,
-    fc: Linear,
+    fc: LinearProj,
     layers: Vec<DecoderLayer>,
     norm: RMSNorm,
 }
@@ -96,8 +96,9 @@ impl Qwen3_5MTPModule {
         let pre_fc_norm_hidden = RMSNorm::new(hidden, Some(config.rms_norm_eps))?;
         let pre_fc_norm_embedding = RMSNorm::new(hidden, Some(config.rms_norm_eps))?;
         // bias=false — MTPLX `_MTPModule.fc = nn.Linear(hidden*2, hidden,
-        // bias=False)`.
-        let fc = Linear::new(hidden * 2, hidden, Some(false))?;
+        // bias=False)`. A bf16 fc is a `LinearProj::Standard`; the loader
+        // swaps it to `Quantized` if the checkpoint ships a quantized fc.
+        let fc = LinearProj::Standard(Linear::new(hidden * 2, hidden, Some(false))?);
         let layers = (0..n_layers as usize)
             .map(|_| DecoderLayer::new(config, fa_idx))
             .collect::<Result<Vec<_>>>()?;
@@ -255,26 +256,16 @@ impl Qwen3_5MTPModule {
             self.norm.set_weight(w)?;
         }
 
-        // fc projection. Affine-quantized via the standard `Linear`
-        // quant path (matches the lm_head pattern in
-        // `apply_weights_inner`). MXFP4 / MXFP8 / NVFP4 fc weights fall
-        // through to the dense `set_weight` branch — MTPLX's
-        // `_quantize_mtp_module("all")` always emits affine-mode fc
-        // quantization, so the dense path is the common fallback for
-        // raw HF checkpoints (which ship fc as dense bf16).
-        if let Some(scales) = params.get("mtp.fc.scales") {
-            let weight = params
-                .get("mtp.fc.weight")
-                .ok_or_else(|| Error::from_reason("Missing mtp.fc.weight for quantized mtp.fc"))?;
-            let biases = params.get("mtp.fc.biases");
-            let plq = per_layer_quant
-                .get("mtp.fc")
-                .copied()
-                .unwrap_or(default_plq);
-            self.fc
-                .load_quantized(weight, scales, biases, plq.group_size, plq.bits)?;
+        // fc projection. Installs through the same mode-aware `try_build_ql`
+        // dispatch as the attention/MLP projections below, so a quantized fc
+        // honors its per-layer mode (affine / mxfp8 / mxfp4 / nvfp4) instead
+        // of being forced through affine-only dequant. A bf16 fc (no
+        // `.scales`) stays a `LinearProj::Standard` — the identical dense
+        // matmul as before; our checkpoints keep the MTP fc bf16.
+        if let Some(ql) = try_build_ql(params, "mtp.fc") {
+            self.fc.set_quantized(ql);
         } else if let Some(w) = params.get("mtp.fc.weight") {
-            self.fc.set_weight(w)?;
+            self.fc.set_weight(w, "mtp.fc")?;
         }
 
         // Per-MTP-layer weights. The body below is a focused copy of
@@ -749,5 +740,163 @@ mod tests {
 
         let out_shape = out.shape().expect("output shape");
         assert_eq!(out_shape.as_ref(), &[1i64, 1, hidden]);
+    }
+
+    /// Run `apply_weights` for an fc-install fixture. Every absent per-layer
+    /// tensor is skipped by its `if let Some(w)` guard, so an fc-only param
+    /// set never errors. Returns `false` (and prints a skip note) when
+    /// MLX/Metal is unavailable so the caller bails cleanly.
+    fn apply_fc_or_skip(
+        mtp: &mut Qwen3_5MTPModule,
+        params: &HashMap<String, MxArray>,
+        default_plq: PerLayerQuant,
+        per_layer_quant: &HashMap<String, PerLayerQuant>,
+        label: &str,
+    ) -> bool {
+        match mtp.apply_weights(params, default_plq, per_layer_quant) {
+            Ok(()) => true,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("Metal") || msg.contains("device") {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {msg}");
+                    false
+                } else {
+                    panic!("unexpected apply_weights failure in {label}: {msg}");
+                }
+            }
+        }
+    }
+
+    /// The MTP `fc` projection must install through the mode-aware
+    /// `LinearProj` dispatch: a quantized fc honors its per-layer mode as
+    /// `LinearProj::Quantized`, and a bf16 fc (no `.scales`) stays
+    /// `LinearProj::Standard` — the identical dense matmul.
+    ///
+    /// Regression guard for the old `self.fc.load_quantized(...)` install,
+    /// which hardcoded affine dequant: a non-affine (mxfp8/nvfp4) quantized
+    /// fc could only load as affine (crash / wrong dequant). The fabricated
+    /// packed tensors are never run through `forward`, so their exact shapes
+    /// do not matter — only the install path (mode dispatch) is asserted.
+    #[test]
+    fn mtp_fc_installs_mode_aware_linearproj() {
+        use super::super::quantized_linear::{
+            DEFAULT_QUANT_MODE, LinearProj, MXFP8_BITS, MXFP8_GROUP_SIZE, MXFP8_MODE,
+        };
+        let label = "mtp_fc_installs_mode_aware_linearproj";
+
+        // fc: Linear(hidden*2 -> hidden); weight is [out=hidden, in=hidden*2].
+        let hidden = tiny_mtp_cfg().hidden_size as i64;
+        let out = hidden;
+        let inp = hidden * 2;
+
+        let u32_arr = |shape: &[i64]| {
+            let n: i64 = shape.iter().product();
+            MxArray::from_float32(&vec![0.0f32; n as usize], shape)
+                .expect("from_float32")
+                .astype(DType::Uint32)
+                .expect("uint32")
+        };
+        let u8_arr = |shape: &[i64]| {
+            let n: i64 = shape.iter().product();
+            MxArray::from_float32(&vec![1.0f32; n as usize], shape)
+                .expect("from_float32")
+                .astype(DType::Uint8)
+                .expect("uint8")
+        };
+        let bf16_arr = |shape: &[i64], v: f32| {
+            let n: i64 = shape.iter().product();
+            MxArray::from_float32(&vec![v; n as usize], shape)
+                .expect("from_float32")
+                .astype(DType::BFloat16)
+                .expect("bf16")
+        };
+
+        // Closure fallback only; each quantized case names its mtp.fc mode
+        // explicitly in `per_layer_quant`.
+        let default_plq = PerLayerQuant {
+            bits: 4,
+            group_size: 64,
+            mode: PerLayerMode::Affine,
+        };
+
+        // (a) affine quantized fc → Quantized (mode "affine").
+        {
+            let Some((mut mtp, _cfg)) = build_mtp_or_skip(label) else {
+                return;
+            };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("mtp.fc.weight".into(), u32_arr(&[out, inp / 8]));
+            params.insert("mtp.fc.scales".into(), bf16_arr(&[out, inp / 32], 1.0));
+            params.insert("mtp.fc.biases".into(), bf16_arr(&[out, inp / 32], 0.0));
+            let mut plq: HashMap<String, PerLayerQuant> = HashMap::new();
+            plq.insert(
+                "mtp.fc".into(),
+                PerLayerQuant {
+                    bits: 4,
+                    group_size: 32,
+                    mode: PerLayerMode::Affine,
+                },
+            );
+            if !apply_fc_or_skip(&mut mtp, &params, default_plq, &plq, label) {
+                return;
+            }
+            assert!(
+                matches!(mtp.fc, LinearProj::Quantized(_)),
+                "affine mtp.fc must install as LinearProj::Quantized"
+            );
+            if let LinearProj::Quantized(ref ql) = mtp.fc {
+                assert_eq!(
+                    ql.mode(),
+                    DEFAULT_QUANT_MODE,
+                    "affine fc must keep affine mode"
+                );
+            }
+        }
+
+        // (b) mxfp8 quantized fc → Quantized (mode "mxfp8"). The case the old
+        //     affine-only `load_quantized` could not represent.
+        {
+            let Some((mut mtp, _cfg)) = build_mtp_or_skip(label) else {
+                return;
+            };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("mtp.fc.weight".into(), u8_arr(&[out, inp]));
+            params.insert("mtp.fc.scales".into(), u8_arr(&[out, inp / 32]));
+            let mut plq: HashMap<String, PerLayerQuant> = HashMap::new();
+            plq.insert(
+                "mtp.fc".into(),
+                PerLayerQuant {
+                    bits: MXFP8_BITS,
+                    group_size: MXFP8_GROUP_SIZE,
+                    mode: PerLayerMode::Mxfp8,
+                },
+            );
+            if !apply_fc_or_skip(&mut mtp, &params, default_plq, &plq, label) {
+                return;
+            }
+            assert!(
+                matches!(mtp.fc, LinearProj::Quantized(_)),
+                "mxfp8 mtp.fc must install as LinearProj::Quantized"
+            );
+            if let LinearProj::Quantized(ref ql) = mtp.fc {
+                assert_eq!(ql.mode(), MXFP8_MODE, "mxfp8 fc must keep mxfp8 mode");
+            }
+        }
+
+        // (c) bf16 fc (no `.scales`) → Standard.
+        {
+            let Some((mut mtp, _cfg)) = build_mtp_or_skip(label) else {
+                return;
+            };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("mtp.fc.weight".into(), bf16_arr(&[out, inp], 0.01));
+            if !apply_fc_or_skip(&mut mtp, &params, default_plq, &HashMap::new(), label) {
+                return;
+            }
+            assert!(
+                matches!(mtp.fc, LinearProj::Standard(_)),
+                "bf16 mtp.fc must install as LinearProj::Standard"
+            );
+        }
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5/mtp.rs
@@ -404,7 +404,7 @@ impl Qwen3_5MTPModule {
         }
 
         let fc_quant = if params.contains_key("mtp.fc.scales") {
-            "affine-quantized"
+            "quantized"
         } else if params.contains_key("mtp.fc.weight") {
             "dense"
         } else {

--- a/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5/paged_forward.rs
@@ -42,11 +42,12 @@ use crate::engine::vision::VisionMerge;
 use crate::inference_trace::{
     elapsed_ms, enabled as inference_trace_enabled, write as write_inference_trace,
 };
-use crate::nn::{Embedding, Linear, RMSNorm};
+use crate::nn::{Embedding, RMSNorm};
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
 
 use super::decoder_layer::{DecoderLayer, Qwen3_5LayerKind};
 use super::layer_cache::Qwen3_5LayerCache;
+use super::quantized_linear::LinearProj;
 
 fn bytes_to_mib(bytes: f64) -> f64 {
     bytes / (1024.0 * 1024.0)
@@ -166,7 +167,7 @@ pub(crate) fn run_paged_prefill_chunk(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
@@ -208,7 +209,7 @@ pub(crate) fn run_paged_prefill_chunk_with_size(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
@@ -362,7 +363,7 @@ fn run_paged_prefill_single_shot(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
@@ -416,7 +417,7 @@ pub(crate) fn run_paged_vlm_prefill(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
@@ -475,7 +476,7 @@ pub(crate) fn run_paged_prefill_chunk_with_hidden(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
@@ -512,7 +513,7 @@ fn run_paged_prefill_chunk_with_hidden_with_size(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
@@ -668,7 +669,7 @@ fn run_paged_prefill_single_shot_with_hidden(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
@@ -791,7 +792,7 @@ fn run_paged_prefill_one_chunk(
 fn project_last_token_logits(
     hidden_states: &MxArray,
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embed: &Embedding,
     embedding_weight: &MxArray,
 ) -> Result<MxArray> {
@@ -825,7 +826,7 @@ fn project_last_token_logits(
 fn project_last_token_logits_with_full_hidden(
     hidden_states: &MxArray,
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embed: &Embedding,
     embedding_weight: &MxArray,
     keep_last_hidden: Option<usize>,
@@ -874,7 +875,7 @@ pub(crate) fn run_paged_decode_step(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     layer_kinds: &[Qwen3_5LayerKind],
     paged_adapter: &mut PagedKVCacheAdapter,
@@ -955,7 +956,7 @@ pub(crate) fn run_paged_step_with_hidden(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     embedding_weight_t: Option<&MxArray>,
     layer_kinds: &[Qwen3_5LayerKind],
@@ -1046,7 +1047,7 @@ pub(crate) fn run_paged_verify_step(
     layers: &mut [DecoderLayer],
     caches: &mut [Qwen3_5LayerCache],
     final_norm: &RMSNorm,
-    lm_head: &Option<Linear>,
+    lm_head: &Option<LinearProj>,
     embedding_weight: &MxArray,
     embedding_weight_t: Option<&MxArray>,
     layer_kinds: &[Qwen3_5LayerKind],

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -2673,7 +2673,7 @@ mod tests {
     #[test]
     fn dense_lm_head_installs_mode_aware_linearproj() {
         use super::super::quantized_linear::{
-            DEFAULT_QUANT_MODE, LinearProj, MXFP8_BITS, MXFP8_GROUP_SIZE, MXFP8_MODE,
+            LinearProj, MXFP8_BITS, MXFP8_GROUP_SIZE, MXFP8_MODE,
         };
         let label = "dense_lm_head_installs_mode_aware_linearproj";
 
@@ -2807,11 +2807,7 @@ mod tests {
                 "affine lm_head must install as LinearProj::Quantized"
             );
             if let Some(LinearProj::Quantized(ref ql)) = inner.lm_head {
-                assert_eq!(
-                    ql.mode(),
-                    DEFAULT_QUANT_MODE,
-                    "affine head must keep affine mode"
-                );
+                assert_eq!(ql.mode(), "affine", "affine head must keep affine mode");
             }
         }
 

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -1032,27 +1032,21 @@ fn apply_weights_inner(
         inner.final_norm.set_weight(w)?;
     }
 
-    // LM head
+    // LM head. The outer `Some(head)` guard preserves the tied-embeddings
+    // path: when `tie_word_embeddings`, `inner.lm_head` is `None` and the head
+    // is never installed even if `lm_head.*` tensors are present. The head
+    // installs through the mode-aware `try_build_ql` dispatch (affine / mxfp8 /
+    // mxfp4 / nvfp4 / sym8) so non-affine quantized heads load, not just affine
+    // — the legacy `Linear::load_quantized` hardcoded affine dequant.
     if let Some(ref mut head) = inner.lm_head {
-        if let Some(scales) = params.get("lm_head.scales") {
-            let weight = params.get("lm_head.weight").ok_or_else(|| {
-                Error::from_reason("Missing lm_head.weight for quantized lm_head")
-            })?;
-            let biases = params.get("lm_head.biases");
-            let plq = per_layer_quant
-                .get("lm_head")
-                .copied()
-                .unwrap_or(default_plq);
-            head.load_quantized(weight, scales, biases, plq.group_size, plq.bits)?;
-            info!(
-                "Loaded quantized lm_head ({}-bit, quantized_matmul on forward)",
-                plq.bits
-            );
+        if let Some(ql) = try_build_ql(params, "lm_head")? {
+            head.set_quantized(ql);
+            info!("Loaded quantized lm_head (mode-aware, quantized_matmul on forward)");
         } else if let Some(w) = params.get("lm_head.weight") {
             // Dense fallback (no `.scales`) — same stripped-quant-group
             // dtype guard as the embedding above.
             ensure_dense_weight_floating("lm_head.weight", w)?;
-            head.set_weight(w)?;
+            head.set_weight(w, "lm_head")?;
         }
     }
 
@@ -2661,6 +2655,223 @@ mod tests {
             inner.embedding.is_packed_quantized(),
             "tied+quantized embedding.* on the paged path must load via load_quantized_packed, not the legacy dense load_quantized"
         );
+    }
+
+    /// The dense `lm_head` must install through the mode-aware `LinearProj`
+    /// dispatch (`try_build_ql`): a non-affine (mxfp8) quantized head and an
+    /// affine quantized head both install as `LinearProj::Quantized`, a bf16
+    /// head installs as `LinearProj::Standard`, and a tied config leaves the
+    /// head `None`.
+    ///
+    /// Regression guard for `Linear::load_quantized` hardcoding affine dequant:
+    /// an mxfp8/nvfp4 head previously crashed ("Biases must be provided for
+    /// affine quantization") because the legacy install called
+    /// `head.load_quantized(...)` unconditionally. The install-only checks
+    /// tolerate the end-of-load completeness gate (this fixture provides only
+    /// `lm_head.*`), which fires strictly AFTER the head backend is installed
+    /// on `inner`.
+    #[test]
+    fn dense_lm_head_installs_mode_aware_linearproj() {
+        use super::super::quantized_linear::{
+            DEFAULT_QUANT_MODE, LinearProj, MXFP8_BITS, MXFP8_GROUP_SIZE, MXFP8_MODE,
+        };
+        let label = "dense_lm_head_installs_mode_aware_linearproj";
+
+        // Construct an untied inner first — this is the op that needs MLX/Metal,
+        // so a clean skip here means the fixture builds below never hit a device
+        // error.
+        let untied_cfg = Qwen3_5Config {
+            vocab_size: 8,
+            tie_word_embeddings: false,
+            ..no_mtp_layer_cfg()
+        };
+        let vocab = untied_cfg.vocab_size as i64;
+        let hidden = untied_cfg.hidden_size as i64;
+
+        let new_inner = || match Qwen35Inner::new(untied_cfg.clone()) {
+            Ok(inner) => Some(inner),
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("Metal") || msg.contains("device") {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {msg}");
+                    None
+                } else {
+                    panic!("unexpected Qwen35Inner::new failure in {label}: {msg}");
+                }
+            }
+        };
+
+        // Array builders. Reachable only after `Qwen35Inner::new` succeeded, so
+        // the device is up and `.expect` is safe.
+        let u32_arr = |shape: &[i64]| {
+            let n: i64 = shape.iter().product();
+            MxArray::from_float32(&vec![0.0f32; n as usize], shape)
+                .expect("from_float32")
+                .astype(DType::Uint32)
+                .expect("uint32")
+        };
+        let u8_arr = |shape: &[i64]| {
+            let n: i64 = shape.iter().product();
+            MxArray::from_float32(&vec![1.0f32; n as usize], shape)
+                .expect("from_float32")
+                .astype(DType::Uint8)
+                .expect("uint8")
+        };
+        let bf16_arr = |shape: &[i64], v: f32| {
+            let n: i64 = shape.iter().product();
+            MxArray::from_float32(&vec![v; n as usize], shape)
+                .expect("from_float32")
+                .astype(DType::BFloat16)
+                .expect("bf16")
+        };
+
+        // Run `apply_weights_inner` for an install-only fixture: the partial
+        // checkpoint (only `lm_head.*`) is rejected by the completeness gate,
+        // which runs AFTER the head install — tolerate only that specific error.
+        let apply_install_only =
+            |inner: &mut Qwen35Inner,
+             params: &HashMap<String, MxArray>,
+             plq: &HashMap<String, PerLayerQuant>| {
+                match apply_weights_inner(
+                    inner,
+                    params,
+                    &untied_cfg,
+                    DEFAULT_QUANT_BITS,
+                    DEFAULT_QUANT_GROUP_SIZE,
+                    None,
+                    plq,
+                    /* has_vision */ false,
+                ) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        let msg = err.reason.to_string();
+                        assert!(
+                            msg.contains("missing mandatory weights"),
+                            "unexpected apply_weights_inner error in {label}: {msg}"
+                        );
+                    }
+                }
+            };
+
+        // (a) Non-affine (mxfp8) head → Quantized. This is the case the legacy
+        //     `head.load_quantized` (affine-only) crashed on.
+        {
+            let Some(mut inner) = new_inner() else { return };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("lm_head.weight".into(), u8_arr(&[vocab, hidden]));
+            params.insert("lm_head.scales".into(), u8_arr(&[vocab, hidden / 32]));
+            let mut plq: HashMap<String, PerLayerQuant> = HashMap::new();
+            plq.insert(
+                "lm_head".into(),
+                PerLayerQuant {
+                    bits: MXFP8_BITS,
+                    group_size: MXFP8_GROUP_SIZE,
+                    mode: PerLayerMode::Mxfp8,
+                },
+            );
+            apply_install_only(&mut inner, &params, &plq);
+            assert!(
+                matches!(inner.lm_head, Some(LinearProj::Quantized(_))),
+                "mxfp8 lm_head must install as LinearProj::Quantized"
+            );
+            if let Some(LinearProj::Quantized(ref ql)) = inner.lm_head {
+                assert_eq!(ql.mode(), MXFP8_MODE, "mxfp8 head must keep mxfp8 mode");
+            }
+        }
+
+        // (b) Affine head → Quantized (mode "affine").
+        {
+            let Some(mut inner) = new_inner() else { return };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("lm_head.weight".into(), u32_arr(&[vocab, hidden / 8]));
+            params.insert(
+                "lm_head.scales".into(),
+                bf16_arr(&[vocab, hidden / 32], 1.0),
+            );
+            params.insert(
+                "lm_head.biases".into(),
+                bf16_arr(&[vocab, hidden / 32], 0.0),
+            );
+            let mut plq: HashMap<String, PerLayerQuant> = HashMap::new();
+            plq.insert(
+                "lm_head".into(),
+                PerLayerQuant {
+                    bits: 4,
+                    group_size: 32,
+                    mode: PerLayerMode::Affine,
+                },
+            );
+            apply_install_only(&mut inner, &params, &plq);
+            assert!(
+                matches!(inner.lm_head, Some(LinearProj::Quantized(_))),
+                "affine lm_head must install as LinearProj::Quantized"
+            );
+            if let Some(LinearProj::Quantized(ref ql)) = inner.lm_head {
+                assert_eq!(
+                    ql.mode(),
+                    DEFAULT_QUANT_MODE,
+                    "affine head must keep affine mode"
+                );
+            }
+        }
+
+        // (c) bf16 dense head (no `.scales`) → Standard.
+        {
+            let Some(mut inner) = new_inner() else { return };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("lm_head.weight".into(), bf16_arr(&[vocab, hidden], 0.01));
+            apply_install_only(&mut inner, &params, &HashMap::new());
+            assert!(
+                matches!(inner.lm_head, Some(LinearProj::Standard(_))),
+                "bf16 lm_head must install as LinearProj::Standard"
+            );
+        }
+
+        // (d) Tied config → head stays `None` regardless of params.
+        {
+            let tied_cfg = Qwen3_5Config {
+                vocab_size: 8,
+                tie_word_embeddings: true,
+                ..no_mtp_layer_cfg()
+            };
+            let mut inner = match Qwen35Inner::new(tied_cfg.clone()) {
+                Ok(inner) => inner,
+                Err(err) => {
+                    let msg = err.reason.to_string();
+                    if msg.contains("Metal") || msg.contains("device") {
+                        eprintln!("skipping {label} tied case (MLX/Metal unavailable): {msg}");
+                        return;
+                    }
+                    panic!("unexpected Qwen35Inner::new failure in {label}: {msg}");
+                }
+            };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("lm_head.weight".into(), u8_arr(&[vocab, hidden]));
+            params.insert("lm_head.scales".into(), u8_arr(&[vocab, hidden / 32]));
+            match apply_weights_inner(
+                &mut inner,
+                &params,
+                &tied_cfg,
+                DEFAULT_QUANT_BITS,
+                DEFAULT_QUANT_GROUP_SIZE,
+                None,
+                &HashMap::new(),
+                false,
+            ) {
+                Ok(()) => {}
+                Err(err) => {
+                    let msg = err.reason.to_string();
+                    assert!(
+                        msg.contains("missing mandatory weights"),
+                        "unexpected apply_weights_inner error in {label} tied case: {msg}"
+                    );
+                }
+            }
+            assert!(
+                inner.lm_head.is_none(),
+                "tied lm_head must remain None when tie_word_embeddings=true"
+            );
+        }
     }
 
     /// Build the three (never-quantized) MTP norms as bf16. Returns `None`

--- a/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
@@ -66,11 +66,11 @@ use super::config::Qwen3_5MoeConfig;
 use super::decoder_layer::{AttentionType, DecoderLayer, MLPType};
 use super::layer_cache::Qwen3_5LayerCache;
 use super::quantized_linear::{
-    MLPVariant, PerLayerMode, PerLayerQuant, QuantizedSwitchLinear, is_quantized_checkpoint,
-    try_build_mxfp4_quantized_linear, try_build_mxfp4_quantized_switch_linear,
-    try_build_mxfp8_quantized_linear, try_build_mxfp8_quantized_switch_linear,
-    try_build_nvfp4_quantized_linear, try_build_nvfp4_quantized_switch_linear,
-    try_build_quantized_linear,
+    LinearProj, MLPVariant, PerLayerMode, PerLayerQuant, QuantizedSwitchLinear,
+    is_quantized_checkpoint, try_build_mxfp4_quantized_linear,
+    try_build_mxfp4_quantized_switch_linear, try_build_mxfp8_quantized_linear,
+    try_build_mxfp8_quantized_switch_linear, try_build_nvfp4_quantized_linear,
+    try_build_nvfp4_quantized_switch_linear, try_build_quantized_linear,
 };
 use super::switch_glu::SwitchGLU;
 
@@ -109,7 +109,7 @@ fn try_build_affine_quantized_switch_linear(
 pub struct Qwen3_5MoeMTPModule {
     pre_fc_norm_hidden: RMSNorm,
     pre_fc_norm_embedding: RMSNorm,
-    fc: Linear,
+    fc: LinearProj,
     layers: Vec<DecoderLayer>,
     norm: RMSNorm,
 }
@@ -150,8 +150,9 @@ impl Qwen3_5MoeMTPModule {
         let pre_fc_norm_hidden = RMSNorm::new(hidden, Some(config.rms_norm_eps))?;
         let pre_fc_norm_embedding = RMSNorm::new(hidden, Some(config.rms_norm_eps))?;
         // bias=false — MTPLX `_MTPModule.fc = nn.Linear(hidden*2, hidden,
-        // bias=False)`.
-        let fc = Linear::new(hidden * 2, hidden, Some(false))?;
+        // bias=False)`. A bf16 fc is a `LinearProj::Standard`; the loader
+        // swaps it to `Quantized` if the checkpoint ships a quantized fc.
+        let fc = LinearProj::Standard(Linear::new(hidden * 2, hidden, Some(false))?);
         let layers = (0..n_layers as usize)
             .map(|_| DecoderLayer::new(config, fa_idx))
             .collect::<Result<Vec<_>>>()?;
@@ -372,23 +373,16 @@ impl Qwen3_5MoeMTPModule {
             self.norm.set_weight(w)?;
         }
 
-        // fc projection. Affine-quantized via the standard `Linear`
-        // quant path (matches the lm_head pattern in the main loader).
-        // MXFP4 / MXFP8 / NVFP4 fc weights fall through to the dense
-        // `set_weight` branch — MTPLX's `_quantize_mtp_module("all")`
-        // always emits affine-mode fc quantization, so the dense path is
-        // the common fallback for raw HF checkpoints (which ship fc as
-        // dense bf16).
-        if let Some(scales) = params.get("mtp.fc.scales") {
-            let weight = params
-                .get("mtp.fc.weight")
-                .ok_or_else(|| Error::from_reason("Missing mtp.fc.weight for quantized mtp.fc"))?;
-            let biases = params.get("mtp.fc.biases");
-            let plq = plq_for("mtp.fc");
-            self.fc
-                .load_quantized(weight, scales, biases, plq.group_size, plq.bits)?;
+        // fc projection. Installs through the same mode-aware `try_build_ql`
+        // dispatch as the attention/MLP projections below, so a quantized fc
+        // honors its per-layer mode (affine / mxfp8 / mxfp4 / nvfp4) instead
+        // of being forced through affine-only dequant. A bf16 fc (no
+        // `.scales`) stays a `LinearProj::Standard` — the identical dense
+        // matmul as before; our checkpoints keep the MTP fc bf16.
+        if let Some(ql) = try_build_ql(params, "mtp.fc") {
+            self.fc.set_quantized(ql);
         } else if let Some(w) = params.get("mtp.fc.weight") {
-            self.fc.set_weight(w)?;
+            self.fc.set_weight(w, "mtp.fc")?;
         }
 
         // Per-MTP-layer weights. The body below is a focused copy of
@@ -1335,5 +1329,191 @@ mod tests {
             got_qproj, default_plq,
             "non-gate projections must use default_plq"
         );
+    }
+
+    /// Run `apply_weights` for an fc-install fixture. Every absent per-layer
+    /// tensor is skipped by its `if let Some(w)` guard, so an fc-only param
+    /// set never errors. Returns `false` (and prints a skip note) when
+    /// MLX/Metal is unavailable so the caller bails cleanly.
+    fn apply_fc_or_skip(
+        mtp: &mut Qwen3_5MoeMTPModule,
+        params: &HashMap<String, MxArray>,
+        default_plq: PerLayerQuant,
+        default_gate_plq: PerLayerQuant,
+        per_layer_quant: &HashMap<String, PerLayerQuant>,
+        label: &str,
+    ) -> bool {
+        match mtp.apply_weights(params, default_plq, default_gate_plq, per_layer_quant) {
+            Ok(()) => true,
+            Err(err) => {
+                let msg = err.reason.to_string();
+                if msg.contains("Metal") || msg.contains("device") {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {msg}");
+                    false
+                } else {
+                    panic!("unexpected apply_weights failure in {label}: {msg}");
+                }
+            }
+        }
+    }
+
+    /// The MoE MTP `fc` projection must install through the mode-aware
+    /// `LinearProj` dispatch: a quantized fc honors its per-layer mode as
+    /// `LinearProj::Quantized`, and a bf16 fc (no `.scales`) stays
+    /// `LinearProj::Standard` — the identical dense matmul.
+    ///
+    /// Regression guard for the old `self.fc.load_quantized(...)` install,
+    /// which hardcoded affine dequant: a non-affine (mxfp8/nvfp4) quantized
+    /// fc could only load as affine (crash / wrong dequant). The fabricated
+    /// packed tensors are never run through `forward`, so their exact shapes
+    /// do not matter — only the install path (mode dispatch) is asserted.
+    #[test]
+    fn mtp_fc_installs_mode_aware_linearproj() {
+        use super::super::quantized_linear::{
+            DEFAULT_QUANT_MODE, LinearProj, MXFP8_BITS, MXFP8_GROUP_SIZE, MXFP8_MODE,
+        };
+        let label = "mtp_fc_installs_mode_aware_linearproj";
+
+        // fc: Linear(hidden*2 -> hidden); weight is [out=hidden, in=hidden*2].
+        let hidden = tiny_mtp_cfg().hidden_size as i64;
+        let out = hidden;
+        let inp = hidden * 2;
+
+        let u32_arr = |shape: &[i64]| {
+            let n: i64 = shape.iter().product();
+            MxArray::from_float32(&vec![0.0f32; n as usize], shape)
+                .expect("from_float32")
+                .astype(DType::Uint32)
+                .expect("uint32")
+        };
+        let u8_arr = |shape: &[i64]| {
+            let n: i64 = shape.iter().product();
+            MxArray::from_float32(&vec![1.0f32; n as usize], shape)
+                .expect("from_float32")
+                .astype(DType::Uint8)
+                .expect("uint8")
+        };
+        let bf16_arr = |shape: &[i64], v: f32| {
+            let n: i64 = shape.iter().product();
+            MxArray::from_float32(&vec![v; n as usize], shape)
+                .expect("from_float32")
+                .astype(DType::BFloat16)
+                .expect("bf16")
+        };
+
+        // Closure fallback only; each quantized case names its mtp.fc mode
+        // explicitly in `per_layer_quant`. The gate default is irrelevant to
+        // the fc prefix (fc is not a router gate).
+        let default_plq = PerLayerQuant {
+            bits: 4,
+            group_size: 64,
+            mode: PerLayerMode::Affine,
+        };
+        let default_gate_plq = PerLayerQuant {
+            bits: 8,
+            group_size: 64,
+            mode: PerLayerMode::Affine,
+        };
+
+        // (a) affine quantized fc → Quantized (mode "affine").
+        {
+            let Some((mut mtp, _cfg)) = build_mtp_or_skip(label) else {
+                return;
+            };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("mtp.fc.weight".into(), u32_arr(&[out, inp / 8]));
+            params.insert("mtp.fc.scales".into(), bf16_arr(&[out, inp / 32], 1.0));
+            params.insert("mtp.fc.biases".into(), bf16_arr(&[out, inp / 32], 0.0));
+            let mut plq: HashMap<String, PerLayerQuant> = HashMap::new();
+            plq.insert(
+                "mtp.fc".into(),
+                PerLayerQuant {
+                    bits: 4,
+                    group_size: 32,
+                    mode: PerLayerMode::Affine,
+                },
+            );
+            if !apply_fc_or_skip(
+                &mut mtp,
+                &params,
+                default_plq,
+                default_gate_plq,
+                &plq,
+                label,
+            ) {
+                return;
+            }
+            assert!(
+                matches!(mtp.fc, LinearProj::Quantized(_)),
+                "affine mtp.fc must install as LinearProj::Quantized"
+            );
+            if let LinearProj::Quantized(ref ql) = mtp.fc {
+                assert_eq!(
+                    ql.mode(),
+                    DEFAULT_QUANT_MODE,
+                    "affine fc must keep affine mode"
+                );
+            }
+        }
+
+        // (b) mxfp8 quantized fc → Quantized (mode "mxfp8"). The case the old
+        //     affine-only `load_quantized` could not represent.
+        {
+            let Some((mut mtp, _cfg)) = build_mtp_or_skip(label) else {
+                return;
+            };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("mtp.fc.weight".into(), u8_arr(&[out, inp]));
+            params.insert("mtp.fc.scales".into(), u8_arr(&[out, inp / 32]));
+            let mut plq: HashMap<String, PerLayerQuant> = HashMap::new();
+            plq.insert(
+                "mtp.fc".into(),
+                PerLayerQuant {
+                    bits: MXFP8_BITS,
+                    group_size: MXFP8_GROUP_SIZE,
+                    mode: PerLayerMode::Mxfp8,
+                },
+            );
+            if !apply_fc_or_skip(
+                &mut mtp,
+                &params,
+                default_plq,
+                default_gate_plq,
+                &plq,
+                label,
+            ) {
+                return;
+            }
+            assert!(
+                matches!(mtp.fc, LinearProj::Quantized(_)),
+                "mxfp8 mtp.fc must install as LinearProj::Quantized"
+            );
+            if let LinearProj::Quantized(ref ql) = mtp.fc {
+                assert_eq!(ql.mode(), MXFP8_MODE, "mxfp8 fc must keep mxfp8 mode");
+            }
+        }
+
+        // (c) bf16 fc (no `.scales`) → Standard.
+        {
+            let Some((mut mtp, _cfg)) = build_mtp_or_skip(label) else {
+                return;
+            };
+            let mut params: HashMap<String, MxArray> = HashMap::new();
+            params.insert("mtp.fc.weight".into(), bf16_arr(&[out, inp], 0.01));
+            if !apply_fc_or_skip(
+                &mut mtp,
+                &params,
+                default_plq,
+                default_gate_plq,
+                &HashMap::new(),
+                label,
+            ) {
+                return;
+            }
+            assert!(
+                matches!(mtp.fc, LinearProj::Standard(_)),
+                "bf16 mtp.fc must install as LinearProj::Standard"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

The qwen3.5 dense `lm_head` and MTP `fc` could only load an **affine** quantized head. `Linear::load_quantized` / `Linear::forward` (`crates/mlx-core/src/nn/linear.rs`) hardcode `c"affine"` (dequant + `mlx_quantized_matmul` mode) and require biases. A micro-scaled head (nvfp4 / mxfp8 — scales only, no biases) crashed at load:

```
Biases must be provided for affine quantization
```

This is an unfinished early path (commit `08354f84`, PR #32, when affine was the only mode). It forced NVIDIA-NVFP4 → MLX transcodes to fall back to an affine-int4 `lm_head` instead of keeping the intended per-layer bit allocation.

## Fix

Migrate the qwen3.5 dense `lm_head` and both MTP `fc` fields (dense + moe) from `Linear` / `Option<Linear>` onto the mode-aware `LinearProj` (`quantized_linear.rs`) and install them via the existing `try_build_ql` dispatch on `plq.mode` — exactly as **gemma4** and **qwen3_5_moe** already do for their heads. `Linear::load_quantized` is left untouched (other families still use it).

```
                       old (affine-only)            new (mode-aware)
lm_head / mtp.fc  ──▶  Linear::load_quantized  ──▶  LinearProj  ─┬─ bf16    → Standard(Linear)
                       (c"affine", needs biases)                 ├─ affine  → Quantized("affine")
                                                                 ├─ mxfp8   → Quantized("mxfp8")   ← was a crash
                                                                 └─ nvfp4   → Quantized("nvfp4")   ← was a crash
```

- **Task 1** `d08372b6` — dense `lm_head: Option<Linear>` → `Option<LinearProj>`; install in `persistence.rs`; threaded through every `model.rs` + `paged_forward.rs` forward call site.
- **Task 2** `96e3e450` — MTP `fc: Linear` → `LinearProj` in `models/qwen3_5/mtp.rs` and `models/qwen3_5_moe/mtp.rs`; removed a stale "falls through to `set_weight`" comment.
- **Tidy** `293482fb` — two cosmetic follow-ups from the final review (literal `"affine"` test assertion; `"quantized"` debug label).

No checkpoint or `convert` change — this removes a **loader** constraint only. Existing checkpoints keep bf16/affine heads unchanged.

## Behavior preservation

- bf16 head/fc → `LinearProj::Standard` → identical `input.matmul(weight_t)` (heads are bias-free).
- affine head/fc → `LinearProj::Quantized` mode `"affine"` → identical `mlx_quantized_matmul(x, weight, scales, biases, true, gs, bits, "affine")` operands.
- tied-embeddings path unchanged (`lm_head` is `None` when tied).

## Validation

3 new install-type unit tests assert the mode dispatch (affine → `Quantized("affine")`, mxfp8 → `Quantized("mxfp8")`, bf16 → `Standard`) for the dense head and both MTP fc. `cargo clippy -D warnings` + `cargo fmt` clean.

E2E runtime (a hand-built qwen3.5-9B checkpoint with an mxfp8 `lm_head` — scales, no biases):

| Head mode | Result |
|---|---|
| bf16 (0.8b tied, 9B-bf16) | ✅ coherent — unchanged path |
| affine (9B-unsloth) | ✅ coherent — behavior preserved |
| **mxfp8 (9B-mxfp8head)** | ✅ **loads (was a crash) + generates correct text** — the fix |

> The authoritative GPU parity suite (`qwen3_5_paged_vs_flat_parity`, `qwen3_5_session`) runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inference and weight-loading paths for lm_head and MTP fc; behavior is intended to be parity-preserving for bf16/affine, with new support for mxfp8/nvfp4.
> 
> **Overview**
> **Fixes quantized checkpoint loading** for dense `lm_head` and MTP `fc` (dense + MoE): those layers no longer go through affine-only `Linear::load_quantized`, which failed on mxfp8/nvfp4 heads missing affine biases.
> 
> They now use **`LinearProj`** with the same **`try_build_ql`** path as other projections, so affine, mxfp8, mxfp4, and nvfp4 install correctly; bf16 stays **`LinearProj::Standard`**. **`set_weight`** calls take a name label (e.g. `"lm_head"`, `"mtp.fc"`). Forward/prefill/paged paths only change types to **`Option<LinearProj>`**; tied embeddings still leave **`lm_head`** as **`None`**.
> 
> **Tests** cover install dispatch for dense **`lm_head`** (mxfp8, affine, bf16, tied) and both MTP **`fc`** modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293482fbcfa2a508869b4ebd1791caaf19df4ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->