### PR TITLE
feat(gemma4): native MTP via Google's official assistant draft checkpoints

### DIFF
--- a/__test__/models/gemma4-assistant-e2e.test.ts
+++ b/__test__/models/gemma4-assistant-e2e.test.ts
@@ -88,6 +88,7 @@ describe.skipIf(!gated)('Gemma4 assistant-draft speculative decoding — TS e2e 
 
     // T=0 losslessness: byte-equal output against the no-draft session.
     expect(assistant.text).toBe(ar.text);
+    expect(assistant.rawText).toBe(ar.rawText);
     expect(assistant.finishReason).toBe(ar.finishReason);
     expect(assistant.numTokens).toBe(ar.numTokens);
 

--- a/__test__/models/gemma4-assistant-e2e.test.ts
+++ b/__test__/models/gemma4-assistant-e2e.test.ts
@@ -1,0 +1,104 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { ChatSession, loadModel, loadSession, type SessionCapableModel } from '@mlx-node/lm';
+import { beforeAll, describe, expect, it } from 'vite-plus/test';
+
+/**
+ * End-to-end test for Gemma4 assistant-checkpoint speculative decoding
+ * (google/gemma-4-12B-it-assistant external draft) through the public TS
+ * surface: `loadSession(modelPath, { draftModelPath })`.
+ *
+ * PRIMARY ORACLE (mirrors `crates/mlx-core/tests/gemma4_assistant.rs`): the
+ * assistant draft is LOSSLESS at T=0 — the greedy turn from the
+ * draft-attached session must byte-match the greedy turn from a plain
+ * no-draft session, and the draft-attached turn must actually run
+ * speculative cycles (`performance.mtpCycles > 0`, not a silent AR
+ * fallback). The no-draft model also pins the `ChatSession` auto-default:
+ * without a draft, `hasMtpWeights()` is `false`, so no MTP config is
+ * injected and the turn reports no cycles.
+ *
+ * Env-gated (the Rust suite's convention — both required, skipped otherwise):
+ *   MLX_TEST_GEMMA4_MODEL_PATH     — bf16 Gemma-4-12B-IT checkpoint dir
+ *   MLX_TEST_GEMMA4_ASSISTANT_PATH — gemma-4-12B-it-assistant draft dir
+ *
+ * To run locally:
+ *   MLX_TEST_GEMMA4_MODEL_PATH=.cache/models/gemma-4-12b-it \
+ *   MLX_TEST_GEMMA4_ASSISTANT_PATH=.cache/models/gemma-4-12B-it-assistant \
+ *     vp test __test__/models/gemma4-assistant-e2e.test.ts --run
+ *
+ * The fixture prompt is tie-screened (see the Rust suite's module doc): a
+ * constrained generation whose greedy top-2 logit gaps sit far above bf16
+ * kernel noise, so the byte-equal oracle stays strict without near-tie
+ * flakes.
+ */
+
+/** True for a directory that looks like a loadable checkpoint. */
+function isCheckpointDir(dir: string): boolean {
+  if (!existsSync(resolve(dir, 'config.json'))) return false;
+  return existsSync(resolve(dir, 'model.safetensors')) || existsSync(resolve(dir, 'model.safetensors.index.json'));
+}
+
+const modelPath = process.env.MLX_TEST_GEMMA4_MODEL_PATH ?? '';
+const draftPath = process.env.MLX_TEST_GEMMA4_ASSISTANT_PATH ?? '';
+const gated = modelPath !== '' && draftPath !== '';
+
+describe.skipIf(!gated)('Gemma4 assistant-draft speculative decoding — TS e2e (greedy matches no-draft)', () => {
+  let arSession: ChatSession;
+  let assistantSession: ChatSession;
+
+  beforeAll(async () => {
+    if (!gated) return;
+    // Fail loudly on a stale env var (the Rust suite asserts the same) —
+    // a skip here would silently stop covering the assistant load path.
+    expect(isCheckpointDir(modelPath), `MLX_TEST_GEMMA4_MODEL_PATH is not a checkpoint dir: ${modelPath}`).toBe(true);
+    expect(isCheckpointDir(draftPath), `MLX_TEST_GEMMA4_ASSISTANT_PATH is not a checkpoint dir: ${draftPath}`).toBe(
+      true,
+    );
+    // Plain model loaded via `loadModel` so the no-draft `hasMtpWeights()`
+    // contract is pinned directly on the model handle; the draft-attached
+    // session goes through `loadSession` — the exact public surface the
+    // zero-TS-change claim is about.
+    const plainModel = await loadModel(modelPath);
+    expect((plainModel as unknown as { hasMtpWeights(): boolean }).hasMtpWeights()).toBe(false);
+    arSession = new ChatSession(plainModel as unknown as SessionCapableModel);
+    assistantSession = await loadSession(modelPath, { draftModelPath: draftPath });
+  }, 900_000);
+
+  // Tie-screened fixture shared with the Rust primary oracle
+  // (`assistant_greedy_matches_ar_multi_cycle`): a constrained numbered
+  // recipe holds 200 greedy tokens without a near-tie.
+  const PROMPT = 'Give a simple recipe for pancakes with numbered steps.';
+
+  async function greedyTurn(session: ChatSession) {
+    return session.send(PROMPT, {
+      config: { maxNewTokens: 200, temperature: 0, reportPerformance: true },
+    });
+  }
+
+  it('greedy assistant send matches the no-draft session and runs speculative cycles', async () => {
+    const ar = await greedyTurn(arSession);
+    const assistant = await greedyTurn(assistantSession);
+
+    // Coherence guard: byte-equality alone would also pass if BOTH runs
+    // produced identical garbage (e.g. a corrupt metallib); a greedy
+    // pancake recipe always names its subject.
+    expect(ar.text.toLowerCase()).toContain('pancake');
+    expect(ar.text.trim().length).toBeGreaterThan(50);
+
+    // T=0 losslessness: byte-equal output against the no-draft session.
+    expect(assistant.text).toBe(ar.text);
+    expect(assistant.finishReason).toBe(ar.finishReason);
+    expect(assistant.numTokens).toBe(ar.numTokens);
+
+    // The draft-attached turn really ran speculative cycles (no silent AR
+    // fallback) and filled the speculative stats.
+    expect(assistant.performance?.mtpCycles ?? 0).toBeGreaterThan(0);
+    expect(assistant.performance?.mtpMeanAcceptedTokensTotal ?? 0).toBeGreaterThan(0);
+
+    // The no-draft session stayed plain AR: `hasMtpWeights()` is false
+    // there (asserted at load), so the ChatSession MTP auto-default never
+    // kicked in.
+    expect(ar.performance?.mtpCycles ?? 0).toBe(0);
+  }, 600_000);
+});

--- a/__test__/models/gemma4-dspark-e2e.test.ts
+++ b/__test__/models/gemma4-dspark-e2e.test.ts
@@ -79,6 +79,7 @@ describe.skipIf(!gated)('Gemma4 DSpark speculative decoding — TS e2e (greedy m
 
     // T=0 losslessness: byte-equal output against the no-draft session.
     expect(dspark.text).toBe(ar.text);
+    expect(dspark.rawText).toBe(ar.rawText);
     expect(dspark.finishReason).toBe(ar.finishReason);
     expect(dspark.numTokens).toBe(ar.numTokens);
 

--- a/__test__/server/anthropic-request-mapper.test.ts
+++ b/__test__/server/anthropic-request-mapper.test.ts
@@ -1370,6 +1370,28 @@ describe('mapAnthropicRequest', () => {
       });
       expect(config.mtpDepth).toBe(2);
     });
+
+    it('forwards mtp_depth 8 (gemma4 assistant max; native owns per-family clamps)', () => {
+      const { config } = mapAnthropicRequest({
+        model: 'claude-3-5-sonnet-20241022',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: 'Hello' }],
+        extra_body: { mtp_depth: 8 },
+      });
+      expect(config.mtpDepth).toBe(8);
+    });
+
+    it('rejects non-integer, non-positive, and > 64 mtp_depth values', () => {
+      for (const depth of [0, -1, 65, 2.5, Number.NaN, null]) {
+        const { config } = mapAnthropicRequest({
+          model: 'claude-3-5-sonnet-20241022',
+          max_tokens: 1024,
+          messages: [{ role: 'user', content: 'Hello' }],
+          extra_body: { mtp_depth: depth as never },
+        });
+        expect(config.mtpDepth).toBeUndefined();
+      }
+    });
   });
 
   // -------------------------------------------------------------------

--- a/__test__/server/request-mapper.test.ts
+++ b/__test__/server/request-mapper.test.ts
@@ -426,8 +426,22 @@ describe('mapRequest', () => {
       expect(config.mtpDepth).toBe(4);
     });
 
