### PR TITLE
fix(convert): keep recipe-pinned o_proj/out_proj/in_proj_a/b 8-bit affine under --q-mxfp

### DIFF
--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -2565,8 +2565,12 @@ export interface ConversionOptions {
   imatrixPath?: string;
   /**
    * Upgrade quantization to micro-scaling FP (mxfp4 / mxfp8).
-   * When true, applies after the recipe predicate: any 8-bit affine decision
-   * becomes mxfp8, any 4-bit decision becomes mxfp4. Requires `quant_mode = "affine"`.
+   * When true, applies after the recipe predicate: eligible 8-bit affine
+   * decisions become mxfp8 and 4-bit become mxfp4. Kept affine (not upgraded):
+   * affine-only loaders (lm_head, embed_tokens, router.proj,
+   * embedding_projection) at their recipe bits, MoE router gates (8-bit affine),
+   * and the recipe-pinned attention/GDN projections (o_proj / out_proj /
+   * in_proj_a / in_proj_b, 8-bit affine). Requires `quant_mode = "affine"`.
    * Forces `group_size = 32` for upgraded layers.
    */
   quantMxfp?: boolean;
@@ -3166,8 +3170,12 @@ export interface GgufConversionOptions {
   vlmKeyPrefix?: boolean;
   /**
    * Upgrade quantization to micro-scaling FP (mxfp4 / mxfp8).
-   * When true, applies after the recipe predicate: any 8-bit affine decision
-   * becomes mxfp8, any 4-bit decision becomes mxfp4. Requires `quant_mode = "affine"`.
+   * When true, applies after the recipe predicate: eligible 8-bit affine
+   * decisions become mxfp8 and 4-bit become mxfp4. Kept affine (not upgraded):
+   * affine-only loaders (lm_head, embed_tokens, router.proj,
+   * embedding_projection) at their recipe bits, MoE router gates (8-bit affine),
+   * and the recipe-pinned attention/GDN projections (o_proj / out_proj /
+   * in_proj_a / in_proj_b, 8-bit affine). Requires `quant_mode = "affine"`.
    * Forces `group_size = 32` for upgraded layers.
    */
   quantMxfp?: boolean;

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -1565,8 +1565,12 @@ pub struct ConversionOptions {
     pub imatrix_path: Option<String>,
 
     /// Upgrade quantization to micro-scaling FP (mxfp4 / mxfp8).
-    /// When true, applies after the recipe predicate: any 8-bit affine decision
-    /// becomes mxfp8, any 4-bit decision becomes mxfp4. Requires `quant_mode = "affine"`.
+    /// When true, applies after the recipe predicate: eligible 8-bit affine
+    /// decisions become mxfp8 and 4-bit become mxfp4. Kept affine (not upgraded):
+    /// affine-only loaders (lm_head, embed_tokens, router.proj,
+    /// embedding_projection) at their recipe bits, MoE router gates (8-bit affine),
+    /// and the recipe-pinned attention/GDN projections (o_proj / out_proj /
+    /// in_proj_a / in_proj_b, 8-bit affine). Requires `quant_mode = "affine"`.
     /// Forces `group_size = 32` for upgraded layers.
     pub quant_mxfp: Option<bool>,
 
@@ -3959,14 +3963,14 @@ pub(crate) fn apply_mxfp_upgrade(
         if is_bitexact_affine_proj(key) {
             return original;
         }
-        // Router gates and shared_expert_gate: ALWAYS force 8-bit affine,
-        // regardless of what the inner predicate returned. MXFP8's coarse
-        // E8M0 scales destroy top-K routing precision. We do not preserve
-        // `Skip` here either: a recipe that wants to keep gates at full
-        // precision would not have a meaningful interaction with `--q-mxfp`
-        // since the loader has no path to load an unquantized gate when
-        // every other weight is quantized. Forcing affine 8-bit matches
-        // Python mlx-lm's `quant_predicate` in `qwen3_5.py`.
+        // Router gates and shared_expert_gate: force 8-bit affine (group_size
+        // 64), but PRESERVE an explicit `Skip` from the inner predicate. MXFP8's
+        // coarse E8M0 scales destroy top-K routing precision, so any non-Skip
+        // gate decision (Default or Custom) is rewritten to affine 8-bit —
+        // matching Python mlx-lm's `quant_predicate` in `qwen3_5.py`
+        // (`{group_size: 64, bits: 8}`). A recipe that returns `Skip` for a gate
+        // (keep it dense/bf16) is honored as-is. Mirrors the Skip-preserving
+        // gate branch in `apply_nvfp4_upgrade`.
         if is_router_gate(key) {
             match original {
                 QuantDecision::Skip => return QuantDecision::Skip,
@@ -5110,8 +5114,8 @@ fn quantize_weights_inner(
 ///
 /// Returns the per-layer override map produced by `quantize_weights_inner`.
 /// The no-recipe path still emits non-default entries for special keys —
-/// e.g. router gates are upgraded to mxfp8 under a global MXFP mode, and
-/// `lm_head` / `router.proj` are forced back to affine — so callers MUST
+/// e.g. router gates are forced to 8-bit affine (regardless of the top-level
+/// MXFP mode), like `lm_head` / `router.proj` — so callers MUST
 /// thread the returned map into `config.json["quantization"]` for the
 /// loader to dispatch correctly.
 fn quantize_weights(

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -3958,9 +3958,17 @@ pub(crate) fn apply_mxfp_upgrade(
         // recipes emit Custom{8, gs64, affine} here so AR (M=1) and MTP-verify
         // (M>=2) both route through the M-invariant qmv kernel for T=0
         // MTP<->AR bit-exactness, and 8-bit *affine* (not mxfp8's coarse E8M0
-        // scales) keeps the worst-KLD out_proj near bf16. Preserve the recipe's
-        // decision (and any Skip for MTP-layer keys) rather than upgrading it.
-        if is_bitexact_affine_proj(key) {
+        // scales) keeps the worst-KLD out_proj near bf16. Preserve THAT pinned
+        // decision from the mxfp8 upgrade — but ONLY when the recipe actually
+        // pinned it to 8-bit affine. `apply_mxfp_upgrade` wraps every recipe,
+        // and generic `mixed_*` recipes give these keys low-bit decisions
+        // (e.g. mixed_4_6 -> 4-bit affine o_proj) that must still upgrade
+        // normally (4-bit -> mxfp4); gating on the pinned decision — not the
+        // key alone — keeps those working. A `Skip` (MTP-layer keys) falls
+        // through to the main match's `Skip => Skip` arm, so it is still kept.
+        if is_bitexact_affine_proj(key)
+            && matches!(&original, QuantDecision::Custom { bits: 8, mode, .. } if mode == "affine")
+        {
             return original;
         }
         // Router gates and shared_expert_gate: force 8-bit affine (group_size
@@ -6626,6 +6634,38 @@ mod tests {
                 mode: "mxfp4".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn apply_mxfp_upgrade_promotes_non_pinned_low_bit_projections() {
+        // The bitexact guard must protect ONLY the recipe-PINNED 8-bit affine
+        // decision (qwen3_5 / unsloth). Under a generic `mixed_*` recipe these
+        // same keys get low-bit decisions (e.g. mixed_4_6 -> 4-bit affine
+        // o_proj) which must still upgrade to mxfp4 — otherwise --q-mxfp is a
+        // silent no-op for them on mixed recipes.
+        let inner: Box<dyn Fn(&str) -> QuantDecision + Send + Sync> =
+            Box::new(|_key: &str| QuantDecision::Custom {
+                bits: 4,
+                group_size: 64,
+                mode: "affine".to_string(),
+            });
+        let wrapped = apply_mxfp_upgrade(inner, 4);
+        for key in [
+            "model.layers.0.self_attn.o_proj.weight",
+            "model.layers.0.linear_attn.out_proj.weight",
+            "model.layers.0.linear_attn.in_proj_a.weight",
+            "model.layers.0.linear_attn.in_proj_b.weight",
+        ] {
+            assert_eq!(
+                wrapped(key),
+                QuantDecision::Custom {
+                    bits: 4,
+                    group_size: 32,
+                    mode: "mxfp4".to_string(),
+                },
+                "{key}: non-pinned 4-bit affine (mixed_* recipe) must upgrade to mxfp4"
+            );
+        }
     }
 
     #[test]

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -3425,6 +3425,38 @@ fn is_affine_only_key(key: &str) -> bool {
         || key.contains("embedding_projection")
 }
 
+/// Check if a key is one of the four attention/GDN projections that the
+/// `unsloth` / `qwen3_5` recipes deliberately pin to 8-bit **affine**
+/// (`self_attn.o_proj`, `linear_attn.out_proj`, `linear_attn.in_proj_a`,
+/// `linear_attn.in_proj_b`).
+///
+/// These are quantized (not left bf16) so that AR (M=1) and MTP-verify (M>=2)
+/// both route through the M-invariant `quantized_matmul` / `qmv` kernel, giving
+/// T=0 MTP<->AR bit-exactness: a bf16 `matmul` dispatches `gemv` at M=1 but a
+/// split-K `steel_matmul` at M>=2, whose different reduction order flips argmax
+/// on near-ties. 8-bit *affine* specifically keeps the worst-KLD tensor
+/// (`out_proj`, KLD ~6.0) and `o_proj` (~1.5) near bf16 — MXFP8's E8M0
+/// power-of-two scales have ~10x the round-trip error of affine 8-bit (the same
+/// reason router gates are protected).
+///
+/// Used by `apply_mxfp_upgrade` ONLY, to skip the 8-bit -> mxfp8 upgrade. It
+/// must NOT be added to `is_affine_only_key`: that helper is also consulted by
+/// the uniform / no-recipe path (`quantize_weights_inner`), and listing these
+/// keys there would wrongly stop a uniform `--q-mode mxfp8` from upgrading
+/// `o_proj`. The nvfp4 path needs no equivalent guard — `apply_nvfp4_upgrade`
+/// has no 8-bit arm, so it already passes these `Custom { bits: 8, .. }`
+/// decisions through unchanged.
+///
+/// Mirrors the exact substrings the recipes match (`build_qwen35_recipe` /
+/// `build_unsloth_recipe`) so it covers precisely the pinned keys and does NOT
+/// catch `q/k/v_proj`, `in_proj_qkv`, or `in_proj_z` (6-bit, must upgrade).
+fn is_bitexact_affine_proj(key: &str) -> bool {
+    key.contains("self_attn.o_proj")
+        || key.contains("linear_attn.out_proj")
+        || key.contains("linear_attn.in_proj_a.")
+        || key.contains("linear_attn.in_proj_b.")
+}
+
 // ── Per-Layer Quantization Recipes ──────────────────────────────────────────
 
 /// Per-weight quantization decision returned by recipe predicates.
@@ -3892,6 +3924,14 @@ pub(crate) fn build_privacy_filter_predicate(
 ///   top-K expert selection and produces gibberish output. Python mlx-lm's
 ///   `quant_predicate` in `qwen3_5.py` hardcodes these gates to
 ///   `{group_size: 64, bits: 8}` affine for exactly this reason.
+/// - Recipe-pinned attention/GDN projections (`self_attn.o_proj`,
+///   `linear_attn.out_proj`, `linear_attn.in_proj_a`, `linear_attn.in_proj_b`):
+///   the `unsloth` / `qwen3_5` recipes pin these to 8-bit affine so AR (M=1)
+///   and MTP-verify (M>=2) both route through the M-invariant `qmv` kernel for
+///   T=0 MTP<->AR bit-exactness. Like the router gates their loader IS
+///   mode-aware, but MXFP8's E8M0 power-of-two scales have ~10x the round-trip
+///   error of affine 8-bit, pushing the worst-KLD `out_proj` (~6.0) and
+///   `o_proj` (~1.5) off bf16. See `is_bitexact_affine_proj`.
 ///
 /// MXFP tensors at any of these keys would be silently misinterpreted at
 /// load time or destroy routing precision. Supporting MXFP on these keys
@@ -3907,6 +3947,16 @@ pub(crate) fn apply_mxfp_upgrade(
         // doc for the full rationale. `embed_tokens` also matches
         // `embed_tokens_per_layer` (Gemma4 PLE embedding) via `contains`.
         if is_affine_only_key(key) {
+            return original;
+        }
+        // Recipe-pinned 8-bit affine attention/GDN projections
+        // (o_proj / out_proj / in_proj_a / in_proj_b). The unsloth / qwen3_5
+        // recipes emit Custom{8, gs64, affine} here so AR (M=1) and MTP-verify
+        // (M>=2) both route through the M-invariant qmv kernel for T=0
+        // MTP<->AR bit-exactness, and 8-bit *affine* (not mxfp8's coarse E8M0
+        // scales) keeps the worst-KLD out_proj near bf16. Preserve the recipe's
+        // decision (and any Skip for MTP-layer keys) rather than upgrading it.
+        if is_bitexact_affine_proj(key) {
             return original;
         }
         // Router gates and shared_expert_gate: ALWAYS force 8-bit affine,
@@ -6488,6 +6538,88 @@ mod tests {
                 bits: 8,
                 group_size: 32,
                 mode: "mxfp8".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn apply_mxfp_upgrade_preserves_bitexact_affine_projections() {
+        // The unsloth / qwen3_5 recipes pin o_proj / out_proj / in_proj_a /
+        // in_proj_b to 8-bit affine so AR (M=1) and MTP-verify (M>=2) both route
+        // through the M-invariant qmv kernel (T=0 MTP<->AR bit-exactness), and
+        // 8-bit *affine* keeps the worst-KLD out_proj near bf16. `--q-mxfp` must
+        // NOT degrade these to mxfp8. q_proj / gate_proj prove the guard is not
+        // over-broad and still upgrade normally.
+        let inner: Box<dyn Fn(&str) -> QuantDecision + Send + Sync> = Box::new(|key: &str| {
+            if key.contains("self_attn.o_proj")
+                || key.contains("linear_attn.out_proj")
+                || key.contains("linear_attn.in_proj_a.")
+                || key.contains("linear_attn.in_proj_b.")
+            {
+                // MTP-layer o_proj is left bf16 by the recipe (Skip).
+                if key.contains("mtp") {
+                    QuantDecision::Skip
+                } else {
+                    QuantDecision::Custom {
+                        bits: 8,
+                        group_size: 64,
+                        mode: "affine".to_string(),
+                    }
+                }
+            } else if key.contains("q_proj") {
+                QuantDecision::Custom {
+                    bits: 6,
+                    group_size: 64,
+                    mode: "affine".to_string(),
+                }
+            } else {
+                QuantDecision::Default
+            }
+        });
+        let wrapped = apply_mxfp_upgrade(inner, 4);
+
+        // The four recipe-pinned projections stay Custom{8, 64, affine}.
+        for key in [
+            "model.layers.0.self_attn.o_proj.weight",
+            "model.layers.0.linear_attn.out_proj.weight",
+            "model.layers.0.linear_attn.in_proj_a.weight",
+            "model.layers.0.linear_attn.in_proj_b.weight",
+        ] {
+            assert_eq!(
+                wrapped(key),
+                QuantDecision::Custom {
+                    bits: 8,
+                    group_size: 64,
+                    mode: "affine".to_string(),
+                },
+                "{key} must stay 8-bit affine, not upgrade to mxfp8"
+            );
+        }
+
+        // An MTP-layer o_proj the recipe Skips stays Skip (not force-quantized).
+        assert_eq!(
+            wrapped("model.mtp.layers.0.self_attn.o_proj.weight"),
+            QuantDecision::Skip,
+            "MTP o_proj Skip must be preserved"
+        );
+
+        // Control: the guard is not over-broad. q_proj (6-bit) passes through
+        // unchanged and gate_proj (Default, default_bits=4) upgrades to mxfp4.
+        assert_eq!(
+            wrapped("model.layers.0.self_attn.q_proj.weight"),
+            QuantDecision::Custom {
+                bits: 6,
+                group_size: 64,
+                mode: "affine".to_string(),
+            },
+            "q_proj must not be caught by the o_proj guard"
+        );
+        assert_eq!(
+            wrapped("model.layers.0.mlp.gate_proj.weight"),
+            QuantDecision::Custom {
+                bits: 4,
+                group_size: 32,
+                mode: "mxfp4".to_string(),
             }
         );
     }

--- a/crates/mlx-core/src/models/lfm2/sparse_moe.rs
+++ b/crates/mlx-core/src/models/lfm2/sparse_moe.rs
@@ -32,8 +32,9 @@ use super::config::Lfm2Config;
 
 /// LFM2.5 sparse MoE block.
 pub struct Lfm2SparseMoeBlock {
-    /// Router gate: `Standard(Linear)` for bf16/f16, `Quantized` (MXFP8) for
-    /// quantized checkpoints.
+    /// Router gate: `Standard(Linear)` for bf16/f16, `Quantized` for quantized
+    /// checkpoints. Convert forces `feed_forward.gate` to 8-bit affine (never
+    /// mxfp8) via `is_router_gate`, so the quantized form is 8-bit affine.
     gate: LinearProj,
     /// Expert-indexed SwiGLU (gather_mm / gather_qmm). Reused from qwen3_5_moe.
     switch_mlp: SwitchGLU,

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -429,17 +429,28 @@ pub(crate) fn try_build_quantized_switch_linear(
 ///
 /// Returns `(default_plq, default_gate_plq)`.
 ///
-/// Router gate fallback. Historically router gates were always affine 8-bit,
-/// but `--q-mxfp --q-bits 8` (no recipe) upgrades router gates to MXFP8 via
-/// `quantize_weights_inner`'s `is_router_gate` branch. When the global
-/// default also becomes MXFP8 the gate entry matches the global default
-/// exactly, so no per-layer override is emitted to config.json; on load
-/// `per_layer_quant.get(gate_prefix)` then returns None and we fall back
-/// to `default_gate_plq`. It MUST track the top-level mode for those cases.
+/// Router gate fallback for a body gate prefix that has NO per-layer override.
+/// `default_gate_plq` is affine 8/64 for every top-level mode except Mxfp8,
+/// where it is mxfp8 8/32.
 ///
-/// Mode mapping: only MXFP8 is meaningful for router gates (gates are
-/// always 8-bit; MXFP4 gates don't exist), so MXFP4 / Affine top-level
-/// modes both keep the historical affine fallback. MXFP8 → mxfp8/gs=32.
+/// Convert forces body router gates to affine 8/64 (`is_router_gate` in
+/// `apply_mxfp_upgrade` / `quantize_weights_inner`) and emits a per-gate
+/// override only when that decision differs from the top-level default:
+///   - top-level affine 8/64 (recipe path, incl. recipe `--q-mxfp`; or an
+///     affine-8/64 no-recipe convert): the redundant override is ELIDED and the
+///     gate resolves via THIS affine `default_gate_plq` fallback — so the affine
+///     branch is live, not vestigial.
+///   - top-level Mxfp8 (`--q-mode mxfp8`, or no-recipe `--q-mxfp --q-bits 8`):
+///     the affine gate decision differs from the mxfp8 default, so an explicit
+///     affine override IS emitted and `effective_plq_for` resolves the gate from
+///     it. Because that override is always present when the top level is Mxfp8,
+///     the mxfp8 `default_gate_plq` branch never resolves a convert-produced
+///     gate (it could only fire for a foreign/hand-edited config declaring
+///     mode=mxfp8 with no per-gate override). No convert path loads a gate mxfp8.
+///
+/// (MTP-layer gates are governed by the `--q-mtp` policy — the quantizing
+/// policies `cyankiwi`/`all` give them direct affine overrides via
+/// `mtp_quant_decision`.)
 fn compute_moe_defaults(
     params: &HashMap<String, MxArray>,
     top_level_mode: Option<PerLayerMode>,

--- a/crates/mlx-core/src/models/qwen3_5_moe/sparse_moe.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/sparse_moe.rs
@@ -107,7 +107,7 @@ impl SparseMoeBlock {
 
         // Routing math (softmax-then-topk, optionally renormalized) is shared
         // with the gpt-oss / privacy-filter path via `moe::topk_from_logits`.
-        // The gate matmul stays here because it may be quantized (MXFP8) —
+        // The gate matmul stays here because it may be quantized (8-bit affine) —
         // the shared `TopKRouter` only handles plain `MxArray` gate weights.
         let (top_weights, top_indices) = topk_from_logits(
             &router_logits,

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -1249,8 +1249,12 @@ pub struct GgufConversionOptions {
     pub vlm_key_prefix: Option<bool>,
 
     /// Upgrade quantization to micro-scaling FP (mxfp4 / mxfp8).
-    /// When true, applies after the recipe predicate: any 8-bit affine decision
-    /// becomes mxfp8, any 4-bit decision becomes mxfp4. Requires `quant_mode = "affine"`.
+    /// When true, applies after the recipe predicate: eligible 8-bit affine
+    /// decisions become mxfp8 and 4-bit become mxfp4. Kept affine (not upgraded):
+    /// affine-only loaders (lm_head, embed_tokens, router.proj,
+    /// embedding_projection) at their recipe bits, MoE router gates (8-bit affine),
+    /// and the recipe-pinned attention/GDN projections (o_proj / out_proj /
+    /// in_proj_a / in_proj_b, 8-bit affine). Requires `quant_mode = "affine"`.
     /// Forces `group_size = 32` for upgraded layers.
     pub quant_mxfp: Option<bool>,
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -183,9 +183,10 @@ Per-tensor bit assignments (N = `--q-bits`):
 | `linear_attn.in_proj_qkv/z` | N+2  | AWQ-correctable via input_layernorm               |
 | `lm_head`                   | N+3  | Safest tensor (KLD ~0.05)                         |
 | Router gates                | 8    | Standard for MoE routing accuracy                 |
-| `self_attn.o_proj`          | bf16 | No preceding norm — not AWQ-correctable           |
-| `linear_attn.out_proj`      | bf16 | Worst tensor (KLD ~6.0) — not AWQ-correctable     |
-| GDN params (`A_log`, etc.)  | bf16 | Recurrent state params, errors compound over time |
+| `self_attn.o_proj`          | 8 affine | No preceding norm (not AWQ) — kept 8-bit for MTP/AR parity |
+| `linear_attn.out_proj`      | 8 affine | Worst tensor (KLD ~6.0) — kept 8-bit for MTP/AR parity     |
+| `linear_attn.in_proj_a/b`   | 8 affine | Split GDN low-rank projs — kept 8-bit for MTP/AR parity    |
+| GDN params (`A_log`, etc.)  | bf16     | Recurrent state params, errors compound over time         |
 
 ## Examples
 

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -54,21 +54,28 @@ Quantization Arguments:
                         with per-layer overrides. NOT mlx-lm-loadable.
   --q-mxfp              Upgrade quantization to micro-scaling FP (mxfp4 / mxfp8).
                         Applies after the recipe predicate: any 8-bit affine
-                        decision becomes mxfp8, any 4-bit becomes mxfp4. Requires
-                        --quantize and --q-mode affine (default). Forces
-                        group_size=32 for upgraded layers. Skipped keys (kept at
-                        8-bit affine for accuracy or loader compatibility):
+                        decision becomes mxfp8, any 4-bit becomes mxfp4 — except
+                        the recipe-pinned attention/GDN projections (o_proj /
+                        out_proj / in_proj_a / in_proj_b), which stay 8-bit
+                        affine. Requires --quantize and --q-mode affine
+                        (default). Forces
+                        group_size=32 for upgraded layers. Skipped keys fall into
+                        two classes: (1) affine-only loaders keep their
+                        recipe-assigned affine bits (NOT necessarily 8-bit) —
                         lm_head, router projections, embed_tokens (incl. Gemma4
-                        embed_tokens_per_layer), embedding_projection, and MoE
-                        router gates (mlp.gate / shared_expert_gate). MXFP8's
-                        coarse E8M0 scales destroy top-K expert routing on the
-                        gates, matching the Python mlx-lm quant_predicate.
+                        embed_tokens_per_layer), embedding_projection; (2) MoE
+                        router gates (e.g. mlp.gate / shared_expert_gate /
+                        feed_forward.gate) are forced to 8-bit affine, because
+                        MXFP8's coarse E8M0 scales destroy
+                        top-K expert routing, matching the Python mlx-lm
+                        quant_predicate.
 
                         Recommended combo: --q-recipe unsloth --q-bits 4 --q-mxfp
                         promotes mlp.gate_proj/up_proj to mxfp4 (q/k/v at 6-bit
                         affine, down_proj at 5-bit affine, router gates at 8-bit
-                        affine, lm_head at 8-bit affine, o_proj/out_proj at
-                        8-bit affine). At default --q-bits 3 only down_proj
+                        affine, lm_head at 8-bit affine,
+                        o_proj/out_proj/in_proj_a/in_proj_b at 8-bit affine). At
+                        default --q-bits 3 only down_proj
                         (4b -> mxfp4) gets the upgrade.
   --q-recipe <string>   Per-layer mixed-bit quantization recipe
                         Options: mixed_2_6, mixed_3_4, mixed_3_6, mixed_4_6, qwen3_5, unsloth
@@ -263,7 +270,7 @@ export async function run(argv: string[]) {
   }
 
   // Apply recipe-specific defaults for bits when not explicitly set.
-  // Unsloth recipe: 3-bit base → MLP gate/up=3b, down=4b, embed=5b, lm_head=6b, attn q/k/v=5b+AWQ, out_proj=bf16
+  // Unsloth recipe: 3-bit base → MLP gate/up=3b, down=4b, embed=5b, lm_head=6b, attn q/k/v=5b+AWQ, o_proj/out_proj/in_proj_a/in_proj_b=8b affine
   // Exception: --q-mode nvfp4 forces bits=4 regardless of recipe, because
   // NVFP4 invariant requires bits=4 (the unsloth 3-bit default would otherwise
   // produce an inconsistent checkpoint: top-level bits=3 but per-layer
@@ -357,7 +364,9 @@ export async function run(argv: string[]) {
       const [defaultBits, defaultGs] = QUANT_MODE_DEFAULTS[qMode] ?? [4, 64];
       const qBits = effectiveQuantBits || defaultBits;
       const qGs = quantGroupSize || defaultGs;
-      const qMxfpSuffix = args['q-mxfp'] ? ', --q-mxfp: 8b->mxfp8, 4b->mxfp4' : '';
+      const qMxfpSuffix = args['q-mxfp']
+        ? ', --q-mxfp: eligible 8b->mxfp8/4b->mxfp4 (protected affine keys stay affine)'
+        : '';
       console.log(
         `Quantize:   ${qBits}-bit ${qMode} (group_size=${qGs})${quantRecipe ? `, recipe=${quantRecipe}` : ''}${qMxfpSuffix}`,
       );
@@ -519,7 +528,9 @@ export async function run(argv: string[]) {
     const [defaultBits, defaultGs] = QUANT_MODE_DEFAULTS[qMode] ?? [4, 64];
     const qBits = effectiveQuantBits || defaultBits;
     const qGs = quantGroupSize || defaultGs;
-    const qMxfpSuffix = args['q-mxfp'] ? ', --q-mxfp: 8b->mxfp8, 4b->mxfp4' : '';
+    const qMxfpSuffix = args['q-mxfp']
+      ? ', --q-mxfp: eligible 8b->mxfp8/4b->mxfp4 (protected affine keys stay affine)'
+      : '';
     const qGsLabel = qMode === 'sym8' ? 'per-output-channel' : `group_size=${qGs}`;
     console.log(
       `Quantize:   ${qBits}-bit ${qMode} (${qGsLabel})${quantRecipe ? `, recipe=${quantRecipe}` : ''}${qMxfpSuffix}${quantMtp !== 'off' ? `, mtp=${quantMtp}` : ''}`,

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -2565,8 +2565,12 @@ export interface ConversionOptions {
   imatrixPath?: string;
   /**
    * Upgrade quantization to micro-scaling FP (mxfp4 / mxfp8).
-   * When true, applies after the recipe predicate: any 8-bit affine decision
-   * becomes mxfp8, any 4-bit decision becomes mxfp4. Requires `quant_mode = "affine"`.
+   * When true, applies after the recipe predicate: eligible 8-bit affine
+   * decisions become mxfp8 and 4-bit become mxfp4. Kept affine (not upgraded):
+   * affine-only loaders (lm_head, embed_tokens, router.proj,
+   * embedding_projection) at their recipe bits, MoE router gates (8-bit affine),
+   * and the recipe-pinned attention/GDN projections (o_proj / out_proj /
+   * in_proj_a / in_proj_b, 8-bit affine). Requires `quant_mode = "affine"`.
    * Forces `group_size = 32` for upgraded layers.
    */
   quantMxfp?: boolean;
@@ -3166,8 +3170,12 @@ export interface GgufConversionOptions {
   vlmKeyPrefix?: boolean;
   /**
    * Upgrade quantization to micro-scaling FP (mxfp4 / mxfp8).
-   * When true, applies after the recipe predicate: any 8-bit affine decision
-   * becomes mxfp8, any 4-bit decision becomes mxfp4. Requires `quant_mode = "affine"`.
+   * When true, applies after the recipe predicate: eligible 8-bit affine
+   * decisions become mxfp8 and 4-bit become mxfp4. Kept affine (not upgraded):
+   * affine-only loaders (lm_head, embed_tokens, router.proj,
+   * embedding_projection) at their recipe bits, MoE router gates (8-bit affine),
+   * and the recipe-pinned attention/GDN projections (o_proj / out_proj /
+   * in_proj_a / in_proj_b, 8-bit affine). Requires `quant_mode = "affine"`.
    * Forces `group_size = 32` for upgraded layers.
    */
   quantMxfp?: boolean;


### PR DESCRIPTION
## Problem

`apply_mxfp_upgrade` upgraded the four recipe-pinned attention/GDN projections — `self_attn.o_proj`, `linear_attn.out_proj`, `linear_attn.in_proj_a`, `linear_attn.in_proj_b` — from **8-bit affine** to **mxfp8** under `--q-recipe … --q-mxfp`.

The `unsloth`/`qwen3_5` recipes deliberately pin these to 8-bit affine so AR (M=1) and MTP-verify (M≥2) both route through the M-invariant `qmv` kernel (T=0 MTP↔AR bit-exactness), and 8-bit **affine** specifically keeps the worst-KLD `out_proj` (~6.0) near bf16. mxfp8's coarse E8M0 scales have ~10× the round-trip error of affine 8-bit, so the upgrade regressed exactly those tensors. The recipe author guarded against the nvfp4 path but not mxfp, and the CLI help already claimed "o_proj/out_proj at 8-bit affine" — contradicting the code.

## Fix

- New `is_bitexact_affine_proj` guard in `apply_mxfp_upgrade`, **gated on the pinned `Custom{bits:8, mode:"affine"}` decision**, so those keys keep 8-bit affine — symmetric with `apply_nvfp4_upgrade`, mirroring the existing router-gate / affine-only exclusions. Scoped to `apply_mxfp_upgrade`; the uniform/no-recipe path is unchanged.
- Decision-scoped (not key-only), so generic `mixed_*` recipes — which give these keys low bits (e.g. `mixed_4_6` → 4-bit affine `o_proj`) — still upgrade to mxfp4. `Skip` (MTP layers) is preserved via the main match.
- Docs/comments made accurate: synced the `quantMxfp` doc across all 6 copies (2 Rust structs + 4 `.d.cts` blocks), fixed the stale `bf16` row in `cli/README.md`, reworded the `--q-mxfp` help + qualified the run banner, added `feed_forward.gate` to the router-gate list, and corrected stale router-gate comments in `convert.rs` / `persistence.rs` / `sparse_moe.rs` against a verified control-flow trace (decision → emission → load-time resolution).

## Tests

- New `apply_mxfp_upgrade_preserves_bitexact_affine_projections` (pinned → stays affine; MTP `Skip` preserved) and `apply_mxfp_upgrade_promotes_non_pinned_low_bit_projections` (mixed_* low-bit → mxfp4).
- 112/112 convert unit tests pass; `yarn typecheck`, `cargo clippy -D warnings`, `cargo fmt --check` all clean.

## Follow-ups (non-blocking, out of scope of this gap)

- Pre-existing `--q-mode` doc drift: `README.md:133` / `docs/cli.md:83` say "affine or mxfp8"; the CLI accepts `affine/mxfp4/mxfp8/nvfp4/sym8` (GGUF: 4 modes) — note the GGUF-vs-SafeTensors mode-support nuance.
- `compute_moe_defaults`' mxfp8 `default_gate_plq` branch is unreachable for convert-produced checkpoints (now documented) — candidate loader cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quantization decisions for `--q-recipe unsloth|qwen3_5 --q-mxfp` checkpoints (affects model quality and MTP parity); logic is well-tested but convert output differs from before.
> 
> **Overview**
> Fixes **`--q-mxfp`** incorrectly promoting **`unsloth` / `qwen3_5`** recipe pins — **`self_attn.o_proj`**, **`linear_attn.out_proj`**, **`in_proj_a`**, **`in_proj_b`** — from **8-bit affine** to **mxfp8**, which hurt MTP↔AR bit-exactness and quality on high-KLD layers.
> 
> **`apply_mxfp_upgrade`** now uses **`is_bitexact_affine_proj`**: only when the inner recipe already returned **`Custom { bits: 8, mode: "affine" }`** those keys skip the mxfp8 upgrade; **`mixed_*`** low-bit decisions on the same keys still upgrade to mxfp4. **MoE router gates** are forced to **8-bit affine** for non-**`Skip`** decisions but **preserve** an explicit **`Skip`** (aligned with nvfp4). **`quantMxfp`** docs, CLI **`--q-mxfp`** help, README recipe table, and MoE gate comments are brought in line with this behavior; two unit tests cover pinned vs mixed-recipe paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 395b8f0a1ad86ab450e8dd6336f6831ccfeedeb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->