### PR TITLE
feat(gemma4): DSpark speculative decoding (DeepSeek DeepSpec external draft)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ MLX-Node brings Apple's [MLX](https://github.com/ml-explore/mlx) framework to Ja
 - Multi-turn `ChatSession` with live KV cache reuse
 - Streaming generation via `sendStream()`
 - Tool calling and chat templates
+- Speculative decoding: Qwen3.5 MTP heads, Gemma4 DSpark draft models ([docs](docs/models.md#speculative-decoding-gemma4--dspark))
 
 </td>
 <td width="33%" valign="top">

--- a/__test__/models/gemma4-dspark-e2e.test.ts
+++ b/__test__/models/gemma4-dspark-e2e.test.ts
@@ -1,0 +1,94 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { ChatSession, loadSession } from '@mlx-node/lm';
+import { beforeAll, describe, expect, it } from 'vite-plus/test';
+
+/**
+ * End-to-end test for Gemma4 DSpark speculative decoding through the public
+ * TS surface: `loadSession(modelPath, { draftModelPath })`.
+ *
+ * PRIMARY ORACLE (mirrors `crates/mlx-core/tests/gemma4_dspark.rs`): DSpark
+ * is LOSSLESS at T=0 — the greedy turn from the draft-attached session must
+ * byte-match the greedy turn from a plain no-draft session, and the
+ * draft-attached turn must actually run speculative cycles
+ * (`performance.mtpCycles > 0`, not a silent AR fallback). The no-draft
+ * session also pins the `ChatSession` auto-default: without a draft,
+ * `hasMtpWeights()` is `false`, so no MTP config is injected and the turn
+ * reports no cycles.
+ *
+ * Env-gated (the Rust suite's convention — both required, skipped otherwise):
+ *   MLX_TEST_GEMMA4_MODEL_PATH   — bf16 Gemma-4-12B-IT checkpoint dir
+ *   MLX_TEST_GEMMA4_DSPARK_PATH  — dspark_gemma4_12b_block7 draft dir
+ *
+ * To run locally:
+ *   MLX_TEST_GEMMA4_MODEL_PATH=.cache/models/gemma-4-12b-it \
+ *   MLX_TEST_GEMMA4_DSPARK_PATH=.cache/models/dspark_gemma4_12b_block7 \
+ *     vp test __test__/models/gemma4-dspark-e2e.test.ts --run
+ *
+ * The fixture prompt is tie-screened (see the Rust suite's module doc): a
+ * constrained generation whose greedy top-2 logit gaps sit far above bf16
+ * kernel noise, so the byte-equal oracle stays strict without near-tie
+ * flakes.
+ */
+
+/** True for a directory that looks like a loadable checkpoint. */
+function isCheckpointDir(dir: string): boolean {
+  if (!existsSync(resolve(dir, 'config.json'))) return false;
+  return existsSync(resolve(dir, 'model.safetensors')) || existsSync(resolve(dir, 'model.safetensors.index.json'));
+}
+
+const modelPath = process.env.MLX_TEST_GEMMA4_MODEL_PATH ?? '';
+const draftPath = process.env.MLX_TEST_GEMMA4_DSPARK_PATH ?? '';
+const gated = modelPath !== '' && draftPath !== '';
+
+describe.skipIf(!gated)('Gemma4 DSpark speculative decoding — TS e2e (greedy matches no-draft)', () => {
+  let arSession: ChatSession;
+  let dsparkSession: ChatSession;
+
+  beforeAll(async () => {
+    if (!gated) return;
+    // Fail loudly on a stale env var (the Rust suite asserts the same) —
+    // a skip here would silently stop covering the DSpark load path.
+    expect(isCheckpointDir(modelPath), `MLX_TEST_GEMMA4_MODEL_PATH is not a checkpoint dir: ${modelPath}`).toBe(true);
+    expect(isCheckpointDir(draftPath), `MLX_TEST_GEMMA4_DSPARK_PATH is not a checkpoint dir: ${draftPath}`).toBe(true);
+    arSession = await loadSession(modelPath);
+    dsparkSession = await loadSession(modelPath, { draftModelPath: draftPath });
+  }, 900_000);
+
+  // Tie-screened fixture shared with the Rust primary oracle
+  // (`dspark_greedy_matches_ar_multi_cycle`): a constrained numbered recipe
+  // holds 200 greedy tokens without a near-tie.
+  const PROMPT = 'Give a simple recipe for pancakes with numbered steps.';
+
+  async function greedyTurn(session: ChatSession) {
+    return session.send(PROMPT, {
+      config: { maxNewTokens: 200, temperature: 0, reportPerformance: true },
+    });
+  }
+
+  it('greedy DSpark send matches the no-draft session and runs speculative cycles', async () => {
+    const ar = await greedyTurn(arSession);
+    const dspark = await greedyTurn(dsparkSession);
+
+    // Coherence guard: byte-equality alone would also pass if BOTH runs
+    // produced identical garbage (e.g. a corrupt metallib); a greedy
+    // pancake recipe always names its subject.
+    expect(ar.text.toLowerCase()).toContain('pancake');
+    expect(ar.text.trim().length).toBeGreaterThan(50);
+
+    // T=0 losslessness: byte-equal output against the no-draft session.
+    expect(dspark.text).toBe(ar.text);
+    expect(dspark.finishReason).toBe(ar.finishReason);
+    expect(dspark.numTokens).toBe(ar.numTokens);
+
+    // The draft-attached turn really ran DSpark (no silent AR fallback)
+    // and filled the speculative stats.
+    expect(dspark.performance?.mtpCycles ?? 0).toBeGreaterThan(0);
+    expect(dspark.performance?.mtpMeanAcceptedTokensTotal ?? 0).toBeGreaterThan(0);
+
+    // The no-draft session stayed plain AR: `hasMtpWeights()` is false
+    // there, so the ChatSession MTP auto-default never kicked in.
+    expect(ar.performance?.mtpCycles ?? 0).toBe(0);
+  }, 600_000);
+});

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -166,8 +166,19 @@ export declare class Gemma4Model {
    */
   hasBlockPagedCache(): boolean;
   modelId(): number;
+  /**
+   * Whether a DSpark draft model is loaded on this instance (via
+   * `Gemma4LoadOptions::draft_model_path`), enabling the speculative-
+   * decode whole-turn path.
+   *
+   * Note: this only reports draft availability. Whether speculative
+   * decoding actually runs on a given call also requires the per-request
+   * `enableMtp` flag. Named `hasMtpWeights` for parity with the Qwen3.5
+   * surface. Stubs from `new(config)` always return `false`.
+   */
+  hasMtpWeights(): boolean;
   /** Load a Gemma4 model from a directory. */
-  static load(modelPath: string): Promise<Gemma4Model>;
+  static load(modelPath: string, options?: Gemma4LoadOptions | undefined | null): Promise<Gemma4Model>;
   /**
    * Reset all caches and clear cached token history. Exposed
    * so tests and session-management code can start from a
@@ -2916,6 +2927,19 @@ export interface Gemma4Config {
    * real Gemma-4-E2B weights.
    */
   useBlockPagedCache?: boolean | undefined;
+}
+
+/** Optional load-time settings for `Gemma4Model.load`. */
+export interface Gemma4LoadOptions {
+  /**
+   * Directory of a DSpark draft checkpoint (config.json +
+   * model.safetensors) to load alongside the target model for
+   * speculative decoding. DSpark runs only on the flat KV-cache path:
+   * setting this while the model config explicitly enables
+   * `use_block_paged_cache` is a hard load error, and an unset
+   * `use_block_paged_cache` is forced to `false`.
+   */
+  draftModelPath?: string | undefined;
 }
 
 /**

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -174,7 +174,9 @@ export declare class Gemma4Model {
    * Note: this only reports draft availability. Whether speculative
    * decoding actually runs on a given call also requires the per-request
    * `enableMtp` flag. Named `hasMtpWeights` for parity with the Qwen3.5
-   * surface. Stubs from `new(config)` always return `false`.
+   * surface, but it reports an external DSpark draft model, not
+   * in-checkpoint MTP heads. Stubs from `new(config)` always return
+   * `false`.
    */
   hasMtpWeights(): boolean;
   /** Load a Gemma4 model from a directory. */
@@ -742,9 +744,20 @@ export declare class MxArray {
   divScalar(value: number): MxArray;
   matmul(other: MxArray): MxArray;
   /**
-   * Fused matrix multiply-add: D = beta * C + alpha * (self @ B)
-   * where self is A. More efficient than separate matmul and add operations.
-   * Default: alpha=1.0, beta=1.0, giving D = C + (self @ B)
+   * Matrix multiply-add: D = beta * C + alpha * (self @ B), where self is A.
+   * Default: alpha=1.0, beta=1.0, giving D = C + (self @ B).
+   *
+   * Computed explicitly (matmul, optional alpha scale, then add beta*C)
+   * rather than via the fused `mlx::core::addmm` primitive. The fused
+   * primitive is correct on a well-formed metallib, but this project's local
+   * release build is known to non-deterministically miscompile fused GEMM
+   * kernels (see the metallib-corruption notes), which manifested as the
+   * fused addmm dropping `beta*C` and corrupting every biased linear — most
+   * visibly the vision tower (`qkv`, `proj`, `fc1`, `fc2`, merger all carry a
+   * bias; bias-free LM/MoE linears pass a zero `C` and were unaffected). The
+   * explicit form keeps the `C` term robust to that build hazard; the
+   * `nn::linear` unit tests assert it applies a non-zero `C`, so they double
+   * as a canary if a future build corrupts the matmul kernel too.
    */
   addmm(c: MxArray, b: MxArray, alpha?: number | undefined | null, beta?: number | undefined | null): MxArray;
   abs(): MxArray;
@@ -1210,11 +1223,11 @@ export declare class Qwen35Model {
    *
    * `true` iff `Qwen35Inner::paged_adapter` was successfully
    * constructed at load time (driven by
-   * `Qwen3_5Config::use_block_paged_cache`, currently default-OFF
-   * because parity is pending real-weights validation). On VLM
-   * checkpoints the adapter can still be active for text-only
-   * inference; image-bearing chat turns are rejected at runtime by
-   * the chat-entry sites. Surfaced through this NAPI method so
+   * `Qwen3_5Config::use_block_paged_cache`, default-OFF for text-only
+   * checkpoints because parity is pending real-weights validation, and
+   * default-ON for VLM checkpoints). On VLM checkpoints dense image turns
+   * ONLY run on the paged-vision core; a vision turn that reaches a None
+   * adapter errors at dispatch. Surfaced through this NAPI method so
    * server endpoints can branch on it without round-tripping through
    * the model thread.
    */
@@ -2338,8 +2351,9 @@ export interface ChatConfig {
   reuseCache?: boolean | undefined;
   /**
    * MTP: opt-in flag enabling the Multi-Token Prediction speculative decode
-   * loop on the dense compiled path. Requires the model checkpoint to carry
-   * an MTP head (otherwise silently ignored). Default: `false`.
+   * loop (pure-Rust eager; qwen3.5 dense and MoE). Requires the model
+   * checkpoint to carry an MTP head (otherwise silently ignored). Default:
+   * `false`.
    */
   enableMtp?: boolean | undefined;
   /**
@@ -2645,11 +2659,11 @@ export declare function createRandomQwen35Checkpoint(config: Qwen35Config, saveP
 /**
  * Create a random-init Qwen3.5 MoE model and save it to disk.
  *
- * Spawns a dedicated `ModelThread<Qwen35MoeCmd>` whose init builds a fresh
- * random-weight `Qwen35MoeInner` directly, then dispatches
- * `Qwen35MoeCmd::SaveModel` on that thread. The thread is dropped at the end
- * of the promise, so the in-memory model is released once the checkpoint has
- * been written. Used by TypeScript test fixtures that need an on-disk
+ * Spawns a dedicated model thread whose init runs
+ * [`create_random_qwen35_moe_checkpoint_sync`] (random-init inner + save);
+ * the thread holds no state and is dropped once the promise resolves, so
+ * the in-memory model is released as soon as the checkpoint has been
+ * written. Used by TypeScript test fixtures that need an on-disk
  * checkpoint without keeping a NAPI model instance alive.
  */
 export declare function createRandomQwen35MoeCheckpoint(config: Qwen35MoeConfig, savePath: string): Promise<undefined>;
@@ -2929,7 +2943,7 @@ export interface Gemma4Config {
   useBlockPagedCache?: boolean | undefined;
 }
 
-/** Optional load-time settings for `Gemma4Model.load`. */
+/** Optional load-time settings for [`Gemma4Model::load`]. */
 export interface Gemma4LoadOptions {
   /**
    * Directory of a DSpark draft checkpoint (config.json +
@@ -2939,7 +2953,7 @@ export interface Gemma4LoadOptions {
    * `use_block_paged_cache` is a hard load error, and an unset
    * `use_block_paged_cache` is forced to `false`.
    */
-  draftModelPath?: string | undefined;
+  draftModelPath?: string;
 }
 
 /**
@@ -3942,13 +3956,18 @@ export interface Qwen35Config {
    * when unset, they run the eager flat decode. Either way the forward
    * is pure-Rust eager.
    *
-   * **VLM is rejected**: when both `vision_encoder.is_some()` and
-   * this flag is `Some(true)`, `Qwen35Inner::new_with_paged` returns
-   * a descriptive error. Paged dispatch through M-RoPE / vision
-   * features is deferred.
+   * **VLM under paged**: a VLM checkpoint defaults this flag ON at load, so
+   * dense image turns ONLY run on the paged-vision core. A fresh single-turn
+   * image-bearing prompt prefills through the paged adapter (M-RoPE positions
+   * feed the rotary; the merged vision embeddings feed the forward) and
+   * decodes plain AR — MTP weights are ignored on image turns. Warm
+   * image-bearing session continues / cache-hit reuse are still rejected at
+   * runtime (the GDN two-pass warm prefix is not byte-exact). A vision turn
+   * that reaches a None adapter (explicit `Some(false)`, non-Metal build, or
+   * a sym8 checkpoint) errors at dispatch.
    *
-   * Default: `None` / `false` (use the eager flat decode path).
-   * Default-flip pending real-weights parity verification.
+   * Default: `None` for text-only checkpoints (eager flat decode);
+   * `Some(true)` for VLM checkpoints (block-paged, set in `parse_config`).
    */
   useBlockPagedCache?: boolean | undefined;
   /**
@@ -4036,8 +4055,12 @@ export interface Qwen35MoeConfig {
    * either way. When disabled, full-attention layers run the eager flat
    * decode instead.
    *
-   * VLM (vision encoder present) is rejected with an error in
-   * `Qwen35MoeInner::new`.
+   * **VLM under paged**: a VLM checkpoint loads with this flag set, and a
+   * fresh single-turn image-bearing prompt prefills through the paged
+   * adapter (M-RoPE positions feed the rotary; the merged vision embeddings
+   * feed the forward). Image-bearing MTP turns are still rejected at
+   * runtime; warm image-bearing session continues / cache-hit reuse are
+   * cold-started (no warm GDN two-pass prefix).
    *
    * Default: `None` / `false`.
    */

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -1756,6 +1756,150 @@ pub(crate) trait MtpStepper {
     fn into_desynced(self) -> bool;
 }
 
+/// Per-turn setup the engine hands to [`DsparkBackend::begin_dspark_decode`].
+///
+/// DSpark analog of [`MtpTurnSetup`] — carries the turn constants the
+/// engine-owned draft/verify loop
+/// ([`crate::engine::dspark_turn::run_dspark_turn`]) needs to construct its
+/// per-turn stepper. Per-cycle scratch (the tapped target hidden states, the
+/// draft-model KV window) lives as STRUCT FIELDS of the concrete
+/// [`DsparkStepper`], never here.
+///
+/// `#[allow(dead_code)]`: constructed by `run_dspark_turn` (exercised via its
+/// mock tests); the gemma4 stepper that consumes it in production lands in a
+/// follow-up.
+#[allow(dead_code)]
+pub(crate) struct DsparkTurnSetup<'a> {
+    /// The turn's resolved [`ChatParams`] — `params.sampling_config` drives
+    /// the per-cycle accept policy and `params.max_new_tokens` is the decode
+    /// budget.
+    pub params: &'a ChatParams,
+    /// Draft block size: the hard upper bound on tokens drafted per
+    /// propose/verify cycle. The engine additionally caps each cycle by
+    /// `params.mtp_depth` and by the remaining token budget minus one.
+    pub block_size: usize,
+}
+
+/// Sub-trait of [`ChatBackend`] for families whose DSpark (draft-model)
+/// speculative-decode whole-turn flows through the engine-owned
+/// propose/verify loop [`crate::engine::dspark_turn::run_dspark_turn`].
+///
+/// Split out of [`ChatBackend`] for the SAME reason as [`MtpBackend`]: the
+/// GAT (`type DsparkDecode<'a>`) has no stable trait-level default. A family
+/// opts in by implementing this trait (+ [`DsparkStepper`] for its stepper)
+/// and overriding `ChatBackend::mtp_turn` to call `run_dspark_turn`;
+/// DSpark-less families do not implement it.
+///
+/// `#[allow(dead_code)]`: exercised by the `engine::dspark_turn` mock tests;
+/// the production gemma4 stepper lands in a follow-up.
+#[allow(dead_code)]
+pub(crate) trait DsparkBackend: ChatBackend {
+    /// Per-turn DSpark propose/verify stepper. Borrows `&mut self` for the
+    /// whole decode loop (the analog of [`MtpBackend::MtpDecode`]).
+    type DsparkDecode<'a>: DsparkStepper
+    where
+        Self: 'a;
+
+    /// Build the per-turn DSpark stepper (the analog of
+    /// [`MtpBackend::begin_mtp_decode`]). Captures the turn constants (draft
+    /// model handle, target tap, block size) into the returned stepper,
+    /// which then drives the engine-owned `run_dspark_turn` loop.
+    fn begin_dspark_decode(
+        &mut self,
+        setup: &DsparkTurnSetup<'_>,
+    ) -> Result<Self::DsparkDecode<'_>>;
+}
+
+/// One cycle's drafted block from [`DsparkStepper::propose`].
+///
+/// `#[allow(dead_code)]`: see [`DsparkBackend`].
+#[allow(dead_code)]
+pub(crate) struct DsparkProposal {
+    /// `L <= max_len` proposed token ids (the stepper may return fewer than
+    /// asked — confidence truncation).
+    pub draft_ids: Vec<i32>,
+    /// Per-position f32 `[vocab]` proposal-density rows `q_i` — the
+    /// distribution `draft_ids[i]` was actually drawn from, consumed by
+    /// `sampling::accept_with_residual` on the sampled accept path. EMPTY
+    /// when the turn is greedy (T=0 argmax accept never reads `q`).
+    pub draft_dists: Vec<MxArray>,
+}
+
+/// Output of [`DsparkStepper::verify`] — ONE batched target forward over
+/// `[anchor, d_0..d_{L-1}]`.
+///
+/// `#[allow(dead_code)]`: see [`DsparkBackend`].
+#[allow(dead_code)]
+pub(crate) struct DsparkVerifyOutput {
+    /// Target logits `[1, 1+L, vocab]`: row `i` is the target's next-token
+    /// distribution AFTER `verify_ids[i]`.
+    pub logits: MxArray,
+}
+
+/// Per-turn DSpark stepper the engine-owned loop
+/// ([`crate::engine::dspark_turn::run_dspark_turn`]) drives.
+///
+/// The `&mut self` borrow model is strictly sequential: the engine calls
+/// exactly one method at a time, in the fixed per-cycle order
+/// `propose → verify → commit → eval_boundary`. `eval_boundary` is `&self`
+/// (schedule-only, no state mutation), the rest are `&mut self`.
+///
+/// # Invariant — tapped hidden states NEVER cross this trait
+///
+/// The real stepper taps the target model's hidden states inside
+/// [`Self::verify`], stashes them as its own fields, and consumes them in
+/// [`Self::commit`] (seeding the next cycle's draft context from the kept
+/// prefix). The engine loop sees only token ids, logits, and the
+/// `keep`/`total_written` bookkeeping — so the draft model's conditioning
+/// stays a stepper-private concern and the trait stays model-agnostic.
+///
+/// `#[allow(dead_code)]`: exercised by the `engine::dspark_turn` mock tests;
+/// the production gemma4 stepper lands in a follow-up.
+#[allow(dead_code)]
+pub(crate) trait DsparkStepper {
+    /// Draft up to `max_len` tokens conditioned on `anchor_id` (the last
+    /// emitted token, whose K/V is NOT yet in the target cache — the
+    /// engine's subsequent [`Self::verify`] writes it at position 0).
+    /// Returns `L <= max_len` drafted ids plus, on sampled turns, the
+    /// per-position proposal densities. `rng` is consumed only on sampled
+    /// turns (greedy drafting must not advance it — mirrors the
+    /// `accept_with_residual` T=0 shortcut's zero-RNG contract). `&mut dyn
+    /// rand::Rng` (rand 0.10's dyn-compatible core trait — the pre-0.10
+    /// `RngCore`) keeps this trait object-safe while the engine loop stays
+    /// generic over `R: rand::Rng`, matching `run_mtp_turn`'s house style.
+    ///
+    /// Never called with `max_len == 0`: the engine skips propose entirely
+    /// on the degenerate single-AR-step cycle.
+    fn propose(
+        &mut self,
+        anchor_id: u32,
+        max_len: usize,
+        params: &ChatParams,
+        rng: &mut dyn rand::Rng,
+    ) -> Result<DsparkProposal>;
+
+    /// ONE batched target forward over `verify_ids = [anchor, d_0..d_{L-1}]`
+    /// (length `1+L`; `L == 0` degenerates to a plain single-token AR step
+    /// THROUGH verify). Writes `1+L` K/V slots into the target cache and
+    /// stashes the tapped per-position hidden states as stepper fields for
+    /// [`Self::commit`].
+    fn verify(&mut self, verify_ids: &[u32]) -> Result<DsparkVerifyOutput>;
+
+    /// Commit the cycle: keep the first `keep` of the `total_written`
+    /// (`== 1+L`) target-cache slots [`Self::verify`] wrote and roll back
+    /// the rest; consume the stashed tapped hiddens to re-seed the draft
+    /// model on the kept prefix. `keep >= 1` always (the anchor's slot is
+    /// unconditionally kept); the cycle's boundary token has NO K/V slot —
+    /// it becomes the next cycle's anchor.
+    fn commit(&mut self, keep: usize, total_written: usize) -> Result<()>;
+
+    /// Schedule async eval for the boundary token that becomes the next
+    /// cycle's anchor. `&self` — schedules only, no mutation. Called at the
+    /// iteration boundary on the continue path (the analog of
+    /// [`MtpStepper::eval_step_with_chained_hidden`]'s placement).
+    fn eval_boundary(&self, token: &MxArray);
+}
+
 /// Per-family training backend the model-neutral training-command handler
 /// ([`crate::engine::cmd::handle_train_cmd`]) drives.
 ///

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -1815,13 +1815,17 @@ pub(crate) trait DsparkBackend: ChatBackend {
 /// `#[allow(dead_code)]`: see [`DsparkBackend`].
 #[allow(dead_code)]
 pub(crate) struct DsparkProposal {
-    /// `L <= max_len` proposed token ids (the stepper may return fewer than
-    /// asked — confidence truncation).
+    /// `L <= max_len` proposed token ids. The stepper may return FEWER than
+    /// asked (confidence truncation) but never more — the engine hard-errors
+    /// on an over-long block (it would overrun the near-tail budget cap's
+    /// target-cache slot expectations).
     pub draft_ids: Vec<i32>,
     /// Per-position f32 `[vocab]` proposal-density rows `q_i` — the
     /// distribution `draft_ids[i]` was actually drawn from, consumed by
     /// `sampling::accept_with_residual` on the sampled accept path. EMPTY
-    /// when the turn is greedy (T=0 argmax accept never reads `q`).
+    /// whenever the turn's temperature is greedy
+    /// (`sampling::is_greedy_temperature`) — greedy acceptance, with or
+    /// without active penalties, is argmax-based and never reads `q`.
     pub draft_dists: Vec<MxArray>,
 }
 
@@ -1860,13 +1864,16 @@ pub(crate) trait DsparkStepper {
     /// Draft up to `max_len` tokens conditioned on `anchor_id` (the last
     /// emitted token, whose K/V is NOT yet in the target cache — the
     /// engine's subsequent [`Self::verify`] writes it at position 0).
-    /// Returns `L <= max_len` drafted ids plus, on sampled turns, the
-    /// per-position proposal densities. `rng` is consumed only on sampled
-    /// turns (greedy drafting must not advance it — mirrors the
-    /// `accept_with_residual` T=0 shortcut's zero-RNG contract). `&mut dyn
-    /// rand::Rng` (rand 0.10's dyn-compatible core trait — the pre-0.10
-    /// `RngCore`) keeps this trait object-safe while the engine loop stays
-    /// generic over `R: rand::Rng`, matching `run_mtp_turn`'s house style.
+    /// Returns `L <= max_len` drafted ids (never more — the engine
+    /// hard-errors on over-return) plus, on sampled-temperature turns, the
+    /// per-position proposal densities. `rng` is consumed only at
+    /// non-greedy temperature: at greedy temperature — regardless of active
+    /// penalties — drafting and acceptance are argmax-based and must not
+    /// advance it (mirrors the `accept_with_residual` T=0 shortcut's
+    /// zero-RNG contract). `&mut dyn rand::Rng` (rand 0.10's dyn-compatible
+    /// core trait — the pre-0.10 `RngCore`) keeps this trait object-safe
+    /// while the engine loop stays generic over `R: rand::Rng`, matching
+    /// `run_mtp_turn`'s house style.
     ///
     /// Never called with `max_len == 0`: the engine skips propose entirely
     /// on the degenerate single-AR-step cycle.

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -1763,11 +1763,9 @@ pub(crate) trait MtpStepper {
 /// ([`crate::engine::dspark_turn::run_dspark_turn`]) needs to construct its
 /// per-turn stepper. Per-cycle scratch (the tapped target hidden states, the
 /// draft-model KV window) lives as STRUCT FIELDS of the concrete
-/// [`DsparkStepper`], never here.
-///
-/// `#[allow(dead_code)]`: constructed by `run_dspark_turn` (exercised via its
-/// mock tests); the gemma4 stepper that consumes it in production lands in a
-/// follow-up.
+/// [`DsparkStepper`], never here. Prefill-derived state (the gemma4 draft
+/// context) travels through the family's own stash
+/// (`Gemma4Inner::dspark_turn_state`), consumed by `begin_dspark_decode`.
 #[allow(dead_code)]
 pub(crate) struct DsparkTurnSetup<'a> {
     /// The turn's resolved [`ChatParams`] — `params.sampling_config` drives
@@ -1788,11 +1786,8 @@ pub(crate) struct DsparkTurnSetup<'a> {
 /// GAT (`type DsparkDecode<'a>`) has no stable trait-level default. A family
 /// opts in by implementing this trait (+ [`DsparkStepper`] for its stepper)
 /// and overriding `ChatBackend::mtp_turn` to call `run_dspark_turn`;
-/// DSpark-less families do not implement it.
-///
-/// `#[allow(dead_code)]`: exercised by the `engine::dspark_turn` mock tests;
-/// the production gemma4 stepper lands in a follow-up.
-#[allow(dead_code)]
+/// DSpark-less families do not implement it. Production implementation:
+/// gemma4 (`models::gemma4::dspark_decode`).
 pub(crate) trait DsparkBackend: ChatBackend {
     /// Per-turn DSpark propose/verify stepper. Borrows `&mut self` for the
     /// whole decode loop (the analog of [`MtpBackend::MtpDecode`]).
@@ -1811,9 +1806,6 @@ pub(crate) trait DsparkBackend: ChatBackend {
 }
 
 /// One cycle's drafted block from [`DsparkStepper::propose`].
-///
-/// `#[allow(dead_code)]`: see [`DsparkBackend`].
-#[allow(dead_code)]
 pub(crate) struct DsparkProposal {
     /// `L <= max_len` proposed token ids. The stepper may return FEWER than
     /// asked (confidence truncation) but never more — the engine hard-errors
@@ -1831,9 +1823,6 @@ pub(crate) struct DsparkProposal {
 
 /// Output of [`DsparkStepper::verify`] — ONE batched target forward over
 /// `[anchor, d_0..d_{L-1}]`.
-///
-/// `#[allow(dead_code)]`: see [`DsparkBackend`].
-#[allow(dead_code)]
 pub(crate) struct DsparkVerifyOutput {
     /// Target logits `[1, 1+L, vocab]`: row `i` is the target's next-token
     /// distribution AFTER `verify_ids[i]`.
@@ -1856,10 +1845,7 @@ pub(crate) struct DsparkVerifyOutput {
 /// prefix). The engine loop sees only token ids, logits, and the
 /// `keep`/`total_written` bookkeeping — so the draft model's conditioning
 /// stays a stepper-private concern and the trait stays model-agnostic.
-///
-/// `#[allow(dead_code)]`: exercised by the `engine::dspark_turn` mock tests;
-/// the production gemma4 stepper lands in a follow-up.
-#[allow(dead_code)]
+/// Production implementation: `Gemma4DsparkStepper`.
 pub(crate) trait DsparkStepper {
     /// Draft up to `max_len` tokens conditioned on `anchor_id` (the last
     /// emitted token, whose K/V is NOT yet in the target cache — the

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -59,11 +59,14 @@ pub(crate) struct DsparkTurnArgs<'a> {
 /// caches can never desync), so only `last_in_cache` is surfaced.
 pub(crate) struct DsparkTurnOutcome {
     /// Whether the LAST emitted token's K/V is already in the target cache.
-    /// `true` iff the last emitted token is the anchor or an accepted draft
-    /// (verify wrote its slot and commit kept it); `false` when it is a
-    /// cycle's boundary token (bonus/residual — never written this cycle;
-    /// it only gains K/V as the NEXT cycle's verify anchor). The save uses
-    /// `drop_last_always = !last_in_cache`.
+    /// `true` iff the last emitted token is a KEPT accepted draft (verify
+    /// wrote its slot and commit kept it); `false` when it is a cycle's
+    /// boundary token (bonus/residual — never written this cycle; it only
+    /// gains K/V as the NEXT cycle's verify anchor) AND on every in-cycle
+    /// stop cut — the stop-clamp's AR-parity exclusion never keeps the
+    /// tripping token's slot, so every stop exit reports `false`, exactly
+    /// like the AR reference (which never forwards its final token on a
+    /// non-length stop). The save uses `drop_last_always = !last_in_cache`.
     pub last_in_cache: bool,
 }
 
@@ -84,8 +87,12 @@ enum CycleStop {
 /// argmax-based — batched fast path when penalties are no-op, per-row
 /// penalized argmax otherwise, never dists/RNG; sampled temperature:
 /// per-position `accept_with_residual`) → STOP-CLAMP over the accepted list
-/// BEFORE commit → `commit(keep = 1 + min(emit_count, k), 1 + L)` → emit →
-/// cache-clear cadence → stop or `anchor = boundary; eval_boundary`.
+/// BEFORE commit → `commit(keep = 1 + kept_drafts, 1 + L)` where
+/// `kept_drafts = min(emit_count, k)` EXCEPT that an in-cycle stop token's
+/// slot is never kept (AR-parity: the tripping token is excluded when the
+/// clamp cut at an accepted draft, so a stop exit leaves the cache exactly
+/// where the AR reference would) → emit → cache-clear cadence → stop or
+/// `anchor = boundary; eval_boundary`.
 ///
 /// Driven in production by gemma4's `mtp_turn` override
 /// (`dspark_chat_turn`); the module's mock tests pin the loop contract.
@@ -464,7 +471,27 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
         // NO K/V (it becomes the next cycle's anchor), so it never counts
         // toward `keep` — hence `min(emit_count, k)` counts only kept
         // accepted-draft slots.
-        let keep = 1 + emit_count.min(accepted_drafts_k);
+        //
+        // AR-PARITY on in-cycle stops: an in-cycle stop token (EOS /
+        // cancel-observed / repetition-tripping — always the LAST emitted
+        // token) is NEVER committed to the target cache. The AR reference
+        // never forwards its final token on a non-length stop and the
+        // family saves drop it from the persisted history, so keeping its
+        // slot here would leave the speculative session one K/V (and one
+        // history token, via `last_in_cache`) AHEAD of the AR session for
+        // the same transcript. When the clamp cut at an ACCEPTED DRAFT
+        // (`emit_count <= k` — Stop/Cancelled/Repetition always follow a
+        // push, so `emit_count >= 1` there), exclude the tripping token's
+        // slot; a boundary-stop cut changes nothing (no slot to exclude).
+        let kept_drafts = match stop {
+            Some(CycleStop::Stop) | Some(CycleStop::Cancelled) | Some(CycleStop::Repetition(_))
+                if emit_count <= accepted_drafts_k =>
+            {
+                emit_count.saturating_sub(1)
+            }
+            _ => emit_count.min(accepted_drafts_k),
+        };
+        let keep = 1 + kept_drafts;
         profiler.begin("dspark_commit");
         let commit_res = step.commit(keep, 1 + draft_len);
         profiler.end();
@@ -520,10 +547,12 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
         }
 
         // `last_in_cache` invariant: true iff the LAST emitted token's K/V
-        // is in the target cache. Accepted drafts (indices < k) and the
-        // anchor have kept K/V slots; the boundary does not. `emit_count ==
-        // k + 1` (full emit incl. boundary) on every non-stop cycle.
-        last_in_cache = emit_count <= accepted_drafts_k;
+        // is in the target cache — i.e. it is one of the `kept_drafts`
+        // slots. `emit_count == k + 1` (full emit incl. boundary) on every
+        // non-stop cycle → false; in-cycle stop tokens are never kept (the
+        // AR-parity exclusion above) → false on every stop cut, whether the
+        // stop token was an accepted draft or the boundary.
+        last_in_cache = emit_count <= kept_drafts;
 
         if let Some(kind) = stop {
             match kind {
@@ -1143,9 +1172,11 @@ mod tests {
     fn dspark_turn_eos_at_accepted_draft_keep_math() {
         // depth 3: drafts [4,15,6] all accepted (verify [4,15,6,7]) + bonus
         // 7 → accepted = [4,15,6,7]. EOS (15) is accepted draft j=1: the
-        // clamp cuts INCLUSIVE at it → emit j+1 = 2 tokens, keep = j+2 = 3
-        // (anchor + drafts 4,15), total = 4, reason "stop". The EOS is an
-        // accepted draft whose verify K/V slot is kept → last_in_cache TRUE.
+        // clamp cuts INCLUSIVE at it → emit j+1 = 2 tokens. AR-PARITY: the
+        // EOS itself is NEVER committed (AR never forwards its final token
+        // on a stop and the save drops it from history) → keep = 1 + j = 2
+        // (anchor + draft 4 only), total = 4, reason "stop", and
+        // last_in_cache FALSE so the save drops the EOS from history too.
         let mut backend = MockDsparkBackend::greedy(
             16,
             vec![CycleScript::greedy(vec![4, 15, 6], vec![4, 15, 6, 7])],
@@ -1157,13 +1188,14 @@ mod tests {
         assert_eq!(out.generated, vec![3, 4, 15], "emit stops at the EOS draft");
         assert_eq!(out.finish_reason, "stop");
         assert!(
-            out.last_in_cache,
-            "EOS at accepted draft j: its K/V is kept → last_in_cache = true"
+            !out.last_in_cache,
+            "EOS at accepted draft j: its slot is excluded from keep → \
+             last_in_cache = false (save drops it, matching AR)"
         );
         assert_eq!(
             commits(&out.ledger),
-            vec![(3, 4)],
-            "keep = j+2 = 3, total = 1+L = 4"
+            vec![(2, 4)],
+            "keep = 1 + j = 2 (EOS slot excluded), total = 1+L = 4"
         );
         // The clamp resolves the stop BEFORE commit — no second cycle runs.
         assert_eq!(count(&out.ledger, |c| matches!(c, Call::Verify { .. })), 1);
@@ -1177,6 +1209,35 @@ mod tests {
         let (mean, _, cycles) = out.acceptance.expect("one cycle recorded");
         assert!((mean - 3.0).abs() < 1e-9);
         assert_eq!(cycles, 1);
+    }
+
+    #[test]
+    fn dspark_turn_eos_at_first_accepted_draft_keeps_anchor_only() {
+        // AR-parity edge: EOS is the FIRST accepted draft (j=0). emit = 1,
+        // its slot is excluded → keep = 1 (anchor only, kept_drafts = 0),
+        // total = 1+L = 4, last_in_cache FALSE. Post-turn state is
+        // identical to an AR turn that generated [anchor, EOS] and dropped
+        // the EOS: only the anchor's K/V (and history entry) survive.
+        let mut backend = MockDsparkBackend::greedy(
+            16,
+            vec![CycleScript::greedy(vec![15, 5, 6], vec![15, 5, 6, 7])],
+        );
+        let mut p = greedy_params();
+        p.mtp_depth = 3;
+        let out = drive_turn(&mut backend, p, 3, 15, 3);
+
+        assert_eq!(out.generated, vec![3, 15], "emit stops at the EOS draft");
+        assert_eq!(out.finish_reason, "stop");
+        assert!(!out.last_in_cache);
+        assert_eq!(
+            commits(&out.ledger),
+            vec![(1, 4)],
+            "keep = 1 (anchor only): the EOS slot and all later verify rows roll back"
+        );
+        assert_eq!(
+            count(&out.ledger, |c| matches!(c, Call::EvalBoundary { .. })),
+            0
+        );
     }
 
     #[test]
@@ -1339,7 +1400,9 @@ mod tests {
         // max_consecutive_tokens = 3: the third consecutive 9 trips the
         // cutoff mid-block. accepted = [9,9,9,9] (drafts [9,9,9] all
         // "accepted", bonus 9); the clamp cuts INCLUSIVE at the third 9 →
-        // emit 3, reason "repetition", keep = 1 + min(3,3) = 4, total 4.
+        // emit 3, reason "repetition". AR-parity: the tripping token is an
+        // in-cycle stop token — its slot is excluded → keep = 1 + 2 = 3,
+        // total 4, last_in_cache FALSE.
         let mut backend = MockDsparkBackend::greedy(
             16,
             vec![CycleScript::greedy(vec![9, 9, 9], vec![9, 9, 9, 9])],
@@ -1352,10 +1415,11 @@ mod tests {
         assert_eq!(out.generated, vec![3, 9, 9, 9]);
         assert_eq!(out.finish_reason, "repetition");
         assert!(
-            out.last_in_cache,
-            "repetition tripped on an accepted draft — its K/V is kept"
+            !out.last_in_cache,
+            "repetition tripped on an accepted draft — the tripping token's \
+             slot is excluded (AR-parity) so the save drops it"
         );
-        assert_eq!(commits(&out.ledger), vec![(4, 4)]);
+        assert_eq!(commits(&out.ledger), vec![(3, 4)]);
     }
 
     // ---- 3. L_cap math -----------------------------------------------------
@@ -1638,9 +1702,11 @@ mod tests {
     fn dspark_turn_streaming_cancel_in_clamp_commits_exactly_once() {
         // Cancel flips DURING the first verify (after the loop-top check).
         // The clamp observes it after the first accepted token: emit 1,
-        // reason "cancelled", commit(keep = 1 + min(1, k=2) = 2, total 3)
-        // — commit still happens EXACTLY once and the cancel token is
-        // committed but NOT streamed (mtp emit-arm parity).
+        // reason "cancelled". AR-parity: the cancel-observed token is an
+        // in-cycle stop token — its slot is excluded → commit(keep = 1,
+        // total 3) — commit still happens EXACTLY once and the cancel token
+        // is emitted (in `generated`) but NOT streamed and NOT persisted
+        // (mtp emit-arm parity + AR drop-last).
         let cancelled = Arc::new(AtomicBool::new(false));
         let mut backend =
             MockDsparkBackend::greedy(7, vec![CycleScript::greedy(vec![1, 3], vec![1, 3, 4])]);
@@ -1654,8 +1720,8 @@ mod tests {
         );
         assert_eq!(out.finish_reason, "cancelled");
         assert!(
-            out.last_in_cache,
-            "the cancel token is an accepted draft with kept K/V"
+            !out.last_in_cache,
+            "the cancel token's slot is excluded from keep (AR-parity)"
         );
         assert_eq!(
             out.chunks,
@@ -1664,8 +1730,8 @@ mod tests {
         );
         assert_eq!(
             commits(&out.ledger),
-            vec![(2, 3)],
-            "commit-exactly-once with the clamped keep"
+            vec![(1, 3)],
+            "commit-exactly-once with the clamped, stop-excluded keep"
         );
         assert_eq!(
             count(&out.ledger, |c| matches!(c, Call::EvalBoundary { .. })),

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -1,0 +1,1496 @@
+//! Engine-owned DSpark (draft-model speculative decode) whole-turn loop —
+//! the DSpark analog of [`crate::engine::mtp_turn`]. Families opt in via
+//! [`crate::engine::backend::DsparkBackend`]; their `ChatBackend::mtp_turn`
+//! override calls [`run_dspark_turn`].
+//!
+//! Structure mirrors [`crate::engine::mtp_turn::run_mtp_turn`] (the
+//! initial-`y` emit guarded by budget, the pre-cycle stop-check order, the
+//! finish-reason strings, the emit-block bookkeeping, the
+//! every-256-emitted-token cache clear). The cycle body is DSpark's own
+//! propose → verify → accept → STOP-CLAMP → commit → emit sequence: unlike
+//! MTP there is NO post-commit rollback/heal path, so every stop condition
+//! is resolved BEFORE [`crate::engine::backend::DsparkStepper::commit`] and
+//! the stepper commits exactly once per cycle.
+
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use napi::bindgen_prelude::*;
+
+use crate::array::{DType, MxArray};
+use crate::decode_profiler::DecodeProfiler;
+use crate::engine::backend::{DsparkBackend, DsparkProposal, DsparkStepper, DsparkTurnSetup};
+use crate::engine::decode::StreamingCtx;
+use crate::engine::params::ChatParams;
+use crate::engine::penalties::{ReasoningTracker, apply_all_penalties};
+use crate::sampling;
+use crate::stream::Stream;
+
+/// Required arguments of [`run_dspark_turn`] — the DSpark analog of
+/// [`crate::engine::mtp_turn::MtpTurnArgs`], minus the MTP-only
+/// prompt-hidden seed fields (the DSpark stepper owns its draft-context
+/// seeding) and plus the draft `block_size`.
+///
+/// `#[allow(dead_code)]`: exercised by the module's mock tests; the gemma4
+/// caller that constructs it in production lands in a follow-up.
+#[allow(dead_code)]
+pub(crate) struct DsparkTurnArgs<'a> {
+    /// First generated token (sampled from the prefill logits BEFORE the
+    /// turn). The loop takes ownership and emits it first (guarded by the
+    /// budget), exactly as `run_mtp_turn` emits its initial `y`.
+    pub y: MxArray,
+    /// Draft block size — the hard per-cycle cap on drafted tokens. The
+    /// per-cycle cap is `min(block_size, params.mtp_depth, remaining - 1)`.
+    pub block_size: usize,
+    pub params: &'a ChatParams,
+    pub reasoning_tracker: &'a mut ReasoningTracker,
+    pub profiler: &'a mut DecodeProfiler,
+    pub max_new_tokens: i32,
+    pub eos_id: u32,
+    pub generated_tokens: &'a mut Vec<u32>,
+    pub token_history: &'a mut Vec<u32>,
+    pub finish_reason: &'a mut String,
+    pub first_token_instant: &'a mut Option<Instant>,
+    pub report_perf: bool,
+    pub generation_stream: Stream,
+}
+
+/// Terminal outs of [`run_dspark_turn`] the caller threads into its save /
+/// next-turn bookkeeping. Minimal mirror of
+/// [`crate::engine::mtp_turn::MtpTurnOutcome`]: DSpark has no flat-desync
+/// side channel (the stop-clamp runs BEFORE commit, so the target and draft
+/// caches can never desync), so only `last_in_cache` is surfaced.
+///
+/// `#[allow(dead_code)]`: see [`DsparkTurnArgs`].
+#[allow(dead_code)]
+pub(crate) struct DsparkTurnOutcome {
+    /// Whether the LAST emitted token's K/V is already in the target cache.
+    /// `true` iff the last emitted token is the anchor or an accepted draft
+    /// (verify wrote its slot and commit kept it); `false` when it is a
+    /// cycle's boundary token (bonus/residual — never written this cycle;
+    /// it only gains K/V as the NEXT cycle's verify anchor). The save uses
+    /// `drop_last_always = !last_in_cache`.
+    pub last_in_cache: bool,
+}
+
+/// In-cycle stop resolved by the pre-commit stop-clamp. Reason strings
+/// byte-match `run_mtp_turn`'s.
+enum CycleStop {
+    Length,
+    Stop,
+    Cancelled,
+    Repetition(&'static str),
+}
+
+/// Engine-owned DSpark propose/verify whole-turn loop.
+///
+/// Per cycle: pre-checks (mtp_turn's exact order) → propose (skipped on the
+/// degenerate `L_cap == 0` cycle) → ONE batched verify over
+/// `[anchor, drafts..]` → acceptance (greedy batched-argmax fast path, or
+/// per-position `accept_with_residual`) → STOP-CLAMP over the accepted list
+/// BEFORE commit → `commit(keep = 1 + min(emit_count, k), 1 + L)` → emit →
+/// cache-clear cadence → stop or `anchor = boundary; eval_boundary`.
+///
+/// `#[allow(dead_code)]`: exercised by the module's mock tests; the gemma4
+/// `mtp_turn` override that drives it in production lands in a follow-up.
+#[allow(dead_code)]
+pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
+    backend: &mut B,
+    rng: &mut R,
+    args: DsparkTurnArgs<'_>,
+    mut streaming: Option<StreamingCtx<'_, '_>>,
+) -> Result<DsparkTurnOutcome> {
+    let DsparkTurnArgs {
+        y,
+        block_size,
+        params: p,
+        reasoning_tracker: tracker,
+        profiler,
+        max_new_tokens: max,
+        eos_id,
+        generated_tokens: generated,
+        token_history: hist,
+        finish_reason: reason,
+        first_token_instant: first_tok,
+        report_perf: report,
+        generation_stream,
+    } = args;
+
+    let setup = DsparkTurnSetup {
+        params: p,
+        block_size,
+    };
+    let mut step = backend.begin_dspark_decode(&setup)?;
+
+    // Materialize the prefill-sampled seed once; it is the first anchor.
+    y.eval();
+    let mut anchor: u32 = y.item_at_int32(0)? as u32;
+
+    // `last_in_cache` default `true`: a zero-budget exit emits nothing, so
+    // the last cached token is the prompt's last token, which IS in cache.
+    let mut last_in_cache = true;
+    let mut last_clear_at: usize = generated.len();
+
+    // Same nonpositive-budget clamp as `run_mtp_turn` (see its PARITY-FIX
+    // comment): a negative `max` must behave as 0, not wrap to a huge usize.
+    let max_as_usize: usize = (max).max(0) as usize;
+
+    // Initial-`y` emit, guarded by the budget — mirrors `run_mtp_turn`'s
+    // initial push verbatim (eval / observe_token / streaming skip-on-cancel
+    // with NO break / profiler bookkeeping).
+    if generated.len() < max_as_usize {
+        let _stream_ctx = crate::stream::StreamContext::new(generation_stream);
+        profiler.begin("extract");
+        let initial_token_id = anchor;
+        profiler.end();
+        profiler.mark_first_token();
+        if report && first_tok.is_none() {
+            *first_tok = Some(std::time::Instant::now());
+        }
+        generated.push(initial_token_id);
+        hist.push(initial_token_id);
+        let _is_reasoning = tracker.observe_token(initial_token_id);
+        if let Some(s) = streaming.as_mut() {
+            *s.last_is_reasoning = _is_reasoning;
+            if !s.cancelled.load(Ordering::Relaxed) {
+                let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
+                    s.decode_stream,
+                    s.tokenizer,
+                    initial_token_id,
+                    generated,
+                    *s.streamed_text_len,
+                );
+                *s.streamed_text_len += token_text.len();
+                s.emitter.on_token_text(
+                    &token_text,
+                    _is_reasoning,
+                    p.include_reasoning,
+                    s.callback,
+                );
+            }
+        }
+        profiler.step();
+        // The just-emitted anchor has no K/V yet — the first cycle's verify
+        // writes it at position 0.
+        last_in_cache = false;
+    }
+
+    // Turn-constant accept-policy gates (params are fixed for the turn).
+    let temperature = p.sampling_config.and_then(|c| c.temperature).unwrap_or(1.0);
+    let sampling_cfg = p.sampling_config.unwrap_or_default();
+    let penalties_no_op =
+        p.repetition_penalty == 1.0 && p.presence_penalty == 0.0 && p.frequency_penalty == 0.0;
+    let greedy = sampling::is_greedy_temperature(temperature) && penalties_no_op;
+
+    // DELIBERATE DIVERGENCE from `run_mtp_turn`: cancellation is checked at
+    // the cycle top and inside the pre-commit stop-clamp, NOT per emitted
+    // token. This bounds cancel latency to <= block_size + 1 tokens while
+    // preserving the commit-exactly-once, caches-never-desync invariant —
+    // gemma4 has no post-commit heal path, so a mid-emit cancel must never
+    // be observed AFTER the cycle's commit already kept its slots.
+    loop {
+        // Pre-cycle stop checks — `run_mtp_turn`'s exact order and reason
+        // strings: zero budget → EOS/extra-EOS → cancel → repetition → max.
+        if max_as_usize == 0 {
+            if reason.is_empty() {
+                *reason = String::from("length");
+            }
+            break;
+        }
+        if let Some(&last) = generated.last()
+            && (last == eos_id || p.extra_eos_ids.contains(&last))
+        {
+            *reason = String::from("stop");
+            // The stop token is the prior cycle's boundary (or the initial
+            // seed) — never verified, so not in the physical cache.
+            last_in_cache = false;
+            break;
+        }
+        if let Some(s) = streaming.as_ref()
+            && s.cancelled.load(Ordering::Relaxed)
+        {
+            *reason = String::from("cancelled");
+            last_in_cache = false;
+            break;
+        }
+        if let Some(reason_str) = crate::sampling::check_repetition_cutoff(
+            generated,
+            p.max_consecutive_tokens,
+            p.max_ngram_repeats,
+            p.ngram_size,
+        ) {
+            *reason = reason_str.to_string();
+            last_in_cache = false;
+            break;
+        }
+        if generated.len() >= max_as_usize {
+            if reason.is_empty() {
+                *reason = String::from("length");
+            }
+            break;
+        }
+
+        let _stream_ctx = crate::stream::StreamContext::new(generation_stream);
+
+        // Per-cycle draft cap. `remaining >= 1` here (the length check above
+        // broke otherwise). `remaining - 1` reserves the boundary token's
+        // budget slot: a cycle emits at most `L + 1` tokens.
+        let remaining: usize = max_as_usize.saturating_sub(generated.len());
+        let l_cap: usize = block_size.min(p.mtp_depth).min(remaining.saturating_sub(1));
+
+        // `L_cap == 0` (remaining == 1): skip propose entirely — the cycle
+        // degenerates to a single AR step THROUGH verify (verify_ids =
+        // [anchor] only), keeping the anchor's K/V write on the one path.
+        let proposal = if l_cap >= 1 {
+            profiler.begin("dspark_propose");
+            let res = step.propose(anchor, l_cap, p, rng);
+            profiler.end();
+            res?
+        } else {
+            DsparkProposal {
+                draft_ids: Vec::new(),
+                draft_dists: Vec::new(),
+            }
+        };
+        // The stepper may return fewer than `l_cap` (confidence truncation);
+        // a longer return is tolerated — the stop-clamp below caps emission
+        // at the budget regardless.
+        let draft_len = proposal.draft_ids.len();
+
+        let mut verify_ids: Vec<u32> = Vec::with_capacity(1 + draft_len);
+        verify_ids.push(anchor);
+        verify_ids.extend(proposal.draft_ids.iter().map(|&id| id as u32));
+
+        profiler.begin("dspark_verify");
+        let verify_res = step.verify(&verify_ids);
+        profiler.end();
+        let verify_out = verify_res?;
+        let logits = verify_out.logits; // [1, 1+L, vocab]
+
+        // Acceptance: `k` accepted drafts (prefix of `draft_ids`) + ONE
+        // boundary token (bonus on full accept, residual on rejection).
+        profiler.begin("dspark_accept");
+        let accept_res: Result<(usize, u32)> = if greedy {
+            // Greedy fast path: ONE batched argmax over all 1+L rows, a
+            // single eval, then CPU reads. No RNG consumed (mirrors
+            // `accept_with_residual`'s T=0 shortcut).
+            (|| {
+                let argmax_arr = logits.argmax(-1, None)?;
+                argmax_arr.eval();
+                let mut target_argmax: Vec<i32> = Vec::with_capacity(draft_len + 1);
+                for i in 0..=draft_len {
+                    target_argmax.push(argmax_arr.item_at_int32(i)?);
+                }
+                let mut k = 0usize;
+                while k < draft_len && target_argmax[k] == proposal.draft_ids[k] {
+                    k += 1;
+                }
+                Ok((k, target_argmax[k] as u32))
+            })()
+        } else {
+            // Sampled path: per-position Leviathan accept + residual
+            // resample against the stepper's proposal densities.
+            (|| {
+                if proposal.draft_dists.len() != draft_len {
+                    return Err(Error::from_reason(format!(
+                        "DSpark sampled accept requires one proposal distribution per \
+                         drafted token (got {} dists for {} drafts)",
+                        proposal.draft_dists.len(),
+                        draft_len
+                    )));
+                }
+                let vocab = logits.shape_at(2)?;
+                let mut hist_extended: Vec<u32> = hist.clone();
+                let mut k = 0usize;
+                let mut boundary: Option<u32> = None;
+                for i in 0..draft_len {
+                    let v_slice = logits.slice(&[0, i as i64, 0], &[1, (i + 1) as i64, vocab])?;
+                    let v_1d = v_slice.squeeze(Some(&[0, 1]))?;
+                    let penalized = apply_all_penalties(v_1d, &hist_extended, p)?;
+                    let p_target = sampling::sampling_distribution(&penalized, p.sampling_config)?
+                        .astype(DType::Float32)?;
+                    p_target.eval();
+                    let (accept, out_tok) = sampling::accept_with_residual(
+                        &p_target,
+                        &proposal.draft_dists[i],
+                        proposal.draft_ids[i],
+                        &sampling_cfg,
+                        rng,
+                    )?;
+                    if accept {
+                        k += 1;
+                        hist_extended.push(out_tok as u32);
+                    } else {
+                        boundary = Some(out_tok as u32);
+                        break;
+                    }
+                }
+                let boundary_id = match boundary {
+                    Some(b) => b,
+                    None => {
+                        // All L drafts accepted: bonus sample from row L.
+                        let i = draft_len;
+                        let v_slice =
+                            logits.slice(&[0, i as i64, 0], &[1, (i + 1) as i64, vocab])?;
+                        let v_1d = v_slice.squeeze(Some(&[0, 1]))?;
+                        let penalized = apply_all_penalties(v_1d, &hist_extended, p)?;
+                        let bonus = sampling::sample(&penalized, p.sampling_config)?;
+                        bonus.eval();
+                        bonus.item_at_int32(0)? as u32
+                    }
+                };
+                Ok((k, boundary_id))
+            })()
+        };
+        profiler.end();
+        let (accepted_drafts_k, boundary_id) = accept_res?;
+
+        let mut accepted: Vec<u32> = Vec::with_capacity(accepted_drafts_k + 1);
+        accepted.extend(
+            proposal.draft_ids[..accepted_drafts_k]
+                .iter()
+                .map(|&id| id as u32),
+        );
+        accepted.push(boundary_id);
+
+        // STOP-CLAMP BEFORE COMMIT: walk the accepted list simulating the
+        // history, replaying `run_mtp_turn`'s emit-loop per-token check
+        // order (budget-before-push → push → cancel → EOS/extra-EOS →
+        // repetition) so the stop decision is byte-equivalent — but taken
+        // BEFORE `commit`, so the stepper keeps exactly the emitted
+        // prefix's K/V and never needs a post-commit rollback. The
+        // EOS/repetition/cancel cuts are INCLUSIVE of the tripping token;
+        // the budget cut is EXCLUSIVE (mtp checks the budget before the
+        // push).
+        let mut emit_count: usize = 0;
+        let mut stop: Option<CycleStop> = None;
+        {
+            let mut sim: Vec<u32> = Vec::with_capacity(generated.len() + accepted.len());
+            sim.extend_from_slice(generated);
+            for (idx, &tok) in accepted.iter().enumerate() {
+                if sim.len() >= max_as_usize {
+                    stop = Some(CycleStop::Length);
+                    break;
+                }
+                sim.push(tok);
+                emit_count = idx + 1;
+                if let Some(s) = streaming.as_ref()
+                    && s.cancelled.load(Ordering::Relaxed)
+                {
+                    stop = Some(CycleStop::Cancelled);
+                    break;
+                }
+                if tok == eos_id || p.extra_eos_ids.contains(&tok) {
+                    stop = Some(CycleStop::Stop);
+                    break;
+                }
+                if let Some(reason_str) = crate::sampling::check_repetition_cutoff(
+                    &sim,
+                    p.max_consecutive_tokens,
+                    p.max_ngram_repeats,
+                    p.ngram_size,
+                ) {
+                    stop = Some(CycleStop::Repetition(reason_str));
+                    break;
+                }
+            }
+        }
+
+        // Anchor's K/V was written at verify position 0; the boundary has
+        // NO K/V (it becomes the next cycle's anchor), so it never counts
+        // toward `keep` — hence `min(emit_count, k)` counts only kept
+        // accepted-draft slots.
+        let keep = 1 + emit_count.min(accepted_drafts_k);
+        profiler.begin("dspark_commit");
+        let commit_res = step.commit(keep, 1 + draft_len);
+        profiler.end();
+        commit_res?;
+
+        // Per-cycle acceptance stats: DRAFTED depth `L` and accepted draft
+        // count `k` — the same argument semantics as `run_mtp_cycle`'s
+        // `record_mtp_cycle(effective_depth, accepted_drafts)` (boundary
+        // excluded from both). Degenerate `L == 0` cycles are plain AR
+        // steps and are NOT recorded.
+        if draft_len >= 1 {
+            profiler.record_mtp_cycle(draft_len, accepted_drafts_k);
+        }
+
+        // Emit the clamped prefix — `run_mtp_turn`'s emit-block bookkeeping
+        // (push / observe / detok / emitter), with the stop checks already
+        // resolved by the clamp above and NO per-token cancel check (see
+        // the divergence note at the loop top). Cancel parity: the token on
+        // which the clamp observed the cancel is committed but NOT streamed,
+        // matching the mtp emit arm's break-before-detok.
+        profiler.begin("dspark_emit_loop");
+        for (idx, &tok_id) in accepted[..emit_count].iter().enumerate() {
+            generated.push(tok_id);
+            hist.push(tok_id);
+            let _is_reasoning = tracker.observe_token(tok_id);
+            if let Some(s) = streaming.as_mut() {
+                *s.last_is_reasoning = _is_reasoning;
+                if matches!(stop, Some(CycleStop::Cancelled)) && idx + 1 == emit_count {
+                    continue;
+                }
+                let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
+                    s.decode_stream,
+                    s.tokenizer,
+                    tok_id,
+                    generated,
+                    *s.streamed_text_len,
+                );
+                *s.streamed_text_len += token_text.len();
+                s.emitter.on_token_text(
+                    &token_text,
+                    _is_reasoning,
+                    p.include_reasoning,
+                    s.callback,
+                );
+            }
+        }
+        profiler.end();
+
+        // Every-256-emitted-token cache clear (mtp_turn's cadence).
+        if generated.len() >= last_clear_at + 256 {
+            crate::array::synchronize_and_clear_cache();
+            last_clear_at = generated.len();
+        }
+
+        // `last_in_cache` invariant: true iff the LAST emitted token's K/V
+        // is in the target cache. Accepted drafts (indices < k) and the
+        // anchor have kept K/V slots; the boundary does not. `emit_count ==
+        // k + 1` (full emit incl. boundary) on every non-stop cycle.
+        last_in_cache = emit_count <= accepted_drafts_k;
+
+        if let Some(kind) = stop {
+            match kind {
+                CycleStop::Length => {
+                    if reason.is_empty() {
+                        *reason = String::from("length");
+                    }
+                }
+                CycleStop::Stop => *reason = String::from("stop"),
+                CycleStop::Cancelled => *reason = String::from("cancelled"),
+                CycleStop::Repetition(r) => *reason = r.to_string(),
+            }
+            break;
+        }
+
+        // Continue: the boundary becomes the next cycle's anchor.
+        anchor = boundary_id;
+        let y_arr = MxArray::from_int32(&[boundary_id as i32], &[1])?;
+        step.eval_boundary(&y_arr);
+        profiler.step();
+    }
+
+    profiler.snapshot_memory_after();
+    profiler.report();
+
+    Ok(DsparkTurnOutcome { last_in_cache })
+}
+
+#[cfg(test)]
+mod tests {
+    //! `run_dspark_turn` tests over a scripted [`MockDsparkStepper`] — NO
+    //! model, NO Metal-heavy ops (tiny vocab-16 arrays only). Mirrors the
+    //! `mtp_turn` mock-test approach: a per-cycle script drives
+    //! propose/verify deterministically and an ordered call ledger records
+    //! every stepper call so the tests assert the REAL sequencing
+    //! (propose → verify → commit(keep, total) → eval_boundary), the
+    //! emitted token stream, the finish-reason strings, `last_in_cache`,
+    //! and the profiler's acceptance stats.
+
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+
+    use napi::bindgen_prelude::*;
+
+    use crate::array::MxArray;
+    use crate::decode_profiler::DecodeProfiler;
+    use crate::engine::backend::{
+        ChatBackend, ChunkSink, DefaultStreamEmitter, DsparkBackend, DsparkProposal, DsparkStepper,
+        DsparkTurnSetup, DsparkVerifyOutput, FinalizeArgs, ResetScope, SaveStateArgs, TurnSetup,
+    };
+    use crate::engine::decode::StreamingCtx;
+    use crate::engine::params::ChatParams;
+    use crate::engine::penalties::ReasoningTracker;
+    use crate::engine::types::{ChatResult, ChatStreamChunk};
+    use crate::sampling::SamplingConfig;
+    use crate::stream::{DeviceType, Stream};
+    use crate::tokenizer::Qwen3Tokenizer;
+
+    use super::{DsparkTurnArgs, run_dspark_turn};
+
+    /// One recorded `DsparkStepper` call, tagged with the payload the loop
+    /// handed it so tests assert the exact per-cycle sequencing.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum Call {
+        Propose { anchor: u32, max_len: usize },
+        Verify { ids: Vec<u32> },
+        Commit { keep: usize, total: usize },
+        EvalBoundary { token: i32 },
+    }
+
+    /// Canned per-cycle script.
+    ///
+    /// `draft_ids` is what `propose` returns (deliberately allowed to exceed
+    /// the requested `max_len` so the budget stop-clamp can be exercised).
+    /// `draft_dists[i]` is the full `[vocab]` f32 proposal row `q_i`
+    /// (empty on greedy scripts). `verify_argmax[j]` is the argmax of
+    /// verify-logits row `j` (`j` in `0..=L`); missing entries fall back
+    /// to 0 so over-long verifies stay defined.
+    #[derive(Clone)]
+    struct CycleScript {
+        draft_ids: Vec<i32>,
+        draft_dists: Vec<Vec<f32>>,
+        verify_argmax: Vec<i32>,
+    }
+
+    impl CycleScript {
+        fn greedy(draft_ids: Vec<i32>, verify_argmax: Vec<i32>) -> Self {
+            Self {
+                draft_ids,
+                draft_dists: Vec::new(),
+                verify_argmax,
+            }
+        }
+    }
+
+    /// Full-vocab one-hot f32 row (mass 1.0 at `id`).
+    fn one_hot(vocab: i64, id: i32) -> Vec<f32> {
+        let mut row = vec![0.0f32; vocab as usize];
+        row[id as usize] = 1.0;
+        row
+    }
+
+    /// `[vocab]` logits row whose argmax is `argmax_id`: spike 10.0 there,
+    /// `fill` elsewhere. `fill == 0.0` for greedy scripts (only the argmax
+    /// matters); `-1e30` for sampled scripts so `softmax` is EXACTLY one-hot
+    /// (f32 `exp(-1e30) == 0.0` underflow) and every accept/residual/bonus
+    /// draw is deterministic BY CONSTRUCTION (the mtp_turn dense-test trick).
+    fn logits_row(vocab: i64, argmax_id: i32, fill: f32) -> Vec<f32> {
+        let mut row = vec![fill; vocab as usize];
+        if (0..vocab as i32).contains(&argmax_id) {
+            row[argmax_id as usize] = 10.0;
+        }
+        row
+    }
+
+    /// Scripted [`DsparkStepper`] double. Records every call into the
+    /// shared ordered ledger and fabricates verify logits from the current
+    /// cycle's `verify_argmax`. The cycle cursor advances on `commit` (the
+    /// one call every cycle makes exactly once).
+    struct MockDsparkStepper {
+        vocab: i64,
+        cycles: Vec<CycleScript>,
+        neg_fill: f32,
+        cursor: Cell<usize>,
+        verify_count: Cell<usize>,
+        /// Flip this flag DURING the Nth (0-based) verify — models a cancel
+        /// arriving mid-cycle, between the loop-top check and the clamp.
+        cancel_on_verify: Option<(usize, Arc<AtomicBool>)>,
+        ledger: Rc<RefCell<Vec<Call>>>,
+    }
+
+    impl MockDsparkStepper {
+        fn script(&self) -> CycleScript {
+            self.cycles
+                .get(self.cursor.get())
+                .cloned()
+                .unwrap_or_else(|| CycleScript::greedy(Vec::new(), Vec::new()))
+        }
+    }
+
+    impl DsparkStepper for MockDsparkStepper {
+        fn propose(
+            &mut self,
+            anchor_id: u32,
+            max_len: usize,
+            _params: &ChatParams,
+            _rng: &mut dyn rand::Rng,
+        ) -> Result<DsparkProposal> {
+            self.ledger.borrow_mut().push(Call::Propose {
+                anchor: anchor_id,
+                max_len,
+            });
+            let script = self.script();
+            let draft_dists = script
+                .draft_dists
+                .iter()
+                .map(|row| MxArray::from_float32(row, &[self.vocab]))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(DsparkProposal {
+                draft_ids: script.draft_ids.clone(),
+                draft_dists,
+            })
+        }
+
+        fn verify(&mut self, verify_ids: &[u32]) -> Result<DsparkVerifyOutput> {
+            self.ledger.borrow_mut().push(Call::Verify {
+                ids: verify_ids.to_vec(),
+            });
+            let script = self.script();
+            let rows = verify_ids.len();
+            let mut flat: Vec<f32> = Vec::with_capacity(rows * self.vocab as usize);
+            for j in 0..rows {
+                let argmax_id = script.verify_argmax.get(j).copied().unwrap_or(0);
+                flat.extend(logits_row(self.vocab, argmax_id, self.neg_fill));
+            }
+            let logits = MxArray::from_float32(&flat, &[1, rows as i64, self.vocab])?;
+            let n = self.verify_count.get();
+            self.verify_count.set(n + 1);
+            if let Some((at, flag)) = self.cancel_on_verify.as_ref()
+                && *at == n
+            {
+                flag.store(true, Ordering::Relaxed);
+            }
+            Ok(DsparkVerifyOutput { logits })
+        }
+
+        fn commit(&mut self, keep: usize, total_written: usize) -> Result<()> {
+            self.ledger.borrow_mut().push(Call::Commit {
+                keep,
+                total: total_written,
+            });
+            self.cursor.set(self.cursor.get() + 1);
+            Ok(())
+        }
+
+        fn eval_boundary(&self, token: &MxArray) {
+            token.eval();
+            let id = token.item_at_int32(0).unwrap_or(-1);
+            self.ledger
+                .borrow_mut()
+                .push(Call::EvalBoundary { token: id });
+        }
+    }
+
+    /// A never-constructed `DecodeStep` so `MockDsparkBackend` satisfies the
+    /// `ChatBackend::Decode<'a>` bound — `begin_decode` is never called on
+    /// the DSpark path.
+    struct NeverDecode;
+    impl crate::engine::backend::DecodeStep for NeverDecode {
+        fn forward(&mut self, _input_ids: &MxArray) -> Result<(MxArray, bool)> {
+            Err(Error::from_reason("NeverDecode::forward must not run"))
+        }
+        fn eval_step(&mut self, _next_token: &MxArray, _logits: &MxArray, _budget_forced: bool) {}
+    }
+
+    /// Scripted [`DsparkBackend`]. `begin_dspark_decode` builds a fresh
+    /// stepper wired to the shared ledger so tests read the call sequence
+    /// after the turn.
+    struct MockDsparkBackend {
+        vocab: i64,
+        cycles: Vec<CycleScript>,
+        neg_fill: f32,
+        cancel_on_verify: Option<(usize, Arc<AtomicBool>)>,
+        ledger: Rc<RefCell<Vec<Call>>>,
+        begin_calls: Cell<usize>,
+        /// `block_size` observed by `begin_dspark_decode` (setup plumbing).
+        seen_block_size: Cell<usize>,
+    }
+
+    impl MockDsparkBackend {
+        fn greedy(vocab: i64, cycles: Vec<CycleScript>) -> Self {
+            Self {
+                vocab,
+                cycles,
+                neg_fill: 0.0,
+                cancel_on_verify: None,
+                ledger: Rc::new(RefCell::new(Vec::new())),
+                begin_calls: Cell::new(0),
+                seen_block_size: Cell::new(usize::MAX),
+            }
+        }
+
+        /// Sampled-path backend: `-1e30` fill makes verify softmax rows
+        /// exactly one-hot (see [`logits_row`]).
+        fn sampled(vocab: i64, cycles: Vec<CycleScript>) -> Self {
+            let mut b = Self::greedy(vocab, cycles);
+            b.neg_fill = -1.0e30;
+            b
+        }
+
+        fn ledger_snapshot(&self) -> Vec<Call> {
+            self.ledger.borrow().clone()
+        }
+    }
+
+    // Minimal `ChatBackend` surface — `run_dspark_turn` calls NONE of these.
+    impl ChatBackend for MockDsparkBackend {
+        fn tokenizer(&self) -> Result<Arc<Qwen3Tokenizer>> {
+            Err(Error::from_reason(
+                "MockDsparkBackend::tokenizer must not run",
+            ))
+        }
+        fn family_name(&self) -> &'static str {
+            "mock_dspark"
+        }
+        fn session_eos_id(&self, _tok: &Qwen3Tokenizer) -> Result<u32> {
+            Ok(u32::MAX)
+        }
+        fn cached_token_history(&self) -> &[u32] {
+            &[]
+        }
+        fn reset_caches(&mut self, _scope: ResetScope) -> Result<()> {
+            Ok(())
+        }
+        fn verify_cache_prefix(&self, _tokens: &[u32], _reuse_cache: bool) -> usize {
+            0
+        }
+        fn save_cache_state(&mut self, _args: SaveStateArgs<'_>) {}
+        fn eval_caches(&self) -> Result<()> {
+            Ok(())
+        }
+        fn prefill(&mut self, _prompt_tokens: &[u32], _stream: Stream) -> Result<MxArray> {
+            Err(Error::from_reason(
+                "MockDsparkBackend::prefill must not run",
+            ))
+        }
+
+        type Decode<'a>
+            = NeverDecode
+        where
+            Self: 'a;
+
+        fn begin_decode(&mut self, _turn: &TurnSetup<'_>) -> Result<Self::Decode<'_>> {
+            Err(Error::from_reason(
+                "MockDsparkBackend::begin_decode must not run on the DSpark path",
+            ))
+        }
+
+        fn finalize_turn(&self, _args: FinalizeArgs<'_>) -> Result<ChatResult> {
+            Err(Error::from_reason(
+                "MockDsparkBackend::finalize_turn must not run",
+            ))
+        }
+    }
+
+    impl DsparkBackend for MockDsparkBackend {
+        type DsparkDecode<'a>
+            = MockDsparkStepper
+        where
+            Self: 'a;
+
+        fn begin_dspark_decode(
+            &mut self,
+            setup: &DsparkTurnSetup<'_>,
+        ) -> Result<Self::DsparkDecode<'_>> {
+            self.begin_calls.set(self.begin_calls.get() + 1);
+            self.seen_block_size.set(setup.block_size);
+            Ok(MockDsparkStepper {
+                vocab: self.vocab,
+                cycles: self.cycles.clone(),
+                neg_fill: self.neg_fill,
+                cursor: Cell::new(0),
+                verify_count: Cell::new(0),
+                cancel_on_verify: self.cancel_on_verify.clone(),
+                ledger: Rc::clone(&self.ledger),
+            })
+        }
+    }
+
+    /// T=0 greedy `ChatParams` with all penalties at their no-op defaults —
+    /// drives the loop's batched-argmax fast path.
+    fn greedy_params() -> ChatParams {
+        ChatParams {
+            max_new_tokens: 64,
+            repetition_penalty: 1.0,
+            repetition_context_size: 0,
+            presence_penalty: 0.0,
+            presence_context_size: 0,
+            frequency_penalty: 0.0,
+            frequency_context_size: 0,
+            max_consecutive_tokens: 0,
+            max_ngram_repeats: 0,
+            ngram_size: 0,
+            sampling_config: Some(SamplingConfig {
+                temperature: Some(0.0),
+                top_k: Some(0),
+                top_p: Some(1.0),
+                min_p: Some(0.0),
+            }),
+            report_performance: false,
+            reuse_cache: true,
+            include_reasoning: true,
+            extra_eos_ids: Vec::new(),
+            enable_mtp: true,
+            mtp_depth: 2,
+            mtp_adaptive_depth: false,
+        }
+    }
+
+    /// T=1.0 `ChatParams` — drives the sampled `accept_with_residual` path
+    /// (deterministic via the one-hot verify rows / proposal dists).
+    fn dense_params() -> ChatParams {
+        ChatParams {
+            sampling_config: Some(SamplingConfig {
+                temperature: Some(1.0),
+                top_k: Some(0),
+                top_p: Some(1.0),
+                min_p: Some(0.0),
+            }),
+            ..greedy_params()
+        }
+    }
+
+    struct TurnOut {
+        generated: Vec<u32>,
+        finish_reason: String,
+        last_in_cache: bool,
+        ledger: Vec<Call>,
+        /// `DecodeProfiler::mtp_acceptance_summary()` — the
+        /// `record_mtp_cycle` seam: `(mean accepted drafts per cycle,
+        /// per-position accept rate, cycles)`, `None` when no cycle
+        /// recorded.
+        acceptance: Option<(f64, Vec<f64>, u32)>,
+    }
+
+    /// Drive the SYNC (non-streaming) turn over the scripted backend.
+    fn drive_turn(
+        backend: &mut MockDsparkBackend,
+        params: ChatParams,
+        first_token: u32,
+        eos_id: u32,
+        block_size: usize,
+    ) -> TurnOut {
+        let mut tracker = ReasoningTracker::new(false, None, None);
+        let mut profiler = DecodeProfiler::new("dspark_turn_test", "test");
+        let mut generated: Vec<u32> = Vec::new();
+        let mut token_history: Vec<u32> = Vec::new();
+        let mut finish_reason = String::from("length");
+        let mut first_token_instant: Option<Instant> = None;
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(0xD5_9A2B_C0DE);
+        let y = MxArray::from_int32(&[first_token as i32], &[1])
+            .unwrap_or_else(|e| panic!("y construction: {}", e.reason));
+        let generation_stream = Stream::new(DeviceType::Gpu);
+        let max_new_tokens = params.max_new_tokens;
+
+        let outcome = run_dspark_turn(
+            backend,
+            &mut rng,
+            DsparkTurnArgs {
+                y,
+                block_size,
+                params: &params,
+                reasoning_tracker: &mut tracker,
+                profiler: &mut profiler,
+                max_new_tokens,
+                eos_id,
+                generated_tokens: &mut generated,
+                token_history: &mut token_history,
+                finish_reason: &mut finish_reason,
+                first_token_instant: &mut first_token_instant,
+                report_perf: false,
+                generation_stream,
+            },
+            None,
+        )
+        .unwrap_or_else(|e| panic!("run_dspark_turn failed: {}", e.reason));
+
+        assert_eq!(token_history, generated, "history must mirror generated");
+
+        TurnOut {
+            generated,
+            finish_reason,
+            last_in_cache: outcome.last_in_cache,
+            ledger: backend.ledger_snapshot(),
+            acceptance: profiler.mtp_acceptance_summary(),
+        }
+    }
+
+    fn count(ledger: &[Call], pred: impl Fn(&Call) -> bool) -> usize {
+        ledger.iter().filter(|c| pred(c)).count()
+    }
+
+    fn commits(ledger: &[Call]) -> Vec<(usize, usize)> {
+        ledger
+            .iter()
+            .filter_map(|c| match c {
+                Call::Commit { keep, total } => Some((*keep, *total)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    // ---- 1. emission order + per-cycle commit ledger ---------------------
+
+    #[test]
+    fn dspark_turn_multi_cycle_greedy_emission_and_commit_ledger() {
+        // vocab 16, eos 15 (never produced). Three cycles:
+        //   cycle0 depth 2: drafts [4,5], verify [4,5,6] → full accept k=2,
+        //          boundary 6, emits [4,5,6], commit(keep 3, total 3).
+        //   cycle1 depth 2: drafts [7,8], verify [7,9,0] → k=1 (9 != 8),
+        //          residual boundary 9, emits [7,9], commit(keep 2, total 3).
+        //   cycle2 near-tail: remaining 2 → l_cap 1 → propose(max_len 1),
+        //          drafts [10], verify [10,11] → k=1, boundary 11, emits
+        //          [10,11], commit(keep 2, total 2).
+        // Budget 8: seed [3] + 3+2+2 cycle tokens = 8 → clean loop-top
+        // length exit.
+        let mut backend = MockDsparkBackend::greedy(
+            16,
+            vec![
+                CycleScript::greedy(vec![4, 5], vec![4, 5, 6]),
+                CycleScript::greedy(vec![7, 8], vec![7, 9, 0]),
+                CycleScript::greedy(vec![10], vec![10, 11]),
+            ],
+        );
+        let mut p = greedy_params();
+        p.max_new_tokens = 8;
+        p.mtp_depth = 2;
+        let out = drive_turn(&mut backend, p, 3, 15, 2);
+
+        assert_eq!(
+            out.generated,
+            vec![3, 4, 5, 6, 7, 9, 10, 11],
+            "seed + per-cycle accepted prefix + boundary, in cycle order"
+        );
+        assert_eq!(out.finish_reason, "length");
+        assert!(
+            !out.last_in_cache,
+            "the last emitted token is cycle2's boundary — no K/V slot"
+        );
+        assert_eq!(
+            backend.begin_calls.get(),
+            1,
+            "exactly one begin_dspark_decode"
+        );
+        assert_eq!(backend.seen_block_size.get(), 2, "setup carries block_size");
+
+        assert_eq!(
+            out.ledger,
+            vec![
+                Call::Propose {
+                    anchor: 3,
+                    max_len: 2
+                },
+                Call::Verify { ids: vec![3, 4, 5] },
+                Call::Commit { keep: 3, total: 3 },
+                Call::EvalBoundary { token: 6 },
+                Call::Propose {
+                    anchor: 6,
+                    max_len: 2
+                },
+                Call::Verify { ids: vec![6, 7, 8] },
+                Call::Commit { keep: 2, total: 3 },
+                Call::EvalBoundary { token: 9 },
+                Call::Propose {
+                    anchor: 9,
+                    max_len: 1
+                },
+                Call::Verify { ids: vec![9, 10] },
+                Call::Commit { keep: 2, total: 2 },
+                Call::EvalBoundary { token: 11 },
+            ],
+            "per cycle: propose → verify([anchor, drafts..]) → \
+             commit(keep = 1 + k, total = 1 + L) → eval_boundary(boundary)"
+        );
+
+        // Stats seam: cycles (L, k) = (2,2), (2,1), (1,1) → mean 4/3,
+        // per-position rates [3/3, 1/2], 3 cycles.
+        let (mean, per_pos, cycles) = out.acceptance.expect("3 cycles recorded");
+        assert!((mean - 4.0 / 3.0).abs() < 1e-9);
+        assert_eq!(per_pos, vec![1.0, 0.5]);
+        assert_eq!(cycles, 3);
+    }
+
+    // ---- 2. keep math (stop-clamp BEFORE commit) --------------------------
+
+    #[test]
+    fn dspark_turn_eos_at_accepted_draft_keep_math() {
+        // depth 3: drafts [4,15,6] all accepted (verify [4,15,6,7]) + bonus
+        // 7 → accepted = [4,15,6,7]. EOS (15) is accepted draft j=1: the
+        // clamp cuts INCLUSIVE at it → emit j+1 = 2 tokens, keep = j+2 = 3
+        // (anchor + drafts 4,15), total = 4, reason "stop". The EOS is an
+        // accepted draft whose verify K/V slot is kept → last_in_cache TRUE.
+        let mut backend = MockDsparkBackend::greedy(
+            16,
+            vec![CycleScript::greedy(vec![4, 15, 6], vec![4, 15, 6, 7])],
+        );
+        let mut p = greedy_params();
+        p.mtp_depth = 3;
+        let out = drive_turn(&mut backend, p, 3, 15, 3);
+
+        assert_eq!(out.generated, vec![3, 4, 15], "emit stops at the EOS draft");
+        assert_eq!(out.finish_reason, "stop");
+        assert!(
+            out.last_in_cache,
+            "EOS at accepted draft j: its K/V is kept → last_in_cache = true"
+        );
+        assert_eq!(
+            commits(&out.ledger),
+            vec![(3, 4)],
+            "keep = j+2 = 3, total = 1+L = 4"
+        );
+        // The clamp resolves the stop BEFORE commit — no second cycle runs.
+        assert_eq!(count(&out.ledger, |c| matches!(c, Call::Verify { .. })), 1);
+        assert_eq!(
+            count(&out.ledger, |c| matches!(c, Call::EvalBoundary { .. })),
+            0,
+            "stop cycles do not schedule a next-anchor eval"
+        );
+        // Acceptance is recorded from the ACCEPT result (k=3), not the
+        // clamped emission.
+        let (mean, _, cycles) = out.acceptance.expect("one cycle recorded");
+        assert!((mean - 3.0).abs() < 1e-9);
+        assert_eq!(cycles, 1);
+    }
+
+    #[test]
+    fn dspark_turn_eos_at_boundary_keep_math() {
+        // depth 2: drafts [4,5] accepted, boundary (bonus) IS the EOS 15 →
+        // accepted = [4,5,15], emit all 3, keep = 1+k = 3, total = 3,
+        // reason "stop". The boundary has NO K/V slot → last_in_cache FALSE.
+        let mut backend =
+            MockDsparkBackend::greedy(16, vec![CycleScript::greedy(vec![4, 5], vec![4, 5, 15])]);
+        let p = greedy_params();
+        let out = drive_turn(&mut backend, p, 3, 15, 2);
+
+        assert_eq!(out.generated, vec![3, 4, 5, 15]);
+        assert_eq!(out.finish_reason, "stop");
+        assert!(
+            !out.last_in_cache,
+            "EOS at the boundary: no K/V slot → last_in_cache = false"
+        );
+        assert_eq!(commits(&out.ledger), vec![(3, 3)], "keep = 1 + k = 3");
+    }
+
+    #[test]
+    fn dspark_turn_budget_clamp_mid_block() {
+        // The stepper over-returns (3 drafts for max_len 2) and everything
+        // verifies — accepted = [4,5,6,7]. Budget 4 (seed + 3): the clamp
+        // cuts BEFORE the boundary (idx 3) → emit 3, reason "length". All 3
+        // emitted tokens are accepted drafts with kept K/V → keep =
+        // 1 + min(3, 3) = 4, total = 1+L = 4, last_in_cache TRUE.
+        let mut backend = MockDsparkBackend::greedy(
+            16,
+            vec![CycleScript::greedy(vec![4, 5, 6], vec![4, 5, 6, 7])],
+        );
+        let mut p = greedy_params();
+        p.max_new_tokens = 4;
+        let out = drive_turn(&mut backend, p, 3, 15, 2);
+
+        assert_eq!(
+            out.generated,
+            vec![3, 4, 5, 6],
+            "budget cut before the boundary"
+        );
+        assert_eq!(out.finish_reason, "length");
+        assert!(
+            out.last_in_cache,
+            "budget clamp cut at the boundary: last emitted is an accepted \
+             draft with kept K/V"
+        );
+        assert_eq!(commits(&out.ledger), vec![(4, 4)]);
+        assert_eq!(
+            count(&out.ledger, |c| matches!(c, Call::EvalBoundary { .. })),
+            0,
+            "budget stop breaks before scheduling a next anchor"
+        );
+    }
+
+    #[test]
+    fn dspark_turn_repetition_clamp_mid_block() {
+        // max_consecutive_tokens = 3: the third consecutive 9 trips the
+        // cutoff mid-block. accepted = [9,9,9,9] (drafts [9,9,9] all
+        // "accepted", bonus 9); the clamp cuts INCLUSIVE at the third 9 →
+        // emit 3, reason "repetition", keep = 1 + min(3,3) = 4, total 4.
+        let mut backend = MockDsparkBackend::greedy(
+            16,
+            vec![CycleScript::greedy(vec![9, 9, 9], vec![9, 9, 9, 9])],
+        );
+        let mut p = greedy_params();
+        p.mtp_depth = 3;
+        p.max_consecutive_tokens = 3;
+        let out = drive_turn(&mut backend, p, 3, 15, 3);
+
+        assert_eq!(out.generated, vec![3, 9, 9, 9]);
+        assert_eq!(out.finish_reason, "repetition");
+        assert!(
+            out.last_in_cache,
+            "repetition tripped on an accepted draft — its K/V is kept"
+        );
+        assert_eq!(commits(&out.ledger), vec![(4, 4)]);
+    }
+
+    // ---- 3. L_cap math -----------------------------------------------------
+
+    #[test]
+    fn dspark_turn_remaining_one_degenerate_ar_cycle() {
+        // Budget 2: after the seed, remaining == 1 → l_cap == 0 → NO
+        // propose; verify runs with the 1-token [anchor] slice, boundary =
+        // argmax(row 0), commit(keep 1, total 1), and NO record_mtp_cycle.
+        let mut backend = MockDsparkBackend::greedy(16, vec![CycleScript::greedy(vec![], vec![8])]);
+        let mut p = greedy_params();
+        p.max_new_tokens = 2;
+        let out = drive_turn(&mut backend, p, 3, 15, 2);
+
+        assert_eq!(
+            out.generated,
+            vec![3, 8],
+            "seed + single AR-through-verify token"
+        );
+        assert_eq!(out.finish_reason, "length");
+        assert_eq!(
+            out.ledger,
+            vec![
+                Call::Verify { ids: vec![3] },
+                Call::Commit { keep: 1, total: 1 },
+                Call::EvalBoundary { token: 8 },
+            ],
+            "degenerate cycle: no propose, verify([anchor]) only"
+        );
+        assert!(
+            out.acceptance.is_none(),
+            "L == 0 cycles are plain AR steps — record_mtp_cycle must NOT run"
+        );
+        assert!(
+            !out.last_in_cache,
+            "the degenerate cycle's emitted token is its boundary — no K/V"
+        );
+    }
+
+    #[test]
+    fn dspark_turn_depth_and_block_size_cap_propose_max_len() {
+        // mtp_depth 1 < block_size 4 → propose asked for max_len 1.
+        let mut backend =
+            MockDsparkBackend::greedy(16, vec![CycleScript::greedy(vec![4], vec![4, 5])]);
+        let mut p = greedy_params();
+        p.max_new_tokens = 3;
+        p.mtp_depth = 1;
+        let out = drive_turn(&mut backend, p, 3, 15, 4);
+        assert_eq!(
+            out.ledger.first(),
+            Some(&Call::Propose {
+                anchor: 3,
+                max_len: 1
+            }),
+            "mtp_depth < block_size caps the proposal request"
+        );
+
+        // block_size 1 < mtp_depth 4 → also max_len 1.
+        let mut backend =
+            MockDsparkBackend::greedy(16, vec![CycleScript::greedy(vec![4], vec![4, 5])]);
+        let mut p = greedy_params();
+        p.max_new_tokens = 3;
+        p.mtp_depth = 4;
+        let out = drive_turn(&mut backend, p, 3, 15, 1);
+        assert_eq!(
+            out.ledger.first(),
+            Some(&Call::Propose {
+                anchor: 3,
+                max_len: 1
+            }),
+            "block_size < mtp_depth caps the proposal request"
+        );
+    }
+
+    // ---- 6. streaming -------------------------------------------------------
+
+    /// Recording sink — collects every chunk the loop emits.
+    struct RecSink {
+        chunks: Mutex<Vec<ChatStreamChunk>>,
+    }
+
+    impl ChunkSink for RecSink {
+        fn send(&self, chunk: Result<ChatStreamChunk>) {
+            if let (Ok(c), Ok(mut v)) = (chunk, self.chunks.lock()) {
+                v.push(c);
+            }
+        }
+    }
+
+    /// Word-level tokenizer over a tiny fixed vocab (ids 0..=6) so the
+    /// DecodeStream produces deterministic per-token text — same fixture as
+    /// the `run_decode_loop` streaming tests.
+    fn tiny_tokenizer() -> tokenizers::Tokenizer {
+        let json = r#"{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [],
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": null,
+            "decoder": null,
+            "model": {
+                "type": "WordLevel",
+                "vocab": {
+                    "t0": 0,
+                    "t1": 1,
+                    "end": 2,
+                    "c3": 3,
+                    "c4": 4,
+                    "eos": 5,
+                    "<unk>": 6
+                },
+                "unk_token": "<unk>"
+            }
+        }"#;
+        tokenizers::Tokenizer::from_bytes(json.as_bytes())
+            .unwrap_or_else(|e| panic!("tiny tokenizer build failed: {e}"))
+    }
+
+    struct StreamOut {
+        generated: Vec<u32>,
+        finish_reason: String,
+        last_in_cache: bool,
+        chunks: Vec<String>,
+        ledger: Vec<Call>,
+    }
+
+    /// Drive the STREAMING turn over the scripted backend. `pre_cancelled`
+    /// sets the cancel flag before the turn starts; the backend's
+    /// `cancel_on_verify` can flip it mid-cycle instead.
+    fn drive_streaming_turn(
+        backend: &mut MockDsparkBackend,
+        params: ChatParams,
+        first_token: u32,
+        eos_id: u32,
+        block_size: usize,
+        cancelled: Arc<AtomicBool>,
+    ) -> StreamOut {
+        let mut tracker = ReasoningTracker::new(false, None, None);
+        let mut profiler = DecodeProfiler::new("dspark_stream_test", "test");
+        let mut generated: Vec<u32> = Vec::new();
+        let mut token_history: Vec<u32> = Vec::new();
+        let mut finish_reason = String::from("length");
+        let mut first_token_instant: Option<Instant> = None;
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(0xD5_9A2B_C0DE);
+        let y = MxArray::from_int32(&[first_token as i32], &[1])
+            .unwrap_or_else(|e| panic!("y construction: {}", e.reason));
+        let generation_stream = Stream::new(DeviceType::Gpu);
+        let max_new_tokens = params.max_new_tokens;
+
+        let tokenizer = tiny_tokenizer();
+        let mut decode_stream = tokenizer.decode_stream(true);
+        let sink = RecSink {
+            chunks: Mutex::new(Vec::new()),
+        };
+        let mut streamed_text_len = 0usize;
+        let mut last_is_reasoning = false;
+        let mut emitter = DefaultStreamEmitter;
+
+        let outcome = run_dspark_turn(
+            backend,
+            &mut rng,
+            DsparkTurnArgs {
+                y,
+                block_size,
+                params: &params,
+                reasoning_tracker: &mut tracker,
+                profiler: &mut profiler,
+                max_new_tokens,
+                eos_id,
+                generated_tokens: &mut generated,
+                token_history: &mut token_history,
+                finish_reason: &mut finish_reason,
+                first_token_instant: &mut first_token_instant,
+                report_perf: false,
+                generation_stream,
+            },
+            Some(StreamingCtx {
+                callback: &sink,
+                cancelled: &cancelled,
+                decode_stream: &mut decode_stream,
+                tokenizer: &tokenizer,
+                streamed_text_len: &mut streamed_text_len,
+                last_is_reasoning: &mut last_is_reasoning,
+                emitter: &mut emitter,
+            }),
+        )
+        .unwrap_or_else(|e| panic!("run_dspark_turn (streaming) failed: {}", e.reason));
+
+        let chunks = sink
+            .chunks
+            .lock()
+            .unwrap_or_else(|e| panic!("sink poisoned: {e}"))
+            .iter()
+            .map(|c| c.text.clone())
+            .collect();
+
+        StreamOut {
+            generated,
+            finish_reason,
+            last_in_cache: outcome.last_in_cache,
+            chunks,
+            ledger: backend.ledger_snapshot(),
+        }
+    }
+
+    #[test]
+    fn dspark_turn_streaming_chunks_match_sync_emission() {
+        // Same script sync vs streaming: identical committed tokens, and the
+        // chunk concatenation equals the full detokenization of the sync run.
+        let script = vec![CycleScript::greedy(vec![1, 3], vec![1, 3, 4])];
+        let params = || {
+            let mut p = greedy_params();
+            p.max_new_tokens = 4;
+            p
+        };
+
+        let mut sync_backend = MockDsparkBackend::greedy(7, script.clone());
+        let sync = drive_turn(&mut sync_backend, params(), 0, 5, 2);
+
+        let mut stream_backend = MockDsparkBackend::greedy(7, script);
+        let streamed = drive_streaming_turn(
+            &mut stream_backend,
+            params(),
+            0,
+            5,
+            2,
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        assert_eq!(streamed.generated, sync.generated);
+        assert_eq!(streamed.finish_reason, sync.finish_reason);
+        assert_eq!(streamed.generated, vec![0, 1, 3, 4]);
+
+        let concat: String = streamed.chunks.concat();
+        let full_text = tiny_tokenizer()
+            .decode(&sync.generated, true)
+            .unwrap_or_else(|e| panic!("decode failed: {e}"));
+        assert_eq!(
+            concat, full_text,
+            "streamed chunk concatenation must equal the sync emission's text"
+        );
+    }
+
+    #[test]
+    fn dspark_turn_streaming_cancel_at_cycle_boundary() {
+        // Cancel set BEFORE the turn: the initial seed is committed but not
+        // streamed (mtp_turn parity: skip, no break), then the loop-top
+        // cancel check exits "cancelled" before any propose/verify.
+        let mut backend =
+            MockDsparkBackend::greedy(7, vec![CycleScript::greedy(vec![1, 3], vec![1, 3, 4])]);
+        let out = drive_streaming_turn(
+            &mut backend,
+            greedy_params(),
+            0,
+            5,
+            2,
+            Arc::new(AtomicBool::new(true)),
+        );
+
+        assert_eq!(
+            out.generated,
+            vec![0],
+            "only the pre-sampled seed is committed"
+        );
+        assert_eq!(out.finish_reason, "cancelled");
+        assert!(!out.last_in_cache, "the unverified seed has no K/V");
+        assert!(
+            out.chunks.is_empty(),
+            "cancelled before any chunk was streamed"
+        );
+        assert!(
+            out.ledger.is_empty(),
+            "cancel at the cycle boundary: no propose/verify/commit ran"
+        );
+    }
+
+    #[test]
+    fn dspark_turn_streaming_cancel_in_clamp_commits_exactly_once() {
+        // Cancel flips DURING the first verify (after the loop-top check).
+        // The clamp observes it after the first accepted token: emit 1,
+        // reason "cancelled", commit(keep = 1 + min(1, k=2) = 2, total 3)
+        // — commit still happens EXACTLY once and the cancel token is
+        // committed but NOT streamed (mtp emit-arm parity).
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let mut backend =
+            MockDsparkBackend::greedy(7, vec![CycleScript::greedy(vec![1, 3], vec![1, 3, 4])]);
+        backend.cancel_on_verify = Some((0, Arc::clone(&cancelled)));
+        let out = drive_streaming_turn(&mut backend, greedy_params(), 0, 5, 2, cancelled);
+
+        assert_eq!(
+            out.generated,
+            vec![0, 1],
+            "seed + the one token emitted before the clamp saw the cancel"
+        );
+        assert_eq!(out.finish_reason, "cancelled");
+        assert!(
+            out.last_in_cache,
+            "the cancel token is an accepted draft with kept K/V"
+        );
+        assert_eq!(
+            out.chunks,
+            vec![String::from("t0")],
+            "the cancel-observed token is committed but not streamed"
+        );
+        assert_eq!(
+            commits(&out.ledger),
+            vec![(2, 3)],
+            "commit-exactly-once with the clamped keep"
+        );
+        assert_eq!(
+            count(&out.ledger, |c| matches!(c, Call::EvalBoundary { .. })),
+            0,
+            "cancel stop breaks before scheduling a next anchor"
+        );
+    }
+
+    // ---- 7. sampled path ----------------------------------------------------
+
+    #[test]
+    fn dspark_turn_sampled_all_accept_and_bonus() {
+        // T=1.0 with exact one-hot rows: drafts [4,5] with proposal dists
+        // one-hot at 4/5 and verify rows one-hot at [4,5,6] → both accept
+        // with ratio exactly 1.0, bonus sample from row 2 is 6
+        // (deterministic by construction). keep = 1 + min(3, 2) = 3.
+        let mut backend = MockDsparkBackend::sampled(
+            16,
+            vec![CycleScript {
+                draft_ids: vec![4, 5],
+                draft_dists: vec![one_hot(16, 4), one_hot(16, 5)],
+                verify_argmax: vec![4, 5, 6],
+            }],
+        );
+        let mut p = dense_params();
+        p.max_new_tokens = 4;
+        let out = drive_turn(&mut backend, p, 3, 15, 2);
+
+        assert_eq!(
+            out.generated,
+            vec![3, 4, 5, 6],
+            "all-accept emits both drafts + the bonus boundary"
+        );
+        assert_eq!(out.finish_reason, "length");
+        assert_eq!(commits(&out.ledger), vec![(3, 3)]);
+        let (mean, _, cycles) = out.acceptance.expect("one sampled cycle recorded");
+        assert!((mean - 2.0).abs() < 1e-9, "k == 2 accepted drafts");
+        assert_eq!(cycles, 1);
+    }
+
+    #[test]
+    fn dspark_turn_sampled_first_position_reject_residual_boundary() {
+        // T=1.0: draft 4 proposed from a one-hot-at-4 dist, but the verify
+        // row 0 puts ALL target mass on 9 → p_t[4] == 0 → deterministic
+        // reject; the residual (p - q)+ is one-hot at 9, so the boundary is
+        // 9. k = 0, keep = 1 + min(1, 0) = 1, total = 1 + L = 3. The
+        // residual doubles as the EOS so the turn ends on this cycle.
+        let mut backend = MockDsparkBackend::sampled(
+            16,
+            vec![CycleScript {
+                draft_ids: vec![4, 5],
+                draft_dists: vec![one_hot(16, 4), one_hot(16, 5)],
+                verify_argmax: vec![9, 0, 0],
+            }],
+        );
+        let p = dense_params();
+        let out = drive_turn(&mut backend, p, 3, 9, 2);
+
+        assert_eq!(
+            out.generated,
+            vec![3, 9],
+            "first-position reject emits only the residual boundary"
+        );
+        assert_eq!(out.finish_reason, "stop");
+        assert!(!out.last_in_cache, "the residual boundary has no K/V");
+        assert_eq!(commits(&out.ledger), vec![(1, 3)]);
+        let (mean, _, cycles) = out.acceptance.expect("cycle recorded with k = 0");
+        assert!(mean.abs() < 1e-9, "zero accepted drafts");
+        assert_eq!(cycles, 1);
+    }
+}

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -85,8 +85,10 @@ enum CycleStop {
 /// Engine-owned DSpark propose/verify whole-turn loop.
 ///
 /// Per cycle: pre-checks (mtp_turn's exact order) → propose (skipped on the
-/// degenerate `L_cap == 0` cycle) → ONE batched verify over
-/// `[anchor, drafts..]` → acceptance (greedy batched-argmax fast path, or
+/// degenerate `L_cap == 0` cycle; hard error on an over-long return) → ONE
+/// batched verify over `[anchor, drafts..]` → acceptance (greedy temperature:
+/// argmax-based — batched fast path when penalties are no-op, per-row
+/// penalized argmax otherwise, never dists/RNG; sampled temperature:
 /// per-position `accept_with_residual`) → STOP-CLAMP over the accepted list
 /// BEFORE commit → `commit(keep = 1 + min(emit_count, k), 1 + L)` → emit →
 /// cache-clear cadence → stop or `anchor = boundary; eval_boundary`.
@@ -176,11 +178,20 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
     }
 
     // Turn-constant accept-policy gates (params are fixed for the turn).
+    // At GREEDY temperature acceptance is ALWAYS argmax-based and never
+    // reads proposal dists or consumes RNG (the DsparkProposal contract
+    // ships empty `draft_dists` there); `penalties_no_op` only selects
+    // between the batched-argmax fast path and the per-row penalized-argmax
+    // path. This matches `run_mtp_cycle`'s T=0-with-penalties behavior: its
+    // legacy dense branch feeds the PENALIZED row into
+    // `accept_with_residual`, whose T=0 shortcut reduces to exactly
+    // "penalized argmax == draft id" with an argmax boundary.
     let temperature = p.sampling_config.and_then(|c| c.temperature).unwrap_or(1.0);
     let sampling_cfg = p.sampling_config.unwrap_or_default();
     let penalties_no_op =
         p.repetition_penalty == 1.0 && p.presence_penalty == 0.0 && p.frequency_penalty == 0.0;
-    let greedy = sampling::is_greedy_temperature(temperature) && penalties_no_op;
+    let greedy_temp = sampling::is_greedy_temperature(temperature);
+    let greedy_fast = greedy_temp && penalties_no_op;
 
     // DELIBERATE DIVERGENCE from `run_mtp_turn`: cancellation is checked at
     // the cycle top and inside the pre-commit stop-clamp, NOT per emitted
@@ -252,10 +263,20 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
                 draft_dists: Vec::new(),
             }
         };
-        // The stepper may return fewer than `l_cap` (confidence truncation);
-        // a longer return is tolerated — the stop-clamp below caps emission
-        // at the budget regardless.
+        // Contract enforcement at the proposal boundary: `propose` may
+        // return FEWER than `l_cap` (confidence truncation), NEVER more. An
+        // over-long block would inflate the verify write past the
+        // `remaining - 1` budget cap's target-cache slot expectations, and
+        // the stop-clamp runs AFTER verify so it cannot un-write those
+        // slots — a hard error surfaces the stepper bug instead of masking
+        // it.
         let draft_len = proposal.draft_ids.len();
+        if draft_len > l_cap {
+            return Err(Error::from_reason(format!(
+                "DSpark propose over-returned: {draft_len} draft tokens for a cap of {l_cap} \
+                 (the DsparkStepper::propose contract allows fewer, never more)"
+            )));
+        }
 
         let mut verify_ids: Vec<u32> = Vec::with_capacity(1 + draft_len);
         verify_ids.push(anchor);
@@ -270,10 +291,10 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
         // Acceptance: `k` accepted drafts (prefix of `draft_ids`) + ONE
         // boundary token (bonus on full accept, residual on rejection).
         profiler.begin("dspark_accept");
-        let accept_res: Result<(usize, u32)> = if greedy {
-            // Greedy fast path: ONE batched argmax over all 1+L rows, a
-            // single eval, then CPU reads. No RNG consumed (mirrors
-            // `accept_with_residual`'s T=0 shortcut).
+        let accept_res: Result<(usize, u32)> = if greedy_fast {
+            // Greedy fast path (penalties no-op): ONE batched argmax over
+            // all 1+L rows, a single eval, then CPU reads. No RNG consumed
+            // (mirrors `accept_with_residual`'s T=0 shortcut).
             (|| {
                 let argmax_arr = logits.argmax(-1, None)?;
                 argmax_arr.eval();
@@ -286,6 +307,51 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
                     k += 1;
                 }
                 Ok((k, target_argmax[k] as u32))
+            })()
+        } else if greedy_temp {
+            // Penalized-greedy path (T=0 with active penalties): per-row
+            // `apply_all_penalties` over the sequentially extended history,
+            // then a plain argmax decides accept/boundary. No proposal
+            // dists, no RNG — behaviorally identical to `run_mtp_cycle`'s
+            // legacy dense branch at T=0, where `accept_with_residual`'s
+            // argmax shortcut reads the penalized row and the bonus
+            // `sample(penalized)` degenerates to its argmax.
+            (|| {
+                let vocab = logits.shape_at(2)?;
+                let mut hist_extended: Vec<u32> = hist.clone();
+                let mut k = 0usize;
+                let mut boundary: Option<u32> = None;
+                for i in 0..draft_len {
+                    let v_slice = logits.slice(&[0, i as i64, 0], &[1, (i + 1) as i64, vocab])?;
+                    let v_1d = v_slice.squeeze(Some(&[0, 1]))?;
+                    let penalized = apply_all_penalties(v_1d, &hist_extended, p)?;
+                    let argmax_arr = penalized.argmax(0, None)?;
+                    argmax_arr.eval();
+                    let target_id = argmax_arr.item_at_int32(0)?;
+                    if target_id == proposal.draft_ids[i] {
+                        k += 1;
+                        hist_extended.push(target_id as u32);
+                    } else {
+                        boundary = Some(target_id as u32);
+                        break;
+                    }
+                }
+                let boundary_id = match boundary {
+                    Some(b) => b,
+                    None => {
+                        // All L drafts accepted: boundary = penalized
+                        // argmax of row L.
+                        let i = draft_len;
+                        let v_slice =
+                            logits.slice(&[0, i as i64, 0], &[1, (i + 1) as i64, vocab])?;
+                        let v_1d = v_slice.squeeze(Some(&[0, 1]))?;
+                        let penalized = apply_all_penalties(v_1d, &hist_extended, p)?;
+                        let argmax_arr = penalized.argmax(0, None)?;
+                        argmax_arr.eval();
+                        argmax_arr.item_at_int32(0)? as u32
+                    }
+                };
+                Ok((k, boundary_id))
             })()
         } else {
             // Sampled path: per-position Leviathan accept + residual
@@ -368,6 +434,11 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
             let mut sim: Vec<u32> = Vec::with_capacity(generated.len() + accepted.len());
             sim.extend_from_slice(generated);
             for (idx, &tok) in accepted.iter().enumerate() {
+                // Defensive: with the over-return check above, a cycle
+                // emits at most `l_cap + 1 <= remaining` tokens, so this
+                // budget arm is unreachable for compliant flows. Kept for
+                // byte-parity with mtp's emit-loop guard and as
+                // defense-in-depth against future L_cap-math regressions.
                 if sim.len() >= max_as_usize {
                     stop = Some(CycleStop::Length);
                     break;
@@ -535,17 +606,19 @@ mod tests {
 
     /// Canned per-cycle script.
     ///
-    /// `draft_ids` is what `propose` returns (deliberately allowed to exceed
-    /// the requested `max_len` so the budget stop-clamp can be exercised).
+    /// `draft_ids` is what `propose` returns (a script MAY exceed the
+    /// requested `max_len` to exercise the engine's over-return error).
     /// `draft_dists[i]` is the full `[vocab]` f32 proposal row `q_i`
-    /// (empty on greedy scripts). `verify_argmax[j]` is the argmax of
-    /// verify-logits row `j` (`j` in `0..=L`); missing entries fall back
-    /// to 0 so over-long verifies stay defined.
+    /// (empty on greedy scripts). Verify logits come from `verify_rows`
+    /// when set (explicit full rows, for penalty-sensitive tests);
+    /// otherwise each row is a one-hot spike at `verify_argmax[j]`
+    /// (`j` in `0..=L`; missing entries fall back to 0).
     #[derive(Clone)]
     struct CycleScript {
         draft_ids: Vec<i32>,
         draft_dists: Vec<Vec<f32>>,
         verify_argmax: Vec<i32>,
+        verify_rows: Option<Vec<Vec<f32>>>,
     }
 
     impl CycleScript {
@@ -554,6 +627,16 @@ mod tests {
                 draft_ids,
                 draft_dists: Vec::new(),
                 verify_argmax,
+                verify_rows: None,
+            }
+        }
+
+        fn with_rows(draft_ids: Vec<i32>, verify_rows: Vec<Vec<f32>>) -> Self {
+            Self {
+                draft_ids,
+                draft_dists: Vec::new(),
+                verify_argmax: Vec::new(),
+                verify_rows: Some(verify_rows),
             }
         }
     }
@@ -635,8 +718,13 @@ mod tests {
             let rows = verify_ids.len();
             let mut flat: Vec<f32> = Vec::with_capacity(rows * self.vocab as usize);
             for j in 0..rows {
-                let argmax_id = script.verify_argmax.get(j).copied().unwrap_or(0);
-                flat.extend(logits_row(self.vocab, argmax_id, self.neg_fill));
+                match script.verify_rows.as_ref().and_then(|r| r.get(j)) {
+                    Some(row) => flat.extend_from_slice(row),
+                    None => {
+                        let argmax_id = script.verify_argmax.get(j).copied().unwrap_or(0);
+                        flat.extend(logits_row(self.vocab, argmax_id, self.neg_fill));
+                    }
+                }
             }
             let logits = MxArray::from_float32(&flat, &[1, rows as i64, self.vocab])?;
             let n = self.verify_count.get();
@@ -848,29 +936,39 @@ mod tests {
         acceptance: Option<(f64, Vec<f64>, u32)>,
     }
 
-    /// Drive the SYNC (non-streaming) turn over the scripted backend.
-    fn drive_turn(
+    /// Raw outcome of a SYNC turn drive — keeps the `Result` so contract-
+    /// error tests can assert the failure alongside the ledger state.
+    struct RawTurnOut {
+        result: Result<super::DsparkTurnOutcome>,
+        generated: Vec<u32>,
+        finish_reason: String,
+        acceptance: Option<(f64, Vec<f64>, u32)>,
+    }
+
+    /// Drive the SYNC (non-streaming) turn over the scripted backend with a
+    /// caller-supplied RNG, without unwrapping the loop result.
+    fn drive_turn_raw<R: rand::Rng>(
         backend: &mut MockDsparkBackend,
         params: ChatParams,
         first_token: u32,
         eos_id: u32,
         block_size: usize,
-    ) -> TurnOut {
+        rng: &mut R,
+    ) -> RawTurnOut {
         let mut tracker = ReasoningTracker::new(false, None, None);
         let mut profiler = DecodeProfiler::new("dspark_turn_test", "test");
         let mut generated: Vec<u32> = Vec::new();
         let mut token_history: Vec<u32> = Vec::new();
         let mut finish_reason = String::from("length");
         let mut first_token_instant: Option<Instant> = None;
-        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(0xD5_9A2B_C0DE);
         let y = MxArray::from_int32(&[first_token as i32], &[1])
             .unwrap_or_else(|e| panic!("y construction: {}", e.reason));
         let generation_stream = Stream::new(DeviceType::Gpu);
         let max_new_tokens = params.max_new_tokens;
 
-        let outcome = run_dspark_turn(
+        let result = run_dspark_turn(
             backend,
-            &mut rng,
+            rng,
             DsparkTurnArgs {
                 y,
                 block_size,
@@ -887,17 +985,67 @@ mod tests {
                 generation_stream,
             },
             None,
-        )
-        .unwrap_or_else(|e| panic!("run_dspark_turn failed: {}", e.reason));
+        );
 
+        // The commit-exactly-once design keeps the histories in lockstep on
+        // BOTH the success and the error path (emission always pushes both).
         assert_eq!(token_history, generated, "history must mirror generated");
 
-        TurnOut {
+        RawTurnOut {
+            result,
             generated,
             finish_reason,
+            acceptance: profiler.mtp_acceptance_summary(),
+        }
+    }
+
+    /// Drive the SYNC (non-streaming) turn over the scripted backend.
+    fn drive_turn(
+        backend: &mut MockDsparkBackend,
+        params: ChatParams,
+        first_token: u32,
+        eos_id: u32,
+        block_size: usize,
+    ) -> TurnOut {
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(0xD5_9A2B_C0DE);
+        let raw = drive_turn_raw(backend, params, first_token, eos_id, block_size, &mut rng);
+        let outcome = raw
+            .result
+            .unwrap_or_else(|e| panic!("run_dspark_turn failed: {}", e.reason));
+
+        TurnOut {
+            generated: raw.generated,
+            finish_reason: raw.finish_reason,
             last_in_cache: outcome.last_in_cache,
             ledger: backend.ledger_snapshot(),
-            acceptance: profiler.mtp_acceptance_summary(),
+            acceptance: raw.acceptance,
+        }
+    }
+
+    /// Counting RNG wrapper — proves the greedy accept paths consume ZERO
+    /// random draws. rand 0.10: implementing `TryRng<Error = Infallible>`
+    /// yields the infallible `Rng` via the blanket impl.
+    struct CountingRng {
+        inner: rand::rngs::StdRng,
+        draws: Rc<Cell<usize>>,
+    }
+
+    impl rand::TryRng for CountingRng {
+        type Error = std::convert::Infallible;
+
+        fn try_next_u32(&mut self) -> std::result::Result<u32, Self::Error> {
+            self.draws.set(self.draws.get() + 1);
+            rand::TryRng::try_next_u32(&mut self.inner)
+        }
+
+        fn try_next_u64(&mut self) -> std::result::Result<u64, Self::Error> {
+            self.draws.set(self.draws.get() + 1);
+            rand::TryRng::try_next_u64(&mut self.inner)
+        }
+
+        fn try_fill_bytes(&mut self, dst: &mut [u8]) -> std::result::Result<(), Self::Error> {
+            self.draws.set(self.draws.get() + 1);
+            rand::TryRng::try_fill_bytes(&mut self.inner, dst)
         }
     }
 
@@ -1058,36 +1206,138 @@ mod tests {
     }
 
     #[test]
-    fn dspark_turn_budget_clamp_mid_block() {
-        // The stepper over-returns (3 drafts for max_len 2) and everything
-        // verifies — accepted = [4,5,6,7]. Budget 4 (seed + 3): the clamp
-        // cuts BEFORE the boundary (idx 3) → emit 3, reason "length". All 3
-        // emitted tokens are accepted drafts with kept K/V → keep =
-        // 1 + min(3, 3) = 4, total = 1+L = 4, last_in_cache TRUE.
-        let mut backend = MockDsparkBackend::greedy(
-            16,
-            vec![CycleScript::greedy(vec![4, 5, 6], vec![4, 5, 6, 7])],
-        );
+    fn dspark_turn_budget_exact_fit_no_mid_block_cut() {
+        // With the over-return contract enforced, a compliant cycle emits at
+        // most `l_cap + 1 <= remaining` tokens, so a mid-block BUDGET cut is
+        // arithmetically unreachable (the clamp's budget arm is defensive).
+        // The tightest compliant case lands EXACTLY on the budget: the cycle
+        // completes uncut (full keep, eval_boundary fired) and the run exits
+        // "length" at the next loop top.
+        let mut backend =
+            MockDsparkBackend::greedy(16, vec![CycleScript::greedy(vec![4, 5], vec![4, 5, 6])]);
         let mut p = greedy_params();
-        p.max_new_tokens = 4;
+        p.max_new_tokens = 4; // seed + l_cap(2) drafts + boundary = exactly 4
         let out = drive_turn(&mut backend, p, 3, 15, 2);
 
         assert_eq!(
             out.generated,
             vec![3, 4, 5, 6],
-            "budget cut before the boundary"
+            "exact fit: every cycle token emitted, no clamp cut"
         );
         assert_eq!(out.finish_reason, "length");
         assert!(
-            out.last_in_cache,
-            "budget clamp cut at the boundary: last emitted is an accepted \
-             draft with kept K/V"
+            !out.last_in_cache,
+            "clean length exit lands on the unverified boundary token"
         );
-        assert_eq!(commits(&out.ledger), vec![(4, 4)]);
+        assert_eq!(
+            commits(&out.ledger),
+            vec![(3, 3)],
+            "full keep — no clamp cut"
+        );
         assert_eq!(
             count(&out.ledger, |c| matches!(c, Call::EvalBoundary { .. })),
+            1,
+            "the cycle completed (no mid-block stop) before the loop-top length exit"
+        );
+    }
+
+    #[test]
+    fn dspark_turn_overlong_proposal_is_rejected() {
+        // propose returns 3 drafts for a cap of 2 — the engine must hard-
+        // error at the proposal boundary, BEFORE verify writes any
+        // target-cache slot (the stop-clamp runs after verify and could not
+        // protect the near-tail slot budget).
+        let mut backend = MockDsparkBackend::greedy(
+            16,
+            vec![CycleScript::greedy(vec![4, 5, 6], vec![4, 5, 6, 7])],
+        );
+        let mut p = greedy_params();
+        p.max_new_tokens = 8;
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(0xD5_9A2B_C0DE);
+        let raw = drive_turn_raw(&mut backend, p, 3, 15, 2, &mut rng);
+
+        let err = match raw.result {
+            Ok(_) => panic!("over-long proposal must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.reason.contains("over-returned"),
+            "error names the contract violation, got: {}",
+            err.reason
+        );
+        assert_eq!(
+            backend.ledger_snapshot(),
+            vec![Call::Propose {
+                anchor: 3,
+                max_len: 2
+            }],
+            "hard error fires before verify — no target-cache slots written"
+        );
+        assert_eq!(raw.generated, vec![3], "only the seed was committed");
+    }
+
+    #[test]
+    fn dspark_turn_greedy_with_penalties_penalized_argmax_no_dists_no_rng() {
+        // T=0 + repetition_penalty 2.0: valid params must run the
+        // penalized-greedy arm — EMPTY draft_dists are accepted (the trait
+        // ships no dists at greedy temperature), the accept decision follows
+        // the PENALIZED argmax, and zero RNG draws are consumed.
+        //
+        // Row 0 (anchor 3, history [3]): raw argmax is 3 (10.0), but 3 is in
+        // history → 10/2 = 5 < 9.0 at token 4 → penalized argmax 4 == draft
+        // 4 → ACCEPT (a raw-argmax accept would reject here — this pins the
+        // penalty actually driving the decision).
+        // Row 1 (boundary, extended history [3, 4]): raw argmax 4 (10.0)
+        // penalized to 5 < 8.0 at token 6 → boundary 6.
+        let mut row0 = vec![0.0f32; 16];
+        row0[3] = 10.0;
+        row0[4] = 9.0;
+        let mut row1 = vec![0.0f32; 16];
+        row1[4] = 10.0;
+        row1[6] = 8.0;
+        let mut backend =
+            MockDsparkBackend::greedy(16, vec![CycleScript::with_rows(vec![4], vec![row0, row1])]);
+        let mut p = greedy_params();
+        p.max_new_tokens = 3; // seed + 1 draft + boundary; l_cap = 1
+        p.repetition_penalty = 2.0;
+        p.repetition_context_size = 20;
+
+        let draws = Rc::new(Cell::new(0usize));
+        let mut rng = CountingRng {
+            inner: <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(0xD5_9A2B_C0DE),
+            draws: Rc::clone(&draws),
+        };
+        let raw = drive_turn_raw(&mut backend, p, 3, 15, 2, &mut rng);
+        let outcome = raw
+            .result
+            .unwrap_or_else(|e| panic!("penalized-greedy turn failed: {}", e.reason));
+
+        assert_eq!(
+            raw.generated,
+            vec![3, 4, 6],
+            "acceptance and boundary follow the PENALIZED argmax"
+        );
+        assert_eq!(raw.finish_reason, "length");
+        assert!(!outcome.last_in_cache, "run ends on the boundary token");
+        let ledger = backend.ledger_snapshot();
+        assert_eq!(
+            ledger.first(),
+            Some(&Call::Propose {
+                anchor: 3,
+                max_len: 1
+            }),
+            "near-tail cap still applies on the penalized-greedy arm"
+        );
+        assert_eq!(commits(&ledger), vec![(2, 2)], "keep = 1 + k = 2");
+        assert_eq!(
+            raw.acceptance.map(|(mean, _, cycles)| (mean, cycles)),
+            Some((1.0, 1)),
+            "record_mtp_cycle(1, 1) for the penalized-greedy cycle"
+        );
+        assert_eq!(
+            draws.get(),
             0,
-            "budget stop breaks before scheduling a next anchor"
+            "greedy temperature must not consume RNG, even with active penalties"
         );
     }
 
@@ -1445,6 +1695,7 @@ mod tests {
                 draft_ids: vec![4, 5],
                 draft_dists: vec![one_hot(16, 4), one_hot(16, 5)],
                 verify_argmax: vec![4, 5, 6],
+                verify_rows: None,
             }],
         );
         let mut p = dense_params();
@@ -1476,6 +1727,7 @@ mod tests {
                 draft_ids: vec![4, 5],
                 draft_dists: vec![one_hot(16, 4), one_hot(16, 5)],
                 verify_argmax: vec![9, 0, 0],
+                verify_rows: None,
             }],
         );
         let p = dense_params();

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -1546,6 +1546,10 @@ mod tests {
         last_in_cache: bool,
         chunks: Vec<String>,
         ledger: Vec<Call>,
+        /// Bytes of `decode(generated)` covered by the step-streamed chunks —
+        /// the whole-turn residual flush emits exactly
+        /// `decode(generated)[streamed_text_len..]` after the loop returns.
+        streamed_text_len: usize,
     }
 
     /// Drive the STREAMING turn over the scripted backend. `pre_cancelled`
@@ -1624,7 +1628,26 @@ mod tests {
             last_in_cache: outcome.last_in_cache,
             chunks,
             ledger: backend.ledger_snapshot(),
+            streamed_text_len,
         }
+    }
+
+    /// The residual the whole-turn core's post-loop flush would emit:
+    /// `decode(generated)[streamed_text_len..]` — the platform-wide
+    /// streaming contract (engine/decode.rs cancel-snapshot comment) is
+    /// that step chunks + this residual reconstruct EXACTLY
+    /// `decode(generated_tokens)`, on cancelled turns included.
+    fn residual_of(out: &StreamOut) -> String {
+        let full = tiny_tokenizer()
+            .decode(&out.generated, true)
+            .unwrap_or_else(|e| panic!("decode failed: {e}"));
+        assert!(
+            out.streamed_text_len <= full.len(),
+            "streamed_text_len {} ran past decode(generated) ({} bytes)",
+            out.streamed_text_len,
+            full.len()
+        );
+        full[out.streamed_text_len..].to_string()
     }
 
     #[test]
@@ -1663,6 +1686,11 @@ mod tests {
             concat, full_text,
             "streamed chunk concatenation must equal the sync emission's text"
         );
+        assert_eq!(
+            residual_of(&streamed),
+            "",
+            "an uncancelled turn leaves nothing for the residual flush"
+        );
     }
 
     #[test]
@@ -1691,6 +1719,12 @@ mod tests {
         assert!(
             out.chunks.is_empty(),
             "cancelled before any chunk was streamed"
+        );
+        assert_eq!(
+            residual_of(&out),
+            "t0",
+            "the whole-turn residual flush delivers the committed-but-unstreamed \
+             seed's text (mtp initial-arm parity: total streamed == decode(generated))"
         );
         assert!(
             out.ledger.is_empty(),
@@ -1727,6 +1761,18 @@ mod tests {
             out.chunks,
             vec![String::from("t0")],
             "the cancel-observed token is committed but not streamed"
+        );
+        // Residual contract (AR/MTP parity): the whole-turn flush emits
+        // decode(generated)[streamed_text_len..]; on a cancel cut that
+        // suffix is EXACTLY the single cancel-observed token's text —
+        // never more (no other suppressed tokens can hide behind it), so
+        // step chunks + residual reconstruct decode(generated), the same
+        // total the AR loop's documented origin/main cancel semantics
+        // produce (engine/decode.rs cancel-snapshot comment).
+        assert_eq!(
+            residual_of(&out),
+            " t1",
+            "the unstreamed suffix must be exactly the cancel-observed token's text"
         );
         assert_eq!(
             commits(&out.ledger),

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -29,11 +29,8 @@ use crate::stream::Stream;
 /// Required arguments of [`run_dspark_turn`] — the DSpark analog of
 /// [`crate::engine::mtp_turn::MtpTurnArgs`], minus the MTP-only
 /// prompt-hidden seed fields (the DSpark stepper owns its draft-context
-/// seeding) and plus the draft `block_size`.
-///
-/// `#[allow(dead_code)]`: exercised by the module's mock tests; the gemma4
-/// caller that constructs it in production lands in a follow-up.
-#[allow(dead_code)]
+/// seeding) and plus the draft `block_size`. Constructed in production by
+/// gemma4's `dspark_chat_turn`.
 pub(crate) struct DsparkTurnArgs<'a> {
     /// First generated token (sampled from the prefill logits BEFORE the
     /// turn). The loop takes ownership and emits it first (guarded by the
@@ -60,9 +57,6 @@ pub(crate) struct DsparkTurnArgs<'a> {
 /// [`crate::engine::mtp_turn::MtpTurnOutcome`]: DSpark has no flat-desync
 /// side channel (the stop-clamp runs BEFORE commit, so the target and draft
 /// caches can never desync), so only `last_in_cache` is surfaced.
-///
-/// `#[allow(dead_code)]`: see [`DsparkTurnArgs`].
-#[allow(dead_code)]
 pub(crate) struct DsparkTurnOutcome {
     /// Whether the LAST emitted token's K/V is already in the target cache.
     /// `true` iff the last emitted token is the anchor or an accepted draft
@@ -93,9 +87,8 @@ enum CycleStop {
 /// BEFORE commit → `commit(keep = 1 + min(emit_count, k), 1 + L)` → emit →
 /// cache-clear cadence → stop or `anchor = boundary; eval_boundary`.
 ///
-/// `#[allow(dead_code)]`: exercised by the module's mock tests; the gemma4
-/// `mtp_turn` override that drives it in production lands in a follow-up.
-#[allow(dead_code)]
+/// Driven in production by gemma4's `mtp_turn` override
+/// (`dspark_chat_turn`); the module's mock tests pin the loop contract.
 pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
     backend: &mut B,
     rng: &mut R,

--- a/crates/mlx-core/src/engine/mod.rs
+++ b/crates/mlx-core/src/engine/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod cache;
 pub(crate) mod cmd;
 pub(crate) mod compiled_lock;
 pub(crate) mod decode;
+pub(crate) mod dspark_turn;
 pub(crate) mod finalize;
 pub(crate) mod mtp_turn;
 pub(crate) mod napi_glue;

--- a/crates/mlx-core/src/models/gemma4/attention.rs
+++ b/crates/mlx-core/src/models/gemma4/attention.rs
@@ -63,7 +63,7 @@ fn trim_mask(mask: Option<&MxArray>, kv_len: i64) -> Result<Option<MxArray>> {
 ///
 /// Key insight: exponent denominator = full `dims` (head_size), not `rotated_dims`.
 /// Only `partial_rotary_factor` fraction of dims are actually rotated.
-struct Gemma4ProportionalRoPE {
+pub(crate) struct Gemma4ProportionalRoPE {
     /// Pre-computed frequencies for `mx.fast.rope`, shape [dims/2].
     /// First rotated_dims/2 entries: factor * base^(2i / dims)
     /// Remaining entries: inf (causes no rotation in mx.fast.rope)
@@ -81,7 +81,7 @@ impl Gemma4ProportionalRoPE {
     /// * `dims` - Full head dimension (e.g. 512)
     /// * `partial_rotary_factor` - Fraction of dims to rotate (e.g. 0.25)
     /// * `base` - RoPE theta (e.g. 1_000_000.0)
-    fn new(dims: i32, partial_rotary_factor: f64, base: f64) -> Result<Self> {
+    pub(crate) fn new(dims: i32, partial_rotary_factor: f64, base: f64) -> Result<Self> {
         // rotated_dims = int(dims * partial_rotary_factor)
         let rotated_dims = (dims as f64 * partial_rotary_factor) as i32;
         let half_rotated = (rotated_dims / 2) as usize;
@@ -106,7 +106,7 @@ impl Gemma4ProportionalRoPE {
     ///
     /// Single fused `mx.fast.rope` call with inf-padded frequencies.
     /// No split/scatter needed — the kernel handles everything.
-    fn forward(&self, x: &MxArray, offset: i32) -> Result<MxArray> {
+    pub(crate) fn forward(&self, x: &MxArray, offset: i32) -> Result<MxArray> {
         let offset_arr = MxArray::from_int32(&[offset], &[1])?;
         let handle = unsafe {
             sys::mlx_fast_rope_with_freqs(

--- a/crates/mlx-core/src/models/gemma4/dspark.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark.rs
@@ -36,6 +36,19 @@ const DSPARK_ARCHITECTURE: &str = "Gemma4DSparkModel";
 /// `temperature < 1e-5`).
 const GREEDY_TEMPERATURE: f64 = 1e-5;
 
+// Fixed DSpark v1 checkpoint geometry. The loader's 74-tensor completeness
+// gate derives its expected keys and shapes from the config, so these values
+// are PINNED at validation rather than trusted from config.json — a
+// config-consistent checkpoint with different geometry (fewer layers, no
+// confidence head, other head widths, other rope constants) must be rejected,
+// not silently loaded under a weaker contract.
+const DSPARK_NUM_LAYERS: usize = 5;
+const DSPARK_NUM_ATTENTION_HEADS: i64 = 16;
+const DSPARK_NUM_KV_HEADS: i64 = 1;
+const DSPARK_GLOBAL_HEAD_DIM: i64 = 512;
+const DSPARK_PARTIAL_ROTARY_FACTOR: f64 = 0.25;
+const DSPARK_ROPE_THETA: f64 = 1_000_000.0;
+
 // ============================================
 // Config
 // ============================================
@@ -148,11 +161,52 @@ impl DsparkConfig {
                 "DSpark draft requires attention_k_eq_v=true (the checkpoint has no v_proj weights)",
             ));
         }
+        if self.num_hidden_layers != DSPARK_NUM_LAYERS {
+            return Err(Error::from_reason(format!(
+                "DSpark draft num_hidden_layers={} is unsupported: the v1 checkpoint contract pins {} decoder layers",
+                self.num_hidden_layers, DSPARK_NUM_LAYERS
+            )));
+        }
+        if self.num_attention_heads != DSPARK_NUM_ATTENTION_HEADS {
+            return Err(Error::from_reason(format!(
+                "DSpark draft num_attention_heads={} is unsupported: the v1 checkpoint contract pins {}",
+                self.num_attention_heads, DSPARK_NUM_ATTENTION_HEADS
+            )));
+        }
+        if self.num_global_key_value_heads != DSPARK_NUM_KV_HEADS {
+            return Err(Error::from_reason(format!(
+                "DSpark draft num_global_key_value_heads={} is unsupported: the v1 checkpoint contract pins {}",
+                self.num_global_key_value_heads, DSPARK_NUM_KV_HEADS
+            )));
+        }
+        if self.global_head_dim != DSPARK_GLOBAL_HEAD_DIM {
+            return Err(Error::from_reason(format!(
+                "DSpark draft global_head_dim={} is unsupported: the v1 checkpoint contract pins {}",
+                self.global_head_dim, DSPARK_GLOBAL_HEAD_DIM
+            )));
+        }
+        if !self.enable_confidence_head {
+            return Err(Error::from_reason(
+                "DSpark draft requires enable_confidence_head=true: the v1 checkpoint contract includes the confidence head tensors",
+            ));
+        }
         let rope = &self.rope_parameters.full_attention;
         if rope.rope_type != "proportional" {
             return Err(Error::from_reason(format!(
                 "DSpark draft rope_parameters.full_attention.rope_type must be \"proportional\", got {:?}",
                 rope.rope_type
+            )));
+        }
+        if rope.partial_rotary_factor != DSPARK_PARTIAL_ROTARY_FACTOR {
+            return Err(Error::from_reason(format!(
+                "DSpark draft rope partial_rotary_factor={} is unsupported: the v1 checkpoint contract pins {}",
+                rope.partial_rotary_factor, DSPARK_PARTIAL_ROTARY_FACTOR
+            )));
+        }
+        if rope.rope_theta != DSPARK_ROPE_THETA {
+            return Err(Error::from_reason(format!(
+                "DSpark draft rope_theta={} is unsupported: the v1 checkpoint contract pins {}",
+                rope.rope_theta, DSPARK_ROPE_THETA
             )));
         }
         if self.markov_rank <= 0 {
@@ -172,20 +226,6 @@ impl DsparkConfig {
             return Err(Error::from_reason(
                 "DSpark draft block_size must be at least 1",
             ));
-        }
-        if self.num_hidden_layers == 0 {
-            return Err(Error::from_reason(
-                "DSpark draft num_hidden_layers must be at least 1",
-            ));
-        }
-        if self.num_attention_heads <= 0
-            || self.num_global_key_value_heads <= 0
-            || self.num_attention_heads % self.num_global_key_value_heads != 0
-        {
-            return Err(Error::from_reason(format!(
-                "DSpark draft num_attention_heads={} must be a positive multiple of num_global_key_value_heads={}",
-                self.num_attention_heads, self.num_global_key_value_heads
-            )));
         }
         if let Some(cap) = self.final_logit_softcapping
             && cap <= 0.0
@@ -796,35 +836,35 @@ impl DsparkDraftModel {
         let head_dim = self.config.global_head_dim;
         let mut missing: Vec<String> = Vec::new();
 
-        if let Some(w) = take_tensor(tensors, "embed_tokens.weight", &mut missing) {
+        if let Some(w) = take_tensor(tensors, "embed_tokens.weight", &mut missing)? {
             self.embed_tokens.load_weight(&w)?;
         }
-        if let Some(w) = take_tensor(tensors, "lm_head.weight", &mut missing) {
+        if let Some(w) = take_tensor(tensors, "lm_head.weight", &mut missing)? {
             self.lm_head.set_weight(&w, "lm_head")?;
         }
-        if let Some(w) = take_tensor(tensors, "norm.weight", &mut missing) {
+        if let Some(w) = take_tensor(tensors, "norm.weight", &mut missing)? {
             apply_norm_weight(&mut self.norm, &w, hidden, "norm")?;
         }
-        if let Some(w) = take_tensor(tensors, "fc.weight", &mut missing) {
+        if let Some(w) = take_tensor(tensors, "fc.weight", &mut missing)? {
             self.fc.set_weight(&w, "fc")?;
         }
-        if let Some(w) = take_tensor(tensors, "hidden_norm.weight", &mut missing) {
+        if let Some(w) = take_tensor(tensors, "hidden_norm.weight", &mut missing)? {
             apply_norm_weight(&mut self.hidden_norm, &w, hidden, "hidden_norm")?;
         }
-        if let Some(w) = take_tensor(tensors, "markov_head.markov_w1.weight", &mut missing) {
+        if let Some(w) = take_tensor(tensors, "markov_head.markov_w1.weight", &mut missing)? {
             check_2d_shape(&w, vocab, rank, "markov_head.markov_w1.weight")?;
             self.markov_w1 = w;
         }
-        if let Some(w) = take_tensor(tensors, "markov_head.markov_w2.weight", &mut missing) {
+        if let Some(w) = take_tensor(tensors, "markov_head.markov_w2.weight", &mut missing)? {
             check_2d_shape(&w, vocab, rank, "markov_head.markov_w2.weight")?;
             self.markov_w2 = w;
         }
         if let Some(proj) = self.confidence_proj.as_mut() {
-            if let Some(w) = take_tensor(tensors, "confidence_head.proj.weight", &mut missing) {
+            if let Some(w) = take_tensor(tensors, "confidence_head.proj.weight", &mut missing)? {
                 check_2d_shape(&w, 1, hidden + rank, "confidence_head.proj.weight")?;
                 proj.set_weight(&w)?;
             }
-            if let Some(b) = take_tensor(tensors, "confidence_head.proj.bias", &mut missing) {
+            if let Some(b) = take_tensor(tensors, "confidence_head.proj.bias", &mut missing)? {
                 if b.ndim()? != 1 || b.shape_at(0)? != 1 {
                     return Err(Error::from_reason(format!(
                         "DSpark confidence_head.proj.bias must be [1], got {:?}",
@@ -858,12 +898,12 @@ impl DsparkDraftModel {
                 ("self_attn.k_norm", &mut layer.self_attn.k_norm, head_dim),
             ] {
                 let key = format!("{prefix}.{suffix}.weight");
-                if let Some(w) = take_tensor(tensors, &key, &mut missing) {
+                if let Some(w) = take_tensor(tensors, &key, &mut missing)? {
                     apply_norm_weight(norm, &w, dims, &key)?;
                 }
             }
             let scalar_key = format!("{prefix}.layer_scalar");
-            if let Some(w) = take_tensor(tensors, &scalar_key, &mut missing) {
+            if let Some(w) = take_tensor(tensors, &scalar_key, &mut missing)? {
                 if w.ndim()? != 1 || w.shape_at(0)? != 1 {
                     return Err(Error::from_reason(format!(
                         "DSpark {scalar_key} must be [1], got {:?}",
@@ -876,42 +916,42 @@ impl DsparkDraftModel {
                 tensors,
                 &format!("{prefix}.self_attn.q_proj.weight"),
                 &mut missing,
-            ) {
+            )? {
                 layer.self_attn.q_proj.set_weight(&w, "q_proj")?;
             }
             if let Some(w) = take_tensor(
                 tensors,
                 &format!("{prefix}.self_attn.k_proj.weight"),
                 &mut missing,
-            ) {
+            )? {
                 layer.self_attn.k_proj.set_weight(&w, "k_proj")?;
             }
             if let Some(w) = take_tensor(
                 tensors,
                 &format!("{prefix}.self_attn.o_proj.weight"),
                 &mut missing,
-            ) {
+            )? {
                 layer.self_attn.o_proj.set_weight(&w, "o_proj")?;
             }
             if let Some(w) = take_tensor(
                 tensors,
                 &format!("{prefix}.mlp.gate_proj.weight"),
                 &mut missing,
-            ) {
+            )? {
                 layer.mlp.set_gate_proj_weight(&w)?;
             }
             if let Some(w) = take_tensor(
                 tensors,
                 &format!("{prefix}.mlp.up_proj.weight"),
                 &mut missing,
-            ) {
+            )? {
                 layer.mlp.set_up_proj_weight(&w)?;
             }
             if let Some(w) = take_tensor(
                 tensors,
                 &format!("{prefix}.mlp.down_proj.weight"),
                 &mut missing,
-            ) {
+            )? {
                 layer.mlp.set_down_proj_weight(&w)?;
             }
         }
@@ -933,18 +973,27 @@ impl DsparkDraftModel {
 }
 
 /// Remove `key` from `tensors`, recording it in `missing` when absent.
+///
+/// A present tensor must be bf16 — the v1 checkpoint contract is bf16-only,
+/// and an exact-key f32/f16 file would otherwise push the whole forward into
+/// an unsupported dtype regime (f32 stays confined to runtime readbacks:
+/// sampling distributions and confidence probabilities).
 fn take_tensor(
     tensors: &mut HashMap<String, MxArray>,
     key: &str,
     missing: &mut Vec<String>,
-) -> Option<MxArray> {
-    match tensors.remove(key) {
-        Some(tensor) => Some(tensor),
-        None => {
-            missing.push(key.to_string());
-            None
-        }
+) -> Result<Option<MxArray>> {
+    let Some(tensor) = tensors.remove(key) else {
+        missing.push(key.to_string());
+        return Ok(None);
+    };
+    let dtype = tensor.dtype()?;
+    if dtype != DType::BFloat16 {
+        return Err(Error::from_reason(format!(
+            "DSpark draft tensor {key} must be bf16, got {dtype:?} (only bf16 checkpoints are supported)"
+        )));
     }
+    Ok(Some(tensor))
 }
 
 fn apply_norm_weight(norm: &mut RMSNorm, w: &MxArray, dims: i64, name: &str) -> Result<()> {
@@ -1221,6 +1270,65 @@ mod tests {
         expect_err(&parse(&json), "markov_rank");
     }
 
+    // Pinned-geometry guards: the loader's expected-key/shape contract is
+    // derived from the config, so any geometry other than the fixed v1
+    // 74-tensor layout must be rejected at validation.
+
+    #[test]
+    fn wrong_num_hidden_layers_rejected() {
+        let json =
+            base_config_json().replace("\"num_hidden_layers\": 5", "\"num_hidden_layers\": 4");
+        expect_err(&parse(&json), "num_hidden_layers");
+    }
+
+    #[test]
+    fn wrong_num_attention_heads_rejected() {
+        let json =
+            base_config_json().replace("\"num_attention_heads\": 16", "\"num_attention_heads\": 8");
+        expect_err(&parse(&json), "num_attention_heads");
+    }
+
+    #[test]
+    fn wrong_num_global_key_value_heads_rejected() {
+        let json = base_config_json().replace(
+            "\"num_global_key_value_heads\": 1",
+            "\"num_global_key_value_heads\": 2",
+        );
+        expect_err(&parse(&json), "num_global_key_value_heads");
+    }
+
+    #[test]
+    fn wrong_global_head_dim_rejected() {
+        let json =
+            base_config_json().replace("\"global_head_dim\": 512", "\"global_head_dim\": 256");
+        expect_err(&parse(&json), "global_head_dim");
+    }
+
+    #[test]
+    fn confidence_head_disabled_rejected() {
+        let json = base_config_json().replace(
+            "\"enable_confidence_head\": true",
+            "\"enable_confidence_head\": false",
+        );
+        expect_err(&parse(&json), "enable_confidence_head");
+    }
+
+    #[test]
+    fn wrong_partial_rotary_factor_rejected() {
+        let json = base_config_json().replace(
+            "\"partial_rotary_factor\": 0.25",
+            "\"partial_rotary_factor\": 0.5",
+        );
+        expect_err(&parse(&json), "partial_rotary_factor");
+    }
+
+    #[test]
+    fn wrong_rope_theta_rejected() {
+        let json =
+            base_config_json().replace("\"rope_theta\": 1000000.0", "\"rope_theta\": 10000.0");
+        expect_err(&parse(&json), "rope_theta");
+    }
+
     // ── Markov correction math ─────────────────────────────────────────
 
     /// Tiny fixture: V=8, rank=2, hand-computed expected correction row.
@@ -1399,6 +1507,99 @@ mod tests {
     fn to_vec_f32(a: &MxArray) -> Vec<f32> {
         a.eval();
         a.to_float32().unwrap().to_vec()
+    }
+
+    // ── Weight-install gate (apply_weights seam) ───────────────────────
+
+    /// Complete bf16 tensor map matching `tiny_config()`'s expected keys and
+    /// shapes. Tests mutate it to simulate broken checkpoints.
+    fn synthetic_tiny_tensors() -> std::collections::HashMap<String, MxArray> {
+        let mut specs: Vec<(String, Vec<i64>)> = vec![
+            ("embed_tokens.weight".into(), vec![16, 8]),
+            ("lm_head.weight".into(), vec![16, 8]),
+            ("norm.weight".into(), vec![8]),
+            ("fc.weight".into(), vec![8, 16]),
+            ("hidden_norm.weight".into(), vec![8]),
+            ("markov_head.markov_w1.weight".into(), vec![16, 2]),
+            ("markov_head.markov_w2.weight".into(), vec![16, 2]),
+            ("confidence_head.proj.weight".into(), vec![1, 10]),
+            ("confidence_head.proj.bias".into(), vec![1]),
+        ];
+        for i in 0..2 {
+            for (suffix, shape) in [
+                ("input_layernorm.weight", vec![8]),
+                ("post_attention_layernorm.weight", vec![8]),
+                ("pre_feedforward_layernorm.weight", vec![8]),
+                ("post_feedforward_layernorm.weight", vec![8]),
+                ("self_attn.q_norm.weight", vec![4]),
+                ("self_attn.k_norm.weight", vec![4]),
+                ("layer_scalar", vec![1]),
+                ("self_attn.q_proj.weight", vec![8, 8]),
+                ("self_attn.k_proj.weight", vec![4, 8]),
+                ("self_attn.o_proj.weight", vec![8, 8]),
+                ("mlp.gate_proj.weight", vec![16, 8]),
+                ("mlp.up_proj.weight", vec![16, 8]),
+                ("mlp.down_proj.weight", vec![8, 16]),
+            ] {
+                specs.push((format!("layers.{i}.{suffix}"), shape));
+            }
+        }
+        specs
+            .into_iter()
+            .map(|(key, shape)| {
+                let arr = MxArray::zeros(&shape, Some(DType::BFloat16)).unwrap();
+                (key, arr)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn apply_weights_accepts_complete_bf16_set() {
+        let mut model = DsparkDraftModel::new(tiny_config()).unwrap();
+        let mut tensors = synthetic_tiny_tensors();
+        model.apply_weights(&mut tensors).unwrap();
+        assert!(tensors.is_empty(), "all tensors must be consumed");
+    }
+
+    #[test]
+    fn apply_weights_rejects_non_bf16_tensor() {
+        let mut model = DsparkDraftModel::new(tiny_config()).unwrap();
+        let mut tensors = synthetic_tiny_tensors();
+        tensors.insert(
+            "fc.weight".to_string(),
+            MxArray::zeros(&[8, 16], Some(DType::Float32)).unwrap(),
+        );
+        let err = model
+            .apply_weights(&mut tensors)
+            .expect_err("an f32 weight must be rejected");
+        assert!(err.reason.contains("fc.weight"), "got: {}", err.reason);
+        assert!(err.reason.contains("bf16"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn apply_weights_reports_missing_and_leftover_keys() {
+        let mut model = DsparkDraftModel::new(tiny_config()).unwrap();
+        let mut tensors = synthetic_tiny_tensors();
+        tensors.remove("layers.1.mlp.up_proj.weight");
+        tensors.insert(
+            "layers.0.self_attn.v_proj.weight".to_string(),
+            MxArray::zeros(&[4, 8], Some(DType::BFloat16)).unwrap(),
+        );
+        let err = model
+            .apply_weights(&mut tensors)
+            .expect_err("missing + stray keys must be rejected");
+        assert!(err.reason.contains("missing"), "got: {}", err.reason);
+        assert!(
+            err.reason.contains("layers.1.mlp.up_proj.weight"),
+            "got: {}",
+            err.reason
+        );
+        assert!(err.reason.contains("unexpected"), "got: {}", err.reason);
+        assert!(
+            err.reason.contains("layers.0.self_attn.v_proj.weight"),
+            "got: {}",
+            err.reason
+        );
     }
 
     // ── Context cache invariants ───────────────────────────────────────

--- a/crates/mlx-core/src/models/gemma4/dspark.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark.rs
@@ -53,6 +53,11 @@ const DSPARK_NUM_KV_HEADS: i64 = 1;
 const DSPARK_GLOBAL_HEAD_DIM: i64 = 512;
 const DSPARK_PARTIAL_ROTARY_FACTOR: f64 = 0.25;
 const DSPARK_ROPE_THETA: f64 = 1_000_000.0;
+/// Pinned like the geometry above: `block_size` flows straight into the
+/// default `mtp_depth` (resolve_params) and sizes every `[1, 1+L, vocab]`
+/// verify forward, so a corrupted config with real weights and a huge
+/// block_size would otherwise turn the first request into an OOM/abort.
+const DSPARK_BLOCK_SIZE: usize = 7;
 
 // ============================================
 // Config
@@ -230,10 +235,18 @@ impl DsparkConfig {
                 "DSpark draft markov_head_type {head_type:?} is unsupported (only \"vanilla\")"
             )));
         }
-        if self.block_size == 0 {
-            return Err(Error::from_reason(
-                "DSpark draft block_size must be at least 1",
-            ));
+        if self.block_size != DSPARK_BLOCK_SIZE {
+            return Err(Error::from_reason(format!(
+                "DSpark draft block_size={} is unsupported: the v1 checkpoint contract pins {} \
+                 (block_size becomes the default mtp_depth and sizes every verify forward)",
+                self.block_size, DSPARK_BLOCK_SIZE
+            )));
+        }
+        if self.mask_token_id < 0 || (self.mask_token_id as i64) >= self.vocab_size {
+            return Err(Error::from_reason(format!(
+                "DSpark draft mask_token_id={} is out of range for vocab_size={}",
+                self.mask_token_id, self.vocab_size
+            )));
         }
         if let Some(cap) = self.final_logit_softcapping
             && cap <= 0.0
@@ -689,6 +702,64 @@ impl DsparkDraftModel {
     /// accounting.
     pub(crate) fn weight_bytes(&self) -> u64 {
         self.weight_bytes
+    }
+
+    /// Every checkpoint-backed tensor the draft owns, as cheap array-handle
+    /// clones — 74 on the v1 contract (9 top-level + 13 per layer). The
+    /// gemma4 loader feeds these to `materialize_weights` right after the
+    /// draft loads, mirroring the target's own materialization pass: left
+    /// lazy, the whole checkpoint would page-fault from cold mmap during
+    /// the FIRST speculative forward (the qwen3.5 cold-mmap load-watchdog
+    /// failure class). The handles are exactly the applied checkpoint
+    /// arrays (`apply_weights` installs them verbatim — bf16-only, no
+    /// casts), so their byte total equals [`Self::weight_bytes`]; the
+    /// coverage test pins both the count and that byte equality.
+    pub(crate) fn collect_weight_arrays(&self) -> Vec<MxArray> {
+        fn push_proj(out: &mut Vec<MxArray>, proj: &LinearProj) {
+            match proj {
+                LinearProj::Standard(l) => {
+                    out.push(l.get_weight());
+                    if let Some(b) = l.get_bias() {
+                        out.push(b);
+                    }
+                }
+                // Unreachable today (apply_weights is bf16-only, so every
+                // draft projection is Standard); collecting nothing here
+                // means a future quantized draft FAILS the byte-coverage
+                // test loudly instead of silently under-materializing.
+                LinearProj::Quantized(_) => {}
+            }
+        }
+        let mut out = Vec::with_capacity(9 + 13 * self.layers.len());
+        out.push(self.embed_tokens.weight());
+        push_proj(&mut out, &self.fc);
+        out.push(self.hidden_norm.get_weight());
+        for layer in &self.layers {
+            out.push(layer.input_layernorm.get_weight());
+            out.push(layer.post_attention_layernorm.get_weight());
+            out.push(layer.pre_feedforward_layernorm.get_weight());
+            out.push(layer.post_feedforward_layernorm.get_weight());
+            out.push(layer.layer_scalar.clone());
+            out.push(layer.self_attn.q_norm.get_weight());
+            out.push(layer.self_attn.k_norm.get_weight());
+            push_proj(&mut out, &layer.self_attn.q_proj);
+            push_proj(&mut out, &layer.self_attn.k_proj);
+            push_proj(&mut out, &layer.self_attn.o_proj);
+            out.push(layer.mlp.gate_proj_weight());
+            out.push(layer.mlp.up_proj_weight());
+            out.push(layer.mlp.down_proj_weight());
+        }
+        out.push(self.norm.get_weight());
+        push_proj(&mut out, &self.lm_head);
+        out.push(self.markov_w1.clone());
+        out.push(self.markov_w2.clone());
+        if let Some(conf) = &self.confidence_proj {
+            out.push(conf.get_weight());
+            if let Some(b) = conf.get_bias() {
+                out.push(b);
+            }
+        }
+        out
     }
 
     /// Fuse the tapped target-layer hidden states into the draft's context
@@ -1332,6 +1403,31 @@ mod tests {
     }
 
     #[test]
+    fn unpinned_block_size_rejected() {
+        // block_size is a PINNED v1 constant, not a free knob: it becomes the
+        // default mtp_depth and sizes every [1, 1+L, vocab] verify forward,
+        // so a corrupted config with real weights and block_size=1000 would
+        // otherwise drive the first request into OOM/abort territory.
+        let json = base_config_json().replace("\"block_size\": 7", "\"block_size\": 1000");
+        let reason = expect_err(&parse(&json), "block_size");
+        assert!(reason.contains("pins 7"), "got: {reason}");
+        // 0 is rejected by the same pin (the old >= 1 floor is subsumed).
+        let json = base_config_json().replace("\"block_size\": 7", "\"block_size\": 0");
+        expect_err(&parse(&json), "block_size");
+    }
+
+    #[test]
+    fn out_of_vocab_mask_token_rejected() {
+        // mask_token_id indexes the draft's embedding table on every propose;
+        // out-of-range values must fail the load, not the first forward.
+        let json = base_config_json().replace("\"mask_token_id\": 4", "\"mask_token_id\": 262144");
+        let reason = expect_err(&parse(&json), "mask_token_id");
+        assert!(reason.contains("262144"), "got: {reason}");
+        let json = base_config_json().replace("\"mask_token_id\": 4", "\"mask_token_id\": -1");
+        expect_err(&parse(&json), "mask_token_id");
+    }
+
+    #[test]
     fn zero_markov_rank_rejected() {
         let json = base_config_json().replace("\"markov_rank\": 256", "\"markov_rank\": 0");
         expect_err(&parse(&json), "markov_rank");
@@ -1674,13 +1770,14 @@ mod tests {
     // ── Cache-limit weight accounting ──────────────────────────────────
 
     /// Smallest config that passes `DsparkConfig::validate`'s v1 pins
-    /// (5 layers, 16 heads x head_dim 512, 1 KV head, rope 0.25/1e6) while
-    /// keeping the FREE dimensions tiny (hidden 8, vocab 16) — for tests
-    /// that must go through the full `load_draft_model` checkpoint path.
+    /// (5 layers, 16 heads x head_dim 512, 1 KV head, block 7, rope
+    /// 0.25/1e6) while keeping the FREE dimensions tiny (hidden 8, vocab
+    /// 16) — for tests that must go through the full `load_draft_model`
+    /// checkpoint path.
     const V1_MINI_CONFIG_JSON: &str = r#"{
                 "architectures": ["Gemma4DSparkModel"],
                 "model_type": "gemma4_text",
-                "block_size": 3,
+                "block_size": 7,
                 "mask_token_id": 4,
                 "hidden_size": 8,
                 "intermediate_size": 16,
@@ -1749,6 +1846,30 @@ mod tests {
             .collect()
     }
 
+    /// Write the v1-mini checkpoint (config + zero-filled bf16 tensors) to a
+    /// fresh temp dir; returns `(dir, checkpoint_byte_total)`.
+    fn write_v1_mini_checkpoint() -> (std::path::PathBuf, u64) {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "gemma4_dspark_v1_mini_checkpoint_{}_{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("create temp checkpoint dir");
+        fs::write(dir.join("config.json"), V1_MINI_CONFIG_JSON).expect("write config.json");
+        let mut tensors = synthetic_v1_mini_tensors();
+        let total: u64 = tensors.values().map(|t| t.nbytes() as u64).sum();
+        assert!(total > 0, "the mini checkpoint must have nonzero bytes");
+        crate::utils::safetensors::save_safetensors(
+            dir.join("model.safetensors"),
+            &mut tensors,
+            None,
+        )
+        .expect("write model.safetensors");
+        (dir, total)
+    }
+
     /// `load_draft_model` must report the checkpoint's exact total tensor
     /// bytes (summed BEFORE `apply_weights` drains the map): the gemma4
     /// loader folds this into the weight-byte total it registers with the
@@ -1756,25 +1877,7 @@ mod tests {
     /// the draft's full resident size (~GBs of bf16 on the real draft).
     #[test]
     fn load_draft_model_reports_checkpoint_weight_bytes() {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-        let dir = std::env::temp_dir().join(format!(
-            "gemma4_dspark_weight_bytes_test_{}_{}",
-            std::process::id(),
-            COUNTER.fetch_add(1, Ordering::Relaxed)
-        ));
-        fs::create_dir_all(&dir).expect("create temp checkpoint dir");
-        fs::write(dir.join("config.json"), V1_MINI_CONFIG_JSON).expect("write config.json");
-        let mut tensors = synthetic_v1_mini_tensors();
-        let expected: u64 = tensors.values().map(|t| t.nbytes() as u64).sum();
-        assert!(expected > 0, "the mini checkpoint must have nonzero bytes");
-        crate::utils::safetensors::save_safetensors(
-            dir.join("model.safetensors"),
-            &mut tensors,
-            None,
-        )
-        .expect("write model.safetensors");
-
+        let (dir, expected) = write_v1_mini_checkpoint();
         let model = load_draft_model(&dir, 8, 16, 4).expect("mini v1 checkpoint must load");
         assert_eq!(
             model.weight_bytes(),
@@ -1786,6 +1889,39 @@ mod tests {
             DsparkDraftModel::new(tiny_config()).unwrap().weight_bytes(),
             0
         );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The loader's post-load materialization pass must cover EVERY
+    /// checkpoint tensor: `collect_weight_arrays` yields exactly the v1
+    /// contract's 74 tensors and their byte total equals `weight_bytes`
+    /// (i.e. nothing the checkpoint shipped stays behind as a lazy mmap
+    /// reference the first speculative forward would page-fault in). Also
+    /// exercises the `materialize_weights` pass itself over the collected
+    /// handles — the exact call the gemma4 loader makes after
+    /// `load_draft_model`.
+    #[test]
+    fn collect_weight_arrays_covers_every_checkpoint_tensor() {
+        let (dir, checkpoint_bytes) = write_v1_mini_checkpoint();
+        let model = load_draft_model(&dir, 8, 16, 4).expect("mini v1 checkpoint must load");
+
+        let arrays = model.collect_weight_arrays();
+        assert_eq!(
+            arrays.len(),
+            74,
+            "v1 contract: 9 top-level + 13 x {} layers",
+            DSPARK_NUM_LAYERS
+        );
+        let total: u64 = arrays.iter().map(|a| a.nbytes() as u64).sum();
+        assert_eq!(
+            total, checkpoint_bytes,
+            "collected arrays must cover every checkpoint byte (a gap here \
+             means the loader's materialization pass leaves lazy mmap refs)"
+        );
+
+        let refs: Vec<&MxArray> = arrays.iter().collect();
+        crate::array::memory::materialize_weights(&refs)
+            .expect("the loader's materialization pass must succeed on the collected handles");
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/crates/mlx-core/src/models/gemma4/dspark.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark.rs
@@ -629,6 +629,12 @@ pub(crate) struct DsparkDraftModel {
     /// `Linear(hidden + markov_rank -> 1)` with bias; `None` when
     /// `enable_confidence_head` is false.
     confidence_proj: Option<Linear>,
+    /// Total checkpoint tensor bytes, summed by `load_draft_model` BEFORE
+    /// `apply_weights` drains the tensor map. Model-owned resident weights
+    /// — the gemma4 loader folds this into the deterministic weight-byte
+    /// total it registers with the cache-limit coordinator. `0` for a
+    /// placeholder-weight model built via `new` alone (tests).
+    weight_bytes: u64,
 }
 
 impl DsparkDraftModel {
@@ -671,11 +677,18 @@ impl DsparkDraftModel {
             markov_w1,
             markov_w2,
             confidence_proj,
+            weight_bytes: 0,
         })
     }
 
     pub(crate) fn num_layers(&self) -> usize {
         self.layers.len()
+    }
+
+    /// Checkpoint tensor bytes (see the field doc) for cache-limit
+    /// accounting.
+    pub(crate) fn weight_bytes(&self) -> u64 {
+        self.weight_bytes
     }
 
     /// Fuse the tapped target-layer hidden states into the draft's context
@@ -1129,8 +1142,16 @@ pub(crate) fn load_draft_model(
         )));
     }
     let mut tensors = load_safetensors_lazy(&weights_path)?;
+    // Sum the checkpoint bytes BEFORE `apply_weights` drains the map.
+    // `nbytes` is shape×itemsize metadata — no eval. `apply_weights`
+    // rejects leftover keys, so this total is exactly the applied set.
+    let weight_bytes: u64 = tensors
+        .values()
+        .map(|t| t.nbytes() as u64)
+        .fold(0u64, |acc, v| acc.saturating_add(v));
     let mut model = DsparkDraftModel::new(config)?;
     model.apply_weights(&mut tensors)?;
+    model.weight_bytes = weight_bytes;
     Ok(model)
 }
 
@@ -1513,9 +1534,9 @@ mod tests {
     /// Sized-down config exercising the same code paths as the real draft:
     /// 2 layers, 2 heads x head_dim 4 with 1 shared KV head, live partial
     /// rotation (factor 0.5 -> pair 0 rotated, pair 1 identity).
-    fn tiny_config() -> DsparkConfig {
-        parse(
-            r#"{
+    /// A raw `&str` so the checkpoint-dir tests can write it verbatim as a
+    /// `config.json`.
+    const TINY_CONFIG_JSON: &str = r#"{
                 "architectures": ["Gemma4DSparkModel"],
                 "model_type": "gemma4_text",
                 "block_size": 3,
@@ -1542,8 +1563,10 @@ mod tests {
                         "rope_type": "proportional"
                     }
                 }
-            }"#,
-        )
+            }"#;
+
+    fn tiny_config() -> DsparkConfig {
+        parse(TINY_CONFIG_JSON)
     }
 
     fn rand_array(shape: &[i64]) -> MxArray {
@@ -1646,6 +1669,124 @@ mod tests {
             "got: {}",
             err.reason
         );
+    }
+
+    // ── Cache-limit weight accounting ──────────────────────────────────
+
+    /// Smallest config that passes `DsparkConfig::validate`'s v1 pins
+    /// (5 layers, 16 heads x head_dim 512, 1 KV head, rope 0.25/1e6) while
+    /// keeping the FREE dimensions tiny (hidden 8, vocab 16) — for tests
+    /// that must go through the full `load_draft_model` checkpoint path.
+    const V1_MINI_CONFIG_JSON: &str = r#"{
+                "architectures": ["Gemma4DSparkModel"],
+                "model_type": "gemma4_text",
+                "block_size": 3,
+                "mask_token_id": 4,
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 5,
+                "num_attention_heads": 16,
+                "global_head_dim": 512,
+                "num_global_key_value_heads": 1,
+                "rms_norm_eps": 1e-6,
+                "final_logit_softcapping": 30.0,
+                "vocab_size": 16,
+                "target_layer_ids": [0, 1],
+                "num_target_layers": 4,
+                "markov_rank": 2,
+                "markov_head_type": "vanilla",
+                "enable_confidence_head": true,
+                "attention_k_eq_v": true,
+                "rope_parameters": {
+                    "full_attention": {
+                        "partial_rotary_factor": 0.25,
+                        "rope_theta": 1000000.0,
+                        "rope_type": "proportional"
+                    }
+                }
+            }"#;
+
+    /// Complete bf16 tensor map for [`V1_MINI_CONFIG_JSON`] (the
+    /// `synthetic_tiny_tensors` key template at the v1-pinned attention
+    /// geometry: 5 layers, q/o over 16*512 dims, q/k norms over 512).
+    fn synthetic_v1_mini_tensors() -> std::collections::HashMap<String, MxArray> {
+        let mut specs: Vec<(String, Vec<i64>)> = vec![
+            ("embed_tokens.weight".into(), vec![16, 8]),
+            ("lm_head.weight".into(), vec![16, 8]),
+            ("norm.weight".into(), vec![8]),
+            ("fc.weight".into(), vec![8, 16]),
+            ("hidden_norm.weight".into(), vec![8]),
+            ("markov_head.markov_w1.weight".into(), vec![16, 2]),
+            ("markov_head.markov_w2.weight".into(), vec![16, 2]),
+            ("confidence_head.proj.weight".into(), vec![1, 10]),
+            ("confidence_head.proj.bias".into(), vec![1]),
+        ];
+        for i in 0..5 {
+            for (suffix, shape) in [
+                ("input_layernorm.weight", vec![8]),
+                ("post_attention_layernorm.weight", vec![8]),
+                ("pre_feedforward_layernorm.weight", vec![8]),
+                ("post_feedforward_layernorm.weight", vec![8]),
+                ("self_attn.q_norm.weight", vec![512]),
+                ("self_attn.k_norm.weight", vec![512]),
+                ("layer_scalar", vec![1]),
+                ("self_attn.q_proj.weight", vec![16 * 512, 8]),
+                ("self_attn.k_proj.weight", vec![512, 8]),
+                ("self_attn.o_proj.weight", vec![8, 16 * 512]),
+                ("mlp.gate_proj.weight", vec![16, 8]),
+                ("mlp.up_proj.weight", vec![16, 8]),
+                ("mlp.down_proj.weight", vec![8, 16]),
+            ] {
+                specs.push((format!("layers.{i}.{suffix}"), shape));
+            }
+        }
+        specs
+            .into_iter()
+            .map(|(key, shape)| {
+                let arr = MxArray::zeros(&shape, Some(DType::BFloat16)).unwrap();
+                (key, arr)
+            })
+            .collect()
+    }
+
+    /// `load_draft_model` must report the checkpoint's exact total tensor
+    /// bytes (summed BEFORE `apply_weights` drains the map): the gemma4
+    /// loader folds this into the weight-byte total it registers with the
+    /// cache-limit coordinator, so a silent 0 would over-grant cache by
+    /// the draft's full resident size (~GBs of bf16 on the real draft).
+    #[test]
+    fn load_draft_model_reports_checkpoint_weight_bytes() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "gemma4_dspark_weight_bytes_test_{}_{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("create temp checkpoint dir");
+        fs::write(dir.join("config.json"), V1_MINI_CONFIG_JSON).expect("write config.json");
+        let mut tensors = synthetic_v1_mini_tensors();
+        let expected: u64 = tensors.values().map(|t| t.nbytes() as u64).sum();
+        assert!(expected > 0, "the mini checkpoint must have nonzero bytes");
+        crate::utils::safetensors::save_safetensors(
+            dir.join("model.safetensors"),
+            &mut tensors,
+            None,
+        )
+        .expect("write model.safetensors");
+
+        let model = load_draft_model(&dir, 8, 16, 4).expect("mini v1 checkpoint must load");
+        assert_eq!(
+            model.weight_bytes(),
+            expected,
+            "weight_bytes must equal the exact checkpoint tensor byte total"
+        );
+        // A placeholder-weight model (no checkpoint) reports 0.
+        assert_eq!(
+            DsparkDraftModel::new(tiny_config()).unwrap().weight_bytes(),
+            0
+        );
+        let _ = fs::remove_dir_all(&dir);
     }
 
     // ── Context cache invariants ───────────────────────────────────────

--- a/crates/mlx-core/src/models/gemma4/dspark.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark.rs
@@ -31,10 +31,15 @@ use super::quantized_linear::LinearProj;
 /// Draft architecture name required in the checkpoint's `architectures` list.
 const DSPARK_ARCHITECTURE: &str = "Gemma4DSparkModel";
 
-/// Temperature below which draft sampling is greedy argmax. Matches the
-/// DeepSpec reference (`deepspec/utils/sampling.py::sample_tokens`,
-/// `temperature < 1e-5`).
-const GREEDY_TEMPERATURE: f64 = 1e-5;
+// Greedy-vs-sampled detection for draft sampling uses the ENGINE's
+// `sampling::is_greedy_temperature` predicate — the same predicate the
+// speculative-decode loop (`engine::dspark_turn::run_dspark_turn`) uses for
+// its accept policy. The two MUST agree: at a "greedy" temperature the loop
+// requires `draft_dists` to be EMPTY (argmax accept, no RNG), while at a
+// "sampled" temperature it requires one proposal distribution per drafted
+// token. A private threshold here (the DeepSpec reference used
+// `temperature < 1e-5`) would disagree with the engine on temperatures in
+// (1e-6, 1e-5) and hard-error the sampled accept path.
 
 // Fixed DSpark v1 checkpoint geometry. The loader's 74-tensor completeness
 // gate derives its expected keys and shapes from the config, so these values
@@ -73,6 +78,9 @@ pub(crate) struct DsparkRopeParameters {
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct DsparkConfig {
     pub(crate) architectures: Vec<String>,
+    /// Checkpoint schema surface (deserialized for completeness; the
+    /// architecture gate keys on `architectures`).
+    #[allow(dead_code)]
     pub(crate) model_type: String,
     pub(crate) block_size: usize,
     pub(crate) mask_token_id: i32,
@@ -546,15 +554,21 @@ impl DsparkContextCache {
         Ok(())
     }
 
-    /// Number of cached context positions.
+    /// Number of cached context positions. Production appends only KEPT
+    /// rows (the stepper never needs len/reset/trim — a fresh cache is
+    /// built every turn); these accessors serve the inline tests and any
+    /// future retention policy.
+    #[allow(dead_code)]
     pub(crate) fn len(&self) -> i32 {
         self.caches.first().map_or(0, |c| c.get_offset())
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    #[allow(dead_code)]
     pub(crate) fn reset(&mut self) {
         for cache in &mut self.caches {
             cache.reset();
@@ -563,6 +577,7 @@ impl DsparkContextCache {
 
     /// Keep only the first `new_len` context positions (passthrough to each
     /// layer's `KVCache::trim`).
+    #[allow(dead_code)]
     pub(crate) fn trim(&mut self, new_len: i32) {
         for cache in &mut self.caches {
             cache.trim(new_len);
@@ -740,11 +755,13 @@ impl DsparkDraftModel {
     /// Position k's logits are `base_logits[:, k] + markov_correction(prev)`
     /// where `prev` starts at `anchor` and chains through the sampled tokens
     /// (the markov bias is added AFTER the softcap; there is no second
-    /// softcap). Greedy below [`GREEDY_TEMPERATURE`]: argmax, empty
-    /// distribution list. Otherwise each token is drawn (via `rng`) from the
-    /// EXACT filtered distribution `sampling::sampling_distribution` builds
-    /// for `cfg`, and the per-position f32 `[vocab]` distribution rows are
-    /// returned for later rejection sampling.
+    /// softcap). Greedy iff [`sampling::is_greedy_temperature`] — the SAME
+    /// predicate the engine's accept loop uses, so draft sampling mode and
+    /// accept mode can never disagree: argmax, empty distribution list.
+    /// Otherwise each token is drawn (via `rng`) from the EXACT filtered
+    /// distribution `sampling::sampling_distribution` builds for `cfg`, and
+    /// the per-position f32 `[vocab]` distribution rows are returned for
+    /// later rejection sampling.
     pub(crate) fn sample_block_sequential<R: Rng + ?Sized>(
         &self,
         base_logits: &MxArray,
@@ -771,7 +788,7 @@ impl DsparkDraftModel {
             )));
         }
         let temperature = cfg.temperature.unwrap_or(1.0);
-        let greedy = temperature < GREEDY_TEMPERATURE;
+        let greedy = sampling::is_greedy_temperature(temperature);
 
         let mut tokens = Vec::with_capacity(len);
         let mut dists = Vec::new();
@@ -1825,6 +1842,38 @@ mod tests {
                 "position {k}: sampled token {token} must have positive probability"
             );
         }
+    }
+
+    /// The greedy/sampled switch must follow the ENGINE predicate
+    /// (`sampling::is_greedy_temperature`, f32 `<= 1e-6`), not the DeepSpec
+    /// reference threshold (`< 1e-5`): a temperature in (1e-6, 1e-5) is
+    /// SAMPLED to the engine's accept loop, which then requires one proposal
+    /// distribution per drafted token — an empty `dists` there would
+    /// hard-error the sampled accept path.
+    #[test]
+    fn sample_block_sequential_greedy_predicate_matches_engine() {
+        let (model, base_logits) = chained_markov_model();
+        let temp = 5e-6f64;
+        assert!(
+            !sampling::is_greedy_temperature(temp),
+            "fixture temperature must be sampled per the engine predicate"
+        );
+        let cfg = SamplingConfig {
+            temperature: Some(temp),
+            top_k: Some(0),
+            top_p: Some(1.0),
+            min_p: Some(0.0),
+        };
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(7);
+        let (tokens, dists) = model
+            .sample_block_sequential(&base_logits, 3, 3, &cfg, &mut rng)
+            .unwrap();
+        assert_eq!(tokens.len(), 3);
+        assert_eq!(
+            dists.len(),
+            3,
+            "engine-sampled temperature must ship one proposal distribution per token"
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/models/gemma4/dspark.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark.rs
@@ -239,6 +239,35 @@ impl DsparkConfig {
 }
 
 // ============================================
+// Target-side hidden tap
+// ============================================
+
+/// Capture request threaded through the TARGET model's forward passes.
+///
+/// `layer_ids` lists the decoder layers whose residual-stream hidden state
+/// the target must capture, and must be strictly ascending (the order the
+/// layer loop pushes captures — matches the `target_layer_ids` contract in
+/// [`DsparkConfig::validate`]). For each forward call the target pushes the
+/// FULL `[B, T, hidden]` hidden of layer `i` taken immediately after the
+/// layer's residual add, PRE final-norm (the HF `hidden_states[i + 1]`
+/// convention) — one entry per `layer_ids` entry, in order. Chunked prefill
+/// therefore appends `layer_ids.len()` entries per chunk; callers slice what
+/// they need.
+pub(crate) struct DsparkTap<'a> {
+    pub layer_ids: &'a [usize],
+    pub captured: Vec<MxArray>,
+}
+
+impl<'a> DsparkTap<'a> {
+    pub(crate) fn new(layer_ids: &'a [usize]) -> Self {
+        Self {
+            layer_ids,
+            captured: Vec::new(),
+        }
+    }
+}
+
+// ============================================
 // Markov head math
 // ============================================
 

--- a/crates/mlx-core/src/models/gemma4/dspark.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark.rs
@@ -1,0 +1,1724 @@
+//! DeepSeek DSpark draft model for Gemma 4 speculative decoding.
+//!
+//! Standalone 5-layer draft transformer that cross-attends to fused
+//! target-layer hidden states and drafts a `block_size`-token block via mask
+//! tokens. Port of the DeepSpec reference
+//! (`deepspec/modeling/dspark/gemma4/modeling.py` + `markov_head.py` +
+//! `common.py`), inference subset only: the draft backbone, markov bias head,
+//! confidence head, context K/V cache, and weight loader. The generation-engine
+//! loop and target-side hidden-state capture live elsewhere.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use mlx_sys as sys;
+use napi::bindgen_prelude::*;
+use rand::{Rng, RngExt};
+use serde::Deserialize;
+
+use crate::array::attention::scaled_dot_product_attention;
+use crate::array::{DType, MxArray};
+use crate::nn::{Embedding, Linear, RMSNorm};
+use crate::sampling::{self, SamplingConfig};
+use crate::transformer::kv_cache::KVCache;
+use crate::utils::safetensors::load_safetensors_lazy;
+
+use super::attention::Gemma4ProportionalRoPE;
+use super::mlp::GemmaMLP;
+use super::quantized_linear::LinearProj;
+
+/// Draft architecture name required in the checkpoint's `architectures` list.
+const DSPARK_ARCHITECTURE: &str = "Gemma4DSparkModel";
+
+/// Temperature below which draft sampling is greedy argmax. Matches the
+/// DeepSpec reference (`deepspec/utils/sampling.py::sample_tokens`,
+/// `temperature < 1e-5`).
+const GREEDY_TEMPERATURE: f64 = 1e-5;
+
+// ============================================
+// Config
+// ============================================
+
+/// RoPE parameters for the draft's full-attention layers
+/// (`rope_parameters.full_attention` in config.json).
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct DsparkFullAttentionRope {
+    pub(crate) partial_rotary_factor: f64,
+    pub(crate) rope_theta: f64,
+    pub(crate) rope_type: String,
+}
+
+/// `rope_parameters` sub-object of the draft config.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct DsparkRopeParameters {
+    pub(crate) full_attention: DsparkFullAttentionRope,
+}
+
+/// DSpark draft model configuration, deserialized from the draft directory's
+/// `config.json`. Field set mirrors the DeepSpec `build_draft_config` output.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct DsparkConfig {
+    pub(crate) architectures: Vec<String>,
+    pub(crate) model_type: String,
+    pub(crate) block_size: usize,
+    pub(crate) mask_token_id: i32,
+    pub(crate) hidden_size: i64,
+    pub(crate) intermediate_size: i64,
+    pub(crate) num_hidden_layers: usize,
+    pub(crate) num_attention_heads: i64,
+    pub(crate) global_head_dim: i64,
+    pub(crate) num_global_key_value_heads: i64,
+    pub(crate) rms_norm_eps: f64,
+    pub(crate) final_logit_softcapping: Option<f64>,
+    pub(crate) vocab_size: i64,
+    pub(crate) target_layer_ids: Vec<i64>,
+    pub(crate) num_target_layers: Option<usize>,
+    pub(crate) markov_rank: i64,
+    pub(crate) markov_head_type: Option<String>,
+    pub(crate) enable_confidence_head: bool,
+    pub(crate) attention_k_eq_v: bool,
+    pub(crate) rope_parameters: DsparkRopeParameters,
+}
+
+impl DsparkConfig {
+    /// Validate the draft config against the target model's geometry.
+    ///
+    /// `target_num_layers` is the target's decoder layer count; tapped
+    /// `target_layer_ids` must reference non-final target layers only (the
+    /// final layer's hidden is where the target's own logits come from, so it
+    /// is never a tap point).
+    pub(crate) fn validate(
+        &self,
+        target_hidden: i64,
+        target_vocab: i64,
+        target_num_layers: usize,
+    ) -> Result<()> {
+        if !self.architectures.iter().any(|a| a == DSPARK_ARCHITECTURE) {
+            return Err(Error::from_reason(format!(
+                "DSpark draft config architectures {:?} must contain {:?}",
+                self.architectures, DSPARK_ARCHITECTURE
+            )));
+        }
+        if self.hidden_size != target_hidden {
+            return Err(Error::from_reason(format!(
+                "DSpark draft hidden_size={} does not match target hidden_size={}",
+                self.hidden_size, target_hidden
+            )));
+        }
+        if self.vocab_size != target_vocab {
+            return Err(Error::from_reason(format!(
+                "DSpark draft vocab_size={} does not match target vocab_size={}",
+                self.vocab_size, target_vocab
+            )));
+        }
+        if let Some(n) = self.num_target_layers
+            && n != target_num_layers
+        {
+            return Err(Error::from_reason(format!(
+                "DSpark draft num_target_layers={n} does not match the target's {target_num_layers} decoder layers"
+            )));
+        }
+        if self.target_layer_ids.is_empty() {
+            return Err(Error::from_reason(
+                "DSpark draft target_layer_ids must not be empty",
+            ));
+        }
+        let mut previous: Option<i64> = None;
+        for &id in &self.target_layer_ids {
+            if let Some(prev) = previous
+                && id <= prev
+            {
+                return Err(Error::from_reason(format!(
+                    "DSpark draft target_layer_ids {:?} must be strictly ascending (found {id} after {prev})",
+                    self.target_layer_ids
+                )));
+            }
+            // The final target layer (target_num_layers - 1) is not tappable.
+            let max_tappable = target_num_layers as i64 - 2;
+            if id < 0 || id > max_tappable {
+                return Err(Error::from_reason(format!(
+                    "DSpark draft target_layer_id {id} is out of range [0, {max_tappable}] for a {target_num_layers}-layer target (the final layer is never tapped)"
+                )));
+            }
+            previous = Some(id);
+        }
+        if !self.attention_k_eq_v {
+            return Err(Error::from_reason(
+                "DSpark draft requires attention_k_eq_v=true (the checkpoint has no v_proj weights)",
+            ));
+        }
+        let rope = &self.rope_parameters.full_attention;
+        if rope.rope_type != "proportional" {
+            return Err(Error::from_reason(format!(
+                "DSpark draft rope_parameters.full_attention.rope_type must be \"proportional\", got {:?}",
+                rope.rope_type
+            )));
+        }
+        if self.markov_rank <= 0 {
+            return Err(Error::from_reason(format!(
+                "DSpark draft markov_rank={} is unsupported: the sequential draft sampler requires a markov head (markov_rank > 0)",
+                self.markov_rank
+            )));
+        }
+        if let Some(ref head_type) = self.markov_head_type
+            && head_type != "vanilla"
+        {
+            return Err(Error::from_reason(format!(
+                "DSpark draft markov_head_type {head_type:?} is unsupported (only \"vanilla\")"
+            )));
+        }
+        if self.block_size == 0 {
+            return Err(Error::from_reason(
+                "DSpark draft block_size must be at least 1",
+            ));
+        }
+        if self.num_hidden_layers == 0 {
+            return Err(Error::from_reason(
+                "DSpark draft num_hidden_layers must be at least 1",
+            ));
+        }
+        if self.num_attention_heads <= 0
+            || self.num_global_key_value_heads <= 0
+            || self.num_attention_heads % self.num_global_key_value_heads != 0
+        {
+            return Err(Error::from_reason(format!(
+                "DSpark draft num_attention_heads={} must be a positive multiple of num_global_key_value_heads={}",
+                self.num_attention_heads, self.num_global_key_value_heads
+            )));
+        }
+        if let Some(cap) = self.final_logit_softcapping
+            && cap <= 0.0
+        {
+            return Err(Error::from_reason(format!(
+                "DSpark draft final_logit_softcapping={cap} must be positive when provided"
+            )));
+        }
+        Ok(())
+    }
+}
+
+// ============================================
+// Markov head math
+// ============================================
+
+/// Markov correction logits for a previous token: `markov_w2 @ markov_w1[prev]`.
+///
+/// `markov_w1` is `[vocab, rank]` (embedding: one row per token), `markov_w2`
+/// is `[vocab, rank]` (the `Linear(rank -> vocab)` weight). Returns the `[vocab]`
+/// bias row added to the (already softcapped) base logits — there is NO second
+/// softcap after this addition (DeepSpec `VanillaMarkov.apply_step_logits`).
+pub(crate) fn markov_correction_logits(
+    markov_w1: &MxArray,
+    markov_w2: &MxArray,
+    prev_token: i32,
+) -> Result<MxArray> {
+    let rank = markov_w1.shape_at(1)?;
+    let vocab = markov_w2.shape_at(0)?;
+    let idx = MxArray::from_int32(&[prev_token], &[1])?;
+    let prev_row = markov_w1.take(&idx, 0)?.reshape(&[rank, 1])?;
+    markov_w2.matmul(&prev_row)?.reshape(&[vocab])
+}
+
+// ============================================
+// Confidence truncation
+// ============================================
+
+/// Keep the longest prefix of `probs` where every keep-probability is at or
+/// above `threshold`; cut at the first position below it. A non-positive
+/// threshold disables truncation (keep all).
+pub(crate) fn truncate_by_confidence(probs: &[f32], threshold: f32) -> usize {
+    if threshold <= 0.0 {
+        return probs.len();
+    }
+    probs
+        .iter()
+        .position(|&p| p < threshold)
+        .unwrap_or(probs.len())
+}
+
+// ============================================
+// Attention
+// ============================================
+
+/// RMS-normalize without a learned scale (`mx.fast.rms_norm` with a NULL
+/// weight), matching the reference `Gemma4RMSNorm(..., with_scale=False)`.
+fn scale_free_rms_norm(x: &MxArray, eps: f32) -> Result<MxArray> {
+    let handle = unsafe { sys::mlx_fast_rms_norm(x.handle.0, std::ptr::null_mut(), eps) };
+    MxArray::from_handle(handle, "dspark_v_norm")
+}
+
+/// Draft cross+self attention (`Gemma4DSparkAttention`).
+///
+/// Geometrically the target's GLOBAL-layer attention: MQA with one shared KV
+/// head, `global_head_dim`-wide heads, learned Q/K RMSNorm + scale-free V
+/// RMSNorm, proportional RoPE on Q/K only, SDPA scale 1.0. K doubles as V
+/// (`attention_k_eq_v`), so there is no v_proj. Queries come from the draft
+/// block; keys/values are the projected fused context (from the ctx cache)
+/// concatenated with the block's own K/V, attended NON-causally.
+struct DsparkAttention {
+    q_proj: LinearProj,
+    k_proj: LinearProj,
+    o_proj: LinearProj,
+    q_norm: RMSNorm,
+    k_norm: RMSNorm,
+    v_norm_eps: f32,
+    rope: Gemma4ProportionalRoPE,
+    num_heads: i64,
+    num_kv_heads: i64,
+    head_dim: i64,
+}
+
+impl DsparkAttention {
+    fn new(config: &DsparkConfig) -> Result<Self> {
+        let hidden = config.hidden_size;
+        let num_heads = config.num_attention_heads;
+        let num_kv_heads = config.num_global_key_value_heads;
+        let head_dim = config.global_head_dim;
+
+        let q_proj = LinearProj::Standard(Linear::new(
+            hidden as u32,
+            (num_heads * head_dim) as u32,
+            Some(false),
+        )?);
+        let k_proj = LinearProj::Standard(Linear::new(
+            hidden as u32,
+            (num_kv_heads * head_dim) as u32,
+            Some(false),
+        )?);
+        let o_proj = LinearProj::Standard(Linear::new(
+            (num_heads * head_dim) as u32,
+            hidden as u32,
+            Some(false),
+        )?);
+        let q_norm = RMSNorm::new(head_dim as u32, Some(config.rms_norm_eps))?;
+        let k_norm = RMSNorm::new(head_dim as u32, Some(config.rms_norm_eps))?;
+        let rope_cfg = &config.rope_parameters.full_attention;
+        let rope = Gemma4ProportionalRoPE::new(
+            head_dim as i32,
+            rope_cfg.partial_rotary_factor,
+            rope_cfg.rope_theta,
+        )?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            v_norm_eps: config.rms_norm_eps as f32,
+            rope,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+        })
+    }
+
+    /// Project hidden states `[B, S, hidden]` into attention K/V
+    /// `[B, H_kv, S, head_dim]`. K is RMS-normed and roped at absolute
+    /// positions `base_pos..base_pos+S`; V is the SAME k_proj output with a
+    /// scale-free RMSNorm and NO RoPE. Used both for the block's own K/V and
+    /// for the fused-context rows persisted in [`DsparkContextCache`].
+    fn project_kv(&self, x: &MxArray, base_pos: i32) -> Result<(MxArray, MxArray)> {
+        let batch = x.shape_at(0)?;
+        let seq_len = x.shape_at(1)?;
+        let k_raw =
+            self.k_proj
+                .forward(x)?
+                .reshape(&[batch, seq_len, self.num_kv_heads, self.head_dim])?;
+        let keys = self
+            .k_norm
+            .forward(&k_raw)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let keys = self.rope.forward(&keys, base_pos)?;
+        let values =
+            scale_free_rms_norm(&k_raw, self.v_norm_eps)?.transpose(Some(&[0, 2, 1, 3]))?;
+        Ok((keys, values))
+    }
+
+    /// Attend the (pre-normed) draft block `x` over context K/V ++ block K/V.
+    ///
+    /// `ctx_kv` is the layer's cached context K/V in `[B, H_kv, S_ctx, D]`
+    /// (already normed + roped). `start_pos` is the absolute position of the
+    /// block's first token (the anchor position). The mask is None over the
+    /// whole ctx+block span — draft attention is non-causal.
+    fn forward(
+        &self,
+        x: &MxArray,
+        ctx_kv: Option<&(MxArray, MxArray)>,
+        start_pos: i32,
+    ) -> Result<MxArray> {
+        let batch = x.shape_at(0)?;
+        let seq_len = x.shape_at(1)?;
+
+        let queries =
+            self.q_proj
+                .forward(x)?
+                .reshape(&[batch, seq_len, self.num_heads, self.head_dim])?;
+        let queries = self
+            .q_norm
+            .forward(&queries)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let queries = self.rope.forward(&queries, start_pos)?;
+
+        let (block_keys, block_values) = self.project_kv(x, start_pos)?;
+        let (keys, values) = match ctx_kv {
+            Some((ctx_keys, ctx_values)) => (
+                MxArray::concatenate(ctx_keys, &block_keys, 2)?,
+                MxArray::concatenate(ctx_values, &block_values, 2)?,
+            ),
+            None => (block_keys, block_values),
+        };
+
+        let output = scaled_dot_product_attention(&queries, &keys, &values, 1.0, None)?;
+        let output = output.transpose(Some(&[0, 2, 1, 3]))?.reshape(&[
+            batch,
+            seq_len,
+            self.num_heads * self.head_dim,
+        ])?;
+        self.o_proj.forward(&output)
+    }
+}
+
+// ============================================
+// Decoder layer
+// ============================================
+
+/// Draft decoder layer (`Gemma4DSparkDecoderLayer`): Gemma sandwich norms
+/// around attention and MLP, then a per-layer `[1]` output scalar.
+struct DsparkDecoderLayer {
+    self_attn: DsparkAttention,
+    mlp: GemmaMLP,
+    input_layernorm: RMSNorm,
+    post_attention_layernorm: RMSNorm,
+    pre_feedforward_layernorm: RMSNorm,
+    post_feedforward_layernorm: RMSNorm,
+    layer_scalar: MxArray,
+}
+
+impl DsparkDecoderLayer {
+    fn new(config: &DsparkConfig) -> Result<Self> {
+        let hidden = config.hidden_size as u32;
+        let eps = Some(config.rms_norm_eps);
+        Ok(Self {
+            self_attn: DsparkAttention::new(config)?,
+            mlp: GemmaMLP::new(hidden, config.intermediate_size as u32)?,
+            input_layernorm: RMSNorm::new(hidden, eps)?,
+            post_attention_layernorm: RMSNorm::new(hidden, eps)?,
+            pre_feedforward_layernorm: RMSNorm::new(hidden, eps)?,
+            post_feedforward_layernorm: RMSNorm::new(hidden, eps)?,
+            layer_scalar: MxArray::ones(&[1], None)?,
+        })
+    }
+
+    fn forward(
+        &self,
+        x: &MxArray,
+        ctx_kv: Option<&(MxArray, MxArray)>,
+        start_pos: i32,
+    ) -> Result<MxArray> {
+        let residual = x;
+        let hidden = self.input_layernorm.forward(x)?;
+        let hidden = self.self_attn.forward(&hidden, ctx_kv, start_pos)?;
+        let hidden = self.post_attention_layernorm.forward(&hidden)?;
+        let hidden = residual.add(&hidden)?;
+
+        let residual = &hidden;
+        let ff = self.pre_feedforward_layernorm.forward(&hidden)?;
+        let ff = self.mlp.forward(&ff)?;
+        let ff = self.post_feedforward_layernorm.forward(&ff)?;
+        let out = residual.add(&ff)?;
+        out.mul(&self.layer_scalar)
+    }
+}
+
+// ============================================
+// Context cache
+// ============================================
+
+/// Per-layer cache of the draft's projected context K/V.
+///
+/// Each layer holds the fused target hidden states (`fuse_context` output)
+/// projected through that layer's `k_proj` and split into roped K / un-roped V
+/// (see [`DsparkAttention::project_kv`]). The draft block's own K/V are
+/// computed inside `forward_block` per call and NEVER persisted here — the
+/// equivalent of the reference's append-then-crop.
+pub(crate) struct DsparkContextCache {
+    caches: Vec<KVCache>,
+}
+
+impl DsparkContextCache {
+    pub(crate) fn new(num_layers: usize) -> Self {
+        Self {
+            caches: (0..num_layers).map(|_| KVCache::new()).collect(),
+        }
+    }
+
+    /// Project `h_ctx` (`[B, S, hidden]` fused context rows, first row at
+    /// absolute position `base_pos`) through every layer's attention and
+    /// append the resulting K/V to the per-layer caches.
+    pub(crate) fn append(
+        &mut self,
+        model: &DsparkDraftModel,
+        h_ctx: &MxArray,
+        base_pos: i32,
+    ) -> Result<()> {
+        if self.caches.len() != model.layers.len() {
+            return Err(Error::from_reason(format!(
+                "DSpark context cache has {} layers but the draft model has {}",
+                self.caches.len(),
+                model.layers.len()
+            )));
+        }
+        for (layer, cache) in model.layers.iter().zip(self.caches.iter_mut()) {
+            let (keys, values) = layer.self_attn.project_kv(h_ctx, base_pos)?;
+            cache.update_and_fetch(&keys, &values)?;
+        }
+        Ok(())
+    }
+
+    /// Number of cached context positions.
+    pub(crate) fn len(&self) -> i32 {
+        self.caches.first().map_or(0, |c| c.get_offset())
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub(crate) fn reset(&mut self) {
+        for cache in &mut self.caches {
+            cache.reset();
+        }
+    }
+
+    /// Keep only the first `new_len` context positions (passthrough to each
+    /// layer's `KVCache::trim`).
+    pub(crate) fn trim(&mut self, new_len: i32) {
+        for cache in &mut self.caches {
+            cache.trim(new_len);
+        }
+    }
+
+    /// The cached context K/V for one layer, sliced to the live length.
+    /// `None` when the cache is empty.
+    fn layer_kv(&self, layer_idx: usize) -> Result<Option<(MxArray, MxArray)>> {
+        let cache = self.caches.get(layer_idx).ok_or_else(|| {
+            Error::from_reason(format!(
+                "DSpark context cache layer index {layer_idx} out of bounds ({} layers)",
+                self.caches.len()
+            ))
+        })?;
+        let offset = cache.get_offset();
+        if offset == 0 {
+            return Ok(None);
+        }
+        let (Some(keys), Some(values)) = (cache.keys_ref(), cache.values_ref()) else {
+            return Ok(None);
+        };
+        Ok(Some((
+            keys.slice_axis(2, 0, offset as i64)?,
+            values.slice_axis(2, 0, offset as i64)?,
+        )))
+    }
+}
+
+// ============================================
+// Draft model
+// ============================================
+
+/// The DSpark draft model: own scaled embedding table, context-fusion
+/// projection, 5-layer cross-attending backbone, untied lm_head with logit
+/// softcap, vanilla markov bias head, and optional confidence head.
+pub(crate) struct DsparkDraftModel {
+    pub(crate) config: DsparkConfig,
+    embed_tokens: Embedding,
+    fc: LinearProj,
+    hidden_norm: RMSNorm,
+    layers: Vec<DsparkDecoderLayer>,
+    norm: RMSNorm,
+    lm_head: LinearProj,
+    /// `[vocab, markov_rank]` — embedding: one row per token.
+    markov_w1: MxArray,
+    /// `[vocab, markov_rank]` — `Linear(markov_rank -> vocab)` weight.
+    markov_w2: MxArray,
+    /// `Linear(hidden + markov_rank -> 1)` with bias; `None` when
+    /// `enable_confidence_head` is false.
+    confidence_proj: Option<Linear>,
+}
+
+impl DsparkDraftModel {
+    /// Build the module tree for `config` with placeholder weights.
+    /// Callers must apply checkpoint weights before running a forward pass.
+    pub(crate) fn new(config: DsparkConfig) -> Result<Self> {
+        let hidden = config.hidden_size;
+        let vocab = config.vocab_size;
+        let embed_tokens = Embedding::new(vocab as u32, hidden as u32)?;
+        let fc = LinearProj::Standard(Linear::new(
+            (config.target_layer_ids.len() as i64 * hidden) as u32,
+            hidden as u32,
+            Some(false),
+        )?);
+        let hidden_norm = RMSNorm::new(hidden as u32, Some(config.rms_norm_eps))?;
+        let layers = (0..config.num_hidden_layers)
+            .map(|_| DsparkDecoderLayer::new(&config))
+            .collect::<Result<Vec<_>>>()?;
+        let norm = RMSNorm::new(hidden as u32, Some(config.rms_norm_eps))?;
+        let lm_head = LinearProj::Standard(Linear::new(hidden as u32, vocab as u32, Some(false))?);
+        let markov_w1 = MxArray::zeros(&[vocab, config.markov_rank], None)?;
+        let markov_w2 = MxArray::zeros(&[vocab, config.markov_rank], None)?;
+        let confidence_proj = if config.enable_confidence_head {
+            Some(Linear::new(
+                (hidden + config.markov_rank) as u32,
+                1,
+                Some(true),
+            )?)
+        } else {
+            None
+        };
+        Ok(Self {
+            config,
+            embed_tokens,
+            fc,
+            hidden_norm,
+            layers,
+            norm,
+            lm_head,
+            markov_w1,
+            markov_w2,
+            confidence_proj,
+        })
+    }
+
+    pub(crate) fn num_layers(&self) -> usize {
+        self.layers.len()
+    }
+
+    /// Fuse the tapped target-layer hidden states into the draft's context
+    /// stream: `H_ctx = hidden_norm(fc(concat_featuredim(tapped)))`.
+    ///
+    /// `tapped` must hold one `[B, S, hidden]` array per configured
+    /// `target_layer_ids` entry, in `target_layer_ids` order.
+    pub(crate) fn fuse_context(&self, tapped: &[MxArray]) -> Result<MxArray> {
+        let expected = self.config.target_layer_ids.len();
+        if tapped.len() != expected || tapped.is_empty() {
+            return Err(Error::from_reason(format!(
+                "DSpark fuse_context expects {} tapped target hiddens (target_layer_ids order), got {}",
+                expected,
+                tapped.len()
+            )));
+        }
+        let feature_axis = tapped[0].ndim()? as i32 - 1;
+        let refs: Vec<&MxArray> = tapped.iter().collect();
+        let concat = MxArray::concatenate_many(refs, Some(feature_axis))?;
+        let fused = self.fc.forward(&concat)?;
+        self.hidden_norm.forward(&fused)
+    }
+
+    /// Run the draft backbone over one block of token ids.
+    ///
+    /// `block_ids` is `[1, T]` (anchor token + mask tokens), `start_pos` the
+    /// absolute position of the block's first token (the anchor position),
+    /// `ctx` the persisted context K/V (positions before the anchor). Returns
+    /// the post-final-norm hidden `[1, T, hidden]` and the softcapped logits
+    /// `[1, T, vocab]`.
+    pub(crate) fn forward_block(
+        &self,
+        block_ids: &MxArray,
+        start_pos: i32,
+        ctx: &DsparkContextCache,
+    ) -> Result<(MxArray, MxArray)> {
+        if ctx.caches.len() != self.layers.len() {
+            return Err(Error::from_reason(format!(
+                "DSpark forward_block: context cache has {} layers but the draft model has {}",
+                ctx.caches.len(),
+                self.layers.len()
+            )));
+        }
+        let embedded = self.embed_tokens.forward(block_ids)?;
+        let mut hidden = embedded.mul_scalar((self.config.hidden_size as f64).sqrt())?;
+        for (layer_idx, layer) in self.layers.iter().enumerate() {
+            let ctx_kv = ctx.layer_kv(layer_idx)?;
+            hidden = layer.forward(&hidden, ctx_kv.as_ref(), start_pos)?;
+        }
+        let hidden = self.norm.forward(&hidden)?;
+        let logits = self.compute_logits(&hidden)?;
+        Ok((hidden, logits))
+    }
+
+    /// lm_head + logit softcap (`tanh(x / cap) * cap`) ONLY — no re-norm.
+    /// The input must already be post-final-norm hidden states.
+    pub(crate) fn compute_logits(&self, hidden: &MxArray) -> Result<MxArray> {
+        let logits = self.lm_head.forward(hidden)?;
+        match self.config.final_logit_softcapping {
+            Some(cap) => {
+                let cap_arr = MxArray::scalar_float_like(cap, &logits)?;
+                let handle = unsafe { sys::mlx_logit_softcap(logits.handle.0, cap_arr.handle.0) };
+                MxArray::from_handle(handle, "dspark_logit_softcap")
+            }
+            None => Ok(logits),
+        }
+    }
+
+    /// Markov correction row for a previous token (see
+    /// [`markov_correction_logits`]).
+    pub(crate) fn markov_correction(&self, prev_token: i32) -> Result<MxArray> {
+        markov_correction_logits(&self.markov_w1, &self.markov_w2, prev_token)
+    }
+
+    /// Sample `len` draft tokens sequentially from softcapped block logits.
+    ///
+    /// Position k's logits are `base_logits[:, k] + markov_correction(prev)`
+    /// where `prev` starts at `anchor` and chains through the sampled tokens
+    /// (the markov bias is added AFTER the softcap; there is no second
+    /// softcap). Greedy below [`GREEDY_TEMPERATURE`]: argmax, empty
+    /// distribution list. Otherwise each token is drawn (via `rng`) from the
+    /// EXACT filtered distribution `sampling::sampling_distribution` builds
+    /// for `cfg`, and the per-position f32 `[vocab]` distribution rows are
+    /// returned for later rejection sampling.
+    pub(crate) fn sample_block_sequential<R: Rng + ?Sized>(
+        &self,
+        base_logits: &MxArray,
+        anchor: i32,
+        len: usize,
+        cfg: &SamplingConfig,
+        rng: &mut R,
+    ) -> Result<(Vec<i32>, Vec<MxArray>)> {
+        let vocab = self.config.vocab_size;
+        if base_logits.ndim()? != 3 || base_logits.shape_at(0)? != 1 {
+            return Err(Error::from_reason(
+                "DSpark sample_block_sequential expects base_logits shaped [1, block, vocab]",
+            ));
+        }
+        let positions = base_logits.shape_at(1)? as usize;
+        if len > positions {
+            return Err(Error::from_reason(format!(
+                "DSpark sample_block_sequential: len={len} exceeds base_logits block size {positions}"
+            )));
+        }
+        if anchor < 0 || (anchor as i64) >= vocab {
+            return Err(Error::from_reason(format!(
+                "DSpark sample_block_sequential: anchor token {anchor} out of vocab range [0, {vocab})"
+            )));
+        }
+        let temperature = cfg.temperature.unwrap_or(1.0);
+        let greedy = temperature < GREEDY_TEMPERATURE;
+
+        let mut tokens = Vec::with_capacity(len);
+        let mut dists = Vec::new();
+        let mut prev = anchor;
+        for k in 0..len {
+            let base_k = base_logits
+                .slice_axis(1, k as i64, k as i64 + 1)?
+                .reshape(&[vocab])?;
+            let correction = self.markov_correction(prev)?;
+            let step_logits = base_k.add(&correction)?;
+            let token = if greedy {
+                let idx = step_logits.argmax(0, Some(false))?.astype(DType::Int32)?;
+                idx.eval();
+                idx.item_at_int32(0)?
+            } else {
+                let dist = sampling::sampling_distribution(&step_logits, Some(*cfg))?
+                    .astype(DType::Float32)?;
+                dist.eval();
+                let probs = dist.to_float32()?;
+                let token = sample_index_from_probs(&probs, rng)?;
+                dists.push(dist);
+                token
+            };
+            tokens.push(token);
+            prev = token;
+        }
+        Ok((tokens, dists))
+    }
+
+    /// Per-position keep probabilities from the confidence head:
+    /// `sigmoid(proj · concat[block_hidden_k, markov_w1[prev_k]] + bias)`.
+    ///
+    /// `block_hidden` is the POST-final-norm `[1, T, hidden]` from
+    /// `forward_block` (the reference feeds `_forward_backbone`'s output,
+    /// which is already `norm(...)`-ed). `prev_tokens` is
+    /// `[anchor, tok_0, .., tok_{T-2}]`.
+    pub(crate) fn confidence_keep_probs(
+        &self,
+        block_hidden: &MxArray,
+        prev_tokens: &[i32],
+    ) -> Result<Vec<f32>> {
+        let proj = self.confidence_proj.as_ref().ok_or_else(|| {
+            Error::from_reason("DSpark confidence head is disabled for this checkpoint")
+        })?;
+        let seq_len = block_hidden.shape_at(1)?;
+        if block_hidden.ndim()? != 3 || block_hidden.shape_at(0)? != 1 {
+            return Err(Error::from_reason(
+                "DSpark confidence_keep_probs expects block_hidden shaped [1, T, hidden]",
+            ));
+        }
+        if prev_tokens.len() != seq_len as usize {
+            return Err(Error::from_reason(format!(
+                "DSpark confidence_keep_probs: {} prev tokens for a block of {} positions",
+                prev_tokens.len(),
+                seq_len
+            )));
+        }
+        let vocab = self.config.vocab_size;
+        for &token in prev_tokens {
+            if token < 0 || (token as i64) >= vocab {
+                return Err(Error::from_reason(format!(
+                    "DSpark confidence_keep_probs: prev token {token} out of vocab range [0, {vocab})"
+                )));
+            }
+        }
+        let idx = MxArray::from_int32(prev_tokens, &[1, seq_len])?;
+        let prev_emb = self
+            .markov_w1
+            .take(&idx, 0)?
+            .astype(block_hidden.dtype()?)?;
+        let features = MxArray::concatenate(block_hidden, &prev_emb, 2)?;
+        let logits = proj.forward(&features)?;
+        let probs = {
+            let handle = unsafe { sys::mlx_array_sigmoid(logits.handle.0) };
+            MxArray::from_handle(handle, "dspark_confidence_sigmoid")?
+        };
+        let probs = probs.astype(DType::Float32)?;
+        probs.eval();
+        Ok(probs.to_float32()?.to_vec())
+    }
+
+    /// Apply checkpoint tensors, consuming entries from `tensors`.
+    ///
+    /// Errors listing every missing expected key and every unexpected
+    /// leftover key, so a truncated or wrong-family checkpoint can never load
+    /// with default-initialized weights.
+    fn apply_weights(&mut self, tensors: &mut HashMap<String, MxArray>) -> Result<()> {
+        let hidden = self.config.hidden_size;
+        let vocab = self.config.vocab_size;
+        let rank = self.config.markov_rank;
+        let head_dim = self.config.global_head_dim;
+        let mut missing: Vec<String> = Vec::new();
+
+        if let Some(w) = take_tensor(tensors, "embed_tokens.weight", &mut missing) {
+            self.embed_tokens.load_weight(&w)?;
+        }
+        if let Some(w) = take_tensor(tensors, "lm_head.weight", &mut missing) {
+            self.lm_head.set_weight(&w, "lm_head")?;
+        }
+        if let Some(w) = take_tensor(tensors, "norm.weight", &mut missing) {
+            apply_norm_weight(&mut self.norm, &w, hidden, "norm")?;
+        }
+        if let Some(w) = take_tensor(tensors, "fc.weight", &mut missing) {
+            self.fc.set_weight(&w, "fc")?;
+        }
+        if let Some(w) = take_tensor(tensors, "hidden_norm.weight", &mut missing) {
+            apply_norm_weight(&mut self.hidden_norm, &w, hidden, "hidden_norm")?;
+        }
+        if let Some(w) = take_tensor(tensors, "markov_head.markov_w1.weight", &mut missing) {
+            check_2d_shape(&w, vocab, rank, "markov_head.markov_w1.weight")?;
+            self.markov_w1 = w;
+        }
+        if let Some(w) = take_tensor(tensors, "markov_head.markov_w2.weight", &mut missing) {
+            check_2d_shape(&w, vocab, rank, "markov_head.markov_w2.weight")?;
+            self.markov_w2 = w;
+        }
+        if let Some(proj) = self.confidence_proj.as_mut() {
+            if let Some(w) = take_tensor(tensors, "confidence_head.proj.weight", &mut missing) {
+                check_2d_shape(&w, 1, hidden + rank, "confidence_head.proj.weight")?;
+                proj.set_weight(&w)?;
+            }
+            if let Some(b) = take_tensor(tensors, "confidence_head.proj.bias", &mut missing) {
+                if b.ndim()? != 1 || b.shape_at(0)? != 1 {
+                    return Err(Error::from_reason(format!(
+                        "DSpark confidence_head.proj.bias must be [1], got {:?}",
+                        b.shape()?.as_ref()
+                    )));
+                }
+                proj.set_bias(Some(&b))?;
+            }
+        }
+
+        for (layer_idx, layer) in self.layers.iter_mut().enumerate() {
+            let prefix = format!("layers.{layer_idx}");
+            for (suffix, norm, dims) in [
+                ("input_layernorm", &mut layer.input_layernorm, hidden),
+                (
+                    "post_attention_layernorm",
+                    &mut layer.post_attention_layernorm,
+                    hidden,
+                ),
+                (
+                    "pre_feedforward_layernorm",
+                    &mut layer.pre_feedforward_layernorm,
+                    hidden,
+                ),
+                (
+                    "post_feedforward_layernorm",
+                    &mut layer.post_feedforward_layernorm,
+                    hidden,
+                ),
+                ("self_attn.q_norm", &mut layer.self_attn.q_norm, head_dim),
+                ("self_attn.k_norm", &mut layer.self_attn.k_norm, head_dim),
+            ] {
+                let key = format!("{prefix}.{suffix}.weight");
+                if let Some(w) = take_tensor(tensors, &key, &mut missing) {
+                    apply_norm_weight(norm, &w, dims, &key)?;
+                }
+            }
+            let scalar_key = format!("{prefix}.layer_scalar");
+            if let Some(w) = take_tensor(tensors, &scalar_key, &mut missing) {
+                if w.ndim()? != 1 || w.shape_at(0)? != 1 {
+                    return Err(Error::from_reason(format!(
+                        "DSpark {scalar_key} must be [1], got {:?}",
+                        w.shape()?.as_ref()
+                    )));
+                }
+                layer.layer_scalar = w;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.self_attn.q_proj.weight"),
+                &mut missing,
+            ) {
+                layer.self_attn.q_proj.set_weight(&w, "q_proj")?;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.self_attn.k_proj.weight"),
+                &mut missing,
+            ) {
+                layer.self_attn.k_proj.set_weight(&w, "k_proj")?;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.self_attn.o_proj.weight"),
+                &mut missing,
+            ) {
+                layer.self_attn.o_proj.set_weight(&w, "o_proj")?;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.mlp.gate_proj.weight"),
+                &mut missing,
+            ) {
+                layer.mlp.set_gate_proj_weight(&w)?;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.mlp.up_proj.weight"),
+                &mut missing,
+            ) {
+                layer.mlp.set_up_proj_weight(&w)?;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.mlp.down_proj.weight"),
+                &mut missing,
+            ) {
+                layer.mlp.set_down_proj_weight(&w)?;
+            }
+        }
+
+        if !missing.is_empty() || !tensors.is_empty() {
+            missing.sort();
+            let mut leftover: Vec<String> = tensors.keys().cloned().collect();
+            leftover.sort();
+            return Err(Error::from_reason(format!(
+                "DSpark draft checkpoint key mismatch: {} missing expected tensor(s) {:?}; {} unexpected leftover tensor(s) {:?}",
+                missing.len(),
+                missing,
+                leftover.len(),
+                leftover
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Remove `key` from `tensors`, recording it in `missing` when absent.
+fn take_tensor(
+    tensors: &mut HashMap<String, MxArray>,
+    key: &str,
+    missing: &mut Vec<String>,
+) -> Option<MxArray> {
+    match tensors.remove(key) {
+        Some(tensor) => Some(tensor),
+        None => {
+            missing.push(key.to_string());
+            None
+        }
+    }
+}
+
+fn apply_norm_weight(norm: &mut RMSNorm, w: &MxArray, dims: i64, name: &str) -> Result<()> {
+    if w.ndim()? != 1 || w.shape_at(0)? != dims {
+        return Err(Error::from_reason(format!(
+            "DSpark {name} weight must be [{dims}], got {:?}",
+            w.shape()?.as_ref()
+        )));
+    }
+    norm.set_weight(w)
+}
+
+fn check_2d_shape(w: &MxArray, rows: i64, cols: i64, name: &str) -> Result<()> {
+    if w.ndim()? != 2 || w.shape_at(0)? != rows || w.shape_at(1)? != cols {
+        return Err(Error::from_reason(format!(
+            "DSpark {name} must be [{rows}, {cols}], got {:?}",
+            w.shape()?.as_ref()
+        )));
+    }
+    Ok(())
+}
+
+/// Inverse-CDF draw from a dense probability row (mirrors the sparse-slice
+/// sampler in `sampling.rs`, but over the full vocab row that
+/// `sampling_distribution` returns).
+fn sample_index_from_probs<R: Rng + ?Sized>(probs: &[f32], rng: &mut R) -> Result<i32> {
+    let total: f64 = probs
+        .iter()
+        .filter(|p| p.is_finite() && **p > 0.0)
+        .map(|&p| p as f64)
+        .sum();
+    if !total.is_finite() || total <= 0.0 {
+        return Err(Error::from_reason(
+            "DSpark draft distribution has no positive probability mass",
+        ));
+    }
+    let u: f64 = rng.random::<f64>() * total;
+    let mut cumulative = 0.0f64;
+    let mut last_positive: Option<usize> = None;
+    for (index, &prob) in probs.iter().enumerate() {
+        if !prob.is_finite() || prob <= 0.0 {
+            continue;
+        }
+        cumulative += prob as f64;
+        last_positive = Some(index);
+        if u < cumulative {
+            return Ok(index as i32);
+        }
+    }
+    last_positive
+        .map(|i| i as i32)
+        .ok_or_else(|| Error::from_reason("DSpark draft distribution has no sampleable token"))
+}
+
+// ============================================
+// Loader
+// ============================================
+
+/// Load a DSpark draft checkpoint (config.json + single model.safetensors)
+/// and validate it against the target model's geometry.
+pub(crate) fn load_draft_model(
+    dir: &Path,
+    target_hidden: i64,
+    target_vocab: i64,
+    target_num_layers: usize,
+) -> Result<DsparkDraftModel> {
+    let config_path = dir.join("config.json");
+    let raw = fs::read_to_string(&config_path).map_err(|e| {
+        Error::from_reason(format!(
+            "Failed to read DSpark draft config {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    let config: DsparkConfig = serde_json::from_str(&raw).map_err(|e| {
+        Error::from_reason(format!(
+            "Failed to parse DSpark draft config {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    config.validate(target_hidden, target_vocab, target_num_layers)?;
+
+    let weights_path = dir.join("model.safetensors");
+    if !weights_path.is_file() {
+        return Err(Error::from_reason(format!(
+            "DSpark draft weights not found: {}",
+            weights_path.display()
+        )));
+    }
+    let mut tensors = load_safetensors_lazy(&weights_path)?;
+    let mut model = DsparkDraftModel::new(config)?;
+    model.apply_weights(&mut tensors)?;
+    Ok(model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Config guard rails ─────────────────────────────────────────────
+
+    /// Serialize a valid draft config JSON matching the real
+    /// dspark_gemma4_12b_block7 checkpoint, with per-test overrides applied
+    /// by string replacement on distinct sub-strings.
+    fn base_config_json() -> String {
+        r#"{
+            "architectures": ["Gemma4DSparkModel"],
+            "model_type": "gemma4_text",
+            "block_size": 7,
+            "mask_token_id": 4,
+            "hidden_size": 3840,
+            "intermediate_size": 15360,
+            "num_hidden_layers": 5,
+            "num_attention_heads": 16,
+            "global_head_dim": 512,
+            "num_global_key_value_heads": 1,
+            "rms_norm_eps": 1e-6,
+            "final_logit_softcapping": 30.0,
+            "vocab_size": 262144,
+            "target_layer_ids": [5, 17, 29, 41, 46],
+            "num_target_layers": 48,
+            "markov_rank": 256,
+            "markov_head_type": "vanilla",
+            "enable_confidence_head": true,
+            "attention_k_eq_v": true,
+            "rope_parameters": {
+                "full_attention": {
+                    "partial_rotary_factor": 0.25,
+                    "rope_theta": 1000000.0,
+                    "rope_type": "proportional"
+                }
+            }
+        }"#
+        .to_string()
+    }
+
+    fn parse(json: &str) -> DsparkConfig {
+        serde_json::from_str(json).expect("test config JSON must parse")
+    }
+
+    const TARGET_HIDDEN: i64 = 3840;
+    const TARGET_VOCAB: i64 = 262144;
+    const TARGET_LAYERS: usize = 48;
+
+    fn expect_err(cfg: &DsparkConfig, needle: &str) -> String {
+        let err = cfg
+            .validate(TARGET_HIDDEN, TARGET_VOCAB, TARGET_LAYERS)
+            .expect_err("config must be rejected");
+        assert!(
+            err.reason.contains(needle),
+            "error {:?} must mention {:?}",
+            err.reason,
+            needle
+        );
+        err.reason.to_string()
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        let cfg = parse(&base_config_json());
+        cfg.validate(TARGET_HIDDEN, TARGET_VOCAB, TARGET_LAYERS)
+            .expect("real checkpoint config must validate");
+    }
+
+    #[test]
+    fn wrong_architecture_rejected() {
+        let json = base_config_json().replace("Gemma4DSparkModel", "Gemma4Model");
+        expect_err(&parse(&json), "architectures");
+    }
+
+    #[test]
+    fn hidden_size_mismatch_rejected() {
+        let cfg = parse(&base_config_json());
+        let err = cfg
+            .validate(5120, TARGET_VOCAB, TARGET_LAYERS)
+            .expect_err("hidden mismatch must be rejected");
+        assert!(err.reason.contains("hidden_size"), "got: {}", err.reason);
+        assert!(err.reason.contains("3840"), "got: {}", err.reason);
+        assert!(err.reason.contains("5120"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn vocab_size_mismatch_rejected() {
+        let cfg = parse(&base_config_json());
+        let err = cfg
+            .validate(TARGET_HIDDEN, 151936, TARGET_LAYERS)
+            .expect_err("vocab mismatch must be rejected");
+        assert!(err.reason.contains("vocab_size"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn unsorted_target_layer_ids_rejected() {
+        let json = base_config_json().replace("[5, 17, 29, 41, 46]", "[17, 5, 29, 41, 46]");
+        expect_err(&parse(&json), "ascending");
+    }
+
+    #[test]
+    fn duplicate_target_layer_ids_rejected() {
+        let json = base_config_json().replace("[5, 17, 29, 41, 46]", "[5, 17, 17, 41, 46]");
+        expect_err(&parse(&json), "ascending");
+    }
+
+    #[test]
+    fn empty_target_layer_ids_rejected() {
+        let json = base_config_json().replace("[5, 17, 29, 41, 46]", "[]");
+        expect_err(&parse(&json), "target_layer_ids");
+    }
+
+    #[test]
+    fn final_target_layer_id_rejected() {
+        // id 47 == num_layers - 1 (the final layer) must be rejected; only
+        // ids strictly below the final layer are tappable.
+        let json = base_config_json().replace("[5, 17, 29, 41, 46]", "[5, 17, 29, 41, 47]");
+        expect_err(&parse(&json), "47");
+    }
+
+    #[test]
+    fn negative_target_layer_id_rejected() {
+        let json = base_config_json().replace("[5, 17, 29, 41, 46]", "[-1, 17, 29, 41, 46]");
+        expect_err(&parse(&json), "-1");
+    }
+
+    #[test]
+    fn num_target_layers_mismatch_rejected() {
+        let cfg = parse(&base_config_json());
+        let err = cfg
+            .validate(TARGET_HIDDEN, TARGET_VOCAB, 40)
+            .expect_err("num_target_layers mismatch must be rejected");
+        assert!(
+            err.reason.contains("num_target_layers"),
+            "got: {}",
+            err.reason
+        );
+    }
+
+    #[test]
+    fn missing_num_target_layers_tolerated() {
+        // num_target_layers is optional; when absent, target_layer_ids range
+        // is still checked against the caller-provided layer count.
+        let json = base_config_json().replace("\"num_target_layers\": 48,", "");
+        let cfg = parse(&json);
+        assert!(cfg.num_target_layers.is_none());
+        cfg.validate(TARGET_HIDDEN, TARGET_VOCAB, TARGET_LAYERS)
+            .expect("config without num_target_layers must validate");
+    }
+
+    #[test]
+    fn k_eq_v_false_rejected() {
+        let json =
+            base_config_json().replace("\"attention_k_eq_v\": true", "\"attention_k_eq_v\": false");
+        expect_err(&parse(&json), "attention_k_eq_v");
+    }
+
+    #[test]
+    fn non_proportional_rope_rejected() {
+        let json = base_config_json().replace(
+            "\"rope_type\": \"proportional\"",
+            "\"rope_type\": \"default\"",
+        );
+        expect_err(&parse(&json), "rope_type");
+    }
+
+    #[test]
+    fn non_vanilla_markov_head_rejected() {
+        let json = base_config_json().replace(
+            "\"markov_head_type\": \"vanilla\"",
+            "\"markov_head_type\": \"gated\"",
+        );
+        expect_err(&parse(&json), "markov_head_type");
+    }
+
+    #[test]
+    fn zero_markov_rank_rejected() {
+        let json = base_config_json().replace("\"markov_rank\": 256", "\"markov_rank\": 0");
+        expect_err(&parse(&json), "markov_rank");
+    }
+
+    // ── Markov correction math ─────────────────────────────────────────
+
+    /// Tiny fixture: V=8, rank=2, hand-computed expected correction row.
+    ///
+    /// w1[t] = [t, 2t]; w2[v] = [v, 1]. For prev token t=3:
+    ///   corr[v] = w2[v] · w1[3] = v*3 + 1*6 = 3v + 6.
+    #[test]
+    fn markov_correction_matches_hand_computed() {
+        let mut w1_data = Vec::new();
+        for t in 0..8 {
+            w1_data.push(t as f32);
+            w1_data.push((2 * t) as f32);
+        }
+        let mut w2_data = Vec::new();
+        for v in 0..8 {
+            w2_data.push(v as f32);
+            w2_data.push(1.0f32);
+        }
+        let w1 = MxArray::from_float32(&w1_data, &[8, 2]).unwrap();
+        let w2 = MxArray::from_float32(&w2_data, &[8, 2]).unwrap();
+
+        let corr = markov_correction_logits(&w1, &w2, 3).unwrap();
+        assert_eq!(corr.shape().unwrap().to_vec(), vec![8]);
+        corr.eval();
+        let got = corr.to_float32().unwrap().to_vec();
+        let expected: Vec<f32> = (0..8).map(|v| (3 * v + 6) as f32).collect();
+        assert_eq!(got, expected);
+    }
+
+    /// A second prev token exercises the row lookup: t=1 → corr[v] = v + 2.
+    #[test]
+    fn markov_correction_uses_prev_token_row() {
+        let mut w1_data = Vec::new();
+        for t in 0..8 {
+            w1_data.push(t as f32);
+            w1_data.push((2 * t) as f32);
+        }
+        let mut w2_data = Vec::new();
+        for v in 0..8 {
+            w2_data.push(v as f32);
+            w2_data.push(1.0f32);
+        }
+        let w1 = MxArray::from_float32(&w1_data, &[8, 2]).unwrap();
+        let w2 = MxArray::from_float32(&w2_data, &[8, 2]).unwrap();
+
+        let corr = markov_correction_logits(&w1, &w2, 1).unwrap();
+        corr.eval();
+        let got = corr.to_float32().unwrap().to_vec();
+        let expected: Vec<f32> = (0..8).map(|v| (v + 2) as f32).collect();
+        assert_eq!(got, expected);
+    }
+
+    // ── Confidence truncation ──────────────────────────────────────────
+
+    #[test]
+    fn truncate_zero_threshold_keeps_all() {
+        assert_eq!(truncate_by_confidence(&[0.1, 0.2, 0.05], 0.0), 3);
+        assert_eq!(truncate_by_confidence(&[0.1, 0.2, 0.05], -1.0), 3);
+    }
+
+    #[test]
+    fn truncate_cuts_at_first_below() {
+        assert_eq!(truncate_by_confidence(&[0.9, 0.8, 0.2, 0.9], 0.5), 2);
+        assert_eq!(truncate_by_confidence(&[0.9, 0.8, 0.7], 0.5), 3);
+    }
+
+    #[test]
+    fn truncate_all_below_keeps_none() {
+        assert_eq!(truncate_by_confidence(&[0.1, 0.2, 0.3], 0.5), 0);
+    }
+
+    #[test]
+    fn truncate_exact_threshold_is_kept() {
+        // prob == threshold satisfies `>= threshold` and is kept.
+        assert_eq!(truncate_by_confidence(&[0.5, 0.5, 0.4], 0.5), 2);
+    }
+
+    #[test]
+    fn truncate_empty_probs() {
+        assert_eq!(truncate_by_confidence(&[], 0.5), 0);
+        assert_eq!(truncate_by_confidence(&[], 0.0), 0);
+    }
+
+    // ── Proportional RoPE fixture ──────────────────────────────────────
+
+    /// Hand-rolled cos/sin reference for the draft's RoPE geometry
+    /// (dims=512, partial_rotary_factor=0.25, base=1e6): pair (j, j+256)
+    /// rotates by `pos / 1e6^(2j/512)` for j < 64 and is identity for
+    /// j >= 64.
+    #[test]
+    fn proportional_rope_matches_hand_rolled_reference() {
+        let dims = 512usize;
+        let half = dims / 2;
+        let rope = Gemma4ProportionalRoPE::new(dims as i32, 0.25, 1e6).unwrap();
+
+        let seq_len = 2usize;
+        let mut data = vec![0f32; seq_len * dims];
+        for (i, v) in data.iter_mut().enumerate() {
+            *v = ((i as f32) * 0.37).sin();
+        }
+        let x = MxArray::from_float32(&data, &[1, 1, seq_len as i64, dims as i64]).unwrap();
+
+        for &offset in &[0i32, 5] {
+            let out = rope.forward(&x, offset).unwrap();
+            out.eval();
+            let got = out.to_float32().unwrap().to_vec();
+            for pos in 0..seq_len {
+                let p = (offset as usize + pos) as f64;
+                for &j in &[0usize, 63, 64, 255] {
+                    let x1 = data[pos * dims + j] as f64;
+                    let x2 = data[pos * dims + j + half] as f64;
+                    let (e1, e2) = if j < 64 {
+                        let freq = 1e6f64.powf((2 * j) as f64 / dims as f64);
+                        let theta = p / freq;
+                        (
+                            x1 * theta.cos() - x2 * theta.sin(),
+                            x1 * theta.sin() + x2 * theta.cos(),
+                        )
+                    } else {
+                        // Non-rotated dims (inf frequency) must be identity.
+                        (x1, x2)
+                    };
+                    let g1 = got[pos * dims + j] as f64;
+                    let g2 = got[pos * dims + j + half] as f64;
+                    assert!(
+                        (g1 - e1).abs() < 1e-4 && (g2 - e2).abs() < 1e-4,
+                        "offset={offset} pos={pos} pair={j}: got ({g1}, {g2}), expected ({e1}, {e2})"
+                    );
+                }
+            }
+        }
+    }
+
+    // ── Tiny-model fixtures ────────────────────────────────────────────
+
+    /// Sized-down config exercising the same code paths as the real draft:
+    /// 2 layers, 2 heads x head_dim 4 with 1 shared KV head, live partial
+    /// rotation (factor 0.5 -> pair 0 rotated, pair 1 identity).
+    fn tiny_config() -> DsparkConfig {
+        parse(
+            r#"{
+                "architectures": ["Gemma4DSparkModel"],
+                "model_type": "gemma4_text",
+                "block_size": 3,
+                "mask_token_id": 4,
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 2,
+                "global_head_dim": 4,
+                "num_global_key_value_heads": 1,
+                "rms_norm_eps": 1e-6,
+                "final_logit_softcapping": 30.0,
+                "vocab_size": 16,
+                "target_layer_ids": [0, 1],
+                "num_target_layers": 4,
+                "markov_rank": 2,
+                "markov_head_type": "vanilla",
+                "enable_confidence_head": true,
+                "attention_k_eq_v": true,
+                "rope_parameters": {
+                    "full_attention": {
+                        "partial_rotary_factor": 0.5,
+                        "rope_theta": 10000.0,
+                        "rope_type": "proportional"
+                    }
+                }
+            }"#,
+        )
+    }
+
+    fn rand_array(shape: &[i64]) -> MxArray {
+        MxArray::random_uniform(shape, -1.0, 1.0, None).unwrap()
+    }
+
+    fn to_vec_f32(a: &MxArray) -> Vec<f32> {
+        a.eval();
+        a.to_float32().unwrap().to_vec()
+    }
+
+    // ── Context cache invariants ───────────────────────────────────────
+
+    #[test]
+    fn context_cache_split_appends_match_single_shot() {
+        let model = DsparkDraftModel::new(tiny_config()).unwrap();
+        let h1 = rand_array(&[1, 3, 8]);
+        let h2 = rand_array(&[1, 2, 8]);
+        let h_full = MxArray::concatenate(&h1, &h2, 1).unwrap();
+
+        let mut split = DsparkContextCache::new(model.num_layers());
+        split.append(&model, &h1, 0).unwrap();
+        assert_eq!(split.len(), 3);
+        split.append(&model, &h2, 3).unwrap();
+        assert_eq!(split.len(), 5);
+
+        let mut single = DsparkContextCache::new(model.num_layers());
+        single.append(&model, &h_full, 0).unwrap();
+        assert_eq!(single.len(), 5);
+
+        for layer in 0..model.num_layers() {
+            let (k_split, v_split) = split.layer_kv(layer).unwrap().unwrap();
+            let (k_single, v_single) = single.layer_kv(layer).unwrap().unwrap();
+            assert_eq!(k_split.shape().unwrap().to_vec(), vec![1, 1, 5, 4]);
+            assert_eq!(k_single.shape().unwrap().to_vec(), vec![1, 1, 5, 4]);
+            let (ks, kf) = (to_vec_f32(&k_split), to_vec_f32(&k_single));
+            let (vs, vf) = (to_vec_f32(&v_split), to_vec_f32(&v_single));
+            for (i, (a, b)) in ks.iter().zip(kf.iter()).enumerate() {
+                assert!(
+                    (a - b).abs() < 1e-5,
+                    "layer {layer} K[{i}]: split={a} single={b}"
+                );
+            }
+            for (i, (a, b)) in vs.iter().zip(vf.iter()).enumerate() {
+                assert!(
+                    (a - b).abs() < 1e-5,
+                    "layer {layer} V[{i}]: split={a} single={b}"
+                );
+            }
+        }
+
+        // Negative control: appending h2 at the WRONG base position must
+        // produce different roped K rows (proves rope actually keys off
+        // base_pos rather than the parity above holding vacuously).
+        let mut wrong = DsparkContextCache::new(model.num_layers());
+        wrong.append(&model, &h1, 0).unwrap();
+        wrong.append(&model, &h2, 0).unwrap();
+        let (k_wrong, _) = wrong.layer_kv(0).unwrap().unwrap();
+        let (k_single, _) = single.layer_kv(0).unwrap().unwrap();
+        let (kw, kf) = (to_vec_f32(&k_wrong), to_vec_f32(&k_single));
+        let tail_differs = kw[3 * 4..]
+            .iter()
+            .zip(kf[3 * 4..].iter())
+            .any(|(a, b)| (a - b).abs() > 1e-6);
+        assert!(
+            tail_differs,
+            "K rows appended at base_pos=0 must differ from rows roped at base_pos=3"
+        );
+
+        // trim() passthrough restores length; reset() empties.
+        split.trim(3);
+        assert_eq!(split.len(), 3);
+        let (k_trimmed, _) = split.layer_kv(0).unwrap().unwrap();
+        assert_eq!(k_trimmed.shape().unwrap().to_vec(), vec![1, 1, 3, 4]);
+        split.reset();
+        assert_eq!(split.len(), 0);
+        assert!(split.is_empty());
+        assert!(split.layer_kv(0).unwrap().is_none());
+    }
+
+    // ── forward_block ──────────────────────────────────────────────────
+
+    #[test]
+    fn forward_block_shapes_finite_softcapped_and_non_causal() {
+        let model = DsparkDraftModel::new(tiny_config()).unwrap();
+        let tapped = vec![rand_array(&[1, 4, 8]), rand_array(&[1, 4, 8])];
+        let h_ctx = model.fuse_context(&tapped).unwrap();
+        assert_eq!(h_ctx.shape().unwrap().to_vec(), vec![1, 4, 8]);
+
+        let mut ctx = DsparkContextCache::new(model.num_layers());
+        ctx.append(&model, &h_ctx, 0).unwrap();
+
+        let block_ids = MxArray::from_int32(&[7, 4, 4], &[1, 3]).unwrap();
+        let (hidden, logits) = model.forward_block(&block_ids, 4, &ctx).unwrap();
+        assert_eq!(hidden.shape().unwrap().to_vec(), vec![1, 3, 8]);
+        assert_eq!(logits.shape().unwrap().to_vec(), vec![1, 3, 16]);
+        assert!(!hidden.has_nan_or_inf().unwrap(), "hidden must be finite");
+        assert!(!logits.has_nan_or_inf().unwrap(), "logits must be finite");
+
+        // Softcap bound: tanh(x/30)*30 keeps every logit within ±30.
+        for (i, v) in to_vec_f32(&logits).iter().enumerate() {
+            assert!(v.abs() <= 30.0 + 1e-3, "logit[{i}]={v} exceeds softcap");
+        }
+
+        // Non-causality: changing the LAST block token must change the FIRST
+        // position's hidden state (mask is None over ctx + block).
+        let block_ids_alt = MxArray::from_int32(&[7, 4, 9], &[1, 3]).unwrap();
+        let (hidden_alt, _) = model.forward_block(&block_ids_alt, 4, &ctx).unwrap();
+        let first = &to_vec_f32(&hidden)[..8];
+        let first_alt = &to_vec_f32(&hidden_alt)[..8];
+        assert!(
+            first
+                .iter()
+                .zip(first_alt.iter())
+                .any(|(a, b)| (a - b).abs() > 1e-6),
+            "changing a later block token must affect an earlier position (non-causal attention)"
+        );
+
+        // An empty context cache is also a valid forward (block-only attention).
+        let empty_ctx = DsparkContextCache::new(model.num_layers());
+        let (hidden_empty, logits_empty) = model.forward_block(&block_ids, 0, &empty_ctx).unwrap();
+        assert_eq!(hidden_empty.shape().unwrap().to_vec(), vec![1, 3, 8]);
+        assert!(!logits_empty.has_nan_or_inf().unwrap());
+    }
+
+    // ── Sequential block sampling ──────────────────────────────────────
+
+    /// Markov fixture for the sequential sampler: w1[t] = [t, 0],
+    /// w2[v] = [v % 2, 0] -> correction[v] = (v % 2) * prev. Base logits are
+    /// crafted so greedy argmax picks 5 -> 7 -> 2, where step 1 only picks 7
+    /// if prev correctly chained to the just-sampled 5 (an un-chained prev=3
+    /// would pick 8 instead).
+    fn chained_markov_model() -> (DsparkDraftModel, MxArray) {
+        let mut model = DsparkDraftModel::new(tiny_config()).unwrap();
+        let mut w1_data = Vec::new();
+        for t in 0..16 {
+            w1_data.push(t as f32);
+            w1_data.push(0.0f32);
+        }
+        let mut w2_data = Vec::new();
+        for v in 0..16 {
+            w2_data.push((v % 2) as f32);
+            w2_data.push(0.0f32);
+        }
+        model.markov_w1 = MxArray::from_float32(&w1_data, &[16, 2]).unwrap();
+        model.markov_w2 = MxArray::from_float32(&w2_data, &[16, 2]).unwrap();
+
+        let mut base = vec![0f32; 3 * 16];
+        base[5] = 2.5; // step 0: 2.5 + 3 (odd corr, prev=3) = 5.5 beats 6 at 4.0
+        base[6] = 4.0;
+        base[16 + 8] = 6.0; // step 1: 7 at 2.0 + 5 = 7.0 beats 8 at 6.0 IF prev==5
+        base[16 + 7] = 2.0;
+        base[2 * 16 + 2] = 8.0; // step 2: even 2 at 8.0 beats odd corr 7.0
+        let base_logits = MxArray::from_float32(&base, &[1, 3, 16]).unwrap();
+        (model, base_logits)
+    }
+
+    #[test]
+    fn sample_block_sequential_greedy_chains_prev_token() {
+        let (model, base_logits) = chained_markov_model();
+        let cfg = SamplingConfig {
+            temperature: Some(0.0),
+            top_k: Some(0),
+            top_p: Some(1.0),
+            min_p: Some(0.0),
+        };
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(7);
+        let (tokens, dists) = model
+            .sample_block_sequential(&base_logits, 3, 3, &cfg, &mut rng)
+            .unwrap();
+        assert_eq!(tokens, vec![5, 7, 2]);
+        assert!(dists.is_empty(), "greedy sampling returns no distributions");
+    }
+
+    #[test]
+    fn sample_block_sequential_stochastic_returns_distributions() {
+        let (model, base_logits) = chained_markov_model();
+        let cfg = SamplingConfig {
+            temperature: Some(1.0),
+            top_k: Some(0),
+            top_p: Some(1.0),
+            min_p: Some(0.0),
+        };
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(42);
+        let (tokens, dists) = model
+            .sample_block_sequential(&base_logits, 3, 3, &cfg, &mut rng)
+            .unwrap();
+        assert_eq!(tokens.len(), 3);
+        assert_eq!(dists.len(), 3, "one f32 distribution row per position");
+        for (k, dist) in dists.iter().enumerate() {
+            assert_eq!(dist.shape().unwrap().to_vec(), vec![16]);
+            assert!(matches!(dist.dtype().unwrap(), DType::Float32));
+            let probs = to_vec_f32(dist);
+            let total: f32 = probs.iter().sum();
+            assert!(
+                (total - 1.0).abs() < 1e-4,
+                "position {k} distribution sums to {total}"
+            );
+            let token = tokens[k];
+            assert!((0..16).contains(&token), "token {token} out of range");
+            assert!(
+                probs[token as usize] > 0.0,
+                "position {k}: sampled token {token} must have positive probability"
+            );
+        }
+    }
+
+    #[test]
+    fn sample_block_sequential_rejects_oversized_len() {
+        let (model, base_logits) = chained_markov_model();
+        let cfg = SamplingConfig {
+            temperature: Some(0.0),
+            top_k: Some(0),
+            top_p: Some(1.0),
+            min_p: Some(0.0),
+        };
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(7);
+        let err = match model.sample_block_sequential(&base_logits, 3, 4, &cfg, &mut rng) {
+            Ok(_) => panic!("len beyond the block must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.reason.contains("exceeds"), "got: {}", err.reason);
+    }
+
+    // ── Confidence head ────────────────────────────────────────────────
+
+    /// With proj weight zero except a 1.0 on the LAST markov-embedding
+    /// feature and w1[t] = [t, 1], every position's keep-prob is
+    /// sigmoid(1) regardless of the hidden state.
+    #[test]
+    fn confidence_keep_probs_uses_prev_token_embeddings() {
+        let mut model = DsparkDraftModel::new(tiny_config()).unwrap();
+        let mut w1_data = Vec::new();
+        for t in 0..16 {
+            w1_data.push(t as f32);
+            w1_data.push(1.0f32);
+        }
+        model.markov_w1 = MxArray::from_float32(&w1_data, &[16, 2]).unwrap();
+        let mut proj_w = vec![0f32; 10];
+        proj_w[9] = 1.0;
+        let w = MxArray::from_float32(&proj_w, &[1, 10]).unwrap();
+        let b = MxArray::from_float32(&[0.0], &[1]).unwrap();
+        model.confidence_proj = Some(Linear::from_weights(&w, Some(&b)).unwrap());
+
+        let block_hidden = rand_array(&[1, 3, 8]);
+        let probs = model
+            .confidence_keep_probs(&block_hidden, &[3, 5, 7])
+            .unwrap();
+        assert_eq!(probs.len(), 3);
+        let expected = 1.0 / (1.0 + (-1.0f32).exp());
+        for (k, p) in probs.iter().enumerate() {
+            assert!(
+                (p - expected).abs() < 1e-4,
+                "position {k}: got {p}, expected sigmoid(1)={expected}"
+            );
+        }
+
+        let err = model
+            .confidence_keep_probs(&block_hidden, &[3, 5])
+            .expect_err("prev token count mismatch must be rejected");
+        assert!(err.reason.contains("prev tokens"), "got: {}", err.reason);
+    }
+
+    // ── Real checkpoint (gated) ────────────────────────────────────────
+
+    /// Full-size load + forward over the real bf16 draft checkpoint.
+    /// Loader success implies all 74 tensors mapped (the completeness gate
+    /// rejects any missing/unexpected key).
+    #[test]
+    #[ignore = "requires a local DSpark draft checkpoint; set MLX_TEST_GEMMA4_DSPARK_PATH and run with --ignored"]
+    fn real_checkpoint_loads_and_forwards() {
+        let Ok(dir) = std::env::var("MLX_TEST_GEMMA4_DSPARK_PATH") else {
+            eprintln!("skipping: MLX_TEST_GEMMA4_DSPARK_PATH not set");
+            return;
+        };
+        let model = load_draft_model(Path::new(&dir), 3840, 262144, 48)
+            .expect("real draft checkpoint must load with all 74 tensors mapped");
+        assert_eq!(model.num_layers(), 5);
+        assert_eq!(model.config.block_size, 7);
+
+        // fuse_context accepts 5 x [1, 4, 3840] bf16 tapped hiddens.
+        let tapped: Vec<MxArray> = (0..5)
+            .map(|_| {
+                MxArray::random_uniform(&[1, 4, 3840], -1.0, 1.0, None)
+                    .unwrap()
+                    .astype(DType::BFloat16)
+                    .unwrap()
+            })
+            .collect();
+        let h_ctx = model.fuse_context(&tapped).expect("fuse_context");
+        assert_eq!(h_ctx.shape().unwrap().to_vec(), vec![1, 4, 3840]);
+
+        let mut ctx = DsparkContextCache::new(model.num_layers());
+        ctx.append(&model, &h_ctx, 0).expect("context append");
+        assert_eq!(ctx.len(), 4);
+
+        // Anchor token + 6 mask tokens at positions 4..11.
+        let block_ids = MxArray::from_int32(&[2, 4, 4, 4, 4, 4, 4], &[1, 7]).unwrap();
+        let (hidden, logits) = model
+            .forward_block(&block_ids, 4, &ctx)
+            .expect("forward_block");
+        assert_eq!(hidden.shape().unwrap().to_vec(), vec![1, 7, 3840]);
+        assert_eq!(logits.shape().unwrap().to_vec(), vec![1, 7, 262144]);
+        assert!(!hidden.has_nan_or_inf().unwrap(), "hidden must be finite");
+        assert!(!logits.has_nan_or_inf().unwrap(), "logits must be finite");
+
+        // Greedy block sampling + confidence over the drafted block.
+        let cfg = SamplingConfig {
+            temperature: Some(0.0),
+            top_k: Some(0),
+            top_p: Some(1.0),
+            min_p: Some(0.0),
+        };
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(0);
+        let (tokens, dists) = model
+            .sample_block_sequential(&logits, 2, 7, &cfg, &mut rng)
+            .expect("sample_block_sequential");
+        assert_eq!(tokens.len(), 7);
+        assert!(dists.is_empty());
+        let mut prev_tokens = vec![2i32];
+        prev_tokens.extend_from_slice(&tokens[..6]);
+        let probs = model
+            .confidence_keep_probs(&hidden, &prev_tokens)
+            .expect("confidence_keep_probs");
+        assert_eq!(probs.len(), 7);
+        assert!(
+            probs
+                .iter()
+                .all(|p| (0.0..=1.0).contains(p) && p.is_finite())
+        );
+    }
+}

--- a/crates/mlx-core/src/models/gemma4/dspark_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark_decode.rs
@@ -317,9 +317,12 @@ impl Gemma4Inner {
     /// existing cache-prefix machinery → chunked prefill WITH the DSpark
     /// tap (per-chunk capture → fuse → context-append → drop; full-prompt
     /// tapped hiddens are never held) → anchor sample (byte-identical to
-    /// the generic flow) → `run_dspark_turn` → save (drop-last driven by
-    /// the loop's `last_in_cache`) → finalize (+ default
-    /// `augment_performance`, which fills the `mtp_*` acceptance fields).
+    /// the generic flow) → `run_dspark_turn` → save (AR-parity: stop exits
+    /// drop the final token, length exits materialize its K/V and keep
+    /// all — post-turn history AND cache offsets equal the AR flow's for
+    /// every stop shape) → finalize (+ default `augment_performance`,
+    /// which fills the `mtp_*` acceptance fields). Every error between
+    /// prefill start and the save fails CLOSED (`dspark_fail_closed`).
     pub(crate) fn dspark_chat_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
         let tokenizer = args.tokenizer.clone();
         let eos_id = args.eos_id;
@@ -399,36 +402,54 @@ impl Gemma4Inner {
             args.sink.map(|_| ChatBackend::stream_emitter(self));
 
         // --- tapped prefill: target K/V + the draft's fused context ---
+        // From here until the save runs, every error FAILS CLOSED
+        // (`dspark_fail_closed`): the target caches advance during
+        // prefill/verify with nothing recorded in `cached_token_history`
+        // yet, so an error abandoned mid-flight would leave a
+        // history-vs-cache offset mismatch that a later prefix-reuse hit
+        // could warm-start corrupt K/V from.
         profiler.begin_prefill();
-        let (last_logits, turn_state) = self.dspark_prefill_with_tap(
+        let (last_logits, turn_state) = match self.dspark_prefill_with_tap(
             &prefill_tokens,
             cached_prefix_len as i32,
             generation_stream,
-        )?;
+        ) {
+            Ok(v) => v,
+            Err(e) => return Err(self.dspark_fail_closed(e)),
+        };
         profiler.end_prefill();
 
         // --- anchor sample: byte-identical to the generic flow ---
-        let last_logits = apply_all_penalties(last_logits, &token_history, &p)?;
-        let y = crate::sampling::sample(&last_logits, p.sampling_config)?;
+        let y = match apply_all_penalties(last_logits, &token_history, &p)
+            .and_then(|logits| crate::sampling::sample(&logits, p.sampling_config))
+        {
+            Ok(y) => y,
+            Err(e) => return Err(self.dspark_fail_closed(e)),
+        };
         y.eval();
 
-        ChatBackend::eval_caches(self)?;
+        if let Err(e) = ChatBackend::eval_caches(self) {
+            return Err(self.dspark_fail_closed(e));
+        }
         if report_perf {
             first_token_instant = Some(Instant::now());
         }
 
-        let block_size = self
-            .dspark
-            .as_ref()
-            .map(|d| d.config.block_size)
-            .ok_or_else(|| Error::from_reason("gemma4 DSpark turn: no draft model loaded"))?;
+        let block_size = match self.dspark.as_ref().map(|d| d.config.block_size) {
+            Some(b) => b,
+            None => {
+                return Err(self.dspark_fail_closed(Error::from_reason(
+                    "gemma4 DSpark turn: no draft model loaded",
+                )));
+            }
+        };
 
         // Hand the prefill-built draft context to the stepper (taken by
         // `begin_dspark_decode` inside the loop).
         self.dspark_turn_state = Some(turn_state);
 
         let mut rng = rand::rng();
-        let last_in_cache;
+        let mut last_in_cache;
         {
             let streaming_ctx = match (args.sink, args.cancelled, emitter.as_mut()) {
                 (Some(sink), Some(cancelled), Some(em)) => Some(StreamingCtx {
@@ -462,27 +483,39 @@ impl Gemma4Inner {
                 },
                 streaming_ctx,
             );
-            // A loop failure before `begin_dspark_decode` consumed the
-            // stash would leave stale per-turn state behind; clear it so
-            // the next turn can never observe it.
-            if outcome.is_err() {
-                self.dspark_turn_state = None;
+            // Fail CLOSED on any loop error: verify advances the target
+            // caches BEFORE commit resolves, so an error mid-cycle (or a
+            // failed rollback/commit) can leave K/V rows the history knows
+            // nothing about. The reset also clears the per-turn draft
+            // stash, whether or not `begin_dspark_decode` consumed it.
+            match outcome {
+                Ok(o) => last_in_cache = o.last_in_cache,
+                Err(e) => return Err(self.dspark_fail_closed(e)),
             }
-            last_in_cache = outcome?.last_in_cache;
         }
 
-        // --- save: drop-last driven by the loop's `last_in_cache` ---
-        // `!last_in_cache` = the final emitted token has no K/V slot (a
-        // cycle boundary, an unverified stop seed, or a clean length exit)
-        // — drop it so `cached_token_history.len()` equals the physical
-        // cache length. A kept final token (EOS accepted as a draft, its
-        // verify slot committed) stays in the history for the same
-        // alignment reason — the qwen3.5 MTP cores' `drop_last_always =
-        // !last_in_cache` convention. The `finish_reason == "length"` arm
-        // is unreachable belt-and-braces (clean length exits always land on
-        // an uncached boundary), kept for parity with
-        // `save_cache_state_direct`'s documented semantics.
-        let drop_last = !last_in_cache || finish_reason == "length";
+        // --- save: AR-parity drop-last + length-exit materialization ---
+        // The loop reports `last_in_cache == false` on EVERY stop-shaped
+        // exit (in-cycle stop tokens are never committed — the loop's
+        // AR-parity exclusion — and boundary stops never had a slot) and on
+        // clean length exits (the final token is an unverified boundary).
+        //   Stop exits (`finish_reason != "length"`): drop the final token
+        //   from the persisted history — exactly the AR save, which never
+        //   forwards its final token and drops it on every non-length stop.
+        //   Length exits: the AR flow keeps ALL tokens and materializes the
+        //   final token's K/V with one extra forward
+        //   (`Gemma4Decode::materialize_final`); mirror it so the physical
+        //   cache offsets equal the keep-all history.
+        if finish_reason == "length"
+            && !last_in_cache
+            && let Some(&final_token) = generated_tokens.last()
+        {
+            if let Err(e) = self.dspark_materialize_final(final_token, generation_stream) {
+                return Err(self.dspark_fail_closed(e));
+            }
+            last_in_cache = true;
+        }
+        let drop_last = !last_in_cache;
         let history_tokens: &[u32] = if drop_last && !generated_tokens.is_empty() {
             &generated_tokens[..generated_tokens.len() - 1]
         } else {
@@ -716,10 +749,61 @@ impl Gemma4Inner {
             },
         ))
     }
+
+    /// Fail CLOSED after a DSpark turn error that may have left the target
+    /// caches advanced beyond `cached_token_history` (prefill and verify
+    /// write K/V before the save records anything): drop the whole warm
+    /// session via `reset_caches_sync` (caches → `None`, history/media
+    /// keys/sliding checkpoints cleared) plus the per-turn draft stash, so
+    /// no later turn can prefix-match into corrupt or misaligned K/V. The
+    /// next fresh turn takes the cold path (full re-prefill); a delta turn
+    /// on the dropped session is rejected by the live-session guard.
+    /// Returns the error for `return Err(self.dspark_fail_closed(e))`
+    /// ergonomics.
+    fn dspark_fail_closed(&mut self, err: Error) -> Error {
+        // Infallible today (`caches = None` + field clears); even if it
+        // ever grows a fallible arm, nothing warm-reusable can survive it.
+        let _ = self.reset_caches_sync();
+        self.dspark_turn_state = None;
+        err
+    }
+
+    /// LENGTH-exit only: run ONE more forward for the final emitted token
+    /// so its K/V lands in the live session caches, then DISCARD the
+    /// logits — the DSpark analog of `Gemma4Decode::materialize_final`
+    /// (the AR flow keeps every token on length exits and materializes the
+    /// final one; the save's keep-all history then equals the physical
+    /// cache offsets). No sample / push / emit; like the AR steppers, this
+    /// deliberately does NOT fire a sliding decode-boundary checkpoint.
+    fn dspark_materialize_final(&mut self, token_id: u32, stream: Stream) -> Result<()> {
+        let caches = self
+            .caches
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("gemma4 DSpark materialize_final: caches missing"))?;
+        let input_ids = MxArray::from_int32(&[token_id as i32], &[1, 1])?;
+        let _stream_ctx = StreamContext::new(stream);
+        crate::models::gemma4::diagnostic::set_step(-1);
+        let _logits = forward_inner(
+            &input_ids,
+            &self.embed_tokens,
+            &self.layers,
+            caches,
+            &self.final_norm,
+            &self.lm_head,
+            self.embed_weight_t.as_ref(),
+            self.ple.as_ref(),
+            &self.config,
+            None,
+        )?;
+        eval_gemma4_caches(caches)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::engine::types::ChatConfig;
     use crate::models::gemma4::config::Gemma4Config;
@@ -728,7 +812,22 @@ mod tests {
     /// Tiny flat-path Gemma4 config (paged OFF so `Gemma4Inner::new` builds
     /// no adapter): 4 hybrid layers, one KV-shared.
     fn tiny_target_config() -> Gemma4Config {
-        serde_json::from_value(serde_json::json!({
+        serde_json::from_value(tiny_target_config_value())
+            .expect("tiny Gemma4 config must deserialize")
+    }
+
+    /// [`tiny_target_config`] with an overridden sliding window — window 2
+    /// makes any verify block over 2 rows violate the
+    /// `snapshot_before_verify` rollback invariant (the fail-closed
+    /// regression's REAL, unmocked mid-turn error).
+    fn tiny_target_config_with_window(window: i64) -> Gemma4Config {
+        let mut v = tiny_target_config_value();
+        v["sliding_window"] = serde_json::json!(window);
+        serde_json::from_value(v).expect("tiny Gemma4 config must deserialize")
+    }
+
+    fn tiny_target_config_value() -> serde_json::Value {
+        serde_json::json!({
             "vocab_size": 16,
             "hidden_size": 8,
             "num_hidden_layers": 4,
@@ -748,8 +847,7 @@ mod tests {
             ],
             "num_kv_shared_layers": 1,
             "use_block_paged_cache": false
-        }))
-        .expect("tiny Gemma4 config must deserialize")
+        })
     }
 
     /// Tiny draft config geometry-matched to [`tiny_target_config`]
@@ -914,5 +1012,347 @@ mod tests {
         unsafe { std::env::set_var("MLX_DSPARK_CONFIDENCE_THRESHOLD", "not-a-number") };
         assert_eq!(dspark_confidence_threshold_from_env(), 0.0);
         unsafe { std::env::remove_var("MLX_DSPARK_CONFIDENCE_THRESHOLD") };
+    }
+
+    // ── fail-closed error path (whole-turn core) ───────────────────────
+
+    /// WordLevel tokenizer covering the full tiny vocab (ids 0..16 as
+    /// `t0`..`t15`) so every decode over tiny-model output succeeds,
+    /// written to a temp `tokenizer.json` for `Qwen3Tokenizer::from_file`.
+    fn tiny_qwen_tokenizer() -> Arc<crate::tokenizer::Qwen3Tokenizer> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "gemma4_dspark_tiny_tokenizer_{}_{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp tokenizer dir");
+        let vocab = (0..16)
+            .map(|i| format!("\"t{i}\": {i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let json = format!(
+            r#"{{
+                "version": "1.0",
+                "truncation": null,
+                "padding": null,
+                "added_tokens": [],
+                "normalizer": null,
+                "pre_tokenizer": null,
+                "post_processor": null,
+                "decoder": null,
+                "model": {{
+                    "type": "WordLevel",
+                    "vocab": {{ {vocab} }},
+                    "unk_token": "t0"
+                }}
+            }}"#
+        );
+        let path = dir.join("tokenizer.json");
+        std::fs::write(&path, json).expect("write tiny tokenizer.json");
+        Arc::new(
+            crate::tokenizer::Qwen3Tokenizer::from_file(&path).expect("tiny tokenizer must load"),
+        )
+    }
+
+    fn tiny_turn_config(mtp_depth: Option<i32>, max_new_tokens: i32) -> ChatConfig {
+        ChatConfig {
+            mtp_depth,
+            max_new_tokens: Some(max_new_tokens),
+            temperature: Some(0.0),
+            reuse_cache: Some(true),
+            report_performance: Some(true),
+            include_reasoning: Some(false),
+            ..ChatConfig::default()
+        }
+    }
+
+    /// Drive `dspark_chat_turn` directly (sync — no model thread), with an
+    /// out-of-vocab `eos_id` so the tiny model can only exit "length".
+    fn run_tiny_dspark_turn(
+        inner: &mut Gemma4Inner,
+        tokenizer: &Arc<crate::tokenizer::Qwen3Tokenizer>,
+        tokens: &[u32],
+        config: &ChatConfig,
+    ) -> Result<crate::engine::types::ChatResult> {
+        let p = ChatBackend::resolve_params(inner, config);
+        let thinking = ChatBackend::thinking_setup(inner, config);
+        let mut args = WholeTurnArgs {
+            tokens,
+            tokenizer,
+            eos_id: 999,
+            config,
+            params: &p,
+            thinking,
+            is_delta: false,
+            sink: None,
+            cancelled: None,
+            images: &[],
+            audio: &[],
+        };
+        match inner.dspark_chat_turn(&mut args)? {
+            TurnOutput::Complete(r) => Ok(*r),
+            TurnOutput::Streamed => panic!("sync dspark turn returned TurnOutput::Streamed"),
+        }
+    }
+
+    /// FAIL-CLOSED regression: a REAL (unmocked) stepper error AFTER
+    /// prefill has advanced the target caches must drop the entire warm
+    /// session — caches, `cached_token_history`, per-turn stash — so no
+    /// later turn can prefix-match into K/V the history knows nothing
+    /// about; and the very next turn must succeed via the cold path.
+    ///
+    /// Error injection: sliding_window 2 with the default depth (draft
+    /// block_size 3) makes the first cycle's 4-row verify block violate
+    /// `snapshot_before_verify`'s window >= block invariant — the error
+    /// fires at the verify seam of cycle 1, after `dspark_prefill_with_tap`
+    /// appended the whole prompt to every active cache.
+    #[test]
+    fn dspark_turn_error_fails_closed_then_cold_turn_recovers() {
+        let mut inner = Gemma4Inner::new(tiny_target_config_with_window(2))
+            .expect("tiny window-2 Gemma4Inner must construct");
+        inner.dspark = Some(DsparkDraftModel::new(tiny_draft_config()).expect("tiny draft model"));
+        let tokenizer = tiny_qwen_tokenizer();
+        let tokens: Vec<u32> = vec![0, 1, 2, 3];
+
+        // Turn 1: unset depth resolves to block_size 3 → 1+3 verify rows
+        // over a 2-token window → hard error mid-turn.
+        let err = run_tiny_dspark_turn(&mut inner, &tokenizer, &tokens, &tiny_turn_config(None, 8))
+            .expect_err("a depth-3 verify block must violate the window-2 rollback invariant");
+        assert!(
+            err.reason.contains("sliding window") && err.reason.contains("verify block"),
+            "expected the snapshot_before_verify window guard, got: {}",
+            err.reason
+        );
+        // Fail CLOSED: nothing warm-reusable may survive the error.
+        assert!(inner.caches.is_none(), "caches must be dropped");
+        assert!(
+            inner.cached_token_history.is_empty(),
+            "cached_token_history must be cleared (it never covered the prefilled K/V)"
+        );
+        assert!(
+            inner.dspark_turn_state.is_none(),
+            "the per-turn draft stash must be cleared"
+        );
+        assert!(
+            !ChatBackend::has_live_session(&inner),
+            "the session must not be warm-reusable after a failed turn"
+        );
+        assert_eq!(
+            ChatBackend::verify_cache_prefix(&inner, &tokens, true),
+            0,
+            "no prefix hit may match against the dropped session"
+        );
+
+        // Turn 2: depth 1 → verify blocks of <= 2 rows fit the window; the
+        // turn must run cold end-to-end and land fully consistent.
+        let res = run_tiny_dspark_turn(
+            &mut inner,
+            &tokenizer,
+            &tokens,
+            &tiny_turn_config(Some(1), 3),
+        )
+        .expect("the next turn after fail-closed must succeed via the cold path");
+        assert_eq!(res.finish_reason, "length");
+        assert_eq!(
+            res.cached_tokens, 0,
+            "nothing may be warm-reused after fail-closed"
+        );
+        assert_eq!(res.num_tokens, 3, "budget-3 length exit");
+
+        // Length-exit AR parity (keep-all + materialize): the saved history
+        // holds prompt + ALL generated tokens and every ACTIVE cache offset
+        // equals the history length — the final token's K/V was
+        // materialized by `dspark_materialize_final`.
+        let history = inner.cached_token_history.clone();
+        assert_eq!(history.len(), tokens.len() + res.num_tokens as usize);
+        assert_eq!(&history[..tokens.len()], &tokens[..]);
+        let mask = dspark_shared_slot_mask(&inner.config);
+        let caches = inner
+            .caches
+            .as_ref()
+            .expect("live caches after a successful turn");
+        for (i, cache) in caches.iter().enumerate() {
+            let expected = if mask[i] { 0 } else { history.len() as i32 };
+            assert_eq!(
+                cache.get_offset(),
+                expected,
+                "cache {i} offset must equal the saved history length \
+                 (length-exit materialize; shared slots stay unwritten)"
+            );
+        }
+    }
+
+    // ── EOS-accepted-as-draft AR state parity (real model, env-gated) ──
+
+    /// EOS-ACCEPTED-AS-DRAFT regression: full post-turn STATE parity vs the
+    /// AR flow — `cached_token_history` byte-equal AND physical cache
+    /// offsets equal to the history length — across a 2-turn warm-continue,
+    /// with the stop SHAPE (EOS cut INSIDE the accepted drafts, not at a
+    /// cycle boundary) pinned via the mtp acceptance stats: on a boundary
+    /// stop or clean cycles, generated == seed + Σk + cycles; a cut inside
+    /// accepted drafts loses the cut cycle's boundary token (and any drafts
+    /// past the EOS), so generated < seed + Σk + cycles.
+    ///
+    /// Run (single-threaded; both env vars required):
+    ///
+    /// ```shell
+    /// PATH=/usr/bin:$PATH SDKROOT=$(xcrun --show-sdk-path) \
+    /// MLX_TEST_GEMMA4_MODEL_PATH=... MLX_TEST_GEMMA4_DSPARK_PATH=... \
+    ///     cargo test -p mlx-core --lib --release -- --ignored \
+    ///     --test-threads=1 dspark_eos_accepted_draft_state_matches_ar_e2e
+    /// ```
+    #[test]
+    #[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH (real 12B + draft)"]
+    fn dspark_eos_accepted_draft_state_matches_ar_e2e() {
+        let (Ok(model_path), Ok(draft_path)) = (
+            std::env::var("MLX_TEST_GEMMA4_MODEL_PATH"),
+            std::env::var("MLX_TEST_GEMMA4_DSPARK_PATH"),
+        ) else {
+            eprintln!("skipping: set MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH");
+            return;
+        };
+
+        // Tie-screened fixture (see tests/gemma4_dspark.rs module doc);
+        // measured shape on this checkpoint: the EOS is cut inside accepted
+        // drafts on turn 1 (deficit >= 1 below).
+        const PROMPT: &str = "What is the capital of France? Answer with just the city name.";
+        const FOLLOW_UP: &str = "And of Italy? Same format.";
+
+        fn cfg(enable_mtp: bool) -> ChatConfig {
+            ChatConfig {
+                max_new_tokens: Some(64),
+                temperature: Some(0.0),
+                include_reasoning: Some(false),
+                report_performance: Some(true),
+                reuse_cache: Some(true),
+                enable_mtp: Some(enable_mtp),
+                mtp_adaptive_depth: Some(false),
+                ..ChatConfig::default()
+            }
+        }
+        fn user(content: &str) -> crate::tokenizer::ChatMessage {
+            crate::tokenizer::ChatMessage {
+                role: "user".to_string(),
+                content: content.to_string(),
+                tool_calls: None,
+                tool_call_id: None,
+                is_error: None,
+                reasoning_content: None,
+                images: None,
+                audio: None,
+            }
+        }
+        fn assert_offsets_match_history(inner: &Gemma4Inner, label: &str) {
+            let h = inner.cached_token_history.len() as i32;
+            let mask = dspark_shared_slot_mask(&inner.config);
+            let caches = inner.caches.as_ref().expect("live caches");
+            assert!(h > 0, "[{label}] saved history must be non-empty");
+            for (i, cache) in caches.iter().enumerate() {
+                let expected = if mask[i] { 0 } else { h };
+                assert_eq!(
+                    cache.get_offset(),
+                    expected,
+                    "[{label}] cache {i} physical offset diverged from the {h}-token history"
+                );
+            }
+        }
+
+        // ONE instance for both passes (the draft never touches the flat AR
+        // path, and a fresh session start resets the prior session).
+        let (mut inner, _weight_bytes) = Gemma4Inner::load_from_dir(&model_path, Some(&draft_path))
+            .expect("12B + draft load failed");
+
+        // --- AR baseline: 2 turns, capturing history + offsets ---
+        let ar1 = crate::engine::session::session_start(&mut inner, vec![user(PROMPT)], cfg(false))
+            .expect("AR turn 1 failed");
+        assert_eq!(ar1.finish_reason, "stop", "fixture must stop early on EOS");
+        let ar_h1 = inner.cached_token_history.clone();
+        assert_offsets_match_history(&inner, "ar_turn1");
+        let ar2 = crate::engine::session::session_continue(
+            &mut inner,
+            FOLLOW_UP.to_string(),
+            None,
+            None,
+            cfg(false),
+        )
+        .expect("AR turn 2 failed");
+        let ar_h2 = inner.cached_token_history.clone();
+        assert_offsets_match_history(&inner, "ar_turn2");
+
+        // --- DSpark pass: same 2 turns ---
+        let sp1 = crate::engine::session::session_start(&mut inner, vec![user(PROMPT)], cfg(true))
+            .expect("DSpark turn 1 failed");
+        assert_eq!(sp1.finish_reason, "stop");
+        // SHAPE fingerprint: the EOS must have been accepted as a DRAFT.
+        let perf = sp1.performance.as_ref().expect("DSpark perf missing");
+        let cycles = perf.mtp_cycles.expect("mtp_cycles missing") as i64;
+        let mean_k = perf
+            .mtp_mean_accepted_tokens
+            .expect("mtp_mean_accepted_tokens missing");
+        let total_k = (mean_k * cycles as f64).round() as i64;
+        let full_emission = 1 + total_k + cycles;
+        assert!(cycles > 0, "DSpark cycles must have run");
+        assert!(
+            (sp1.num_tokens as i64) < full_emission,
+            "fixture no longer stops INSIDE accepted drafts (generated {} == seed + \u{03a3}k + \
+             cycles = {full_emission}; the EOS landed on a cycle boundary) — re-screen the \
+             prompt so the accepted-draft-EOS shape is actually exercised",
+            sp1.num_tokens,
+        );
+        let sp_h1 = inner.cached_token_history.clone();
+        assert_offsets_match_history(&inner, "dspark_turn1");
+
+        let sp2 = crate::engine::session::session_continue(
+            &mut inner,
+            FOLLOW_UP.to_string(),
+            None,
+            None,
+            cfg(true),
+        )
+        .expect("DSpark turn 2 failed");
+        assert!(
+            sp2.cached_tokens > 0,
+            "turn 2 must warm-continue on the saved session, got cached_tokens=0"
+        );
+        assert!(
+            sp2.performance
+                .as_ref()
+                .and_then(|p| p.mtp_cycles)
+                .unwrap_or(0)
+                > 0,
+            "the warm-continue turn must also run DSpark cycles"
+        );
+        let sp_h2 = inner.cached_token_history.clone();
+        assert_offsets_match_history(&inner, "dspark_turn2");
+
+        // --- Parity: transcript AND full logical/physical session state ---
+        assert_eq!(sp1.text, ar1.text, "turn 1 text diverged from AR");
+        assert_eq!(sp1.raw_text, ar1.raw_text, "turn 1 raw_text diverged");
+        assert_eq!(sp1.num_tokens, ar1.num_tokens);
+        assert_eq!(sp2.text, ar2.text, "turn 2 text diverged from AR");
+        assert_eq!(sp2.raw_text, ar2.raw_text, "turn 2 raw_text diverged");
+        assert_eq!(sp2.finish_reason, ar2.finish_reason);
+        assert_eq!(sp2.num_tokens, ar2.num_tokens);
+        assert_eq!(
+            sp_h1, ar_h1,
+            "post-turn-1 cached_token_history diverged from AR \
+             (the accepted-draft EOS must be dropped from the persisted state)"
+        );
+        assert_eq!(
+            sp_h2, ar_h2,
+            "post-turn-2 cached_token_history diverged from AR"
+        );
+        println!(
+            "[eos_accepted_draft_state] turn1: tokens={} cycles={cycles} \u{03a3}k={total_k} \
+             deficit={} | turn2: tokens={} cached={} | history lens: {} / {}",
+            sp1.num_tokens,
+            full_emission - sp1.num_tokens as i64,
+            sp2.num_tokens,
+            sp2.cached_tokens,
+            sp_h1.len(),
+            sp_h2.len(),
+        );
     }
 }

--- a/crates/mlx-core/src/models/gemma4/dspark_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark_decode.rs
@@ -555,6 +555,21 @@ impl Gemma4Inner {
             // Residual flush through the emitter (same skip-special flag as
             // the in-loop DecodeStream so `streamed_text_len` accounting
             // stays consistent).
+            //
+            // CANCEL SEMANTICS (deliberate, verified AR/MTP parity): on a
+            // cancelled turn the loop's clamp commits the cancel-observed
+            // token to `generated_tokens` without step-streaming it; this
+            // flush then delivers its text, so the TOTAL streamed text
+            // equals `decode(generated_tokens)` — exactly the AR loop's
+            // documented origin/main contract (`engine/decode.rs`
+            // cancel-snapshot comment: the token is pushed at the loop top,
+            // the break skips the detok, and the post-loop residual flush
+            // re-streams the tail) and the MTP core's behavior (initial-arm
+            // skip + unconditioned family flush). Suppressing the suffix
+            // here would make a cancelled DSpark stream the ONLY path whose
+            // streamed text cannot reconstruct the terminal chunk's
+            // raw_text. The suffix is pinned to exactly ONE token by
+            // `dspark_turn_streaming_cancel_in_clamp_commits_exactly_once`.
             let full_text = tokenizer
                 .decode_sync(&generated_tokens, stream_skip_special)
                 .unwrap_or_else(|e| {
@@ -846,7 +861,13 @@ mod tests {
                 "full_attention"
             ],
             "num_kv_shared_layers": 1,
-            "use_block_paged_cache": false
+            "use_block_paged_cache": false,
+            // Explicitly EMPTY: the config default is [1], which is inside
+            // the tiny 16-token vocab — random placeholder-weight turns
+            // would then stop nondeterministically on token 1 instead of
+            // running to their length budget (the whole-turn tests pass an
+            // out-of-vocab session eos_id=999 as the only stop).
+            "eos_token_ids": []
         })
     }
 
@@ -1182,6 +1203,140 @@ mod tests {
                  (length-exit materialize; shared slots stay unwritten)"
             );
         }
+    }
+
+    // ── streaming cancellation (whole-turn) ────────────────────────────
+
+    /// Records every chunk and flips the shared cancel flag once
+    /// `flip_after` NON-TERMINAL chunks have arrived (the sink runs inline
+    /// on the decode thread, so the flip lands mid-turn deterministically).
+    struct CancelAfterSink {
+        chunks: std::sync::Mutex<Vec<crate::engine::types::ChatStreamChunk>>,
+        cancelled: Arc<std::sync::atomic::AtomicBool>,
+        flip_after: usize,
+    }
+
+    impl crate::engine::backend::ChunkSink for CancelAfterSink {
+        fn send(&self, chunk: Result<crate::engine::types::ChatStreamChunk>) {
+            if let (Ok(c), Ok(mut v)) = (chunk, self.chunks.lock()) {
+                v.push(c);
+                if v.iter().filter(|c| !c.done).count() >= self.flip_after {
+                    self.cancelled
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    /// WHOLE-TURN streaming cancellation through `dspark_chat_turn`: a
+    /// cancel raised from the chunk sink must terminate the stream promptly
+    /// ("cancelled", bounded block-granular overrun — never running on to
+    /// the budget) and leave the cached session state consistent (AR-parity
+    /// drop-last: the final emitted token is persisted in NEITHER the
+    /// history NOR the caches; offsets equal the history), with the next
+    /// turn running normally. Chunk-vs-residual byte accounting for the
+    /// cancel suffix is pinned at the engine seam
+    /// (`dspark_turn_streaming_cancel_in_clamp_commits_exactly_once`),
+    /// where the mid-clamp cancel point is injectable; a sink-driven flip
+    /// lands at the next loop-top by construction.
+    #[test]
+    fn dspark_streaming_cancel_whole_turn_state_consistent() {
+        // Placeholder weights come from MLX's global PRNG (`Linear::new` is
+        // Xavier-uniform); pin it so the token stream — and with it the
+        // chunk/flip timing the `n` bound below asserts on — is identical
+        // on every run (the repo's established `mlx_seed` test pattern).
+        unsafe { mlx_sys::mlx_seed(0xD5_9A4B_0001) };
+        let mut inner =
+            Gemma4Inner::new(tiny_target_config()).expect("tiny Gemma4Inner must construct");
+        inner.dspark = Some(DsparkDraftModel::new(tiny_draft_config()).expect("tiny draft model"));
+        let tokenizer = tiny_qwen_tokenizer();
+        let tokens: Vec<u32> = vec![0, 1, 2, 3];
+        // Budget 12 with a flip after 2 chunks: a broken cancel would run to
+        // the length exit and emit ~12 chunks.
+        let mut config = tiny_turn_config(Some(1), 12);
+        config.include_reasoning = Some(true);
+
+        let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let sink = CancelAfterSink {
+            chunks: std::sync::Mutex::new(Vec::new()),
+            cancelled: Arc::clone(&cancelled),
+            flip_after: 2,
+        };
+        let p = ChatBackend::resolve_params(&inner, &config);
+        let thinking = ChatBackend::thinking_setup(&inner, &config);
+        let mut args = WholeTurnArgs {
+            tokens: &tokens,
+            tokenizer: &tokenizer,
+            eos_id: 999,
+            config: &config,
+            params: &p,
+            thinking,
+            is_delta: false,
+            sink: Some(&sink),
+            cancelled: Some(&cancelled),
+            images: &[],
+            audio: &[],
+        };
+        let out = inner
+            .dspark_chat_turn(&mut args)
+            .expect("streaming cancelled turn must complete cleanly");
+        assert!(
+            matches!(out, TurnOutput::Streamed),
+            "streaming turn must return TurnOutput::Streamed"
+        );
+
+        let chunks = sink.chunks.into_inner().expect("sink poisoned");
+        let terminal = chunks
+            .iter()
+            .find(|c| c.done)
+            .expect("stream must end with a terminal done-chunk");
+        assert_eq!(
+            terminal.finish_reason.as_deref(),
+            Some("cancelled"),
+            "sink-raised cancel must finish the turn as cancelled"
+        );
+        let n = terminal.num_tokens.expect("terminal must carry num_tokens") as usize;
+        assert!(
+            (1..=5).contains(&n),
+            "cancel must stop within one depth-1 cycle of the flip \
+             (seed + <= 2 cycles of <= 2 tokens), got {n} generated tokens"
+        );
+
+        // AR-parity cancelled save: the final emitted token is dropped from
+        // the history AND was never committed to the caches.
+        let history = inner.cached_token_history.clone();
+        assert_eq!(
+            history.len(),
+            tokens.len() + n - 1,
+            "cancelled turn must persist prompt + generated minus the final token"
+        );
+        assert_eq!(&history[..tokens.len()], &tokens[..]);
+        let mask = dspark_shared_slot_mask(&inner.config);
+        let caches = inner.caches.as_ref().expect("live caches after the turn");
+        for (i, cache) in caches.iter().enumerate() {
+            let expected = if mask[i] { 0 } else { history.len() as i32 };
+            assert_eq!(
+                cache.get_offset(),
+                expected,
+                "cache {i} offset must equal the saved history length after a cancel"
+            );
+        }
+        assert!(
+            ChatBackend::has_live_session(&inner),
+            "a cleanly cancelled turn leaves a warm-reusable session (AR parity)"
+        );
+
+        // The next turn runs normally (fresh prompt: the longer saved
+        // history is a prefix-miss, so it takes the cold path).
+        let res = run_tiny_dspark_turn(
+            &mut inner,
+            &tokenizer,
+            &tokens,
+            &tiny_turn_config(Some(1), 3),
+        )
+        .expect("the turn after a cancelled stream must succeed");
+        assert_eq!(res.finish_reason, "length");
+        assert_eq!(res.num_tokens, 3);
     }
 
     // ── EOS-accepted-as-draft AR state parity (real model, env-gated) ──

--- a/crates/mlx-core/src/models/gemma4/dspark_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark_decode.rs
@@ -1,0 +1,918 @@
+//! Gemma4 DSpark speculative-decode wiring: the family-side
+//! [`DsparkStepper`]/[`DsparkBackend`] implementation the engine-owned
+//! [`crate::engine::dspark_turn::run_dspark_turn`] loop drives, plus the
+//! whole-turn core (`dspark_chat_turn`) behind gemma4's
+//! `ChatBackend::mtp_turn` override.
+//!
+//! Split of responsibilities:
+//!   * the DRAFT model (5-layer cross-attending transformer, markov head,
+//!     confidence head, context K/V cache) lives in [`super::dspark`];
+//!   * the TARGET-side primitives (hidden tap, verify forward,
+//!     snapshot/commit rollback, shared-slot mask) live in
+//!     [`super::model`] / [`super::layer_cache`];
+//!   * the model-agnostic propose → verify → accept → stop-clamp → commit
+//!     loop lives in [`crate::engine::dspark_turn`];
+//!   * THIS module glues them together for gemma4.
+
+use std::time::Instant;
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::decode_profiler::DecodeProfiler;
+use crate::engine::backend::{
+    ChatBackend, DsparkBackend, DsparkProposal, DsparkStepper, DsparkTurnSetup, DsparkVerifyOutput,
+    FinalizeArgs, ResetScope, StreamEmitter, TurnOutput, WholeTurnArgs,
+};
+use crate::engine::decode::StreamingCtx;
+use crate::engine::dspark_turn::{DsparkTurnArgs, run_dspark_turn};
+use crate::engine::finalize::compute_performance_metrics;
+use crate::engine::params::{ChatParams, generated_capacity_hint};
+use crate::engine::penalties::{ReasoningTracker, apply_all_penalties};
+use crate::stream::{DeviceType, Stream, StreamContext};
+
+use super::dspark::{DsparkContextCache, DsparkTap, truncate_by_confidence};
+use super::layer_cache::{Gemma4VerifyRollback, commit_after_verify, snapshot_before_verify};
+use super::model::{
+    GEMMA4_PREFILL_STEP_SIZE, Gemma4Inner, compute_ple, dspark_shared_slot_mask,
+    dspark_verify_forward, eval_gemma4_caches, forward_body, forward_inner,
+};
+
+/// Per-turn draft-context handoff from `dspark_chat_turn`'s tapped prefill
+/// to [`DsparkBackend::begin_dspark_decode`].
+///
+/// The engine's [`DsparkTurnSetup`] carries only turn constants, so the
+/// prefill-derived draft context travels through
+/// `Gemma4Inner::dspark_turn_state`: the whole-turn core stashes it right
+/// before calling `run_dspark_turn`, and `begin_dspark_decode` TAKES it
+/// into the stepper (so it can never leak across turns — a fresh context is
+/// built every turn).
+pub(crate) struct DsparkTurnState {
+    /// The draft's fused-context K/V cache, holding one row per freshly
+    /// prefilled prompt token (absolute positions
+    /// `position_base .. position_base + rows`).
+    pub(crate) ctx: DsparkContextCache,
+    /// Absolute sequence position of the NEXT context row / target-cache
+    /// slot — `cached_prefix_len + prefill_len` right after prefill, then
+    /// advanced by `keep` on every commit.
+    pub(crate) next_pos: i32,
+}
+
+/// Confidence-truncation threshold for drafted blocks, read ONCE at stepper
+/// construction. Default `0.0` = keep-all (truncation disabled); invalid
+/// values fall back to the default.
+fn dspark_confidence_threshold_from_env() -> f32 {
+    std::env::var("MLX_DSPARK_CONFIDENCE_THRESHOLD")
+        .ok()
+        .and_then(|v| v.parse::<f32>().ok())
+        .unwrap_or(0.0)
+}
+
+/// Per-turn gemma4 DSpark stepper ([`DsparkBackend::DsparkDecode`]).
+///
+/// Owns the turn's draft context cache and position cursor; borrows the
+/// model for the whole decode loop. The tapped target hiddens and the
+/// verify rollback are stashed between `verify` and `commit` — they never
+/// cross the engine trait (see the invariant on [`DsparkStepper`]).
+pub(crate) struct Gemma4DsparkStepper<'a> {
+    inner: &'a mut Gemma4Inner,
+    ctx: DsparkContextCache,
+    /// Absolute position of the next verify block's anchor (== the current
+    /// committed sequence length: prompt + anchor-exclusive generation).
+    next_pos: i32,
+    /// Draft `target_layer_ids` as decoder indices (strictly ascending).
+    layer_ids: Vec<usize>,
+    /// Config-derived KV-shared slot mask ([`dspark_shared_slot_mask`]),
+    /// passed to every `snapshot_before_verify`.
+    shared_slots: Vec<bool>,
+    confidence_threshold: f32,
+    /// Pending rollback from the last `verify`, consumed by `commit`.
+    rollback: Option<Gemma4VerifyRollback>,
+    /// Tapped `[1, 1+L, hidden]` hiddens from the last `verify` (one per
+    /// `layer_ids` entry), consumed by `commit`.
+    tapped: Option<Vec<MxArray>>,
+}
+
+impl DsparkStepper for Gemma4DsparkStepper<'_> {
+    fn propose(
+        &mut self,
+        anchor_id: u32,
+        max_len: usize,
+        params: &ChatParams,
+        rng: &mut dyn rand::Rng,
+    ) -> Result<DsparkProposal> {
+        let draft =
+            self.inner.dspark.as_ref().ok_or_else(|| {
+                Error::from_reason("gemma4 DSpark propose: no draft model loaded")
+            })?;
+        if max_len == 0 {
+            return Err(Error::from_reason(
+                "gemma4 DSpark propose: engine contract violation (max_len == 0 cycles skip propose)",
+            ));
+        }
+
+        // Draft block: `[anchor, MASK x (max_len - 1)]` at the block's
+        // absolute positions (anchor sits at `next_pos`). ONE forward over
+        // the persisted fused context; row k's logits draft the token at
+        // absolute position `next_pos + k + 1`.
+        let mask_id = draft.config.mask_token_id;
+        let mut block_ids: Vec<i32> = Vec::with_capacity(max_len);
+        block_ids.push(anchor_id as i32);
+        block_ids.resize(max_len, mask_id);
+        let block = MxArray::from_int32(&block_ids, &[1, max_len as i64])?;
+        let (block_hidden, block_logits) = draft.forward_block(&block, self.next_pos, &self.ctx)?;
+
+        // Sequential markov-chained sampling. Greedy detection INSIDE
+        // `sample_block_sequential` uses the engine's
+        // `sampling::is_greedy_temperature` predicate — the same predicate
+        // `run_dspark_turn` keys its accept policy on — so the returned
+        // `dists` are empty exactly when the engine expects them empty, and
+        // at sampled temperature each row is the EXACT distribution the
+        // draw came from.
+        let cfg = params.sampling_config.unwrap_or_default();
+        let (mut draft_ids, mut draft_dists) =
+            draft.sample_block_sequential(&block_logits, anchor_id as i32, max_len, &cfg, rng)?;
+
+        // Confidence truncation (opt-in via MLX_DSPARK_CONFIDENCE_THRESHOLD,
+        // read once at stepper construction): keep the longest prefix whose
+        // keep-probability clears the threshold. Returning FEWER tokens than
+        // `max_len` is allowed by the engine contract (never more).
+        if self.confidence_threshold > 0.0 {
+            let mut prev_tokens: Vec<i32> = Vec::with_capacity(max_len);
+            prev_tokens.push(anchor_id as i32);
+            prev_tokens.extend_from_slice(&draft_ids[..max_len - 1]);
+            let keep_probs = draft.confidence_keep_probs(&block_hidden, &prev_tokens)?;
+            let keep = truncate_by_confidence(&keep_probs, self.confidence_threshold);
+            draft_ids.truncate(keep);
+            draft_dists.truncate(keep);
+        }
+
+        Ok(DsparkProposal {
+            draft_ids,
+            draft_dists,
+        })
+    }
+
+    fn verify(&mut self, verify_ids: &[u32]) -> Result<DsparkVerifyOutput> {
+        if verify_ids.is_empty() {
+            return Err(Error::from_reason(
+                "gemma4 DSpark verify: empty verify block",
+            ));
+        }
+        // Commit-exactly-once defense: a second verify before the previous
+        // cycle's commit would orphan its rollback (the caches would then
+        // hold TWO uncommitted verify blocks).
+        if self.rollback.is_some() || self.tapped.is_some() {
+            return Err(Error::from_reason(
+                "gemma4 DSpark verify: previous verify was never committed",
+            ));
+        }
+
+        let inner = &mut *self.inner;
+        let caches = inner
+            .caches
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("gemma4 DSpark verify: caches missing"))?;
+        let rb = snapshot_before_verify(caches, verify_ids.len(), &self.shared_slots)?;
+
+        let ids_i32: Vec<i32> = verify_ids.iter().map(|&t| t as i32).collect();
+        let block = MxArray::from_int32(&ids_i32, &[1, verify_ids.len() as i64])?;
+        let mut tap = DsparkTap::new(&self.layer_ids);
+        let logits = dspark_verify_forward(
+            &block,
+            &inner.embed_tokens,
+            &inner.layers,
+            caches,
+            &inner.final_norm,
+            &inner.lm_head,
+            inner.embed_weight_t.as_ref(),
+            inner.ple.as_ref(),
+            &inner.config,
+            &mut tap,
+        )?;
+        if tap.captured.len() != self.layer_ids.len() {
+            return Err(Error::from_reason(format!(
+                "gemma4 DSpark verify: tapped {} hiddens for {} configured target layers",
+                tap.captured.len(),
+                self.layer_ids.len()
+            )));
+        }
+
+        self.rollback = Some(rb);
+        self.tapped = Some(tap.captured);
+        Ok(DsparkVerifyOutput { logits })
+    }
+
+    fn commit(&mut self, keep: usize, total_written: usize) -> Result<()> {
+        let rb = self.rollback.take().ok_or_else(|| {
+            Error::from_reason("gemma4 DSpark commit: no pending verify rollback")
+        })?;
+        let tapped = self
+            .tapped
+            .take()
+            .ok_or_else(|| Error::from_reason("gemma4 DSpark commit: no stashed tapped hiddens"))?;
+        if keep == 0 {
+            return Err(Error::from_reason(
+                "gemma4 DSpark commit: engine contract violation (keep must be >= 1 — the anchor's slot is unconditionally kept)",
+            ));
+        }
+        if let Some(first) = tapped.first()
+            && first.shape_at(1)? != total_written as i64
+        {
+            return Err(Error::from_reason(format!(
+                "gemma4 DSpark commit: stashed tapped hiddens cover {} positions but the engine reports a {}-token verify block",
+                first.shape_at(1)?,
+                total_written
+            )));
+        }
+
+        // Target side: keep the first `keep` of the verify block's K/V
+        // slots, roll back the rest (validated against the shared-slot mask
+        // on every commit, full keep included).
+        {
+            let caches = self
+                .inner
+                .caches
+                .as_mut()
+                .ok_or_else(|| Error::from_reason("gemma4 DSpark commit: caches missing"))?;
+            commit_after_verify(caches, &rb, keep)?;
+        }
+
+        // Draft side: fuse the kept prefix of the tapped hiddens and append
+        // it to the persisted context at the block's base position, then
+        // advance the cursor. The boundary token has no slot on either side
+        // — it re-enters as the next cycle's verify anchor.
+        let draft = self
+            .inner
+            .dspark
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("gemma4 DSpark commit: no draft model loaded"))?;
+        let mut kept: Vec<MxArray> = Vec::with_capacity(tapped.len());
+        for hidden in &tapped {
+            kept.push(hidden.slice_axis(1, 0, keep as i64)?);
+        }
+        let fused = draft.fuse_context(&kept)?;
+        self.ctx.append(draft, &fused, self.next_pos)?;
+        self.next_pos += keep as i32;
+        Ok(())
+    }
+
+    fn eval_boundary(&self, token: &MxArray) {
+        // Schedule-only async eval of the next cycle's anchor (gemma4's
+        // decode eval pattern: token only, never the logits).
+        MxArray::async_eval_arrays(&[token]);
+    }
+}
+
+impl DsparkBackend for Gemma4Inner {
+    type DsparkDecode<'a>
+        = Gemma4DsparkStepper<'a>
+    where
+        Self: 'a;
+
+    fn begin_dspark_decode(
+        &mut self,
+        _setup: &DsparkTurnSetup<'_>,
+    ) -> Result<Self::DsparkDecode<'_>> {
+        let state = self.dspark_turn_state.take().ok_or_else(|| {
+            Error::from_reason(
+                "gemma4 DSpark: begin_dspark_decode requires a prepared draft context \
+                 (dspark_chat_turn's tapped prefill must run first)",
+            )
+        })?;
+        let layer_ids: Vec<usize> = {
+            let draft = self.dspark.as_ref().ok_or_else(|| {
+                Error::from_reason("gemma4 DSpark: begin_dspark_decode without a draft model")
+            })?;
+            draft
+                .config
+                .target_layer_ids
+                .iter()
+                .map(|&id| id as usize)
+                .collect()
+        };
+        let shared_slots = dspark_shared_slot_mask(&self.config);
+        let confidence_threshold = dspark_confidence_threshold_from_env();
+        Ok(Gemma4DsparkStepper {
+            inner: self,
+            ctx: state.ctx,
+            next_pos: state.next_pos,
+            layer_ids,
+            shared_slots,
+            confidence_threshold,
+            rollback: None,
+            tapped: None,
+        })
+    }
+}
+
+impl Gemma4Inner {
+    /// DSpark whole-turn core behind gemma4's `ChatBackend::mtp_turn`
+    /// override — the DSpark analog of the engine's generic
+    /// `chat_turn_core` tail, sync AND streaming through the same body
+    /// (`args.sink` presence selects the mode, mirroring
+    /// `vision_chat_turn` / the MTP whole-turn cores).
+    ///
+    /// Flow: resolve params (+ `extra_eos_ids`) → prefix decision via the
+    /// existing cache-prefix machinery → chunked prefill WITH the DSpark
+    /// tap (per-chunk capture → fuse → context-append → drop; full-prompt
+    /// tapped hiddens are never held) → anchor sample (byte-identical to
+    /// the generic flow) → `run_dspark_turn` → save (drop-last driven by
+    /// the loop's `last_in_cache`) → finalize (+ default
+    /// `augment_performance`, which fills the `mtp_*` acceptance fields).
+    pub(crate) fn dspark_chat_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
+        let tokenizer = args.tokenizer.clone();
+        let eos_id = args.eos_id;
+        let thinking = args.thinking;
+        let is_delta = args.is_delta;
+        let tokens: Vec<u32> = args.tokens.to_vec();
+        let is_streaming = args.sink.is_some();
+
+        let think_end_id = tokenizer.think_end_id();
+        let think_end_str = tokenizer.think_end_str().map(|s| s.to_string());
+
+        // Owned params: re-resolve from the request config (deterministic —
+        // identical to what the session core handed us in `args.params`),
+        // then populate the stop-set the loop reads from
+        // `ChatParams::extra_eos_ids` (the generic flow threads it as a
+        // separate decode-loop argument instead).
+        let mut p = ChatBackend::resolve_params(self, args.config);
+        p.extra_eos_ids = ChatBackend::extra_eos_ids(self);
+        let reuse_cache = p.reuse_cache;
+        let report_perf = p.report_performance;
+        let max_new_tokens = p.max_new_tokens;
+
+        let generation_start = report_perf.then(Instant::now);
+        let mut first_token_instant: Option<Instant> = None;
+
+        // Prefix decision — the generic core's reset-or-delta split:
+        //   Fresh: all-or-nothing `verify_cache_prefix`; strict-extend hits
+        //   prefill only the tail, miss AND exact-match reset + re-prefill.
+        //   Delta: strict extension by construction (`tokens` == cached
+        //   history ++ delta); prefill exactly the tail.
+        let prior_cached_len = if is_delta {
+            self.cached_token_history.len()
+        } else {
+            0
+        };
+        let (prefill_tokens, cached_prefix_len): (Vec<u32>, usize) = if is_delta {
+            (tokens[prior_cached_len..].to_vec(), prior_cached_len)
+        } else {
+            let hit = ChatBackend::verify_cache_prefix(self, &tokens, reuse_cache);
+            if hit > 0 && hit < tokens.len() {
+                tracing::info!(
+                    "DSpark cache reuse: {} cached tokens, {} new tokens to prefill",
+                    hit,
+                    tokens.len() - hit,
+                );
+                (tokens[hit..].to_vec(), hit)
+            } else {
+                ChatBackend::reset_caches(self, ResetScope::PrefixMiss)?;
+                (tokens.clone(), 0)
+            }
+        };
+
+        let prompt_token_count = tokens.len();
+        let mut token_history: Vec<u32> = tokens.clone();
+        let mut generated_tokens: Vec<u32> =
+            Vec::with_capacity(generated_capacity_hint(max_new_tokens));
+        let mut finish_reason = String::from("length");
+
+        let generation_stream = Stream::new(DeviceType::Gpu);
+
+        let mut profiler = DecodeProfiler::new(
+            ChatBackend::profiler_label(self, is_delta, is_streaming),
+            ChatBackend::family_name(self),
+        );
+        profiler.set_prompt_tokens(prefill_tokens.len() as u32);
+        profiler.snapshot_memory_before();
+
+        let mut reasoning_tracker = ReasoningTracker::from_setup(&thinking, think_end_id);
+
+        // Streaming decode state (mirrors the generic core; only the
+        // streaming branch reads it).
+        let stream_skip_special = ChatBackend::stream_skip_special_tokens(self);
+        let mut decode_stream = tokenizer.inner().decode_stream(stream_skip_special);
+        let mut streamed_text_len = 0usize;
+        let mut last_is_reasoning = thinking.enabled;
+        let mut emitter: Option<Box<dyn StreamEmitter>> =
+            args.sink.map(|_| ChatBackend::stream_emitter(self));
+
+        // --- tapped prefill: target K/V + the draft's fused context ---
+        profiler.begin_prefill();
+        let (last_logits, turn_state) = self.dspark_prefill_with_tap(
+            &prefill_tokens,
+            cached_prefix_len as i32,
+            generation_stream,
+        )?;
+        profiler.end_prefill();
+
+        // --- anchor sample: byte-identical to the generic flow ---
+        let last_logits = apply_all_penalties(last_logits, &token_history, &p)?;
+        let y = crate::sampling::sample(&last_logits, p.sampling_config)?;
+        y.eval();
+
+        ChatBackend::eval_caches(self)?;
+        if report_perf {
+            first_token_instant = Some(Instant::now());
+        }
+
+        let block_size = self
+            .dspark
+            .as_ref()
+            .map(|d| d.config.block_size)
+            .ok_or_else(|| Error::from_reason("gemma4 DSpark turn: no draft model loaded"))?;
+
+        // Hand the prefill-built draft context to the stepper (taken by
+        // `begin_dspark_decode` inside the loop).
+        self.dspark_turn_state = Some(turn_state);
+
+        let mut rng = rand::rng();
+        let last_in_cache;
+        {
+            let streaming_ctx = match (args.sink, args.cancelled, emitter.as_mut()) {
+                (Some(sink), Some(cancelled), Some(em)) => Some(StreamingCtx {
+                    callback: sink,
+                    cancelled,
+                    decode_stream: &mut decode_stream,
+                    tokenizer: tokenizer.inner(),
+                    streamed_text_len: &mut streamed_text_len,
+                    last_is_reasoning: &mut last_is_reasoning,
+                    emitter: em.as_mut(),
+                }),
+                _ => None,
+            };
+            let outcome = run_dspark_turn(
+                self,
+                &mut rng,
+                DsparkTurnArgs {
+                    y,
+                    block_size,
+                    params: &p,
+                    reasoning_tracker: &mut reasoning_tracker,
+                    profiler: &mut profiler,
+                    max_new_tokens,
+                    eos_id,
+                    generated_tokens: &mut generated_tokens,
+                    token_history: &mut token_history,
+                    finish_reason: &mut finish_reason,
+                    first_token_instant: &mut first_token_instant,
+                    report_perf,
+                    generation_stream,
+                },
+                streaming_ctx,
+            );
+            // A loop failure before `begin_dspark_decode` consumed the
+            // stash would leave stale per-turn state behind; clear it so
+            // the next turn can never observe it.
+            if outcome.is_err() {
+                self.dspark_turn_state = None;
+            }
+            last_in_cache = outcome?.last_in_cache;
+        }
+
+        // --- save: drop-last driven by the loop's `last_in_cache` ---
+        // `!last_in_cache` = the final emitted token has no K/V slot (a
+        // cycle boundary, an unverified stop seed, or a clean length exit)
+        // — drop it so `cached_token_history.len()` equals the physical
+        // cache length. A kept final token (EOS accepted as a draft, its
+        // verify slot committed) stays in the history for the same
+        // alignment reason — the qwen3.5 MTP cores' `drop_last_always =
+        // !last_in_cache` convention. The `finish_reason == "length"` arm
+        // is unreachable belt-and-braces (clean length exits always land on
+        // an uncached boundary), kept for parity with
+        // `save_cache_state_direct`'s documented semantics.
+        let drop_last = !last_in_cache || finish_reason == "length";
+        let history_tokens: &[u32] = if drop_last && !generated_tokens.is_empty() {
+            &generated_tokens[..generated_tokens.len() - 1]
+        } else {
+            &generated_tokens
+        };
+        let mut new_history = Vec::with_capacity(tokens.len() + history_tokens.len());
+        new_history.extend_from_slice(&tokens);
+        new_history.extend_from_slice(history_tokens);
+        self.cached_token_history = new_history;
+        if !is_delta {
+            // Fresh text-only turn: clear any stale media keys (the DSpark
+            // path is text-only by its `mtp_turn` gate).
+            self.cached_image_key = None;
+            self.cached_audio_key = None;
+        }
+
+        // --- finalize ---
+        let performance = if report_perf {
+            compute_performance_metrics(
+                generation_start,
+                first_token_instant,
+                prefill_tokens.len(),
+                generated_tokens.len(),
+            )
+            .map(|mut m| {
+                // Default augmentation fills the mtp_* acceptance fields
+                // from the profiler's recorded DSpark cycles.
+                ChatBackend::augment_performance(self, &profiler, &mut m);
+                m
+            })
+        } else {
+            None
+        };
+        let reasoning_tokens = reasoning_tracker.reasoning_token_count();
+
+        if let (Some(sink), Some(em)) = (args.sink, emitter.as_mut()) {
+            // Residual flush through the emitter (same skip-special flag as
+            // the in-loop DecodeStream so `streamed_text_len` accounting
+            // stays consistent).
+            let full_text = tokenizer
+                .decode_sync(&generated_tokens, stream_skip_special)
+                .unwrap_or_else(|e| {
+                    tracing::warn!("Failed to decode generated tokens: {}", e);
+                    String::new()
+                });
+            if full_text.len() > streamed_text_len {
+                let residual = &full_text[streamed_text_len..];
+                em.on_residual(residual, last_is_reasoning, p.include_reasoning, sink);
+            }
+        }
+
+        let reported_prompt_tokens: u32 = if is_delta && is_streaming {
+            let delta_len = prompt_token_count - prior_cached_len;
+            ChatBackend::stream_delta_prompt_tokens(self, prompt_token_count, delta_len)
+        } else {
+            prompt_token_count as u32
+        };
+
+        let mut result = ChatBackend::finalize_turn(
+            self,
+            FinalizeArgs {
+                tokenizer: &tokenizer,
+                generated_tokens: &generated_tokens,
+                finish_reason,
+                think_end_id,
+                think_end_str: think_end_str.as_deref(),
+                performance,
+                include_reasoning: p.include_reasoning,
+                thinking_enabled: thinking.enabled,
+                prompt_tokens: reported_prompt_tokens,
+                reasoning_tokens,
+            },
+        )?;
+        // cached_tokens mirrors the session core's overwrite: fresh turns
+        // report the matched prefix, delta turns the prior history length.
+        result.cached_tokens = if is_delta {
+            prior_cached_len as u32
+        } else {
+            cached_prefix_len as u32
+        };
+
+        if let (Some(sink), Some(em)) = (args.sink, emitter.as_mut()) {
+            em.finish(&result, sink);
+            return Ok(TurnOutput::Streamed);
+        }
+        Ok(TurnOutput::Complete(Box::new(result)))
+    }
+
+    /// Chunked prefill WITH the DSpark hidden tap.
+    ///
+    /// Target-side compute is byte-identical to the AR path
+    /// (`prefill_body_gemma4` + the last-token `forward_inner`): same
+    /// upfront embedding/PLE, same 512-token chunking, same eval cadence
+    /// and `clear_cache`, same last-token split — the tap only CLONES the
+    /// residual-stream hiddens (tap purity is pinned by
+    /// `dspark_tap_purity_and_verify_forward`).
+    ///
+    /// Per chunk: forward w/ a FRESH tap → `fuse_context` → context-append
+    /// at the chunk's absolute base → drop the tap. Full-prompt tapped
+    /// hiddens are never held. `position_base` is the cached-prefix length
+    /// (the absolute position of `prefill_tokens[0]`); cached-prefix tokens
+    /// have NO context rows — the draft cross-attends over whatever rows
+    /// exist, and verification always re-derives ground truth from the
+    /// target, so a shorter context can only depress acceptance, never
+    /// correctness.
+    ///
+    /// Returns the sampling-ready last-token logits `[1, vocab]` plus the
+    /// turn's [`DsparkTurnState`].
+    fn dspark_prefill_with_tap(
+        &mut self,
+        prefill_tokens: &[u32],
+        position_base: i32,
+        stream: Stream,
+    ) -> Result<(MxArray, DsparkTurnState)> {
+        if prefill_tokens.is_empty() {
+            return Err(Error::from_reason(
+                "gemma4 DSpark prefill: empty prefill token set",
+            ));
+        }
+        if self.caches.is_none() {
+            self.init_caches_sync()?;
+        }
+
+        let inner = &mut *self;
+        let draft = inner
+            .dspark
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("gemma4 DSpark prefill: no draft model loaded"))?;
+        let caches = inner
+            .caches
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("gemma4 DSpark prefill: caches missing"))?;
+        let layer_ids: Vec<usize> = draft
+            .config
+            .target_layer_ids
+            .iter()
+            .map(|&id| id as usize)
+            .collect();
+        let mut ctx = DsparkContextCache::new(draft.num_layers());
+
+        let n = prefill_tokens.len() as i64;
+        let ids_i32: Vec<i32> = prefill_tokens.iter().map(|&t| t as i32).collect();
+        let prompt = MxArray::from_int32(&ids_i32, &[1, n])?;
+
+        {
+            let _stream_ctx = StreamContext::new(stream);
+            if n > 1 {
+                // Body over tokens [0 .. n-1] — the last token is handled by
+                // the full forward below (`prefill_body_gemma4`'s split).
+                let prefill_len = n - 1;
+                let prefill_ids = prompt.slice_axis(1, 0, prefill_len)?;
+                let all_embeds = {
+                    let emb = inner.embed_tokens.forward(&prefill_ids)?;
+                    emb.mul_scalar((inner.config.hidden_size as f64).sqrt())?
+                };
+                let all_ple: Option<MxArray> = match inner.ple.as_ref() {
+                    Some(ple) => Some(compute_ple(&prefill_ids, &all_embeds, ple, prefill_len)?),
+                    None => None,
+                };
+                let mut offset: i64 = 0;
+                while offset < prefill_len {
+                    let end = if prefill_len - offset > GEMMA4_PREFILL_STEP_SIZE {
+                        offset + GEMMA4_PREFILL_STEP_SIZE
+                    } else {
+                        prefill_len
+                    };
+                    let chunk_embeds = all_embeds.slice_axis(1, offset, end)?;
+                    let chunk_ple = all_ple
+                        .as_ref()
+                        .map(|p| p.slice_axis(1, offset, end))
+                        .transpose()?;
+                    let mut tap = DsparkTap::new(&layer_ids);
+                    let _hidden = forward_body(
+                        None,
+                        Some(chunk_embeds),
+                        &inner.embed_tokens,
+                        &inner.layers,
+                        caches,
+                        &inner.final_norm,
+                        inner.ple.as_ref(),
+                        chunk_ple.as_ref(),
+                        &inner.config,
+                        Some(&mut tap),
+                    )?;
+                    // capture → fuse → append → drop, per chunk.
+                    let fused = draft.fuse_context(&tap.captured)?;
+                    ctx.append(draft, &fused, position_base + offset as i32)?;
+                    // Eval cadence mirrors `prefill_body_gemma4`: full
+                    // chunks eval+clear between iterations; the remainder
+                    // chunk is covered by the post-body eval below.
+                    if end < prefill_len {
+                        eval_gemma4_caches(caches)?;
+                        crate::array::clear_cache();
+                    }
+                    offset = end;
+                }
+            }
+        }
+        eval_gemma4_caches(caches)?;
+
+        // Last token: full forward (lm_head + softcap) with one more tapped
+        // context row, exactly the AR prefill's last-token split.
+        let last = prompt.slice_axis(1, n - 1, n)?;
+        let last_logits = {
+            let _stream_ctx = StreamContext::new(stream);
+            crate::models::gemma4::diagnostic::set_step(-1);
+            let mut tap = DsparkTap::new(&layer_ids);
+            let logits = forward_inner(
+                &last,
+                &inner.embed_tokens,
+                &inner.layers,
+                caches,
+                &inner.final_norm,
+                &inner.lm_head,
+                inner.embed_weight_t.as_ref(),
+                inner.ple.as_ref(),
+                &inner.config,
+                Some(&mut tap),
+            )?;
+            let fused = draft.fuse_context(&tap.captured)?;
+            ctx.append(draft, &fused, position_base + (n - 1) as i32)?;
+            logits
+        };
+        let last_logits = last_logits.squeeze(Some(&[1]))?;
+
+        Ok((
+            last_logits,
+            DsparkTurnState {
+                ctx,
+                next_pos: position_base + n as i32,
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::types::ChatConfig;
+    use crate::models::gemma4::config::Gemma4Config;
+    use crate::models::gemma4::dspark::{DsparkConfig, DsparkDraftModel};
+
+    /// Tiny flat-path Gemma4 config (paged OFF so `Gemma4Inner::new` builds
+    /// no adapter): 4 hybrid layers, one KV-shared.
+    fn tiny_target_config() -> Gemma4Config {
+        serde_json::from_value(serde_json::json!({
+            "vocab_size": 16,
+            "hidden_size": 8,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "intermediate_size": 16,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 128,
+            "sliding_window": 8,
+            "layer_types": [
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention"
+            ],
+            "num_kv_shared_layers": 1,
+            "use_block_paged_cache": false
+        }))
+        .expect("tiny Gemma4 config must deserialize")
+    }
+
+    /// Tiny draft config geometry-matched to [`tiny_target_config`]
+    /// (hidden 8, vocab 16, 4 target layers, block_size 3).
+    fn tiny_draft_config() -> DsparkConfig {
+        serde_json::from_str(
+            r#"{
+                "architectures": ["Gemma4DSparkModel"],
+                "model_type": "gemma4_text",
+                "block_size": 3,
+                "mask_token_id": 4,
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 2,
+                "global_head_dim": 4,
+                "num_global_key_value_heads": 1,
+                "rms_norm_eps": 1e-6,
+                "final_logit_softcapping": 30.0,
+                "vocab_size": 16,
+                "target_layer_ids": [0, 2],
+                "num_target_layers": 4,
+                "markov_rank": 2,
+                "markov_head_type": "vanilla",
+                "enable_confidence_head": true,
+                "attention_k_eq_v": true,
+                "rope_parameters": {
+                    "full_attention": {
+                        "partial_rotary_factor": 0.5,
+                        "rope_theta": 10000.0,
+                        "rope_type": "proportional"
+                    }
+                }
+            }"#,
+        )
+        .expect("tiny draft config must deserialize")
+    }
+
+    fn tiny_inner_with_draft() -> Gemma4Inner {
+        let mut inner =
+            Gemma4Inner::new(tiny_target_config()).expect("tiny Gemma4Inner must construct");
+        let draft =
+            DsparkDraftModel::new(tiny_draft_config()).expect("tiny draft model must construct");
+        inner.dspark = Some(draft);
+        inner
+    }
+
+    fn chat_config(mtp_depth: Option<i32>) -> ChatConfig {
+        ChatConfig {
+            mtp_depth,
+            ..ChatConfig::default()
+        }
+    }
+
+    // ── resolve_params depth override ──────────────────────────────────
+
+    /// With a draft loaded, an UNSET `mtpDepth` resolves to the draft's
+    /// block_size (full blocks), bypassing the engine's default of 1.
+    #[test]
+    fn resolve_params_unset_depth_defaults_to_block_size() {
+        let inner = tiny_inner_with_draft();
+        let p = ChatBackend::resolve_params(&inner, &chat_config(None));
+        assert_eq!(p.mtp_depth, 3, "unset depth must resolve to block_size");
+    }
+
+    /// An explicit depth is clamped to `[1, block_size]` from the RAW
+    /// config value — the engine's central [1, 5] clamp must not cap a
+    /// block_size wider than 5 (the real checkpoint's block_size is 7),
+    /// and nonpositive values clamp up to 1 without wrapping.
+    #[test]
+    fn resolve_params_explicit_depth_clamps_to_block_size() {
+        let inner = tiny_inner_with_draft();
+        for (requested, expected) in [(1, 1), (2, 2), (3, 3), (99, 3), (0, 1), (-7, 1)] {
+            let p = ChatBackend::resolve_params(&inner, &chat_config(Some(requested)));
+            assert_eq!(
+                p.mtp_depth, expected,
+                "mtpDepth={requested} must resolve to {expected}"
+            );
+        }
+    }
+
+    /// Without a draft model the family override is inert: the engine's
+    /// central [1, 5] clamp is untouched.
+    #[test]
+    fn resolve_params_without_draft_keeps_engine_clamp() {
+        let inner = Gemma4Inner::new(tiny_target_config()).expect("tiny inner");
+        let p = ChatBackend::resolve_params(&inner, &chat_config(None));
+        assert_eq!(p.mtp_depth, 1);
+        let p = ChatBackend::resolve_params(&inner, &chat_config(Some(99)));
+        assert_eq!(p.mtp_depth, 5, "engine clamp caps at 5 without a draft");
+    }
+
+    // ── begin_dspark_decode plumbing ───────────────────────────────────
+
+    /// The stepper derives the shared-slot mask from the target config
+    /// (`dspark_shared_slot_mask`) and the layer ids from the draft's
+    /// `target_layer_ids`; the per-turn context stash is TAKEN (single
+    /// use), and calling begin without a stash is a hard error.
+    #[test]
+    fn begin_dspark_decode_takes_stash_and_derives_mask() {
+        let mut inner = tiny_inner_with_draft();
+        let num_draft_layers = inner
+            .dspark
+            .as_ref()
+            .map(|d| d.num_layers())
+            .expect("draft loaded");
+
+        let p = ChatBackend::resolve_params(&inner, &chat_config(None));
+        let setup = DsparkTurnSetup {
+            params: &p,
+            block_size: 3,
+        };
+
+        // No stash → hard error naming the missing prefill.
+        let err = inner
+            .begin_dspark_decode(&setup)
+            .err()
+            .expect("begin without a stash must fail");
+        assert!(
+            err.reason.contains("prepared draft context"),
+            "got: {}",
+            err.reason
+        );
+
+        // Stash → stepper carries the config-derived mask + draft layer ids
+        // and the stash is consumed.
+        inner.dspark_turn_state = Some(DsparkTurnState {
+            ctx: DsparkContextCache::new(num_draft_layers),
+            next_pos: 7,
+        });
+        {
+            let stepper = inner
+                .begin_dspark_decode(&setup)
+                .expect("begin with a stash must succeed");
+            assert_eq!(
+                stepper.shared_slots,
+                vec![false, false, false, true],
+                "mask must come from dspark_shared_slot_mask(config)"
+            );
+            assert_eq!(stepper.layer_ids, vec![0, 2]);
+            assert_eq!(stepper.next_pos, 7);
+            assert!(stepper.rollback.is_none() && stepper.tapped.is_none());
+        }
+        assert!(
+            inner.dspark_turn_state.is_none(),
+            "the per-turn stash must be consumed by begin_dspark_decode"
+        );
+    }
+
+    // ── confidence threshold env ───────────────────────────────────────
+
+    /// Threshold parsing: unset/invalid → 0.0 (keep-all). NOTE: reads the
+    /// process env — no parallel test mutates this variable.
+    #[test]
+    fn confidence_threshold_env_parsing() {
+        // SAFETY: test-local env mutation; no other test in this binary
+        // touches MLX_DSPARK_CONFIDENCE_THRESHOLD.
+        unsafe { std::env::remove_var("MLX_DSPARK_CONFIDENCE_THRESHOLD") };
+        assert_eq!(dspark_confidence_threshold_from_env(), 0.0);
+        unsafe { std::env::set_var("MLX_DSPARK_CONFIDENCE_THRESHOLD", "0.25") };
+        assert_eq!(dspark_confidence_threshold_from_env(), 0.25);
+        unsafe { std::env::set_var("MLX_DSPARK_CONFIDENCE_THRESHOLD", "not-a-number") };
+        assert_eq!(dspark_confidence_threshold_from_env(), 0.0);
+        unsafe { std::env::remove_var("MLX_DSPARK_CONFIDENCE_THRESHOLD") };
+    }
+}

--- a/crates/mlx-core/src/models/gemma4/layer_cache.rs
+++ b/crates/mlx-core/src/models/gemma4/layer_cache.rs
@@ -291,16 +291,24 @@ pub(crate) struct Gemma4VerifyRollback {
     /// Per-cache sliding snapshots, index-aligned with the caches slice.
     /// `None` for global layers and for sliding caches that were empty.
     snapshots: Vec<Option<RotatingKVCacheSnapshot>>,
-    /// Per-cache offsets before the verify forward. KV-shared layers keep an
-    /// allocated-but-never-written vec entry that stays at offset 0; storing
-    /// the offset per cache lets commit recognize those entries.
+    /// Per-cache offsets before the verify forward.
     start_offsets: Vec<i32>,
-    /// Tokens the verify forward appends to every cache it writes.
+    /// Caller-declared KV-shared slots, index-aligned with the caches slice.
+    /// A shared layer reads its anchor's cache; its own vec entry is never
+    /// written by a forward pass and must not move across a verify.
+    shared_slots: Vec<bool>,
+    /// Tokens the verify forward appends to every ACTIVE (non-shared) cache.
     total_written: usize,
 }
 
 /// Snapshot every cache before a verify forward that will append
 /// `total_to_write` tokens.
+///
+/// `shared_slots` must mark exactly the cache vec entries that belong to
+/// KV-shared layers (`Gemma4Config::is_kv_shared_layer` per index — see
+/// `dspark_shared_slot_mask`). Declaring them explicitly lets commit enforce
+/// the exact-advance invariant on every active cache instead of inferring
+/// activity from offsets.
 ///
 /// Global caches need no snapshot (rollback is a `trim`); sliding caches
 /// snapshot their ordered window tail. Errors when a sliding window is
@@ -310,11 +318,22 @@ pub(crate) struct Gemma4VerifyRollback {
 pub(crate) fn snapshot_before_verify(
     caches: &[Gemma4LayerCache],
     total_to_write: usize,
+    shared_slots: &[bool],
 ) -> Result<Gemma4VerifyRollback> {
     if total_to_write == 0 {
         return Err(Error::new(
             Status::InvalidArg,
             "snapshot_before_verify: total_to_write must be at least 1",
+        ));
+    }
+    if shared_slots.len() != caches.len() {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "snapshot_before_verify: {} caches but shared_slots covers {}",
+                caches.len(),
+                shared_slots.len()
+            ),
         ));
     }
     let mut snapshots = Vec::with_capacity(caches.len());
@@ -337,6 +356,7 @@ pub(crate) fn snapshot_before_verify(
     Ok(Gemma4VerifyRollback {
         snapshots,
         start_offsets,
+        shared_slots: shared_slots.to_vec(),
         total_written: total_to_write,
     })
 }
@@ -344,16 +364,21 @@ pub(crate) fn snapshot_before_verify(
 /// Commit the first `keep` tokens of a verify block and roll back the rest.
 ///
 /// Preconditions: `rb` was taken right before the verify forward, and the
-/// verify forward appended `rb.total_written` tokens to every cache it
-/// writes. Caches whose offset did not move (KV-shared layers' unused vec
-/// entries) are skipped, so each physical cache is touched exactly once.
+/// verify forward appended `rb.total_written` tokens to every ACTIVE cache.
+/// EVERY commit (including full keep) validates the whole vec against the
+/// declared `shared_slots`: an active cache must sit at exactly
+/// `start + total_written` and a shared slot must not have moved, else a
+/// hard error — a routing bug that leaves an owner cache unwritten can
+/// never be silently committed. Validation runs over the full vec before
+/// any cache is mutated, so a failed commit leaves all caches untouched.
 ///
-/// * `keep == total_written`: no-op — the appended block is kept as-is.
+/// * `keep == total_written`: validated no-op — the appended block is kept.
 /// * `keep < total_written`: global caches trim to `start + keep`; sliding
 ///   caches slice the block tail, restore the pre-verify snapshot, then
 ///   re-append the first `keep` tail rows through the normal update path,
 ///   leaving state identical to a cache that only ever saw the kept prefix.
-///   `keep == 0` discards the block entirely.
+///   `keep == 0` discards the block entirely. Shared slots are untouched,
+///   so each physical cache is touched exactly once.
 #[allow(dead_code)]
 pub(crate) fn commit_after_verify(
     caches: &mut [Gemma4LayerCache],
@@ -379,6 +404,33 @@ pub(crate) fn commit_after_verify(
             ),
         ));
     }
+
+    for (idx, cache) in caches.iter().enumerate() {
+        let start = rb.start_offsets[idx];
+        let current = cache.get_offset();
+        if rb.shared_slots[idx] {
+            if current != start {
+                return Err(Error::new(
+                    Status::InvalidArg,
+                    format!(
+                        "commit_after_verify: cache {idx} is a KV-shared slot but moved from offset {start} to {current}; shared slots are never written by a verify forward"
+                    ),
+                ));
+            }
+        } else {
+            let expected = start + rb.total_written as i32;
+            if current != expected {
+                return Err(Error::new(
+                    Status::InvalidArg,
+                    format!(
+                        "commit_after_verify: active cache {idx} is at offset {current}, expected {expected} (start {start} + {}-token verify block)",
+                        rb.total_written
+                    ),
+                ));
+            }
+        }
+    }
+
     if keep == rb.total_written {
         return Ok(());
     }
@@ -388,22 +440,8 @@ pub(crate) fn commit_after_verify(
         .zip(rb.snapshots.iter().zip(rb.start_offsets.iter()))
         .enumerate()
     {
-        let current = cache.get_offset();
-        if current == start {
-            // This cache was not written by the verify forward (KV-shared
-            // layers read their anchor's cache; their own vec entry never
-            // advances). Nothing to roll back.
+        if rb.shared_slots[idx] {
             continue;
-        }
-        let expected = start + rb.total_written as i32;
-        if current != expected {
-            return Err(Error::new(
-                Status::InvalidArg,
-                format!(
-                    "commit_after_verify: cache {idx} moved from offset {start} to {current}, expected {expected} after a {}-token verify block",
-                    rb.total_written
-                ),
-            ));
         }
 
         if cache.is_sliding() {
@@ -577,7 +615,7 @@ mod tests {
 
                 let mut live = [Gemma4LayerCache::new_sliding(window)];
                 apply_appends(&mut live[0], prefill);
-                let rollback = snapshot_before_verify(&live, block.len()).unwrap();
+                let rollback = snapshot_before_verify(&live, block.len(), &[false]).unwrap();
                 let (bk, bv) = kv_pair(&block);
                 live[0].update_and_fetch(&bk, &bv).unwrap();
                 commit_after_verify(&mut live, &rollback, keep).unwrap();
@@ -647,107 +685,177 @@ mod tests {
         assert!(empty.sliding_tail(1).is_err());
     }
 
-    /// Mixed vec of global + sliding caches, including untouched entries that
-    /// model KV-shared layers (their vec slot is never written by a forward).
+    /// Mixed vec of global + sliding caches, including entries declared as
+    /// KV-shared slots (their vec entry is never written by a forward).
+    const MIXED_ACTIVE: [usize; 4] = [0, 1, 2, 3];
+    const MIXED_SHARED: [usize; 2] = [4, 5];
+    const MIXED_MASK: [bool; 6] = [false, false, false, false, true, true];
+
+    fn build_mixed_caches() -> Vec<Gemma4LayerCache> {
+        let mut caches = vec![
+            Gemma4LayerCache::new_global(),
+            Gemma4LayerCache::new_sliding(8),
+            Gemma4LayerCache::new_global(),
+            Gemma4LayerCache::new_sliding(8),
+            // KV-shared entries: allocated but never written.
+            Gemma4LayerCache::new_sliding(8),
+            Gemma4LayerCache::new_global(),
+        ];
+        for &i in &MIXED_ACTIVE {
+            let (k, v) = kv_pair(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+            caches[i].update_and_fetch(&k, &v).unwrap();
+        }
+        caches
+    }
+
+    fn append_block_to(caches: &mut [Gemma4LayerCache], indices: &[usize], block: &[f32]) {
+        for &i in indices {
+            let (k, v) = kv_pair(block);
+            caches[i].update_and_fetch(&k, &v).unwrap();
+        }
+    }
+
     #[test]
     fn commit_after_verify_mixed_caches() {
-        const ACTIVE: [usize; 4] = [0, 1, 2, 3];
-        const DEAD: [usize; 2] = [4, 5];
-
-        fn build() -> Vec<Gemma4LayerCache> {
-            let mut caches = vec![
-                Gemma4LayerCache::new_global(),
-                Gemma4LayerCache::new_sliding(8),
-                Gemma4LayerCache::new_global(),
-                Gemma4LayerCache::new_sliding(8),
-                // KV-shared style entries: allocated but never written.
-                Gemma4LayerCache::new_sliding(8),
-                Gemma4LayerCache::new_global(),
-            ];
-            for &i in &ACTIVE {
-                let (k, v) = kv_pair(&[1.0, 2.0, 3.0, 4.0, 5.0]);
-                caches[i].update_and_fetch(&k, &v).unwrap();
-            }
-            caches
-        }
-
-        fn append_block(caches: &mut [Gemma4LayerCache], block: &[f32]) {
-            for &i in &ACTIVE {
-                let (k, v) = kv_pair(block);
-                caches[i].update_and_fetch(&k, &v).unwrap();
-            }
-        }
-
         let block = [101.0f32, 102.0, 103.0];
 
-        // Full keep: no-op, all active offsets stay at n + T.
-        let mut caches = build();
-        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
-        append_block(&mut caches, &block);
+        // Full keep: validated no-op, all active offsets stay at n + T.
+        let mut caches = build_mixed_caches();
+        let rollback = snapshot_before_verify(&caches, block.len(), &MIXED_MASK).unwrap();
+        append_block_to(&mut caches, &MIXED_ACTIVE, &block);
         commit_after_verify(&mut caches, &rollback, block.len()).unwrap();
-        for &i in &ACTIVE {
+        for &i in &MIXED_ACTIVE {
             assert_eq!(caches[i].get_offset(), 8, "cache {i} full-keep offset");
         }
-        for &i in &DEAD {
-            assert_eq!(caches[i].get_offset(), 0, "dead cache {i} must stay empty");
+        for &i in &MIXED_SHARED {
+            assert_eq!(caches[i].get_offset(), 0, "shared slot {i} must stay empty");
         }
 
         // Partial keep: every active cache lands at n + keep with exactly the
-        // kept prefix appended; dead caches untouched.
-        let mut caches = build();
-        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
-        append_block(&mut caches, &block);
+        // kept prefix appended; shared slots untouched.
+        let mut caches = build_mixed_caches();
+        let rollback = snapshot_before_verify(&caches, block.len(), &MIXED_MASK).unwrap();
+        append_block_to(&mut caches, &MIXED_ACTIVE, &block);
         commit_after_verify(&mut caches, &rollback, 1).unwrap();
-        for &i in &ACTIVE {
+        for &i in &MIXED_ACTIVE {
             assert_eq!(caches[i].get_offset(), 6, "cache {i} partial-keep offset");
             let (k, v) = caches[i].get_cached_kv().unwrap();
             assert_float_data(&k, &[1.0, 2.0, 3.0, 4.0, 5.0, 101.0]);
             assert_float_data(&v, &[10.0, 20.0, 30.0, 40.0, 50.0, 1010.0]);
         }
-        for &i in &DEAD {
-            assert_eq!(caches[i].get_offset(), 0, "dead cache {i} must stay empty");
+        for &i in &MIXED_SHARED {
+            assert_eq!(caches[i].get_offset(), 0, "shared slot {i} must stay empty");
         }
 
         // keep == 0: the verify block is fully discarded.
-        let mut caches = build();
-        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
-        append_block(&mut caches, &block);
+        let mut caches = build_mixed_caches();
+        let rollback = snapshot_before_verify(&caches, block.len(), &MIXED_MASK).unwrap();
+        append_block_to(&mut caches, &MIXED_ACTIVE, &block);
         commit_after_verify(&mut caches, &rollback, 0).unwrap();
-        for &i in &ACTIVE {
+        for &i in &MIXED_ACTIVE {
             assert_eq!(caches[i].get_offset(), 5, "cache {i} keep-0 offset");
             let (k, _) = caches[i].get_cached_kv().unwrap();
             assert_float_data(&k, &[1.0, 2.0, 3.0, 4.0, 5.0]);
         }
 
         // keep > total_written is rejected.
-        let mut caches = build();
-        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
-        append_block(&mut caches, &block);
+        let mut caches = build_mixed_caches();
+        let rollback = snapshot_before_verify(&caches, block.len(), &MIXED_MASK).unwrap();
+        append_block_to(&mut caches, &MIXED_ACTIVE, &block);
         assert!(commit_after_verify(&mut caches, &rollback, 4).is_err());
 
         // A cache that advanced by anything other than total_written is a
         // contract violation, not something to silently "fix".
-        let mut caches = build();
-        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
-        append_block(&mut caches, &block[..2]);
+        let mut caches = build_mixed_caches();
+        let rollback = snapshot_before_verify(&caches, block.len(), &MIXED_MASK).unwrap();
+        append_block_to(&mut caches, &MIXED_ACTIVE, &block[..2]);
         assert!(commit_after_verify(&mut caches, &rollback, 1).is_err());
 
         // Cache-count mismatch between snapshot and commit is rejected.
-        let mut caches = build();
-        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
-        append_block(&mut caches, &block);
+        let mut caches = build_mixed_caches();
+        let rollback = snapshot_before_verify(&caches, block.len(), &MIXED_MASK).unwrap();
+        append_block_to(&mut caches, &MIXED_ACTIVE, &block);
         assert!(commit_after_verify(&mut caches[..5], &rollback, 1).is_err());
     }
 
+    /// An ACTIVE cache the verify forward failed to write is a hard error on
+    /// partial keep — and commit must not have mutated ANY cache (validation
+    /// runs over the whole vec before rollback starts).
     #[test]
-    fn snapshot_before_verify_validates_window_and_block() {
+    fn commit_rejects_unmoved_active_cache_on_partial_keep() {
+        let block = [101.0f32, 102.0, 103.0];
+        let mut caches = build_mixed_caches();
+        let rollback = snapshot_before_verify(&caches, block.len(), &MIXED_MASK).unwrap();
+        // Cache 2 (active, global) is skipped by the "verify forward".
+        append_block_to(&mut caches, &[0, 1, 3], &block);
+
+        let err = commit_after_verify(&mut caches, &rollback, 1)
+            .expect_err("unmoved active cache must fail partial-keep commit");
+        assert!(
+            err.reason.contains("active cache 2"),
+            "error must name the unmoved active cache, got: {}",
+            err.reason
+        );
+        // No cache was rolled back by the failed commit.
+        for &i in &[0usize, 1, 3] {
+            assert_eq!(caches[i].get_offset(), 8, "cache {i} must be untouched");
+        }
+        assert_eq!(caches[2].get_offset(), 5, "cache 2 must be untouched");
+    }
+
+    /// Full keep is no longer a blind no-op: an active cache at the wrong
+    /// offset fails commit even when keep == total_written.
+    #[test]
+    fn commit_validates_active_offsets_on_full_keep() {
+        let block = [101.0f32, 102.0, 103.0];
+        let mut caches = build_mixed_caches();
+        let rollback = snapshot_before_verify(&caches, block.len(), &MIXED_MASK).unwrap();
+        // Cache 1 (active, sliding) is skipped by the "verify forward".
+        append_block_to(&mut caches, &[0, 2, 3], &block);
+
+        let err = commit_after_verify(&mut caches, &rollback, block.len())
+            .expect_err("unmoved active cache must fail full-keep commit");
+        assert!(
+            err.reason.contains("active cache 1"),
+            "error must name the unmoved active cache, got: {}",
+            err.reason
+        );
+    }
+
+    /// A slot declared KV-shared that MOVED during verify is a routing bug,
+    /// rejected on both full and partial keep.
+    #[test]
+    fn commit_rejects_moved_shared_slot() {
+        let block = [101.0f32, 102.0, 103.0];
+        for keep in [block.len(), 1] {
+            let mut caches = build_mixed_caches();
+            let rollback = snapshot_before_verify(&caches, block.len(), &MIXED_MASK).unwrap();
+            // Shared slot 4 is unexpectedly written too.
+            append_block_to(&mut caches, &[0, 1, 2, 3, 4], &block);
+
+            let err = commit_after_verify(&mut caches, &rollback, keep)
+                .expect_err("moved shared slot must fail commit");
+            assert!(
+                err.reason.contains("cache 4") && err.reason.contains("KV-shared"),
+                "error must name the moved shared slot, got: {}",
+                err.reason
+            );
+        }
+    }
+
+    #[test]
+    fn snapshot_before_verify_validates_window_block_and_mask() {
         let caches = vec![Gemma4LayerCache::new_sliding(2)];
         assert!(
-            snapshot_before_verify(&caches, 3).is_err(),
+            snapshot_before_verify(&caches, 3, &[false]).is_err(),
             "window smaller than the verify block cannot be rolled back"
         );
-        assert!(snapshot_before_verify(&caches, 0).is_err());
-        assert!(snapshot_before_verify(&caches, 2).is_ok());
+        assert!(snapshot_before_verify(&caches, 0, &[false]).is_err());
+        assert!(
+            snapshot_before_verify(&caches, 2, &[false, true]).is_err(),
+            "shared_slots length must match the caches vec"
+        );
+        assert!(snapshot_before_verify(&caches, 2, &[false]).is_ok());
     }
 
     /// A one-token verify block (T = 1 + 0 drafts) takes the rotating
@@ -765,7 +873,7 @@ mod tests {
 
         let mut live = [Gemma4LayerCache::new_sliding(8)];
         apply_appends(&mut live[0], std::slice::from_ref(&prefill));
-        let rollback = snapshot_before_verify(&live, 1).unwrap();
+        let rollback = snapshot_before_verify(&live, 1, &[false]).unwrap();
         let (bk, bv) = kv_pair(&[999.0]);
         live[0].update_and_fetch(&bk, &bv).unwrap();
         commit_after_verify(&mut live, &rollback, 0).unwrap();

--- a/crates/mlx-core/src/models/gemma4/layer_cache.rs
+++ b/crates/mlx-core/src/models/gemma4/layer_cache.rs
@@ -284,9 +284,6 @@ impl Gemma4LayerCache {
 /// Cache state captured before a DSpark verify forward, used by
 /// [`commit_after_verify`] to roll every cache back to the kept prefix when
 /// the target accepts only part of the verified block.
-// Consumed by the DSpark speculative-decode engine loop, which is wired in
-// separately; until then only the inline tests exercise these primitives.
-#[allow(dead_code)]
 pub(crate) struct Gemma4VerifyRollback {
     /// Per-cache sliding snapshots, index-aligned with the caches slice.
     /// `None` for global layers and for sliding caches that were empty.
@@ -314,7 +311,6 @@ pub(crate) struct Gemma4VerifyRollback {
 /// snapshot their ordered window tail. Errors when a sliding window is
 /// smaller than the verify block, because the block tail could then not be
 /// recovered for a partial-keep rollback.
-#[allow(dead_code)]
 pub(crate) fn snapshot_before_verify(
     caches: &[Gemma4LayerCache],
     total_to_write: usize,
@@ -379,7 +375,6 @@ pub(crate) fn snapshot_before_verify(
 ///   leaving state identical to a cache that only ever saw the kept prefix.
 ///   `keep == 0` discards the block entirely. Shared slots are untouched,
 ///   so each physical cache is touched exactly once.
-#[allow(dead_code)]
 pub(crate) fn commit_after_verify(
     caches: &mut [Gemma4LayerCache],
     rb: &Gemma4VerifyRollback,

--- a/crates/mlx-core/src/models/gemma4/layer_cache.rs
+++ b/crates/mlx-core/src/models/gemma4/layer_cache.rs
@@ -189,6 +189,74 @@ impl Gemma4LayerCache {
         self.stashed_kv.take()
     }
 
+    /// Rewind a global cache to `new_len` tokens (passthrough to
+    /// `KVCache::trim`; the next append overwrites the trimmed region in
+    /// place). Errors on sliding caches — a rotating window cannot be
+    /// rewound by moving the offset; use the snapshot/restore rollback path.
+    pub(crate) fn trim_global(&mut self, new_len: i32) -> Result<()> {
+        match &mut self.inner {
+            CacheType::Global(c) => {
+                c.trim(new_len);
+                self.stashed_kv = None;
+                Ok(())
+            }
+            CacheType::Sliding(_) => Err(Error::new(
+                Status::InvalidArg,
+                "trim_global cannot rewind a Gemma4 sliding cache; use snapshot/restore rollback",
+            )),
+        }
+    }
+
+    /// The LAST `n` cached entries of a sliding cache in temporal order,
+    /// as `(keys, values)` slices of the current window contents.
+    ///
+    /// After a T-token verify append on a window >= T, the last T entries
+    /// are exactly the verify block's K/V. Errors on global caches and when
+    /// `n` is zero or exceeds the cached token count.
+    pub(crate) fn sliding_tail(&self, n: usize) -> Result<(MxArray, MxArray)> {
+        match &self.inner {
+            CacheType::Global(_) => Err(Error::new(
+                Status::InvalidArg,
+                "sliding_tail is only valid on a Gemma4 sliding cache",
+            )),
+            CacheType::Sliding(c) => {
+                let (keys, values) = c.fetch_current_kv().ok_or_else(|| {
+                    Error::new(
+                        Status::InvalidArg,
+                        "sliding_tail requested on an empty Gemma4 sliding cache",
+                    )
+                })?;
+                let cached = keys.shape_at(2)?;
+                let n = n as i64;
+                if n < 1 || n > cached {
+                    return Err(Error::new(
+                        Status::InvalidArg,
+                        format!("sliding_tail: n={n} out of range for {cached} cached tokens"),
+                    ));
+                }
+                Ok((
+                    keys.slice_axis(2, cached - n, cached)?,
+                    values.slice_axis(2, cached - n, cached)?,
+                ))
+            }
+        }
+    }
+
+    /// Clear a sliding cache back to empty. Errors on global caches.
+    fn reset_sliding(&mut self) -> Result<()> {
+        match &mut self.inner {
+            CacheType::Global(_) => Err(Error::new(
+                Status::InvalidArg,
+                "reset_sliding is only valid on a Gemma4 sliding cache",
+            )),
+            CacheType::Sliding(c) => {
+                c.reset();
+                self.stashed_kv = None;
+                Ok(())
+            }
+        }
+    }
+
     /// Collect references to the raw internal K/V arrays for eval between
     /// chunked prefill steps. Matches Qwen3.5's `collect_arrays` pattern.
     pub fn collect_cache_arrays<'a>(&'a self, out: &mut Vec<&'a MxArray>) {
@@ -213,6 +281,151 @@ impl Gemma4LayerCache {
     }
 }
 
+/// Cache state captured before a DSpark verify forward, used by
+/// [`commit_after_verify`] to roll every cache back to the kept prefix when
+/// the target accepts only part of the verified block.
+// Consumed by the DSpark speculative-decode engine loop, which is wired in
+// separately; until then only the inline tests exercise these primitives.
+#[allow(dead_code)]
+pub(crate) struct Gemma4VerifyRollback {
+    /// Per-cache sliding snapshots, index-aligned with the caches slice.
+    /// `None` for global layers and for sliding caches that were empty.
+    snapshots: Vec<Option<RotatingKVCacheSnapshot>>,
+    /// Per-cache offsets before the verify forward. KV-shared layers keep an
+    /// allocated-but-never-written vec entry that stays at offset 0; storing
+    /// the offset per cache lets commit recognize those entries.
+    start_offsets: Vec<i32>,
+    /// Tokens the verify forward appends to every cache it writes.
+    total_written: usize,
+}
+
+/// Snapshot every cache before a verify forward that will append
+/// `total_to_write` tokens.
+///
+/// Global caches need no snapshot (rollback is a `trim`); sliding caches
+/// snapshot their ordered window tail. Errors when a sliding window is
+/// smaller than the verify block, because the block tail could then not be
+/// recovered for a partial-keep rollback.
+#[allow(dead_code)]
+pub(crate) fn snapshot_before_verify(
+    caches: &[Gemma4LayerCache],
+    total_to_write: usize,
+) -> Result<Gemma4VerifyRollback> {
+    if total_to_write == 0 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            "snapshot_before_verify: total_to_write must be at least 1",
+        ));
+    }
+    let mut snapshots = Vec::with_capacity(caches.len());
+    let mut start_offsets = Vec::with_capacity(caches.len());
+    for (idx, cache) in caches.iter().enumerate() {
+        if let Some(state) = cache.sliding_state()?
+            && (state.window_size as i64) < total_to_write as i64
+        {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "snapshot_before_verify: cache {idx} sliding window {} is smaller than the {total_to_write}-token verify block; its tail could not be recovered for rollback",
+                    state.window_size
+                ),
+            ));
+        }
+        start_offsets.push(cache.get_offset());
+        snapshots.push(cache.snapshot_sliding()?);
+    }
+    Ok(Gemma4VerifyRollback {
+        snapshots,
+        start_offsets,
+        total_written: total_to_write,
+    })
+}
+
+/// Commit the first `keep` tokens of a verify block and roll back the rest.
+///
+/// Preconditions: `rb` was taken right before the verify forward, and the
+/// verify forward appended `rb.total_written` tokens to every cache it
+/// writes. Caches whose offset did not move (KV-shared layers' unused vec
+/// entries) are skipped, so each physical cache is touched exactly once.
+///
+/// * `keep == total_written`: no-op — the appended block is kept as-is.
+/// * `keep < total_written`: global caches trim to `start + keep`; sliding
+///   caches slice the block tail, restore the pre-verify snapshot, then
+///   re-append the first `keep` tail rows through the normal update path,
+///   leaving state identical to a cache that only ever saw the kept prefix.
+///   `keep == 0` discards the block entirely.
+#[allow(dead_code)]
+pub(crate) fn commit_after_verify(
+    caches: &mut [Gemma4LayerCache],
+    rb: &Gemma4VerifyRollback,
+    keep: usize,
+) -> Result<()> {
+    if caches.len() != rb.snapshots.len() {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "commit_after_verify: {} caches but rollback snapshot covers {}",
+                caches.len(),
+                rb.snapshots.len()
+            ),
+        ));
+    }
+    if keep > rb.total_written {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "commit_after_verify: keep={keep} exceeds the {}-token verify block",
+                rb.total_written
+            ),
+        ));
+    }
+    if keep == rb.total_written {
+        return Ok(());
+    }
+
+    for (idx, (cache, (snapshot, &start))) in caches
+        .iter_mut()
+        .zip(rb.snapshots.iter().zip(rb.start_offsets.iter()))
+        .enumerate()
+    {
+        let current = cache.get_offset();
+        if current == start {
+            // This cache was not written by the verify forward (KV-shared
+            // layers read their anchor's cache; their own vec entry never
+            // advances). Nothing to roll back.
+            continue;
+        }
+        let expected = start + rb.total_written as i32;
+        if current != expected {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "commit_after_verify: cache {idx} moved from offset {start} to {current}, expected {expected} after a {}-token verify block",
+                    rb.total_written
+                ),
+            ));
+        }
+
+        if cache.is_sliding() {
+            let (tail_keys, tail_values) = cache.sliding_tail(rb.total_written)?;
+            match snapshot {
+                Some(snapshot) => cache.restore_sliding_snapshot(snapshot)?,
+                // The sliding cache was empty before the verify forward;
+                // rolling back means clearing it entirely.
+                None => cache.reset_sliding()?,
+            }
+            if keep > 0 {
+                let kept_keys = tail_keys.slice_axis(2, 0, keep as i64)?;
+                let kept_values = tail_values.slice_axis(2, 0, keep as i64)?;
+                cache.update_and_fetch(&kept_keys, &kept_values)?;
+            }
+        } else {
+            cache.trim_global(start + keep as i32)?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,6 +434,351 @@ mod tests {
         arr.eval();
         let data = arr.to_float32().unwrap().to_vec();
         assert_eq!(data, expected);
+    }
+
+    /// Build a K/V pair shaped [1, 1, n, 1]: keys carry `values` verbatim,
+    /// values carry `values * 10` so K and V mixups are visible.
+    fn kv_pair(values: &[f32]) -> (MxArray, MxArray) {
+        let n = values.len() as i64;
+        let keys = MxArray::from_float32(values, &[1, 1, n, 1]).unwrap();
+        let scaled: Vec<f32> = values.iter().map(|v| v * 10.0).collect();
+        let vals = MxArray::from_float32(&scaled, &[1, 1, n, 1]).unwrap();
+        (keys, vals)
+    }
+
+    /// Apply a sequence of appends (each inner vec is one `update_and_fetch`
+    /// call; single-element vecs take the single-token path).
+    fn apply_appends(cache: &mut Gemma4LayerCache, appends: &[Vec<f32>]) {
+        for chunk in appends {
+            let (k, v) = kv_pair(chunk);
+            cache.update_and_fetch(&k, &v).unwrap();
+        }
+    }
+
+    fn assert_same_f32(a: &MxArray, b: &MxArray, ctx: &str) {
+        a.eval();
+        b.eval();
+        assert_eq!(
+            a.shape().unwrap().to_vec(),
+            b.shape().unwrap().to_vec(),
+            "{ctx}: shape"
+        );
+        let a_bits: Vec<u32> = a
+            .to_float32()
+            .unwrap()
+            .iter()
+            .map(|v| v.to_bits())
+            .collect();
+        let b_bits: Vec<u32> = b
+            .to_float32()
+            .unwrap()
+            .iter()
+            .map(|v| v.to_bits())
+            .collect();
+        assert_eq!(a_bits, b_bits, "{ctx}: contents");
+    }
+
+    /// Compare a rolled-back cache against a reference cache that only ever
+    /// saw prefill + kept prefix: logical state, temporal contents, and the
+    /// behavior of one subsequent single-token append.
+    ///
+    /// `compare_idx` gates comparing the raw write index and raw attention
+    /// views: a rollback restores storage in temporal order, so when the
+    /// reference's backing buffer is ROTATED (idx mid-window) the physical
+    /// layout legitimately differs while offset, temporal contents, and all
+    /// subsequent appends remain identical.
+    fn assert_rollback_matches_reference(
+        live: &mut Gemma4LayerCache,
+        reference: &mut Gemma4LayerCache,
+        compare_idx: bool,
+        ctx: &str,
+    ) {
+        let ls = live.sliding_state().unwrap().unwrap();
+        let rs = reference.sliding_state().unwrap().unwrap();
+        if compare_idx {
+            assert_eq!(ls, rs, "{ctx}: state");
+        } else {
+            assert_eq!(ls.offset, rs.offset, "{ctx}: offset");
+            assert_eq!(ls.window_size, rs.window_size, "{ctx}: window");
+            assert_eq!(ls.keep, rs.keep, "{ctx}: keep param");
+            assert_eq!(ls.cached_tokens, rs.cached_tokens, "{ctx}: cached_tokens");
+            assert_eq!(ls.initialized, rs.initialized, "{ctx}: initialized");
+        }
+
+        match (live.get_cached_kv(), reference.get_cached_kv()) {
+            (Some((lk, lv)), Some((rk, rv))) => {
+                assert_same_f32(&lk, &rk, &format!("{ctx}: temporal keys"));
+                assert_same_f32(&lv, &rv, &format!("{ctx}: temporal values"));
+            }
+            (None, None) => {}
+            (l, r) => panic!(
+                "{ctx}: cache emptiness mismatch: live={} reference={}",
+                l.is_some(),
+                r.is_some()
+            ),
+        }
+
+        let (ak, av) = kv_pair(&[201.0]);
+        let (live_k, live_v) = live.update_and_fetch(&ak, &av).unwrap();
+        let (ref_k, ref_v) = reference.update_and_fetch(&ak, &av).unwrap();
+        if compare_idx {
+            assert_same_f32(
+                &live_k,
+                &ref_k,
+                &format!("{ctx}: post-append attention keys"),
+            );
+            assert_same_f32(
+                &live_v,
+                &ref_v,
+                &format!("{ctx}: post-append attention values"),
+            );
+        }
+        assert_eq!(
+            live.get_offset(),
+            reference.get_offset(),
+            "{ctx}: post-append offset"
+        );
+        let (lk2, lv2) = live.get_cached_kv().unwrap();
+        let (rk2, rv2) = reference.get_cached_kv().unwrap();
+        assert_same_f32(&lk2, &rk2, &format!("{ctx}: post-append temporal keys"));
+        assert_same_f32(&lv2, &rv2, &format!("{ctx}: post-append temporal values"));
+    }
+
+    /// The critical rollback invariant: snapshot → multi-token verify append
+    /// → rollback-to-keep leaves the sliding cache byte-identical to a cache
+    /// that only ever saw prefill + kept prefix, for every keep in 0..=T,
+    /// pre-wrap, post-wrap, rotated-storage, and empty-prefill.
+    #[test]
+    fn sliding_reappend_matches_reference() {
+        let window = 8;
+        let block: Vec<f32> = (101..=108).map(|v| v as f32).collect();
+
+        let rotated_prefill: Vec<Vec<f32>> = {
+            let mut appends = vec![(1..=5).map(|v| v as f32).collect::<Vec<f32>>()];
+            for v in 6..=12 {
+                appends.push(vec![v as f32]);
+            }
+            appends
+        };
+        let scenarios: Vec<(&str, Vec<Vec<f32>>, bool)> = vec![
+            ("pre_wrap", vec![(1..=5).map(|v| v as f32).collect()], true),
+            (
+                "post_wrap",
+                vec![(1..=40).map(|v| v as f32).collect()],
+                true,
+            ),
+            ("rotated_idx", rotated_prefill, false),
+            ("empty_prefill", vec![], true),
+        ];
+
+        for (name, prefill, compare_idx) in &scenarios {
+            for keep in 0..=block.len() {
+                let ctx = format!("{name} keep={keep}");
+
+                let mut live = [Gemma4LayerCache::new_sliding(window)];
+                apply_appends(&mut live[0], prefill);
+                let rollback = snapshot_before_verify(&live, block.len()).unwrap();
+                let (bk, bv) = kv_pair(&block);
+                live[0].update_and_fetch(&bk, &bv).unwrap();
+                commit_after_verify(&mut live, &rollback, keep).unwrap();
+
+                let mut reference = Gemma4LayerCache::new_sliding(window);
+                apply_appends(&mut reference, prefill);
+                if keep > 0 {
+                    let (kk, kv) = kv_pair(&block[..keep]);
+                    reference.update_and_fetch(&kk, &kv).unwrap();
+                }
+
+                assert_rollback_matches_reference(&mut live[0], &mut reference, *compare_idx, &ctx);
+            }
+        }
+    }
+
+    #[test]
+    fn trim_global_trims_global_and_errors_on_sliding() {
+        let mut global = Gemma4LayerCache::new_global();
+        let (k, v) = kv_pair(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+        global.update_and_fetch(&k, &v).unwrap();
+        assert_eq!(global.get_offset(), 8);
+
+        global.trim_global(5).unwrap();
+        assert_eq!(global.get_offset(), 5);
+        let (cached_k, cached_v) = global.get_cached_kv().unwrap();
+        assert_float_data(&cached_k, &[1.0, 2.0, 3.0, 4.0, 5.0]);
+        assert_float_data(&cached_v, &[10.0, 20.0, 30.0, 40.0, 50.0]);
+
+        // The next append overwrites the trimmed region in place.
+        let (nk, nv) = kv_pair(&[99.0]);
+        global.update_and_fetch(&nk, &nv).unwrap();
+        assert_eq!(global.get_offset(), 6);
+        let (cached_k, cached_v) = global.get_cached_kv().unwrap();
+        assert_float_data(&cached_k, &[1.0, 2.0, 3.0, 4.0, 5.0, 99.0]);
+        assert_float_data(&cached_v, &[10.0, 20.0, 30.0, 40.0, 50.0, 990.0]);
+
+        let mut sliding = Gemma4LayerCache::new_sliding(4);
+        let (sk, sv) = kv_pair(&[1.0, 2.0]);
+        sliding.update_and_fetch(&sk, &sv).unwrap();
+        assert!(sliding.trim_global(1).is_err());
+        assert_eq!(sliding.get_offset(), 2, "failed trim must not mutate");
+    }
+
+    #[test]
+    fn sliding_tail_returns_block_rows_and_errors_on_global() {
+        let mut sliding = Gemma4LayerCache::new_sliding(8);
+        let (pk, pv) = kv_pair(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+        sliding.update_and_fetch(&pk, &pv).unwrap();
+        let (bk, bv) = kv_pair(&[101.0, 102.0, 103.0, 104.0]);
+        sliding.update_and_fetch(&bk, &bv).unwrap();
+
+        let (tail_k, tail_v) = sliding.sliding_tail(4).unwrap();
+        assert_float_data(&tail_k, &[101.0, 102.0, 103.0, 104.0]);
+        assert_float_data(&tail_v, &[1010.0, 1020.0, 1030.0, 1040.0]);
+
+        // n beyond the cached token count and n == 0 are rejected.
+        assert!(sliding.sliding_tail(9).is_err());
+        assert!(sliding.sliding_tail(0).is_err());
+
+        let mut global = Gemma4LayerCache::new_global();
+        let (gk, gv) = kv_pair(&[1.0, 2.0]);
+        global.update_and_fetch(&gk, &gv).unwrap();
+        assert!(global.sliding_tail(1).is_err());
+
+        let empty = Gemma4LayerCache::new_sliding(8);
+        assert!(empty.sliding_tail(1).is_err());
+    }
+
+    /// Mixed vec of global + sliding caches, including untouched entries that
+    /// model KV-shared layers (their vec slot is never written by a forward).
+    #[test]
+    fn commit_after_verify_mixed_caches() {
+        const ACTIVE: [usize; 4] = [0, 1, 2, 3];
+        const DEAD: [usize; 2] = [4, 5];
+
+        fn build() -> Vec<Gemma4LayerCache> {
+            let mut caches = vec![
+                Gemma4LayerCache::new_global(),
+                Gemma4LayerCache::new_sliding(8),
+                Gemma4LayerCache::new_global(),
+                Gemma4LayerCache::new_sliding(8),
+                // KV-shared style entries: allocated but never written.
+                Gemma4LayerCache::new_sliding(8),
+                Gemma4LayerCache::new_global(),
+            ];
+            for &i in &ACTIVE {
+                let (k, v) = kv_pair(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+                caches[i].update_and_fetch(&k, &v).unwrap();
+            }
+            caches
+        }
+
+        fn append_block(caches: &mut [Gemma4LayerCache], block: &[f32]) {
+            for &i in &ACTIVE {
+                let (k, v) = kv_pair(block);
+                caches[i].update_and_fetch(&k, &v).unwrap();
+            }
+        }
+
+        let block = [101.0f32, 102.0, 103.0];
+
+        // Full keep: no-op, all active offsets stay at n + T.
+        let mut caches = build();
+        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
+        append_block(&mut caches, &block);
+        commit_after_verify(&mut caches, &rollback, block.len()).unwrap();
+        for &i in &ACTIVE {
+            assert_eq!(caches[i].get_offset(), 8, "cache {i} full-keep offset");
+        }
+        for &i in &DEAD {
+            assert_eq!(caches[i].get_offset(), 0, "dead cache {i} must stay empty");
+        }
+
+        // Partial keep: every active cache lands at n + keep with exactly the
+        // kept prefix appended; dead caches untouched.
+        let mut caches = build();
+        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
+        append_block(&mut caches, &block);
+        commit_after_verify(&mut caches, &rollback, 1).unwrap();
+        for &i in &ACTIVE {
+            assert_eq!(caches[i].get_offset(), 6, "cache {i} partial-keep offset");
+            let (k, v) = caches[i].get_cached_kv().unwrap();
+            assert_float_data(&k, &[1.0, 2.0, 3.0, 4.0, 5.0, 101.0]);
+            assert_float_data(&v, &[10.0, 20.0, 30.0, 40.0, 50.0, 1010.0]);
+        }
+        for &i in &DEAD {
+            assert_eq!(caches[i].get_offset(), 0, "dead cache {i} must stay empty");
+        }
+
+        // keep == 0: the verify block is fully discarded.
+        let mut caches = build();
+        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
+        append_block(&mut caches, &block);
+        commit_after_verify(&mut caches, &rollback, 0).unwrap();
+        for &i in &ACTIVE {
+            assert_eq!(caches[i].get_offset(), 5, "cache {i} keep-0 offset");
+            let (k, _) = caches[i].get_cached_kv().unwrap();
+            assert_float_data(&k, &[1.0, 2.0, 3.0, 4.0, 5.0]);
+        }
+
+        // keep > total_written is rejected.
+        let mut caches = build();
+        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
+        append_block(&mut caches, &block);
+        assert!(commit_after_verify(&mut caches, &rollback, 4).is_err());
+
+        // A cache that advanced by anything other than total_written is a
+        // contract violation, not something to silently "fix".
+        let mut caches = build();
+        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
+        append_block(&mut caches, &block[..2]);
+        assert!(commit_after_verify(&mut caches, &rollback, 1).is_err());
+
+        // Cache-count mismatch between snapshot and commit is rejected.
+        let mut caches = build();
+        let rollback = snapshot_before_verify(&caches, block.len()).unwrap();
+        append_block(&mut caches, &block);
+        assert!(commit_after_verify(&mut caches[..5], &rollback, 1).is_err());
+    }
+
+    #[test]
+    fn snapshot_before_verify_validates_window_and_block() {
+        let caches = vec![Gemma4LayerCache::new_sliding(2)];
+        assert!(
+            snapshot_before_verify(&caches, 3).is_err(),
+            "window smaller than the verify block cannot be rolled back"
+        );
+        assert!(snapshot_before_verify(&caches, 0).is_err());
+        assert!(snapshot_before_verify(&caches, 2).is_ok());
+    }
+
+    /// A one-token verify block (T = 1 + 0 drafts) takes the rotating
+    /// cache's IN-PLACE single-token update path, which overwrites the
+    /// backing array's descriptor rather than rebinding it. The pre-verify
+    /// snapshot must not alias that array, or the rollback would restore
+    /// post-verify data. Regression test for the `temporal_order` clone
+    /// branch (`idx == cache_len`) sharing the live handle.
+    #[test]
+    fn sliding_rollback_survives_single_token_verify_append() {
+        // Post-wrap single-concat prefill leaves idx == cached length ==
+        // window, exactly the state where the snapshot would alias the
+        // live storage and the next single-token append writes in place.
+        let prefill: Vec<f32> = (1..=40).map(|v| v as f32).collect();
+
+        let mut live = [Gemma4LayerCache::new_sliding(8)];
+        apply_appends(&mut live[0], std::slice::from_ref(&prefill));
+        let rollback = snapshot_before_verify(&live, 1).unwrap();
+        let (bk, bv) = kv_pair(&[999.0]);
+        live[0].update_and_fetch(&bk, &bv).unwrap();
+        commit_after_verify(&mut live, &rollback, 0).unwrap();
+
+        let mut reference = Gemma4LayerCache::new_sliding(8);
+        apply_appends(&mut reference, &[prefill]);
+
+        assert_rollback_matches_reference(
+            &mut live[0],
+            &mut reference,
+            false,
+            "single-token verify keep=0",
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/models/gemma4/mlp.rs
+++ b/crates/mlx-core/src/models/gemma4/mlp.rs
@@ -53,16 +53,15 @@ impl GemmaMLP {
         self.down_proj.set_weight(weight)
     }
 
-    // Test-only weight getters.
-    #[cfg(test)]
+    // Weight getters (cheap handle clones). Production use: the DSpark
+    // draft's post-load weight-materialization pass
+    // (`DsparkDraftModel::collect_weight_arrays`); also used by tests.
     pub(crate) fn gate_proj_weight(&self) -> MxArray {
         self.gate_proj.get_weight()
     }
-    #[cfg(test)]
     pub(crate) fn up_proj_weight(&self) -> MxArray {
         self.up_proj.get_weight()
     }
-    #[cfg(test)]
     pub(crate) fn down_proj_weight(&self) -> MxArray {
         self.down_proj.get_weight()
     }

--- a/crates/mlx-core/src/models/gemma4/mod.rs
+++ b/crates/mlx-core/src/models/gemma4/mod.rs
@@ -4,6 +4,10 @@ pub mod clippable_linear;
 pub mod config;
 pub mod decoder_layer;
 pub(crate) mod diagnostic;
+// Consumed by the DSpark speculative-decode engine loop, which is wired in
+// separately; until then only the inline tests exercise this module.
+#[allow(dead_code)]
+pub(crate) mod dspark;
 pub mod image_processor;
 pub mod layer_cache;
 pub mod mlp;

--- a/crates/mlx-core/src/models/gemma4/mod.rs
+++ b/crates/mlx-core/src/models/gemma4/mod.rs
@@ -4,10 +4,8 @@ pub mod clippable_linear;
 pub mod config;
 pub mod decoder_layer;
 pub(crate) mod diagnostic;
-// Consumed by the DSpark speculative-decode engine loop, which is wired in
-// separately; until then only the inline tests exercise this module.
-#[allow(dead_code)]
 pub(crate) mod dspark;
+pub(crate) mod dspark_decode;
 pub mod image_processor;
 pub mod layer_cache;
 pub mod mlp;

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -8,7 +8,6 @@ use napi_derive::napi;
 
 use crate::array::mask::create_causal_mask;
 use crate::array::{DType, MxArray};
-use crate::decode_profiler::DecodeProfiler;
 use crate::engine::backend::{
     ChatBackend, ChunkSink, DecodeStep, FinalizeArgs, PagedBackend, PagedPrefix, PagedTurnSetup,
     ResetScope, SaveStateArgs, StreamEmitter, TurnOutput, TurnSetup, WholeTurnArgs,
@@ -20,7 +19,6 @@ use crate::inference_trace::{
 };
 use crate::models::gemma4::quantized_linear::LinearProj;
 use crate::nn::{Embedding, Linear, RMSNorm};
-use crate::profiling::PerformanceMetrics;
 use crate::sampling::{SamplingConfig, sample};
 use crate::stream::{DeviceType, Stream, StreamContext};
 use crate::tokenizer::{ChatMessage, Qwen3Tokenizer};
@@ -405,6 +403,19 @@ pub(crate) struct Gemma4Inner {
     /// when the config flag is unset, in which case the model falls
     /// back to the flat `Gemma4LayerCache` path.
     pub(crate) paged_adapter: Option<PagedKVCacheAdapter>,
+    /// DSpark draft model for speculative decoding (`Gemma4LoadOptions::
+    /// draft_model_path`). Mutually exclusive with `paged_adapter`: the
+    /// load path hard-errors on an explicit `use_block_paged_cache: true`
+    /// conflict and forces the unset default to flat, so `dspark.is_some()`
+    /// implies `paged_adapter.is_none()`.
+    pub(crate) dspark: Option<super::dspark::DsparkDraftModel>,
+    /// Per-turn DSpark draft-context handoff: `dspark_chat_turn` builds the
+    /// draft's fused-context cache during its tapped prefill and stashes it
+    /// here; `DsparkBackend::begin_dspark_decode` TAKES it into the turn's
+    /// stepper (the engine's `DsparkTurnSetup` carries only turn constants,
+    /// so prefill-derived state travels through this seam). Always `None`
+    /// outside a live `dspark_chat_turn`.
+    pub(crate) dspark_turn_state: Option<super::dspark_decode::DsparkTurnState>,
     /// Cached result of `compute_layer_kinds_from_kv_cache_specs(&config)`,
     /// computed once here in `Gemma4Inner::new` instead of re-derived
     /// (BTreeMap/BTreeSet grouping + a sort) on every paged prefill-chunk /
@@ -480,6 +491,27 @@ pub struct Gemma4Model {
     /// coordinator on drop. `None` for instances constructed via the
     /// synchronous `new(config)` path that never loaded weights.
     pub(crate) _cache_limit_guard: Option<crate::cache_limit::CacheLimitGuard>,
+    /// Snapshot of `Gemma4Inner::dspark.is_some()` captured at load time
+    /// (same mirroring pattern as `paged_active`): whether a DSpark draft
+    /// model was loaded via `Gemma4LoadOptions::draft_model_path`. Surfaced
+    /// through the `hasMtpWeights()` NAPI method (named for parity with the
+    /// Qwen3.5 surface) so server endpoints can branch without a
+    /// model-thread roundtrip. Stubs from `new(config)` always report
+    /// `false`.
+    pub(crate) dspark_active: bool,
+}
+
+/// Optional load-time settings for [`Gemma4Model::load`].
+#[napi(object)]
+#[derive(Debug, Clone, Default)]
+pub struct Gemma4LoadOptions {
+    /// Directory of a DSpark draft checkpoint (config.json +
+    /// model.safetensors) to load alongside the target model for
+    /// speculative decoding. DSpark runs only on the flat KV-cache path:
+    /// setting this while the model config explicitly enables
+    /// `use_block_paged_cache` is a hard load error, and an unset
+    /// `use_block_paged_cache` is forced to `false`.
+    pub draft_model_path: Option<String>,
 }
 
 static MODEL_ID_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -1020,6 +1052,8 @@ impl Gemma4Inner {
             cached_image_key: None,
             cached_audio_key: None,
             paged_adapter,
+            dspark: None,
+            dspark_turn_state: None,
             layer_kinds,
             sliding_prefix_checkpoints: VecDeque::new(),
             sliding_prompt_boundary_checkpoint: None,
@@ -4945,6 +4979,20 @@ impl ChatBackend for Gemma4Inner {
         // channel segments itself). Defensive: pin `true` so the engine's
         // emitter gate can never suppress.
         p.include_reasoning = true;
+        // DSpark draft depth: with a draft model loaded, an unset
+        // `mtpDepth` runs full draft blocks (`block_size`, 7 on the v1
+        // checkpoint); an explicit value is clamped to `[1, block_size]`
+        // from the RAW config value — the engine's central clamp is
+        // `[1, 5]` (an MTP-head contract that does not apply to DSpark),
+        // so this family-local post-edit widens it without touching the
+        // shared clamp.
+        if let Some(draft) = self.dspark.as_ref() {
+            let block_size = draft.config.block_size;
+            p.mtp_depth = match config.mtp_depth {
+                Some(d) => (d.max(1) as usize).min(block_size),
+                None => block_size,
+            };
+        }
         p
     }
 
@@ -5399,11 +5447,11 @@ impl ChatBackend for Gemma4Inner {
         }
     }
 
-    fn augment_performance(&self, _profiler: &DecodeProfiler, _metrics: &mut PerformanceMetrics) {
-        // No-op: gemma4 has no MTP heads (acceptance fields stay None) and
-        // its metrics carry no `profile_phases`. The default would only add
-        // profiling-gated extras; keep the payload byte-stable instead.
-    }
+    // `augment_performance` deliberately NOT overridden: the default
+    // (`profiler.fill_mtp_acceptance`) fills the `mtp_*` acceptance fields
+    // after a DSpark turn (and copies `profile_phases` when profiling is
+    // enabled). AR turns record no MTP cycle, so their acceptance fields
+    // stay `None` as before.
 
     fn has_live_session(&self) -> bool {
         // Requires an initialized session: a non-empty
@@ -5421,6 +5469,24 @@ impl ChatBackend for Gemma4Inner {
         // paged engine, which drives the adapter lifecycle via
         // [`PagedBackend`] and reuses the shared `run_decode_loop`.
         Some(crate::engine::paged_turn::run_paged_turn(self, args))
+    }
+
+    /// DSpark speculative-decode whole-turn path. Dispatches only when the
+    /// request opted in (`enableMtp`), a draft model is loaded, the flat KV
+    /// path is active (no paged adapter — enforced at load, re-checked here
+    /// defensively), and the turn is text-only (image/audio turns were
+    /// already routed to `vision_turn` by the session core; re-checked
+    /// defensively). Everything else falls through to the generic AR flow.
+    fn mtp_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Option<Result<TurnOutput>> {
+        if !(args.params.enable_mtp
+            && self.dspark.is_some()
+            && self.paged_adapter.is_none()
+            && args.images.is_empty()
+            && args.audio.is_empty())
+        {
+            return None;
+        }
+        Some(self.dspark_chat_turn(args))
     }
 
     fn vision_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Option<Result<TurnOutput>> {
@@ -5520,6 +5586,7 @@ impl Gemma4Model {
             initialized: false,
             paged_active: false,
             _cache_limit_guard: None,
+            dspark_active: false,
         }
     }
 
@@ -5550,10 +5617,59 @@ impl Gemma4Model {
         self.model_id as u32
     }
 
+    /// Whether a DSpark draft model is loaded on this instance (via
+    /// `Gemma4LoadOptions::draft_model_path`), enabling the speculative-
+    /// decode whole-turn path.
+    ///
+    /// Note: this only reports draft availability. Whether speculative
+    /// decoding actually runs on a given call also requires the per-request
+    /// `enableMtp` flag. Named `hasMtpWeights` for parity with the Qwen3.5
+    /// surface. Stubs from `new(config)` always return `false`.
+    #[napi]
+    pub fn has_mtp_weights(&self) -> bool {
+        self.dspark_active
+    }
+
     /// Load a Gemma4 model from a directory.
     #[napi]
-    pub async fn load(model_path: String) -> Result<Gemma4Model> {
-        Self::load_from_dir(&model_path).await
+    pub async fn load(
+        model_path: String,
+        options: Option<Gemma4LoadOptions>,
+    ) -> Result<Gemma4Model> {
+        Self::load_from_dir(&model_path, options).await
+    }
+
+    /// Test-only entry point that dispatches `ChatCmd::StreamSessionStart`
+    /// and returns the raw mpsc receiver the model thread writes into, so a
+    /// pure-Rust integration test can exercise the streaming path without a
+    /// NAPI host (same pattern as `Qwen3_5Model::chat_stream_session_start_for_test`).
+    #[doc(hidden)]
+    pub fn chat_stream_session_start_for_test(
+        &self,
+        messages: Vec<ChatMessage>,
+        config: Option<ChatConfig>,
+    ) -> Result<(
+        crate::engine::types::ChatStreamHandle,
+        tokio::sync::mpsc::UnboundedReceiver<Result<ChatStreamChunk>>,
+    )> {
+        let thread = self.thread.as_ref().ok_or_else(|| {
+            Error::from_reason("Model not initialized. Call Gemma4Model.load() first.")
+        })?;
+        let config = config.unwrap_or_default();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancelled_inner = cancelled.clone();
+        let (stream_tx, stream_rx) =
+            tokio::sync::mpsc::unbounded_channel::<Result<ChatStreamChunk>>();
+        thread.send(ChatCmd::StreamSessionStart {
+            messages,
+            config,
+            stream_tx,
+            cancelled: cancelled_inner,
+        })?;
+        Ok((
+            crate::engine::types::ChatStreamHandle { cancelled },
+            stream_rx,
+        ))
     }
 }
 
@@ -5762,7 +5878,7 @@ fn is_greedy_sampling(config: Option<SamplingConfig>) -> bool {
 /// When `tap` is provided, the residual-stream hidden of each tapped layer
 /// (post residual add, PRE final-norm) is pushed onto `tap.captured` in
 /// `layer_ids` order; the compute graph is otherwise unchanged.
-fn forward_body(
+pub(crate) fn forward_body(
     input_ids: Option<&MxArray>,
     inputs_embeds: Option<MxArray>,
     embedding: &Embedding,
@@ -5956,7 +6072,7 @@ fn forward_body(
 /// Full forward pass: transformer body + lm_head + logit softcapping.
 ///
 /// Used for the final prefill chunk and for each decode step.
-fn forward_inner(
+pub(crate) fn forward_inner(
     input_ids: &MxArray,
     embedding: &Embedding,
     layers: &[Gemma4DecoderLayer],
@@ -6019,9 +6135,6 @@ fn forward_inner(
 /// the same masks/rope the chunked prefill uses). It does not sample and
 /// touches no history bookkeeping; caches advance by T. Callers pair it with
 /// `snapshot_before_verify` / `commit_after_verify` for rollback.
-// Consumed by the DSpark speculative-decode engine loop, which is wired in
-// separately; until then only the inline tests exercise this wrapper.
-#[allow(dead_code)]
 pub(crate) fn dspark_verify_forward(
     block_ids: &MxArray,
     embedding: &Embedding,
@@ -6058,9 +6171,6 @@ pub(crate) fn dspark_verify_forward(
 /// per-layer caches vec: entry i is true iff decoder layer i is KV-shared.
 /// Shared layers read their anchor layer's cache; their own vec entry is
 /// never written by a forward pass.
-// Consumed by the DSpark speculative-decode engine loop, which is wired in
-// separately; until then only the inline tests exercise this helper.
-#[allow(dead_code)]
 pub(crate) fn dspark_shared_slot_mask(config: &Gemma4Config) -> Vec<bool> {
     (0..config.num_hidden_layers as usize)
         .map(|i| config.is_kv_shared_layer(i))
@@ -6069,7 +6179,7 @@ pub(crate) fn dspark_shared_slot_mask(config: &Gemma4Config) -> Vec<bool> {
 
 /// Compute PLE (per-layer embeddings) from input_ids.
 /// Returns shape [B, T, num_layers, ple_dim].
-fn compute_ple(
+pub(crate) fn compute_ple(
     input_ids: &MxArray,
     h: &MxArray,
     ple: &PleComponents,
@@ -6334,7 +6444,7 @@ fn gemma4_default_paged_cache_memory_mb(
 /// Note: mlx-lm uses 2048 but the first eval triggers Metal shader compilation
 /// which can GPU-timeout with very large graphs. Using 512 keeps individual
 /// command buffers under Metal's timeout limit.
-const GEMMA4_PREFILL_STEP_SIZE: i64 = 512;
+pub(crate) const GEMMA4_PREFILL_STEP_SIZE: i64 = 512;
 const GEMMA4_PAGED_ATTENTION_V2_PARTITION_SIZE: u64 = 512;
 const GEMMA4_PAGED_ATTENTION_V2_AUX_ELEM_LIMIT: u128 = i32::MAX as u128;
 
@@ -6749,7 +6859,7 @@ fn gemma4_paged_prefill_body_chunk_plan_inner(
 
 /// Evaluate all Gemma4 cache arrays to materialize them on GPU.
 /// Must be called between prefill chunks to break lazy dependency chains.
-fn eval_gemma4_caches(caches: &[Gemma4LayerCache]) -> Result<()> {
+pub(crate) fn eval_gemma4_caches(caches: &[Gemma4LayerCache]) -> Result<()> {
     let mut arrays: Vec<&MxArray> = Vec::new();
     for cache in caches {
         cache.collect_cache_arrays(&mut arrays);

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -6054,6 +6054,19 @@ pub(crate) fn dspark_verify_forward(
     )
 }
 
+/// Shared-slot mask for `snapshot_before_verify`, index-aligned with the
+/// per-layer caches vec: entry i is true iff decoder layer i is KV-shared.
+/// Shared layers read their anchor layer's cache; their own vec entry is
+/// never written by a forward pass.
+// Consumed by the DSpark speculative-decode engine loop, which is wired in
+// separately; until then only the inline tests exercise this helper.
+#[allow(dead_code)]
+pub(crate) fn dspark_shared_slot_mask(config: &Gemma4Config) -> Vec<bool> {
+    (0..config.num_hidden_layers as usize)
+        .map(|i| config.is_kv_shared_layer(i))
+        .collect()
+}
+
 /// Compute PLE (per-layer embeddings) from input_ids.
 /// Returns shape [B, T, num_layers, ple_dim].
 fn compute_ple(
@@ -9590,8 +9603,15 @@ mod dspark_tap_tests {
         )
         .unwrap();
 
-        // Pass B: tapped, including the KV-shared layer 3 (anchor = layer 1).
+        // Pass B: tapped, including the KV-shared layer 3 (anchor = layer 1),
+        // with the real snapshot → verify → commit flow around the verify.
         let layer_ids = [0usize, 2, 3];
+        let shared_slots = dspark_shared_slot_mask(&config);
+        assert_eq!(
+            shared_slots,
+            vec![false, false, false, true],
+            "config-derived shared-slot mask"
+        );
         let mut caches_b = init_caches_for_config(&config);
         let mut prefill_tap = DsparkTap::new(&layer_ids);
         let hidden_b = forward_body(
@@ -9605,6 +9625,12 @@ mod dspark_tap_tests {
             None,
             &config,
             Some(&mut prefill_tap),
+        )
+        .unwrap();
+        let rollback = super::super::layer_cache::snapshot_before_verify(
+            &caches_b,
+            block_ids.shape_at(1).unwrap() as usize,
+            &shared_slots,
         )
         .unwrap();
         let mut verify_tap = DsparkTap::new(&layer_ids);
@@ -9653,6 +9679,18 @@ mod dspark_tap_tests {
             caches_b[3].get_offset(),
             0,
             "KV-shared layer's cache entry must stay untouched"
+        );
+
+        // Partial-keep commit on the real model: active caches land at
+        // prefill + keep, the shared slot stays untouched.
+        super::super::layer_cache::commit_after_verify(&mut caches_b, &rollback, 1).unwrap();
+        for (idx, cache) in caches_b.iter().enumerate().take(3) {
+            assert_eq!(cache.get_offset(), 7, "cache {idx} post-commit offset");
+        }
+        assert_eq!(
+            caches_b[3].get_offset(),
+            0,
+            "KV-shared layer's cache entry must stay untouched after commit"
         );
     }
 

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -5624,7 +5624,9 @@ impl Gemma4Model {
     /// Note: this only reports draft availability. Whether speculative
     /// decoding actually runs on a given call also requires the per-request
     /// `enableMtp` flag. Named `hasMtpWeights` for parity with the Qwen3.5
-    /// surface. Stubs from `new(config)` always return `false`.
+    /// surface, but it reports an external DSpark draft model, not
+    /// in-checkpoint MTP heads. Stubs from `new(config)` always return
+    /// `false`.
     #[napi]
     pub fn has_mtp_weights(&self) -> bool {
         self.dspark_active

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -108,6 +108,7 @@ fn escape_gemma4_content(s: &str) -> String {
 
 use super::config::Gemma4Config;
 use super::decoder_layer::{Gemma4DecoderLayer, Gemma4LayerKind};
+use super::dspark::DsparkTap;
 use super::layer_cache::Gemma4LayerCache;
 use crate::engine;
 use crate::engine::types::{ChatConfig, ChatResult, ChatStreamChunk};
@@ -4568,6 +4569,7 @@ impl DecodeStep for Gemma4Decode<'_> {
             inner.embed_weight_t.as_ref(),
             inner.ple.as_ref(),
             &inner.config,
+            None,
         )?;
         // `true` requests the engine's `squeeze(Some(&[1]))`: the eager
         // forward returns `[1, 1, vocab]`.
@@ -4603,6 +4605,7 @@ impl DecodeStep for Gemma4Decode<'_> {
             inner.embed_weight_t.as_ref(),
             inner.ple.as_ref(),
             &inner.config,
+            None,
         )?;
         Ok(())
     }
@@ -5203,6 +5206,7 @@ impl ChatBackend for Gemma4Inner {
                 &self.final_norm,
                 self.ple.as_ref(),
                 &self.config,
+                None,
             )?;
         }
         eval_gemma4_caches(
@@ -5231,6 +5235,7 @@ impl ChatBackend for Gemma4Inner {
                 self.embed_weight_t.as_ref(),
                 self.ple.as_ref(),
                 &self.config,
+                None,
             )?
         };
         logits.squeeze(Some(&[1]))
@@ -5753,6 +5758,10 @@ fn is_greedy_sampling(config: Option<SamplingConfig>) -> bool {
 ///
 /// When `inputs_embeds` is provided, uses it directly (skipping embedding lookup).
 /// When `per_layer_inputs` is provided, uses it directly (skipping PLE computation).
+///
+/// When `tap` is provided, the residual-stream hidden of each tapped layer
+/// (post residual add, PRE final-norm) is pushed onto `tap.captured` in
+/// `layer_ids` order; the compute graph is otherwise unchanged.
 fn forward_body(
     input_ids: Option<&MxArray>,
     inputs_embeds: Option<MxArray>,
@@ -5763,7 +5772,22 @@ fn forward_body(
     ple: Option<&PleComponents>,
     per_layer_inputs: Option<&MxArray>,
     config: &Gemma4Config,
+    mut tap: Option<&mut DsparkTap<'_>>,
 ) -> Result<MxArray> {
+    if let Some(t) = tap.as_deref() {
+        let mut previous: Option<usize> = None;
+        for &id in t.layer_ids {
+            if id >= layers.len() || previous.is_some_and(|prev| id <= prev) {
+                return Err(Error::from_reason(format!(
+                    "forward_body: tap layer_ids {:?} must be strictly ascending decoder indices below {}",
+                    t.layer_ids,
+                    layers.len()
+                )));
+            }
+            previous = Some(id);
+        }
+    }
+
     // Step 1: Embedding (or use pre-computed embeddings)
     let mut h = if let Some(embeds) = inputs_embeds {
         embeds
@@ -5914,6 +5938,15 @@ fn forward_body(
                 shared_kv.insert(i, (keys, values));
             }
         }
+
+        // Residual-stream hidden of layer i (post residual add, pre
+        // final-norm — HF `hidden_states[i + 1]`), captured for both the
+        // regular and the KV-shared branch.
+        if let Some(t) = tap.as_deref_mut()
+            && t.layer_ids.contains(&i)
+        {
+            t.captured.push(h.clone());
+        }
     }
 
     // Final norm
@@ -5933,6 +5966,7 @@ fn forward_inner(
     embed_weight_t: Option<&MxArray>,
     ple: Option<&PleComponents>,
     config: &Gemma4Config,
+    tap: Option<&mut DsparkTap<'_>>,
 ) -> Result<MxArray> {
     let h = forward_body(
         Some(input_ids),
@@ -5944,6 +5978,7 @@ fn forward_inner(
         ple,
         None,
         config,
+        tap,
     )?;
 
     crate::models::gemma4::diagnostic::dump_norm(0, "post_final_norm", &h, None);
@@ -5975,6 +6010,48 @@ fn forward_inner(
         crate::models::gemma4::diagnostic::dump_logits("post_softcap", &logits);
         Ok(logits)
     }
+}
+
+/// Run the target over a `[1, T]` verify block at the current cache offset,
+/// capturing the tapped hidden states, and return the `[1, T, vocab]` logits.
+///
+/// This is exactly the existing T>1-at-offset forward (`forward_inner`, with
+/// the same masks/rope the chunked prefill uses). It does not sample and
+/// touches no history bookkeeping; caches advance by T. Callers pair it with
+/// `snapshot_before_verify` / `commit_after_verify` for rollback.
+// Consumed by the DSpark speculative-decode engine loop, which is wired in
+// separately; until then only the inline tests exercise this wrapper.
+#[allow(dead_code)]
+pub(crate) fn dspark_verify_forward(
+    block_ids: &MxArray,
+    embedding: &Embedding,
+    layers: &[Gemma4DecoderLayer],
+    caches: &mut [Gemma4LayerCache],
+    final_norm: &RMSNorm,
+    lm_head: &Option<LinearProj>,
+    embed_weight_t: Option<&MxArray>,
+    ple: Option<&PleComponents>,
+    config: &Gemma4Config,
+    tap: &mut DsparkTap<'_>,
+) -> Result<MxArray> {
+    if block_ids.ndim()? != 2 || block_ids.shape_at(0)? != 1 || block_ids.shape_at(1)? < 1 {
+        return Err(Error::from_reason(format!(
+            "dspark_verify_forward expects block_ids shaped [1, T] with T >= 1, got {:?}",
+            block_ids.shape()?.as_ref()
+        )));
+    }
+    forward_inner(
+        block_ids,
+        embedding,
+        layers,
+        caches,
+        final_norm,
+        lm_head,
+        embed_weight_t,
+        ple,
+        config,
+        Some(tap),
+    )
 }
 
 /// Compute PLE (per-layer embeddings) from input_ids.
@@ -6702,6 +6779,7 @@ fn prefill_body_gemma4(
     final_norm: &RMSNorm,
     ple: Option<&PleComponents>,
     config: &Gemma4Config,
+    mut tap: Option<&mut DsparkTap<'_>>,
 ) -> Result<()> {
     let total_len = prompt.shape_at(1)?;
 
@@ -6747,6 +6825,7 @@ fn prefill_body_gemma4(
             ple,
             chunk_ple.as_ref(),
             config,
+            tap.as_deref_mut(),
         )?;
         eval_gemma4_caches(caches)?;
         crate::array::clear_cache();
@@ -6771,6 +6850,7 @@ fn prefill_body_gemma4(
             ple,
             remaining_ple.as_ref(),
             config,
+            tap,
         )?;
     }
 
@@ -9396,6 +9476,255 @@ mod tool_delta_marker_tests {
         assert_eq!(
             occurrences, 1,
             "marker count should be 1 (the original literal); got {occurrences} in:\n{rendered}",
+        );
+    }
+}
+
+#[cfg(test)]
+mod dspark_tap_tests {
+    //! Tap purity: threading a `DsparkTap` through the Gemma4 forward
+    //! paths must leave the compute graph byte-identical to a tap-less
+    //! run, while capturing the residual-stream hiddens of the tapped
+    //! layers. Runs a tiny random-weight Gemma4 (4 layers, hybrid
+    //! sliding/global types, one KV-shared layer) through the REAL
+    //! `forward_body` / `forward_inner` / `dspark_verify_forward` paths.
+
+    use super::*;
+    use crate::models::gemma4::dspark::DsparkTap;
+
+    fn tiny_config() -> Gemma4Config {
+        serde_json::from_value(serde_json::json!({
+            "vocab_size": 64,
+            "hidden_size": 32,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 16,
+            "intermediate_size": 64,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 128,
+            "sliding_window": 8,
+            "layer_types": [
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention"
+            ],
+            "num_kv_shared_layers": 1,
+        }))
+        .expect("tiny Gemma4 config must deserialize")
+    }
+
+    fn tiny_model(config: &Gemma4Config) -> (Embedding, Vec<Gemma4DecoderLayer>, RMSNorm) {
+        let embedding =
+            Embedding::new(config.vocab_size as u32, config.hidden_size as u32).unwrap();
+        let layers: Vec<Gemma4DecoderLayer> = (0..config.num_hidden_layers as usize)
+            .map(|i| Gemma4DecoderLayer::new(config, i).unwrap())
+            .collect();
+        let final_norm =
+            RMSNorm::new(config.hidden_size as u32, Some(config.rms_norm_eps)).unwrap();
+        (embedding, layers, final_norm)
+    }
+
+    fn assert_bitwise_eq(a: &MxArray, b: &MxArray, ctx: &str) {
+        a.eval();
+        b.eval();
+        assert_eq!(
+            a.shape().unwrap().to_vec(),
+            b.shape().unwrap().to_vec(),
+            "{ctx}: shape"
+        );
+        let a_bits: Vec<u32> = a
+            .to_float32()
+            .unwrap()
+            .iter()
+            .map(|v| v.to_bits())
+            .collect();
+        let b_bits: Vec<u32> = b
+            .to_float32()
+            .unwrap()
+            .iter()
+            .map(|v| v.to_bits())
+            .collect();
+        assert_eq!(a_bits, b_bits, "{ctx}: bits");
+    }
+
+    #[test]
+    fn dspark_tap_purity_and_verify_forward() {
+        let config = tiny_config();
+        let (embedding, layers, final_norm) = tiny_model(&config);
+
+        // 6-token prefill then a 3-token verify block: the block runs
+        // T>1 at offset 6, which also crosses the sliding window (6+3 > 8)
+        // so the windowed-mask path is exercised.
+        let prefill_ids = MxArray::from_int32(&[3, 9, 17, 25, 33, 41], &[1, 6]).unwrap();
+        let block_ids = MxArray::from_int32(&[7, 11, 13], &[1, 3]).unwrap();
+
+        // Pass A: no tap.
+        let mut caches_a = init_caches_for_config(&config);
+        let hidden_a = forward_body(
+            Some(&prefill_ids),
+            None,
+            &embedding,
+            &layers,
+            &mut caches_a,
+            &final_norm,
+            None,
+            None,
+            &config,
+            None,
+        )
+        .unwrap();
+        let logits_a = forward_inner(
+            &block_ids,
+            &embedding,
+            &layers,
+            &mut caches_a,
+            &final_norm,
+            &None,
+            None,
+            None,
+            &config,
+            None,
+        )
+        .unwrap();
+
+        // Pass B: tapped, including the KV-shared layer 3 (anchor = layer 1).
+        let layer_ids = [0usize, 2, 3];
+        let mut caches_b = init_caches_for_config(&config);
+        let mut prefill_tap = DsparkTap::new(&layer_ids);
+        let hidden_b = forward_body(
+            Some(&prefill_ids),
+            None,
+            &embedding,
+            &layers,
+            &mut caches_b,
+            &final_norm,
+            None,
+            None,
+            &config,
+            Some(&mut prefill_tap),
+        )
+        .unwrap();
+        let mut verify_tap = DsparkTap::new(&layer_ids);
+        let logits_b = dspark_verify_forward(
+            &block_ids,
+            &embedding,
+            &layers,
+            &mut caches_b,
+            &final_norm,
+            &None,
+            None,
+            None,
+            &config,
+            &mut verify_tap,
+        )
+        .unwrap();
+
+        // Tap must not perturb the compute graph.
+        assert_bitwise_eq(&hidden_a, &hidden_b, "prefill hidden");
+        assert_bitwise_eq(&logits_a, &logits_b, "verify logits");
+        assert_eq!(logits_b.shape().unwrap().to_vec(), vec![1, 3, 64]);
+
+        // One [B, T, hidden] capture per tapped layer, per forward call.
+        assert_eq!(prefill_tap.captured.len(), layer_ids.len());
+        for arr in &prefill_tap.captured {
+            assert_eq!(arr.shape().unwrap().to_vec(), vec![1, 6, 32]);
+        }
+        assert_eq!(verify_tap.captured.len(), layer_ids.len());
+        for arr in &verify_tap.captured {
+            assert_eq!(arr.shape().unwrap().to_vec(), vec![1, 3, 32]);
+        }
+
+        // Different layers must yield different hiddens (real per-layer
+        // captures, not one array pushed repeatedly).
+        let first = verify_tap.captured[0].to_float32().unwrap().to_vec();
+        let second = verify_tap.captured[1].to_float32().unwrap().to_vec();
+        assert_ne!(first, second, "captures must differ across layers");
+
+        // Caches advance by T on both passes; the KV-shared layer's own
+        // vec entry is never written (it reads its anchor's cache).
+        for (idx, cache) in caches_b.iter().enumerate().take(3) {
+            assert_eq!(cache.get_offset(), 9, "cache {idx} offset");
+            assert_eq!(caches_a[idx].get_offset(), 9, "cache {idx} tapless offset");
+        }
+        assert_eq!(
+            caches_b[3].get_offset(),
+            0,
+            "KV-shared layer's cache entry must stay untouched"
+        );
+    }
+
+    #[test]
+    fn dspark_tap_rejects_unsorted_or_out_of_range_layer_ids() {
+        let config = tiny_config();
+        let (embedding, layers, final_norm) = tiny_model(&config);
+        let ids = MxArray::from_int32(&[3, 9], &[1, 2]).unwrap();
+
+        for bad in [vec![2usize, 0], vec![1, 1], vec![7]] {
+            let mut caches = init_caches_for_config(&config);
+            let mut tap = DsparkTap::new(&bad);
+            let result = forward_body(
+                Some(&ids),
+                None,
+                &embedding,
+                &layers,
+                &mut caches,
+                &final_norm,
+                None,
+                None,
+                &config,
+                Some(&mut tap),
+            );
+            assert!(result.is_err(), "layer_ids {bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn dspark_verify_forward_rejects_bad_block_shape() {
+        let config = tiny_config();
+        let (embedding, layers, final_norm) = tiny_model(&config);
+        let layer_ids = [0usize];
+
+        // Batch > 1 is rejected.
+        let batch2 = MxArray::from_int32(&[1, 2], &[2, 1]).unwrap();
+        let mut caches = init_caches_for_config(&config);
+        let mut tap = DsparkTap::new(&layer_ids);
+        assert!(
+            dspark_verify_forward(
+                &batch2,
+                &embedding,
+                &layers,
+                &mut caches,
+                &final_norm,
+                &None,
+                None,
+                None,
+                &config,
+                &mut tap,
+            )
+            .is_err()
+        );
+
+        // 1-D input is rejected.
+        let flat = MxArray::from_int32(&[1, 2], &[2]).unwrap();
+        let mut caches = init_caches_for_config(&config);
+        let mut tap = DsparkTap::new(&layer_ids);
+        assert!(
+            dspark_verify_forward(
+                &flat,
+                &embedding,
+                &layers,
+                &mut caches,
+                &final_norm,
+                &None,
+                None,
+                None,
+                &config,
+                &mut tap,
+            )
+            .is_err()
         );
     }
 }

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -2183,6 +2183,17 @@ impl Gemma4Inner {
                 draft.config.block_size,
                 draft.config.target_layer_ids,
             );
+            // Materialize the draft's mmap-backed tensors NOW, with the same
+            // chunked mechanism as the target's pass below: left lazy, the
+            // FIRST speculative forward would page-fault the whole multi-GB
+            // checkpoint from cold mmap mid-GPU-work (the qwen3.5 cold-mmap
+            // load-watchdog failure class the target pass exists to prevent).
+            // `collect_weight_arrays` enumerates every checkpoint tensor (74
+            // on the v1 contract) — byte-coverage pinned by
+            // `collect_weight_arrays_covers_every_checkpoint_tensor`.
+            let draft_weights = draft.collect_weight_arrays();
+            let draft_refs: Vec<&MxArray> = draft_weights.iter().collect();
+            crate::array::memory::materialize_weights(&draft_refs)?;
             inner.dspark = Some(draft);
         }
 

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -1850,11 +1850,34 @@ impl Gemma4Inner {
     /// cache-limit coordinator. See `cache_limit.rs` module docs for
     /// why this deterministic measurement is preferred over a
     /// process-wide `get_active_memory()` delta.
-    pub fn load_from_dir(model_path: &str) -> Result<(Self, u64)> {
+    ///
+    /// `draft_model_path` optionally points at a DSpark draft checkpoint
+    /// directory loaded alongside the target for speculative decoding.
+    /// DSpark runs only on the flat KV-cache path, so an explicit
+    /// `use_block_paged_cache: true` in the target config is a hard error
+    /// (silently ignoring the explicit draft request would be worse), and
+    /// the unset default (paged ON) is forced to flat.
+    pub fn load_from_dir(model_path: &str, draft_model_path: Option<&str>) -> Result<(Self, u64)> {
         let path = Path::new(model_path);
 
         // Parse config
         let mut config = parse_config(path)?;
+
+        // DSpark/paged conflict guard — BEFORE any weight I/O so a
+        // misconfigured request fails fast. `use_block_paged_cache`
+        // defaults ON (`unwrap_or(true)` in `Gemma4Inner::new`); a draft
+        // request flips that default to flat, but an EXPLICIT `true` is a
+        // config-level conflict the caller must resolve.
+        if draft_model_path.is_some() {
+            if config.use_block_paged_cache == Some(true) {
+                return Err(Error::from_reason(
+                    "Gemma4 draft_model_path conflicts with use_block_paged_cache=true: DSpark \
+                     speculative decoding runs only on the flat KV-cache path. Remove \
+                     draft_model_path or set use_block_paged_cache to false in config.json.",
+                ));
+            }
+            config.use_block_paged_cache = Some(false);
+        }
 
         // Merge stop tokens and sampling defaults from generation_config.json
         let gen_config_path = path.join("generation_config.json");
@@ -2139,6 +2162,30 @@ impl Gemma4Inner {
             );
         }
 
+        // DSpark draft model — loaded AFTER the target body so its geometry
+        // validation runs against the fully-parsed target config. Loader
+        // errors propagate verbatim (they carry the guard-rail messages:
+        // geometry pins, bf16-only gate, 74-tensor completeness).
+        if let Some(draft_dir) = draft_model_path {
+            let draft_path = Path::new(draft_dir);
+            // Same cold-mmap pre-warm as the target shards: the draft's
+            // first forward must not page-fault a cold region on the GPU.
+            prewarm_checkpoint_pages(draft_path);
+            let draft = super::dspark::load_draft_model(
+                draft_path,
+                config.hidden_size as i64,
+                config.vocab_size as i64,
+                config.num_hidden_layers as usize,
+            )?;
+            info!(
+                "[gemma4] DSpark draft model loaded: {} layers, block_size={}, target_layer_ids={:?}",
+                draft.num_layers(),
+                draft.config.block_size,
+                draft.config.target_layer_ids,
+            );
+            inner.dspark = Some(draft);
+        }
+
         // Deterministic weight-byte total for the cache-limit
         // coordinator. Computed from the still-live `params` map
         // before it is dropped at end-of-function.
@@ -2168,8 +2215,12 @@ impl Gemma4Model {
     ///
     /// Spawns a dedicated model thread. The init_fn runs all weight loading on
     /// that thread, then the thread enters its command loop.
-    pub async fn load_from_dir(model_path: &str) -> Result<Self> {
+    pub async fn load_from_dir(
+        model_path: &str,
+        options: Option<super::model::Gemma4LoadOptions>,
+    ) -> Result<Self> {
         let model_path = model_path.to_string();
+        let draft_model_path = options.and_then(|o| o.draft_model_path);
 
         let (thread, init_rx) = crate::model_thread::ModelThread::spawn_with_init(
             move || {
@@ -2180,12 +2231,14 @@ impl Gemma4Model {
                 // sampling — the deterministic path is race-free
                 // against concurrent inference. See `cache_limit.rs`
                 // module docs.
-                let (inner, weight_bytes) = Gemma4Inner::load_from_dir(&model_path)?;
+                let (inner, weight_bytes) =
+                    Gemma4Inner::load_from_dir(&model_path, draft_model_path.as_deref())?;
                 let cache_limit_guard = crate::cache_limit::coordinator().register(weight_bytes);
                 let model_id = inner.model_id;
                 let has_vision = inner.image_processor.is_some();
                 let has_audio = inner.embed_audio.is_some();
                 let paged_active = inner.paged_adapter.is_some();
+                let dspark_active = inner.dspark.is_some();
                 Ok((
                     inner,
                     (
@@ -2194,13 +2247,14 @@ impl Gemma4Model {
                         has_audio,
                         cache_limit_guard,
                         paged_active,
+                        dspark_active,
                     ),
                 ))
             },
             crate::engine::cmd::handle_chat_cmd::<super::model::Gemma4Inner>,
         );
 
-        let (model_id, has_vision, has_audio, cache_limit_guard, paged_active) =
+        let (model_id, has_vision, has_audio, cache_limit_guard, paged_active, dspark_active) =
             init_rx
                 .await
                 .map_err(|_| napi::Error::from_reason("Model thread exited during load"))??;
@@ -2213,6 +2267,7 @@ impl Gemma4Model {
             initialized: true,
             paged_active,
             _cache_limit_guard: Some(cache_limit_guard),
+            dspark_active,
         })
     }
 }
@@ -2336,6 +2391,80 @@ mod tests {
         assert!(
             cfg.unified_vision_config.is_none(),
             "plain gemma4 must leave unified_vision_config None"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Write a config.json into a fresh temp dir (no weights) for
+    /// `load_from_dir` guard tests that must fail BEFORE any weight I/O.
+    fn write_config_dir(json: serde_json::Value) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "gemma4_dspark_load_guard_test_{}_{}",
+            std::process::id(),
+            id
+        ));
+        fs::create_dir_all(&dir).expect("create temp config dir");
+        fs::write(
+            dir.join("config.json"),
+            serde_json::to_string(&json).expect("serialize config json"),
+        )
+        .expect("write config.json");
+        dir
+    }
+
+    /// draft_model_path + an EXPLICIT `use_block_paged_cache: true` is a
+    /// hard load error, surfaced from the config guard BEFORE any weight
+    /// I/O (the temp dir deliberately carries no safetensors).
+    #[test]
+    fn dspark_draft_conflicts_with_explicit_paged_cache() {
+        let dir = write_config_dir(serde_json::json!({
+            "model_type": "gemma4_text",
+            "text_config": { "hidden_size": 64 },
+            "use_block_paged_cache": true
+        }));
+        let err = match Gemma4Inner::load_from_dir(
+            dir.to_str().expect("utf8 temp dir"),
+            Some("/nonexistent/dspark-draft"),
+        ) {
+            Ok(_) => panic!("explicit paged + draft must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.reason.contains("use_block_paged_cache=true"),
+            "error must name the conflicting flag, got: {}",
+            err.reason
+        );
+        assert!(
+            err.reason.contains("draft_model_path"),
+            "error must name the draft option, got: {}",
+            err.reason
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// With `use_block_paged_cache` UNSET, a draft request passes the guard
+    /// (the default is forced to flat) — the load then fails later on the
+    /// missing weights, NOT on the conflict guard.
+    #[test]
+    fn dspark_draft_with_unset_paged_flag_passes_the_guard() {
+        let dir = write_config_dir(serde_json::json!({
+            "model_type": "gemma4_text",
+            "text_config": { "hidden_size": 64 }
+        }));
+        let err = match Gemma4Inner::load_from_dir(
+            dir.to_str().expect("utf8 temp dir"),
+            Some("/nonexistent/dspark-draft"),
+        ) {
+            Ok(_) => panic!("temp dir has no weights; the load must still fail downstream"),
+            Err(e) => e,
+        };
+        assert!(
+            !err.reason.contains("use_block_paged_cache=true"),
+            "unset paged flag must not trip the conflict guard, got: {}",
+            err.reason
         );
         let _ = fs::remove_dir_all(&dir);
     }

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -2205,6 +2205,13 @@ impl Gemma4Inner {
                 weight_bytes = weight_bytes.saturating_add(shard.nbytes() as u64);
             }
         }
+        // The DSpark draft's checkpoint tensors are model-owned resident
+        // weights too (~GBs of bf16 for the 12B draft); fold them in so
+        // the cache-limit coordinator sees the true footprint instead of
+        // silently over-granting cache on draft-loaded sessions.
+        if let Some(draft) = inner.dspark.as_ref() {
+            weight_bytes = weight_bytes.saturating_add(draft.weight_bytes());
+        }
 
         Ok((inner, weight_bytes))
     }
@@ -2467,6 +2474,68 @@ mod tests {
             err.reason
         );
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Loading WITH the draft must report a strictly larger weight-byte
+    /// total to the cache-limit coordinator than loading without — larger
+    /// by EXACTLY the draft checkpoint's tensor bytes (the draft's ~GBs of
+    /// bf16 are model-owned resident weights; omitting them over-grants
+    /// cache on exactly the constrained devices the limit protects).
+    ///
+    /// Run (single-threaded; two sequential full 12B loads):
+    ///
+    /// ```shell
+    /// PATH=/usr/bin:$PATH SDKROOT=$(xcrun --show-sdk-path) \
+    /// MLX_TEST_GEMMA4_MODEL_PATH=... MLX_TEST_GEMMA4_DSPARK_PATH=... \
+    ///     cargo test -p mlx-core --lib --release -- --ignored \
+    ///     --test-threads=1 load_with_draft_registers_strictly_larger_weight_bytes
+    /// ```
+    #[test]
+    #[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH (two full 12B loads)"]
+    fn load_with_draft_registers_strictly_larger_weight_bytes() {
+        let (Ok(model), Ok(draft)) = (
+            std::env::var("MLX_TEST_GEMMA4_MODEL_PATH"),
+            std::env::var("MLX_TEST_GEMMA4_DSPARK_PATH"),
+        ) else {
+            eprintln!("skipping: set MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH");
+            return;
+        };
+        // Two full loads back-to-back: skip the warmup forwards.
+        // SAFETY: env-gated model test, run single-threaded by contract.
+        unsafe { std::env::set_var("GEMMA4_NO_WARMUP", "1") };
+        let plain_bytes = {
+            let (_inner, bytes) =
+                Gemma4Inner::load_from_dir(&model, None).expect("plain 12B load failed");
+            bytes
+        };
+        crate::array::clear_cache();
+        let (inner, with_draft_bytes) =
+            Gemma4Inner::load_from_dir(&model, Some(&draft)).expect("12B + draft load failed");
+        unsafe { std::env::remove_var("GEMMA4_NO_WARMUP") };
+
+        let draft_bytes = inner
+            .dspark
+            .as_ref()
+            .expect("draft must be attached")
+            .weight_bytes();
+        assert!(
+            draft_bytes > (1u64 << 30),
+            "the real 12B draft checkpoint is multi-GB, got {draft_bytes} bytes"
+        );
+        assert!(
+            with_draft_bytes > plain_bytes,
+            "draft load must register strictly more weight bytes \
+             (with={with_draft_bytes} without={plain_bytes})"
+        );
+        assert_eq!(
+            with_draft_bytes,
+            plain_bytes.saturating_add(draft_bytes),
+            "the weight-byte delta must be exactly the draft checkpoint's tensor bytes"
+        );
+        println!(
+            "[draft_weight_bytes] without={plain_bytes} with={with_draft_bytes} \
+             draft={draft_bytes}"
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/transformer/rotating_kv_cache.rs
+++ b/crates/mlx-core/src/transformer/rotating_kv_cache.rs
@@ -472,6 +472,15 @@ impl RotatingKVCache {
             ));
         }
 
+        // Full-range slices, not clones: `temporal_order` returns a CLONE of
+        // the live storage when it is already in temporal order, and a cloned
+        // `MxArray` shares the same underlying handle. The single-token
+        // update path overwrites that handle's descriptor in place, which
+        // would silently rewrite the snapshot. Slicing creates a new array
+        // object that captures the current descriptor by value.
+        let ordered_keys = ordered_keys.slice_axis(2, 0, cached_tokens as i64)?;
+        let ordered_values = ordered_values.slice_axis(2, 0, cached_tokens as i64)?;
+
         Ok(Some(RotatingKVCacheSnapshot {
             keys: ordered_keys,
             values: ordered_values,
@@ -542,8 +551,12 @@ impl RotatingKVCache {
             ));
         }
 
-        self.keys = Some(snapshot.keys.clone());
-        self.values = Some(snapshot.values.clone());
+        // Full-range slices, not clones, so the restored cache does not share
+        // the snapshot's array handles: a later single-token in-place update
+        // on this cache must not rewrite the snapshot (which callers may
+        // restore again, e.g. checkpoint heal paths).
+        self.keys = Some(snapshot.keys.slice_axis(2, 0, cached_tokens as i64)?);
+        self.values = Some(snapshot.values.slice_axis(2, 0, cached_tokens as i64)?);
         self.offset = snapshot.offset;
         self.idx = cached_tokens;
         Ok(())
@@ -859,6 +872,45 @@ mod tests {
         assert_float_data(&stored_after_chunk2, &[10.0, 11.0, 12.0, 13.0]);
         assert_eq!(cache.get_offset(), 13);
         assert_eq!(cache.get_cached_token_count().unwrap(), 4);
+    }
+
+    /// A snapshot must stay intact when the source cache (or a cache
+    /// restored from it) later takes the single-token IN-PLACE update path,
+    /// which overwrites the live array's descriptor instead of rebinding it.
+    #[test]
+    fn test_snapshot_is_immune_to_in_place_updates() {
+        // Single over-window concat leaves storage in temporal order with
+        // idx == max_size, so the next single-token update writes in place.
+        let mut source = RotatingKVCache::new(4, None);
+        let keys = MxArray::from_float32(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[1, 1, 6, 1]).unwrap();
+        let values =
+            MxArray::from_float32(&[10.0, 20.0, 30.0, 40.0, 50.0, 60.0], &[1, 1, 6, 1]).unwrap();
+        source.update_and_fetch(&keys, &values).unwrap();
+
+        let snapshot = source.snapshot().unwrap().unwrap();
+        assert_float_data(&snapshot.keys, &[3.0, 4.0, 5.0, 6.0]);
+
+        // In-place single-token update on the SOURCE must not leak into the
+        // snapshot.
+        let k7 = MxArray::from_float32(&[7.0], &[1, 1, 1, 1]).unwrap();
+        let v7 = MxArray::from_float32(&[70.0], &[1, 1, 1, 1]).unwrap();
+        source.update_and_fetch(&k7, &v7).unwrap();
+        assert_float_data(&snapshot.keys, &[3.0, 4.0, 5.0, 6.0]);
+        assert_float_data(&snapshot.values, &[30.0, 40.0, 50.0, 60.0]);
+
+        // In-place single-token update on a RESTORED cache must not leak
+        // into the snapshot either; a second restore still sees the
+        // original tail.
+        let mut restored = RotatingKVCache::new(4, None);
+        restored.restore_snapshot(&snapshot).unwrap();
+        restored.update_and_fetch(&k7, &v7).unwrap();
+        assert_float_data(&snapshot.keys, &[3.0, 4.0, 5.0, 6.0]);
+
+        let mut restored_again = RotatingKVCache::new(4, None);
+        restored_again.restore_snapshot(&snapshot).unwrap();
+        let (again_keys, again_values) = restored_again.fetch_current_kv().unwrap();
+        assert_float_data(&again_keys, &[3.0, 4.0, 5.0, 6.0]);
+        assert_float_data(&again_values, &[30.0, 40.0, 50.0, 60.0]);
     }
 
     #[test]

--- a/crates/mlx-core/tests/gemma4_dspark.rs
+++ b/crates/mlx-core/tests/gemma4_dspark.rs
@@ -1,0 +1,564 @@
+//! Gated end-to-end tests for Gemma4 DSpark speculative decoding.
+//!
+//! Loads ONE Gemma4 target model per test WITH the DSpark draft attached
+//! (`Gemma4LoadOptions::draft_model_path`); the plain-AR oracle runs on the
+//! SAME instance with `enableMtp: false` (the draft never touches the target
+//! weights or the flat AR path, so this is the exact byte-parity reference —
+//! and only one ~24 GB target is resident at a time).
+//!
+//! PRIMARY ORACLE: speculative decoding must be LOSSLESS at T=0 — the
+//! DSpark turn's text/raw_text/finish_reason must byte-match the AR run.
+//!
+//! # Fixture selection: bf16 near-tie robustness (READ BEFORE EDITING PROMPTS)
+//!
+//! The verify forward evaluates T=1+L rows with the SAME chunked-prefill
+//! kernels the AR prompt prefill uses, but the AR DECODE evaluates each
+//! token with the single-token (T=1) kernels. Per-row bf16 results differ
+//! between the two kernel shapes by ~1 ULP (the effect gemma4's own
+//! `prefill_body_gemma4` doc documents — it is why AR prefill splits the
+//! last prompt token out). At a position whose top-2 softcapped logits are
+//! within ~1-2 bf16 ULP (0.125-0.25 at |logit|≈20), the greedy argmax can
+//! legitimately differ between the shapes: measured directly (stock
+//! forwards only, zero DSpark code), a 200-step AR trajectory on an
+//! open-prose prompt hit exactly one such flip — single-token gap 0.25 (2
+//! ULP), batched row top-2 EXACTLY tied — and depth-1/depth-2/depth-7
+//! DSpark runs all byte-agree with each other while flipping that one
+//! near-tie against AR. The repo already accepts this class as inherent
+//! (`paged_decode_long_context_1ulp`: vLLM never asserts bitwise; the
+//! qwen3.5 MTP heal de-flake: "AR diverges at T=0 near-ties").
+//!
+//! The byte-equal oracle is therefore kept STRICT and the fixtures are
+//! chosen to be tie-free: constrained generations (counting, single-word
+//! answers, recipes) whose greedy top-2 gaps are far above kernel noise.
+//! Every fixture below was screened to be byte-equal AR-vs-DSpark on this
+//! checkpoint; MLX runs are deterministic, so green is stable per
+//! machine + MLX pin. If one of these tests diverges after an MLX bump,
+//! check whether the divergence point is a near-tie (top-2 gap <= ~2 bf16
+//! ULP → re-screen the fixture) before suspecting the DSpark wiring; a
+//! REAL bookkeeping bug (positions, rollback offsets, masks) diverges
+//! grossly and immediately, not at a single near-tied token.
+//!
+//! Env (both required; unset → skip-with-message):
+//!   MLX_TEST_GEMMA4_MODEL_PATH   — bf16 unified 48L Gemma-4-12B-IT checkout
+//!   MLX_TEST_GEMMA4_DSPARK_PATH  — dspark_gemma4_12b_block7 draft checkout
+//!
+//! Run (single-threaded is MANDATORY — concurrent model tests oversubscribe
+//! the GPU and SIGABRT):
+//!
+//! ```shell
+//! PATH=/usr/bin:$PATH SDKROOT=$(xcrun --show-sdk-path) \
+//! MLX_TEST_GEMMA4_MODEL_PATH=/abs/path/to/gemma-4-12b-it \
+//! MLX_TEST_GEMMA4_DSPARK_PATH=/abs/path/to/dspark_gemma4_12b_block7 \
+//!     cargo test -p mlx-core --test gemma4_dspark --release -- \
+//!     --ignored --nocapture --test-threads=1
+//! ```
+
+use std::path::Path;
+
+use mlx_core::engine::types::{ChatConfig, ChatResult};
+use mlx_core::models::gemma4::model::{Gemma4LoadOptions, Gemma4Model};
+use mlx_core::tokenizer::ChatMessage;
+
+const SKIP_MSG: &str = "skipping: set MLX_TEST_GEMMA4_MODEL_PATH (bf16 Gemma-4-12B-IT dir) and \
+     MLX_TEST_GEMMA4_DSPARK_PATH (dspark_gemma4_12b_block7 dir) to run the DSpark e2e suite";
+
+fn env_paths() -> Option<(String, String)> {
+    let (Ok(model), Ok(draft)) = (
+        std::env::var("MLX_TEST_GEMMA4_MODEL_PATH"),
+        std::env::var("MLX_TEST_GEMMA4_DSPARK_PATH"),
+    ) else {
+        eprintln!("{SKIP_MSG}");
+        return None;
+    };
+    assert!(
+        Path::new(&model).exists(),
+        "MLX_TEST_GEMMA4_MODEL_PATH does not exist: {model}"
+    );
+    assert!(
+        Path::new(&draft).exists(),
+        "MLX_TEST_GEMMA4_DSPARK_PATH does not exist: {draft}"
+    );
+    Some((model, draft))
+}
+
+async fn load_dspark_model(model: &str, draft: &str) -> Gemma4Model {
+    let m = Gemma4Model::load(
+        model.to_string(),
+        Some(Gemma4LoadOptions {
+            draft_model_path: Some(draft.to_string()),
+        }),
+    )
+    .await
+    .expect("Gemma4Model::load with draft_model_path failed");
+    assert!(
+        m.has_mtp_weights(),
+        "draft loaded via Gemma4LoadOptions must flip hasMtpWeights()"
+    );
+    assert!(
+        !m.has_block_paged_cache(),
+        "a DSpark load must force the flat KV path (paged adapter off)"
+    );
+    m
+}
+
+fn chat_config(max_new_tokens: i32, enable_mtp: bool) -> ChatConfig {
+    ChatConfig {
+        max_new_tokens: Some(max_new_tokens),
+        temperature: Some(0.0),
+        top_k: None,
+        top_p: None,
+        min_p: None,
+        repetition_penalty: None,
+        repetition_context_size: None,
+        presence_penalty: None,
+        presence_context_size: None,
+        frequency_penalty: None,
+        frequency_context_size: None,
+        max_consecutive_tokens: None,
+        max_ngram_repeats: None,
+        ngram_size: None,
+        tools: None,
+        reasoning_effort: None,
+        thinking_token_budget: None,
+        include_reasoning: Some(false),
+        report_performance: Some(true),
+        reuse_cache: Some(true),
+        enable_mtp: Some(enable_mtp),
+        mtp_depth: None,
+        mtp_adaptive_depth: Some(false),
+    }
+}
+
+fn user_message(content: &str) -> ChatMessage {
+    ChatMessage {
+        role: "user".to_string(),
+        content: content.to_string(),
+        tool_calls: None,
+        tool_call_id: None,
+        is_error: None,
+        reasoning_content: None,
+        images: None,
+        audio: None,
+    }
+}
+
+/// Assert the DSpark run byte-matches the AR reference AND actually ran
+/// DSpark cycles (not a silent AR fallback), then print the headline stats.
+fn assert_matches_ar(label: &str, dspark: &ChatResult, ar: &ChatResult) {
+    assert_eq!(
+        dspark.text, ar.text,
+        "[{label}] DSpark text diverged from AR at T=0"
+    );
+    assert_eq!(
+        dspark.raw_text, ar.raw_text,
+        "[{label}] DSpark raw_text diverged from AR at T=0"
+    );
+    assert_eq!(
+        dspark.finish_reason, ar.finish_reason,
+        "[{label}] DSpark finish_reason diverged from AR"
+    );
+    assert_eq!(
+        dspark.num_tokens, ar.num_tokens,
+        "[{label}] DSpark token count diverged from AR"
+    );
+    let perf = dspark
+        .performance
+        .as_ref()
+        .expect("DSpark performance metrics missing (gemma4 always reports)");
+    let cycles = perf.mtp_cycles.unwrap_or(0);
+    assert!(
+        cycles > 0,
+        "[{label}] expected DSpark cycles to run, got mtp_cycles={cycles:?} (silent AR fallback?)"
+    );
+    assert!(
+        perf.mtp_mean_accepted_tokens_total.is_some(),
+        "[{label}] mtp_mean_accepted_tokens_total must be filled after a DSpark turn"
+    );
+    let ar_perf = ar.performance.as_ref().expect("AR performance missing");
+    println!(
+        "[{label}] tokens={} cycles={} mean_accepted_total={:?} mean_depth={:?} | decode tok/s: dspark={:.1} ar={:.1}",
+        dspark.num_tokens,
+        cycles,
+        perf.mtp_mean_accepted_tokens_total,
+        perf.mtp_mean_depth,
+        perf.decode_tokens_per_second,
+        ar_perf.decode_tokens_per_second,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 1. PRIMARY ORACLE: greedy multi-cycle matches-AR
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH (real 12B + draft)"]
+async fn dspark_greedy_matches_ar_multi_cycle() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_dspark_model(&model_path, &draft_path).await;
+
+    // Tie-screened fixture (see the module doc): a constrained numbered
+    // recipe holds 200 greedy tokens without a near-tie.
+    const PROMPT: &str = "Give a simple recipe for pancakes with numbered steps.";
+
+    let ar = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(200, false)))
+        .await
+        .expect("AR chat_session_start failed");
+    let dspark = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(200, true)))
+        .await
+        .expect("DSpark chat_session_start failed");
+
+    assert_matches_ar("multi_cycle", &dspark, &ar);
+    let perf = dspark.performance.as_ref().expect("perf missing");
+    assert!(
+        perf.mtp_cycles.unwrap_or(0) > 1,
+        "expected multiple DSpark cycles over 200 tokens"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. RotatingKVCache trap: sliding-window wrap during decode AND prefill
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH (real 12B + draft)"]
+async fn dspark_greedy_matches_ar_across_sliding_wrap() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_dspark_model(&model_path, &draft_path).await;
+
+    let paragraph = "The expedition crossed the ridge at dawn, cataloguing mosses, lichens, \
+         glacial striations, and the slow braided rivers below, while the cartographer argued \
+         with the botanist about the correct name for a small blue flower none of them had \
+         seen before. ";
+
+    // (a) Sub-window prompt (~832 tokens) + 600-token budget: the
+    // 1024-token sliding window wraps MID-DECODE, so verify blocks append
+    // to (and partially roll back from) rotated RotatingKVCache state.
+    // The decode tail is a constrained count (tie-free; module doc).
+    let mut mid_prompt = String::new();
+    for _ in 0..15 {
+        mid_prompt.push_str(paragraph);
+    }
+    mid_prompt.push_str(
+        "\n\nIgnore the text above entirely. Count from 1 to 150, one number per line, \
+         digits only, no other words. Start immediately with 1.",
+    );
+    let ar_a = model
+        .chat_session_start(
+            vec![user_message(&mid_prompt)],
+            Some(chat_config(600, false)),
+        )
+        .await
+        .expect("AR (decode wrap) failed");
+    assert!(
+        ar_a.prompt_tokens < 1024,
+        "decode-wrap fixture must START below the sliding window, got {} prompt tokens",
+        ar_a.prompt_tokens
+    );
+    assert!(
+        ar_a.prompt_tokens + ar_a.num_tokens > 1024 + 128,
+        "decode-wrap fixture must decode WELL past the 1024-token sliding window \
+         (prompt {} + generated {})",
+        ar_a.prompt_tokens,
+        ar_a.num_tokens
+    );
+    let dspark_a = model
+        .chat_session_start(
+            vec![user_message(&mid_prompt)],
+            Some(chat_config(600, true)),
+        )
+        .await
+        .expect("DSpark (decode wrap) failed");
+    assert_matches_ar("decode_wrap", &dspark_a, &ar_a);
+
+    // (b) >1100-token prompt + 300-token budget: the window wraps DURING
+    // PREFILL, so the tapped chunked prefill and every verify block run on
+    // already-rotated sliding caches.
+    let mut long_prompt = String::new();
+    for _ in 0..60 {
+        long_prompt.push_str(paragraph);
+    }
+    long_prompt.push_str(
+        "\n\nIgnore the text above entirely. Count from 1 to 100, one number per line, \
+         digits only, no other words.",
+    );
+    let ar_b = model
+        .chat_session_start(
+            vec![user_message(&long_prompt)],
+            Some(chat_config(300, false)),
+        )
+        .await
+        .expect("AR (prefill wrap) failed");
+    assert!(
+        ar_b.prompt_tokens > 1100,
+        "prefill-wrap fixture must exceed the sliding window during prefill, got {} tokens",
+        ar_b.prompt_tokens
+    );
+    let dspark_b = model
+        .chat_session_start(
+            vec![user_message(&long_prompt)],
+            Some(chat_config(300, true)),
+        )
+        .await
+        .expect("DSpark (prefill wrap) failed");
+    assert_matches_ar("prefill_wrap", &dspark_b, &ar_b);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Early EOS stop parity + warm-continue delta turn
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH (real 12B + draft)"]
+async fn dspark_stop_mid_block_then_delta_turn() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_dspark_model(&model_path, &draft_path).await;
+
+    // A prompt that stops WELL before the budget, so the EOS lands inside a
+    // speculative block (either as an accepted draft or as the boundary).
+    const PROMPT: &str = "What is the capital of France? Answer with just the city name.";
+    const FOLLOW_UP: &str = "And of Italy? Same format.";
+
+    // AR baseline: turn 1 (fresh) + turn 2 (warm continue on the session).
+    let ar1 = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(64, false)))
+        .await
+        .expect("AR turn 1 failed");
+    assert_eq!(
+        ar1.finish_reason, "stop",
+        "fixture must stop early on EOS, got {:?} ({} tokens)",
+        ar1.finish_reason, ar1.num_tokens
+    );
+    let ar2 = model
+        .chat_session_continue(
+            FOLLOW_UP.to_string(),
+            None,
+            None,
+            Some(chat_config(64, false)),
+        )
+        .await
+        .expect("AR turn 2 (continue) failed");
+
+    // DSpark: same 2-turn shape on the same instance (the fresh start's
+    // prefix verification resets the AR session's caches).
+    let sp1 = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(64, true)))
+        .await
+        .expect("DSpark turn 1 failed");
+    assert_matches_ar("stop_turn1", &sp1, &ar1);
+
+    let sp2 = model
+        .chat_session_continue(
+            FOLLOW_UP.to_string(),
+            None,
+            None,
+            Some(chat_config(64, true)),
+        )
+        .await
+        .expect("DSpark turn 2 (continue) failed");
+    let perf2 = sp2.performance.as_ref().expect("turn 2 perf missing");
+    assert!(
+        perf2.mtp_cycles.unwrap_or(0) > 0,
+        "the warm-continue turn must also run DSpark cycles"
+    );
+    assert!(
+        sp2.cached_tokens > 0,
+        "turn 2 must warm-continue on the saved session (cached_tokens > 0), got {}",
+        sp2.cached_tokens
+    );
+
+    // 2-turn transcript parity vs the AR baseline.
+    let ar_transcript = format!("{}\n---\n{}", ar1.text, ar2.text);
+    let sp_transcript = format!("{}\n---\n{}", sp1.text, sp2.text);
+    assert_eq!(
+        sp_transcript, ar_transcript,
+        "2-turn DSpark transcript diverged from the AR 2-turn baseline \
+         (turn2 finish: dspark={:?} ar={:?})",
+        sp2.finish_reason, ar2.finish_reason
+    );
+    assert_eq!(
+        sp2.raw_text, ar2.raw_text,
+        "warm-continue turn raw_text diverged from AR"
+    );
+    assert_eq!(sp2.finish_reason, ar2.finish_reason);
+    println!(
+        "[stop_then_delta] turn1={:?} ({} tok) turn2={:?} ({} tok, cached={})",
+        sp1.finish_reason, sp1.num_tokens, sp2.finish_reason, sp2.num_tokens, sp2.cached_tokens
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Draft-fidelity oracle: acceptance sanity
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH (real 12B + draft)"]
+async fn dspark_acceptance_sanity() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_dspark_model(&model_path, &draft_path).await;
+
+    // Natural prose: the regime the draft was distilled on. matches-AR
+    // cannot catch draft bugs (verification re-derives ground truth from
+    // the target), they only DEPRESS acceptance — so gate on the headline
+    // accept rate instead.
+    const PROMPT: &str = "Explain in two paragraphs why the sky is blue during the day and \
+         reddish at sunset.";
+    let dspark = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(200, true)))
+        .await
+        .expect("DSpark chat_session_start failed");
+    let perf = dspark.performance.as_ref().expect("perf missing");
+    let total = perf
+        .mtp_mean_accepted_tokens_total
+        .expect("mtp_mean_accepted_tokens_total missing after a DSpark run");
+    println!(
+        "[acceptance_sanity] mean_accepted_tokens_total={:.3} cycles={:?} mean_depth={:?} \
+         decode_tok_s={:.1} ttft_ms={:.1}",
+        total, perf.mtp_cycles, perf.mtp_mean_depth, perf.decode_tokens_per_second, perf.ttft_ms,
+    );
+    assert!(
+        total >= 2.0,
+        "draft-fidelity floor: expected mean accepted tokens/cycle >= 2.0 on natural prose, \
+         got {total:.3} (a broken draft/context wiring depresses acceptance without breaking \
+         matches-AR)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Sampled-temperature smoke
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH (real 12B + draft)"]
+async fn dspark_sampled_smoke() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_dspark_model(&model_path, &draft_path).await;
+
+    let mut cfg = chat_config(128, true);
+    cfg.temperature = Some(0.7);
+    let dspark = model
+        .chat_session_start(
+            vec![user_message(
+                "Describe an imaginary small coastal town in a few sentences.",
+            )],
+            Some(cfg),
+        )
+        .await
+        .expect("sampled DSpark chat_session_start failed");
+
+    assert!(dspark.num_tokens > 0, "sampled run must emit tokens");
+    assert!(
+        !dspark.text.trim().is_empty(),
+        "sampled run must produce text"
+    );
+    assert!(
+        dspark.finish_reason == "stop" || dspark.finish_reason == "length",
+        "unexpected finish_reason {:?}",
+        dspark.finish_reason
+    );
+    let perf = dspark.performance.as_ref().expect("perf missing");
+    let cycles = perf.mtp_cycles.unwrap_or(0);
+    assert!(cycles > 0, "sampled run must still take the DSpark path");
+    let total = perf
+        .mtp_mean_accepted_tokens_total
+        .expect("acceptance stats missing");
+    assert!(
+        (1.0..=8.0).contains(&total),
+        "mean accepted tokens/cycle {total:.3} out of the sane [1, 1+block_size] range"
+    );
+    println!(
+        "[sampled_smoke] T=0.7 tokens={} finish={:?} cycles={} mean_accepted_total={:.3}",
+        dspark.num_tokens, dspark.finish_reason, cycles, total
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Streaming == sync
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_DSPARK_PATH (real 12B + draft)"]
+async fn dspark_stream_matches_send() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_dspark_model(&model_path, &draft_path).await;
+
+    const PROMPT: &str = "List four common uses of a paperclip, one short sentence each.";
+
+    let sync = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(160, true)))
+        .await
+        .expect("sync DSpark chat_session_start failed");
+
+    let (_handle, mut rx) = model
+        .chat_stream_session_start_for_test(
+            vec![user_message(PROMPT)],
+            Some(chat_config(160, true)),
+        )
+        .expect("stream dispatch failed");
+
+    let mut visible = String::new();
+    let mut done_chunk = None;
+    while let Some(result) = rx.recv().await {
+        let chunk = result.expect("stream chunk error");
+        if chunk.done {
+            done_chunk = Some(chunk);
+            break;
+        }
+        if chunk.is_reasoning != Some(true) {
+            visible.push_str(&chunk.text);
+        }
+    }
+    let done = done_chunk.expect("stream ended without a terminal done-chunk");
+
+    // The strongest stream-vs-sync oracle: the terminal chunk's raw_text is
+    // the full undecoded generation — byte-equality pins that the streaming
+    // turn committed the exact same token sequence as the sync turn.
+    assert_eq!(
+        done.raw_text.as_deref(),
+        Some(sync.raw_text.as_str()),
+        "streaming DSpark turn generated a different token stream than the sync turn"
+    );
+    // Chunk-routing parity, modulo the parser's TRAILING trim: on a
+    // channel-only output the sync result promotes `parser.thinking()`
+    // (which `.trim()`s — `output_parser.rs`) into `.text`, while the
+    // streaming promotion emits the buffered reasoning untrimmed — a
+    // PRE-EXISTING gemma4 emitter/parser semantic shared with the plain AR
+    // path (verified: an AR stream-vs-sync run of this same prompt shows
+    // the identical trailing-whitespace delta with byte-equal raw_text).
+    assert_eq!(
+        visible.trim_end(),
+        sync.text.trim_end(),
+        "concatenated streaming chunks diverged from the sync DSpark text"
+    );
+    assert_eq!(
+        done.finish_reason.as_deref(),
+        Some(sync.finish_reason.as_str()),
+        "terminal chunk finish_reason mismatch"
+    );
+    assert_eq!(done.num_tokens, Some(sync.num_tokens));
+    let perf = done
+        .performance
+        .as_ref()
+        .expect("terminal chunk must carry performance");
+    assert!(
+        perf.mtp_cycles.unwrap_or(0) > 0,
+        "the streaming turn must run DSpark cycles"
+    );
+    println!(
+        "[stream_matches_send] tokens={:?} finish={:?} cycles={:?}",
+        done.num_tokens, done.finish_reason, perf.mtp_cycles
+    );
+}

--- a/crates/mlx-core/tests/gemma4_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/gemma4_paged_vs_flat_parity.rs
@@ -198,10 +198,10 @@ async fn gemma4_paged_vs_flat_greedy_token_parity() {
         Err(e) => panic!("failed to clone model dir for paged path: {e}"),
     };
 
-    let flat_model = Gemma4Model::load_from_dir(&flat_dir.to_string_lossy())
+    let flat_model = Gemma4Model::load_from_dir(&flat_dir.to_string_lossy(), None)
         .await
         .expect("failed to load flat-path Gemma4 model");
-    let paged_model = Gemma4Model::load_from_dir(&paged_dir.to_string_lossy())
+    let paged_model = Gemma4Model::load_from_dir(&paged_dir.to_string_lossy(), None)
         .await
         .expect("failed to load paged-path Gemma4 model");
 
@@ -277,10 +277,10 @@ async fn gemma4_paged_vs_flat_prefix_reuse_parity() {
         Err(e) => panic!("failed to clone model dir for paged path: {e}"),
     };
 
-    let flat_model = Gemma4Model::load_from_dir(&flat_dir.to_string_lossy())
+    let flat_model = Gemma4Model::load_from_dir(&flat_dir.to_string_lossy(), None)
         .await
         .expect("failed to load flat-path Gemma4 model");
-    let paged_model = Gemma4Model::load_from_dir(&paged_dir.to_string_lossy())
+    let paged_model = Gemma4Model::load_from_dir(&paged_dir.to_string_lossy(), None)
         .await
         .expect("failed to load paged-path Gemma4 model");
 

--- a/crates/mlx-core/tests/gemma4_paged_vs_flat_vlm_parity.rs
+++ b/crates/mlx-core/tests/gemma4_paged_vs_flat_vlm_parity.rs
@@ -193,7 +193,7 @@ async fn gemma4_paged_vlm_correctness() {
     let paged_dir =
         clone_model_dir(&src, "gemma4-vlm-paged", true).expect("clone paged model dir failed");
 
-    let paged_model = Gemma4Model::load(paged_dir.to_string_lossy().to_string())
+    let paged_model = Gemma4Model::load(paged_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load paged-path Gemma-4-VL model");
 
@@ -285,7 +285,7 @@ async fn gemma4_paged_vlm_continue_is_rejected() {
 
     let paged_dir = clone_model_dir(&src, "gemma4-vlm-paged-continue", true)
         .expect("clone paged model dir failed");
-    let paged_model = Gemma4Model::load(paged_dir.to_string_lossy().to_string())
+    let paged_model = Gemma4Model::load(paged_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load paged-path Gemma-4-VL model");
 
@@ -353,7 +353,7 @@ async fn gemma4_image_turn_without_paged_adapter_errors() {
     // paged adapter (the only configuration where the vision path is absent).
     let flat_dir = clone_model_dir(&src, "gemma4-vlm-no-paged", false)
         .expect("clone no-paged model dir failed");
-    let flat_model = Gemma4Model::load(flat_dir.to_string_lossy().to_string())
+    let flat_model = Gemma4Model::load(flat_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load no-paged Gemma-4-VL model");
 

--- a/crates/mlx-core/tests/gemma4_session.rs
+++ b/crates/mlx-core/tests/gemma4_session.rs
@@ -78,7 +78,7 @@ async fn gemma4_session_start_prefix_reuse_append_hit() {
         model_path
     );
 
-    let model = Gemma4Model::load(model_path.clone())
+    let model = Gemma4Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Gemma4 model");
 
@@ -179,7 +179,7 @@ async fn gemma4_session_start_prefix_reuse_divergence_miss() {
         model_path
     );
 
-    let model = Gemma4Model::load(model_path.clone())
+    let model = Gemma4Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Gemma4 model");
 
@@ -242,7 +242,7 @@ async fn gemma4_session_reset_purges_prefix_cache_cold_prefill() {
         model_path
     );
 
-    let model = Gemma4Model::load(model_path.clone())
+    let model = Gemma4Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Gemma4 model");
 

--- a/crates/mlx-core/tests/gemma4_vl_image_chat.rs
+++ b/crates/mlx-core/tests/gemma4_vl_image_chat.rs
@@ -151,7 +151,7 @@ async fn gemma4_vl_image_chat_t0_capture() {
     };
     let image = std::fs::read(&image_path).expect("failed to read test image");
 
-    let model = Gemma4Model::load(model_path.clone())
+    let model = Gemma4Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Gemma-4-VL model");
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -9,7 +9,7 @@ All language wrappers share a uniform `ChatSession<M>` surface (`send` / `sendSt
 | **Qwen3**         |     yes      |     yes     | GRPO + SFT | Speculative decoding; paged attention                            |
 | **Qwen3.5 Dense** |     yes      |     yes     | GRPO + SFT | Compiled C++ forward (see [ffi-cpp.md](ffi-cpp.md)); VLM variant |
 | **Qwen3.5 MoE**   |     yes      |     yes     | GRPO + SFT | Compiled C++ forward with expert routing; VLM variant            |
-| **Gemma4**        |     yes      |     yes     |     —      | Hybrid sliding/global attention + MoE/PLE                        |
+| **Gemma4**        |     yes      |     yes     |     —      | Hybrid sliding/global attention + MoE/PLE; DSpark spec. decoding |
 | **LFM2.5**        |     yes      |     yes     |     —      | Hybrid conv + attention                                          |
 
 `Qwen3Model | Qwen35Model | Qwen35MoeModel` is the public `TrainableModel` union in `@mlx-node/lm` — Gemma4 and LFM2.5 are inference-only.
@@ -73,6 +73,28 @@ for await (const event of session.sendStream('Hello!')) {
 ```
 
 The streaming bridge is implemented in `packages/lm/src/stream.ts`: native callback-based methods are captured at module load and re-exposed as `AsyncGenerator` via `_runChatStream`.
+
+## Speculative decoding: Gemma4 + DSpark
+
+Gemma4 supports DSpark speculative decoding: an external draft model proposes a block of tokens per cycle and the target model verifies the whole block in one forward, committing the accepted prefix. Pass `draftModelPath` (a DSpark draft checkpoint directory, e.g. `deepseek-ai/dspark_gemma4_12b_block7`) when loading:
+
+```typescript
+import { loadSession } from '@mlx-node/lm';
+
+const session = await loadSession('./models/gemma-4-12b-it', {
+  draftModelPath: './models/dspark_gemma4_12b_block7',
+});
+// The attached draft flips hasMtpWeights(), so ChatSession auto-enables the
+// speculative path; pass `enableMtp: false` per call to opt out.
+const result = await session.send('Give a simple recipe for pancakes.', { config: { temperature: 0 } });
+console.log(result.performance?.mtpCycles, result.performance?.mtpMeanAcceptedTokensTotal);
+```
+
+- **Lossless at T=0** — every committed token is verified by the target model, so greedy output matches the plain autoregressive run (up to inherent bf16 near-ties; see the oracle suite in `crates/mlx-core/tests/gemma4_dspark.rs`).
+- **Stats** — `ChatResult.performance` reports `mtpCycles` (draft+verify cycles executed) and `mtpMeanAcceptedTokensTotal` (mean committed tokens per cycle, including the always-verified token).
+- **Knobs** — an unset `mtpDepth` runs full draft blocks (7 tokens on the v1 draft); an explicit `mtpDepth` caps the block. `mtpAdaptiveDepth` is ignored.
+- **Memory** — the draft loads alongside the target (~6.9 GB extra for the bf16 12B draft). DSpark runs on the flat KV-cache path; a target config that explicitly enables `use_block_paged_cache` is rejected at load.
+- `draftModelPath` is gemma4-only: `loadModel` / `loadSession` reject it for every other family.
 
 ## Server-side sessions
 

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -174,7 +174,9 @@ export declare class Gemma4Model {
    * Note: this only reports draft availability. Whether speculative
    * decoding actually runs on a given call also requires the per-request
    * `enableMtp` flag. Named `hasMtpWeights` for parity with the Qwen3.5
-   * surface. Stubs from `new(config)` always return `false`.
+   * surface, but it reports an external DSpark draft model, not
+   * in-checkpoint MTP heads. Stubs from `new(config)` always return
+   * `false`.
    */
   hasMtpWeights(): boolean;
   /** Load a Gemma4 model from a directory. */
@@ -742,9 +744,20 @@ export declare class MxArray {
   divScalar(value: number): MxArray;
   matmul(other: MxArray): MxArray;
   /**
-   * Fused matrix multiply-add: D = beta * C + alpha * (self @ B)
-   * where self is A. More efficient than separate matmul and add operations.
-   * Default: alpha=1.0, beta=1.0, giving D = C + (self @ B)
+   * Matrix multiply-add: D = beta * C + alpha * (self @ B), where self is A.
+   * Default: alpha=1.0, beta=1.0, giving D = C + (self @ B).
+   *
+   * Computed explicitly (matmul, optional alpha scale, then add beta*C)
+   * rather than via the fused `mlx::core::addmm` primitive. The fused
+   * primitive is correct on a well-formed metallib, but this project's local
+   * release build is known to non-deterministically miscompile fused GEMM
+   * kernels (see the metallib-corruption notes), which manifested as the
+   * fused addmm dropping `beta*C` and corrupting every biased linear — most
+   * visibly the vision tower (`qkv`, `proj`, `fc1`, `fc2`, merger all carry a
+   * bias; bias-free LM/MoE linears pass a zero `C` and were unaffected). The
+   * explicit form keeps the `C` term robust to that build hazard; the
+   * `nn::linear` unit tests assert it applies a non-zero `C`, so they double
+   * as a canary if a future build corrupts the matmul kernel too.
    */
   addmm(c: MxArray, b: MxArray, alpha?: number | undefined | null, beta?: number | undefined | null): MxArray;
   abs(): MxArray;
@@ -2338,8 +2351,9 @@ export interface ChatConfig {
   reuseCache?: boolean | undefined;
   /**
    * MTP: opt-in flag enabling the Multi-Token Prediction speculative decode
-   * loop on the dense compiled path. Requires the model checkpoint to carry
-   * an MTP head (otherwise silently ignored). Default: `false`.
+   * loop (pure-Rust eager; qwen3.5 dense and MoE). Requires the model
+   * checkpoint to carry an MTP head (otherwise silently ignored). Default:
+   * `false`.
    */
   enableMtp?: boolean | undefined;
   /**
@@ -2535,7 +2549,7 @@ export interface ConversionOptions {
   quantGroupSize?: number;
   /**
    * Quantization mode: "affine" (default), "mxfp4", "mxfp8", "nvfp4", or
-   * "sym8" (per-output-channel symmetric int8; dense qwen3_5 + lfm2/lfm2_moe + gemma4 in v1,
+   * "sym8" (per-output-channel symmetric int8; qwen3_5 + qwen3_5_moe + lfm2/lfm2_moe + gemma4,
    * implies bits=8, no group_size — consciously NOT mlx-lm-loadable)
    */
   quantMode?: string;
@@ -2645,11 +2659,11 @@ export declare function createRandomQwen35Checkpoint(config: Qwen35Config, saveP
 /**
  * Create a random-init Qwen3.5 MoE model and save it to disk.
  *
- * Spawns a dedicated `ModelThread<Qwen35MoeCmd>` whose init builds a fresh
- * random-weight `Qwen35MoeInner` directly, then dispatches
- * `Qwen35MoeCmd::SaveModel` on that thread. The thread is dropped at the end
- * of the promise, so the in-memory model is released once the checkpoint has
- * been written. Used by TypeScript test fixtures that need an on-disk
+ * Spawns a dedicated model thread whose init runs
+ * [`create_random_qwen35_moe_checkpoint_sync`] (random-init inner + save);
+ * the thread holds no state and is dropped once the promise resolves, so
+ * the in-memory model is released as soon as the checkpoint has been
+ * written. Used by TypeScript test fixtures that need an on-disk
  * checkpoint without keeping a NAPI model instance alive.
  */
 export declare function createRandomQwen35MoeCheckpoint(config: Qwen35MoeConfig, savePath: string): Promise<undefined>;
@@ -2929,7 +2943,7 @@ export interface Gemma4Config {
   useBlockPagedCache?: boolean | undefined;
 }
 
-/** Optional load-time settings for `Gemma4Model.load`. */
+/** Optional load-time settings for [`Gemma4Model::load`]. */
 export interface Gemma4LoadOptions {
   /**
    * Directory of a DSpark draft checkpoint (config.json +
@@ -2939,7 +2953,7 @@ export interface Gemma4LoadOptions {
    * `use_block_paged_cache` is a hard load error, and an unset
    * `use_block_paged_cache` is forced to `false`.
    */
-  draftModelPath?: string | undefined;
+  draftModelPath?: string;
 }
 
 /**

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -166,8 +166,19 @@ export declare class Gemma4Model {
    */
   hasBlockPagedCache(): boolean;
   modelId(): number;
+  /**
+   * Whether a DSpark draft model is loaded on this instance (via
+   * `Gemma4LoadOptions::draft_model_path`), enabling the speculative-
+   * decode whole-turn path.
+   *
+   * Note: this only reports draft availability. Whether speculative
+   * decoding actually runs on a given call also requires the per-request
+   * `enableMtp` flag. Named `hasMtpWeights` for parity with the Qwen3.5
+   * surface. Stubs from `new(config)` always return `false`.
+   */
+  hasMtpWeights(): boolean;
   /** Load a Gemma4 model from a directory. */
-  static load(modelPath: string): Promise<Gemma4Model>;
+  static load(modelPath: string, options?: Gemma4LoadOptions | undefined | null): Promise<Gemma4Model>;
   /**
    * Reset all caches and clear cached token history. Exposed
    * so tests and session-management code can start from a
@@ -2916,6 +2927,19 @@ export interface Gemma4Config {
    * real Gemma-4-E2B weights.
    */
   useBlockPagedCache?: boolean | undefined;
+}
+
+/** Optional load-time settings for `Gemma4Model.load`. */
+export interface Gemma4LoadOptions {
+  /**
+   * Directory of a DSpark draft checkpoint (config.json +
+   * model.safetensors) to load alongside the target model for
+   * speculative decoding. DSpark runs only on the flat KV-cache path:
+   * setting this while the model config explicitly enables
+   * `use_block_paged_cache` is a hard load error, and an unset
+   * `use_block_paged_cache` is forced to `false`.
+   */
+  draftModelPath?: string | undefined;
 }
 
 /**

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -300,10 +300,12 @@ export interface SessionCapableModel {
    */
   hasBlockPagedCache?(): boolean;
   /**
-   * MTP: whether the underlying native model checkpoint shipped
-   * an MTP (Multi-Token-Prediction) head loaded by persistence.
-   * Currently surfaced by `Qwen3_5Model` and
-   * `Qwen3_5MoeModel`; all other native wrappers omit the method, in
+   * MTP: whether the underlying native model can run speculative
+   * decoding. Surfaced by `Qwen3_5Model` / `Qwen3_5MoeModel` (an MTP
+   * head shipped in the checkpoint and loaded by persistence) and by
+   * `Gemma4Model` (an external DSpark draft model attached via
+   * `loadModel` / `loadSession` `draftModelPath` — NOT in-checkpoint
+   * MTP heads); all other native wrappers omit the method, in
    * which case callers treat a missing getter as `false` (no MTP).
    *
    * When `true`, {@link ChatSession#mergeConfig} auto-defaults the
@@ -353,6 +355,13 @@ export interface SessionCapableModel {
    * flag inventory), so omitting them from `defaultConfig` /
    * `SendOptions.config` is the recommended path for callers that
    * just want speculative decoding "on with sensible defaults".
+   *
+   * Gemma4 + DSpark reinterprets the knobs: an unset `mtpDepth` runs
+   * full draft blocks (the draft checkpoint's block size — 7 tokens on
+   * `dspark_gemma4_12b_block7`), and an explicit `mtpDepth` acts as a
+   * CAP on that block (clamped to `[1, blockSize]`, not `[1, 5]`).
+   * `mtpAdaptiveDepth` is ignored — the DSpark loop has no adaptive
+   * depth policy.
    */
   hasMtpWeights?(): boolean;
 }
@@ -1290,7 +1299,9 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
    * `hasMtpWeights()` returning `true`, set `enableMtp = true` so the
    * speculative-decode path runs out of the box on MTP-capable
    * checkpoints. An explicit `false` from either source wins (the
-   * undefined-check below preserves it).
+   * undefined-check below preserves it). This duck-typed check also
+   * covers Gemma4 with a DSpark draft attached (`hasMtpWeights()`
+   * reports the external draft there, not in-checkpoint MTP heads).
    */
   private mergeConfig(overlay: ChatConfig | undefined): ChatConfig {
     const merged: ChatConfig = {

--- a/packages/lm/src/index.ts
+++ b/packages/lm/src/index.ts
@@ -87,7 +87,13 @@ export {
 } from './models/qwen3-configs.js';
 
 // Model loading
-export { loadModel, loadSession, detectModelType, type ModelType } from './models/model-loader.js';
+export {
+  loadModel,
+  loadSession,
+  detectModelType,
+  type ModelType,
+  type LoadModelOptions,
+} from './models/model-loader.js';
 
 // Interfaces
 export type { TrainableModel, LoadableModel } from './interfaces.js';

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -34,7 +34,11 @@ const MODEL_REGISTRY = {
   qwen3: { load: (p: string) => Qwen3Model.load(p), kind: 'trainable' },
   qwen3_5: { load: (p: string) => Qwen35Model.load(p), kind: 'trainable' },
   qwen3_5_moe: { load: (p: string) => Qwen35MoeModel.load(p), kind: 'trainable' },
-  gemma4: { load: (p: string) => Gemma4Model.load(p), kind: 'loadable' },
+  gemma4: {
+    load: (p: string, o?: LoadModelOptions) =>
+      Gemma4Model.load(p, o?.draftModelPath === undefined ? null : { draftModelPath: o.draftModelPath }),
+    kind: 'loadable',
+  },
   lfm2: { load: (p: string) => Lfm2Model.load(p), kind: 'loadable' },
   lfm2_moe: { load: (p: string) => Lfm2Model.load(p), kind: 'loadable' },
   harrier: { load: (p: string) => HarrierModel.load(p), kind: 'embedding' },
@@ -46,15 +50,53 @@ export type ModelType = keyof typeof MODEL_REGISTRY;
 
 const SUPPORTED_MODEL_TYPES = new Set<ModelType>(Object.keys(MODEL_REGISTRY) as ModelType[]);
 
+/** Optional settings for {@link loadModel} / {@link loadSession}. */
+export interface LoadModelOptions {
+  /**
+   * Gemma4 only: directory of a DSpark draft checkpoint (config.json +
+   * model.safetensors) loaded alongside the target model for speculative
+   * decoding (forwarded as `Gemma4LoadOptions.draftModelPath`). DSpark runs
+   * on the flat KV-cache path, so the target checkpoint must not explicitly
+   * enable `use_block_paged_cache`. Setting this for any other model family
+   * is a hard error — no other loader accepts a draft model.
+   */
+  draftModelPath?: string;
+}
+
+/**
+ * Dispatch a load through the registry, validating gemma4-only options.
+ * `draftModelPath` reaches ONLY the gemma4 row; every other family rejects
+ * it loudly instead of silently ignoring a caller's speculative-decode
+ * intent.
+ */
+function dispatchLoad(
+  modelType: ModelType,
+  modelPath: string,
+  options: LoadModelOptions | undefined,
+): Promise<unknown> {
+  if (options?.draftModelPath !== undefined && modelType !== 'gemma4') {
+    throw new Error(
+      `draftModelPath (DSpark speculative decoding) is only supported by gemma4 models; ` +
+        `${modelPath} has model_type "${modelType}"`,
+    );
+  }
+  return modelType === 'gemma4'
+    ? MODEL_REGISTRY.gemma4.load(modelPath, options)
+    : MODEL_REGISTRY[modelType].load(modelPath);
+}
+
 /**
  * Load a model from disk, auto-detecting architecture from config.json.
  *
  * Supports both language models (Qwen3, Qwen3.5) and vision-language models
  * (Qianfan-OCR / InternVL). Use `instanceof` to narrow the returned type.
+ *
+ * `options.draftModelPath` attaches a DSpark draft checkpoint for
+ * speculative decoding — gemma4 only; any other detected family rejects it.
  */
-export async function loadModel(modelPath: string): Promise<LoadableModel> {
+export async function loadModel(modelPath: string, options?: LoadModelOptions): Promise<LoadableModel> {
   const modelType = await detectModelType(modelPath);
-  return MODEL_REGISTRY[modelType].load(modelPath) as unknown as Promise<LoadableModel>;
+  return dispatchLoad(modelType, modelPath, options) as Promise<LoadableModel>;
 }
 
 /**
@@ -72,8 +114,16 @@ export async function loadModel(modelPath: string): Promise<LoadableModel> {
  *     package dependency), so callers who want a Qianfan-OCR session
  *     must import `QianfanOCRModel` from `@mlx-node/vlm` and construct
  *     `new ChatSession(model)` directly.
+ *
+ * `options.draftModelPath` attaches a DSpark draft checkpoint for
+ * speculative decoding — gemma4 only; any other detected family rejects it.
+ * The resulting session auto-enables the speculative path (the model
+ * reports `hasMtpWeights()`); pass `enableMtp: false` per call to opt out.
  */
-export async function loadSession(modelPath: string): Promise<ChatSession<SessionCapableModel>> {
+export async function loadSession(
+  modelPath: string,
+  options?: LoadModelOptions,
+): Promise<ChatSession<SessionCapableModel>> {
   const modelType = await detectModelType(modelPath);
   const kind = MODEL_REGISTRY[modelType].kind;
   if (kind === 'embedding') {
@@ -84,7 +134,7 @@ export async function loadSession(modelPath: string): Promise<ChatSession<Sessio
       'loadSession: Qianfan-OCR / InternVL session support lives in @mlx-node/vlm. Import QianfanOCRModel from @mlx-node/vlm and construct ChatSession(model) directly.',
     );
   }
-  const m = await MODEL_REGISTRY[modelType].load(modelPath);
+  const m = await dispatchLoad(modelType, modelPath, options);
   return new ChatSession(m as unknown as SessionCapableModel);
 }
 

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -418,9 +418,12 @@ export function makeStreamingModel<C extends NativeStreamingCtor, const O extend
   //
   // `ConstructorParameters<C>` (not `never[]`) keeps each native config
   // constructor — e.g. `new Gemma4Model(config)` / `new QianfanOCRModel(config)`
-  // — visible on the generated wrapper for TypeScript consumers.
+  // — visible on the generated wrapper for TypeScript consumers. Likewise,
+  // `Parameters<C['load']>` keeps each family's native load signature —
+  // `[modelPath]` for most, `[modelPath, options?]` for Gemma4
+  // (`Gemma4LoadOptions.draftModelPath` / DSpark).
   new (...args: ConstructorParameters<C>): StreamingInstance<C, O>;
-  load(modelPath: string): Promise<StreamingInstance<C, O>>;
+  load(...args: Parameters<C['load']>): Promise<StreamingInstance<C, O>>;
 } {
   const recordPath = opts.recordModelPath;
   const applyTemplate = opts.applyTemplate ?? recordPath;
@@ -437,8 +440,13 @@ export function makeStreamingModel<C extends NativeStreamingCtor, const O extend
   const Base = NativeClass as unknown as new (...args: never[]) => SessionCapableModel;
 
   class StreamingModelImpl extends Base {
-    static async load(modelPath: string): Promise<StreamingModel> {
-      const instance = await NativeClass.load(modelPath);
+    static async load(modelPath: string, ...rest: unknown[]): Promise<StreamingModel> {
+      // Forward any trailing family-specific load options verbatim (e.g.
+      // Gemma4's `Gemma4LoadOptions` with `draftModelPath`); families whose
+      // native `load` takes only the path receive no extras. The public
+      // signature is re-narrowed per family via `Parameters<C['load']>` in
+      // the factory return type below.
+      const instance = await (NativeClass.load as (...args: unknown[]) => Promise<object>)(modelPath, ...rest);
       // Use `this.prototype` (not `StreamingModelImpl.prototype`) so the
       // concrete subclass declared per family supplies the prototype and
       // `instanceof ConcreteSubclass` holds.
@@ -524,7 +532,7 @@ export function makeStreamingModel<C extends NativeStreamingCtor, const O extend
 
   return StreamingModelImpl as unknown as {
     new (...args: ConstructorParameters<C>): StreamingInstance<C, O>;
-    load(modelPath: string): Promise<StreamingInstance<C, O>>;
+    load(...args: Parameters<C['load']>): Promise<StreamingInstance<C, O>>;
   };
 }
 


### PR DESCRIPTION
## Summary

Adds **DSpark speculative decoding** for Gemma 4, using DeepSeek's [DeepSpec](https://github.com/deepseek-ai/DeepSpec) released draft checkpoint `deepseek-ai/dspark_gemma4_12b_block7` (external 5-layer draft transformer for `google/gemma-4-12B-it`).

```
ChatSession (enableMtp auto-on when draft loaded)
  └─ gemma4 dspark_chat_turn
       ├─ chunked prefill w/ hidden taps @ layers [5,17,29,41,46]
       └─ engine run_dspark_turn (per cycle)
            ├─ draft: [anchor, MASK×6] → one non-causal forward
            │         + sequential markov head + confidence truncation
            ├─ verify: ONE target forward over 1+L tokens (w/ taps)
            ├─ accept: greedy argmax / Leviathan rejection sampling
            └─ commit: global KV trim + sliding snapshot/re-append
                       (explicit KV-shared-slot mask, validated every commit)
```

## Usage

```ts
const session = await loadSession('.cache/models/gemma-4-12b-it', {
  draftModelPath: '.cache/models/dspark_gemma4_12b_block7',
});
const res = await session.send('...');   // enableMtp auto-enabled
res.performance.mtpCycles / mtpMeanAcceptedTokensTotal  // acceptance stats
```

## Correctness

Speculative decoding is **lossless at T=0**: the E2E oracle asserts greedy byte-equality vs plain AR — including generation crossing the sliding-window (1024) wrap, wrap during prefill, stop shapes (EOS as boundary AND as accepted draft), warm-continue delta turns, and streaming==sync.

- Rust `#[ignore]` suite: **6/6 black-box + white-box regressions green** on the real 12B + draft (`--release --test-threads=1`)
- TS gated e2e green; full `cargo test -p mlx-core` (2000+), `vp test` (1415), clippy `-D warnings`, fmt, typecheck all clean

## Performance (M5 Max, bf16 12B target)

Mean accepted 2.86–6.05 tokens/cycle depending on content; decode up to **2.46× AR** (46.8 vs 19.0 tok/s).

## Notable internals

- `RotatingKVCache::snapshot` had a latent aliasing bug (snapshot shared storage with in-place single-token writes) — fixed and hardened for all existing users
- Sliding-window rollback: snapshot-before-verify + restore + re-append of the verify block tail — exact pre- and post-wrap (mlx-lm's trim-based approach silently breaks post-wrap)
- Draft geometry pinned at load (5L/16H/512/rope/block-7, bf16-only, mask-token bounds); draft weights materialized at load (cold-mmap watchdog class); draft's 6.9GB counted in cache-limit accounting
- Cancel/stream residual semantics deliberately match the documented AR/MTP contract (`engine/decode.rs`), pinned by tests
- Memory: +6.9 GB bf16 draft; docs note the requirement. `mtpDepth` caps the block (≤7); `mtpAdaptiveDepth` is ignored for gemma4 (confidence head is DSpark's adaptive mechanism)

Eagle3 (`eagle3_gemma4_12b_ttt7`) can follow as a small PR — it shares the tap/verify/rollback infra added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new decode path touching KV commit, sliding-window rollback, and load-time memory (~7GB draft); incorrect cache or accept logic would change generation semantics despite T=0 oracles.
> 
> **Overview**
> **Gemma 4** can load an external **DSpark** draft via `Gemma4Model.load(..., { draftModelPath })` (flat KV only; paged cache is rejected or forced off). `hasMtpWeights()` exposes draft availability so **`ChatSession`** can auto-enable the speculative path (`enableMtp`), reusing existing MTP perf fields for cycle stats.
> 
> The core addition is an **engine-owned propose → verify → accept → pre-commit stop-clamp → commit** loop (`run_dspark_turn`) behind new **`DsparkBackend` / `DsparkStepper`** traits, plus a large **`dspark.rs`** module (checkpoint validation, fused context from tapped target hiddens, markov + confidence truncation, bf16 loader). Greedy output is intended to be **lossless at T=0**; a gated TS e2e mirrors the Rust greedy byte-match oracle.
> 
> **`MxArray.addmm`** is changed to an explicit matmul+scale+add path instead of fused `addmm`, avoiding a known local metallib miscompile that dropped bias terms (notably in biased vision linears).
> 
> Docs/README note Gemma4 DSpark; NAPI/types add **`Gemma4LoadOptions`**. Qwen3.5 config comments are updated for **VLM default-on block-paged cache** and image-turn behavior (not a full new feature in this diff slice).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a656f3326646b1de979b4404b09dbea0856088cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->