-    it('rejects mtp_depth values outside the [1, 5] integer range', () => {
-      for (const depth of [0, -1, 6, 2.5, Number.NaN, null]) {
+    it('forwards depths above the old qwen cap (6-8, e.g. gemma4 assistant max 8)', () => {
+      // Per-family native `resolve_params` owns the real clamps (qwen3.5
+      // native MTP [1,5]; gemma4 DSpark ≤ block size; gemma4 assistant
+      // [1,8]) — the server must not re-encode any single family's cap.
+      for (const depth of [6, 7, 8]) {
+        const { config } = mapRequest({
+          model: 'test-model',
+          input: 'Hello',
+          extra_body: { mtp_depth: depth },
+        });
+        expect(config.mtpDepth).toBe(depth);
+      }
+    });
+
+    it('rejects non-integer, non-positive, and > 64 mtp_depth values', () => {
+      for (const depth of [0, -1, 65, 2.5, Number.NaN, null]) {
         const { config } = mapRequest({
           model: 'test-model',
           input: 'Hello',

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -2357,13 +2357,28 @@ export interface ChatConfig {
    */
   enableMtp?: boolean | undefined;
   /**
-   * MTP: number of draft tokens per speculative cycle. Clamped to `[1, 5]`
-   * by the verify FFI contract. Default: 1.
+   * MTP: number of draft tokens per speculative cycle.
    *
+   * On Qwen3.5 native MTP heads it is clamped to `[1, 5]` by the verify
+   * FFI contract, and when unset native code currently pins depth 1.
    * When `mtpAdaptiveDepth` is `true`, this value is used as the
    * throughput-policy seed and the expected-value policy's max depth.
    * Adaptive depth is opt-in; set `mtpAdaptiveDepth: true` explicitly to
    * enable it.
+   *
+   * Gemma4 external drafts (`draftModelPath`) resolve the field per draft
+   * variant instead (`gemma4/model.rs` `resolve_params`, always from the
+   * RAW config value — the engine's central `[1, 5]` clamp is an MTP-head
+   * contract that does not apply to external drafts):
+   * - DSpark: an unset `mtpDepth` runs full draft blocks (the draft
+   *   checkpoint's block size — 7 tokens on `dspark_gemma4_12b_block7`),
+   *   and an explicit `mtpDepth` acts as a CAP on that block (clamped to
+   *   `[1, blockSize]`).
+   * - Assistant (Google `gemma-4-*-it-assistant`): an unset `mtpDepth`
+   *   drafts 3 tokens per cycle (`ASSISTANT_DEFAULT_DEPTH`), and an
+   *   explicit `mtpDepth` clamps to `[1, 8]` (`ASSISTANT_MAX_DEPTH`).
+   *
+   * `mtpAdaptiveDepth` is ignored for both Gemma4 external-draft variants.
    */
   mtpDepth?: number | undefined;
   /**

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -167,15 +167,15 @@ export declare class Gemma4Model {
   hasBlockPagedCache(): boolean;
   modelId(): number;
   /**
-   * Whether a DSpark draft model is loaded on this instance (via
-   * `Gemma4LoadOptions::draft_model_path`), enabling the speculative-
-   * decode whole-turn path.
+   * Whether a draft model — DSpark or Google assistant — is loaded on
+   * this instance (via `Gemma4LoadOptions::draft_model_path`), enabling
+   * the speculative-decode whole-turn path.
    *
    * Note: this only reports draft availability. Whether speculative
    * decoding actually runs on a given call also requires the per-request
    * `enableMtp` flag. Named `hasMtpWeights` for parity with the Qwen3.5
-   * surface, but it reports an external DSpark draft model, not
-   * in-checkpoint MTP heads. Stubs from `new(config)` always return
+   * surface, but it reports an external draft model (either variant),
+   * not in-checkpoint MTP heads. Stubs from `new(config)` always return
    * `false`.
    */
   hasMtpWeights(): boolean;
@@ -2946,10 +2946,11 @@ export interface Gemma4Config {
 /** Optional load-time settings for [`Gemma4Model::load`]. */
 export interface Gemma4LoadOptions {
   /**
-   * Directory of a DSpark draft checkpoint (config.json +
-   * model.safetensors) to load alongside the target model for
-   * speculative decoding. DSpark runs only on the flat KV-cache path:
-   * setting this while the model config explicitly enables
+   * Directory of a draft checkpoint (config.json + safetensors) to load
+   * alongside the target model for speculative decoding — either a
+   * DSpark draft or a Google assistant draft; the kind is probed from
+   * the draft config.json. Draft decoding runs only on the flat KV-cache
+   * path: setting this while the model config explicitly enables
    * `use_block_paged_cache` is a hard load error, and an unset
    * `use_block_paged_cache` is forced to `false`.
    */

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -1764,8 +1764,8 @@ pub(crate) trait MtpStepper {
 /// per-turn stepper. Per-cycle scratch (the tapped target hidden states, the
 /// draft-model KV window) lives as STRUCT FIELDS of the concrete
 /// [`DsparkStepper`], never here. Prefill-derived state (the gemma4 draft
-/// context) travels through the family's own stash
-/// (`Gemma4Inner::dspark_turn_state`), consumed by `begin_dspark_decode`.
+/// context / assistant seed hidden) travels through the family's own stash
+/// (`Gemma4Inner::draft_turn_state`), consumed by `begin_dspark_decode`.
 #[allow(dead_code)]
 pub(crate) struct DsparkTurnSetup<'a> {
     /// The turn's resolved [`ChatParams`] — `params.sampling_config` drives

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -30,7 +30,7 @@ use crate::stream::Stream;
 /// [`crate::engine::mtp_turn::MtpTurnArgs`], minus the MTP-only
 /// prompt-hidden seed fields (the DSpark stepper owns its draft-context
 /// seeding) and plus the draft `block_size`. Constructed in production by
-/// gemma4's `dspark_chat_turn`.
+/// gemma4's `draft_chat_turn`.
 pub(crate) struct DsparkTurnArgs<'a> {
     /// First generated token (sampled from the prefill logits BEFORE the
     /// turn). The loop takes ownership and emits it first (guarded by the
@@ -95,7 +95,7 @@ enum CycleStop {
 /// `anchor = boundary; eval_boundary`.
 ///
 /// Driven in production by gemma4's `mtp_turn` override
-/// (`dspark_chat_turn`); the module's mock tests pin the loop contract.
+/// (`draft_chat_turn`); the module's mock tests pin the loop contract.
 pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
     backend: &mut B,
     rng: &mut R,

--- a/crates/mlx-core/src/engine/types.rs
+++ b/crates/mlx-core/src/engine/types.rs
@@ -91,13 +91,28 @@ pub struct ChatConfig {
     /// `false`.
     #[napi(ts_type = "boolean | undefined")]
     pub enable_mtp: Option<bool>,
-    /// MTP: number of draft tokens per speculative cycle. Clamped to `[1, 5]`
-    /// by the verify FFI contract. Default: 1.
+    /// MTP: number of draft tokens per speculative cycle.
     ///
+    /// On Qwen3.5 native MTP heads it is clamped to `[1, 5]` by the verify
+    /// FFI contract, and when unset native code currently pins depth 1.
     /// When `mtpAdaptiveDepth` is `true`, this value is used as the
     /// throughput-policy seed and the expected-value policy's max depth.
     /// Adaptive depth is opt-in; set `mtpAdaptiveDepth: true` explicitly to
     /// enable it.
+    ///
+    /// Gemma4 external drafts (`draftModelPath`) resolve the field per draft
+    /// variant instead (`gemma4/model.rs` `resolve_params`, always from the
+    /// RAW config value — the engine's central `[1, 5]` clamp is an MTP-head
+    /// contract that does not apply to external drafts):
+    /// - DSpark: an unset `mtpDepth` runs full draft blocks (the draft
+    ///   checkpoint's block size — 7 tokens on `dspark_gemma4_12b_block7`),
+    ///   and an explicit `mtpDepth` acts as a CAP on that block (clamped to
+    ///   `[1, blockSize]`).
+    /// - Assistant (Google `gemma-4-*-it-assistant`): an unset `mtpDepth`
+    ///   drafts 3 tokens per cycle (`ASSISTANT_DEFAULT_DEPTH`), and an
+    ///   explicit `mtpDepth` clamps to `[1, 8]` (`ASSISTANT_MAX_DEPTH`).
+    ///
+    /// `mtpAdaptiveDepth` is ignored for both Gemma4 external-draft variants.
     #[napi(ts_type = "number | undefined")]
     pub mtp_depth: Option<i32>,
     /// MTP: when true, the decode loop runs the adaptive

--- a/crates/mlx-core/src/models/gemma4/assistant.rs
+++ b/crates/mlx-core/src/models/gemma4/assistant.rs
@@ -1,0 +1,1654 @@
+//! Google assistant draft model for Gemma 4 speculative decoding.
+//!
+//! Standalone 4-layer draft transformer shipped alongside the official
+//! Gemma 4 checkpoints (`google/gemma-4-*-it-assistant`). Unlike the DSpark
+//! draft it owns NO K/V projections: every layer runs Q-only attention over
+//! the TARGET model's committed KV caches (one shared pair per attention
+//! type), and the input embedding comes from the TARGET's embed table — the
+//! draft's own `embed_tokens` is used exclusively as the tied lm_head.
+//! Inference subset only: config, module tree, single-step forward, and the
+//! weight loader. The chained drafting loop and target-side plumbing live in
+//! the decode stepper.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use mlx_sys as sys;
+use napi::bindgen_prelude::*;
+use serde::Deserialize;
+
+use crate::array::MxArray;
+use crate::array::attention::scaled_dot_product_attention;
+use crate::engine::persistence::load_all_safetensors;
+use crate::nn::{Linear, RMSNorm, RoPE};
+
+use super::attention::Gemma4ProportionalRoPE;
+use super::config::Gemma4Config;
+use super::dspark::{apply_norm_weight, take_tensor};
+use super::mlp::GemmaMLP;
+use super::quantized_linear::LinearProj;
+
+/// Draft `model_type` values accepted by the loader: the dense/MoE assistant
+/// (`26B-A4B`/`31B`) and the unified-multimodal assistant (`12B`).
+pub(crate) const ASSISTANT_MODEL_TYPES: [&str; 2] =
+    ["gemma4_assistant", "gemma4_unified_assistant"];
+
+const SLIDING_ATTENTION: &str = "sliding_attention";
+const FULL_ATTENTION: &str = "full_attention";
+
+// ============================================
+// Config
+// ============================================
+
+/// `text_config.rope_parameters.full_attention` in the draft config.json.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AssistantFullAttentionRope {
+    pub(crate) partial_rotary_factor: f64,
+    pub(crate) rope_theta: f64,
+    pub(crate) rope_type: String,
+}
+
+/// `text_config.rope_parameters.sliding_attention` in the draft config.json.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AssistantSlidingAttentionRope {
+    pub(crate) rope_theta: f64,
+    pub(crate) rope_type: String,
+}
+
+/// `text_config.rope_parameters` sub-object: one entry per attention type.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AssistantRopeParameters {
+    pub(crate) full_attention: AssistantFullAttentionRope,
+    pub(crate) sliding_attention: AssistantSlidingAttentionRope,
+}
+
+/// `text_config` sub-object of the draft config.json. `hidden_size` is the
+/// draft-internal width H; the backbone width B lives on the outer config.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AssistantTextConfig {
+    pub(crate) hidden_size: i64,
+    pub(crate) intermediate_size: i64,
+    pub(crate) num_hidden_layers: usize,
+    pub(crate) layer_types: Vec<String>,
+    pub(crate) num_attention_heads: i64,
+    pub(crate) num_key_value_heads: i64,
+    pub(crate) num_global_key_value_heads: i64,
+    pub(crate) head_dim: i64,
+    #[serde(default)]
+    pub(crate) global_head_dim: Option<i64>,
+    pub(crate) attention_k_eq_v: bool,
+    pub(crate) sliding_window: i64,
+    pub(crate) rms_norm_eps: f64,
+    pub(crate) vocab_size: i64,
+    #[serde(default)]
+    pub(crate) final_logit_softcapping: Option<f64>,
+    pub(crate) rope_parameters: AssistantRopeParameters,
+}
+
+impl AssistantTextConfig {
+    /// Head dimension of the full-attention layers
+    /// (`global_head_dim`, falling back to `head_dim` like the target).
+    pub(crate) fn full_head_dim(&self) -> i64 {
+        self.global_head_dim.unwrap_or(self.head_dim)
+    }
+}
+
+/// Assistant draft model configuration, deserialized from the draft
+/// directory's `config.json`. The HF layout is NESTED: pairing fields
+/// (`backbone_hidden_size`, `use_ordered_embeddings`) sit at the top level
+/// next to a `text_config` sub-object carrying the transformer geometry.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AssistantConfig {
+    pub(crate) model_type: String,
+    /// Checkpoint schema surface (deserialized for completeness; the
+    /// loader gate keys on `model_type`).
+    #[allow(dead_code)]
+    pub(crate) architectures: Vec<String>,
+    /// Backbone width B — the TARGET model's hidden size. The draft consumes
+    /// `[token_embed, h_prev]` pairs in this width and projects back to it.
+    pub(crate) backbone_hidden_size: i64,
+    /// True on the E2B/E4B assistant heads, which replace the dense tied
+    /// lm_head with an ordered/centroid masked-embedding head — unsupported.
+    #[serde(default)]
+    pub(crate) use_ordered_embeddings: bool,
+    /// Checkpoint schema surface (the draft head is tied by construction:
+    /// `embed_tokens` IS the lm_head and is never used for input lookup).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub(crate) tie_word_embeddings: bool,
+    pub(crate) text_config: AssistantTextConfig,
+}
+
+impl AssistantConfig {
+    /// Validate the draft config against the target model's geometry.
+    ///
+    /// The draft attends over the TARGET's KV caches verbatim, so every K/V
+    /// geometry field (head dims, KV head counts, K=V sharing, RoPE, window)
+    /// must match the target exactly — the target values are ground truth.
+    pub(crate) fn validate(&self, target: &Gemma4Config) -> Result<()> {
+        if !ASSISTANT_MODEL_TYPES.contains(&self.model_type.as_str()) {
+            return Err(Error::from_reason(format!(
+                "assistant draft model_type {:?} must be one of {:?}",
+                self.model_type, ASSISTANT_MODEL_TYPES
+            )));
+        }
+        if self.use_ordered_embeddings {
+            return Err(Error::from_reason(
+                "ordered/centroid masked-embedding assistant heads (E2B/E4B) are not yet supported",
+            ));
+        }
+        if self.backbone_hidden_size != target.hidden_size as i64 {
+            return Err(Error::from_reason(format!(
+                "assistant draft backbone_hidden_size={} does not match target hidden_size={}",
+                self.backbone_hidden_size, target.hidden_size
+            )));
+        }
+        let text = &self.text_config;
+        if text.vocab_size != target.vocab_size as i64 {
+            return Err(Error::from_reason(format!(
+                "assistant draft vocab_size={} does not match target vocab_size={}",
+                text.vocab_size, target.vocab_size
+            )));
+        }
+        if text.layer_types.len() != text.num_hidden_layers {
+            return Err(Error::from_reason(format!(
+                "assistant draft layer_types has {} entries but num_hidden_layers={}",
+                text.layer_types.len(),
+                text.num_hidden_layers
+            )));
+        }
+        for layer_type in &text.layer_types {
+            if layer_type != SLIDING_ATTENTION && layer_type != FULL_ATTENTION {
+                return Err(Error::from_reason(format!(
+                    "assistant draft has unrecognized layer_types entry {layer_type:?} (expected {SLIDING_ATTENTION:?} or {FULL_ATTENTION:?})"
+                )));
+            }
+        }
+        if !text.layer_types.iter().any(|t| t == SLIDING_ATTENTION) {
+            return Err(Error::from_reason(
+                "assistant draft needs at least one sliding_attention layer (it reads one target KV pair per attention type)",
+            ));
+        }
+        if !text.layer_types.iter().any(|t| t == FULL_ATTENTION) {
+            return Err(Error::from_reason(
+                "assistant draft needs at least one full_attention layer (it reads one target KV pair per attention type)",
+            ));
+        }
+        if text.head_dim != target.head_dim as i64 {
+            return Err(Error::from_reason(format!(
+                "assistant draft head_dim={} does not match target head_dim={}",
+                text.head_dim, target.head_dim
+            )));
+        }
+        let target_full_head_dim = target.effective_head_dim(true) as i64;
+        if text.full_head_dim() != target_full_head_dim {
+            return Err(Error::from_reason(format!(
+                "assistant draft global_head_dim={} does not match the target's full-attention head_dim={}",
+                text.full_head_dim(),
+                target_full_head_dim
+            )));
+        }
+        let target_sliding_kv = target.effective_kv_heads(false) as i64;
+        if text.num_key_value_heads != target_sliding_kv {
+            return Err(Error::from_reason(format!(
+                "assistant draft num_key_value_heads={} does not match the target's sliding-attention KV heads={}",
+                text.num_key_value_heads, target_sliding_kv
+            )));
+        }
+        let target_full_kv = target.effective_kv_heads(true) as i64;
+        if text.num_global_key_value_heads != target_full_kv {
+            return Err(Error::from_reason(format!(
+                "assistant draft num_global_key_value_heads={} does not match the target's full-attention KV heads={}",
+                text.num_global_key_value_heads, target_full_kv
+            )));
+        }
+        if text.attention_k_eq_v != target.attention_k_eq_v {
+            return Err(Error::from_reason(format!(
+                "assistant draft attention_k_eq_v={} does not match target attention_k_eq_v={}",
+                text.attention_k_eq_v, target.attention_k_eq_v
+            )));
+        }
+        for (type_name, kv_heads) in [
+            (SLIDING_ATTENTION, text.num_key_value_heads),
+            (FULL_ATTENTION, text.num_global_key_value_heads),
+        ] {
+            if kv_heads <= 0 || text.num_attention_heads % kv_heads != 0 {
+                return Err(Error::from_reason(format!(
+                    "assistant draft num_attention_heads={} is not divisible by the {type_name} KV head count {kv_heads}",
+                    text.num_attention_heads
+                )));
+            }
+        }
+        let full_rope = &text.rope_parameters.full_attention;
+        if full_rope.rope_type != "proportional" {
+            return Err(Error::from_reason(format!(
+                "assistant draft rope_parameters.full_attention.rope_type must be \"proportional\", got {:?}",
+                full_rope.rope_type
+            )));
+        }
+        if full_rope.rope_theta != target.rope_theta {
+            return Err(Error::from_reason(format!(
+                "assistant draft full_attention rope_theta={} does not match target rope_theta={}",
+                full_rope.rope_theta, target.rope_theta
+            )));
+        }
+        if full_rope.partial_rotary_factor != target.partial_rotary_factor {
+            return Err(Error::from_reason(format!(
+                "assistant draft partial_rotary_factor={} does not match target partial_rotary_factor={}",
+                full_rope.partial_rotary_factor, target.partial_rotary_factor
+            )));
+        }
+        let sliding_rope = &text.rope_parameters.sliding_attention;
+        if sliding_rope.rope_type != "default" {
+            return Err(Error::from_reason(format!(
+                "assistant draft rope_parameters.sliding_attention.rope_type must be \"default\", got {:?}",
+                sliding_rope.rope_type
+            )));
+        }
+        if sliding_rope.rope_theta != target.rope_local_base_freq {
+            return Err(Error::from_reason(format!(
+                "assistant draft sliding_attention rope_theta={} does not match target rope_local_base_freq={}",
+                sliding_rope.rope_theta, target.rope_local_base_freq
+            )));
+        }
+        if text.sliding_window != target.sliding_window as i64 {
+            return Err(Error::from_reason(format!(
+                "assistant draft sliding_window={} does not match target sliding_window={}",
+                text.sliding_window, target.sliding_window
+            )));
+        }
+        if let Some(cap) = text.final_logit_softcapping
+            && cap <= 0.0
+        {
+            return Err(Error::from_reason(format!(
+                "assistant draft final_logit_softcapping={cap} must be positive when provided"
+            )));
+        }
+        Ok(())
+    }
+}
+
+// ============================================
+// Attention
+// ============================================
+
+/// RoPE variant for the draft's Q-only attention: sliding layers rotate the
+/// full `head_dim` with the standard kernel; full layers partially rotate
+/// `global_head_dim` with the target's proportional kernel.
+enum AssistantRope {
+    Sliding(RoPE),
+    Full(Gemma4ProportionalRoPE),
+}
+
+impl AssistantRope {
+    fn forward(&self, x: &MxArray, offset: i32) -> Result<MxArray> {
+        match self {
+            Self::Sliding(rope) => rope.forward(x, Some(offset)),
+            Self::Full(rope) => rope.forward(x, offset),
+        }
+    }
+}
+
+/// Draft Q-only attention (`Gemma4AssistantAttention`).
+///
+/// Geometrically the target's attention for the same layer type, minus every
+/// K/V-side module: NO k_proj/v_proj/k_norm/v_norm. Keys and values arrive
+/// VERBATIM from the target's committed KV caches (`[1, H_kv, S, Dh]`, K
+/// already RoPE'd at absolute positions and V already scale-free-normed by
+/// the target's own attention), so the draft must not re-rope or re-norm
+/// them. Queries are RoPE'd at the round-constant `q_pos`; SDPA runs with
+/// scale 1.0 (Q norm handles scaling; GQA over the shared KV heads is
+/// native) and mask None (single-token queries over past-only K/V; sliding
+/// K/V stays within the window by cache construction).
+struct AssistantAttention {
+    q_proj: LinearProj,
+    o_proj: LinearProj,
+    q_norm: RMSNorm,
+    rope: AssistantRope,
+    num_heads: i64,
+    num_kv_heads: i64,
+    head_dim: i64,
+}
+
+impl AssistantAttention {
+    fn new(config: &AssistantConfig, is_sliding: bool) -> Result<Self> {
+        let text = &config.text_config;
+        let hidden = text.hidden_size;
+        let num_heads = text.num_attention_heads;
+        let (num_kv_heads, head_dim, rope) = if is_sliding {
+            let rope = AssistantRope::Sliding(RoPE::new(
+                text.head_dim as i32,
+                Some(false),
+                Some(text.rope_parameters.sliding_attention.rope_theta),
+                None,
+            ));
+            (text.num_key_value_heads, text.head_dim, rope)
+        } else {
+            let full_rope = &text.rope_parameters.full_attention;
+            let head_dim = text.full_head_dim();
+            let rope = AssistantRope::Full(Gemma4ProportionalRoPE::new(
+                head_dim as i32,
+                full_rope.partial_rotary_factor,
+                full_rope.rope_theta,
+            )?);
+            (text.num_global_key_value_heads, head_dim, rope)
+        };
+
+        let q_proj = LinearProj::Standard(Linear::new(
+            hidden as u32,
+            (num_heads * head_dim) as u32,
+            Some(false),
+        )?);
+        let o_proj = LinearProj::Standard(Linear::new(
+            (num_heads * head_dim) as u32,
+            hidden as u32,
+            Some(false),
+        )?);
+        let q_norm = RMSNorm::new(head_dim as u32, Some(text.rms_norm_eps))?;
+
+        Ok(Self {
+            q_proj,
+            o_proj,
+            q_norm,
+            rope,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+        })
+    }
+
+    /// Attend the (pre-normed) draft hidden `x` over one target K/V pair.
+    ///
+    /// `q_pos` is the absolute position of the last committed token, held
+    /// CONSTANT across every chained step of a drafting round.
+    fn forward(&self, x: &MxArray, kv: &(MxArray, MxArray), q_pos: i32) -> Result<MxArray> {
+        let (keys, values) = kv;
+        if keys.shape_at(1)? != self.num_kv_heads || keys.shape_at(3)? != self.head_dim {
+            return Err(Error::from_reason(format!(
+                "assistant attention expects target K/V shaped [1, {}, S, {}], got {:?} (sliding/full pair swapped?)",
+                self.num_kv_heads,
+                self.head_dim,
+                keys.shape()?.as_ref()
+            )));
+        }
+        let batch = x.shape_at(0)?;
+        let seq_len = x.shape_at(1)?;
+
+        let queries =
+            self.q_proj
+                .forward(x)?
+                .reshape(&[batch, seq_len, self.num_heads, self.head_dim])?;
+        let queries = self
+            .q_norm
+            .forward(&queries)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let queries = self.rope.forward(&queries, q_pos)?;
+
+        let output = scaled_dot_product_attention(&queries, keys, values, 1.0, None)?;
+        let output = output.transpose(Some(&[0, 2, 1, 3]))?.reshape(&[
+            batch,
+            seq_len,
+            self.num_heads * self.head_dim,
+        ])?;
+        self.o_proj.forward(&output)
+    }
+}
+
+// ============================================
+// Decoder layer
+// ============================================
+
+/// Draft decoder layer (`Gemma4AssistantDecoderLayer`): Gemma sandwich norms
+/// around attention and MLP, then a per-layer `[1]` output scalar — the
+/// exact residual shape of the DSpark draft layer, with the type-dispatched
+/// Q-only attention in place of the cross+self attention.
+struct AssistantDecoderLayer {
+    self_attn: AssistantAttention,
+    mlp: GemmaMLP,
+    input_layernorm: RMSNorm,
+    post_attention_layernorm: RMSNorm,
+    pre_feedforward_layernorm: RMSNorm,
+    post_feedforward_layernorm: RMSNorm,
+    layer_scalar: MxArray,
+    is_sliding: bool,
+}
+
+impl AssistantDecoderLayer {
+    fn new(config: &AssistantConfig, is_sliding: bool) -> Result<Self> {
+        let text = &config.text_config;
+        let hidden = text.hidden_size as u32;
+        let eps = Some(text.rms_norm_eps);
+        Ok(Self {
+            self_attn: AssistantAttention::new(config, is_sliding)?,
+            mlp: GemmaMLP::new(hidden, text.intermediate_size as u32)?,
+            input_layernorm: RMSNorm::new(hidden, eps)?,
+            post_attention_layernorm: RMSNorm::new(hidden, eps)?,
+            pre_feedforward_layernorm: RMSNorm::new(hidden, eps)?,
+            post_feedforward_layernorm: RMSNorm::new(hidden, eps)?,
+            layer_scalar: MxArray::ones(&[1], None)?,
+            is_sliding,
+        })
+    }
+
+    fn forward(&self, x: &MxArray, kv: &(MxArray, MxArray), q_pos: i32) -> Result<MxArray> {
+        let residual = x;
+        let hidden = self.input_layernorm.forward(x)?;
+        let hidden = self.self_attn.forward(&hidden, kv, q_pos)?;
+        let hidden = self.post_attention_layernorm.forward(&hidden)?;
+        let hidden = residual.add(&hidden)?;
+
+        let residual = &hidden;
+        let ff = self.pre_feedforward_layernorm.forward(&hidden)?;
+        let ff = self.mlp.forward(&ff)?;
+        let ff = self.post_feedforward_layernorm.forward(&ff)?;
+        let out = residual.add(&ff)?;
+        out.mul(&self.layer_scalar)
+    }
+}
+
+// ============================================
+// Draft model
+// ============================================
+
+/// The two target K/V pairs one drafting round reads (each `[1, H_kv, S,
+/// Dh]`, committed positions only): the last non-KV-shared target layer of
+/// each attention type. Every draft layer attends to the pair matching its
+/// own type.
+#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
+pub(crate) struct AssistantSharedKv {
+    pub sliding: (MxArray, MxArray),
+    pub full: (MxArray, MxArray),
+}
+
+/// One chained draft step's outputs.
+#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
+pub(crate) struct AssistantStepOutput {
+    /// Softcapped draft logits `[1, 1, vocab]`.
+    pub logits: MxArray,
+    /// The next step's chained backbone hidden `[1, 1, backbone_hidden_size]`.
+    pub h_prev_next: MxArray,
+}
+
+/// The assistant draft model: backbone-pair input projection, hybrid Q-only
+/// decoder layers over the target's shared K/V, final norm, tied lm_head,
+/// and backbone output projection.
+#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
+pub(crate) struct AssistantDraftModel {
+    pub(crate) config: AssistantConfig,
+    /// `Linear(2B -> H)` over `concat([token_embed, h_prev])` — token FIRST.
+    pre_projection: LinearProj,
+    /// `Linear(H -> B)` producing the next chained `h_prev`.
+    post_projection: LinearProj,
+    layers: Vec<AssistantDecoderLayer>,
+    norm: RMSNorm,
+    /// The checkpoint's `model.embed_tokens.weight` `[V, H]`, used ONLY as
+    /// the tied lm_head. The draft never embeds input tokens itself — token
+    /// embeddings come from the TARGET's table (already scaled by sqrt(B)).
+    lm_head: LinearProj,
+    /// Total checkpoint tensor bytes, summed by `load_draft_model` BEFORE
+    /// `apply_weights` drains the tensor map (see the DSpark field doc for
+    /// the cache-limit contract). `0` for a placeholder-weight model.
+    weight_bytes: u64,
+}
+
+#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
+impl AssistantDraftModel {
+    /// Build the module tree for `config` with placeholder weights.
+    /// Callers must apply checkpoint weights before running a forward pass.
+    pub(crate) fn new(config: AssistantConfig) -> Result<Self> {
+        let text = &config.text_config;
+        let hidden = text.hidden_size;
+        let backbone = config.backbone_hidden_size;
+        let vocab = text.vocab_size;
+        let pre_projection = LinearProj::Standard(Linear::new(
+            (2 * backbone) as u32,
+            hidden as u32,
+            Some(false),
+        )?);
+        let post_projection =
+            LinearProj::Standard(Linear::new(hidden as u32, backbone as u32, Some(false))?);
+        let layers = text
+            .layer_types
+            .iter()
+            .map(|t| AssistantDecoderLayer::new(&config, t == SLIDING_ATTENTION))
+            .collect::<Result<Vec<_>>>()?;
+        let norm = RMSNorm::new(hidden as u32, Some(text.rms_norm_eps))?;
+        let lm_head = LinearProj::Standard(Linear::new(hidden as u32, vocab as u32, Some(false))?);
+        Ok(Self {
+            config,
+            pre_projection,
+            post_projection,
+            layers,
+            norm,
+            lm_head,
+            weight_bytes: 0,
+        })
+    }
+
+    pub(crate) fn num_layers(&self) -> usize {
+        self.layers.len()
+    }
+
+    /// Checkpoint tensor bytes (see the field doc) for cache-limit
+    /// accounting.
+    pub(crate) fn weight_bytes(&self) -> u64 {
+        self.weight_bytes
+    }
+
+    /// Every checkpoint-backed tensor the draft owns, as cheap array-handle
+    /// clones — `4 + 11 * num_layers` on the assistant contract (48 on the
+    /// real 4-layer checkpoints). Same materialization contract as
+    /// `DsparkDraftModel::collect_weight_arrays`: the handles are exactly
+    /// the applied checkpoint arrays, so their byte total equals
+    /// [`Self::weight_bytes`]; the coverage test pins count and byte
+    /// equality.
+    pub(crate) fn collect_weight_arrays(&self) -> Vec<MxArray> {
+        fn push_proj(out: &mut Vec<MxArray>, proj: &LinearProj) {
+            match proj {
+                LinearProj::Standard(l) => {
+                    out.push(l.get_weight());
+                    if let Some(b) = l.get_bias() {
+                        out.push(b);
+                    }
+                }
+                // Unreachable today (apply_weights is bf16-only, so every
+                // draft projection is Standard); collecting nothing here
+                // means a future quantized draft FAILS the byte-coverage
+                // test loudly instead of silently under-materializing.
+                LinearProj::Quantized(_) => {}
+            }
+        }
+        let mut out = Vec::with_capacity(4 + 11 * self.layers.len());
+        push_proj(&mut out, &self.pre_projection);
+        push_proj(&mut out, &self.post_projection);
+        push_proj(&mut out, &self.lm_head);
+        out.push(self.norm.get_weight());
+        for layer in &self.layers {
+            out.push(layer.input_layernorm.get_weight());
+            out.push(layer.post_attention_layernorm.get_weight());
+            out.push(layer.pre_feedforward_layernorm.get_weight());
+            out.push(layer.post_feedforward_layernorm.get_weight());
+            out.push(layer.layer_scalar.clone());
+            out.push(layer.self_attn.q_norm.get_weight());
+            push_proj(&mut out, &layer.self_attn.q_proj);
+            push_proj(&mut out, &layer.self_attn.o_proj);
+            out.push(layer.mlp.gate_proj_weight());
+            out.push(layer.mlp.up_proj_weight());
+            out.push(layer.mlp.down_proj_weight());
+        }
+        out
+    }
+
+    /// Run ONE chained draft step.
+    ///
+    /// `token_embed` is the TARGET's embedding of the previous token,
+    /// already scaled by `sqrt(backbone_hidden_size)` (the target's own
+    /// `forward_body` step 1); `h_prev` is the chained backbone hidden
+    /// (round 1: the target's post-final-norm hidden of the anchor slot;
+    /// later steps: the previous step's `h_prev_next`). Both `[1, 1, B]`.
+    /// `kv` holds the two target K/V pairs and `q_pos` the round-constant
+    /// query position.
+    pub(crate) fn forward_step(
+        &self,
+        token_embed: &MxArray,
+        h_prev: &MxArray,
+        kv: &AssistantSharedKv,
+        q_pos: i32,
+    ) -> Result<AssistantStepOutput> {
+        let backbone = self.config.backbone_hidden_size;
+        for (name, arr) in [("token_embed", token_embed), ("h_prev", h_prev)] {
+            if arr.ndim()? != 3
+                || arr.shape_at(0)? != 1
+                || arr.shape_at(1)? != 1
+                || arr.shape_at(2)? != backbone
+            {
+                return Err(Error::from_reason(format!(
+                    "assistant forward_step expects {name} shaped [1, 1, {backbone}], got {:?}",
+                    arr.shape()?.as_ref()
+                )));
+            }
+        }
+        let stacked = MxArray::concatenate(token_embed, h_prev, 2)?;
+        let mut hidden = self.pre_projection.forward(&stacked)?;
+        for layer in &self.layers {
+            let pair = if layer.is_sliding {
+                &kv.sliding
+            } else {
+                &kv.full
+            };
+            hidden = layer.forward(&hidden, pair, q_pos)?;
+        }
+        let hidden = self.norm.forward(&hidden)?;
+        let logits = self.compute_logits(&hidden)?;
+        let h_prev_next = self.post_projection.forward(&hidden)?;
+        Ok(AssistantStepOutput {
+            logits,
+            h_prev_next,
+        })
+    }
+
+    /// Tied lm_head + logit softcap (`tanh(x / cap) * cap`) ONLY — no
+    /// re-norm. The input must already be post-final-norm hidden states.
+    fn compute_logits(&self, hidden: &MxArray) -> Result<MxArray> {
+        let logits = self.lm_head.forward(hidden)?;
+        match self.config.text_config.final_logit_softcapping {
+            Some(cap) => {
+                let cap_arr = MxArray::scalar_float_like(cap, &logits)?;
+                let handle = unsafe { sys::mlx_logit_softcap(logits.handle.0, cap_arr.handle.0) };
+                MxArray::from_handle(handle, "assistant_logit_softcap")
+            }
+            None => Ok(logits),
+        }
+    }
+
+    /// Apply checkpoint tensors, consuming entries from `tensors`.
+    ///
+    /// Key names are the checkpoint's EXACT names: `pre_projection.weight`
+    /// and `post_projection.weight` are bare (no `model.` prefix), the rest
+    /// live under `model.` and `layer_scalar` carries no `.weight` suffix.
+    /// Errors listing every missing expected key and every unexpected
+    /// leftover key, so a truncated or wrong-family checkpoint can never
+    /// load with default-initialized weights.
+    fn apply_weights(&mut self, tensors: &mut HashMap<String, MxArray>) -> Result<()> {
+        let hidden = self.config.text_config.hidden_size;
+        let sliding_head_dim = self.config.text_config.head_dim;
+        let full_head_dim = self.config.text_config.full_head_dim();
+        let mut missing: Vec<String> = Vec::new();
+
+        if let Some(w) = take_tensor(tensors, "model.embed_tokens.weight", &mut missing)? {
+            self.lm_head.set_weight(&w, "tied lm_head (embed_tokens)")?;
+        }
+        if let Some(w) = take_tensor(tensors, "model.norm.weight", &mut missing)? {
+            apply_norm_weight(&mut self.norm, &w, hidden, "model.norm")?;
+        }
+        if let Some(w) = take_tensor(tensors, "pre_projection.weight", &mut missing)? {
+            self.pre_projection.set_weight(&w, "pre_projection")?;
+        }
+        if let Some(w) = take_tensor(tensors, "post_projection.weight", &mut missing)? {
+            self.post_projection.set_weight(&w, "post_projection")?;
+        }
+
+        for (layer_idx, layer) in self.layers.iter_mut().enumerate() {
+            let prefix = format!("model.layers.{layer_idx}");
+            let head_dim = if layer.is_sliding {
+                sliding_head_dim
+            } else {
+                full_head_dim
+            };
+            for (suffix, norm, dims) in [
+                ("input_layernorm", &mut layer.input_layernorm, hidden),
+                (
+                    "post_attention_layernorm",
+                    &mut layer.post_attention_layernorm,
+                    hidden,
+                ),
+                (
+                    "pre_feedforward_layernorm",
+                    &mut layer.pre_feedforward_layernorm,
+                    hidden,
+                ),
+                (
+                    "post_feedforward_layernorm",
+                    &mut layer.post_feedforward_layernorm,
+                    hidden,
+                ),
+                ("self_attn.q_norm", &mut layer.self_attn.q_norm, head_dim),
+            ] {
+                let key = format!("{prefix}.{suffix}.weight");
+                if let Some(w) = take_tensor(tensors, &key, &mut missing)? {
+                    apply_norm_weight(norm, &w, dims, &key)?;
+                }
+            }
+            let scalar_key = format!("{prefix}.layer_scalar");
+            if let Some(w) = take_tensor(tensors, &scalar_key, &mut missing)? {
+                if w.ndim()? != 1 || w.shape_at(0)? != 1 {
+                    return Err(Error::from_reason(format!(
+                        "assistant draft {scalar_key} must be [1], got {:?}",
+                        w.shape()?.as_ref()
+                    )));
+                }
+                layer.layer_scalar = w;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.self_attn.q_proj.weight"),
+                &mut missing,
+            )? {
+                layer.self_attn.q_proj.set_weight(&w, "q_proj")?;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.self_attn.o_proj.weight"),
+                &mut missing,
+            )? {
+                layer.self_attn.o_proj.set_weight(&w, "o_proj")?;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.mlp.gate_proj.weight"),
+                &mut missing,
+            )? {
+                layer.mlp.set_gate_proj_weight(&w)?;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.mlp.up_proj.weight"),
+                &mut missing,
+            )? {
+                layer.mlp.set_up_proj_weight(&w)?;
+            }
+            if let Some(w) = take_tensor(
+                tensors,
+                &format!("{prefix}.mlp.down_proj.weight"),
+                &mut missing,
+            )? {
+                layer.mlp.set_down_proj_weight(&w)?;
+            }
+        }
+
+        if !missing.is_empty() || !tensors.is_empty() {
+            missing.sort();
+            let mut leftover: Vec<String> = tensors.keys().cloned().collect();
+            leftover.sort();
+            return Err(Error::from_reason(format!(
+                "assistant draft checkpoint key mismatch: {} missing expected tensor(s) {:?}; {} unexpected leftover tensor(s) {:?}",
+                missing.len(),
+                missing,
+                leftover.len(),
+                leftover
+            )));
+        }
+        Ok(())
+    }
+}
+
+// ============================================
+// Loader
+// ============================================
+
+/// Load an assistant draft checkpoint (config.json + safetensors, single
+/// file or sharded) and validate it against the target model's geometry.
+#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
+pub(crate) fn load_draft_model(dir: &Path, target: &Gemma4Config) -> Result<AssistantDraftModel> {
+    let config_path = dir.join("config.json");
+    let raw = fs::read_to_string(&config_path).map_err(|e| {
+        Error::from_reason(format!(
+            "Failed to read assistant draft config {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    let config: AssistantConfig = serde_json::from_str(&raw).map_err(|e| {
+        Error::from_reason(format!(
+            "Failed to parse assistant draft config {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    config.validate(target)?;
+
+    let mut tensors = load_all_safetensors(dir, false)?;
+    // Sum the checkpoint bytes BEFORE `apply_weights` drains the map.
+    // `nbytes` is shape×itemsize metadata — no eval. `apply_weights`
+    // rejects leftover keys, so this total is exactly the applied set.
+    let weight_bytes: u64 = tensors
+        .values()
+        .map(|t| t.nbytes() as u64)
+        .fold(0u64, |acc, v| acc.saturating_add(v));
+    let mut model = AssistantDraftModel::new(config)?;
+    model.apply_weights(&mut tensors)?;
+    model.weight_bytes = weight_bytes;
+    Ok(model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::DType;
+    use serde_json::json;
+
+    // ── Config guard rails ─────────────────────────────────────────────
+
+    /// Serialize a valid draft config JSON matching the real
+    /// google/gemma-4-12B-it-assistant checkpoint, with per-test overrides
+    /// applied by string replacement on distinct sub-strings. `layer_types`
+    /// is kept on one line so the whole array is a replaceable unit
+    /// (`"sliding_attention"` alone also matches a rope_parameters key).
+    fn base_config_json() -> String {
+        r#"{
+            "architectures": ["Gemma4UnifiedAssistantForCausalLM"],
+            "model_type": "gemma4_unified_assistant",
+            "backbone_hidden_size": 3840,
+            "use_ordered_embeddings": false,
+            "tie_word_embeddings": true,
+            "num_centroids": 2048,
+            "text_config": {
+                "hidden_size": 1024,
+                "intermediate_size": 8192,
+                "num_hidden_layers": 4,
+                "layer_types": ["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"],
+                "num_attention_heads": 16,
+                "num_key_value_heads": 8,
+                "num_global_key_value_heads": 1,
+                "head_dim": 256,
+                "global_head_dim": 512,
+                "attention_k_eq_v": true,
+                "sliding_window": 1024,
+                "rms_norm_eps": 1e-06,
+                "vocab_size": 262144,
+                "final_logit_softcapping": null,
+                "num_kv_shared_layers": 4,
+                "rope_parameters": {
+                    "full_attention": {
+                        "partial_rotary_factor": 0.25,
+                        "rope_theta": 1000000.0,
+                        "rope_type": "proportional"
+                    },
+                    "sliding_attention": {
+                        "rope_theta": 10000.0,
+                        "rope_type": "default"
+                    }
+                }
+            }
+        }"#
+        .to_string()
+    }
+
+    fn parse(json: &str) -> AssistantConfig {
+        serde_json::from_str(json).expect("test config JSON must parse")
+    }
+
+    /// Gemma-4-12B target geometry (the fields `validate` reads).
+    fn target_12b_value() -> serde_json::Value {
+        json!({
+            "vocab_size": 262144,
+            "hidden_size": 3840,
+            "num_hidden_layers": 48,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 8,
+            "head_dim": 256,
+            "intermediate_size": 15360,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 131072,
+            "sliding_window": 1024,
+            "global_head_dim": 512,
+            "global_num_key_value_heads": 1,
+            "attention_k_eq_v": true,
+            "rope_theta": 1000000.0,
+            "rope_local_base_freq": 10000.0,
+            "partial_rotary_factor": 0.25,
+            "eos_token_ids": []
+        })
+    }
+
+    fn target_12b() -> Gemma4Config {
+        serde_json::from_value(target_12b_value()).expect("target config must deserialize")
+    }
+
+    fn expect_err(cfg: &AssistantConfig, target: &Gemma4Config, needle: &str) -> String {
+        let err = cfg.validate(target).expect_err("config must be rejected");
+        assert!(
+            err.reason.contains(needle),
+            "error {:?} must mention {:?}",
+            err.reason,
+            needle
+        );
+        err.reason.to_string()
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        let cfg = parse(&base_config_json());
+        cfg.validate(&target_12b())
+            .expect("real checkpoint config must validate");
+    }
+
+    #[test]
+    fn dense_assistant_model_type_accepted() {
+        let json = base_config_json().replace("gemma4_unified_assistant", "gemma4_assistant");
+        parse(&json)
+            .validate(&target_12b())
+            .expect("gemma4_assistant must also validate");
+    }
+
+    #[test]
+    fn wrong_model_type_rejected() {
+        let json = base_config_json().replace("gemma4_unified_assistant", "gemma4_text");
+        expect_err(&parse(&json), &target_12b(), "model_type");
+    }
+
+    #[test]
+    fn ordered_embeddings_rejected() {
+        let json = base_config_json().replace(
+            "\"use_ordered_embeddings\": false",
+            "\"use_ordered_embeddings\": true",
+        );
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "ordered/centroid masked-embedding assistant heads (E2B/E4B) are not yet supported",
+        );
+    }
+
+    #[test]
+    fn backbone_hidden_size_mismatch_rejected() {
+        let json = base_config_json().replace(
+            "\"backbone_hidden_size\": 3840",
+            "\"backbone_hidden_size\": 2816",
+        );
+        let reason = expect_err(&parse(&json), &target_12b(), "backbone_hidden_size");
+        assert!(reason.contains("2816"), "got: {reason}");
+        assert!(reason.contains("3840"), "got: {reason}");
+    }
+
+    #[test]
+    fn vocab_size_mismatch_rejected() {
+        let json = base_config_json().replace("\"vocab_size\": 262144", "\"vocab_size\": 151936");
+        expect_err(&parse(&json), &target_12b(), "vocab_size");
+    }
+
+    #[test]
+    fn layer_types_length_mismatch_rejected() {
+        let json = base_config_json().replace(
+            "[\"sliding_attention\", \"sliding_attention\", \"sliding_attention\", \"full_attention\"]",
+            "[\"sliding_attention\", \"sliding_attention\", \"full_attention\"]",
+        );
+        expect_err(&parse(&json), &target_12b(), "layer_types has 3 entries");
+    }
+
+    #[test]
+    fn unknown_layer_type_rejected() {
+        let json = base_config_json().replace(
+            "[\"sliding_attention\", \"sliding_attention\", \"sliding_attention\", \"full_attention\"]",
+            "[\"sliding_attention\", \"sliding_attention\", \"cross_attention\", \"full_attention\"]",
+        );
+        expect_err(&parse(&json), &target_12b(), "unrecognized layer_types");
+    }
+
+    #[test]
+    fn missing_full_attention_layer_rejected() {
+        let json = base_config_json().replace(
+            "[\"sliding_attention\", \"sliding_attention\", \"sliding_attention\", \"full_attention\"]",
+            "[\"sliding_attention\", \"sliding_attention\", \"sliding_attention\", \"sliding_attention\"]",
+        );
+        expect_err(&parse(&json), &target_12b(), "at least one full_attention");
+    }
+
+    #[test]
+    fn missing_sliding_attention_layer_rejected() {
+        let json = base_config_json().replace(
+            "[\"sliding_attention\", \"sliding_attention\", \"sliding_attention\", \"full_attention\"]",
+            "[\"full_attention\", \"full_attention\", \"full_attention\", \"full_attention\"]",
+        );
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "at least one sliding_attention",
+        );
+    }
+
+    #[test]
+    fn head_dim_mismatch_rejected() {
+        let json = base_config_json().replace("\"head_dim\": 256", "\"head_dim\": 128");
+        let reason = expect_err(&parse(&json), &target_12b(), "draft head_dim=128");
+        assert!(reason.contains("256"), "got: {reason}");
+    }
+
+    #[test]
+    fn global_head_dim_mismatch_rejected() {
+        let json =
+            base_config_json().replace("\"global_head_dim\": 512", "\"global_head_dim\": 256");
+        expect_err(&parse(&json), &target_12b(), "global_head_dim=256");
+    }
+
+    #[test]
+    fn sliding_kv_heads_mismatch_rejected() {
+        let json =
+            base_config_json().replace("\"num_key_value_heads\": 8", "\"num_key_value_heads\": 4");
+        expect_err(&parse(&json), &target_12b(), "num_key_value_heads=4");
+    }
+
+    #[test]
+    fn full_kv_heads_mismatch_rejected() {
+        let json = base_config_json().replace(
+            "\"num_global_key_value_heads\": 1",
+            "\"num_global_key_value_heads\": 2",
+        );
+        expect_err(&parse(&json), &target_12b(), "num_global_key_value_heads=2");
+    }
+
+    #[test]
+    fn attention_k_eq_v_mismatch_rejected() {
+        // Target keeps attention_k_eq_v=true, so its full-attention KV heads
+        // stay at global_num_key_value_heads=1 and the k_eq_v arm is the
+        // first to fire.
+        let json =
+            base_config_json().replace("\"attention_k_eq_v\": true", "\"attention_k_eq_v\": false");
+        expect_err(&parse(&json), &target_12b(), "attention_k_eq_v");
+    }
+
+    #[test]
+    fn heads_not_divisible_by_sliding_kv_heads_rejected() {
+        // 6 query heads over the (matching) 8 sliding KV heads.
+        let json =
+            base_config_json().replace("\"num_attention_heads\": 16", "\"num_attention_heads\": 6");
+        let reason = expect_err(&parse(&json), &target_12b(), "not divisible");
+        assert!(reason.contains(SLIDING_ATTENTION), "got: {reason}");
+    }
+
+    #[test]
+    fn heads_not_divisible_by_full_kv_heads_rejected() {
+        // Both sides agree on 3 full-attention KV heads (16 % 3 != 0);
+        // sliding stays at 8 (16 % 8 == 0) so only the full arm fires.
+        let mut target_value = target_12b_value();
+        target_value["global_num_key_value_heads"] = json!(3);
+        let target: Gemma4Config =
+            serde_json::from_value(target_value).expect("target config must deserialize");
+        let json = base_config_json().replace(
+            "\"num_global_key_value_heads\": 1",
+            "\"num_global_key_value_heads\": 3",
+        );
+        let reason = expect_err(&parse(&json), &target, "not divisible");
+        assert!(reason.contains(FULL_ATTENTION), "got: {reason}");
+    }
+
+    #[test]
+    fn full_rope_type_rejected() {
+        let json = base_config_json().replace(
+            "\"rope_type\": \"proportional\"",
+            "\"rope_type\": \"linear\"",
+        );
+        expect_err(&parse(&json), &target_12b(), "proportional");
+    }
+
+    #[test]
+    fn sliding_rope_type_rejected() {
+        let json =
+            base_config_json().replace("\"rope_type\": \"default\"", "\"rope_type\": \"yarn\"");
+        expect_err(&parse(&json), &target_12b(), "default");
+    }
+
+    #[test]
+    fn full_rope_theta_mismatch_rejected() {
+        let json =
+            base_config_json().replace("\"rope_theta\": 1000000.0", "\"rope_theta\": 500000.0");
+        expect_err(&parse(&json), &target_12b(), "full_attention rope_theta");
+    }
+
+    #[test]
+    fn sliding_rope_theta_mismatch_rejected() {
+        let json = base_config_json().replace("\"rope_theta\": 10000.0", "\"rope_theta\": 20000.0");
+        expect_err(&parse(&json), &target_12b(), "sliding_attention rope_theta");
+    }
+
+    #[test]
+    fn partial_rotary_factor_mismatch_rejected() {
+        let json = base_config_json().replace(
+            "\"partial_rotary_factor\": 0.25",
+            "\"partial_rotary_factor\": 0.5",
+        );
+        expect_err(&parse(&json), &target_12b(), "partial_rotary_factor");
+    }
+
+    #[test]
+    fn sliding_window_mismatch_rejected() {
+        let json =
+            base_config_json().replace("\"sliding_window\": 1024", "\"sliding_window\": 512");
+        expect_err(&parse(&json), &target_12b(), "sliding_window");
+    }
+
+    #[test]
+    fn nonpositive_softcap_rejected() {
+        let json = base_config_json().replace(
+            "\"final_logit_softcapping\": null",
+            "\"final_logit_softcapping\": -3.0",
+        );
+        expect_err(&parse(&json), &target_12b(), "final_logit_softcapping");
+        let json = base_config_json().replace(
+            "\"final_logit_softcapping\": null",
+            "\"final_logit_softcapping\": 0.0",
+        );
+        expect_err(&parse(&json), &target_12b(), "final_logit_softcapping");
+    }
+
+    // ── Tiny-model fixtures ────────────────────────────────────────────
+
+    /// Sized-down draft config exercising the same code paths as the real
+    /// assistant: one sliding + one full layer, 2 heads over head_dim 4 / 8,
+    /// 1 KV head each, live partial rotation on the full layer. A raw `&str`
+    /// so the checkpoint-dir tests can write it verbatim as `config.json`;
+    /// `layer_types` stays on one line for string-replacement overrides.
+    const TINY_DRAFT_JSON: &str = r#"{
+                "architectures": ["Gemma4UnifiedAssistantForCausalLM"],
+                "model_type": "gemma4_unified_assistant",
+                "backbone_hidden_size": 8,
+                "use_ordered_embeddings": false,
+                "tie_word_embeddings": true,
+                "text_config": {
+                    "hidden_size": 4,
+                    "intermediate_size": 8,
+                    "num_hidden_layers": 2,
+                    "layer_types": ["sliding_attention", "full_attention"],
+                    "num_attention_heads": 2,
+                    "num_key_value_heads": 1,
+                    "num_global_key_value_heads": 1,
+                    "head_dim": 4,
+                    "global_head_dim": 8,
+                    "attention_k_eq_v": true,
+                    "sliding_window": 4,
+                    "rms_norm_eps": 1e-6,
+                    "vocab_size": 16,
+                    "final_logit_softcapping": null,
+                    "rope_parameters": {
+                        "full_attention": {
+                            "partial_rotary_factor": 0.25,
+                            "rope_theta": 1000000.0,
+                            "rope_type": "proportional"
+                        },
+                        "sliding_attention": {
+                            "rope_theta": 10000.0,
+                            "rope_type": "default"
+                        }
+                    }
+                }
+            }"#;
+
+    fn tiny_draft_config() -> AssistantConfig {
+        parse(TINY_DRAFT_JSON)
+    }
+
+    /// Target geometry the tiny draft pairs with (hidden 8, vocab 16,
+    /// head_dim 4 / global 8, one KV head per type, window 4).
+    fn tiny_target() -> Gemma4Config {
+        serde_json::from_value(json!({
+            "vocab_size": 16,
+            "hidden_size": 8,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "intermediate_size": 16,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 128,
+            "sliding_window": 4,
+            "layer_types": [
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention"
+            ],
+            "global_head_dim": 8,
+            "global_num_key_value_heads": 1,
+            "attention_k_eq_v": true,
+            "rope_theta": 1000000.0,
+            "rope_local_base_freq": 10000.0,
+            "partial_rotary_factor": 0.25,
+            "use_block_paged_cache": false,
+            "eos_token_ids": []
+        }))
+        .expect("tiny target config must deserialize")
+    }
+
+    /// The tiny fixtures must be a VALID pair — everything downstream
+    /// assumes it.
+    #[test]
+    fn tiny_fixture_pair_validates() {
+        tiny_draft_config()
+            .validate(&tiny_target())
+            .expect("tiny draft/target pair must validate");
+    }
+
+    fn tiny_model() -> AssistantDraftModel {
+        AssistantDraftModel::new(tiny_draft_config()).expect("tiny model must build")
+    }
+
+    fn rand_array(shape: &[i64]) -> MxArray {
+        MxArray::random_uniform(shape, -1.0, 1.0, None).unwrap()
+    }
+
+    /// Random target K/V pairs at the tiny geometry: sliding `[1, 1, s, 4]`,
+    /// full `[1, 1, s, 8]`.
+    fn tiny_shared_kv(s: i64) -> AssistantSharedKv {
+        AssistantSharedKv {
+            sliding: (rand_array(&[1, 1, s, 4]), rand_array(&[1, 1, s, 4])),
+            full: (rand_array(&[1, 1, s, 8]), rand_array(&[1, 1, s, 8])),
+        }
+    }
+
+    fn to_vec_f32(a: &MxArray) -> Vec<f32> {
+        a.eval();
+        a.to_float32().unwrap().to_vec()
+    }
+
+    // ── Pre/post projection order ──────────────────────────────────────
+
+    /// `forward_step` concatenates `[token_embed, h_prev]` with token_embed
+    /// FIRST. With a crafted `pre_projection = [P | 0]` (right B columns
+    /// zero) the whole step is a function of token_embed only; a reversed
+    /// concat would route h_prev through P and break the equality. The
+    /// mirrored `[0 | P]` weight pins the complement.
+    #[test]
+    fn forward_step_concat_puts_token_embed_first() {
+        let mut model = tiny_model();
+        let mut left = vec![0f32; 4 * 16];
+        for r in 0..4 {
+            for c in 0..8 {
+                left[r * 16 + c] = ((r * 8 + c) as f32 * 0.13).sin() + 0.1;
+            }
+        }
+        let w = MxArray::from_float32(&left, &[4, 16]).unwrap();
+        model
+            .pre_projection
+            .set_weight(&w, "pre_projection")
+            .unwrap();
+
+        let kv = tiny_shared_kv(3);
+        let token_embed = rand_array(&[1, 1, 8]);
+        let token_embed_alt = rand_array(&[1, 1, 8]);
+        let h_prev_a = rand_array(&[1, 1, 8]);
+        let h_prev_b = rand_array(&[1, 1, 8]);
+
+        let out_a = model.forward_step(&token_embed, &h_prev_a, &kv, 3).unwrap();
+        assert_eq!(out_a.logits.shape().unwrap().to_vec(), vec![1, 1, 16]);
+        assert_eq!(out_a.h_prev_next.shape().unwrap().to_vec(), vec![1, 1, 8]);
+
+        let out_b = model.forward_step(&token_embed, &h_prev_b, &kv, 3).unwrap();
+        assert_eq!(
+            to_vec_f32(&out_a.logits),
+            to_vec_f32(&out_b.logits),
+            "with the h_prev columns zeroed, changing h_prev must not reach the logits"
+        );
+        assert_eq!(
+            to_vec_f32(&out_a.h_prev_next),
+            to_vec_f32(&out_b.h_prev_next),
+            "with the h_prev columns zeroed, changing h_prev must not reach h_prev_next"
+        );
+        let out_c = model
+            .forward_step(&token_embed_alt, &h_prev_a, &kv, 3)
+            .unwrap();
+        assert_ne!(
+            to_vec_f32(&out_a.logits),
+            to_vec_f32(&out_c.logits),
+            "token_embed must drive the step through the FIRST B columns"
+        );
+
+        // Mirror: [0 | P] makes the step a function of h_prev only.
+        let mut right = vec![0f32; 4 * 16];
+        for r in 0..4 {
+            for c in 0..8 {
+                right[r * 16 + 8 + c] = ((r * 8 + c) as f32 * 0.13).sin() + 0.1;
+            }
+        }
+        let w = MxArray::from_float32(&right, &[4, 16]).unwrap();
+        model
+            .pre_projection
+            .set_weight(&w, "pre_projection")
+            .unwrap();
+        let out_d = model.forward_step(&token_embed, &h_prev_a, &kv, 3).unwrap();
+        let out_e = model
+            .forward_step(&token_embed_alt, &h_prev_a, &kv, 3)
+            .unwrap();
+        assert_eq!(
+            to_vec_f32(&out_d.logits),
+            to_vec_f32(&out_e.logits),
+            "with the token columns zeroed, changing token_embed must not reach the logits"
+        );
+        let out_f = model.forward_step(&token_embed, &h_prev_b, &kv, 3).unwrap();
+        assert_ne!(
+            to_vec_f32(&out_d.logits),
+            to_vec_f32(&out_f.logits),
+            "h_prev must drive the step through the LAST B columns"
+        );
+    }
+
+    #[test]
+    fn forward_step_rejects_wrong_input_shapes() {
+        let model = tiny_model();
+        let kv = tiny_shared_kv(3);
+        let good = rand_array(&[1, 1, 8]);
+        let bad = rand_array(&[1, 1, 4]);
+        let err = match model.forward_step(&bad, &good, &kv, 0) {
+            Ok(_) => panic!("wrong token_embed width must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.reason.contains("token_embed"), "got: {}", err.reason);
+        let err = match model.forward_step(&good, &bad, &kv, 0) {
+            Ok(_) => panic!("wrong h_prev width must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.reason.contains("h_prev"), "got: {}", err.reason);
+    }
+
+    /// A swapped sliding/full K/V pair must fail the attention shape guard,
+    /// not silently mis-attend.
+    #[test]
+    fn forward_step_rejects_swapped_kv_pair() {
+        let model = tiny_model();
+        let kv = tiny_shared_kv(3);
+        let swapped = AssistantSharedKv {
+            sliding: kv.full,
+            full: kv.sliding,
+        };
+        let err = match model.forward_step(
+            &rand_array(&[1, 1, 8]),
+            &rand_array(&[1, 1, 8]),
+            &swapped,
+            0,
+        ) {
+            Ok(_) => panic!("swapped K/V pair must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.reason.contains("K/V"), "got: {}", err.reason);
+    }
+
+    // ── RoPE at a round-constant position ──────────────────────────────
+
+    /// The draft queries are RoPE'd at a CONSTANT `q_pos` — repeated calls
+    /// at the same position are bitwise identical (no per-step drift), and
+    /// a shifted position changes the output. Exercised on both rope arms.
+    fn assert_rope_constant_position(is_sliding: bool) {
+        let config = tiny_draft_config();
+        let attn = AssistantAttention::new(&config, is_sliding).expect("attention must build");
+        let head_dim = if is_sliding { 4 } else { 8 };
+        let x = rand_array(&[1, 1, 4]);
+        let kv = (
+            rand_array(&[1, 1, 5, head_dim]),
+            rand_array(&[1, 1, 5, head_dim]),
+        );
+
+        let y1 = attn.forward(&x, &kv, 7).unwrap();
+        assert_eq!(y1.shape().unwrap().to_vec(), vec![1, 1, 4]);
+        let y2 = attn.forward(&x, &kv, 7).unwrap();
+        assert_eq!(
+            to_vec_f32(&y1),
+            to_vec_f32(&y2),
+            "same q_pos must be bitwise identical across calls"
+        );
+        let y3 = attn.forward(&x, &kv, 8).unwrap();
+        assert_ne!(
+            to_vec_f32(&y1),
+            to_vec_f32(&y3),
+            "q_pos must actually reach the query rope"
+        );
+    }
+
+    #[test]
+    fn sliding_attention_query_rope_held_constant() {
+        assert_rope_constant_position(true);
+    }
+
+    #[test]
+    fn full_attention_query_rope_held_constant() {
+        assert_rope_constant_position(false);
+    }
+
+    // ── Logit softcap ──────────────────────────────────────────────────
+
+    /// lm_head `[16, 4]` with `W[v][j] = 100 if j == v % 4`: the post-norm
+    /// hidden has RMS 1, so some `|h_j| >= 1` and the hottest raw logit is
+    /// `>= 100` — far past the 30.0 cap.
+    fn install_hot_lm_head(model: &mut AssistantDraftModel) {
+        let mut w = vec![0f32; 16 * 4];
+        for v in 0..16 {
+            w[v * 4 + (v % 4)] = 100.0;
+        }
+        let w = MxArray::from_float32(&w, &[16, 4]).unwrap();
+        model.lm_head.set_weight(&w, "lm_head").unwrap();
+    }
+
+    #[test]
+    fn softcap_bounds_logits_when_configured() {
+        let json = TINY_DRAFT_JSON.replace(
+            "\"final_logit_softcapping\": null",
+            "\"final_logit_softcapping\": 30.0",
+        );
+        let mut model = AssistantDraftModel::new(parse(&json)).unwrap();
+        install_hot_lm_head(&mut model);
+        let kv = tiny_shared_kv(3);
+        let out = model
+            .forward_step(&rand_array(&[1, 1, 8]), &rand_array(&[1, 1, 8]), &kv, 2)
+            .unwrap();
+        let logits = to_vec_f32(&out.logits);
+        for (i, v) in logits.iter().enumerate() {
+            assert!(v.abs() <= 30.0 + 1e-3, "logit[{i}]={v} exceeds softcap");
+        }
+        assert!(
+            logits.iter().any(|v| v.abs() > 25.0),
+            "the cap must actually engage (raw magnitude is >= 100): {logits:?}"
+        );
+    }
+
+    #[test]
+    fn no_softcap_when_null() {
+        let mut model = tiny_model();
+        install_hot_lm_head(&mut model);
+        let kv = tiny_shared_kv(3);
+        let out = model
+            .forward_step(&rand_array(&[1, 1, 8]), &rand_array(&[1, 1, 8]), &kv, 2)
+            .unwrap();
+        let logits = to_vec_f32(&out.logits);
+        assert!(
+            logits.iter().any(|v| v.abs() > 30.0),
+            "a null softcap must leave the raw logits uncapped: {logits:?}"
+        );
+    }
+
+    // ── Weight-install gate (apply_weights seam) ───────────────────────
+
+    /// Complete bf16 tensor map matching `tiny_draft_config()`'s expected
+    /// keys and shapes — the checkpoint's EXACT naming (bare projections,
+    /// `model.` prefix elsewhere, `layer_scalar` without `.weight`).
+    fn synthetic_tiny_tensors() -> HashMap<String, MxArray> {
+        let mut specs: Vec<(String, Vec<i64>)> = vec![
+            ("pre_projection.weight".into(), vec![4, 16]),
+            ("post_projection.weight".into(), vec![8, 4]),
+            ("model.embed_tokens.weight".into(), vec![16, 4]),
+            ("model.norm.weight".into(), vec![4]),
+        ];
+        for (i, head_dim) in [(0i64, 4i64), (1, 8)] {
+            for (suffix, shape) in [
+                ("input_layernorm.weight", vec![4]),
+                ("post_attention_layernorm.weight", vec![4]),
+                ("pre_feedforward_layernorm.weight", vec![4]),
+                ("post_feedforward_layernorm.weight", vec![4]),
+                ("self_attn.q_norm.weight", vec![head_dim]),
+                ("layer_scalar", vec![1]),
+                ("self_attn.q_proj.weight", vec![2 * head_dim, 4]),
+                ("self_attn.o_proj.weight", vec![4, 2 * head_dim]),
+                ("mlp.gate_proj.weight", vec![8, 4]),
+                ("mlp.up_proj.weight", vec![8, 4]),
+                ("mlp.down_proj.weight", vec![4, 8]),
+            ] {
+                specs.push((format!("model.layers.{i}.{suffix}"), shape));
+            }
+        }
+        specs
+            .into_iter()
+            .map(|(key, shape)| {
+                let arr = MxArray::zeros(&shape, Some(DType::BFloat16)).unwrap();
+                (key, arr)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn apply_weights_accepts_complete_bf16_set() {
+        let mut model = tiny_model();
+        let mut tensors = synthetic_tiny_tensors();
+        model.apply_weights(&mut tensors).unwrap();
+        assert!(tensors.is_empty(), "all tensors must be consumed");
+    }
+
+    #[test]
+    fn apply_weights_rejects_non_bf16_tensor() {
+        let mut model = tiny_model();
+        let mut tensors = synthetic_tiny_tensors();
+        tensors.insert(
+            "pre_projection.weight".to_string(),
+            MxArray::zeros(&[4, 16], Some(DType::Float32)).unwrap(),
+        );
+        let err = model
+            .apply_weights(&mut tensors)
+            .expect_err("an f32 weight must be rejected");
+        assert!(
+            err.reason.contains("pre_projection.weight"),
+            "got: {}",
+            err.reason
+        );
+        assert!(err.reason.contains("bf16"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn apply_weights_reports_missing_and_leftover_keys() {
+        let mut model = tiny_model();
+        let mut tensors = synthetic_tiny_tensors();
+        tensors.remove("model.layers.1.mlp.up_proj.weight");
+        tensors.insert(
+            "model.layers.0.self_attn.k_proj.weight".to_string(),
+            MxArray::zeros(&[4, 4], Some(DType::BFloat16)).unwrap(),
+        );
+        let err = model
+            .apply_weights(&mut tensors)
+            .expect_err("missing + stray keys must be rejected");
+        assert!(err.reason.contains("missing"), "got: {}", err.reason);
+        assert!(
+            err.reason.contains("model.layers.1.mlp.up_proj.weight"),
+            "got: {}",
+            err.reason
+        );
+        assert!(err.reason.contains("unexpected"), "got: {}", err.reason);
+        assert!(
+            err.reason
+                .contains("model.layers.0.self_attn.k_proj.weight"),
+            "got: {}",
+            err.reason
+        );
+    }
+
+    // ── Loader + cache-limit weight accounting ─────────────────────────
+
+    /// Write the tiny checkpoint (config + zero-filled bf16 tensors) to a
+    /// fresh temp dir; returns `(dir, checkpoint_byte_total)`.
+    fn write_tiny_checkpoint() -> (std::path::PathBuf, u64) {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "gemma4_assistant_tiny_checkpoint_{}_{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).expect("create temp checkpoint dir");
+        fs::write(dir.join("config.json"), TINY_DRAFT_JSON).expect("write config.json");
+        let mut tensors = synthetic_tiny_tensors();
+        let total: u64 = tensors.values().map(|t| t.nbytes() as u64).sum();
+        assert!(total > 0, "the tiny checkpoint must have nonzero bytes");
+        crate::utils::safetensors::save_safetensors(
+            dir.join("model.safetensors"),
+            &mut tensors,
+            None,
+        )
+        .expect("write model.safetensors");
+        (dir, total)
+    }
+
+    /// `load_draft_model` must report the checkpoint's exact total tensor
+    /// bytes (summed BEFORE `apply_weights` drains the map) — same
+    /// cache-limit contract as the DSpark loader.
+    #[test]
+    fn load_draft_model_reports_checkpoint_weight_bytes() {
+        let (dir, expected) = write_tiny_checkpoint();
+        let model = load_draft_model(&dir, &tiny_target()).expect("tiny checkpoint must load");
+        assert_eq!(
+            model.weight_bytes(),
+            expected,
+            "weight_bytes must equal the exact checkpoint tensor byte total"
+        );
+        // A placeholder-weight model (no checkpoint) reports 0.
+        assert_eq!(tiny_model().weight_bytes(), 0);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The post-load materialization pass must cover EVERY checkpoint
+    /// tensor: `collect_weight_arrays` yields exactly `4 + 11 * num_layers`
+    /// tensors whose byte total equals `weight_bytes` (nothing the
+    /// checkpoint shipped stays behind as a lazy mmap reference the first
+    /// speculative forward would page-fault in). Also exercises the
+    /// `materialize_weights` pass itself over the collected handles.
+    #[test]
+    fn collect_weight_arrays_covers_every_checkpoint_tensor() {
+        let (dir, checkpoint_bytes) = write_tiny_checkpoint();
+        let model = load_draft_model(&dir, &tiny_target()).expect("tiny checkpoint must load");
+
+        let arrays = model.collect_weight_arrays();
+        assert_eq!(
+            arrays.len(),
+            4 + 11 * model.num_layers(),
+            "assistant contract: 4 top-level + 11 x {} layers",
+            model.num_layers()
+        );
+        let total: u64 = arrays.iter().map(|a| a.nbytes() as u64).sum();
+        assert_eq!(
+            total, checkpoint_bytes,
+            "collected arrays must cover every checkpoint byte (a gap here \
+             means the loader's materialization pass leaves lazy mmap refs)"
+        );
+
+        let refs: Vec<&MxArray> = arrays.iter().collect();
+        crate::array::memory::materialize_weights(&refs)
+            .expect("the loader's materialization pass must succeed on the collected handles");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // ── Real checkpoint (gated) ────────────────────────────────────────
+
+    /// Full-size load + chained forward_step over the real bf16 assistant
+    /// checkpoint. Loader success implies all 48 tensors mapped (the
+    /// completeness gate rejects any missing/unexpected key).
+    #[test]
+    #[ignore = "requires a local assistant draft checkpoint; set MLX_TEST_GEMMA4_ASSISTANT_PATH and run with --ignored"]
+    fn real_checkpoint_loads_and_forwards() {
+        let Ok(dir) = std::env::var("MLX_TEST_GEMMA4_ASSISTANT_PATH") else {
+            eprintln!("skipping: MLX_TEST_GEMMA4_ASSISTANT_PATH not set");
+            return;
+        };
+        let target = target_12b();
+        let model = load_draft_model(Path::new(&dir), &target)
+            .expect("real draft checkpoint must load with all 48 tensors mapped");
+        assert_eq!(model.num_layers(), 4);
+        assert_eq!(model.collect_weight_arrays().len(), 48);
+        assert!(model.weight_bytes() > 0);
+
+        let rand_bf16 = |shape: &[i64]| {
+            MxArray::random_uniform(shape, -1.0, 1.0, None)
+                .unwrap()
+                .astype(DType::BFloat16)
+                .unwrap()
+        };
+        let kv = AssistantSharedKv {
+            sliding: (rand_bf16(&[1, 8, 6, 256]), rand_bf16(&[1, 8, 6, 256])),
+            full: (rand_bf16(&[1, 1, 6, 512]), rand_bf16(&[1, 1, 6, 512])),
+        };
+        let token_embed = rand_bf16(&[1, 1, 3840])
+            .mul_scalar((3840f64).sqrt())
+            .unwrap();
+        let mut h_prev = rand_bf16(&[1, 1, 3840]);
+        // Two chained steps at the SAME q_pos (the round-constant contract).
+        for _ in 0..2 {
+            let out = model
+                .forward_step(&token_embed, &h_prev, &kv, 5)
+                .expect("forward_step");
+            assert_eq!(out.logits.shape().unwrap().to_vec(), vec![1, 1, 262144]);
+            assert_eq!(out.h_prev_next.shape().unwrap().to_vec(), vec![1, 1, 3840]);
+            assert!(
+                !out.logits.has_nan_or_inf().unwrap(),
+                "logits must be finite"
+            );
+            assert!(
+                !out.h_prev_next.has_nan_or_inf().unwrap(),
+                "h_prev_next must be finite"
+            );
+            h_prev = out.h_prev_next;
+        }
+    }
+}

--- a/crates/mlx-core/src/models/gemma4/assistant.rs
+++ b/crates/mlx-core/src/models/gemma4/assistant.rs
@@ -138,13 +138,56 @@ impl AssistantConfig {
                 "ordered/centroid masked-embedding assistant heads (E2B/E4B) are not yet supported",
             ));
         }
+        // Draft-local sanity BEFORE the target-compat arms: every signed
+        // dimension below is later cast with `as u32`/`as usize` (or used in
+        // modulo math) during module construction, so zero/negative values
+        // must be rejected here rather than wrap into absurd allocations.
+        let text = &self.text_config;
+        for (field, value) in [
+            ("backbone_hidden_size", self.backbone_hidden_size),
+            ("hidden_size", text.hidden_size),
+            ("intermediate_size", text.intermediate_size),
+            ("num_attention_heads", text.num_attention_heads),
+            ("num_key_value_heads", text.num_key_value_heads),
+            (
+                "num_global_key_value_heads",
+                text.num_global_key_value_heads,
+            ),
+            ("head_dim", text.head_dim),
+            ("vocab_size", text.vocab_size),
+            ("sliding_window", text.sliding_window),
+        ] {
+            if value <= 0 {
+                return Err(Error::from_reason(format!(
+                    "assistant draft {field}={value} must be positive"
+                )));
+            }
+        }
+        if let Some(global_head_dim) = text.global_head_dim
+            && global_head_dim <= 0
+        {
+            return Err(Error::from_reason(format!(
+                "assistant draft global_head_dim={global_head_dim} must be positive"
+            )));
+        }
+        if text.num_hidden_layers < 1 {
+            return Err(Error::from_reason(format!(
+                "assistant draft num_hidden_layers={} must be at least 1",
+                text.num_hidden_layers
+            )));
+        }
+        if text.rms_norm_eps <= 0.0 {
+            return Err(Error::from_reason(format!(
+                "assistant draft rms_norm_eps={} must be positive",
+                text.rms_norm_eps
+            )));
+        }
         if self.backbone_hidden_size != target.hidden_size as i64 {
             return Err(Error::from_reason(format!(
                 "assistant draft backbone_hidden_size={} does not match target hidden_size={}",
                 self.backbone_hidden_size, target.hidden_size
             )));
         }
-        let text = &self.text_config;
         if text.vocab_size != target.vocab_size as i64 {
             return Err(Error::from_reason(format!(
                 "assistant draft vocab_size={} does not match target vocab_size={}",
@@ -1109,6 +1152,76 @@ mod tests {
             "\"final_logit_softcapping\": 0.0",
         );
         expect_err(&parse(&json), &target_12b(), "final_logit_softcapping");
+    }
+
+    /// Draft-local dimension sanity must fire BEFORE any target-compat arm:
+    /// zero/negative geometry would otherwise reach the `as u32`/`as usize`
+    /// casts in module construction and wrap into absurd allocations.
+    #[test]
+    fn negative_hidden_size_rejected() {
+        let json = base_config_json().replace("\"hidden_size\": 1024", "\"hidden_size\": -1024");
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "hidden_size=-1024 must be positive",
+        );
+    }
+
+    #[test]
+    fn zero_intermediate_size_rejected() {
+        let json =
+            base_config_json().replace("\"intermediate_size\": 8192", "\"intermediate_size\": 0");
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "intermediate_size=0 must be positive",
+        );
+    }
+
+    #[test]
+    fn zero_num_hidden_layers_rejected() {
+        let json =
+            base_config_json().replace("\"num_hidden_layers\": 4", "\"num_hidden_layers\": 0");
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "num_hidden_layers=0 must be at least 1",
+        );
+    }
+
+    #[test]
+    fn negative_head_dim_rejected() {
+        let json = base_config_json().replace("\"head_dim\": 256", "\"head_dim\": -256");
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "head_dim=-256 must be positive",
+        );
+    }
+
+    #[test]
+    fn negative_num_attention_heads_rejected() {
+        // -16 % 8 == 0, so the existing divisibility arm alone would let a
+        // negative head count through to the (num_heads * head_dim) cast.
+        let json = base_config_json().replace(
+            "\"num_attention_heads\": 16",
+            "\"num_attention_heads\": -16",
+        );
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "num_attention_heads=-16 must be positive",
+        );
+    }
+
+    #[test]
+    fn nonpositive_rms_norm_eps_rejected() {
+        let json = base_config_json().replace("\"rms_norm_eps\": 1e-06", "\"rms_norm_eps\": 0.0");
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "rms_norm_eps=0 must be positive",
+        );
     }
 
     // ── Tiny-model fixtures ────────────────────────────────────────────

--- a/crates/mlx-core/src/models/gemma4/assistant.rs
+++ b/crates/mlx-core/src/models/gemma4/assistant.rs
@@ -37,6 +37,14 @@ pub(crate) const ASSISTANT_MODEL_TYPES: [&str; 2] =
 const SLIDING_ATTENTION: &str = "sliding_attention";
 const FULL_ATTENTION: &str = "full_attention";
 
+/// Upper bound on every draft config dimension AND on the projection widths
+/// derived from them (`num_attention_heads * head_dim`, `2 *
+/// backbone_hidden_size`): 2^24 = 16,777,216 — far above any real checkpoint
+/// value (max real: vocab_size 262144, intermediate_size 8192) and low
+/// enough that every downstream `as u32`/`as i32` cast and dimension product
+/// in module construction is lossless.
+const ASSISTANT_MAX_DIM: i64 = 1 << 24;
+
 // ============================================
 // Config
 // ============================================
@@ -139,9 +147,12 @@ impl AssistantConfig {
             ));
         }
         // Draft-local sanity BEFORE the target-compat arms: every signed
-        // dimension below is later cast with `as u32`/`as usize` (or used in
-        // modulo math) during module construction, so zero/negative values
-        // must be rejected here rather than wrap into absurd allocations.
+        // dimension below is later cast with `as u32`/`as i32`/`as usize`
+        // (or used in modulo math) during module construction. Bounding each
+        // field to (0, ASSISTANT_MAX_DIM] — and the projection-width
+        // products below to the same bound — guarantees all of those casts
+        // and dimension products are lossless, instead of zero/negative or
+        // oversized values wrapping into absurd placeholder allocations.
         let text = &self.text_config;
         for (field, value) in [
             ("backbone_hidden_size", self.backbone_hidden_size),
@@ -162,13 +173,46 @@ impl AssistantConfig {
                     "assistant draft {field}={value} must be positive"
                 )));
             }
+            if value > ASSISTANT_MAX_DIM {
+                return Err(Error::from_reason(format!(
+                    "assistant draft {field}={value} exceeds sane bound {ASSISTANT_MAX_DIM}"
+                )));
+            }
         }
-        if let Some(global_head_dim) = text.global_head_dim
-            && global_head_dim <= 0
-        {
-            return Err(Error::from_reason(format!(
-                "assistant draft global_head_dim={global_head_dim} must be positive"
-            )));
+        if let Some(global_head_dim) = text.global_head_dim {
+            if global_head_dim <= 0 {
+                return Err(Error::from_reason(format!(
+                    "assistant draft global_head_dim={global_head_dim} must be positive"
+                )));
+            }
+            if global_head_dim > ASSISTANT_MAX_DIM {
+                return Err(Error::from_reason(format!(
+                    "assistant draft global_head_dim={global_head_dim} exceeds sane bound {ASSISTANT_MAX_DIM}"
+                )));
+            }
+        }
+        // The projection widths built from these fields must stay within the
+        // bound too: each factor can pass individually while the product
+        // still overflows the `as u32` casts at the construction sites.
+        for (expr, product) in [
+            (
+                "num_attention_heads*head_dim",
+                text.num_attention_heads.checked_mul(text.head_dim),
+            ),
+            (
+                "num_attention_heads*global_head_dim",
+                text.num_attention_heads.checked_mul(text.full_head_dim()),
+            ),
+            (
+                "2*backbone_hidden_size",
+                self.backbone_hidden_size.checked_mul(2),
+            ),
+        ] {
+            if product.is_none_or(|p| p > ASSISTANT_MAX_DIM) {
+                return Err(Error::from_reason(format!(
+                    "assistant draft {expr} overflows/exceeds sane bound {ASSISTANT_MAX_DIM}"
+                )));
+            }
         }
         if text.num_hidden_layers < 1 {
             return Err(Error::from_reason(format!(
@@ -1155,8 +1199,9 @@ mod tests {
     }
 
     /// Draft-local dimension sanity must fire BEFORE any target-compat arm:
-    /// zero/negative geometry would otherwise reach the `as u32`/`as usize`
-    /// casts in module construction and wrap into absurd allocations.
+    /// zero/negative or out-of-bound geometry would otherwise reach the
+    /// `as u32`/`as i32`/`as usize` casts in module construction and wrap
+    /// into absurd allocations.
     #[test]
     fn negative_hidden_size_rejected() {
         let json = base_config_json().replace("\"hidden_size\": 1024", "\"hidden_size\": -1024");
@@ -1222,6 +1267,47 @@ mod tests {
             &target_12b(),
             "rms_norm_eps=0 must be positive",
         );
+    }
+
+    /// POSITIVE out-of-range dimensions must be rejected too: without the
+    /// upper bound they reach the wrapping `as u32`/`as i32` casts (and the
+    /// placeholder allocations) in module construction.
+    #[test]
+    fn oversized_hidden_size_rejected() {
+        let json = base_config_json().replace("\"hidden_size\": 1024", "\"hidden_size\": 17000000");
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "hidden_size=17000000 exceeds sane bound",
+        );
+    }
+
+    #[test]
+    fn oversized_intermediate_size_rejected() {
+        // 2^40: positive, so the positivity arm alone would wave it through
+        // to the wrapping `as u32` cast in GemmaMLP construction.
+        let json = base_config_json().replace(
+            "\"intermediate_size\": 8192",
+            "\"intermediate_size\": 1099511627776",
+        );
+        expect_err(
+            &parse(&json),
+            &target_12b(),
+            "intermediate_size=1099511627776 exceeds sane bound",
+        );
+    }
+
+    #[test]
+    fn oversized_attention_width_product_rejected() {
+        // Each factor is individually within ASSISTANT_MAX_DIM, but the q/o
+        // projection width num_attention_heads * head_dim = 2^25 exceeds it.
+        let json = base_config_json()
+            .replace(
+                "\"num_attention_heads\": 16",
+                "\"num_attention_heads\": 16384",
+            )
+            .replace("\"head_dim\": 256", "\"head_dim\": 2048");
+        expect_err(&parse(&json), &target_12b(), "num_attention_heads*head_dim");
     }
 
     // ── Tiny-model fixtures ────────────────────────────────────────────

--- a/crates/mlx-core/src/models/gemma4/assistant.rs
+++ b/crates/mlx-core/src/models/gemma4/assistant.rs
@@ -34,6 +34,17 @@ use super::quantized_linear::LinearProj;
 pub(crate) const ASSISTANT_MODEL_TYPES: [&str; 2] =
     ["gemma4_assistant", "gemma4_unified_assistant"];
 
+/// Tokens drafted per propose/verify cycle when the request leaves
+/// `mtpDepth` unset. Unlike DSpark there is no checkpoint-pinned block
+/// size — the assistant drafts by chained single-token AR steps — so the
+/// default is a quality/latency tradeoff, not a checkpoint contract.
+pub(crate) const ASSISTANT_DEFAULT_DEPTH: usize = 3;
+
+/// Hard cap on an explicit `mtpDepth` for the assistant draft: each drafted
+/// token is one full chained draft forward AND one extra verify row, so an
+/// unbounded depth would let a single request inflate every verify block.
+pub(crate) const ASSISTANT_MAX_DEPTH: usize = 8;
+
 const SLIDING_ATTENTION: &str = "sliding_attention";
 const FULL_ATTENTION: &str = "full_attention";
 

--- a/crates/mlx-core/src/models/gemma4/assistant.rs
+++ b/crates/mlx-core/src/models/gemma4/assistant.rs
@@ -553,14 +553,12 @@ impl AssistantDecoderLayer {
 /// Dh]`, committed positions only): the last non-KV-shared target layer of
 /// each attention type. Every draft layer attends to the pair matching its
 /// own type.
-#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
 pub(crate) struct AssistantSharedKv {
     pub sliding: (MxArray, MxArray),
     pub full: (MxArray, MxArray),
 }
 
 /// One chained draft step's outputs.
-#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
 pub(crate) struct AssistantStepOutput {
     /// Softcapped draft logits `[1, 1, vocab]`.
     pub logits: MxArray,
@@ -571,7 +569,6 @@ pub(crate) struct AssistantStepOutput {
 /// The assistant draft model: backbone-pair input projection, hybrid Q-only
 /// decoder layers over the target's shared K/V, final norm, tied lm_head,
 /// and backbone output projection.
-#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
 pub(crate) struct AssistantDraftModel {
     pub(crate) config: AssistantConfig,
     /// `Linear(2B -> H)` over `concat([token_embed, h_prev])` — token FIRST.
@@ -590,7 +587,6 @@ pub(crate) struct AssistantDraftModel {
     weight_bytes: u64,
 }
 
-#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
 impl AssistantDraftModel {
     /// Build the module tree for `config` with placeholder weights.
     /// Callers must apply checkpoint weights before running a forward pass.
@@ -867,7 +863,6 @@ impl AssistantDraftModel {
 
 /// Load an assistant draft checkpoint (config.json + safetensors, single
 /// file or sharded) and validate it against the target model's geometry.
-#[allow(dead_code)] // consumed by the assistant decode stepper; exercised by the inline tests until it lands
 pub(crate) fn load_draft_model(dir: &Path, target: &Gemma4Config) -> Result<AssistantDraftModel> {
     let config_path = dir.join("config.json");
     let raw = fs::read_to_string(&config_path).map_err(|e| {

--- a/crates/mlx-core/src/models/gemma4/assistant_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/assistant_decode.rs
@@ -1,0 +1,756 @@
+//! Gemma4 assistant-draft speculative-decode wiring: the family-side
+//! [`DsparkStepper`] implementation for the Google assistant draft, plus the
+//! assistant prefill that seeds the per-turn state.
+//!
+//! Split of responsibilities (the assistant mirror of
+//! [`super::dspark_decode`]):
+//!   * the DRAFT model (Q-only transformer over the target's shared KV,
+//!     backbone pre/post projections, tied lm_head) lives in
+//!     [`super::assistant`];
+//!   * the TARGET-side primitives (verify forward with exposed hidden,
+//!     snapshot/commit rollback, KV-source mapping, shared-slot mask) live
+//!     in [`super::model`] / [`super::layer_cache`];
+//!   * the model-agnostic propose → verify → accept → stop-clamp → commit
+//!     loop lives in [`crate::engine::dspark_turn`];
+//!   * variant dispatch (`Gemma4DraftStepper`, `begin_dspark_decode`, the
+//!     whole-turn core) lives in [`super::dspark_decode`];
+//!   * THIS module implements the assistant stepper and prefill.
+//!
+//! Drafting per round follows mlx-vlm's `_mtp_rounds` semantics: chained
+//! single-token AR steps, each attending the target's COMMITTED K/V with the
+//! query RoPE'd at the round-constant position of the last committed token,
+//! chaining the draft's own `h_prev` output locally. Round 1's `h_prev` is
+//! the target's post-final-norm hidden of the last prompt token; after every
+//! commit it becomes the verify hidden at the last kept slot.
+
+use napi::bindgen_prelude::*;
+
+use crate::array::{DType, MxArray};
+use crate::engine::backend::{DsparkProposal, DsparkStepper, DsparkVerifyOutput};
+use crate::engine::params::ChatParams;
+use crate::sampling;
+use crate::stream::{Stream, StreamContext};
+
+use super::assistant::AssistantSharedKv;
+use super::dspark::sample_index_from_probs;
+use super::layer_cache::{Gemma4VerifyRollback, commit_after_verify, snapshot_before_verify};
+use super::model::{
+    AssistantKvSources, GEMMA4_PREFILL_STEP_SIZE, Gemma4Inner, assistant_verify_forward,
+    compute_ple, eval_gemma4_caches, forward_body, lm_head_logits,
+};
+
+/// Assistant payload of [`super::dspark_decode::Gemma4DraftTurnState`]: the
+/// per-turn handoff from `assistant_prefill_with_hidden` to
+/// [`crate::engine::backend::DsparkBackend::begin_dspark_decode`].
+pub(crate) struct AssistantTurnState {
+    /// The target's post-final-norm hidden of the LAST PROMPT token,
+    /// `[1, 1, backbone_hidden_size]` — round 1's chained `h_prev` seed
+    /// (mlx-vlm's deliberate deviation from HF, which seeds from the
+    /// pre-norm hidden).
+    pub(crate) h_prev: MxArray,
+    /// Absolute sequence position of the NEXT target-cache slot —
+    /// `cached_prefix_len + prefill_len` right after prefill, then advanced
+    /// by `keep` on every commit.
+    pub(crate) next_pos: i32,
+}
+
+/// Per-turn gemma4 assistant stepper (the assistant arm of
+/// [`super::dspark_decode::Gemma4DraftStepper`]).
+///
+/// Borrows the model for the whole decode loop. The verify hidden and the
+/// rollback are stashed between `verify` and `commit` — they never cross the
+/// engine trait (see the invariant on [`DsparkStepper`]).
+pub(crate) struct Gemma4AssistantStepper<'a> {
+    inner: &'a mut Gemma4Inner,
+    /// Chained backbone hidden `[1, 1, B]` conditioning the next drafting
+    /// round — the target's post-final-norm hidden at the LAST COMMITTED
+    /// slot. Advanced ONLY by `commit` (propose chains a local copy).
+    h_prev: MxArray,
+    /// Absolute position of the next verify block's anchor (== the current
+    /// committed sequence length: prompt + anchor-exclusive generation).
+    next_pos: i32,
+    /// Target-layer indices whose caches hold the draft's shared K/V, one
+    /// per attention type ([`super::model::assistant_kv_source_indices`]).
+    kv_sources: AssistantKvSources,
+    /// Config-derived KV-shared slot mask
+    /// ([`super::model::dspark_shared_slot_mask`]), passed to every
+    /// `snapshot_before_verify`.
+    shared_slots: Vec<bool>,
+    /// Pending rollback from the last `verify`, consumed by `commit`.
+    rollback: Option<Gemma4VerifyRollback>,
+    /// `[1, 1+L, B]` post-final-norm hidden from the last `verify`,
+    /// consumed by `commit`.
+    verify_hidden: Option<MxArray>,
+}
+
+impl<'a> Gemma4AssistantStepper<'a> {
+    /// Assemble the per-turn stepper from the prefill-derived state plus the
+    /// config-derived KV routing (computed by `begin_dspark_decode`).
+    pub(crate) fn from_turn_state(
+        inner: &'a mut Gemma4Inner,
+        state: AssistantTurnState,
+        kv_sources: AssistantKvSources,
+        shared_slots: Vec<bool>,
+    ) -> Self {
+        Self {
+            inner,
+            h_prev: state.h_prev,
+            next_pos: state.next_pos,
+            kv_sources,
+            shared_slots,
+            rollback: None,
+            verify_hidden: None,
+        }
+    }
+}
+
+impl DsparkStepper for Gemma4AssistantStepper<'_> {
+    fn propose(
+        &mut self,
+        anchor_id: u32,
+        max_len: usize,
+        params: &ChatParams,
+        rng: &mut dyn rand::Rng,
+    ) -> Result<DsparkProposal> {
+        let draft = self
+            .inner
+            .assistant_draft()
+            .ok_or_else(|| Error::from_reason("gemma4 assistant propose: no draft model loaded"))?;
+        if max_len == 0 {
+            return Err(Error::from_reason(
+                "gemma4 assistant propose: engine contract violation (max_len == 0 cycles skip propose)",
+            ));
+        }
+        let vocab = draft.config.text_config.vocab_size;
+        if (anchor_id as i64) >= vocab {
+            return Err(Error::from_reason(format!(
+                "gemma4 assistant propose: anchor token {anchor_id} out of vocab range [0, {vocab})"
+            )));
+        }
+
+        // Shared K/V handles, re-read from the target caches at the START of
+        // every propose — always after the previous cycle's commit, so the
+        // contents are exactly the committed positions. Never cached across
+        // cycles.
+        let kv = {
+            let caches =
+                self.inner.caches.as_ref().ok_or_else(|| {
+                    Error::from_reason("gemma4 assistant propose: caches missing")
+                })?;
+            let fetch = |idx: usize, label: &str| -> Result<(MxArray, MxArray)> {
+                caches
+                    .get(idx)
+                    .ok_or_else(|| {
+                        Error::from_reason(format!(
+                            "gemma4 assistant propose: {label} KV source layer {idx} out of range \
+                             ({} caches)",
+                            caches.len()
+                        ))
+                    })?
+                    .get_cached_kv()
+                    .ok_or_else(|| {
+                        Error::from_reason(format!(
+                            "gemma4 assistant propose: {label} KV source layer {idx} has no \
+                             committed K/V (empty cache)"
+                        ))
+                    })
+            };
+            AssistantSharedKv {
+                sliding: fetch(self.kv_sources.sliding, "sliding")?,
+                full: fetch(self.kv_sources.full, "full")?,
+            }
+        };
+
+        // Round-constant query position: the absolute position of the LAST
+        // COMMITTED token, computed ONCE and held fixed across all chained
+        // steps of this round.
+        let q_pos = self.next_pos - 1;
+
+        // Greedy detection uses the engine's `sampling::is_greedy_temperature`
+        // predicate — the same predicate `run_dspark_turn` keys its accept
+        // policy on — so the returned `dists` are empty exactly when the
+        // engine expects them empty, and at sampled temperature each row is
+        // the EXACT distribution the draw came from.
+        let cfg = params.sampling_config.unwrap_or_default();
+        let greedy = sampling::is_greedy_temperature(cfg.temperature.unwrap_or(1.0));
+
+        // Chained single-token AR drafting. `h_prev` chains LOCALLY — the
+        // stepper's field is advanced only by `commit` — and no target state
+        // (caches, cursor) is touched, so propose is repeatable.
+        let embed_scale = (self.inner.config.hidden_size as f64).sqrt();
+        let mut draft_ids: Vec<i32> = Vec::with_capacity(max_len);
+        let mut draft_dists: Vec<MxArray> = Vec::new();
+        let mut h_prev = self.h_prev.clone();
+        let mut prev_token = anchor_id as i32;
+        for _ in 0..max_len {
+            // Token embedding from the TARGET's table, scaled exactly like
+            // the target's own `forward_body` step 1 (handles
+            // packed-quantized tables), cast to the chained hidden's dtype
+            // when the two differ.
+            let ids = MxArray::from_int32(&[prev_token], &[1, 1])?;
+            let token_embed = {
+                let raw = self
+                    .inner
+                    .embed_tokens
+                    .forward(&ids)?
+                    .mul_scalar(embed_scale)?;
+                let want = h_prev.dtype()?;
+                if raw.dtype()? == want {
+                    raw
+                } else {
+                    raw.astype(want)?
+                }
+            };
+            let step = draft.forward_step(&token_embed, &h_prev, &kv, q_pos)?;
+            let step_logits = step.logits.reshape(&[vocab])?;
+            let token = if greedy {
+                let idx = step_logits.argmax(0, Some(false))?.astype(DType::Int32)?;
+                idx.eval();
+                idx.item_at_int32(0)?
+            } else {
+                let dist = sampling::sampling_distribution(&step_logits, Some(cfg))?
+                    .astype(DType::Float32)?;
+                dist.eval();
+                let probs = dist.to_float32()?;
+                let token = sample_index_from_probs(&probs, rng)?;
+                draft_dists.push(dist);
+                token
+            };
+            draft_ids.push(token);
+            prev_token = token;
+            h_prev = step.h_prev_next;
+        }
+
+        Ok(DsparkProposal {
+            draft_ids,
+            draft_dists,
+        })
+    }
+
+    fn verify(&mut self, verify_ids: &[u32]) -> Result<DsparkVerifyOutput> {
+        if verify_ids.is_empty() {
+            return Err(Error::from_reason(
+                "gemma4 assistant verify: empty verify block",
+            ));
+        }
+        // Commit-exactly-once defense: a second verify before the previous
+        // cycle's commit would orphan its rollback (the caches would then
+        // hold TWO uncommitted verify blocks).
+        if self.rollback.is_some() || self.verify_hidden.is_some() {
+            return Err(Error::from_reason(
+                "gemma4 assistant verify: previous verify was never committed",
+            ));
+        }
+
+        let inner = &mut *self.inner;
+        let caches = inner
+            .caches
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("gemma4 assistant verify: caches missing"))?;
+        let rb = snapshot_before_verify(caches, verify_ids.len(), &self.shared_slots)?;
+
+        let ids_i32: Vec<i32> = verify_ids.iter().map(|&t| t as i32).collect();
+        let block = MxArray::from_int32(&ids_i32, &[1, verify_ids.len() as i64])?;
+        let (logits, hidden) = assistant_verify_forward(
+            &block,
+            &inner.embed_tokens,
+            &inner.layers,
+            caches,
+            &inner.final_norm,
+            &inner.lm_head,
+            inner.embed_weight_t.as_ref(),
+            inner.ple.as_ref(),
+            &inner.config,
+        )?;
+
+        self.rollback = Some(rb);
+        self.verify_hidden = Some(hidden);
+        Ok(DsparkVerifyOutput { logits })
+    }
+
+    fn commit(&mut self, keep: usize, total_written: usize) -> Result<()> {
+        let rb = self.rollback.take().ok_or_else(|| {
+            Error::from_reason("gemma4 assistant commit: no pending verify rollback")
+        })?;
+        let hidden = self.verify_hidden.take().ok_or_else(|| {
+            Error::from_reason("gemma4 assistant commit: no stashed verify hidden")
+        })?;
+        if keep == 0 {
+            return Err(Error::from_reason(
+                "gemma4 assistant commit: engine contract violation (keep must be >= 1 — the anchor's slot is unconditionally kept)",
+            ));
+        }
+        if hidden.shape_at(1)? != total_written as i64 {
+            return Err(Error::from_reason(format!(
+                "gemma4 assistant commit: stashed verify hidden covers {} positions but the engine reports a {}-token verify block",
+                hidden.shape_at(1)?,
+                total_written
+            )));
+        }
+
+        // Target side: keep the first `keep` of the verify block's K/V
+        // slots, roll back the rest (validated against the shared-slot mask
+        // on every commit, full keep included). `commit_after_verify` also
+        // rejects `keep > total_written`, so the slice below is in range.
+        {
+            let caches = self
+                .inner
+                .caches
+                .as_mut()
+                .ok_or_else(|| Error::from_reason("gemma4 assistant commit: caches missing"))?;
+            commit_after_verify(caches, &rb, keep)?;
+        }
+
+        // Draft side: the next round chains from the verify hidden at the
+        // LAST KEPT slot; advance the cursor by the kept prefix. The
+        // boundary token has no slot — it re-enters as the next cycle's
+        // verify anchor.
+        self.h_prev = hidden.slice_axis(1, keep as i64 - 1, keep as i64)?;
+        self.next_pos += keep as i32;
+        Ok(())
+    }
+
+    fn eval_boundary(&self, token: &MxArray) {
+        // Schedule-only async eval of the next cycle's anchor (gemma4's
+        // decode eval pattern: token only, never the logits).
+        MxArray::async_eval_arrays(&[token]);
+    }
+}
+
+impl Gemma4Inner {
+    /// Chunked prefill for the assistant draft: target-side compute
+    /// byte-identical to the AR path, plus the LAST prompt token's
+    /// post-final-norm hidden.
+    ///
+    /// Mirrors `dspark_prefill_with_tap` MINUS all tap/fuse/context work
+    /// (same upfront embedding/PLE, same 512-token chunking, same eval
+    /// cadence and `clear_cache`, same last-token split) — the last token
+    /// runs `forward_body` with the hidden kept, then the `lm_head_logits`
+    /// tail, which composes to exactly `forward_inner`.
+    ///
+    /// Returns the sampling-ready last-token logits `[1, vocab]` plus the
+    /// turn's [`AssistantTurnState`].
+    #[allow(dead_code)] // wired into the whole-turn core with the draft turn generalization
+    pub(crate) fn assistant_prefill_with_hidden(
+        &mut self,
+        prefill_tokens: &[u32],
+        position_base: i32,
+        stream: Stream,
+    ) -> Result<(MxArray, AssistantTurnState)> {
+        if prefill_tokens.is_empty() {
+            return Err(Error::from_reason(
+                "gemma4 assistant prefill: empty prefill token set",
+            ));
+        }
+        if self.caches.is_none() {
+            self.init_caches_sync()?;
+        }
+
+        let inner = &mut *self;
+        let caches = inner
+            .caches
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("gemma4 assistant prefill: caches missing"))?;
+
+        let n = prefill_tokens.len() as i64;
+        let ids_i32: Vec<i32> = prefill_tokens.iter().map(|&t| t as i32).collect();
+        let prompt = MxArray::from_int32(&ids_i32, &[1, n])?;
+
+        {
+            let _stream_ctx = StreamContext::new(stream);
+            if n > 1 {
+                // Body over tokens [0 .. n-1] — the last token is handled by
+                // the hidden-keeping forward below (`prefill_body_gemma4`'s
+                // split).
+                let prefill_len = n - 1;
+                let prefill_ids = prompt.slice_axis(1, 0, prefill_len)?;
+                let all_embeds = {
+                    let emb = inner.embed_tokens.forward(&prefill_ids)?;
+                    emb.mul_scalar((inner.config.hidden_size as f64).sqrt())?
+                };
+                let all_ple: Option<MxArray> = match inner.ple.as_ref() {
+                    Some(ple) => Some(compute_ple(&prefill_ids, &all_embeds, ple, prefill_len)?),
+                    None => None,
+                };
+                let mut offset: i64 = 0;
+                while offset < prefill_len {
+                    let end = if prefill_len - offset > GEMMA4_PREFILL_STEP_SIZE {
+                        offset + GEMMA4_PREFILL_STEP_SIZE
+                    } else {
+                        prefill_len
+                    };
+                    let chunk_embeds = all_embeds.slice_axis(1, offset, end)?;
+                    let chunk_ple = all_ple
+                        .as_ref()
+                        .map(|p| p.slice_axis(1, offset, end))
+                        .transpose()?;
+                    let _hidden = forward_body(
+                        None,
+                        Some(chunk_embeds),
+                        &inner.embed_tokens,
+                        &inner.layers,
+                        caches,
+                        &inner.final_norm,
+                        inner.ple.as_ref(),
+                        chunk_ple.as_ref(),
+                        &inner.config,
+                        None,
+                    )?;
+                    // Eval cadence mirrors `prefill_body_gemma4`: full
+                    // chunks eval+clear between iterations; the remainder
+                    // chunk is covered by the post-body eval below.
+                    if end < prefill_len {
+                        eval_gemma4_caches(caches)?;
+                        crate::array::clear_cache();
+                    }
+                    offset = end;
+                }
+            }
+        }
+        eval_gemma4_caches(caches)?;
+
+        // Last token: `forward_body` keeping the `[1, 1, hidden]`
+        // post-final-norm hidden (the turn's h_prev seed) + the
+        // `lm_head_logits` tail — together exactly the AR prefill's
+        // last-token `forward_inner`.
+        let last = prompt.slice_axis(1, n - 1, n)?;
+        let (last_logits, h_last) = {
+            let _stream_ctx = StreamContext::new(stream);
+            crate::models::gemma4::diagnostic::set_step(-1);
+            let hidden = forward_body(
+                Some(&last),
+                None,
+                &inner.embed_tokens,
+                &inner.layers,
+                caches,
+                &inner.final_norm,
+                inner.ple.as_ref(),
+                None,
+                &inner.config,
+                None,
+            )?;
+            let logits = lm_head_logits(
+                &hidden,
+                &inner.embed_tokens,
+                &inner.lm_head,
+                inner.embed_weight_t.as_ref(),
+                &inner.config,
+            )?;
+            (logits, hidden)
+        };
+        let last_logits = last_logits.squeeze(Some(&[1]))?;
+
+        Ok((
+            last_logits,
+            AssistantTurnState {
+                h_prev: h_last,
+                next_pos: position_base + n as i32,
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::backend::{ChatBackend, DsparkBackend, DsparkTurnSetup};
+    use crate::engine::types::ChatConfig;
+    use crate::models::gemma4::dspark::DsparkContextCache;
+    use crate::models::gemma4::dspark_decode::tests::{
+        chat_config, tiny_inner_with_assistant_draft, tiny_inner_with_draft,
+    };
+    use crate::models::gemma4::dspark_decode::{
+        DsparkTurnState, Gemma4DraftStepper, Gemma4DraftTurnState,
+    };
+    use crate::models::gemma4::model::dspark_shared_slot_mask;
+    use crate::stream::DeviceType;
+
+    fn to_vec_f32(a: &MxArray) -> Vec<f32> {
+        a.eval();
+        a.to_float32().expect("array must convert to f32").to_vec()
+    }
+
+    fn greedy_config(mtp_depth: Option<i32>) -> ChatConfig {
+        ChatConfig {
+            mtp_depth,
+            temperature: Some(0.0),
+            ..ChatConfig::default()
+        }
+    }
+
+    /// Prefill the 4-token tiny prompt, stash the turn state, and return the
+    /// assistant stepper's enum wrapper (via the REAL `begin_dspark_decode`
+    /// dispatch).
+    fn prefilled_assistant_stepper<'a>(
+        inner: &'a mut Gemma4Inner,
+        p: &ChatParams,
+        block_size: usize,
+    ) -> Gemma4DraftStepper<'a> {
+        let tokens: Vec<u32> = vec![0, 1, 2, 3];
+        let stream = Stream::new(DeviceType::Gpu);
+        let (_logits, state) = inner
+            .assistant_prefill_with_hidden(&tokens, 0, stream)
+            .expect("tiny assistant prefill must succeed");
+        assert_eq!(state.next_pos, 4, "prefill must report the prompt length");
+        inner.draft_turn_state = Some(Gemma4DraftTurnState::Assistant(state));
+        let setup = DsparkTurnSetup {
+            params: p,
+            block_size,
+        };
+        inner
+            .begin_dspark_decode(&setup)
+            .expect("begin with an assistant stash must succeed")
+    }
+
+    // ── begin_dspark_decode dispatch ───────────────────────────────────
+
+    /// The assistant arm of `begin_dspark_decode`: KV sources computed from
+    /// the target config, shared slots from the mask, cursor from the
+    /// stash; the stash is consumed; no-stash and BOTH variant-mismatch
+    /// directions are hard errors.
+    #[test]
+    fn begin_dspark_decode_dispatches_assistant() {
+        let mut inner = tiny_inner_with_assistant_draft();
+        let p = ChatBackend::resolve_params(&inner, &chat_config(None));
+        let setup = DsparkTurnSetup {
+            params: &p,
+            block_size: 3,
+        };
+
+        // No stash → hard error naming the missing prefill.
+        let err = inner
+            .begin_dspark_decode(&setup)
+            .err()
+            .expect("begin without a stash must fail");
+        assert!(
+            err.reason.contains("prepared draft context"),
+            "got: {}",
+            err.reason
+        );
+
+        // Assistant stash → assistant stepper with config-derived routing.
+        inner.draft_turn_state = Some(Gemma4DraftTurnState::Assistant(AssistantTurnState {
+            h_prev: MxArray::zeros(&[1, 1, 8], None).expect("zeros"),
+            next_pos: 7,
+        }));
+        {
+            let stepper = match inner
+                .begin_dspark_decode(&setup)
+                .expect("begin with an assistant stash must succeed")
+            {
+                Gemma4DraftStepper::Assistant(stepper) => stepper,
+                Gemma4DraftStepper::Dspark(_) => {
+                    panic!("an assistant draft must yield the assistant stepper")
+                }
+            };
+            assert_eq!(
+                stepper.kv_sources,
+                AssistantKvSources {
+                    sliding: 2,
+                    full: 1
+                },
+                "KV sources must be the last non-shared layer of each type"
+            );
+            assert_eq!(
+                stepper.shared_slots,
+                vec![false, false, false, true],
+                "mask must come from dspark_shared_slot_mask(config)"
+            );
+            assert_eq!(stepper.next_pos, 7);
+            assert!(stepper.rollback.is_none() && stepper.verify_hidden.is_none());
+        }
+        assert!(
+            inner.draft_turn_state.is_none(),
+            "the per-turn stash must be consumed by begin_dspark_decode"
+        );
+
+        // Mismatch 1: DSpark stash on an assistant draft.
+        inner.draft_turn_state = Some(Gemma4DraftTurnState::Dspark(DsparkTurnState {
+            ctx: DsparkContextCache::new(2),
+            next_pos: 3,
+        }));
+        let err = inner
+            .begin_dspark_decode(&setup)
+            .err()
+            .expect("a DSpark stash on an assistant draft must fail");
+        assert!(
+            err.reason.contains("DSpark turn state")
+                && err.reason.contains("not the DSpark variant"),
+            "got: {}",
+            err.reason
+        );
+
+        // Mismatch 2: assistant stash on a DSpark draft.
+        let mut dspark_inner = tiny_inner_with_draft();
+        dspark_inner.draft_turn_state = Some(Gemma4DraftTurnState::Assistant(AssistantTurnState {
+            h_prev: MxArray::zeros(&[1, 1, 8], None).expect("zeros"),
+            next_pos: 7,
+        }));
+        let err = dspark_inner
+            .begin_dspark_decode(&setup)
+            .err()
+            .expect("an assistant stash on a DSpark draft must fail");
+        assert!(
+            err.reason.contains("assistant turn state")
+                && err.reason.contains("not the assistant variant"),
+            "got: {}",
+            err.reason
+        );
+    }
+
+    // ── propose: committed KV, held position, no target mutation ──────
+
+    /// After a real tiny prefill, a depth-3 propose returns 3 ids with
+    /// EMPTY dists at greedy temperature, is deterministic on repeat, and
+    /// mutates NO target state (cursor and every cache offset unchanged).
+    #[test]
+    fn propose_reads_committed_kv_and_holds_position() {
+        // Pin MLX's global PRNG so the placeholder weights — and the drafted
+        // ids — are identical on every run (the repo's `mlx_seed` pattern).
+        unsafe { mlx_sys::mlx_seed(0xA551_0001) };
+        let mut inner = tiny_inner_with_assistant_draft();
+        let p = ChatBackend::resolve_params(&inner, &greedy_config(Some(3)));
+
+        let offsets_before: Vec<i32>;
+        let (prop1_ids, prop2_ids);
+        {
+            let mut stepper = match prefilled_assistant_stepper(&mut inner, &p, 3) {
+                Gemma4DraftStepper::Assistant(stepper) => stepper,
+                Gemma4DraftStepper::Dspark(_) => panic!("expected the assistant stepper"),
+            };
+            offsets_before = stepper
+                .inner
+                .caches
+                .as_ref()
+                .expect("caches live after prefill")
+                .iter()
+                .map(|c| c.get_offset())
+                .collect();
+
+            let mut rng = rand::rng();
+            let prop1 = stepper
+                .propose(3, 3, &p, &mut rng)
+                .expect("first propose must succeed");
+            assert_eq!(prop1.draft_ids.len(), 3, "depth-3 propose returns 3 ids");
+            assert!(
+                prop1.draft_dists.is_empty(),
+                "greedy-temperature propose must ship empty dists"
+            );
+            for &id in &prop1.draft_ids {
+                assert!((0..16).contains(&id), "drafted id {id} out of tiny vocab");
+            }
+
+            let prop2 = stepper
+                .propose(3, 3, &p, &mut rng)
+                .expect("second propose must succeed");
+            assert_eq!(
+                prop1.draft_ids, prop2.draft_ids,
+                "propose must be deterministic on repeat (it mutates no state)"
+            );
+            assert_eq!(stepper.next_pos, 4, "propose must not advance the cursor");
+            prop1_ids = prop1.draft_ids;
+            prop2_ids = prop2.draft_ids;
+        }
+        assert_eq!(prop1_ids, prop2_ids);
+
+        let offsets_after: Vec<i32> = inner
+            .caches
+            .as_ref()
+            .expect("caches live")
+            .iter()
+            .map(|c| c.get_offset())
+            .collect();
+        assert_eq!(
+            offsets_before, offsets_after,
+            "propose must not touch the target caches"
+        );
+    }
+
+    // ── verify + commit: h_prev chaining and cursor advance ───────────
+
+    /// Verify anchor+2 then commit keep=2: the cursor advances by 2, h_prev
+    /// becomes the verify hidden's row keep-1 bitwise, active caches roll
+    /// back to the kept prefix — and both commit-without-verify and
+    /// verify-before-commit are hard errors.
+    #[test]
+    fn commit_updates_h_prev_and_cursor() {
+        unsafe { mlx_sys::mlx_seed(0xA551_0002) };
+        let mut inner = tiny_inner_with_assistant_draft();
+        let p = ChatBackend::resolve_params(&inner, &greedy_config(Some(2)));
+        {
+            let mut stepper = match prefilled_assistant_stepper(&mut inner, &p, 2) {
+                Gemma4DraftStepper::Assistant(stepper) => stepper,
+                Gemma4DraftStepper::Dspark(_) => panic!("expected the assistant stepper"),
+            };
+
+            // Commit without a verify → hard error.
+            let err = stepper
+                .commit(1, 1)
+                .expect_err("commit without a pending verify must fail");
+            assert!(
+                err.reason.contains("no pending verify rollback"),
+                "got: {}",
+                err.reason
+            );
+
+            // Verify [anchor, d0, d1].
+            let out = stepper
+                .verify(&[3, 1, 2])
+                .expect("3-token verify must succeed");
+            assert_eq!(
+                out.logits.shape().expect("logits shape").to_vec(),
+                vec![1, 3, 16]
+            );
+
+            // A second verify before commit → hard error.
+            let err = match stepper.verify(&[3, 1, 2]) {
+                Ok(_) => panic!("verify before the previous commit must fail"),
+                Err(err) => err,
+            };
+            assert!(
+                err.reason.contains("never committed"),
+                "got: {}",
+                err.reason
+            );
+
+            let hidden = stepper
+                .verify_hidden
+                .as_ref()
+                .expect("verify must stash the hidden")
+                .clone();
+            assert_eq!(
+                hidden.shape().expect("hidden shape").to_vec(),
+                vec![1, 3, 8]
+            );
+
+            stepper.commit(2, 3).expect("commit keep=2 must succeed");
+            assert_eq!(
+                stepper.next_pos, 6,
+                "commit must advance the cursor by keep"
+            );
+            let expected = hidden.slice_axis(1, 1, 2).expect("slice row keep-1");
+            assert_eq!(
+                to_vec_f32(&stepper.h_prev),
+                to_vec_f32(&expected),
+                "h_prev must be the verify hidden at the LAST KEPT slot"
+            );
+            assert!(
+                stepper.rollback.is_none() && stepper.verify_hidden.is_none(),
+                "commit must consume the verify stash"
+            );
+        }
+
+        // Physical rollback: active caches at prompt(4) + keep(2); the
+        // KV-shared slot untouched.
+        let mask = dspark_shared_slot_mask(&inner.config);
+        let caches = inner.caches.as_ref().expect("caches live");
+        for (i, cache) in caches.iter().enumerate() {
+            let expected = if mask[i] { 0 } else { 6 };
+            assert_eq!(
+                cache.get_offset(),
+                expected,
+                "cache {i} offset after commit keep=2"
+            );
+        }
+    }
+}

--- a/crates/mlx-core/src/models/gemma4/assistant_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/assistant_decode.rs
@@ -330,7 +330,6 @@ impl Gemma4Inner {
     ///
     /// Returns the sampling-ready last-token logits `[1, vocab]` plus the
     /// turn's [`AssistantTurnState`].
-    #[allow(dead_code)] // wired into the whole-turn core with the draft turn generalization
     pub(crate) fn assistant_prefill_with_hidden(
         &mut self,
         prefill_tokens: &[u32],
@@ -452,17 +451,24 @@ impl Gemma4Inner {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use crate::engine::backend::{ChatBackend, DsparkBackend, DsparkTurnSetup};
+    use crate::engine::backend::{
+        ChatBackend, DsparkBackend, DsparkTurnSetup, TurnOutput, WholeTurnArgs,
+    };
     use crate::engine::types::ChatConfig;
+    use crate::models::gemma4::assistant::AssistantDraftModel;
     use crate::models::gemma4::dspark::DsparkContextCache;
     use crate::models::gemma4::dspark_decode::tests::{
-        chat_config, tiny_inner_with_assistant_draft, tiny_inner_with_draft,
+        CancelAfterSink, chat_config, run_tiny_draft_turn, tiny_assistant_config,
+        tiny_inner_with_assistant_draft, tiny_inner_with_draft, tiny_qwen_tokenizer,
+        tiny_target_config, tiny_target_config_with_window, tiny_turn_config,
     };
     use crate::models::gemma4::dspark_decode::{
         DsparkTurnState, Gemma4DraftStepper, Gemma4DraftTurnState,
     };
-    use crate::models::gemma4::model::dspark_shared_slot_mask;
+    use crate::models::gemma4::model::{Gemma4Draft, dspark_shared_slot_mask};
     use crate::stream::DeviceType;
 
     fn to_vec_f32(a: &MxArray) -> Vec<f32> {
@@ -752,5 +758,208 @@ mod tests {
                 "cache {i} offset after commit keep=2"
             );
         }
+    }
+
+    // ── fail-closed error path (whole-turn core) ───────────────────────
+
+    /// FAIL-CLOSED regression on the ASSISTANT variant (the port of the
+    /// DSpark `dspark_turn_error_fails_closed_then_cold_turn_recovers`
+    /// test): a REAL (unmocked) stepper error AFTER prefill has advanced
+    /// the target caches must drop the entire warm session, and the very
+    /// next turn must succeed via the cold path.
+    ///
+    /// Error injection: sliding_window 2 with the default assistant depth
+    /// (3) makes the first cycle's 4-row verify block violate
+    /// `snapshot_before_verify`'s window >= block invariant — the error
+    /// fires at the verify seam of cycle 1, after
+    /// `assistant_prefill_with_hidden` appended the whole prompt to every
+    /// active cache.
+    #[test]
+    fn assistant_turn_error_fails_closed_then_cold_turn_recovers() {
+        let mut inner = Gemma4Inner::new(tiny_target_config_with_window(2))
+            .expect("tiny window-2 Gemma4Inner must construct");
+        inner.draft = Some(Gemma4Draft::Assistant(
+            AssistantDraftModel::new(tiny_assistant_config()).expect("tiny assistant draft"),
+        ));
+        let tokenizer = tiny_qwen_tokenizer();
+        let tokens: Vec<u32> = vec![0, 1, 2, 3];
+
+        // Turn 1: unset depth resolves to ASSISTANT_DEFAULT_DEPTH (3) →
+        // 1+3 verify rows over a 2-token window → hard error mid-turn.
+        let err = run_tiny_draft_turn(&mut inner, &tokenizer, &tokens, &tiny_turn_config(None, 8))
+            .expect_err("a depth-3 verify block must violate the window-2 rollback invariant");
+        assert!(
+            err.reason.contains("sliding window") && err.reason.contains("verify block"),
+            "expected the snapshot_before_verify window guard, got: {}",
+            err.reason
+        );
+        // Fail CLOSED: nothing warm-reusable may survive the error.
+        assert!(inner.caches.is_none(), "caches must be dropped");
+        assert!(
+            inner.cached_token_history.is_empty(),
+            "cached_token_history must be cleared (it never covered the prefilled K/V)"
+        );
+        assert!(
+            inner.draft_turn_state.is_none(),
+            "the per-turn draft stash must be cleared"
+        );
+        assert!(
+            !ChatBackend::has_live_session(&inner),
+            "the session must not be warm-reusable after a failed turn"
+        );
+        assert_eq!(
+            ChatBackend::verify_cache_prefix(&inner, &tokens, true),
+            0,
+            "no prefix hit may match against the dropped session"
+        );
+
+        // Turn 2: depth 1 → verify blocks of <= 2 rows fit the window; the
+        // turn must run cold end-to-end and land fully consistent.
+        let res = run_tiny_draft_turn(
+            &mut inner,
+            &tokenizer,
+            &tokens,
+            &tiny_turn_config(Some(1), 3),
+        )
+        .expect("the next turn after fail-closed must succeed via the cold path");
+        assert_eq!(res.finish_reason, "length");
+        assert_eq!(
+            res.cached_tokens, 0,
+            "nothing may be warm-reused after fail-closed"
+        );
+        assert_eq!(res.num_tokens, 3, "budget-3 length exit");
+
+        // Length-exit AR parity (keep-all + materialize): the saved history
+        // holds prompt + ALL generated tokens and every ACTIVE cache offset
+        // equals the history length.
+        let history = inner.cached_token_history.clone();
+        assert_eq!(history.len(), tokens.len() + res.num_tokens as usize);
+        assert_eq!(&history[..tokens.len()], &tokens[..]);
+        let mask = dspark_shared_slot_mask(&inner.config);
+        let caches = inner
+            .caches
+            .as_ref()
+            .expect("live caches after a successful turn");
+        for (i, cache) in caches.iter().enumerate() {
+            let expected = if mask[i] { 0 } else { history.len() as i32 };
+            assert_eq!(
+                cache.get_offset(),
+                expected,
+                "cache {i} offset must equal the saved history length \
+                 (length-exit materialize; shared slots stay unwritten)"
+            );
+        }
+    }
+
+    // ── streaming cancellation (whole-turn) ────────────────────────────
+
+    /// WHOLE-TURN streaming cancellation through `draft_chat_turn` on the
+    /// ASSISTANT variant (mechanical port of the DSpark
+    /// `dspark_streaming_cancel_whole_turn_state_consistent` test): a
+    /// cancel raised from the chunk sink must terminate the stream promptly
+    /// ("cancelled", bounded block-granular overrun — never running on to
+    /// the budget) and leave the cached session state consistent (AR-parity
+    /// drop-last: the final emitted token is persisted in NEITHER the
+    /// history NOR the caches; offsets equal the history), with the next
+    /// turn running normally.
+    #[test]
+    fn assistant_streaming_cancel_whole_turn_state_consistent() {
+        // Placeholder weights come from MLX's global PRNG; pin it so the
+        // token stream — and with it the chunk/flip timing the `n` bound
+        // below asserts on — is identical on every run.
+        unsafe { mlx_sys::mlx_seed(0xA551_0003) };
+        let mut inner =
+            Gemma4Inner::new(tiny_target_config()).expect("tiny Gemma4Inner must construct");
+        inner.draft = Some(Gemma4Draft::Assistant(
+            AssistantDraftModel::new(tiny_assistant_config()).expect("tiny assistant draft"),
+        ));
+        let tokenizer = tiny_qwen_tokenizer();
+        let tokens: Vec<u32> = vec![0, 1, 2, 3];
+        // Budget 12 with a flip after 2 chunks: a broken cancel would run to
+        // the length exit and emit ~12 chunks.
+        let mut config = tiny_turn_config(Some(1), 12);
+        config.include_reasoning = Some(true);
+
+        let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let sink = CancelAfterSink {
+            chunks: std::sync::Mutex::new(Vec::new()),
+            cancelled: Arc::clone(&cancelled),
+            flip_after: 2,
+        };
+        let p = ChatBackend::resolve_params(&inner, &config);
+        let thinking = ChatBackend::thinking_setup(&inner, &config);
+        let mut args = WholeTurnArgs {
+            tokens: &tokens,
+            tokenizer: &tokenizer,
+            eos_id: 999,
+            config: &config,
+            params: &p,
+            thinking,
+            is_delta: false,
+            sink: Some(&sink),
+            cancelled: Some(&cancelled),
+            images: &[],
+            audio: &[],
+        };
+        let out = inner
+            .draft_chat_turn(&mut args)
+            .expect("streaming cancelled turn must complete cleanly");
+        assert!(
+            matches!(out, TurnOutput::Streamed),
+            "streaming turn must return TurnOutput::Streamed"
+        );
+
+        let chunks = sink.chunks.into_inner().expect("sink poisoned");
+        let terminal = chunks
+            .iter()
+            .find(|c| c.done)
+            .expect("stream must end with a terminal done-chunk");
+        assert_eq!(
+            terminal.finish_reason.as_deref(),
+            Some("cancelled"),
+            "sink-raised cancel must finish the turn as cancelled"
+        );
+        let n = terminal.num_tokens.expect("terminal must carry num_tokens") as usize;
+        assert!(
+            (1..=5).contains(&n),
+            "cancel must stop within one depth-1 cycle of the flip \
+             (seed + <= 2 cycles of <= 2 tokens), got {n} generated tokens"
+        );
+
+        // AR-parity cancelled save: the final emitted token is dropped from
+        // the history AND was never committed to the caches.
+        let history = inner.cached_token_history.clone();
+        assert_eq!(
+            history.len(),
+            tokens.len() + n - 1,
+            "cancelled turn must persist prompt + generated minus the final token"
+        );
+        assert_eq!(&history[..tokens.len()], &tokens[..]);
+        let mask = dspark_shared_slot_mask(&inner.config);
+        let caches = inner.caches.as_ref().expect("live caches after the turn");
+        for (i, cache) in caches.iter().enumerate() {
+            let expected = if mask[i] { 0 } else { history.len() as i32 };
+            assert_eq!(
+                cache.get_offset(),
+                expected,
+                "cache {i} offset must equal the saved history length after a cancel"
+            );
+        }
+        assert!(
+            ChatBackend::has_live_session(&inner),
+            "a cleanly cancelled turn leaves a warm-reusable session (AR parity)"
+        );
+
+        // The next turn runs normally (fresh prompt: the longer saved
+        // history is a prefix-miss, so it takes the cold path).
+        let res = run_tiny_draft_turn(
+            &mut inner,
+            &tokenizer,
+            &tokens,
+            &tiny_turn_config(Some(1), 3),
+        )
+        .expect("the turn after a cancelled stream must succeed");
+        assert_eq!(res.finish_reason, "length");
+        assert_eq!(res.num_tokens, 3);
     }
 }

--- a/crates/mlx-core/src/models/gemma4/dspark.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark.rs
@@ -29,7 +29,7 @@ use super::mlp::GemmaMLP;
 use super::quantized_linear::LinearProj;
 
 /// Draft architecture name required in the checkpoint's `architectures` list.
-const DSPARK_ARCHITECTURE: &str = "Gemma4DSparkModel";
+pub(crate) const DSPARK_ARCHITECTURE: &str = "Gemma4DSparkModel";
 
 // Greedy-vs-sampled detection for draft sampling uses the ENGINE's
 // `sampling::is_greedy_temperature` predicate — the same predicate the

--- a/crates/mlx-core/src/models/gemma4/dspark.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark.rs
@@ -1108,7 +1108,7 @@ impl DsparkDraftModel {
 /// and an exact-key f32/f16 file would otherwise push the whole forward into
 /// an unsupported dtype regime (f32 stays confined to runtime readbacks:
 /// sampling distributions and confidence probabilities).
-fn take_tensor(
+pub(crate) fn take_tensor(
     tensors: &mut HashMap<String, MxArray>,
     key: &str,
     missing: &mut Vec<String>,
@@ -1126,7 +1126,12 @@ fn take_tensor(
     Ok(Some(tensor))
 }
 
-fn apply_norm_weight(norm: &mut RMSNorm, w: &MxArray, dims: i64, name: &str) -> Result<()> {
+pub(crate) fn apply_norm_weight(
+    norm: &mut RMSNorm,
+    w: &MxArray,
+    dims: i64,
+    name: &str,
+) -> Result<()> {
     if w.ndim()? != 1 || w.shape_at(0)? != dims {
         return Err(Error::from_reason(format!(
             "DSpark {name} weight must be [{dims}], got {:?}",
@@ -1136,7 +1141,7 @@ fn apply_norm_weight(norm: &mut RMSNorm, w: &MxArray, dims: i64, name: &str) -> 
     norm.set_weight(w)
 }
 
-fn check_2d_shape(w: &MxArray, rows: i64, cols: i64, name: &str) -> Result<()> {
+pub(crate) fn check_2d_shape(w: &MxArray, rows: i64, cols: i64, name: &str) -> Result<()> {
     if w.ndim()? != 2 || w.shape_at(0)? != rows || w.shape_at(1)? != cols {
         return Err(Error::from_reason(format!(
             "DSpark {name} must be [{rows}, {cols}], got {:?}",
@@ -1149,7 +1154,7 @@ fn check_2d_shape(w: &MxArray, rows: i64, cols: i64, name: &str) -> Result<()> {
 /// Inverse-CDF draw from a dense probability row (mirrors the sparse-slice
 /// sampler in `sampling.rs`, but over the full vocab row that
 /// `sampling_distribution` returns).
-fn sample_index_from_probs<R: Rng + ?Sized>(probs: &[f32], rng: &mut R) -> Result<i32> {
+pub(crate) fn sample_index_from_probs<R: Rng + ?Sized>(probs: &[f32], rng: &mut R) -> Result<i32> {
     let total: f64 = probs
         .iter()
         .filter(|p| p.is_finite() && **p > 0.0)

--- a/crates/mlx-core/src/models/gemma4/dspark.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark.rs
@@ -1103,11 +1103,12 @@ impl DsparkDraftModel {
 }
 
 /// Remove `key` from `tensors`, recording it in `missing` when absent.
+/// Shared by the DSpark and assistant draft loaders.
 ///
-/// A present tensor must be bf16 — the v1 checkpoint contract is bf16-only,
-/// and an exact-key f32/f16 file would otherwise push the whole forward into
-/// an unsupported dtype regime (f32 stays confined to runtime readbacks:
-/// sampling distributions and confidence probabilities).
+/// A present tensor must be bf16 — the draft checkpoint contract is
+/// bf16-only, and an exact-key f32/f16 file would otherwise push the whole
+/// forward into an unsupported dtype regime (f32 stays confined to runtime
+/// readbacks: sampling distributions and confidence probabilities).
 pub(crate) fn take_tensor(
     tensors: &mut HashMap<String, MxArray>,
     key: &str,
@@ -1120,12 +1121,14 @@ pub(crate) fn take_tensor(
     let dtype = tensor.dtype()?;
     if dtype != DType::BFloat16 {
         return Err(Error::from_reason(format!(
-            "DSpark draft tensor {key} must be bf16, got {dtype:?} (only bf16 checkpoints are supported)"
+            "Gemma4 draft tensor {key} must be bf16, got {dtype:?} (only bf16 checkpoints are supported)"
         )));
     }
     Ok(Some(tensor))
 }
 
+/// Shape-checked RMSNorm weight install, shared by the DSpark and assistant
+/// draft loaders.
 pub(crate) fn apply_norm_weight(
     norm: &mut RMSNorm,
     w: &MxArray,
@@ -1134,7 +1137,7 @@ pub(crate) fn apply_norm_weight(
 ) -> Result<()> {
     if w.ndim()? != 1 || w.shape_at(0)? != dims {
         return Err(Error::from_reason(format!(
-            "DSpark {name} weight must be [{dims}], got {:?}",
+            "Gemma4 draft {name} weight must be [{dims}], got {:?}",
             w.shape()?.as_ref()
         )));
     }

--- a/crates/mlx-core/src/models/gemma4/dspark_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark_decode.rs
@@ -1,18 +1,22 @@
-//! Gemma4 DSpark speculative-decode wiring: the family-side
+//! Gemma4 draft speculative-decode wiring: the family-side
 //! [`DsparkStepper`]/[`DsparkBackend`] implementation the engine-owned
 //! [`crate::engine::dspark_turn::run_dspark_turn`] loop drives, plus the
-//! whole-turn core (`dspark_chat_turn`) behind gemma4's
+//! variant-generic whole-turn core (`draft_chat_turn`) behind gemma4's
 //! `ChatBackend::mtp_turn` override.
 //!
 //! Split of responsibilities:
-//!   * the DRAFT model (5-layer cross-attending transformer, markov head,
-//!     confidence head, context K/V cache) lives in [`super::dspark`];
+//!   * the DSpark DRAFT model (5-layer cross-attending transformer, markov
+//!     head, confidence head, context K/V cache) lives in [`super::dspark`];
+//!     the assistant draft + its stepper live in [`super::assistant`] /
+//!     [`super::assistant_decode`];
 //!   * the TARGET-side primitives (hidden tap, verify forward,
 //!     snapshot/commit rollback, shared-slot mask) live in
 //!     [`super::model`] / [`super::layer_cache`];
 //!   * the model-agnostic propose → verify → accept → stop-clamp → commit
 //!     loop lives in [`crate::engine::dspark_turn`];
-//!   * THIS module glues them together for gemma4.
+//!   * THIS module glues them together for gemma4: the DSpark stepper, the
+//!     variant dispatch ([`Gemma4DraftTurnState`] / [`Gemma4DraftStepper`] /
+//!     `begin_dspark_decode`), and the whole-turn core.
 
 use std::time::Instant;
 
@@ -53,14 +57,12 @@ use super::model::{
 /// with the loaded draft variant.
 pub(crate) enum Gemma4DraftTurnState {
     Dspark(DsparkTurnState),
-    // Stashed by the whole-turn core's assistant prefill arm; exercised by
-    // the assistant decode tests until that arm lands.
-    #[allow(dead_code)]
     Assistant(AssistantTurnState),
 }
 
 /// DSpark's [`Gemma4DraftTurnState`] payload: the draft's fused-context
-/// cache built by `dspark_chat_turn`'s tapped prefill.
+/// cache built by the whole-turn core's tapped prefill
+/// (`dspark_prefill_with_tap`).
 pub(crate) struct DsparkTurnState {
     /// The draft's fused-context K/V cache, holding one row per freshly
     /// prefilled prompt token (absolute positions
@@ -387,23 +389,25 @@ impl DsparkBackend for Gemma4Inner {
 }
 
 impl Gemma4Inner {
-    /// DSpark whole-turn core behind gemma4's `ChatBackend::mtp_turn`
-    /// override — the DSpark analog of the engine's generic
-    /// `chat_turn_core` tail, sync AND streaming through the same body
-    /// (`args.sink` presence selects the mode, mirroring
+    /// Draft whole-turn core (both [`Gemma4Draft`] variants) behind
+    /// gemma4's `ChatBackend::mtp_turn` override — the draft analog of the
+    /// engine's generic `chat_turn_core` tail, sync AND streaming through
+    /// the same body (`args.sink` presence selects the mode, mirroring
     /// `vision_chat_turn` / the MTP whole-turn cores).
     ///
     /// Flow: resolve params (+ `extra_eos_ids`) → prefix decision via the
-    /// existing cache-prefix machinery → chunked prefill WITH the DSpark
-    /// tap (per-chunk capture → fuse → context-append → drop; full-prompt
-    /// tapped hiddens are never held) → anchor sample (byte-identical to
-    /// the generic flow) → `run_dspark_turn` → save (AR-parity: stop exits
-    /// drop the final token, length exits materialize its K/V and keep
-    /// all — post-turn history AND cache offsets equal the AR flow's for
-    /// every stop shape) → finalize (+ default `augment_performance`,
-    /// which fills the `mtp_*` acceptance fields). Every error between
-    /// prefill start and the save fails CLOSED (`dspark_fail_closed`).
-    pub(crate) fn dspark_chat_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
+    /// existing cache-prefix machinery → the VARIANT's prefill (DSpark:
+    /// chunked prefill WITH the hidden tap, per-chunk capture → fuse →
+    /// context-append → drop; assistant: the same chunked prefill keeping
+    /// only the last token's post-final-norm hidden) → anchor sample
+    /// (byte-identical to the generic flow) → `run_dspark_turn` → save
+    /// (AR-parity: stop exits drop the final token, length exits
+    /// materialize its K/V and keep all — post-turn history AND cache
+    /// offsets equal the AR flow's for every stop shape) → finalize
+    /// (+ default `augment_performance`, which fills the `mtp_*`
+    /// acceptance fields). Every error between prefill start and the save
+    /// fails CLOSED (`draft_fail_closed`).
+    pub(crate) fn draft_chat_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
         let tokenizer = args.tokenizer.clone();
         let eos_id = args.eos_id;
         let thinking = args.thinking;
@@ -481,21 +485,36 @@ impl Gemma4Inner {
         let mut emitter: Option<Box<dyn StreamEmitter>> =
             args.sink.map(|_| ChatBackend::stream_emitter(self));
 
-        // --- tapped prefill: target K/V + the draft's fused context ---
+        // --- variant prefill: target K/V + the draft's per-turn state ---
         // From here until the save runs, every error FAILS CLOSED
-        // (`dspark_fail_closed`): the target caches advance during
+        // (`draft_fail_closed`): the target caches advance during
         // prefill/verify with nothing recorded in `cached_token_history`
         // yet, so an error abandoned mid-flight would leave a
         // history-vs-cache offset mismatch that a later prefix-reuse hit
         // could warm-start corrupt K/V from.
         profiler.begin_prefill();
-        let (last_logits, turn_state) = match self.dspark_prefill_with_tap(
-            &prefill_tokens,
-            cached_prefix_len as i32,
-            generation_stream,
-        ) {
-            Ok(v) => v,
-            Err(e) => return Err(self.dspark_fail_closed(e)),
+        let (last_logits, turn_state) = match self.draft.as_ref() {
+            Some(Gemma4Draft::Dspark(_)) => match self.dspark_prefill_with_tap(
+                &prefill_tokens,
+                cached_prefix_len as i32,
+                generation_stream,
+            ) {
+                Ok((logits, state)) => (logits, Gemma4DraftTurnState::Dspark(state)),
+                Err(e) => return Err(self.draft_fail_closed(e)),
+            },
+            Some(Gemma4Draft::Assistant(_)) => match self.assistant_prefill_with_hidden(
+                &prefill_tokens,
+                cached_prefix_len as i32,
+                generation_stream,
+            ) {
+                Ok((logits, state)) => (logits, Gemma4DraftTurnState::Assistant(state)),
+                Err(e) => return Err(self.draft_fail_closed(e)),
+            },
+            None => {
+                return Err(self.draft_fail_closed(Error::from_reason(
+                    "gemma4 draft turn: no draft model loaded",
+                )));
+            }
         };
         profiler.end_prefill();
 
@@ -504,29 +523,33 @@ impl Gemma4Inner {
             .and_then(|logits| crate::sampling::sample(&logits, p.sampling_config))
         {
             Ok(y) => y,
-            Err(e) => return Err(self.dspark_fail_closed(e)),
+            Err(e) => return Err(self.draft_fail_closed(e)),
         };
         y.eval();
 
         if let Err(e) = ChatBackend::eval_caches(self) {
-            return Err(self.dspark_fail_closed(e));
+            return Err(self.draft_fail_closed(e));
         }
         if report_perf {
             first_token_instant = Some(Instant::now());
         }
 
-        let block_size = match self.dspark_draft().map(|d| d.config.block_size) {
-            Some(b) => b,
+        // Per-cycle draft cap: DSpark blocks are checkpoint-pinned; the
+        // assistant drafts by chained AR steps, so the resolved depth IS
+        // the cap.
+        let block_size = match self.draft.as_ref() {
+            Some(Gemma4Draft::Dspark(draft)) => draft.config.block_size,
+            Some(Gemma4Draft::Assistant(_)) => p.mtp_depth,
             None => {
-                return Err(self.dspark_fail_closed(Error::from_reason(
-                    "gemma4 DSpark turn: no draft model loaded",
+                return Err(self.draft_fail_closed(Error::from_reason(
+                    "gemma4 draft turn: no draft model loaded",
                 )));
             }
         };
 
-        // Hand the prefill-built draft context to the stepper (taken by
+        // Hand the prefill-built draft state to the stepper (taken by
         // `begin_dspark_decode` inside the loop).
-        self.draft_turn_state = Some(Gemma4DraftTurnState::Dspark(turn_state));
+        self.draft_turn_state = Some(turn_state);
 
         let mut rng = rand::rng();
         let mut last_in_cache;
@@ -570,7 +593,7 @@ impl Gemma4Inner {
             // stash, whether or not `begin_dspark_decode` consumed it.
             match outcome {
                 Ok(o) => last_in_cache = o.last_in_cache,
-                Err(e) => return Err(self.dspark_fail_closed(e)),
+                Err(e) => return Err(self.draft_fail_closed(e)),
             }
         }
 
@@ -591,7 +614,7 @@ impl Gemma4Inner {
             && let Some(&final_token) = generated_tokens.last()
         {
             if let Err(e) = self.dspark_materialize_final(final_token, generation_stream) {
-                return Err(self.dspark_fail_closed(e));
+                return Err(self.draft_fail_closed(e));
             }
             last_in_cache = true;
         }
@@ -851,7 +874,7 @@ impl Gemma4Inner {
         ))
     }
 
-    /// Fail CLOSED after a DSpark turn error that may have left the target
+    /// Fail CLOSED after a draft turn error that may have left the target
     /// caches advanced beyond `cached_token_history` (prefill and verify
     /// write K/V before the save records anything): drop the whole warm
     /// session via `reset_caches_sync` (caches → `None`, history/media
@@ -859,9 +882,9 @@ impl Gemma4Inner {
     /// no later turn can prefix-match into corrupt or misaligned K/V. The
     /// next fresh turn takes the cold path (full re-prefill); a delta turn
     /// on the dropped session is rejected by the live-session guard.
-    /// Returns the error for `return Err(self.dspark_fail_closed(e))`
+    /// Returns the error for `return Err(self.draft_fail_closed(e))`
     /// ergonomics.
-    fn dspark_fail_closed(&mut self, err: Error) -> Error {
+    fn draft_fail_closed(&mut self, err: Error) -> Error {
         // Infallible today (`caches = None` + field clears); even if it
         // ever grows a fallible arm, nothing warm-reusable can survive it.
         let _ = self.reset_caches_sync();
@@ -1226,7 +1249,7 @@ pub(crate) mod tests {
     /// WordLevel tokenizer covering the full tiny vocab (ids 0..16 as
     /// `t0`..`t15`) so every decode over tiny-model output succeeds,
     /// written to a temp `tokenizer.json` for `Qwen3Tokenizer::from_file`.
-    fn tiny_qwen_tokenizer() -> Arc<crate::tokenizer::Qwen3Tokenizer> {
+    pub(crate) fn tiny_qwen_tokenizer() -> Arc<crate::tokenizer::Qwen3Tokenizer> {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let dir = std::env::temp_dir().join(format!(
@@ -1263,7 +1286,7 @@ pub(crate) mod tests {
         )
     }
 
-    fn tiny_turn_config(mtp_depth: Option<i32>, max_new_tokens: i32) -> ChatConfig {
+    pub(crate) fn tiny_turn_config(mtp_depth: Option<i32>, max_new_tokens: i32) -> ChatConfig {
         ChatConfig {
             mtp_depth,
             max_new_tokens: Some(max_new_tokens),
@@ -1275,9 +1298,9 @@ pub(crate) mod tests {
         }
     }
 
-    /// Drive `dspark_chat_turn` directly (sync — no model thread), with an
+    /// Drive `draft_chat_turn` directly (sync — no model thread), with an
     /// out-of-vocab `eos_id` so the tiny model can only exit "length".
-    fn run_tiny_dspark_turn(
+    pub(crate) fn run_tiny_draft_turn(
         inner: &mut Gemma4Inner,
         tokenizer: &Arc<crate::tokenizer::Qwen3Tokenizer>,
         tokens: &[u32],
@@ -1298,9 +1321,9 @@ pub(crate) mod tests {
             images: &[],
             audio: &[],
         };
-        match inner.dspark_chat_turn(&mut args)? {
+        match inner.draft_chat_turn(&mut args)? {
             TurnOutput::Complete(r) => Ok(*r),
-            TurnOutput::Streamed => panic!("sync dspark turn returned TurnOutput::Streamed"),
+            TurnOutput::Streamed => panic!("sync draft turn returned TurnOutput::Streamed"),
         }
     }
 
@@ -1327,7 +1350,7 @@ pub(crate) mod tests {
 
         // Turn 1: unset depth resolves to block_size 3 → 1+3 verify rows
         // over a 2-token window → hard error mid-turn.
-        let err = run_tiny_dspark_turn(&mut inner, &tokenizer, &tokens, &tiny_turn_config(None, 8))
+        let err = run_tiny_draft_turn(&mut inner, &tokenizer, &tokens, &tiny_turn_config(None, 8))
             .expect_err("a depth-3 verify block must violate the window-2 rollback invariant");
         assert!(
             err.reason.contains("sliding window") && err.reason.contains("verify block"),
@@ -1356,7 +1379,7 @@ pub(crate) mod tests {
 
         // Turn 2: depth 1 → verify blocks of <= 2 rows fit the window; the
         // turn must run cold end-to-end and land fully consistent.
-        let res = run_tiny_dspark_turn(
+        let res = run_tiny_draft_turn(
             &mut inner,
             &tokenizer,
             &tokens,
@@ -1398,10 +1421,10 @@ pub(crate) mod tests {
     /// Records every chunk and flips the shared cancel flag once
     /// `flip_after` NON-TERMINAL chunks have arrived (the sink runs inline
     /// on the decode thread, so the flip lands mid-turn deterministically).
-    struct CancelAfterSink {
-        chunks: std::sync::Mutex<Vec<crate::engine::types::ChatStreamChunk>>,
-        cancelled: Arc<std::sync::atomic::AtomicBool>,
-        flip_after: usize,
+    pub(crate) struct CancelAfterSink {
+        pub(crate) chunks: std::sync::Mutex<Vec<crate::engine::types::ChatStreamChunk>>,
+        pub(crate) cancelled: Arc<std::sync::atomic::AtomicBool>,
+        pub(crate) flip_after: usize,
     }
 
     impl crate::engine::backend::ChunkSink for CancelAfterSink {
@@ -1416,7 +1439,7 @@ pub(crate) mod tests {
         }
     }
 
-    /// WHOLE-TURN streaming cancellation through `dspark_chat_turn`: a
+    /// WHOLE-TURN streaming cancellation through `draft_chat_turn`: a
     /// cancel raised from the chunk sink must terminate the stream promptly
     /// ("cancelled", bounded block-granular overrun — never running on to
     /// the budget) and leave the cached session state consistent (AR-parity
@@ -1468,7 +1491,7 @@ pub(crate) mod tests {
             audio: &[],
         };
         let out = inner
-            .dspark_chat_turn(&mut args)
+            .draft_chat_turn(&mut args)
             .expect("streaming cancelled turn must complete cleanly");
         assert!(
             matches!(out, TurnOutput::Streamed),
@@ -1518,7 +1541,7 @@ pub(crate) mod tests {
 
         // The next turn runs normally (fresh prompt: the longer saved
         // history is a prefix-miss, so it takes the cold path).
-        let res = run_tiny_dspark_turn(
+        let res = run_tiny_draft_turn(
             &mut inner,
             &tokenizer,
             &tokens,

--- a/crates/mlx-core/src/models/gemma4/dspark_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark_decode.rs
@@ -34,19 +34,27 @@ use crate::stream::{DeviceType, Stream, StreamContext};
 use super::dspark::{DsparkContextCache, DsparkTap, truncate_by_confidence};
 use super::layer_cache::{Gemma4VerifyRollback, commit_after_verify, snapshot_before_verify};
 use super::model::{
-    GEMMA4_PREFILL_STEP_SIZE, Gemma4Inner, compute_ple, dspark_shared_slot_mask,
+    GEMMA4_PREFILL_STEP_SIZE, Gemma4Draft, Gemma4Inner, compute_ple, dspark_shared_slot_mask,
     dspark_verify_forward, eval_gemma4_caches, forward_body, forward_inner,
 };
 
-/// Per-turn draft-context handoff from `dspark_chat_turn`'s tapped prefill
-/// to [`DsparkBackend::begin_dspark_decode`].
+/// Per-turn draft handoff from the whole-turn core's prefill to
+/// [`DsparkBackend::begin_dspark_decode`], one variant per
+/// [`super::model::Gemma4Draft`] variant.
 ///
 /// The engine's [`DsparkTurnSetup`] carries only turn constants, so the
-/// prefill-derived draft context travels through
-/// `Gemma4Inner::dspark_turn_state`: the whole-turn core stashes it right
-/// before calling `run_dspark_turn`, and `begin_dspark_decode` TAKES it
-/// into the stepper (so it can never leak across turns — a fresh context is
-/// built every turn).
+/// prefill-derived state travels through `Gemma4Inner::draft_turn_state`:
+/// the whole-turn core stashes it right before calling `run_dspark_turn`,
+/// and `begin_dspark_decode` TAKES it into the stepper (so it can never
+/// leak across turns — fresh state is built every turn).
+/// `begin_dspark_decode` hard-errors when the stashed variant disagrees
+/// with the loaded draft variant.
+pub(crate) enum Gemma4DraftTurnState {
+    Dspark(DsparkTurnState),
+}
+
+/// DSpark's [`Gemma4DraftTurnState`] payload: the draft's fused-context
+/// cache built by `dspark_chat_turn`'s tapped prefill.
 pub(crate) struct DsparkTurnState {
     /// The draft's fused-context K/V cache, holding one row per freshly
     /// prefilled prompt token (absolute positions
@@ -101,10 +109,10 @@ impl DsparkStepper for Gemma4DsparkStepper<'_> {
         params: &ChatParams,
         rng: &mut dyn rand::Rng,
     ) -> Result<DsparkProposal> {
-        let draft =
-            self.inner.dspark.as_ref().ok_or_else(|| {
-                Error::from_reason("gemma4 DSpark propose: no draft model loaded")
-            })?;
+        let draft = self
+            .inner
+            .dspark_draft()
+            .ok_or_else(|| Error::from_reason("gemma4 DSpark propose: no draft model loaded"))?;
         if max_len == 0 {
             return Err(Error::from_reason(
                 "gemma4 DSpark propose: engine contract violation (max_len == 0 cycles skip propose)",
@@ -244,8 +252,7 @@ impl DsparkStepper for Gemma4DsparkStepper<'_> {
         // — it re-enters as the next cycle's verify anchor.
         let draft = self
             .inner
-            .dspark
-            .as_ref()
+            .dspark_draft()
             .ok_or_else(|| Error::from_reason("gemma4 DSpark commit: no draft model loaded"))?;
         let mut kept: Vec<MxArray> = Vec::with_capacity(tapped.len());
         for hidden in &tapped {
@@ -274,35 +281,42 @@ impl DsparkBackend for Gemma4Inner {
         &mut self,
         _setup: &DsparkTurnSetup<'_>,
     ) -> Result<Self::DsparkDecode<'_>> {
-        let state = self.dspark_turn_state.take().ok_or_else(|| {
+        let state = self.draft_turn_state.take().ok_or_else(|| {
             Error::from_reason(
-                "gemma4 DSpark: begin_dspark_decode requires a prepared draft context \
-                 (dspark_chat_turn's tapped prefill must run first)",
+                "gemma4 draft decode: begin_dspark_decode requires a prepared draft context \
+                 (the draft whole-turn core's prefill must run first)",
             )
         })?;
-        let layer_ids: Vec<usize> = {
-            let draft = self.dspark.as_ref().ok_or_else(|| {
-                Error::from_reason("gemma4 DSpark: begin_dspark_decode without a draft model")
-            })?;
-            draft
-                .config
-                .target_layer_ids
-                .iter()
-                .map(|&id| id as usize)
-                .collect()
-        };
-        let shared_slots = dspark_shared_slot_mask(&self.config);
-        let confidence_threshold = dspark_confidence_threshold_from_env();
-        Ok(Gemma4DsparkStepper {
-            inner: self,
-            ctx: state.ctx,
-            next_pos: state.next_pos,
-            layer_ids,
-            shared_slots,
-            confidence_threshold,
-            rollback: None,
-            tapped: None,
-        })
+        match state {
+            Gemma4DraftTurnState::Dspark(state) => {
+                let layer_ids: Vec<usize> = {
+                    let draft = self.dspark_draft().ok_or_else(|| {
+                        Error::from_reason(
+                            "gemma4 draft decode: a DSpark turn state is stashed but the loaded \
+                             draft is not the DSpark variant",
+                        )
+                    })?;
+                    draft
+                        .config
+                        .target_layer_ids
+                        .iter()
+                        .map(|&id| id as usize)
+                        .collect()
+                };
+                let shared_slots = dspark_shared_slot_mask(&self.config);
+                let confidence_threshold = dspark_confidence_threshold_from_env();
+                Ok(Gemma4DsparkStepper {
+                    inner: self,
+                    ctx: state.ctx,
+                    next_pos: state.next_pos,
+                    layer_ids,
+                    shared_slots,
+                    confidence_threshold,
+                    rollback: None,
+                    tapped: None,
+                })
+            }
+        }
     }
 }
 
@@ -435,7 +449,7 @@ impl Gemma4Inner {
             first_token_instant = Some(Instant::now());
         }
 
-        let block_size = match self.dspark.as_ref().map(|d| d.config.block_size) {
+        let block_size = match self.dspark_draft().map(|d| d.config.block_size) {
             Some(b) => b,
             None => {
                 return Err(self.dspark_fail_closed(Error::from_reason(
@@ -446,7 +460,7 @@ impl Gemma4Inner {
 
         // Hand the prefill-built draft context to the stepper (taken by
         // `begin_dspark_decode` inside the loop).
-        self.dspark_turn_state = Some(turn_state);
+        self.draft_turn_state = Some(Gemma4DraftTurnState::Dspark(turn_state));
 
         let mut rng = rand::rng();
         let mut last_in_cache;
@@ -655,10 +669,16 @@ impl Gemma4Inner {
         }
 
         let inner = &mut *self;
-        let draft = inner
-            .dspark
-            .as_ref()
-            .ok_or_else(|| Error::from_reason("gemma4 DSpark prefill: no draft model loaded"))?;
+        // Field-level borrow (not the whole-struct accessor) so the draft
+        // borrow stays disjoint from the `caches` borrow below.
+        let draft = match inner.draft.as_ref() {
+            Some(Gemma4Draft::Dspark(draft)) => draft,
+            _ => {
+                return Err(Error::from_reason(
+                    "gemma4 DSpark prefill: no DSpark draft model loaded",
+                ));
+            }
+        };
         let caches = inner
             .caches
             .as_mut()
@@ -779,7 +799,7 @@ impl Gemma4Inner {
         // Infallible today (`caches = None` + field clears); even if it
         // ever grows a fallible arm, nothing warm-reusable can survive it.
         let _ = self.reset_caches_sync();
-        self.dspark_turn_state = None;
+        self.draft_turn_state = None;
         err
     }
 
@@ -816,17 +836,19 @@ impl Gemma4Inner {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::sync::Arc;
 
     use super::*;
     use crate::engine::types::ChatConfig;
+    use crate::models::gemma4::assistant::{AssistantConfig, AssistantDraftModel};
     use crate::models::gemma4::config::Gemma4Config;
     use crate::models::gemma4::dspark::{DsparkConfig, DsparkDraftModel};
+    use crate::models::gemma4::model::Gemma4Draft;
 
     /// Tiny flat-path Gemma4 config (paged OFF so `Gemma4Inner::new` builds
     /// no adapter): 4 hybrid layers, one KV-shared.
-    fn tiny_target_config() -> Gemma4Config {
+    pub(crate) fn tiny_target_config() -> Gemma4Config {
         serde_json::from_value(tiny_target_config_value())
             .expect("tiny Gemma4 config must deserialize")
     }
@@ -835,7 +857,7 @@ mod tests {
     /// makes any verify block over 2 rows violate the
     /// `snapshot_before_verify` rollback invariant (the fail-closed
     /// regression's REAL, unmocked mid-turn error).
-    fn tiny_target_config_with_window(window: i64) -> Gemma4Config {
+    pub(crate) fn tiny_target_config_with_window(window: i64) -> Gemma4Config {
         let mut v = tiny_target_config_value();
         v["sliding_window"] = serde_json::json!(window);
         serde_json::from_value(v).expect("tiny Gemma4 config must deserialize")
@@ -912,11 +934,66 @@ mod tests {
             Gemma4Inner::new(tiny_target_config()).expect("tiny Gemma4Inner must construct");
         let draft =
             DsparkDraftModel::new(tiny_draft_config()).expect("tiny draft model must construct");
-        inner.dspark = Some(draft);
+        inner.draft = Some(Gemma4Draft::Dspark(draft));
         inner
     }
 
-    fn chat_config(mtp_depth: Option<i32>) -> ChatConfig {
+    /// Tiny assistant draft config geometry-matched to
+    /// [`tiny_target_config`]: backbone 8 / vocab 16 / head_dim 4 on both
+    /// attention types (the tiny target sets no `global_head_dim`), one KV
+    /// head each, `attention_k_eq_v` false (the target's serde default),
+    /// window 8, and the target's default rope constants — so
+    /// `AssistantConfig::validate(tiny_target_config())` passes.
+    pub(crate) fn tiny_assistant_config() -> AssistantConfig {
+        serde_json::from_str(
+            r#"{
+                "architectures": ["Gemma4UnifiedAssistantForCausalLM"],
+                "model_type": "gemma4_unified_assistant",
+                "backbone_hidden_size": 8,
+                "use_ordered_embeddings": false,
+                "tie_word_embeddings": true,
+                "text_config": {
+                    "hidden_size": 4,
+                    "intermediate_size": 8,
+                    "num_hidden_layers": 2,
+                    "layer_types": ["sliding_attention", "full_attention"],
+                    "num_attention_heads": 2,
+                    "num_key_value_heads": 1,
+                    "num_global_key_value_heads": 1,
+                    "head_dim": 4,
+                    "global_head_dim": null,
+                    "attention_k_eq_v": false,
+                    "sliding_window": 8,
+                    "rms_norm_eps": 1e-6,
+                    "vocab_size": 16,
+                    "final_logit_softcapping": null,
+                    "rope_parameters": {
+                        "full_attention": {
+                            "partial_rotary_factor": 0.25,
+                            "rope_theta": 1000000.0,
+                            "rope_type": "proportional"
+                        },
+                        "sliding_attention": {
+                            "rope_theta": 10000.0,
+                            "rope_type": "default"
+                        }
+                    }
+                }
+            }"#,
+        )
+        .expect("tiny assistant config must deserialize")
+    }
+
+    pub(crate) fn tiny_inner_with_assistant_draft() -> Gemma4Inner {
+        let mut inner =
+            Gemma4Inner::new(tiny_target_config()).expect("tiny Gemma4Inner must construct");
+        let draft = AssistantDraftModel::new(tiny_assistant_config())
+            .expect("tiny assistant draft model must construct");
+        inner.draft = Some(Gemma4Draft::Assistant(draft));
+        inner
+    }
+
+    pub(crate) fn chat_config(mtp_depth: Option<i32>) -> ChatConfig {
         ChatConfig {
             mtp_depth,
             ..ChatConfig::default()
@@ -961,6 +1038,44 @@ mod tests {
         assert_eq!(p.mtp_depth, 5, "engine clamp caps at 5 without a draft");
     }
 
+    /// The tiny assistant fixture must be a VALID pair with the tiny target
+    /// — the assistant decode tests build on that geometry match.
+    #[test]
+    fn tiny_assistant_fixture_validates_against_tiny_target() {
+        tiny_assistant_config()
+            .validate(&tiny_target_config())
+            .expect("tiny assistant draft must validate against the tiny target");
+    }
+
+    /// With an ASSISTANT draft loaded, an unset `mtpDepth` resolves to
+    /// `ASSISTANT_DEFAULT_DEPTH` (no checkpoint-pinned block size).
+    #[test]
+    fn resolve_params_assistant_unset_depth_defaults() {
+        let inner = tiny_inner_with_assistant_draft();
+        let p = ChatBackend::resolve_params(&inner, &chat_config(None));
+        assert_eq!(
+            p.mtp_depth,
+            crate::models::gemma4::assistant::ASSISTANT_DEFAULT_DEPTH,
+            "unset depth must resolve to the assistant default (3)"
+        );
+        assert_eq!(p.mtp_depth, 3);
+    }
+
+    /// An explicit assistant depth is clamped to `[1, ASSISTANT_MAX_DEPTH]`
+    /// from the RAW config value — wider than the engine's central [1, 5]
+    /// clamp, and nonpositive values clamp up to 1 without wrapping.
+    #[test]
+    fn resolve_params_assistant_explicit_depth_clamps() {
+        let inner = tiny_inner_with_assistant_draft();
+        for (requested, expected) in [(1, 1), (8, 8), (99, 8), (0, 1), (-7, 1)] {
+            let p = ChatBackend::resolve_params(&inner, &chat_config(Some(requested)));
+            assert_eq!(
+                p.mtp_depth, expected,
+                "mtpDepth={requested} must resolve to {expected}"
+            );
+        }
+    }
+
     // ── begin_dspark_decode plumbing ───────────────────────────────────
 
     /// The stepper derives the shared-slot mask from the target config
@@ -971,8 +1086,7 @@ mod tests {
     fn begin_dspark_decode_takes_stash_and_derives_mask() {
         let mut inner = tiny_inner_with_draft();
         let num_draft_layers = inner
-            .dspark
-            .as_ref()
+            .dspark_draft()
             .map(|d| d.num_layers())
             .expect("draft loaded");
 
@@ -995,10 +1109,10 @@ mod tests {
 
         // Stash → stepper carries the config-derived mask + draft layer ids
         // and the stash is consumed.
-        inner.dspark_turn_state = Some(DsparkTurnState {
+        inner.draft_turn_state = Some(Gemma4DraftTurnState::Dspark(DsparkTurnState {
             ctx: DsparkContextCache::new(num_draft_layers),
             next_pos: 7,
-        });
+        }));
         {
             let stepper = inner
                 .begin_dspark_decode(&setup)
@@ -1013,7 +1127,7 @@ mod tests {
             assert!(stepper.rollback.is_none() && stepper.tapped.is_none());
         }
         assert!(
-            inner.dspark_turn_state.is_none(),
+            inner.draft_turn_state.is_none(),
             "the per-turn stash must be consumed by begin_dspark_decode"
         );
     }
@@ -1133,7 +1247,9 @@ mod tests {
     fn dspark_turn_error_fails_closed_then_cold_turn_recovers() {
         let mut inner = Gemma4Inner::new(tiny_target_config_with_window(2))
             .expect("tiny window-2 Gemma4Inner must construct");
-        inner.dspark = Some(DsparkDraftModel::new(tiny_draft_config()).expect("tiny draft model"));
+        inner.draft = Some(Gemma4Draft::Dspark(
+            DsparkDraftModel::new(tiny_draft_config()).expect("tiny draft model"),
+        ));
         let tokenizer = tiny_qwen_tokenizer();
         let tokens: Vec<u32> = vec![0, 1, 2, 3];
 
@@ -1153,7 +1269,7 @@ mod tests {
             "cached_token_history must be cleared (it never covered the prefilled K/V)"
         );
         assert!(
-            inner.dspark_turn_state.is_none(),
+            inner.draft_turn_state.is_none(),
             "the per-turn draft stash must be cleared"
         );
         assert!(
@@ -1248,7 +1364,9 @@ mod tests {
         unsafe { mlx_sys::mlx_seed(0xD5_9A4B_0001) };
         let mut inner =
             Gemma4Inner::new(tiny_target_config()).expect("tiny Gemma4Inner must construct");
-        inner.dspark = Some(DsparkDraftModel::new(tiny_draft_config()).expect("tiny draft model"));
+        inner.draft = Some(Gemma4Draft::Dspark(
+            DsparkDraftModel::new(tiny_draft_config()).expect("tiny draft model"),
+        ));
         let tokenizer = tiny_qwen_tokenizer();
         let tokens: Vec<u32> = vec![0, 1, 2, 3];
         // Budget 12 with a flip after 2 chunks: a broken cancel would run to

--- a/crates/mlx-core/src/models/gemma4/dspark_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark_decode.rs
@@ -31,11 +31,13 @@ use crate::engine::params::{ChatParams, generated_capacity_hint};
 use crate::engine::penalties::{ReasoningTracker, apply_all_penalties};
 use crate::stream::{DeviceType, Stream, StreamContext};
 
+use super::assistant_decode::{AssistantTurnState, Gemma4AssistantStepper};
 use super::dspark::{DsparkContextCache, DsparkTap, truncate_by_confidence};
 use super::layer_cache::{Gemma4VerifyRollback, commit_after_verify, snapshot_before_verify};
 use super::model::{
-    GEMMA4_PREFILL_STEP_SIZE, Gemma4Draft, Gemma4Inner, compute_ple, dspark_shared_slot_mask,
-    dspark_verify_forward, eval_gemma4_caches, forward_body, forward_inner,
+    GEMMA4_PREFILL_STEP_SIZE, Gemma4Draft, Gemma4Inner, assistant_kv_source_indices, compute_ple,
+    dspark_shared_slot_mask, dspark_verify_forward, eval_gemma4_caches, forward_body,
+    forward_inner,
 };
 
 /// Per-turn draft handoff from the whole-turn core's prefill to
@@ -51,6 +53,10 @@ use super::model::{
 /// with the loaded draft variant.
 pub(crate) enum Gemma4DraftTurnState {
     Dspark(DsparkTurnState),
+    // Stashed by the whole-turn core's assistant prefill arm; exercised by
+    // the assistant decode tests until that arm lands.
+    #[allow(dead_code)]
+    Assistant(AssistantTurnState),
 }
 
 /// DSpark's [`Gemma4DraftTurnState`] payload: the draft's fused-context
@@ -271,9 +277,56 @@ impl DsparkStepper for Gemma4DsparkStepper<'_> {
     }
 }
 
+/// Per-turn stepper dispatch: [`DsparkBackend::DsparkDecode`] is ONE
+/// associated type, so the two variant steppers ship behind this enum with
+/// straight 4-method delegation. Constructed only by
+/// [`DsparkBackend::begin_dspark_decode`], which hard-errors when the
+/// stashed [`Gemma4DraftTurnState`] variant disagrees with the loaded
+/// [`Gemma4Draft`] variant.
+pub(crate) enum Gemma4DraftStepper<'a> {
+    Dspark(Gemma4DsparkStepper<'a>),
+    Assistant(Gemma4AssistantStepper<'a>),
+}
+
+impl DsparkStepper for Gemma4DraftStepper<'_> {
+    fn propose(
+        &mut self,
+        anchor_id: u32,
+        max_len: usize,
+        params: &ChatParams,
+        rng: &mut dyn rand::Rng,
+    ) -> Result<DsparkProposal> {
+        match self {
+            Self::Dspark(stepper) => stepper.propose(anchor_id, max_len, params, rng),
+            Self::Assistant(stepper) => stepper.propose(anchor_id, max_len, params, rng),
+        }
+    }
+
+    fn verify(&mut self, verify_ids: &[u32]) -> Result<DsparkVerifyOutput> {
+        match self {
+            Self::Dspark(stepper) => stepper.verify(verify_ids),
+            Self::Assistant(stepper) => stepper.verify(verify_ids),
+        }
+    }
+
+    fn commit(&mut self, keep: usize, total_written: usize) -> Result<()> {
+        match self {
+            Self::Dspark(stepper) => stepper.commit(keep, total_written),
+            Self::Assistant(stepper) => stepper.commit(keep, total_written),
+        }
+    }
+
+    fn eval_boundary(&self, token: &MxArray) {
+        match self {
+            Self::Dspark(stepper) => stepper.eval_boundary(token),
+            Self::Assistant(stepper) => stepper.eval_boundary(token),
+        }
+    }
+}
+
 impl DsparkBackend for Gemma4Inner {
     type DsparkDecode<'a>
-        = Gemma4DsparkStepper<'a>
+        = Gemma4DraftStepper<'a>
     where
         Self: 'a;
 
@@ -305,7 +358,7 @@ impl DsparkBackend for Gemma4Inner {
                 };
                 let shared_slots = dspark_shared_slot_mask(&self.config);
                 let confidence_threshold = dspark_confidence_threshold_from_env();
-                Ok(Gemma4DsparkStepper {
+                Ok(Gemma4DraftStepper::Dspark(Gemma4DsparkStepper {
                     inner: self,
                     ctx: state.ctx,
                     next_pos: state.next_pos,
@@ -314,7 +367,20 @@ impl DsparkBackend for Gemma4Inner {
                     confidence_threshold,
                     rollback: None,
                     tapped: None,
-                })
+                }))
+            }
+            Gemma4DraftTurnState::Assistant(state) => {
+                if self.assistant_draft().is_none() {
+                    return Err(Error::from_reason(
+                        "gemma4 draft decode: an assistant turn state is stashed but the loaded \
+                         draft is not the assistant variant",
+                    ));
+                }
+                let kv_sources = assistant_kv_source_indices(&self.config)?;
+                let shared_slots = dspark_shared_slot_mask(&self.config);
+                Ok(Gemma4DraftStepper::Assistant(
+                    Gemma4AssistantStepper::from_turn_state(self, state, kv_sources, shared_slots),
+                ))
             }
         }
     }
@@ -929,7 +995,7 @@ pub(crate) mod tests {
         .expect("tiny draft config must deserialize")
     }
 
-    fn tiny_inner_with_draft() -> Gemma4Inner {
+    pub(crate) fn tiny_inner_with_draft() -> Gemma4Inner {
         let mut inner =
             Gemma4Inner::new(tiny_target_config()).expect("tiny Gemma4Inner must construct");
         let draft =
@@ -1114,9 +1180,15 @@ pub(crate) mod tests {
             next_pos: 7,
         }));
         {
-            let stepper = inner
+            let stepper = match inner
                 .begin_dspark_decode(&setup)
-                .expect("begin with a stash must succeed");
+                .expect("begin with a stash must succeed")
+            {
+                Gemma4DraftStepper::Dspark(stepper) => stepper,
+                Gemma4DraftStepper::Assistant(_) => {
+                    panic!("a DSpark draft must yield the DSpark stepper")
+                }
+            };
             assert_eq!(
                 stepper.shared_slots,
                 vec![false, false, false, true],

--- a/crates/mlx-core/src/models/gemma4/mod.rs
+++ b/crates/mlx-core/src/models/gemma4/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod assistant;
+pub(crate) mod assistant_decode;
 pub mod attention;
 pub mod audio_processor;
 pub mod clippable_linear;

--- a/crates/mlx-core/src/models/gemma4/mod.rs
+++ b/crates/mlx-core/src/models/gemma4/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod assistant;
 pub mod attention;
 pub mod audio_processor;
 pub mod clippable_linear;

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -6249,22 +6249,25 @@ pub(crate) struct AssistantKvSources {
 
 /// Resolve the assistant draft's K/V source layers: for each attention type,
 /// the LAST non-KV-shared target layer of that type — the max index
-/// `i < config.first_kv_shared_layer()` whose layer type matches. With KV
-/// sharing enabled these are exactly the anchor layers
-/// `should_store_shared_kv` marks; without sharing they are simply the last
-/// layer of each type. Errors when the non-shared prefix lacks either
-/// attention type — the draft needs one K/V source per type.
+/// `i < config.first_kv_shared_layer()` whose `layer_types` entry equals the
+/// type string exactly, the same matching `should_store_shared_kv` uses to
+/// mark anchors. Layers with a missing or unrecognized `layer_types` entry
+/// match neither type. With KV sharing enabled these are exactly the anchor
+/// layers `should_store_shared_kv` marks; without sharing they are simply
+/// the last layer of each type. Errors when the non-shared prefix lacks
+/// either attention type — the draft needs one K/V source per type.
 #[allow(dead_code)] // exercised by the inline tests until the assistant decode stepper lands
 pub(crate) fn assistant_kv_source_indices(config: &Gemma4Config) -> Result<AssistantKvSources> {
     let first_shared = config.first_kv_shared_layer();
-    let last_below_boundary =
-        |is_global: bool| (0..first_shared).rfind(|&i| config.is_global_layer(i) == is_global);
-    let sliding = last_below_boundary(false).ok_or_else(|| {
+    let last_below_boundary = |layer_type: &str| {
+        (0..first_shared).rfind(|&i| config.layer_types.get(i).is_some_and(|t| t == layer_type))
+    };
+    let sliding = last_below_boundary("sliding_attention").ok_or_else(|| {
         Error::from_reason(format!(
             "assistant KV source mapping: no non-KV-shared sliding_attention layer in layers 0..{first_shared}"
         ))
     })?;
-    let full = last_below_boundary(true).ok_or_else(|| {
+    let full = last_below_boundary("full_attention").ok_or_else(|| {
         Error::from_reason(format!(
             "assistant KV source mapping: no non-KV-shared full_attention layer in layers 0..{first_shared}"
         ))
@@ -10119,6 +10122,43 @@ mod assistant_seam_tests {
             "got: {}",
             err.reason
         );
+    }
+
+    /// A truncated `layer_types` vec leaves trailing layers without an
+    /// entry. Such layers match neither attention type: the mapping resolves
+    /// only exact `layer_types` entries (like `should_store_shared_kv`) and
+    /// errors when a type has no exact entry below the boundary, instead of
+    /// treating the missing entries as full attention.
+    #[test]
+    fn kv_source_indices_ignore_layers_with_missing_layer_types_entry() {
+        // 4 layers, `layer_types` truncated to 2 entries, no KV sharing.
+        let truncated = |layer_types: &[&str]| -> Gemma4Config {
+            let mut v = tiny_target_config_value();
+            v["layer_types"] = serde_json::json!(layer_types);
+            v.as_object_mut()
+                .expect("tiny config value is an object")
+                .remove("num_kv_shared_layers");
+            serde_json::from_value(v).expect("tiny Gemma4 config must deserialize")
+        };
+
+        // Both types have exact entries: layers 2/3 (no entry) must not be
+        // selected even though the full-attention fallback would claim them.
+        let sources =
+            assistant_kv_source_indices(&truncated(&["sliding_attention", "full_attention"]))
+                .expect("mapping must resolve from the exact entries");
+        assert_eq!(
+            sources,
+            AssistantKvSources {
+                sliding: 0,
+                full: 1
+            }
+        );
+
+        // No exact full_attention entry anywhere: hard error, not index 3.
+        let err =
+            assistant_kv_source_indices(&truncated(&["sliding_attention", "sliding_attention"]))
+                .expect_err("missing full_attention entry must error");
+        assert!(err.reason.contains("full_attention"), "got: {}", err.reason);
     }
 
     // ── lm_head tail extraction ────────────────────────────────────────

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -5560,7 +5560,7 @@ impl ChatBackend for Gemma4Inner {
         {
             return None;
         }
-        Some(self.dspark_chat_turn(args))
+        Some(self.draft_chat_turn(args))
     }
 
     fn vision_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Option<Result<TurnOutput>> {

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -6098,16 +6098,32 @@ pub(crate) fn forward_inner(
         config,
         tap,
     )?;
+    lm_head_logits(&h, embedding, lm_head, embed_weight_t, config)
+}
 
-    crate::models::gemma4::diagnostic::dump_norm(0, "post_final_norm", &h, None);
+/// LM head + logit softcapping over a post-final-norm hidden state — the
+/// tail `forward_inner` runs after `forward_body`.
+///
+/// Projects through the explicit lm_head when present, otherwise through the
+/// tied embedding table (packed-quantized, pre-transposed, or dense
+/// transpose fallback), then applies `final_logit_softcapping` when the
+/// config sets it.
+pub(crate) fn lm_head_logits(
+    h: &MxArray,
+    embedding: &Embedding,
+    lm_head: &Option<LinearProj>,
+    embed_weight_t: Option<&MxArray>,
+    config: &Gemma4Config,
+) -> Result<MxArray> {
+    crate::models::gemma4::diagnostic::dump_norm(0, "post_final_norm", h, None);
 
     // LM head or tied embeddings
     let logits = if let Some(head) = lm_head {
-        head.forward(&h)?
+        head.forward(h)?
     } else if embedding.is_packed_quantized() {
         // Packed tied lm_head: project through the quantized matmul without
         // materializing the dense table.
-        embedding.as_linear(&h)?
+        embedding.as_linear(h)?
     } else if let Some(w_t) = embed_weight_t {
         h.matmul(w_t)?
     } else {
@@ -6169,6 +6185,49 @@ pub(crate) fn dspark_verify_forward(
     )
 }
 
+/// Run the target over a `[1, T]` verify block at the current cache offset
+/// and return the `[1, T, vocab]` softcapped logits together with the
+/// `[1, T, hidden]` post-final-norm hidden state (the assistant draft chains
+/// its next round's `h_prev` from the hidden at the last kept slot).
+///
+/// Same forward as [`dspark_verify_forward`] minus the residual-stream tap:
+/// it does not sample and touches no history bookkeeping; caches advance by
+/// T. Callers pair it with `snapshot_before_verify` / `commit_after_verify`
+/// for rollback.
+#[allow(dead_code)] // exercised by the inline tests until the assistant decode stepper lands
+pub(crate) fn assistant_verify_forward(
+    block_ids: &MxArray,
+    embedding: &Embedding,
+    layers: &[Gemma4DecoderLayer],
+    caches: &mut [Gemma4LayerCache],
+    final_norm: &RMSNorm,
+    lm_head: &Option<LinearProj>,
+    embed_weight_t: Option<&MxArray>,
+    ple: Option<&PleComponents>,
+    config: &Gemma4Config,
+) -> Result<(MxArray, MxArray)> {
+    if block_ids.ndim()? != 2 || block_ids.shape_at(0)? != 1 || block_ids.shape_at(1)? < 1 {
+        return Err(Error::from_reason(format!(
+            "assistant_verify_forward expects block_ids shaped [1, T] with T >= 1, got {:?}",
+            block_ids.shape()?.as_ref()
+        )));
+    }
+    let hidden = forward_body(
+        Some(block_ids),
+        None,
+        embedding,
+        layers,
+        caches,
+        final_norm,
+        ple,
+        None,
+        config,
+        None,
+    )?;
+    let logits = lm_head_logits(&hidden, embedding, lm_head, embed_weight_t, config)?;
+    Ok((logits, hidden))
+}
+
 /// Shared-slot mask for `snapshot_before_verify`, index-aligned with the
 /// per-layer caches vec: entry i is true iff decoder layer i is KV-shared.
 /// Shared layers read their anchor layer's cache; their own vec entry is
@@ -6177,6 +6236,40 @@ pub(crate) fn dspark_shared_slot_mask(config: &Gemma4Config) -> Vec<bool> {
     (0..config.num_hidden_layers as usize)
         .map(|i| config.is_kv_shared_layer(i))
         .collect()
+}
+
+/// Target-layer indices whose KV caches the assistant draft reads: one
+/// source per attention type, index-aligned with the per-layer caches vec.
+#[allow(dead_code)] // exercised by the inline tests until the assistant decode stepper lands
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AssistantKvSources {
+    pub sliding: usize,
+    pub full: usize,
+}
+
+/// Resolve the assistant draft's K/V source layers: for each attention type,
+/// the LAST non-KV-shared target layer of that type — the max index
+/// `i < config.first_kv_shared_layer()` whose layer type matches. With KV
+/// sharing enabled these are exactly the anchor layers
+/// `should_store_shared_kv` marks; without sharing they are simply the last
+/// layer of each type. Errors when the non-shared prefix lacks either
+/// attention type — the draft needs one K/V source per type.
+#[allow(dead_code)] // exercised by the inline tests until the assistant decode stepper lands
+pub(crate) fn assistant_kv_source_indices(config: &Gemma4Config) -> Result<AssistantKvSources> {
+    let first_shared = config.first_kv_shared_layer();
+    let last_below_boundary =
+        |is_global: bool| (0..first_shared).rfind(|&i| config.is_global_layer(i) == is_global);
+    let sliding = last_below_boundary(false).ok_or_else(|| {
+        Error::from_reason(format!(
+            "assistant KV source mapping: no non-KV-shared sliding_attention layer in layers 0..{first_shared}"
+        ))
+    })?;
+    let full = last_below_boundary(true).ok_or_else(|| {
+        Error::from_reason(format!(
+            "assistant KV source mapping: no non-KV-shared full_attention layer in layers 0..{first_shared}"
+        ))
+    })?;
+    Ok(AssistantKvSources { sliding, full })
 }
 
 /// Compute PLE (per-layer embeddings) from input_ids.
@@ -9641,7 +9734,9 @@ mod dspark_tap_tests {
         .expect("tiny Gemma4 config must deserialize")
     }
 
-    fn tiny_model(config: &Gemma4Config) -> (Embedding, Vec<Gemma4DecoderLayer>, RMSNorm) {
+    pub(super) fn tiny_model(
+        config: &Gemma4Config,
+    ) -> (Embedding, Vec<Gemma4DecoderLayer>, RMSNorm) {
         let embedding =
             Embedding::new(config.vocab_size as u32, config.hidden_size as u32).unwrap();
         let layers: Vec<Gemma4DecoderLayer> = (0..config.num_hidden_layers as usize)
@@ -9652,7 +9747,7 @@ mod dspark_tap_tests {
         (embedding, layers, final_norm)
     }
 
-    fn assert_bitwise_eq(a: &MxArray, b: &MxArray, ctx: &str) {
+    pub(super) fn assert_bitwise_eq(a: &MxArray, b: &MxArray, ctx: &str) {
         a.eval();
         b.eval();
         assert_eq!(
@@ -9876,5 +9971,332 @@ mod dspark_tap_tests {
             )
             .is_err()
         );
+    }
+}
+
+#[cfg(test)]
+mod assistant_seam_tests {
+    //! Target-side seams for the assistant draft model: the K/V source
+    //! mapping (which target caches the draft reads), the extracted
+    //! `lm_head_logits` tail, and `assistant_verify_forward` (verify logits
+    //! plus the post-final-norm hidden the draft chains from). Runs a tiny
+    //! random-weight Gemma4 (4 hybrid layers, one KV-shared) through the
+    //! REAL forward paths.
+
+    use super::dspark_tap_tests::{assert_bitwise_eq, tiny_model};
+    use super::*;
+    use crate::models::gemma4::dspark::DsparkTap;
+
+    /// Tiny flat-path Gemma4 config (mirrors the DSpark decode tests):
+    /// 4 hybrid layers, one KV-shared.
+    fn tiny_target_config() -> Gemma4Config {
+        serde_json::from_value(tiny_target_config_value())
+            .expect("tiny Gemma4 config must deserialize")
+    }
+
+    fn tiny_target_config_value() -> serde_json::Value {
+        serde_json::json!({
+            "vocab_size": 16,
+            "hidden_size": 8,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "intermediate_size": 16,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 128,
+            "sliding_window": 8,
+            "layer_types": [
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention"
+            ],
+            "num_kv_shared_layers": 1,
+            "use_block_paged_cache": false,
+            "eos_token_ids": []
+        })
+    }
+
+    /// [`tiny_target_config`] with overridden layer types and KV sharing
+    /// (the two inputs `assistant_kv_source_indices` reads).
+    fn hybrid_config(layer_types: &[&str], num_kv_shared_layers: Option<i32>) -> Gemma4Config {
+        let mut v = tiny_target_config_value();
+        v["layer_types"] = serde_json::json!(layer_types);
+        v["num_hidden_layers"] = serde_json::json!(layer_types.len());
+        match num_kv_shared_layers {
+            Some(n) => v["num_kv_shared_layers"] = serde_json::json!(n),
+            None => {
+                v.as_object_mut()
+                    .expect("tiny config value is an object")
+                    .remove("num_kv_shared_layers");
+            }
+        }
+        serde_json::from_value(v).expect("tiny Gemma4 config must deserialize")
+    }
+
+    // ── K/V source mapping ─────────────────────────────────────────────
+
+    /// With one KV-shared layer the non-shared prefix is [s, f, s]: the
+    /// draft reads the last sliding layer (2) and the last full layer (1)
+    /// — exactly the anchors `should_store_shared_kv` marks.
+    #[test]
+    fn kv_source_indices_pick_last_non_shared_layer_of_each_type() {
+        let config = hybrid_config(
+            &[
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            Some(1),
+        );
+        let sources = assistant_kv_source_indices(&config).expect("mapping must resolve");
+        assert_eq!(
+            sources,
+            AssistantKvSources {
+                sliding: 2,
+                full: 1
+            }
+        );
+    }
+
+    /// Without KV sharing the boundary is num_hidden_layers, so the mapping
+    /// is simply the last layer of each type.
+    #[test]
+    fn kv_source_indices_without_sharing_pick_last_layer_of_each_type() {
+        let config = hybrid_config(
+            &[
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            None,
+        );
+        let sources = assistant_kv_source_indices(&config).expect("mapping must resolve");
+        assert_eq!(
+            sources,
+            AssistantKvSources {
+                sliding: 2,
+                full: 3
+            }
+        );
+    }
+
+    /// A non-shared prefix lacking either attention type is a hard error —
+    /// the draft needs one K/V source per type.
+    #[test]
+    fn kv_source_indices_error_when_type_missing_below_boundary() {
+        // Prefix [sliding, sliding] has no full_attention layer.
+        let config = hybrid_config(
+            &[
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+                "full_attention",
+            ],
+            Some(2),
+        );
+        let err = assistant_kv_source_indices(&config).expect_err("missing full layer must error");
+        assert!(err.reason.contains("full_attention"), "got: {}", err.reason);
+
+        // Prefix [full, full] has no sliding_attention layer.
+        let config = hybrid_config(
+            &[
+                "full_attention",
+                "full_attention",
+                "sliding_attention",
+                "sliding_attention",
+            ],
+            Some(2),
+        );
+        let err =
+            assistant_kv_source_indices(&config).expect_err("missing sliding layer must error");
+        assert!(
+            err.reason.contains("sliding_attention"),
+            "got: {}",
+            err.reason
+        );
+    }
+
+    // ── lm_head tail extraction ────────────────────────────────────────
+
+    /// `forward_body` + `lm_head_logits` composed by hand must reproduce
+    /// `forward_inner` bitwise, with and without logit softcapping.
+    #[test]
+    fn lm_head_logits_matches_forward_inner() {
+        let mut capped = tiny_target_config_value();
+        capped["final_logit_softcapping"] = serde_json::json!(30.0);
+        let configs: [Gemma4Config; 2] = [
+            tiny_target_config(),
+            serde_json::from_value(capped).expect("tiny Gemma4 config must deserialize"),
+        ];
+        for config in &configs {
+            let (embedding, layers, final_norm) = tiny_model(config);
+            let ids = MxArray::from_int32(&[3, 9, 1, 5], &[1, 4]).unwrap();
+
+            let mut caches_a = init_caches_for_config(config);
+            let logits_a = forward_inner(
+                &ids,
+                &embedding,
+                &layers,
+                &mut caches_a,
+                &final_norm,
+                &None,
+                None,
+                None,
+                config,
+                None,
+            )
+            .unwrap();
+
+            let mut caches_b = init_caches_for_config(config);
+            let hidden = forward_body(
+                Some(&ids),
+                None,
+                &embedding,
+                &layers,
+                &mut caches_b,
+                &final_norm,
+                None,
+                None,
+                config,
+                None,
+            )
+            .unwrap();
+            let logits_b = lm_head_logits(&hidden, &embedding, &None, None, config).unwrap();
+
+            let ctx = format!(
+                "lm_head tail (softcap {:?})",
+                config.final_logit_softcapping
+            );
+            assert_bitwise_eq(&logits_a, &logits_b, &ctx);
+        }
+    }
+
+    // ── assistant verify forward ───────────────────────────────────────
+
+    /// Same forward as `dspark_verify_forward` (bitwise-equal logits against
+    /// an empty-tap run on equivalent fresh caches), plus the post-final-norm
+    /// hidden as the second tuple element; caches advance by T and bad block
+    /// shapes are rejected.
+    #[test]
+    fn assistant_verify_forward_returns_hidden_and_logits() {
+        let config = tiny_target_config();
+        let (embedding, layers, final_norm) = tiny_model(&config);
+
+        // 6-token prefill then a 3-token verify block: the block runs T>1
+        // at offset 6 and crosses the sliding window (6+3 > 8).
+        let prefill_ids = MxArray::from_int32(&[3, 9, 1, 5, 2, 8], &[1, 6]).unwrap();
+        let block_ids = MxArray::from_int32(&[7, 11, 13], &[1, 3]).unwrap();
+        let prefill = |caches: &mut [Gemma4LayerCache]| {
+            forward_body(
+                Some(&prefill_ids),
+                None,
+                &embedding,
+                &layers,
+                caches,
+                &final_norm,
+                None,
+                None,
+                &config,
+                None,
+            )
+            .unwrap()
+        };
+
+        // Reference: dspark_verify_forward with an EMPTY tap.
+        let mut caches_a = init_caches_for_config(&config);
+        prefill(&mut caches_a);
+        let mut tap = DsparkTap::new(&[]);
+        let logits_a = dspark_verify_forward(
+            &block_ids,
+            &embedding,
+            &layers,
+            &mut caches_a,
+            &final_norm,
+            &None,
+            None,
+            None,
+            &config,
+            &mut tap,
+        )
+        .unwrap();
+        assert!(tap.captured.is_empty(), "empty tap must capture nothing");
+
+        // Assistant seam on equivalent fresh caches.
+        let mut caches_b = init_caches_for_config(&config);
+        prefill(&mut caches_b);
+        let (logits_b, hidden) = assistant_verify_forward(
+            &block_ids,
+            &embedding,
+            &layers,
+            &mut caches_b,
+            &final_norm,
+            &None,
+            None,
+            None,
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(logits_b.shape().unwrap().to_vec(), vec![1, 3, 16]);
+        assert_eq!(hidden.shape().unwrap().to_vec(), vec![1, 3, 8]);
+        assert_bitwise_eq(&logits_a, &logits_b, "verify logits");
+
+        // The hidden is the post-final-norm state of the same block forward.
+        let mut caches_c = init_caches_for_config(&config);
+        prefill(&mut caches_c);
+        let hidden_ref = forward_body(
+            Some(&block_ids),
+            None,
+            &embedding,
+            &layers,
+            &mut caches_c,
+            &final_norm,
+            None,
+            None,
+            &config,
+            None,
+        )
+        .unwrap();
+        assert_bitwise_eq(&hidden_ref, &hidden, "post-final-norm hidden");
+
+        // Caches advance by T; the KV-shared layer's own vec entry is never
+        // written (it reads its anchor's cache).
+        for (idx, cache) in caches_b.iter().enumerate().take(3) {
+            assert_eq!(cache.get_offset(), 9, "cache {idx} offset");
+        }
+        assert_eq!(
+            caches_b[3].get_offset(),
+            0,
+            "KV-shared layer's cache entry must stay untouched"
+        );
+
+        // Bad block shapes are rejected: batch > 1 and 1-D input.
+        for bad in [
+            MxArray::from_int32(&[1, 2], &[2, 1]).unwrap(),
+            MxArray::from_int32(&[1, 2], &[2]).unwrap(),
+        ] {
+            let mut caches = init_caches_for_config(&config);
+            assert!(
+                assistant_verify_forward(
+                    &bad,
+                    &embedding,
+                    &layers,
+                    &mut caches,
+                    &final_norm,
+                    &None,
+                    None,
+                    None,
+                    &config,
+                )
+                .is_err(),
+                "block shape {:?} must be rejected",
+                bad.shape().unwrap().as_ref()
+            );
+        }
     }
 }

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -403,19 +403,21 @@ pub(crate) struct Gemma4Inner {
     /// when the config flag is unset, in which case the model falls
     /// back to the flat `Gemma4LayerCache` path.
     pub(crate) paged_adapter: Option<PagedKVCacheAdapter>,
-    /// DSpark draft model for speculative decoding (`Gemma4LoadOptions::
-    /// draft_model_path`). Mutually exclusive with `paged_adapter`: the
-    /// load path hard-errors on an explicit `use_block_paged_cache: true`
-    /// conflict and forces the unset default to flat, so `dspark.is_some()`
-    /// implies `paged_adapter.is_none()`.
-    pub(crate) dspark: Option<super::dspark::DsparkDraftModel>,
-    /// Per-turn DSpark draft-context handoff: `dspark_chat_turn` builds the
-    /// draft's fused-context cache during its tapped prefill and stashes it
-    /// here; `DsparkBackend::begin_dspark_decode` TAKES it into the turn's
+    /// Draft model for speculative decoding (`Gemma4LoadOptions::
+    /// draft_model_path`), either [`Gemma4Draft`] variant. Mutually
+    /// exclusive with `paged_adapter`: the load path hard-errors on an
+    /// explicit `use_block_paged_cache: true` conflict and forces the unset
+    /// default to flat, so `draft.is_some()` implies
+    /// `paged_adapter.is_none()`.
+    pub(crate) draft: Option<Gemma4Draft>,
+    /// Per-turn draft handoff: the whole-turn core builds the variant's
+    /// prefill-derived state (DSpark fused-context cache / assistant
+    /// last-prompt hidden) during prefill and stashes it here;
+    /// `DsparkBackend::begin_dspark_decode` TAKES it into the turn's
     /// stepper (the engine's `DsparkTurnSetup` carries only turn constants,
     /// so prefill-derived state travels through this seam). Always `None`
-    /// outside a live `dspark_chat_turn`.
-    pub(crate) dspark_turn_state: Option<super::dspark_decode::DsparkTurnState>,
+    /// outside a live draft whole-turn.
+    pub(crate) draft_turn_state: Option<super::dspark_decode::Gemma4DraftTurnState>,
     /// Cached result of `compute_layer_kinds_from_kv_cache_specs(&config)`,
     /// computed once here in `Gemma4Inner::new` instead of re-derived
     /// (BTreeMap/BTreeSet grouping + a sort) on every paged prefill-chunk /
@@ -437,6 +439,43 @@ pub(crate) struct Gemma4Inner {
     /// `text_delta_image_guard` rejects a media-session delta as today.
     media_session_continuable: bool,
     pub(crate) model_id: u64,
+}
+
+/// Draft-model variant loaded alongside the target for speculative decoding
+/// (`Gemma4LoadOptions::draft_model_path`). The kind probe in
+/// `persistence.rs` picks the variant from the draft checkpoint's
+/// config.json identity fields, then hands the directory to that variant's
+/// strict loader.
+pub(crate) enum Gemma4Draft {
+    /// DeepSpec DSpark external draft: 5-layer cross-attending transformer
+    /// drafting whole masked blocks over a fused target-hidden context
+    /// ([`super::dspark`]).
+    Dspark(super::dspark::DsparkDraftModel),
+    /// Google assistant checkpoint draft: Q-only transformer drafting by
+    /// chained single-token AR steps over the target's committed KV caches
+    /// ([`super::assistant`]).
+    Assistant(super::assistant::AssistantDraftModel),
+}
+
+impl Gemma4Draft {
+    /// Checkpoint tensor bytes for cache-limit accounting (see the variant
+    /// loaders' `weight_bytes` docs for the measurement contract).
+    pub(crate) fn weight_bytes(&self) -> u64 {
+        match self {
+            Self::Dspark(draft) => draft.weight_bytes(),
+            Self::Assistant(draft) => draft.weight_bytes(),
+        }
+    }
+
+    /// Every checkpoint-backed tensor the draft owns, for the post-load
+    /// materialization pass (cheap array-handle clones covering exactly the
+    /// applied checkpoint set — byte-coverage pinned per variant).
+    pub(crate) fn collect_weight_arrays(&self) -> Vec<MxArray> {
+        match self {
+            Self::Dspark(draft) => draft.collect_weight_arrays(),
+            Self::Assistant(draft) => draft.collect_weight_arrays(),
+        }
+    }
 }
 
 /// Gemma 4 dense language model.
@@ -491,24 +530,25 @@ pub struct Gemma4Model {
     /// coordinator on drop. `None` for instances constructed via the
     /// synchronous `new(config)` path that never loaded weights.
     pub(crate) _cache_limit_guard: Option<crate::cache_limit::CacheLimitGuard>,
-    /// Snapshot of `Gemma4Inner::dspark.is_some()` captured at load time
-    /// (same mirroring pattern as `paged_active`): whether a DSpark draft
-    /// model was loaded via `Gemma4LoadOptions::draft_model_path`. Surfaced
-    /// through the `hasMtpWeights()` NAPI method (named for parity with the
-    /// Qwen3.5 surface) so server endpoints can branch without a
-    /// model-thread roundtrip. Stubs from `new(config)` always report
-    /// `false`.
-    pub(crate) dspark_active: bool,
+    /// Snapshot of `Gemma4Inner::draft.is_some()` captured at load time
+    /// (same mirroring pattern as `paged_active`): whether a draft model —
+    /// either [`Gemma4Draft`] variant — was loaded via
+    /// `Gemma4LoadOptions::draft_model_path`. Surfaced through the
+    /// `hasMtpWeights()` NAPI method (named for parity with the Qwen3.5
+    /// surface) so server endpoints can branch without a model-thread
+    /// roundtrip. Stubs from `new(config)` always report `false`.
+    pub(crate) draft_active: bool,
 }
 
 /// Optional load-time settings for [`Gemma4Model::load`].
 #[napi(object)]
 #[derive(Debug, Clone, Default)]
 pub struct Gemma4LoadOptions {
-    /// Directory of a DSpark draft checkpoint (config.json +
-    /// model.safetensors) to load alongside the target model for
-    /// speculative decoding. DSpark runs only on the flat KV-cache path:
-    /// setting this while the model config explicitly enables
+    /// Directory of a draft checkpoint (config.json + safetensors) to load
+    /// alongside the target model for speculative decoding — either a
+    /// DSpark draft or a Google assistant draft; the kind is probed from
+    /// the draft config.json. Draft decoding runs only on the flat KV-cache
+    /// path: setting this while the model config explicitly enables
     /// `use_block_paged_cache` is a hard load error, and an unset
     /// `use_block_paged_cache` is forced to `false`.
     pub draft_model_path: Option<String>,
@@ -1052,8 +1092,8 @@ impl Gemma4Inner {
             cached_image_key: None,
             cached_audio_key: None,
             paged_adapter,
-            dspark: None,
-            dspark_turn_state: None,
+            draft: None,
+            draft_turn_state: None,
             layer_kinds,
             sliding_prefix_checkpoints: VecDeque::new(),
             sliding_prompt_boundary_checkpoint: None,
@@ -1061,6 +1101,29 @@ impl Gemma4Inner {
             media_session_continuable: false,
             model_id,
         })
+    }
+
+    /// The loaded DSpark draft, when the draft variant is DSpark.
+    pub(crate) fn dspark_draft(&self) -> Option<&super::dspark::DsparkDraftModel> {
+        match self.draft.as_ref() {
+            Some(Gemma4Draft::Dspark(draft)) => Some(draft),
+            _ => None,
+        }
+    }
+
+    /// The loaded assistant draft, when the draft variant is assistant.
+    #[allow(dead_code)] // consumed by the assistant decode stepper
+    pub(crate) fn assistant_draft(&self) -> Option<&super::assistant::AssistantDraftModel> {
+        match self.draft.as_ref() {
+            Some(Gemma4Draft::Assistant(draft)) => Some(draft),
+            _ => None,
+        }
+    }
+
+    /// Whether ANY draft variant is loaded (the speculative whole-turn
+    /// gate; see `mtp_turn`).
+    pub(crate) fn has_draft(&self) -> bool {
+        self.draft.is_some()
     }
 
     /// Initialize the per-turn KV caches in-place.
@@ -4979,19 +5042,30 @@ impl ChatBackend for Gemma4Inner {
         // channel segments itself). Defensive: pin `true` so the engine's
         // emitter gate can never suppress.
         p.include_reasoning = true;
-        // DSpark draft depth: with a draft model loaded, an unset
-        // `mtpDepth` runs full draft blocks (`block_size`, 7 on the v1
-        // checkpoint); an explicit value is clamped to `[1, block_size]`
-        // from the RAW config value — the engine's central clamp is
-        // `[1, 5]` (an MTP-head contract that does not apply to DSpark),
-        // so this family-local post-edit widens it without touching the
-        // shared clamp.
-        if let Some(draft) = self.dspark.as_ref() {
-            let block_size = draft.config.block_size;
-            p.mtp_depth = match config.mtp_depth {
-                Some(d) => (d.max(1) as usize).min(block_size),
-                None => block_size,
-            };
+        // Draft depth: with a draft model loaded, `mtpDepth` resolves per
+        // variant — a family-local post-edit of the engine's central
+        // `[1, 5]` clamp (an MTP-head contract that does not apply to
+        // external drafts), always clamping from the RAW config value.
+        //   * DSpark: unset runs full draft blocks (`block_size`, 7 on the
+        //     v1 checkpoint); explicit values clamp to `[1, block_size]`.
+        //   * Assistant: chained AR drafting has no checkpoint-pinned block
+        //     size — unset resolves to `ASSISTANT_DEFAULT_DEPTH`; explicit
+        //     values clamp to `[1, ASSISTANT_MAX_DEPTH]`.
+        match self.draft.as_ref() {
+            Some(Gemma4Draft::Dspark(draft)) => {
+                let block_size = draft.config.block_size;
+                p.mtp_depth = match config.mtp_depth {
+                    Some(d) => (d.max(1) as usize).min(block_size),
+                    None => block_size,
+                };
+            }
+            Some(Gemma4Draft::Assistant(_)) => {
+                p.mtp_depth = match config.mtp_depth {
+                    Some(d) => (d.max(1) as usize).min(super::assistant::ASSISTANT_MAX_DEPTH),
+                    None => super::assistant::ASSISTANT_DEFAULT_DEPTH,
+                };
+            }
+            None => {}
         }
         p
     }
@@ -5471,15 +5545,16 @@ impl ChatBackend for Gemma4Inner {
         Some(crate::engine::paged_turn::run_paged_turn(self, args))
     }
 
-    /// DSpark speculative-decode whole-turn path. Dispatches only when the
-    /// request opted in (`enableMtp`), a draft model is loaded, the flat KV
-    /// path is active (no paged adapter — enforced at load, re-checked here
-    /// defensively), and the turn is text-only (image/audio turns were
-    /// already routed to `vision_turn` by the session core; re-checked
-    /// defensively). Everything else falls through to the generic AR flow.
+    /// Draft speculative-decode whole-turn path (either [`Gemma4Draft`]
+    /// variant). Dispatches only when the request opted in (`enableMtp`), a
+    /// draft model is loaded, the flat KV path is active (no paged adapter
+    /// — enforced at load, re-checked here defensively), and the turn is
+    /// text-only (image/audio turns were already routed to `vision_turn`
+    /// by the session core; re-checked defensively). Everything else falls
+    /// through to the generic AR flow.
     fn mtp_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Option<Result<TurnOutput>> {
         if !(args.params.enable_mtp
-            && self.dspark.is_some()
+            && self.has_draft()
             && self.paged_adapter.is_none()
             && args.images.is_empty()
             && args.audio.is_empty())
@@ -5586,7 +5661,7 @@ impl Gemma4Model {
             initialized: false,
             paged_active: false,
             _cache_limit_guard: None,
-            dspark_active: false,
+            draft_active: false,
         }
     }
 
@@ -5617,19 +5692,19 @@ impl Gemma4Model {
         self.model_id as u32
     }
 
-    /// Whether a DSpark draft model is loaded on this instance (via
-    /// `Gemma4LoadOptions::draft_model_path`), enabling the speculative-
-    /// decode whole-turn path.
+    /// Whether a draft model — DSpark or Google assistant — is loaded on
+    /// this instance (via `Gemma4LoadOptions::draft_model_path`), enabling
+    /// the speculative-decode whole-turn path.
     ///
     /// Note: this only reports draft availability. Whether speculative
     /// decoding actually runs on a given call also requires the per-request
     /// `enableMtp` flag. Named `hasMtpWeights` for parity with the Qwen3.5
-    /// surface, but it reports an external DSpark draft model, not
-    /// in-checkpoint MTP heads. Stubs from `new(config)` always return
+    /// surface, but it reports an external draft model (either variant),
+    /// not in-checkpoint MTP heads. Stubs from `new(config)` always return
     /// `false`.
     #[napi]
     pub fn has_mtp_weights(&self) -> bool {
-        self.dspark_active
+        self.draft_active
     }
 
     /// Load a Gemma4 model from a directory.

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -1112,7 +1112,6 @@ impl Gemma4Inner {
     }
 
     /// The loaded assistant draft, when the draft variant is assistant.
-    #[allow(dead_code)] // consumed by the assistant decode stepper
     pub(crate) fn assistant_draft(&self) -> Option<&super::assistant::AssistantDraftModel> {
         match self.draft.as_ref() {
             Some(Gemma4Draft::Assistant(draft)) => Some(draft),
@@ -6269,7 +6268,6 @@ pub(crate) fn dspark_verify_forward(
 /// it does not sample and touches no history bookkeeping; caches advance by
 /// T. Callers pair it with `snapshot_before_verify` / `commit_after_verify`
 /// for rollback.
-#[allow(dead_code)] // exercised by the inline tests until the assistant decode stepper lands
 pub(crate) fn assistant_verify_forward(
     block_ids: &MxArray,
     embedding: &Embedding,
@@ -6315,7 +6313,6 @@ pub(crate) fn dspark_shared_slot_mask(config: &Gemma4Config) -> Vec<bool> {
 
 /// Target-layer indices whose KV caches the assistant draft reads: one
 /// source per attention type, index-aligned with the per-layer caches vec.
-#[allow(dead_code)] // exercised by the inline tests until the assistant decode stepper lands
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct AssistantKvSources {
     pub sliding: usize,
@@ -6331,7 +6328,6 @@ pub(crate) struct AssistantKvSources {
 /// layers `should_store_shared_kv` marks; without sharing they are simply
 /// the last layer of each type. Errors when the non-shared prefix lacks
 /// either attention type — the draft needs one K/V source per type.
-#[allow(dead_code)] // exercised by the inline tests until the assistant decode stepper lands
 pub(crate) fn assistant_kv_source_indices(config: &Gemma4Config) -> Result<AssistantKvSources> {
     let first_shared = config.first_kv_shared_layer();
     let last_below_boundary = |layer_type: &str| {

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -19,7 +19,7 @@ use crate::models::quant_dispatch::{
 use crate::tokenizer::Qwen3Tokenizer;
 
 use super::config::Gemma4Config;
-use super::model::{Gemma4Inner, Gemma4Model, warmup_forward};
+use super::model::{Gemma4Draft, Gemma4Inner, Gemma4Model, warmup_forward};
 use super::quantized_linear::{
     DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, MXFP8_BITS, MXFP8_GROUP_SIZE, MXFP8_MODE,
     PerLayerMode, PerLayerQuant, is_mxfp8_checkpoint, is_quantized_checkpoint,
@@ -1851,12 +1851,13 @@ impl Gemma4Inner {
     /// why this deterministic measurement is preferred over a
     /// process-wide `get_active_memory()` delta.
     ///
-    /// `draft_model_path` optionally points at a DSpark draft checkpoint
-    /// directory loaded alongside the target for speculative decoding.
-    /// DSpark runs only on the flat KV-cache path, so an explicit
-    /// `use_block_paged_cache: true` in the target config is a hard error
-    /// (silently ignoring the explicit draft request would be worse), and
-    /// the unset default (paged ON) is forced to flat.
+    /// `draft_model_path` optionally points at a draft checkpoint directory
+    /// (DSpark or assistant — probed from its config.json) loaded alongside
+    /// the target for speculative decoding. Draft decoding runs only on the
+    /// flat KV-cache path, so an explicit `use_block_paged_cache: true` in
+    /// the target config is a hard error (silently ignoring the explicit
+    /// draft request would be worse), and the unset default (paged ON) is
+    /// forced to flat.
     pub fn load_from_dir(model_path: &str, draft_model_path: Option<&str>) -> Result<(Self, u64)> {
         let path = Path::new(model_path);
 
@@ -2162,39 +2163,44 @@ impl Gemma4Inner {
             );
         }
 
-        // DSpark draft model — loaded AFTER the target body so its geometry
-        // validation runs against the fully-parsed target config. Loader
-        // errors propagate verbatim (they carry the guard-rail messages:
-        // geometry pins, bf16-only gate, 74-tensor completeness).
+        // Draft model — loaded AFTER the target body so its geometry
+        // validation runs against the fully-parsed target config. The kind
+        // probe reads the draft config.json ONCE to pick the variant; each
+        // variant's strict loader errors propagate verbatim (they carry the
+        // guard-rail messages: geometry pins, bf16-only gates, tensor-set
+        // completeness).
         if let Some(draft_dir) = draft_model_path {
             let draft_path = Path::new(draft_dir);
             // Same cold-mmap pre-warm as the target shards: the draft's
             // first forward must not page-fault a cold region on the GPU.
             prewarm_checkpoint_pages(draft_path);
-            let draft = super::dspark::load_draft_model(
-                draft_path,
-                config.hidden_size as i64,
-                config.vocab_size as i64,
-                config.num_hidden_layers as usize,
-            )?;
-            info!(
-                "[gemma4] DSpark draft model loaded: {} layers, block_size={}, target_layer_ids={:?}",
-                draft.num_layers(),
-                draft.config.block_size,
-                draft.config.target_layer_ids,
-            );
+            let draft = load_draft_variant(draft_path, &config)?;
+            match &draft {
+                Gemma4Draft::Dspark(d) => info!(
+                    "[gemma4] DSpark draft model loaded: {} layers, block_size={}, target_layer_ids={:?}",
+                    d.num_layers(),
+                    d.config.block_size,
+                    d.config.target_layer_ids,
+                ),
+                Gemma4Draft::Assistant(a) => info!(
+                    "[gemma4] assistant draft model loaded: {} layers, draft hidden={}, backbone={}",
+                    a.num_layers(),
+                    a.config.text_config.hidden_size,
+                    a.config.backbone_hidden_size,
+                ),
+            }
             // Materialize the draft's mmap-backed tensors NOW, with the same
             // chunked mechanism as the target's pass below: left lazy, the
             // FIRST speculative forward would page-fault the whole multi-GB
             // checkpoint from cold mmap mid-GPU-work (the qwen3.5 cold-mmap
             // load-watchdog failure class the target pass exists to prevent).
-            // `collect_weight_arrays` enumerates every checkpoint tensor (74
-            // on the v1 contract) — byte-coverage pinned by
-            // `collect_weight_arrays_covers_every_checkpoint_tensor`.
+            // `collect_weight_arrays` enumerates every checkpoint tensor —
+            // byte-coverage pinned per variant by the
+            // `collect_weight_arrays_covers_every_checkpoint_tensor` tests.
             let draft_weights = draft.collect_weight_arrays();
             let draft_refs: Vec<&MxArray> = draft_weights.iter().collect();
             crate::array::memory::materialize_weights(&draft_refs)?;
-            inner.dspark = Some(draft);
+            inner.draft = Some(draft);
         }
 
         // Deterministic weight-byte total for the cache-limit
@@ -2216,16 +2222,80 @@ impl Gemma4Inner {
                 weight_bytes = weight_bytes.saturating_add(shard.nbytes() as u64);
             }
         }
-        // The DSpark draft's checkpoint tensors are model-owned resident
-        // weights too (~GBs of bf16 for the 12B draft); fold them in so
+        // The draft's checkpoint tensors are model-owned resident weights
+        // too (~GBs of bf16 for the 12B DSpark draft); fold them in so
         // the cache-limit coordinator sees the true footprint instead of
         // silently over-granting cache on draft-loaded sessions.
-        if let Some(draft) = inner.dspark.as_ref() {
+        if let Some(draft) = inner.draft.as_ref() {
             weight_bytes = weight_bytes.saturating_add(draft.weight_bytes());
         }
 
         Ok((inner, weight_bytes))
     }
+}
+
+/// Checkpoint identity fields of a draft config.json, read ONCE by
+/// [`load_draft_variant`] to pick the [`Gemma4Draft`] variant before handing
+/// the directory to that variant's strict loader (which re-parses the full
+/// config under its own schema).
+#[derive(serde::Deserialize)]
+struct DraftKindProbe {
+    #[serde(default)]
+    model_type: Option<String>,
+    #[serde(default)]
+    architectures: Vec<String>,
+}
+
+/// Probe the draft checkpoint's kind and run the matching loader:
+/// `model_type` in [`super::assistant::ASSISTANT_MODEL_TYPES`] routes to the
+/// assistant loader, an `architectures` entry of
+/// [`super::dspark::DSPARK_ARCHITECTURE`] to the DSpark loader; anything
+/// else is a hard error naming both accepted kinds.
+fn load_draft_variant(draft_path: &Path, target: &Gemma4Config) -> Result<Gemma4Draft> {
+    let config_path = draft_path.join("config.json");
+    let raw = fs::read_to_string(&config_path).map_err(|e| {
+        Error::from_reason(format!(
+            "Failed to read draft config {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    let probe: DraftKindProbe = serde_json::from_str(&raw).map_err(|e| {
+        Error::from_reason(format!(
+            "Failed to parse draft config {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    if probe
+        .model_type
+        .as_deref()
+        .is_some_and(|t| super::assistant::ASSISTANT_MODEL_TYPES.contains(&t))
+    {
+        return Ok(Gemma4Draft::Assistant(super::assistant::load_draft_model(
+            draft_path, target,
+        )?));
+    }
+    if probe
+        .architectures
+        .iter()
+        .any(|a| a == super::dspark::DSPARK_ARCHITECTURE)
+    {
+        return Ok(Gemma4Draft::Dspark(super::dspark::load_draft_model(
+            draft_path,
+            target.hidden_size as i64,
+            target.vocab_size as i64,
+            target.num_hidden_layers as usize,
+        )?));
+    }
+    Err(Error::from_reason(format!(
+        "Unrecognized gemma4 draft checkpoint {}: expected an assistant draft (model_type one of \
+         {:?}) or a DSpark draft (architectures containing {:?}); got model_type {:?}, \
+         architectures {:?}",
+        config_path.display(),
+        super::assistant::ASSISTANT_MODEL_TYPES,
+        super::dspark::DSPARK_ARCHITECTURE,
+        probe.model_type,
+        probe.architectures,
+    )))
 }
 
 impl Gemma4Model {
@@ -2256,7 +2326,7 @@ impl Gemma4Model {
                 let has_vision = inner.image_processor.is_some();
                 let has_audio = inner.embed_audio.is_some();
                 let paged_active = inner.paged_adapter.is_some();
-                let dspark_active = inner.dspark.is_some();
+                let draft_active = inner.draft.is_some();
                 Ok((
                     inner,
                     (
@@ -2265,14 +2335,14 @@ impl Gemma4Model {
                         has_audio,
                         cache_limit_guard,
                         paged_active,
-                        dspark_active,
+                        draft_active,
                     ),
                 ))
             },
             crate::engine::cmd::handle_chat_cmd::<super::model::Gemma4Inner>,
         );
 
-        let (model_id, has_vision, has_audio, cache_limit_guard, paged_active, dspark_active) =
+        let (model_id, has_vision, has_audio, cache_limit_guard, paged_active, draft_active) =
             init_rx
                 .await
                 .map_err(|_| napi::Error::from_reason("Model thread exited during load"))??;
@@ -2285,7 +2355,7 @@ impl Gemma4Model {
             initialized: true,
             paged_active,
             _cache_limit_guard: Some(cache_limit_guard),
-            dspark_active,
+            draft_active,
         })
     }
 }
@@ -2487,6 +2557,160 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
     }
 
+    // ── draft kind probe (load_draft_variant) ──────────────────────────
+
+    /// Tiny target config for the kind-probe tests: only the geometry the
+    /// variant validators compare matters (hidden 8 / vocab 16 guarantees a
+    /// mismatch against both real-checkpoint-shaped draft configs below).
+    fn probe_target_config() -> Gemma4Config {
+        serde_json::from_value(serde_json::json!({
+            "vocab_size": 16,
+            "hidden_size": 8,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "intermediate_size": 16,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 128,
+            "sliding_window": 8,
+            "layer_types": [
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention"
+            ],
+            "eos_token_ids": []
+        }))
+        .expect("probe target config must deserialize")
+    }
+
+    /// An assistant `model_type` must route to the ASSISTANT loader: the
+    /// error is the assistant validator's distinct geometry mismatch
+    /// against the tiny target, not a DSpark schema/architecture error.
+    #[test]
+    fn draft_probe_routes_assistant_model_type_to_assistant_loader() {
+        let dir = write_config_dir(serde_json::json!({
+            "architectures": ["Gemma4UnifiedAssistantForCausalLM"],
+            "model_type": "gemma4_unified_assistant",
+            "backbone_hidden_size": 3840,
+            "use_ordered_embeddings": false,
+            "tie_word_embeddings": true,
+            "text_config": {
+                "hidden_size": 1024,
+                "intermediate_size": 8192,
+                "num_hidden_layers": 4,
+                "layer_types": [
+                    "sliding_attention",
+                    "sliding_attention",
+                    "sliding_attention",
+                    "full_attention"
+                ],
+                "num_attention_heads": 16,
+                "num_key_value_heads": 8,
+                "num_global_key_value_heads": 1,
+                "head_dim": 256,
+                "global_head_dim": 512,
+                "attention_k_eq_v": true,
+                "sliding_window": 1024,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 262144,
+                "final_logit_softcapping": null,
+                "rope_parameters": {
+                    "full_attention": {
+                        "partial_rotary_factor": 0.25,
+                        "rope_theta": 1000000.0,
+                        "rope_type": "proportional"
+                    },
+                    "sliding_attention": {
+                        "rope_theta": 10000.0,
+                        "rope_type": "default"
+                    }
+                }
+            }
+        }));
+        let err = match load_draft_variant(&dir, &probe_target_config()) {
+            Ok(_) => panic!("a geometry-mismatched assistant draft must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.reason.contains("backbone_hidden_size=3840")
+                && err.reason.contains("does not match target hidden_size=8"),
+            "expected the assistant validator's geometry error, got: {}",
+            err.reason
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A `Gemma4DSparkModel` architecture (and no assistant model_type)
+    /// must still route to the DSPARK loader: the error is the DSpark
+    /// validator's distinct geometry mismatch.
+    #[test]
+    fn draft_probe_routes_dspark_architecture_to_dspark_loader() {
+        let dir = write_config_dir(serde_json::json!({
+            "architectures": ["Gemma4DSparkModel"],
+            "model_type": "gemma4_text",
+            "block_size": 7,
+            "mask_token_id": 4,
+            "hidden_size": 3840,
+            "intermediate_size": 8192,
+            "num_hidden_layers": 5,
+            "num_attention_heads": 16,
+            "global_head_dim": 512,
+            "num_global_key_value_heads": 1,
+            "rms_norm_eps": 1e-6,
+            "final_logit_softcapping": 30.0,
+            "vocab_size": 262144,
+            "target_layer_ids": [0, 2],
+            "num_target_layers": 4,
+            "markov_rank": 2,
+            "markov_head_type": "vanilla",
+            "enable_confidence_head": true,
+            "attention_k_eq_v": true,
+            "rope_parameters": {
+                "full_attention": {
+                    "partial_rotary_factor": 0.25,
+                    "rope_theta": 1000000.0,
+                    "rope_type": "proportional"
+                }
+            }
+        }));
+        let err = match load_draft_variant(&dir, &probe_target_config()) {
+            Ok(_) => panic!("a geometry-mismatched DSpark draft must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.reason.contains("DSpark draft hidden_size=3840")
+                && err.reason.contains("does not match target hidden_size=8"),
+            "expected the DSpark validator's geometry error, got: {}",
+            err.reason
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// A draft config matching NEITHER kind is a hard error naming both
+    /// accepted kinds (so a typo'd checkpoint points at the fix).
+    #[test]
+    fn draft_probe_unknown_kind_errors_naming_both_kinds() {
+        let dir = write_config_dir(serde_json::json!({
+            "architectures": ["SomeOtherModel"],
+            "model_type": "gemma4_text"
+        }));
+        let err = match load_draft_variant(&dir, &probe_target_config()) {
+            Ok(_) => panic!("an unknown draft kind must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.reason.contains("gemma4_assistant")
+                && err.reason.contains("gemma4_unified_assistant")
+                && err.reason.contains("Gemma4DSparkModel"),
+            "the error must name both accepted draft kinds, got: {}",
+            err.reason
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
     /// Loading WITH the draft must report a strictly larger weight-byte
     /// total to the cache-limit coordinator than loading without — larger
     /// by EXACTLY the draft checkpoint's tensor bytes (the draft's ~GBs of
@@ -2525,7 +2749,7 @@ mod tests {
         unsafe { std::env::remove_var("GEMMA4_NO_WARMUP") };
 
         let draft_bytes = inner
-            .dspark
+            .draft
             .as_ref()
             .expect("draft must be attached")
             .weight_bytes();

--- a/crates/mlx-core/tests/gemma4_assistant.rs
+++ b/crates/mlx-core/tests/gemma4_assistant.rs
@@ -1,0 +1,584 @@
+//! Gated end-to-end tests for Gemma4 assistant-checkpoint speculative
+//! decoding (google/gemma-4-12B-it-assistant external draft).
+//!
+//! Loads ONE Gemma4 target model per test WITH the assistant draft attached
+//! (`Gemma4LoadOptions::draft_model_path`); the plain-AR oracle runs on the
+//! SAME instance with `enableMtp: false` (the draft never touches the target
+//! weights or the flat AR path, so this is the exact byte-parity reference —
+//! and only one ~24 GB target is resident at a time).
+//!
+//! PRIMARY ORACLE: speculative decoding must be LOSSLESS at T=0 — the
+//! assistant turn's text/raw_text/finish_reason must byte-match the AR run.
+//!
+//! # Fixture selection: bf16 near-tie robustness (READ BEFORE EDITING PROMPTS)
+//!
+//! The verify forward evaluates T=1+L rows with the SAME chunked-prefill
+//! kernels the AR prompt prefill uses, but the AR DECODE evaluates each
+//! token with the single-token (T=1) kernels. Per-row bf16 results differ
+//! between the two kernel shapes by ~1 ULP (the effect gemma4's own
+//! `prefill_body_gemma4` doc documents — it is why AR prefill splits the
+//! last prompt token out). At a position whose top-2 softcapped logits are
+//! within ~1-2 bf16 ULP (0.125-0.25 at |logit|≈20), the greedy argmax can
+//! legitimately differ between the shapes: measured directly (stock
+//! forwards only, zero draft code), a 200-step AR trajectory on an
+//! open-prose prompt hit exactly one such flip — single-token gap 0.25 (2
+//! ULP), batched row top-2 EXACTLY tied. The repo already accepts this
+//! class as inherent (`paged_decode_long_context_1ulp`: vLLM never asserts
+//! bitwise; the qwen3.5 MTP heal de-flake: "AR diverges at T=0 near-ties").
+//!
+//! The byte-equal oracle is therefore kept STRICT and the fixtures are
+//! chosen to be tie-free: constrained generations (counting, single-word
+//! answers, recipes) whose greedy top-2 gaps are far above kernel noise.
+//! The fixtures are inherited from the DSpark suite (`gemma4_dspark.rs`),
+//! which screened them on this exact bf16 12B target checkpoint, and were
+//! re-validated byte-equal AR-vs-assistant here; MLX runs are
+//! deterministic, so green is stable per machine + MLX pin. If one of
+//! these tests diverges after an MLX bump, check whether the divergence
+//! point is a near-tie (top-2 gap <= ~2 bf16 ULP → re-screen the fixture)
+//! before suspecting the assistant wiring; a REAL bookkeeping bug
+//! (positions, rollback offsets, masks, K/V source mapping) diverges
+//! grossly and immediately, not at a single near-tied token.
+//!
+//! Env (both required; unset → skip-with-message):
+//!   MLX_TEST_GEMMA4_MODEL_PATH     — bf16 unified 48L Gemma-4-12B-IT checkout
+//!   MLX_TEST_GEMMA4_ASSISTANT_PATH — gemma-4-12B-it-assistant draft checkout
+//!
+//! Run (single-threaded is MANDATORY — concurrent model tests oversubscribe
+//! the GPU and SIGABRT):
+//!
+//! ```shell
+//! PATH=/usr/bin:$PATH SDKROOT=$(xcrun --show-sdk-path) \
+//! MLX_TEST_GEMMA4_MODEL_PATH=/abs/path/to/gemma-4-12b-it \
+//! MLX_TEST_GEMMA4_ASSISTANT_PATH=/abs/path/to/gemma-4-12B-it-assistant \
+//!     cargo test -p mlx-core --test gemma4_assistant --release -- \
+//!     --ignored --nocapture --test-threads=1
+//! ```
+
+use std::path::Path;
+
+use mlx_core::engine::types::{ChatConfig, ChatResult};
+use mlx_core::models::gemma4::model::{Gemma4LoadOptions, Gemma4Model};
+use mlx_core::tokenizer::ChatMessage;
+
+const SKIP_MSG: &str = "skipping: set MLX_TEST_GEMMA4_MODEL_PATH (bf16 Gemma-4-12B-IT dir) and \
+     MLX_TEST_GEMMA4_ASSISTANT_PATH (gemma-4-12B-it-assistant dir) to run the assistant e2e suite";
+
+fn env_paths() -> Option<(String, String)> {
+    let (Ok(model), Ok(draft)) = (
+        std::env::var("MLX_TEST_GEMMA4_MODEL_PATH"),
+        std::env::var("MLX_TEST_GEMMA4_ASSISTANT_PATH"),
+    ) else {
+        eprintln!("{SKIP_MSG}");
+        return None;
+    };
+    assert!(
+        Path::new(&model).exists(),
+        "MLX_TEST_GEMMA4_MODEL_PATH does not exist: {model}"
+    );
+    assert!(
+        Path::new(&draft).exists(),
+        "MLX_TEST_GEMMA4_ASSISTANT_PATH does not exist: {draft}"
+    );
+    Some((model, draft))
+}
+
+async fn load_assistant_model(model: &str, draft: &str) -> Gemma4Model {
+    let m = Gemma4Model::load(
+        model.to_string(),
+        Some(Gemma4LoadOptions {
+            draft_model_path: Some(draft.to_string()),
+        }),
+    )
+    .await
+    .expect("Gemma4Model::load with draft_model_path failed");
+    assert!(
+        m.has_mtp_weights(),
+        "assistant draft loaded via Gemma4LoadOptions must flip hasMtpWeights()"
+    );
+    assert!(
+        !m.has_block_paged_cache(),
+        "an assistant-draft load must force the flat KV path (paged adapter off)"
+    );
+    m
+}
+
+fn chat_config(max_new_tokens: i32, enable_mtp: bool) -> ChatConfig {
+    ChatConfig {
+        max_new_tokens: Some(max_new_tokens),
+        temperature: Some(0.0),
+        top_k: None,
+        top_p: None,
+        min_p: None,
+        repetition_penalty: None,
+        repetition_context_size: None,
+        presence_penalty: None,
+        presence_context_size: None,
+        frequency_penalty: None,
+        frequency_context_size: None,
+        max_consecutive_tokens: None,
+        max_ngram_repeats: None,
+        ngram_size: None,
+        tools: None,
+        reasoning_effort: None,
+        thinking_token_budget: None,
+        include_reasoning: Some(false),
+        report_performance: Some(true),
+        reuse_cache: Some(true),
+        enable_mtp: Some(enable_mtp),
+        mtp_depth: None,
+        mtp_adaptive_depth: Some(false),
+    }
+}
+
+fn user_message(content: &str) -> ChatMessage {
+    ChatMessage {
+        role: "user".to_string(),
+        content: content.to_string(),
+        tool_calls: None,
+        tool_call_id: None,
+        is_error: None,
+        reasoning_content: None,
+        images: None,
+        audio: None,
+    }
+}
+
+/// Assert the assistant run byte-matches the AR reference AND actually ran
+/// speculative cycles (not a silent AR fallback), then print the headline
+/// stats.
+fn assert_matches_ar(label: &str, assistant: &ChatResult, ar: &ChatResult) {
+    assert_eq!(
+        assistant.text, ar.text,
+        "[{label}] assistant text diverged from AR at T=0"
+    );
+    assert_eq!(
+        assistant.raw_text, ar.raw_text,
+        "[{label}] assistant raw_text diverged from AR at T=0"
+    );
+    assert_eq!(
+        assistant.finish_reason, ar.finish_reason,
+        "[{label}] assistant finish_reason diverged from AR"
+    );
+    assert_eq!(
+        assistant.num_tokens, ar.num_tokens,
+        "[{label}] assistant token count diverged from AR"
+    );
+    let perf = assistant
+        .performance
+        .as_ref()
+        .expect("assistant performance metrics missing (gemma4 always reports)");
+    let cycles = perf.mtp_cycles.unwrap_or(0);
+    assert!(
+        cycles > 0,
+        "[{label}] expected assistant cycles to run, got mtp_cycles={cycles:?} (silent AR fallback?)"
+    );
+    assert!(
+        perf.mtp_mean_accepted_tokens_total.is_some(),
+        "[{label}] mtp_mean_accepted_tokens_total must be filled after an assistant turn"
+    );
+    let ar_perf = ar.performance.as_ref().expect("AR performance missing");
+    println!(
+        "[{label}] tokens={} cycles={} mean_accepted_total={:?} mean_depth={:?} | decode tok/s: assistant={:.1} ar={:.1}",
+        assistant.num_tokens,
+        cycles,
+        perf.mtp_mean_accepted_tokens_total,
+        perf.mtp_mean_depth,
+        perf.decode_tokens_per_second,
+        ar_perf.decode_tokens_per_second,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 1. PRIMARY ORACLE: greedy multi-cycle matches-AR
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_ASSISTANT_PATH (real 12B + draft)"]
+async fn assistant_greedy_matches_ar_multi_cycle() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_assistant_model(&model_path, &draft_path).await;
+
+    // Tie-screened fixture (see the module doc): a constrained numbered
+    // recipe holds 200 greedy tokens without a near-tie.
+    const PROMPT: &str = "Give a simple recipe for pancakes with numbered steps.";
+
+    let ar = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(200, false)))
+        .await
+        .expect("AR chat_session_start failed");
+    let assistant = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(200, true)))
+        .await
+        .expect("assistant chat_session_start failed");
+
+    assert_matches_ar("multi_cycle", &assistant, &ar);
+    let perf = assistant.performance.as_ref().expect("perf missing");
+    assert!(
+        perf.mtp_cycles.unwrap_or(0) > 1,
+        "expected multiple assistant cycles over 200 tokens"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. RotatingKVCache trap: sliding-window wrap during decode AND prefill
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_ASSISTANT_PATH (real 12B + draft)"]
+async fn assistant_greedy_matches_ar_across_sliding_wrap() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_assistant_model(&model_path, &draft_path).await;
+
+    let paragraph = "The expedition crossed the ridge at dawn, cataloguing mosses, lichens, \
+         glacial striations, and the slow braided rivers below, while the cartographer argued \
+         with the botanist about the correct name for a small blue flower none of them had \
+         seen before. ";
+
+    // (a) Sub-window prompt (~832 tokens) + 600-token budget: the
+    // 1024-token sliding window wraps MID-DECODE, so the draft's shared-KV
+    // re-reads (`get_cached_kv`) and every verify block append to (and
+    // partially roll back from) rotated RotatingKVCache state. The decode
+    // tail is a constrained count (tie-free; module doc).
+    let mut mid_prompt = String::new();
+    for _ in 0..15 {
+        mid_prompt.push_str(paragraph);
+    }
+    mid_prompt.push_str(
+        "\n\nIgnore the text above entirely. Count from 1 to 150, one number per line, \
+         digits only, no other words. Start immediately with 1.",
+    );
+    let ar_a = model
+        .chat_session_start(
+            vec![user_message(&mid_prompt)],
+            Some(chat_config(600, false)),
+        )
+        .await
+        .expect("AR (decode wrap) failed");
+    assert!(
+        ar_a.prompt_tokens < 1024,
+        "decode-wrap fixture must START below the sliding window, got {} prompt tokens",
+        ar_a.prompt_tokens
+    );
+    assert!(
+        ar_a.prompt_tokens + ar_a.num_tokens > 1024 + 128,
+        "decode-wrap fixture must decode WELL past the 1024-token sliding window \
+         (prompt {} + generated {})",
+        ar_a.prompt_tokens,
+        ar_a.num_tokens
+    );
+    let assistant_a = model
+        .chat_session_start(
+            vec![user_message(&mid_prompt)],
+            Some(chat_config(600, true)),
+        )
+        .await
+        .expect("assistant (decode wrap) failed");
+    assert_matches_ar("decode_wrap", &assistant_a, &ar_a);
+
+    // (b) >1100-token prompt + 300-token budget: the window wraps DURING
+    // PREFILL, so the hidden-keeping chunked prefill and every verify block
+    // run on already-rotated sliding caches.
+    let mut long_prompt = String::new();
+    for _ in 0..60 {
+        long_prompt.push_str(paragraph);
+    }
+    long_prompt.push_str(
+        "\n\nIgnore the text above entirely. Count from 1 to 100, one number per line, \
+         digits only, no other words.",
+    );
+    let ar_b = model
+        .chat_session_start(
+            vec![user_message(&long_prompt)],
+            Some(chat_config(300, false)),
+        )
+        .await
+        .expect("AR (prefill wrap) failed");
+    assert!(
+        ar_b.prompt_tokens > 1100,
+        "prefill-wrap fixture must exceed the sliding window during prefill, got {} tokens",
+        ar_b.prompt_tokens
+    );
+    let assistant_b = model
+        .chat_session_start(
+            vec![user_message(&long_prompt)],
+            Some(chat_config(300, true)),
+        )
+        .await
+        .expect("assistant (prefill wrap) failed");
+    assert_matches_ar("prefill_wrap", &assistant_b, &ar_b);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Early EOS stop parity + warm-continue delta turn
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_ASSISTANT_PATH (real 12B + draft)"]
+async fn assistant_stop_mid_block_then_delta_turn() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_assistant_model(&model_path, &draft_path).await;
+
+    // A prompt that stops WELL before the budget, so the EOS lands inside a
+    // speculative block (either as an accepted draft or as the boundary).
+    const PROMPT: &str = "What is the capital of France? Answer with just the city name.";
+    const FOLLOW_UP: &str = "And of Italy? Same format.";
+
+    // AR baseline: turn 1 (fresh) + turn 2 (warm continue on the session).
+    let ar1 = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(64, false)))
+        .await
+        .expect("AR turn 1 failed");
+    assert_eq!(
+        ar1.finish_reason, "stop",
+        "fixture must stop early on EOS, got {:?} ({} tokens)",
+        ar1.finish_reason, ar1.num_tokens
+    );
+    let ar2 = model
+        .chat_session_continue(
+            FOLLOW_UP.to_string(),
+            None,
+            None,
+            Some(chat_config(64, false)),
+        )
+        .await
+        .expect("AR turn 2 (continue) failed");
+
+    // Assistant: same 2-turn shape on the same instance (the fresh start's
+    // prefix verification resets the AR session's caches).
+    let sp1 = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(64, true)))
+        .await
+        .expect("assistant turn 1 failed");
+    assert_matches_ar("stop_turn1", &sp1, &ar1);
+
+    let sp2 = model
+        .chat_session_continue(
+            FOLLOW_UP.to_string(),
+            None,
+            None,
+            Some(chat_config(64, true)),
+        )
+        .await
+        .expect("assistant turn 2 (continue) failed");
+    let perf2 = sp2.performance.as_ref().expect("turn 2 perf missing");
+    assert!(
+        perf2.mtp_cycles.unwrap_or(0) > 0,
+        "the warm-continue turn must also run assistant cycles"
+    );
+    assert!(
+        sp2.cached_tokens > 0,
+        "turn 2 must warm-continue on the saved session (cached_tokens > 0), got {}",
+        sp2.cached_tokens
+    );
+
+    // 2-turn transcript parity vs the AR baseline.
+    let ar_transcript = format!("{}\n---\n{}", ar1.text, ar2.text);
+    let sp_transcript = format!("{}\n---\n{}", sp1.text, sp2.text);
+    assert_eq!(
+        sp_transcript, ar_transcript,
+        "2-turn assistant transcript diverged from the AR 2-turn baseline \
+         (turn2 finish: assistant={:?} ar={:?})",
+        sp2.finish_reason, ar2.finish_reason
+    );
+    assert_eq!(
+        sp2.raw_text, ar2.raw_text,
+        "warm-continue turn raw_text diverged from AR"
+    );
+    assert_eq!(sp2.finish_reason, ar2.finish_reason);
+    println!(
+        "[stop_then_delta] turn1={:?} ({} tok) turn2={:?} ({} tok, cached={})",
+        sp1.finish_reason, sp1.num_tokens, sp2.finish_reason, sp2.num_tokens, sp2.cached_tokens
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Draft-fidelity oracle: acceptance sanity
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_ASSISTANT_PATH (real 12B + draft)"]
+async fn assistant_acceptance_sanity() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_assistant_model(&model_path, &draft_path).await;
+
+    // Natural prose: the regime the assistant draft was trained on.
+    // matches-AR cannot catch draft-side conditioning bugs (verification
+    // re-derives ground truth from the target) — q_pos off-by-ones, K/V
+    // source mis-mapping, or h_prev slot math only DEPRESS acceptance —
+    // so gate on the accept rate instead. This also doubles as a
+    // target-quality canary (a degraded target makes prose unpredictable
+    // for a healthy draft, collapsing acceptance).
+    const PROMPT: &str = "Explain in two paragraphs why the sky is blue during the day and \
+         reddish at sunset.";
+    let mut cfg = chat_config(200, true);
+    cfg.mtp_depth = Some(3);
+    let assistant = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(cfg))
+        .await
+        .expect("assistant chat_session_start failed");
+    let perf = assistant.performance.as_ref().expect("perf missing");
+    let drafts = perf
+        .mtp_mean_accepted_tokens
+        .expect("mtp_mean_accepted_tokens missing after an assistant run");
+    let total = perf
+        .mtp_mean_accepted_tokens_total
+        .expect("mtp_mean_accepted_tokens_total missing after an assistant run");
+    println!(
+        "[acceptance_sanity] depth=3 mean_accepted_drafts={drafts:.3} \
+         mean_accepted_tokens_total={total:.3} cycles={:?} mean_depth={:?} \
+         decode_tok_s={:.1} ttft_ms={:.1}",
+        perf.mtp_cycles, perf.mtp_mean_depth, perf.decode_tokens_per_second, perf.ttft_ms,
+    );
+    // Floor tuned up from the plan's provisional 0.75 after the first real
+    // run measured 2.159 accepted drafts/cycle (total 3.159) on this
+    // fixture: 1.25 keeps wide headroom below the measured value for
+    // MLX-bump drift while a real conditioning bug collapses acceptance
+    // to ~0.
+    assert!(
+        drafts >= 1.25,
+        "draft-fidelity floor: expected mean accepted DRAFT tokens/cycle >= 1.25 at depth 3 \
+         on natural prose, got {drafts:.3} (total={total:.3}; a draft-side conditioning bug — \
+         q_pos off-by-one, K/V source mapping, h_prev slot math — depresses acceptance \
+         without breaking matches-AR)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Sampled-temperature smoke
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_ASSISTANT_PATH (real 12B + draft)"]
+async fn assistant_sampled_smoke() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_assistant_model(&model_path, &draft_path).await;
+
+    let mut cfg = chat_config(128, true);
+    cfg.temperature = Some(0.8);
+    let assistant = model
+        .chat_session_start(
+            vec![user_message(
+                "Describe an imaginary small coastal town in a few sentences.",
+            )],
+            Some(cfg),
+        )
+        .await
+        .expect("sampled assistant chat_session_start failed");
+
+    assert!(assistant.num_tokens > 0, "sampled run must emit tokens");
+    assert!(
+        !assistant.text.trim().is_empty(),
+        "sampled run must produce text"
+    );
+    assert!(
+        assistant.finish_reason == "stop" || assistant.finish_reason == "length",
+        "unexpected finish_reason {:?}",
+        assistant.finish_reason
+    );
+    let perf = assistant.performance.as_ref().expect("perf missing");
+    let cycles = perf.mtp_cycles.unwrap_or(0);
+    assert!(cycles > 0, "sampled run must still take the assistant path");
+    let total = perf
+        .mtp_mean_accepted_tokens_total
+        .expect("acceptance stats missing");
+    assert!(
+        (1.0..=4.0).contains(&total),
+        "mean accepted tokens/cycle {total:.3} out of the sane [1, 1+depth] range \
+         (assistant default depth 3)"
+    );
+    println!(
+        "[sampled_smoke] T=0.8 tokens={} finish={:?} cycles={} mean_accepted_total={:.3}",
+        assistant.num_tokens, assistant.finish_reason, cycles, total
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Streaming == sync
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "needs MLX_TEST_GEMMA4_MODEL_PATH + MLX_TEST_GEMMA4_ASSISTANT_PATH (real 12B + draft)"]
+async fn assistant_stream_matches_send() {
+    let Some((model_path, draft_path)) = env_paths() else {
+        return;
+    };
+    let model = load_assistant_model(&model_path, &draft_path).await;
+
+    const PROMPT: &str = "List four common uses of a paperclip, one short sentence each.";
+
+    let sync = model
+        .chat_session_start(vec![user_message(PROMPT)], Some(chat_config(160, true)))
+        .await
+        .expect("sync assistant chat_session_start failed");
+
+    let (_handle, mut rx) = model
+        .chat_stream_session_start_for_test(
+            vec![user_message(PROMPT)],
+            Some(chat_config(160, true)),
+        )
+        .expect("stream dispatch failed");
+
+    let mut visible = String::new();
+    let mut done_chunk = None;
+    while let Some(result) = rx.recv().await {
+        let chunk = result.expect("stream chunk error");
+        if chunk.done {
+            done_chunk = Some(chunk);
+            break;
+        }
+        if chunk.is_reasoning != Some(true) {
+            visible.push_str(&chunk.text);
+        }
+    }
+    let done = done_chunk.expect("stream ended without a terminal done-chunk");
+
+    // The strongest stream-vs-sync oracle: the terminal chunk's raw_text is
+    // the full undecoded generation — byte-equality pins that the streaming
+    // turn committed the exact same token sequence as the sync turn.
+    assert_eq!(
+        done.raw_text.as_deref(),
+        Some(sync.raw_text.as_str()),
+        "streaming assistant turn generated a different token stream than the sync turn"
+    );
+    // Chunk-routing parity, modulo the parser's TRAILING trim: on a
+    // channel-only output the sync result promotes `parser.thinking()`
+    // (which `.trim()`s — `output_parser.rs`) into `.text`, while the
+    // streaming promotion emits the buffered reasoning untrimmed — a
+    // PRE-EXISTING gemma4 emitter/parser semantic shared with the plain AR
+    // path (verified for the DSpark suite: an AR stream-vs-sync run of this
+    // same prompt shows the identical trailing-whitespace delta with
+    // byte-equal raw_text).
+    assert_eq!(
+        visible.trim_end(),
+        sync.text.trim_end(),
+        "concatenated streaming chunks diverged from the sync assistant text"
+    );
+    assert_eq!(
+        done.finish_reason.as_deref(),
+        Some(sync.finish_reason.as_str()),
+        "terminal chunk finish_reason mismatch"
+    );
+    assert_eq!(done.num_tokens, Some(sync.num_tokens));
+    let perf = done
+        .performance
+        .as_ref()
+        .expect("terminal chunk must carry performance");
+    assert!(
+        perf.mtp_cycles.unwrap_or(0) > 0,
+        "the streaming turn must run assistant cycles"
+    );
+    println!(
+        "[stream_matches_send] tokens={:?} finish={:?} cycles={:?}",
+        done.num_tokens, done.finish_reason, perf.mtp_cycles
+    );
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -4,13 +4,13 @@
 
 All language wrappers share a uniform `ChatSession<M>` surface (`send` / `sendStream` / `sendToolResult` / `reset`) driven by the native `chatSessionStart` / `chatSessionContinue` / `chatSessionContinueTool` NAPI entry points. The legacy `model.chat()` / `model.chatStream()` methods are removed from every generative model.
 
-| Model             | `generate()` | Session API |  Training  | Notes                                                            |
-| ----------------- | :----------: | :---------: | :--------: | ---------------------------------------------------------------- |
-| **Qwen3**         |     yes      |     yes     | GRPO + SFT | Speculative decoding; paged attention                            |
-| **Qwen3.5 Dense** |     yes      |     yes     | GRPO + SFT | Compiled C++ forward (see [ffi-cpp.md](ffi-cpp.md)); VLM variant |
-| **Qwen3.5 MoE**   |     yes      |     yes     | GRPO + SFT | Compiled C++ forward with expert routing; VLM variant            |
+| Model             | `generate()` | Session API |  Training  | Notes                                                                            |
+| ----------------- | :----------: | :---------: | :--------: | -------------------------------------------------------------------------------- |
+| **Qwen3**         |     yes      |     yes     | GRPO + SFT | Speculative decoding; paged attention                                            |
+| **Qwen3.5 Dense** |     yes      |     yes     | GRPO + SFT | Compiled C++ forward (see [ffi-cpp.md](ffi-cpp.md)); VLM variant                 |
+| **Qwen3.5 MoE**   |     yes      |     yes     | GRPO + SFT | Compiled C++ forward with expert routing; VLM variant                            |
 | **Gemma4**        |     yes      |     yes     |     —      | Hybrid sliding/global attention + MoE/PLE; DSpark + assistant-MTP spec. decoding |
-| **LFM2.5**        |     yes      |     yes     |     —      | Hybrid conv + attention                                          |
+| **LFM2.5**        |     yes      |     yes     |     —      | Hybrid conv + attention                                                          |
 
 `Qwen3Model | Qwen35Model | Qwen35MoeModel` is the public `TrainableModel` union in `@mlx-node/lm` — Gemma4 and LFM2.5 are inference-only.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -9,7 +9,7 @@ All language wrappers share a uniform `ChatSession<M>` surface (`send` / `sendSt
 | **Qwen3**         |     yes      |     yes     | GRPO + SFT | Speculative decoding; paged attention                            |
 | **Qwen3.5 Dense** |     yes      |     yes     | GRPO + SFT | Compiled C++ forward (see [ffi-cpp.md](ffi-cpp.md)); VLM variant |
 | **Qwen3.5 MoE**   |     yes      |     yes     | GRPO + SFT | Compiled C++ forward with expert routing; VLM variant            |
-| **Gemma4**        |     yes      |     yes     |     —      | Hybrid sliding/global attention + MoE/PLE; DSpark spec. decoding |
+| **Gemma4**        |     yes      |     yes     |     —      | Hybrid sliding/global attention + MoE/PLE; DSpark + assistant-MTP spec. decoding |
 | **LFM2.5**        |     yes      |     yes     |     —      | Hybrid conv + attention                                          |
 
 `Qwen3Model | Qwen35Model | Qwen35MoeModel` is the public `TrainableModel` union in `@mlx-node/lm` — Gemma4 and LFM2.5 are inference-only.
@@ -74,9 +74,14 @@ for await (const event of session.sendStream('Hello!')) {
 
 The streaming bridge is implemented in `packages/lm/src/stream.ts`: native callback-based methods are captured at module load and re-exposed as `AsyncGenerator` via `_runChatStream`.
 
-## Speculative decoding: Gemma4 + DSpark
+## Speculative decoding: Gemma4 drafts (DSpark + assistant MTP)
 
-Gemma4 supports DSpark speculative decoding: an external draft model proposes a block of tokens per cycle and the target model verifies the whole block in one forward, committing the accepted prefix. Pass `draftModelPath` (a DSpark draft checkpoint directory, e.g. `deepseek-ai/dspark_gemma4_12b_block7`) when loading:
+Gemma4 supports two external-draft speculative decoding variants behind one load surface — the loader picks the variant from the draft checkpoint's `config.json`:
+
+- **DSpark** (`deepseek-ai/dspark_gemma4_12b_block7`): a 5-layer draft that proposes a block of up to 7 tokens per cycle from mask tokens, conditioned on tapped target hidden states.
+- **Assistant MTP** (`google/gemma-4-{12B,26B-A4B,31B}-it-assistant`, apache-2.0, ~800 MB): Google's official 4-layer draft. Its attention layers are Q-only and read the **target's own KV caches** (last non-KV-shared sliding/full layers) — the draft keeps no KV cache and never prefills. Tokens are drafted one at a time, chained through a hidden-state feedback loop, `mtpDepth` per cycle (default 3). The E2B/E4B assistants (centroid sparse lm_head) are not yet supported and are rejected at load.
+
+Pass `draftModelPath` when loading:
 
 ```typescript
 import { loadSession } from '@mlx-node/lm';
@@ -90,10 +95,10 @@ const result = await session.send('Give a simple recipe for pancakes.', { config
 console.log(result.performance?.mtpCycles, result.performance?.mtpMeanAcceptedTokensTotal);
 ```
 
-- **Lossless at T=0** — every committed token is verified by the target model, so greedy output matches the plain autoregressive run (up to inherent bf16 near-ties; see the oracle suite in `crates/mlx-core/tests/gemma4_dspark.rs`).
+- **Lossless at T=0** — every committed token is verified by the target model, so greedy output matches the plain autoregressive run (up to inherent bf16 near-ties; see the oracle suites in `crates/mlx-core/tests/gemma4_dspark.rs` and `crates/mlx-core/tests/gemma4_assistant.rs`).
 - **Stats** — `ChatResult.performance` reports `mtpCycles` (draft+verify cycles executed) and `mtpMeanAcceptedTokensTotal` (mean committed tokens per cycle, including the always-verified token).
-- **Knobs** — an unset `mtpDepth` runs full draft blocks (7 tokens on the v1 draft); an explicit `mtpDepth` caps the block. `mtpAdaptiveDepth` is ignored.
-- **Memory** — the draft loads alongside the target (~6.9 GB extra for the bf16 12B draft). DSpark runs on the flat KV-cache path; a target config that explicitly enables `use_block_paged_cache` is rejected at load.
+- **Knobs** — DSpark: an unset `mtpDepth` runs full draft blocks (7 tokens on the v1 draft); an explicit `mtpDepth` caps the block. Assistant: unset `mtpDepth` defaults to 3 drafts per cycle, explicit values clamp to [1, 8]. `mtpAdaptiveDepth` is ignored for both.
+- **Memory** — the draft loads alongside the target (~6.9 GB extra for the bf16 DSpark 12B draft; ~0.8 GB for an assistant). Both variants run on the flat KV-cache path; a target config that explicitly enables `use_block_paged_cache` is rejected at load.
 - `draftModelPath` is gemma4-only: `loadModel` / `loadSession` reject it for every other family.
 
 ## Server-side sessions

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -2357,13 +2357,28 @@ export interface ChatConfig {
    */
   enableMtp?: boolean | undefined;
   /**
-   * MTP: number of draft tokens per speculative cycle. Clamped to `[1, 5]`
-   * by the verify FFI contract. Default: 1.
+   * MTP: number of draft tokens per speculative cycle.
    *
+   * On Qwen3.5 native MTP heads it is clamped to `[1, 5]` by the verify
+   * FFI contract, and when unset native code currently pins depth 1.
    * When `mtpAdaptiveDepth` is `true`, this value is used as the
    * throughput-policy seed and the expected-value policy's max depth.
    * Adaptive depth is opt-in; set `mtpAdaptiveDepth: true` explicitly to
    * enable it.
+   *
+   * Gemma4 external drafts (`draftModelPath`) resolve the field per draft
+   * variant instead (`gemma4/model.rs` `resolve_params`, always from the
+   * RAW config value — the engine's central `[1, 5]` clamp is an MTP-head
+   * contract that does not apply to external drafts):
+   * - DSpark: an unset `mtpDepth` runs full draft blocks (the draft
+   *   checkpoint's block size — 7 tokens on `dspark_gemma4_12b_block7`),
+   *   and an explicit `mtpDepth` acts as a CAP on that block (clamped to
+   *   `[1, blockSize]`).
+   * - Assistant (Google `gemma-4-*-it-assistant`): an unset `mtpDepth`
+   *   drafts 3 tokens per cycle (`ASSISTANT_DEFAULT_DEPTH`), and an
+   *   explicit `mtpDepth` clamps to `[1, 8]` (`ASSISTANT_MAX_DEPTH`).
+   *
+   * `mtpAdaptiveDepth` is ignored for both Gemma4 external-draft variants.
    */
   mtpDepth?: number | undefined;
   /**

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -167,15 +167,15 @@ export declare class Gemma4Model {
   hasBlockPagedCache(): boolean;
   modelId(): number;
   /**
-   * Whether a DSpark draft model is loaded on this instance (via
-   * `Gemma4LoadOptions::draft_model_path`), enabling the speculative-
-   * decode whole-turn path.
+   * Whether a draft model — DSpark or Google assistant — is loaded on
+   * this instance (via `Gemma4LoadOptions::draft_model_path`), enabling
+   * the speculative-decode whole-turn path.
    *
    * Note: this only reports draft availability. Whether speculative
    * decoding actually runs on a given call also requires the per-request
    * `enableMtp` flag. Named `hasMtpWeights` for parity with the Qwen3.5
-   * surface, but it reports an external DSpark draft model, not
-   * in-checkpoint MTP heads. Stubs from `new(config)` always return
+   * surface, but it reports an external draft model (either variant),
+   * not in-checkpoint MTP heads. Stubs from `new(config)` always return
    * `false`.
    */
   hasMtpWeights(): boolean;
@@ -2946,10 +2946,11 @@ export interface Gemma4Config {
 /** Optional load-time settings for [`Gemma4Model::load`]. */
 export interface Gemma4LoadOptions {
   /**
-   * Directory of a DSpark draft checkpoint (config.json +
-   * model.safetensors) to load alongside the target model for
-   * speculative decoding. DSpark runs only on the flat KV-cache path:
-   * setting this while the model config explicitly enables
+   * Directory of a draft checkpoint (config.json + safetensors) to load
+   * alongside the target model for speculative decoding — either a
+   * DSpark draft or a Google assistant draft; the kind is probed from
+   * the draft config.json. Draft decoding runs only on the flat KV-cache
+   * path: setting this while the model config explicitly enables
    * `use_block_paged_cache` is a hard load error, and an unset
    * `use_block_paged_cache` is forced to `false`.
    */

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -303,8 +303,9 @@ export interface SessionCapableModel {
    * MTP: whether the underlying native model can run speculative
    * decoding. Surfaced by `Qwen3_5Model` / `Qwen3_5MoeModel` (an MTP
    * head shipped in the checkpoint and loaded by persistence) and by
-   * `Gemma4Model` (an external DSpark draft model attached via
-   * `loadModel` / `loadSession` `draftModelPath` — NOT in-checkpoint
+   * `Gemma4Model` (an external draft model — DSpark or Google gemma-4
+   * assistant, auto-detected from the draft's config.json — attached
+   * via `loadModel` / `loadSession` `draftModelPath`; NOT in-checkpoint
    * MTP heads); all other native wrappers omit the method, in
    * which case callers treat a missing getter as `false` (no MTP).
    *
@@ -330,11 +331,13 @@ export interface SessionCapableModel {
    * the same field.
    *
    * - **`mtpDepth`** — pins the MTP draft depth per speculative cycle.
-   *   Clamped to `[1, 5]` by the verify FFI contract. When unset,
-   *   native code currently pins depth 1. Setting `mtpDepth` explicitly
-   *   pins that value unless the caller also passes
-   *   `mtpAdaptiveDepth: true` to opt into adaptive depth with the
-   *   supplied maximum/seed.
+   *   On Qwen3.5 native MTP heads it is clamped to `[1, 5]` by the
+   *   verify FFI contract, and when unset native code currently pins
+   *   depth 1. Setting `mtpDepth` explicitly pins that value unless
+   *   the caller also passes `mtpAdaptiveDepth: true` to opt into
+   *   adaptive depth with the supplied maximum/seed. Gemma4 external
+   *   drafts resolve the field per draft variant instead — see the
+   *   Gemma4 section below.
    * - **`mtpAdaptiveDepth`** — toggles the adaptive depth policy.
    *   Defaults to OFF. When ON, the default mode runs a 5-state machine
    *   (`Explore` → `Full` → {`NeighborProbe` | `Reduced` → `Probe`})
@@ -356,12 +359,26 @@ export interface SessionCapableModel {
    * `SendOptions.config` is the recommended path for callers that
    * just want speculative decoding "on with sensible defaults".
    *
-   * Gemma4 + DSpark reinterprets the knobs: an unset `mtpDepth` runs
-   * full draft blocks (the draft checkpoint's block size — 7 tokens on
-   * `dspark_gemma4_12b_block7`), and an explicit `mtpDepth` acts as a
-   * CAP on that block (clamped to `[1, blockSize]`, not `[1, 5]`).
-   * `mtpAdaptiveDepth` is ignored — the DSpark loop has no adaptive
-   * depth policy.
+   * ## Gemma4 external drafts (`draftModelPath`)
+   *
+   * Gemma4 reinterprets the knobs per draft variant (resolved in
+   * `gemma4/model.rs` `resolve_params`, always from the RAW config
+   * value — the engine's central `[1, 5]` clamp is an MTP-head
+   * contract that does not apply to external drafts):
+   *
+   * - **DSpark**: an unset `mtpDepth` runs full draft blocks (the
+   *   draft checkpoint's block size — 7 tokens on
+   *   `dspark_gemma4_12b_block7`), and an explicit `mtpDepth` acts as
+   *   a CAP on that block (clamped to `[1, blockSize]`).
+   * - **Assistant** (Google `gemma-4-*-it-assistant`): chained AR
+   *   drafting has no checkpoint-pinned block size — an unset
+   *   `mtpDepth` drafts 3 tokens per cycle (`ASSISTANT_DEFAULT_DEPTH`,
+   *   a quality/latency tradeoff, not a checkpoint contract), and an
+   *   explicit `mtpDepth` clamps to `[1, 8]` (`ASSISTANT_MAX_DEPTH`).
+   *
+   * `mtpAdaptiveDepth` is ignored for BOTH variants — neither external
+   * draft loop has an adaptive depth policy. Qwen3.5 native-MTP
+   * semantics above are unchanged.
    */
   hasMtpWeights?(): boolean;
 }
@@ -1300,8 +1317,9 @@ export class ChatSession<M extends SessionCapableModel = SessionCapableModel> {
    * speculative-decode path runs out of the box on MTP-capable
    * checkpoints. An explicit `false` from either source wins (the
    * undefined-check below preserves it). This duck-typed check also
-   * covers Gemma4 with a DSpark draft attached (`hasMtpWeights()`
-   * reports the external draft there, not in-checkpoint MTP heads).
+   * covers Gemma4 with an external draft attached — DSpark or Google
+   * assistant (`hasMtpWeights()` reports the external draft there,
+   * not in-checkpoint MTP heads).
    */
   private mergeConfig(overlay: ChatConfig | undefined): ChatConfig {
     const merged: ChatConfig = {

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -53,12 +53,17 @@ const SUPPORTED_MODEL_TYPES = new Set<ModelType>(Object.keys(MODEL_REGISTRY) as 
 /** Optional settings for {@link loadModel} / {@link loadSession}. */
 export interface LoadModelOptions {
   /**
-   * Gemma4 only: directory of a DSpark draft checkpoint (config.json +
+   * Gemma4 only: directory of an external draft checkpoint (config.json +
    * model.safetensors) loaded alongside the target model for speculative
-   * decoding (forwarded as `Gemma4LoadOptions.draftModelPath`). DSpark runs
-   * on the flat KV-cache path, so the target checkpoint must not explicitly
-   * enable `use_block_paged_cache`. Setting this for any other model family
-   * is a hard error — no other loader accepts a draft model.
+   * decoding (forwarded as `Gemma4LoadOptions.draftModelPath`). Accepts
+   * either a DSpark draft or a Google gemma-4 assistant draft
+   * (`google/gemma-4-*-it-assistant`); the variant is auto-detected from
+   * the draft's config.json (`model_type` `gemma4_assistant` /
+   * `gemma4_unified_assistant` → assistant, `architectures` containing
+   * `Gemma4DSparkModel` → DSpark). Draft decoding runs on the flat
+   * KV-cache path, so the target checkpoint must not explicitly enable
+   * `use_block_paged_cache`. Setting this for any other model family is a
+   * hard error — no other loader accepts a draft model.
    */
   draftModelPath?: string;
 }
@@ -91,7 +96,8 @@ function dispatchLoad(
  * Supports both language models (Qwen3, Qwen3.5) and vision-language models
  * (Qianfan-OCR / InternVL). Use `instanceof` to narrow the returned type.
  *
- * `options.draftModelPath` attaches a DSpark draft checkpoint for
+ * `options.draftModelPath` attaches an external draft checkpoint (DSpark or
+ * Google gemma-4 assistant, auto-detected from the draft's config.json) for
  * speculative decoding — gemma4 only; any other detected family rejects it.
  */
 export async function loadModel(modelPath: string, options?: LoadModelOptions): Promise<LoadableModel> {
@@ -115,7 +121,8 @@ export async function loadModel(modelPath: string, options?: LoadModelOptions): 
  *     must import `QianfanOCRModel` from `@mlx-node/vlm` and construct
  *     `new ChatSession(model)` directly.
  *
- * `options.draftModelPath` attaches a DSpark draft checkpoint for
+ * `options.draftModelPath` attaches an external draft checkpoint (DSpark or
+ * Google gemma-4 assistant, auto-detected from the draft's config.json) for
  * speculative decoding — gemma4 only; any other detected family rejects it.
  * The resulting session auto-enables the speculative path (the model
  * reports `hasMtpWeights()`); pass `enableMtp: false` per call to opt out.

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -81,7 +81,7 @@ function dispatchLoad(
 ): Promise<unknown> {
   if (options?.draftModelPath !== undefined && modelType !== 'gemma4') {
     throw new Error(
-      `draftModelPath (DSpark speculative decoding) is only supported by gemma4 models; ` +
+      `draftModelPath (speculative-decoding draft) is only supported by gemma4 models; ` +
         `${modelPath} has model_type "${modelType}"`,
     );
   }

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -421,7 +421,8 @@ export function makeStreamingModel<C extends NativeStreamingCtor, const O extend
   // — visible on the generated wrapper for TypeScript consumers. Likewise,
   // `Parameters<C['load']>` keeps each family's native load signature —
   // `[modelPath]` for most, `[modelPath, options?]` for Gemma4
-  // (`Gemma4LoadOptions.draftModelPath` / DSpark).
+  // (`Gemma4LoadOptions.draftModelPath` — external DSpark or Google
+  // assistant draft).
   new (...args: ConstructorParameters<C>): StreamingInstance<C, O>;
   load(...args: Parameters<C['load']>): Promise<StreamingInstance<C, O>>;
 } {

--- a/packages/server/src/mappers/request.ts
+++ b/packages/server/src/mappers/request.ts
@@ -125,12 +125,15 @@ export interface MappedRequest {
  *     downstream `ChatSession.mergeConfig` auto-default (true when
  *     the model ships an MTP head) applies.
  *
- *   * `mtp_depth: <positive int ≤ 5>` → `mtpDepth = value`
- *   * non-integer, out-of-range, or absent → `mtpDepth` untouched;
- *     downstream Rust validation (W5 FFI) catches any pathological
- *     value the server didn't reject. Cheap server-side rejection
- *     for the obvious cases (zero, negative, NaN, > 5) saves a
- *     round-trip into the model thread.
+ *   * `mtp_depth: <positive int ≤ 64>` → `mtpDepth = value`
+ *   * non-integer, out-of-range, or absent → `mtpDepth` untouched.
+ *     The real clamps are per-family and owned by native
+ *     `resolve_params`: qwen3.5 native MTP clamps to [1, 5], gemma4
+ *     DSpark caps at the draft block size (7 on v1), and the gemma4
+ *     assistant draft clamps to [1, 8]. The server therefore only
+ *     rejects garbage — non-integers, non-positives, and values
+ *     > 64 (a generous sanity ceiling far above any family's real
+ *     clamp) — which saves a round-trip into the model thread.
  *
  * Kept as a pure helper rather than inlined into each mapper so the
  * two endpoints can't drift in semantics.
@@ -149,7 +152,7 @@ export function applyExtraBodyMtpOverrides(
   // Any other value (null, undefined, unknown string) → leave alone.
 
   const depth = extraBody.mtp_depth;
-  if (depth != null && Number.isInteger(depth) && depth > 0 && depth <= 5) {
+  if (depth != null && Number.isInteger(depth) && depth > 0 && depth <= 64) {
     config.mtpDepth = depth;
   }
 }

--- a/packages/server/src/types-anthropic.ts
+++ b/packages/server/src/types-anthropic.ts
@@ -129,8 +129,11 @@ export interface AnthropicMessagesRequest {
    *     `enableMtp` untouched so the downstream `ChatSession` auto-
    *     default (true when the model ships an MTP head) applies.
    *   * `mtp_depth`: positive integer override for the per-call draft
-   *     depth. Forwarded to `ChatConfig.mtpDepth` as-is; the native
-   *     side validates it.
+   *     depth. The server forwards any positive integer ≤ 64 (a sanity
+   *     ceiling that only blocks garbage) and the native per-family
+   *     `resolve_params` owns the real clamps: qwen3.5 native MTP
+   *     [1, 5], gemma4 DSpark capped at the draft block size, gemma4
+   *     assistant drafts [1, 8].
    */
   extra_body?: {
     // Typed as `string | null` (not the literal union `'mtp' | 'ar'`)

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -196,9 +196,11 @@ export interface ResponsesAPIRequest {
    *     `enableMtp` untouched so the downstream `ChatSession` auto-
    *     default (true when the model ships an MTP head) applies.
    *   * `mtp_depth`: positive integer override for the per-call draft
-   *     depth. Forwarded to `ChatConfig.mtpDepth` as-is; the native
-   *     side validates it (W5 FFI rejects out-of-range values with a
-   *     normal NAPI error, which the server surfaces as 4xx/5xx).
+   *     depth. The server forwards any positive integer ≤ 64 (a sanity
+   *     ceiling that only blocks garbage) and the native per-family
+   *     `resolve_params` owns the real clamps: qwen3.5 native MTP
+   *     [1, 5], gemma4 DSpark capped at the draft block size, gemma4
+   *     assistant drafts [1, 8].
    */
   extra_body?: {
     // Typed as `string | null` (not the literal union `'mtp' | 'ar'`)


### PR DESCRIPTION
## What

Adds gemma-4 **native MTP** speculative decoding: support for Google's official assistant draft checkpoints (`google/gemma-4-{12B,26B-A4B,31B}-it-assistant`, apache-2.0, ~800 MB) as a **second draft variant** next to DSpark (#86), behind the same `loadSession(path, { draftModelPath })` surface — the loader picks the variant from the draft checkpoint's `config.json`.

```
DSpark (existing):    5-layer draft, masked block-7 proposals, tapped target hiddens
Assistant MTP (new):  4-layer draft, Q-only attention reading the TARGET's KV caches
                      (last non-KV-shared sliding/full layers), no draft KV, no prefill;
                      one token per step chained through a hidden feedback loop,
                      constant RoPE position per cycle; mtpDepth drafts/cycle (default 3, clamp [1,8])
```

Both variants share the engine turn loop (`run_dspark_turn`), verify/rollback machinery, stop-clamp semantics, and telemetry. E2B/E4B assistants (centroid sparse lm_head) are rejected at load with a clear error — follow-up.

## Design

- `Gemma4Draft { Dspark, Assistant }` enum dispatch (invalid states unrepresentable); `Gemma4DraftStepper`/`Gemma4DraftTurnState` enums delegate the engine seam; whole-turn core generalized with exactly 3 variant points.
- Draft reads target K/V **verbatim** (target caches K post-RoPE) via `get_cached_kv()` re-read after every commit; sliding caches return temporally-ordered windows.
- Target-side seams: `lm_head_logits` extraction (pure refactor), `assistant_verify_forward` (logits + post-final-norm hidden), `assistant_kv_source_indices` (exact `layer_types` matching, consistent with `should_store_shared_kv`).
- Greedy longest-prefix + Leviathan rejection sampling from the engine — distribution-preserving at T>0 (stronger than mlx-vlm's naive match).
- **Zero TS surface changes** — proven by the TS e2e passing with no edits under `packages/` (only doc comments + the server `extra_body.mtp_depth` cap lift landed there).

## Verification

- **E2E oracles 6/6 green first run** on real 12B (`tests/gemma4_assistant.rs`): greedy byte-parity vs AR incl. sliding-window wraps, stop-mid-block + warm delta turn, acceptance canary, sampled smoke, stream==sync. DSpark regression suite 6/6 unchanged. TS e2e mirror 1/1.
- Unit: 2078 lib tests green; clippy `-D warnings` + fmt clean; typecheck + type-aware lint clean.
- Per-phase codex adversarial reviews (5 fix rounds all resolved: exact layer_types KV mapping, draft-dim validation gates ×2, rawText parity asserts, stale MTP docs + server depth cap) + whole-branch review **PASS**.

## Numbers (M5 Max, bf16 12B target, greedy, cooled 3 min between runs)

Structured prompt (numbered pancake recipe, 200 tok — same prompt as the PR #86/#87 quantized benches):

| Path | tok/s | vs AR | accepted/cycle |
|---|---|---|---|
| AR | 18.4 | — | — |
| **Assistant MTP** | **29.9** | **1.63×** | 3.25 |
| DSpark | 27.0 | 1.47× | 3.41 |

Open-prose prompt (pour-over brewing guide, run to EOS ~1.7k tok):

| Path | tok/s | vs AR | accepted/cycle |
|---|---|---|---|
| AR | 19.8 | — | — |
| **Assistant MTP** | **24.5** | **1.24×** | 2.80 |
| DSpark | 27.4 | 1.38× | 3.78 |

Speedup is acceptance-driven and prompt-dependent — the PR #86 "2.46×" headline was the `decode_wrap` oracle fixture (highly predictable 600-tok continuation, accept 6.05/cycle, the ceiling); its `multi_cycle` fixture printed 26.7 tok/s accept 3.49, matching these numbers exactly. The assistant beats DSpark on the structured prompt despite lower acceptance because its cycles are much cheaper (0.8 GB Q-only draft + 4-row verify at depth 3 vs 6.9 GB draft + 8-row verify at block 7); it needs no per-cycle context fusion and no draft prefill.

Docs: `docs/models.md` speculative-decoding section covers both variants; `ChatConfig.mtpDepth`/TSDoc scoped per family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large change to the Gemma4 speculative-decode and KV rollback path; wrong assistant wiring could break greedy parity or session reuse, though fail-closed reset and T=0 e2e oracles target that.
> 
> **Overview**
> Adds **Google `gemma-4-*-it-assistant`** as a second Gemma4 external draft alongside DSpark, still loaded through **`loadSession` / `draftModelPath`** with variant chosen from the draft `config.json`.
> 
> The assistant is a Q-only draft that reads the **target’s committed KV** (no draft KV / DSpark-style context fusion), chains single-token proposals with a fixed query position per cycle, and uses family-specific **`mtpDepth`** (default 3, clamp **[1, 8]**). DSpark and assistant share a refactored **`Gemma4Draft`** / **`Gemma4DraftStepper`** / **`draft_chat_turn`** path instead of DSpark-only `dspark_chat_turn` and `dspark_turn_state`.
> 
> **Server/API:** HTTP mappers stop capping `extra_body.mtp_depth` at 5; they forward **6–8** and reject invalid values above **64**, leaving per-family clamps to native code. NAPI/TSDoc now describe both draft kinds and depth rules.
> 
> **Tests:** New env-gated TS e2e for assistant greedy **byte-parity vs no-draft** plus real speculative cycles; DSpark e2e also asserts **`rawText`** parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff9c98e1a2f107a801355fb35884cd8b627796d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
