### PR TITLE
fix(ci): drop redundant reference in format! arg (clippy 0.1.97 gate)

### DIFF
--- a/crates/mlx-core/src/tools/mod.rs
+++ b/crates/mlx-core/src/tools/mod.rs
@@ -92,7 +92,7 @@ impl ToolCallResult {
             name: String::new(),
             arguments: Value::Object(serde_json::Map::new()),
             status: "missing_name".to_string(),
-            error: Some(format!("Tool call missing name: {}", &raw_content)),
+            error: Some(format!("Tool call missing name: {raw_content}")),
             raw_content,
         }
     }


### PR DESCRIPTION
## What

CI's rolling `stable` toolchain bumped to **rustc/clippy 1.97.0 (2026-07-07)**, which added the **"redundant reference in `format!` argument"** lint. That trips the existing `cargo clippy --all-targets -- -D warnings` gate on a pre-existing line in `crates/mlx-core/src/tools/mod.rs`:

```rust
error: Some(format!("Tool call missing name: {}", &raw_content)),   // &raw_content is now flagged
```

This is what turned the **Rust Lint → Clippy** job red on `main` (first failure on #89, then the #90 merge — run `29022183758`). The code itself dates back to #64; nothing on #90 touched it — a toolchain bump surfaced it.

## Fix

Inline the captured identifier:

```rust
error: Some(format!("Tool call missing name: {raw_content}")),
```

`raw_content` is still moved into the struct field on the next line, so behavior is unchanged.

## Verification

Reproduced the CI toolchain locally (`rustup update stable` → clippy `0.1.97 (2d8144b788 2026-07-07)`) and ran the exact gate:

```
cargo clippy -p mlx-core --all-targets -- -D warnings
    Finished `dev` profile in 2m 34s   # exit 0, no redundant-reference error
```

Only remaining output is the pre-existing `block v0.1.6` future-incompat note (present on all green runs; not a `-D warnings` failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line formatting change in an error message path; no logic or API changes.
> 
> **Overview**
> Unblocks **Rust Lint → Clippy** on CI after **clippy 0.1.97** started enforcing the redundant-reference-in-`format!` lint under `-D warnings`.
> 
> In `ToolCallResult::missing_name`, the error string now uses inline capture (`{raw_content}`) instead of `{}", &raw_content`. The message and move semantics are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44cc4cd9b2127e88be9b8f67271e9d6530e9be97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->