### PR TITLE
feat(convert): add official Unsloth MXFP and NVFP4 maps for Qwen3.5/3.6

### DIFF
--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -2549,18 +2549,35 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
             } else {
                 quant_group_size
             };
-            let predicate = build_predicate_for_recipe(recipe, &weight_keys, quant_bits, recipe_gs)
-                .map_err(Error::from_reason)?;
-            let predicate: Box<dyn Fn(&str) -> QuantDecision + Send + Sync> = if quant_mxfp {
-                apply_mxfp_upgrade(predicate, quant_bits)
-            } else if quant_mode == "nvfp4" {
-                // Recipe + --q-mode nvfp4: promote 4-bit recipe decisions to
-                // NVFP4 (group_size=16). Mutually exclusive with quant_mxfp,
-                // since --q-mxfp requires --q-mode affine.
-                apply_nvfp4_upgrade(predicate)
-            } else {
-                predicate
+            // Verified Qwen hybrids use Unsloth's official float class map:
+            // `--q-mxfp` translates FP8/NVFP4 to MXFP8/MXFP4, while
+            // `--q-mode nvfp4` preserves NVFP4 for the low FFN class and uses
+            // MXFP8 for the high class. This is not a mechanical rewrite of
+            // the legacy Dynamic 2.0 affine decisions.
+            // The official map is Qwen3.5/Qwen3.6-hybrid-specific. Gate on the
+            // input config (ground truth), the requested sanitizer family, and
+            // the sanitized weight shape. If any of those are unavailable or
+            // disagree, preserve the legacy family-agnostic upgrade wrappers.
+            let is_qwen35_hybrid =
+                is_qwen35_hybrid_checkpoint(&config, model_type.as_deref(), &weight_keys);
+            let official_unsloth_kind =
+                select_official_unsloth_recipe(recipe, quant_mxfp, &quant_mode, is_qwen35_hybrid);
+            let predicate = match official_unsloth_kind {
+                Some(kind) => build_official_unsloth_recipe(&weight_keys, kind),
+                None => build_predicate_for_recipe(recipe, &weight_keys, quant_bits, recipe_gs)
+                    .map_err(Error::from_reason)?,
             };
+            let predicate: Box<dyn Fn(&str) -> QuantDecision + Send + Sync> =
+                if quant_mxfp && official_unsloth_kind.is_none() {
+                    apply_mxfp_upgrade(predicate, quant_bits)
+                } else if quant_mode == "nvfp4" && official_unsloth_kind.is_none() {
+                    // Recipe + --q-mode nvfp4: promote 4-bit recipe decisions to
+                    // NVFP4 (group_size=16). Mutually exclusive with quant_mxfp,
+                    // since --q-mxfp requires --q-mode affine.
+                    apply_nvfp4_upgrade(predicate)
+                } else {
+                    predicate
+                };
             // `--q-mtp split` (alias `drafter`) keeps the MTP head BF16 by
             // contract: the head is extracted into a standalone `mtp-drafter/`
             // directory below, and the on-disk drafter must NOT carry `.scales`
@@ -3966,6 +3983,206 @@ pub(crate) fn build_unsloth_recipe(
 
         // Everything else (ffn_gate_proj, ffn_up_proj, etc.) → default bits
         QuantDecision::Default
+    })
+}
+
+/// Collapse Qwen3.5 wrapper/text aliases to the converter's two sanitizer
+/// families. Qwen3.6 checkpoints intentionally use the same Qwen3.5 model
+/// families and loaders in this repository.
+fn qwen35_recipe_family(model_type: Option<&str>) -> Option<&'static str> {
+    match model_type {
+        Some("qwen3_5") | Some("qwen3_5_text") => Some("qwen3_5"),
+        Some("qwen3_5_moe") | Some("qwen3_5_moe_text") => Some("qwen3_5_moe"),
+        _ => None,
+    }
+}
+
+/// Require the characteristic hybrid Qwen3.5/Qwen3.6 tensor shape rather than
+/// trusting a caller-supplied model type alone. Both dense and MoE variants mix
+/// full attention with GatedDeltaNet layers; older Qwen3 and unrelated families
+/// do not have this combination.
+pub(crate) fn has_qwen35_hybrid_weight_shape(weight_keys: &[String]) -> bool {
+    let has_full_attention = weight_keys
+        .iter()
+        .any(|key| key.contains("self_attn.q_proj") && key.ends_with(".weight"));
+    let has_gdn_qkv = weight_keys
+        .iter()
+        .any(|key| key.contains("linear_attn.in_proj_qkv") && key.ends_with(".weight"));
+    let has_gdn_z = weight_keys
+        .iter()
+        .any(|key| key.contains("linear_attn.in_proj_z") && key.ends_with(".weight"));
+    let has_gdn_out = weight_keys
+        .iter()
+        .any(|key| key.contains("linear_attn.out_proj") && key.ends_with(".weight"));
+
+    has_full_attention && has_gdn_qkv && has_gdn_z && has_gdn_out
+}
+
+/// Verify a SafeTensors checkpoint from independent sources of truth: its own
+/// config family, the sanitizer family requested by the caller, and its
+/// sanitized tensor shape. Nested `text_config.model_type` supports VLM wrapper
+/// configs whose root model type is not itself the text family.
+fn is_qwen35_hybrid_checkpoint(
+    config: &serde_json::Value,
+    requested_model_type: Option<&str>,
+    weight_keys: &[String],
+) -> bool {
+    let config_family = qwen35_recipe_family(
+        config.get("model_type").and_then(|value| value.as_str()),
+    )
+    .or_else(|| {
+        qwen35_recipe_family(
+            config
+                .get("text_config")
+                .and_then(|value| value.get("model_type"))
+                .and_then(|value| value.as_str()),
+        )
+    });
+    let requested_family = qwen35_recipe_family(requested_model_type);
+
+    config_family.is_some()
+        && requested_family == config_family
+        && has_qwen35_hybrid_weight_shape(weight_keys)
+}
+
+/// Which official Unsloth float class map to emit. The two variants differ only
+/// in the early-FFN low format; their MXFP8 and BF16 tensor classes are shared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OfficialUnslothRecipeKind {
+    /// Translate the official NVFP4 class to MLX MXFP4 (4/32).
+    Mxfp,
+    /// Preserve the official DGX NVFP4 class (4/16).
+    Nvfp4,
+}
+
+/// Select an official class map only for a verified Qwen3.5/Qwen3.6 hybrid
+/// checkpoint. Plain affine and non-Qwen/ambiguous inputs continue through the
+/// legacy Dynamic 2.0 predicate and its existing upgrade wrappers.
+pub(crate) fn select_official_unsloth_recipe(
+    recipe: &str,
+    quant_mxfp: bool,
+    quant_mode: &str,
+    is_qwen35_hybrid: bool,
+) -> Option<OfficialUnslothRecipeKind> {
+    if recipe != "unsloth" || !is_qwen35_hybrid {
+        return None;
+    }
+    if quant_mxfp {
+        Some(OfficialUnslothRecipeKind::Mxfp)
+    } else if quant_mode == "nvfp4" {
+        Some(OfficialUnslothRecipeKind::Nvfp4)
+    } else {
+        None
+    }
+}
+
+/// Build the official Unsloth float class map for Qwen3.5 hybrid models.
+///
+/// Selected for verified Qwen hybrids under either `--q-mxfp` (early FFNs use
+/// MXFP4) or `--q-mode nvfp4` (early FFNs use NVFP4). The existing
+/// [`build_unsloth_recipe`] remains unchanged for plain affine and as the safe
+/// fallback for non-Qwen/ambiguous inputs. AWQ pre-scaling is unchanged.
+///
+/// The language-model depth is inferred from the weight keys. FFNs in the final
+/// eight transformer layers use MXFP8; earlier FFNs use the selected MXFP4 or
+/// NVFP4 low format. Attention, GDN qkv/z/out, and lm_head use MXFP8 at every
+/// depth. Embeddings, router gates, split GDN a/b, vision, MTP, norms, and
+/// recurrent parameters remain BF16.
+pub(crate) fn build_official_unsloth_recipe(
+    weight_keys: &[String],
+    kind: OfficialUnslothRecipeKind,
+) -> Box<dyn Fn(&str) -> QuantDecision + Send + Sync> {
+    // Side modules can have their own `layers.N` namespace. Excluding them keeps
+    // a VLM/MTP layer index from shifting the language model's final-eight cut.
+    let num_layers = weight_keys
+        .iter()
+        .filter(|key| {
+            !is_mtp_key(key)
+                && !key.contains("vision_tower")
+                && !key.contains("visual.")
+                && !key.contains("vision_embedder")
+        })
+        .filter_map(|key| extract_layer_index(key))
+        .max()
+        .map(|max_layer| max_layer + 1)
+        .unwrap_or(0);
+    let final_eight_start = num_layers.saturating_sub(8);
+
+    Box::new(move |key: &str| -> QuantDecision {
+        let mxfp8 = || QuantDecision::Custom {
+            bits: 8,
+            group_size: 32,
+            mode: "mxfp8".to_string(),
+        };
+        let mxfp4 = || QuantDecision::Custom {
+            bits: 4,
+            group_size: 32,
+            mode: "mxfp4".to_string(),
+        };
+        let nvfp4 = || QuantDecision::Custom {
+            bits: 4,
+            group_size: 16,
+            mode: "nvfp4".to_string(),
+        };
+        let low_ffn = || match kind {
+            OfficialUnslothRecipeKind::Mxfp => mxfp4(),
+            OfficialUnslothRecipeKind::Nvfp4 => nvfp4(),
+        };
+
+        // Fail closed for side modules and embeddings, even when a nested key
+        // contains a projection name that would otherwise match below.
+        if is_mtp_key(key)
+            || key.contains("vision_tower")
+            || key.contains("visual.")
+            || key.contains("vision_embedder")
+            || key.contains("embed_tokens")
+            || key.contains("embedding.")
+        {
+            return QuantDecision::Skip;
+        }
+
+        // should_quantize() excludes lm_head family-wide, but Qwen3.5's head is
+        // mode-aware and the official MXFP map explicitly assigns it MXFP8.
+        if key.contains("lm_head") && key.ends_with(".weight") {
+            return mxfp8();
+        }
+
+        if !should_quantize(key, /* embed_quantizable */ false) {
+            return QuantDecision::Skip;
+        }
+
+        // Official map: routers and GDN low-rank a/b remain BF16.
+        if is_router_gate(key)
+            || key.contains("linear_attn.in_proj_a.")
+            || key.contains("linear_attn.in_proj_b.")
+        {
+            return QuantDecision::Skip;
+        }
+
+        let is_attention = key.contains("self_attn.q_proj")
+            || key.contains("self_attn.k_proj")
+            || key.contains("self_attn.v_proj")
+            || key.contains("self_attn.o_proj");
+        let is_gdn = key.contains("linear_attn.in_proj_qkv")
+            || key.contains("linear_attn.in_proj_z")
+            || key.contains("linear_attn.out_proj");
+        if is_attention || is_gdn {
+            return mxfp8();
+        }
+
+        // Covers dense MLPs, stacked routed experts (`switch_mlp`), raw expert
+        // spellings, and shared experts after either HF or GGUF sanitization.
+        let is_ffn = key.contains(".mlp.")
+            && (key.contains("gate_proj") || key.contains("up_proj") || key.contains("down_proj"));
+        if is_ffn {
+            return match extract_layer_index(key) {
+                Some(layer) if layer >= final_eight_start => mxfp8(),
+                Some(_) => low_ffn(),
+                None => QuantDecision::Skip,
+            };
+        }
+
+        QuantDecision::Skip
     })
 }
 
@@ -10939,6 +11156,368 @@ mod tests {
             predicate("model.layers.0.self_attn.q_proj.weight"),
             QuantDecision::Skip,
             "body attention proj must still quantize"
+        );
+    }
+
+    // ── official Unsloth MXFP/NVFP4 recipes ─────────────────────────
+
+    #[test]
+    fn official_unsloth_selector_is_exact() {
+        assert_eq!(
+            select_official_unsloth_recipe("unsloth", true, "affine", true),
+            Some(OfficialUnslothRecipeKind::Mxfp)
+        );
+        assert_eq!(
+            select_official_unsloth_recipe("unsloth", false, "nvfp4", true),
+            Some(OfficialUnslothRecipeKind::Nvfp4)
+        );
+        assert_eq!(
+            select_official_unsloth_recipe("unsloth", false, "affine", true),
+            None
+        );
+        assert_eq!(
+            select_official_unsloth_recipe("unsloth", true, "affine", false),
+            None
+        );
+        assert_eq!(
+            select_official_unsloth_recipe("unsloth", false, "nvfp4", false),
+            None
+        );
+        assert_eq!(
+            select_official_unsloth_recipe("qwen3_5", true, "affine", true),
+            None
+        );
+        assert_eq!(
+            select_official_unsloth_recipe("nvidia", true, "affine", true),
+            None
+        );
+    }
+
+    fn qwen35_hybrid_test_keys() -> Vec<String> {
+        [
+            "language_model.model.layers.0.self_attn.q_proj.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_qkv.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_z.weight",
+            "language_model.model.layers.1.linear_attn.out_proj.weight",
+            "language_model.model.layers.1.mlp.gate_proj.weight",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    }
+
+    #[test]
+    fn unsloth_mxfp_family_gate_accepts_dense_moe_and_vlm_wrappers() {
+        let keys = qwen35_hybrid_test_keys();
+        for (config, requested) in [
+            (serde_json::json!({ "model_type": "qwen3_5" }), "qwen3_5"),
+            (
+                serde_json::json!({
+                    "model_type": "qwen3_5_moe",
+                    "text_config": { "model_type": "qwen3_5_moe_text" }
+                }),
+                "qwen3_5_moe",
+            ),
+            (
+                serde_json::json!({
+                    "model_type": "qwen3_5_vl",
+                    "text_config": { "model_type": "qwen3_5_text" }
+                }),
+                "qwen3_5",
+            ),
+        ] {
+            assert!(
+                is_qwen35_hybrid_checkpoint(&config, Some(requested), &keys),
+                "config={config}, requested={requested} must select the official map"
+            );
+        }
+    }
+
+    #[test]
+    fn unsloth_mxfp_family_gate_fails_closed_on_non_qwen_mismatch_or_missing_shape() {
+        let keys = qwen35_hybrid_test_keys();
+        assert!(!is_qwen35_hybrid_checkpoint(
+            &serde_json::json!({ "model_type": "gemma4" }),
+            Some("gemma4"),
+            &keys,
+        ));
+        assert!(!is_qwen35_hybrid_checkpoint(
+            &serde_json::json!({ "model_type": "qwen3_5" }),
+            Some("gemma4"),
+            &keys,
+        ));
+        assert!(!is_qwen35_hybrid_checkpoint(
+            &serde_json::json!({ "model_type": "qwen3_5" }),
+            None,
+            &keys,
+        ));
+        assert!(!is_qwen35_hybrid_checkpoint(
+            &serde_json::json!({ "model_type": "qwen3_5" }),
+            Some("qwen3_5"),
+            &["model.layers.0.self_attn.q_proj.weight".to_string()],
+        ));
+    }
+
+    #[test]
+    fn non_qwen_unsloth_mxfp_preserves_legacy_affine_only_head() {
+        let is_qwen35_hybrid = is_qwen35_hybrid_checkpoint(
+            &serde_json::json!({ "model_type": "gemma4" }),
+            Some("gemma4"),
+            &qwen35_hybrid_test_keys(),
+        );
+        assert_eq!(
+            select_official_unsloth_recipe("unsloth", true, "affine", is_qwen35_hybrid),
+            None
+        );
+
+        // This is the fallback used by both conversion entry points. In
+        // particular, Gemma4's affine-only lm_head must never become MXFP8.
+        let predicate = apply_mxfp_upgrade(build_unsloth_recipe(4, 64), 4);
+        assert_eq!(
+            predicate("language_model.lm_head.weight"),
+            QuantDecision::Custom {
+                bits: 8,
+                group_size: 64,
+                mode: "affine".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn unsloth_mxfp_recipe_maps_40_layer_dense_and_vlm_keys() {
+        let weight_keys = [
+            "language_model.model.layers.0.mlp.gate_proj.weight",
+            "language_model.model.layers.31.mlp.down_proj.weight",
+            "language_model.model.layers.32.mlp.gate_proj.weight",
+            "language_model.model.layers.39.mlp.down_proj.weight",
+            // Side-module depth must not alter the 40-layer LM boundary.
+            "language_model.model.mtp.layers.99.mlp.gate_proj.weight",
+            "vision_tower.layers.99.self_attn.q_proj.weight",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let predicate =
+            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::Mxfp);
+
+        let mxfp4 = || QuantDecision::Custom {
+            bits: 4,
+            group_size: 32,
+            mode: "mxfp4".to_string(),
+        };
+        let mxfp8 = || QuantDecision::Custom {
+            bits: 8,
+            group_size: 32,
+            mode: "mxfp8".to_string(),
+        };
+
+        for suffix in ["gate_proj", "up_proj", "down_proj"] {
+            for layer in [0, 31] {
+                let key = format!("language_model.model.layers.{layer}.mlp.{suffix}.weight");
+                assert_eq!(predicate(&key), mxfp4(), "{key} must be mxfp4");
+            }
+            for layer in [32, 39] {
+                let key = format!("language_model.model.layers.{layer}.mlp.{suffix}.weight");
+                assert_eq!(predicate(&key), mxfp8(), "{key} must be mxfp8");
+            }
+        }
+
+        for key in [
+            "language_model.model.layers.0.self_attn.q_proj.weight",
+            "language_model.model.layers.0.self_attn.k_proj.weight",
+            "language_model.model.layers.0.self_attn.v_proj.weight",
+            "language_model.model.layers.0.self_attn.o_proj.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_qkv.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_z.weight",
+            "language_model.model.layers.1.linear_attn.out_proj.weight",
+            "language_model.lm_head.weight",
+        ] {
+            assert_eq!(predicate(key), mxfp8(), "{key} must be mxfp8");
+        }
+
+        for key in [
+            "language_model.model.embed_tokens.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_a.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_b.weight",
+            "language_model.model.layers.0.mlp.gate.weight",
+            "language_model.model.layers.0.input_layernorm.weight",
+            "language_model.model.layers.1.linear_attn.A_log",
+            "language_model.model.layers.1.linear_attn.dt_bias",
+            "language_model.model.mtp.layers.99.self_attn.q_proj.weight",
+            "vision_tower.layers.99.self_attn.q_proj.weight",
+            "visual.blocks.0.mlp.gate_proj.weight",
+        ] {
+            assert_eq!(predicate(key), QuantDecision::Skip, "{key} must stay bf16");
+        }
+    }
+
+    #[test]
+    fn unsloth_mxfp_recipe_maps_routed_and_shared_experts() {
+        let weight_keys = [
+            "language_model.model.layers.31.mlp.switch_mlp.gate_proj.weight",
+            "language_model.model.layers.32.mlp.switch_mlp.gate_proj.weight",
+            "language_model.model.layers.39.mlp.shared_expert.down_proj.weight",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let predicate =
+            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::Mxfp);
+
+        for family in ["switch_mlp", "experts", "shared_expert"] {
+            for suffix in ["gate_proj", "up_proj", "down_proj"] {
+                let early = format!("language_model.model.layers.31.mlp.{family}.{suffix}.weight");
+                assert_eq!(
+                    predicate(&early),
+                    QuantDecision::Custom {
+                        bits: 4,
+                        group_size: 32,
+                        mode: "mxfp4".to_string(),
+                    },
+                    "{early} must be mxfp4"
+                );
+                let late = format!("language_model.model.layers.32.mlp.{family}.{suffix}.weight");
+                assert_eq!(
+                    predicate(&late),
+                    QuantDecision::Custom {
+                        bits: 8,
+                        group_size: 32,
+                        mode: "mxfp8".to_string(),
+                    },
+                    "{late} must be mxfp8"
+                );
+            }
+        }
+
+        for key in [
+            "language_model.model.layers.32.mlp.gate.weight",
+            "language_model.model.layers.32.mlp.shared_expert_gate.weight",
+        ] {
+            assert_eq!(predicate(key), QuantDecision::Skip, "{key} must stay bf16");
+        }
+    }
+
+    #[test]
+    fn unsloth_nvfp4_recipe_uses_official_dgx_classes_and_invariants() {
+        let weight_keys = [
+            "language_model.model.layers.0.self_attn.q_proj.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_qkv.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_z.weight",
+            "language_model.model.layers.1.linear_attn.out_proj.weight",
+            "language_model.model.layers.31.mlp.switch_mlp.gate_proj.weight",
+            "language_model.model.layers.32.mlp.switch_mlp.gate_proj.weight",
+            "language_model.model.layers.39.mlp.shared_expert.down_proj.weight",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        let predicate =
+            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::Nvfp4);
+
+        let nvfp4 = || QuantDecision::Custom {
+            bits: 4,
+            group_size: 16,
+            mode: "nvfp4".to_string(),
+        };
+        let mxfp8 = || QuantDecision::Custom {
+            bits: 8,
+            group_size: 32,
+            mode: "mxfp8".to_string(),
+        };
+
+        for family in ["switch_mlp", "experts", "shared_expert"] {
+            for suffix in ["gate_proj", "up_proj", "down_proj"] {
+                let early = format!("language_model.model.layers.31.mlp.{family}.{suffix}.weight");
+                assert_eq!(predicate(&early), nvfp4(), "{early} must be nvfp4 4/16");
+                let late = format!("language_model.model.layers.32.mlp.{family}.{suffix}.weight");
+                assert_eq!(predicate(&late), mxfp8(), "{late} must be mxfp8 8/32");
+            }
+        }
+
+        for key in [
+            "language_model.model.layers.0.self_attn.q_proj.weight",
+            "language_model.model.layers.0.self_attn.k_proj.weight",
+            "language_model.model.layers.0.self_attn.v_proj.weight",
+            "language_model.model.layers.0.self_attn.o_proj.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_qkv.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_z.weight",
+            "language_model.model.layers.1.linear_attn.out_proj.weight",
+            "language_model.lm_head.weight",
+        ] {
+            assert_eq!(predicate(key), mxfp8(), "{key} must be mxfp8 8/32");
+        }
+
+        for key in [
+            "language_model.model.embed_tokens.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_a.weight",
+            "language_model.model.layers.1.linear_attn.in_proj_b.weight",
+            "language_model.model.layers.0.mlp.gate.weight",
+            "language_model.model.layers.0.input_layernorm.weight",
+            "language_model.model.layers.1.linear_attn.A_log",
+            "language_model.model.mtp.layers.0.self_attn.q_proj.weight",
+            "vision_tower.layers.0.self_attn.q_proj.weight",
+        ] {
+            assert_eq!(predicate(key), QuantDecision::Skip, "{key} must stay bf16");
+        }
+    }
+
+    #[test]
+    fn unsloth_plain_affine_predicate_remains_legacy_dynamic_map() {
+        let predicate = build_predicate_for_recipe("unsloth", &[], 4, 64)
+            .expect("legacy unsloth predicate must dispatch");
+        assert_eq!(
+            predicate("model.layers.0.self_attn.q_proj.weight"),
+            QuantDecision::Custom {
+                bits: 6,
+                group_size: 64,
+                mode: "affine".to_string(),
+            }
+        );
+        assert_eq!(
+            predicate("model.layers.0.linear_attn.in_proj_a.weight"),
+            QuantDecision::Custom {
+                bits: 8,
+                group_size: 64,
+                mode: "affine".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn non_qwen_unsloth_nvfp4_fallback_remains_legacy_dynamic_map() {
+        assert_eq!(
+            select_official_unsloth_recipe("unsloth", false, "nvfp4", false),
+            None
+        );
+        let legacy = build_predicate_for_recipe("unsloth", &[], 4, 64)
+            .expect("legacy unsloth predicate must dispatch");
+        let predicate = apply_nvfp4_upgrade(legacy);
+
+        // Sensitive projections preserve the old 6/8-bit affine fallbacks.
+        assert_eq!(
+            predicate("model.layers.0.self_attn.q_proj.weight"),
+            QuantDecision::Custom {
+                bits: 6,
+                group_size: 64,
+                mode: "affine".to_string(),
+            }
+        );
+        assert_eq!(
+            predicate("model.layers.0.linear_attn.in_proj_a.weight"),
+            QuantDecision::Custom {
+                bits: 8,
+                group_size: 64,
+                mode: "affine".to_string(),
+            }
+        );
+        // The legacy 4-bit FFN default still upgrades to NVFP4.
+        assert_eq!(
+            predicate("model.layers.0.mlp.gate_proj.weight"),
+            QuantDecision::Custom {
+                bits: 4,
+                group_size: 16,
+                mode: "nvfp4".to_string(),
+            }
         );
     }
 

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -1102,6 +1102,22 @@ fn fixup_qwen35_linear_attn(
     Ok(())
 }
 
+/// GGUF has no HuggingFace `model_type`, so require both a known llama.cpp
+/// Qwen3.5 architecture tag and the characteristic mixed full-attention/GDN
+/// tensor shape before enabling the official Unsloth MXFP map. `qwen3` is kept
+/// for older Qwen3.5 writers; ordinary Qwen3 fails the weight-shape check.
+fn is_qwen35_hybrid_gguf(
+    metadata: &HashMap<String, GgufMetaValue>,
+    weight_keys: &[String],
+) -> bool {
+    let is_qwen35_arch = metadata
+        .get("general.architecture")
+        .and_then(|value| value.as_str())
+        .is_some_and(|arch| matches!(arch, "qwen35" | "qwen35moe" | "qwen3"));
+
+    is_qwen35_arch && crate::convert::has_qwen35_hybrid_weight_shape(weight_keys)
+}
+
 // ── Config Extraction ───────────────────────────────────────────────────────
 
 /// Extract HuggingFace-compatible config.json fields from GGUF metadata
@@ -1513,17 +1529,30 @@ pub async fn convert_gguf_to_safetensors(
             } else {
                 quant_group_size
             };
-            let predicate = crate::convert::build_predicate_for_recipe(
+            // Mirror the SafeTensors selector: verified Qwen hybrids use the
+            // official class map for both translated MXFP and DGX NVFP4;
+            // plain affine and ambiguous/non-Qwen inputs retain Dynamic 2.0.
+            let is_qwen35_hybrid = is_qwen35_hybrid_gguf(&gguf.metadata, &weight_keys);
+            let official_unsloth_kind = crate::convert::select_official_unsloth_recipe(
                 recipe,
-                &weight_keys,
-                quant_bits,
-                recipe_gs,
-            )
-            .map_err(Error::from_reason)?;
+                quant_mxfp,
+                &quant_mode_str,
+                is_qwen35_hybrid,
+            );
+            let predicate = match official_unsloth_kind {
+                Some(kind) => crate::convert::build_official_unsloth_recipe(&weight_keys, kind),
+                None => crate::convert::build_predicate_for_recipe(
+                    recipe,
+                    &weight_keys,
+                    quant_bits,
+                    recipe_gs,
+                )
+                .map_err(Error::from_reason)?,
+            };
             let predicate: Box<dyn Fn(&str) -> crate::convert::QuantDecision + Send + Sync> =
-                if quant_mxfp {
+                if quant_mxfp && official_unsloth_kind.is_none() {
                     crate::convert::apply_mxfp_upgrade(predicate, quant_bits)
-                } else if quant_mode_str == "nvfp4" {
+                } else if quant_mode_str == "nvfp4" && official_unsloth_kind.is_none() {
                     // Recipe + --q-mode nvfp4: promote 4-bit recipe decisions
                     // to NVFP4 (group_size=16). Mutually exclusive with
                     // quant_mxfp, since --q-mxfp requires --q-mode affine.
@@ -2002,6 +2031,72 @@ mod tests {
             gguf_name_to_hf("blk.0.ssm_a"),
             "model.layers.0.linear_attn.A_log"
         );
+    }
+
+    fn qwen35_hybrid_test_keys() -> Vec<String> {
+        [
+            "model.layers.0.self_attn.q_proj.weight",
+            "model.layers.1.linear_attn.in_proj_qkv.weight",
+            "model.layers.1.linear_attn.in_proj_z.weight",
+            "model.layers.1.linear_attn.out_proj.weight",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    }
+
+    #[test]
+    fn official_unsloth_gguf_gate_requires_qwen35_arch_and_hybrid_shape() {
+        let keys = qwen35_hybrid_test_keys();
+        for arch in ["qwen35", "qwen35moe", "qwen3"] {
+            let metadata = HashMap::from([(
+                "general.architecture".to_string(),
+                GgufMetaValue::String(arch.to_string()),
+            )]);
+            let is_qwen35_hybrid = is_qwen35_hybrid_gguf(&metadata, &keys);
+            assert!(
+                is_qwen35_hybrid,
+                "{arch} plus the hybrid shape must select the official map"
+            );
+            assert_eq!(
+                crate::convert::select_official_unsloth_recipe(
+                    "unsloth",
+                    true,
+                    "affine",
+                    is_qwen35_hybrid,
+                ),
+                Some(crate::convert::OfficialUnslothRecipeKind::Mxfp)
+            );
+            assert_eq!(
+                crate::convert::select_official_unsloth_recipe(
+                    "unsloth",
+                    false,
+                    "nvfp4",
+                    is_qwen35_hybrid,
+                ),
+                Some(crate::convert::OfficialUnslothRecipeKind::Nvfp4)
+            );
+        }
+
+        for arch in ["gemma", "llama", "qwen3next"] {
+            let metadata = HashMap::from([(
+                "general.architecture".to_string(),
+                GgufMetaValue::String(arch.to_string()),
+            )]);
+            assert!(
+                !is_qwen35_hybrid_gguf(&metadata, &keys),
+                "non-Qwen3.5 arch {arch} must preserve the legacy upgrader"
+            );
+        }
+
+        let metadata = HashMap::from([(
+            "general.architecture".to_string(),
+            GgufMetaValue::String("qwen35".to_string()),
+        )]);
+        assert!(!is_qwen35_hybrid_gguf(
+            &metadata,
+            &["model.layers.0.self_attn.q_proj.weight".to_string()]
+        ));
     }
 
     #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,6 +47,31 @@ mlx convert --input ./model --output ./model-bf16 --dtype bf16
 mlx convert --input ./model --output ./model-q --quantize --q-recipe mixed_4_6
 ```
 
+### Official Unsloth MXFP and DGX recipes for Qwen3.5
+
+For verified dense and MoE Qwen3.5/Qwen3.6-family checkpoints, the fixed
+[official Unsloth class map](https://unsloth.ai/docs/models/qwen3.6#nvfp4) is
+available in two forms. Both keep FP8-class weights as MXFP8 and use the same
+AWQ imatrix pre-scaling:
+
+```bash
+# Apple MXFP variant: replace NVFP4 with MXFP4
+mlx convert -m qwen3_5_moe -q --q-recipe unsloth --q-mxfp \
+  --imatrix-path ./imatrix_unsloth.gguf_file \
+  -i ./qwen3.5-35b-a3b -o ./qwen3.5-35b-a3b-unsloth-mxfp4-mlx
+
+# Official DGX variant: retain NVFP4
+mlx convert -m qwen3_5_moe -q --q-mode nvfp4 --q-recipe unsloth \
+  --imatrix-path ./imatrix_unsloth.gguf_file \
+  -i ./qwen3.5-35b-a3b -o ./qwen3.5-35b-a3b-unsloth-nvfp4-mlx
+```
+
+Early FFNs use MXFP4 4/32 with `--q-mxfp`, or NVFP4 4/16 with
+`--q-mode nvfp4`. The final eight FFNs, attention q/k/v/o, GDN qkv/z/out, and
+`lm_head` use MXFP8 8/32 in both. Embeddings, routers, GDN a/b, vision, MTP,
+norms, and recurrent parameters remain BF16. Plain affine Unsloth alone keeps
+the legacy Dynamic 2.0 recipe.
+
 ### NVIDIA modelopt recipe (data-free MXFP4 port)
 
 `--q-recipe nvidia` ports NVIDIA modelopt's `w4a16_nvfp4-fp8_attn-kv_fp8_cast`
@@ -104,7 +129,8 @@ split). `--q-mtp split` (alias `drafter`) emits a body checkpoint with **no
 | `-d`, `--dtype`    | Target dtype: `float32` / `float16` / `bfloat16`                                          |
 | `-q`, `--quantize` | Enable quantization                                                                       |
 | `--q-recipe`       | One of `mixed_2_6`, `mixed_3_4`, `mixed_3_6`, `mixed_4_6`, `qwen3_5`, `unsloth`, `nvidia` |
-| `--q-mode`         | `affine` (default) or `mxfp8`                                                             |
+| `--q-mode`         | `affine` (default), `mxfp4`, `mxfp8`, `nvfp4`, or `sym8`                                  |
+| `--q-mxfp`         | Select Unsloth's fixed MXFP map, or upgrade eligible decisions for other recipes          |
 | `--q-mtp`          | Qwen MTP-quant policy: `off`, `cyankiwi`, `all`, or `split` (alias `drafter`)             |
 | `--imatrix-path`   | Path to imatrix file for AWQ pre-scaling                                                  |
 | `--mmproj`         | Vision-encoder conversion path                                                            |

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -417,7 +417,9 @@ The Qwen3.5 GDN recurrence uses the **per-step** kernel by default on **every** 
 | Scheme       | How it's invoked                                                                                                                                         |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 4-bit affine | `mlx_quantized_matmul` (mode `affine`, configurable group size and bits)                                                                                 |
+| MXFP4        | `--q-mode mxfp4`, or the early-FFN class in `--q-recipe unsloth --q-mxfp`; 4-bit microscaling with group size 32                                         |
 | MXFP8        | `mlx_gather_qmm` with `mode="mxfp8"` (used for MoE expert routing); returns `[quantized, scales]`                                                        |
+| NVFP4        | `--q-recipe unsloth --q-mode nvfp4`; early FFNs use NVFP4 4/16 in the official DGX class map                                                             |
 | FP8 E4M3     | `mlx_dequantize` — dequant **before** expert stacking; no re-quantization after stacking                                                                 |
 | FP8 KV cache | Paged-adapter only — `KVCacheDType::Fp8` with per-layer scale management via `KvScaleManager`. FP8 KV is intentionally rejected by the flat-path attach. |
 
@@ -427,7 +429,10 @@ The Qwen3.5 GDN recurrence uses the **per-step** kernel by default on **every** 
 
 - mlx-lm-style mixed-bit: `mixed_2_6`, `mixed_3_4`, `mixed_3_6`, `mixed_4_6`
 - `qwen3_5` — Qwen3.5-tuned recipe
-- `unsloth` — requires imatrix calibration
+- `unsloth` — requires imatrix calibration. `--q-mxfp` selects the official map
+  translated from NVFP4/FP8 to MXFP4/MXFP8; `--q-mode nvfp4` selects the
+  official DGX map with NVFP4/MXFP8. Both use the final-eight FFN split and the
+  same BF16 exclusions. Plain affine alone keeps the legacy Dynamic 2.0 map.
 
 AWQ-style imatrix pre-scaling is supported for improved low-bit quality.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -108,6 +108,10 @@ mlx convert --input ./model.gguf --output ./model-vlm --mmproj ./mmproj.gguf
 # imatrix AWQ pre-scaling with unsloth dynamic quantization
 mlx convert --input ./model --output ./model-unsloth --quantize --q-recipe unsloth --imatrix-path ./imatrix.gguf
 
+# Qwen3.5 family: official Unsloth map translated to MXFP4/MXFP8
+mlx convert --input ./model --output ./model-unsloth-mxfp4 --quantize \
+  --q-recipe unsloth --q-mxfp --imatrix-path ./imatrix.gguf
+
 # Qwen3.6 with MTPLX-style MTP sidecar
 mlx convert \
   --input .cache/models/qwen3.6-27b \
@@ -151,14 +155,14 @@ Auto-detected from `config.json` when not specified:
 
 #### Quantization Recipes
 
-| Recipe      | Description                                     |
-| ----------- | ----------------------------------------------- |
-| `mixed_2_6` | 2-bit base, 6-bit sensitive layers              |
-| `mixed_3_4` | 3-bit base, 4-bit sensitive layers              |
-| `mixed_3_6` | 3-bit base, 6-bit sensitive layers              |
-| `mixed_4_6` | 4-bit base, 6-bit sensitive layers              |
-| `qwen3_5`   | Optimized for Qwen3.5 hybrid architecture       |
-| `unsloth`   | Unsloth Dynamic 2.0 (requires `--imatrix-path`) |
+| Recipe      | Description                                                            |
+| ----------- | ---------------------------------------------------------------------- |
+| `mixed_2_6` | 2-bit base, 6-bit sensitive layers                                     |
+| `mixed_3_4` | 3-bit base, 4-bit sensitive layers                                     |
+| `mixed_3_6` | 3-bit base, 6-bit sensitive layers                                     |
+| `mixed_4_6` | 4-bit base, 6-bit sensitive layers                                     |
+| `qwen3_5`   | Optimized for Qwen3.5 hybrid architecture                              |
+| `unsloth`   | Legacy affine, official MXFP/DGX maps with `--q-mxfp`/`--q-mode nvfp4` |
 
 #### Unsloth Recipe
 
@@ -172,21 +176,43 @@ mlx convert -i ./model -o ./model-q3 -q --q-bits 3 --q-recipe unsloth --imatrix-
 mlx convert -i ./model -o ./model-q4 -q --q-bits 4 --q-recipe unsloth --imatrix-path ./imatrix.gguf
 ```
 
+For verified Qwen3.5/Qwen3.6-family checkpoints, select the fixed [official
+Unsloth class map](https://unsloth.ai/docs/models/qwen3.6#nvfp4) with either
+`--q-mxfp` (NVFP4 → MXFP4, FP8 → MXFP8) or `--q-mode nvfp4` (the official DGX
+map, retaining NVFP4 and using MXFP8 for FP8 classes). AWQ imatrix pre-scaling
+is the same for both. Plain affine Unsloth alone keeps legacy Dynamic 2.0.
+
+```bash
+mlx convert -i ./model -o ./model-unsloth-mxfp4 -q \
+  --q-recipe unsloth --q-mxfp --imatrix-path ./imatrix.gguf
+
+mlx convert -i ./model -o ./model-unsloth-nvfp4 -q \
+  --q-recipe unsloth --q-mode nvfp4 --imatrix-path ./imatrix.gguf
+```
+
+The two official maps share the high-precision and BF16 classes:
+
+| Weight class                                                                     | `--q-mxfp` | `--q-mode nvfp4` |
+| -------------------------------------------------------------------------------- | ---------- | ---------------- |
+| FFN `gate_proj` / `up_proj` / `down_proj`, except the final 8 transformer layers | MXFP4 4/32 | NVFP4 4/16       |
+| Final 8 FFNs; attention q/k/v/o; GDN qkv/z/out; `lm_head`                        | MXFP8 8/32 | MXFP8 8/32       |
+| Embeddings; routers; GDN a/b; vision; MTP; norms; recurrent parameters           | BF16       | BF16             |
+
 Per-tensor bit assignments (N = `--q-bits`):
 
-| Weight                      | Bits | Rationale                                         |
-| --------------------------- | ---- | ------------------------------------------------- |
-| `gate_proj`, `up_proj`      | N    | Bulk of MoE expert params, safe at low bits       |
-| `down_proj`                 | N+1  | Slightly more sensitive than other FFN weights    |
-| `embed_tokens`              | N+2  | Very low KLD sensitivity (~0.15)                  |
-| `self_attn.q/k/v_proj`      | N+2  | AWQ-correctable via input_layernorm               |
-| `linear_attn.in_proj_qkv/z` | N+2  | AWQ-correctable via input_layernorm               |
-| `lm_head`                   | N+3  | Safest tensor (KLD ~0.05)                         |
-| Router gates                | 8    | Standard for MoE routing accuracy                 |
+| Weight                      | Bits     | Rationale                                                  |
+| --------------------------- | -------- | ---------------------------------------------------------- |
+| `gate_proj`, `up_proj`      | N        | Bulk of MoE expert params, safe at low bits                |
+| `down_proj`                 | N+1      | Slightly more sensitive than other FFN weights             |
+| `embed_tokens`              | N+2      | Very low KLD sensitivity (~0.15)                           |
+| `self_attn.q/k/v_proj`      | N+2      | AWQ-correctable via input_layernorm                        |
+| `linear_attn.in_proj_qkv/z` | N+2      | AWQ-correctable via input_layernorm                        |
+| `lm_head`                   | N+3      | Safest tensor (KLD ~0.05)                                  |
+| Router gates                | 8        | Standard for MoE routing accuracy                          |
 | `self_attn.o_proj`          | 8 affine | No preceding norm (not AWQ) — kept 8-bit for MTP/AR parity |
 | `linear_attn.out_proj`      | 8 affine | Worst tensor (KLD ~6.0) — kept 8-bit for MTP/AR parity     |
 | `linear_attn.in_proj_a/b`   | 8 affine | Split GDN low-rank projs — kept 8-bit for MTP/AR parity    |
-| GDN params (`A_log`, etc.)  | bf16     | Recurrent state params, errors compound over time         |
+| GDN params (`A_log`, etc.)  | bf16     | Recurrent state params, errors compound over time          |
 
 ## Examples
 

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -20,7 +20,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 vi.mock('@mlx-node/core', () => ({
   convertModel: vi.fn(async () => ({ numTensors: 0, numParameters: 0, outputPath: '', tensorNames: [] })),
   convertForeignWeights: vi.fn(() => ({})),
-  convertGgufToSafetensors: vi.fn(async () => ({})),
+  convertGgufToSafetensors: vi.fn(async () => ({
+    numTensors: 0,
+    numParameters: 0,
+    sourceFormat: 'gguf',
+    outputPath: '',
+    tensorNames: [],
+  })),
 }));
 
 import { convertModel, convertGgufToSafetensors } from '@mlx-node/core';
@@ -110,6 +116,195 @@ describe('mlx convert model-type auto-detection', () => {
     // unloadable.
     expect(await detectModelTypeFromConfig({ architectures: ['Gemma4UnifiedForConditionalGeneration'] })).toBe(
       'gemma4_unified',
+    );
+  });
+});
+
+describe('mlx convert Unsloth MXFP messaging', () => {
+  it('documents the official fixed map without the stale mechanical-upgrade recipe', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runConvert(['--help']);
+
+    const help = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(help).toContain('Qwen3.5 MXFP map: early FFNs=mxfp4');
+    expect(help).toContain('Use --q-mode nvfp4 for the official DGX map');
+    expect(help).toContain('Plain affine keeps legacy Dynamic 2.0');
+    expect(help).not.toContain('Recommended combo: --q-recipe unsloth --q-bits 4 --q-mxfp');
+  });
+
+  it('reports the requested DGX map and forwards it without replacing its NVFP4 FFNs', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const imatrixPath = join(tmp, 'imatrix.gguf_file');
+    writeFileSync(imatrixPath, '');
+    writeFileSync(join(tmp, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
+
+    await runConvert([
+      '--input',
+      tmp,
+      '--output',
+      join(tmp, 'out'),
+      '--model-type',
+      'qwen3_5',
+      '--quantize',
+      '--q-mode',
+      'nvfp4',
+      '--q-recipe',
+      'unsloth',
+      '--imatrix-path',
+      imatrixPath,
+    ]);
+
+    const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logs).toContain('requested official Unsloth DGX/NVFP4 map');
+    expect(logs).toContain('backend verifies Qwen family/shape');
+    expect(logs).toContain('early FFN=nvfp4');
+    expect(logs).toContain('final 8 FFN + attention/GDN/head=mxfp8');
+    expect(logs).not.toContain('early FFN=mxfp4');
+    expect(logs).not.toContain('Quantize:   official Unsloth DGX/NVFP4 map');
+    expect(vi.mocked(convertModel)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quantBits: 4,
+        quantMode: 'nvfp4',
+        quantMxfp: false,
+        quantRecipe: 'unsloth',
+        imatrixPath,
+      }),
+    );
+  });
+
+  it('reports the requested MXFP map and forwards the selector to SafeTensors conversion', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const imatrixPath = join(tmp, 'imatrix.gguf_file');
+    writeFileSync(imatrixPath, '');
+    writeFileSync(join(tmp, 'config.json'), JSON.stringify({ model_type: 'qwen3_5_moe' }));
+
+    await runConvert([
+      '--input',
+      tmp,
+      '--output',
+      join(tmp, 'out'),
+      '--model-type',
+      'qwen3_5_moe',
+      '--quantize',
+      '--q-recipe',
+      'unsloth',
+      '--q-mxfp',
+      '--imatrix-path',
+      imatrixPath,
+    ]);
+
+    const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logs).toContain('requested official Unsloth MXFP map');
+    expect(logs).toContain('backend verifies Qwen family/shape');
+    expect(logs).toContain('early FFN=mxfp4');
+    expect(logs).toContain('final 8 FFN + attention/GDN/head=mxfp8');
+    expect(logs).not.toContain('unsloth recipe defaults to 3-bit base');
+    expect(logs).not.toContain('eligible 8b->mxfp8/4b->mxfp4');
+    expect(logs).not.toContain('Quantize:   official Unsloth MXFP map');
+
+    expect(vi.mocked(convertModel)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quantize: true,
+        quantRecipe: 'unsloth',
+        quantMxfp: true,
+        imatrixPath,
+      }),
+    );
+  });
+
+  it('preserves the generic --q-mxfp upgrade messaging for other recipes', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await runConvert([
+      '--input',
+      join(tmp, 'model'),
+      '--output',
+      join(tmp, 'out'),
+      '--model-type',
+      'qwen3_5',
+      '--quantize',
+      '--q-recipe',
+      'qwen3_5',
+      '--q-mxfp',
+    ]);
+
+    const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logs).toContain('eligible 8b->mxfp8/4b->mxfp4');
+    expect(logs).not.toContain('official Unsloth MXFP map');
+    expect(vi.mocked(convertModel)).toHaveBeenCalledWith(
+      expect.objectContaining({ quantRecipe: 'qwen3_5', quantMxfp: true }),
+    );
+  });
+
+  it.each([
+    ['a non-Qwen config', { input: 'tmp', configModelType: 'lfm2', modelArgs: [] }],
+    [
+      'a non-Qwen config with a mismatched explicit Qwen override',
+      { input: 'tmp', configModelType: 'lfm2', modelArgs: ['--model-type', 'qwen3_5'] },
+    ],
+    ['an ambiguous input without a detected family', { input: 'missing', configModelType: undefined, modelArgs: [] }],
+    [
+      'an unverified explicit Qwen override',
+      { input: 'missing', configModelType: undefined, modelArgs: ['--model-type', 'qwen3_5'] },
+    ],
+  ])('does not claim the official map was applied for %s', async (_label, scenario) => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const imatrixPath = join(tmp, 'imatrix.gguf');
+    writeFileSync(imatrixPath, '');
+    if (scenario.configModelType) {
+      writeFileSync(join(tmp, 'config.json'), JSON.stringify({ model_type: scenario.configModelType }));
+    }
+
+    await runConvert([
+      '--input',
+      scenario.input === 'tmp' ? tmp : join(tmp, 'model'),
+      '--output',
+      join(tmp, 'out'),
+      ...scenario.modelArgs,
+      '--quantize',
+      '--q-recipe',
+      'unsloth',
+      '--q-mxfp',
+      '--imatrix-path',
+      imatrixPath,
+    ]);
+
+    const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logs).toContain('requested official Unsloth MXFP map');
+    expect(logs).toContain('backend verifies Qwen family/shape');
+    expect(logs).not.toContain('Quantize:   official Unsloth MXFP map');
+  });
+
+  it('marks a GGUF official-map selection as requested until the backend verifies its shape', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const imatrixPath = join(tmp, 'imatrix.gguf');
+    writeFileSync(imatrixPath, '');
+
+    await runConvert([
+      '--input',
+      ggufPath,
+      '--output',
+      join(tmp, 'out'),
+      '--quantize',
+      '--q-recipe',
+      'unsloth',
+      '--q-mxfp',
+      '--imatrix-path',
+      imatrixPath,
+    ]);
+
+    const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logs).toContain('requested official Unsloth MXFP map');
+    expect(logs).toContain('backend verifies Qwen family/shape');
+    expect(logs).not.toContain('Quantize:   official Unsloth MXFP map');
+    expect(vi.mocked(convertGgufToSafetensors)).toHaveBeenCalledWith(
+      expect.objectContaining({ quantRecipe: 'unsloth', quantMxfp: true, imatrixPath }),
     );
   });
 });

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -53,8 +53,17 @@ Quantization Arguments:
                         K%16!=0 layers fall back to 8-bit affine (or bf16)
                         with per-layer overrides. NOT mlx-lm-loadable.
   --q-mxfp              Upgrade quantization to micro-scaling FP (mxfp4 / mxfp8).
-                        Applies after the recipe predicate: any 8-bit affine
-                        decision becomes mxfp8, any 4-bit becomes mxfp4 — except
+                        With --q-recipe unsloth, selects the fixed official
+                        Qwen3.5 MXFP map: early FFNs=mxfp4; final eight FFNs,
+                        attention q/k/v/o, GDN qkv/z/out, and lm_head=mxfp8;
+                        embeddings, routers, GDN a/b, vision, MTP, norms, and
+                        recurrent tensors stay bf16. AWQ imatrix pre-scaling
+                        remains enabled. --q-bits/--q-group-size do not alter
+                        this fixed map.
+
+                        With other recipes (or no recipe), applies after the
+                        recipe predicate: any 8-bit affine decision becomes
+                        mxfp8, any 4-bit becomes mxfp4 — except
                         the recipe-pinned attention/GDN projections (o_proj /
                         out_proj / in_proj_a / in_proj_b), which stay 8-bit
                         affine. Requires --quantize and --q-mode affine
@@ -70,19 +79,18 @@ Quantization Arguments:
                         top-K expert routing, matching the Python mlx-lm
                         quant_predicate.
 
-                        Recommended combo: --q-recipe unsloth --q-bits 4 --q-mxfp
-                        promotes mlp.gate_proj/up_proj to mxfp4 (q/k/v at 6-bit
-                        affine, down_proj at 5-bit affine, router gates at 8-bit
-                        affine, lm_head at 8-bit affine,
-                        o_proj/out_proj/in_proj_a/in_proj_b at 8-bit affine). At
-                        default --q-bits 3 only down_proj
-                        (4b -> mxfp4) gets the upgrade.
   --q-recipe <string>   Per-layer mixed-bit quantization recipe
                         Options: mixed_2_6, mixed_3_4, mixed_3_6, mixed_4_6, qwen3_5, unsloth, nvidia
                         "unsloth" defaults to 3-bit base (gate/up=3b, down=4b,
                         embed=5b, lm_head=6b, attn q/k/v=5b+AWQ,
                         o_proj/out_proj/in_proj_a/in_proj_b=8b affine)
                         "unsloth" requires --imatrix-path for quality
+                        Add --q-mxfp for the official Qwen3.5 MXFP class map
+                        (NVFP4 translated to MXFP4, FP8 translated to MXFP8).
+                        Use --q-mode nvfp4 for the official DGX map: early
+                        FFNs=nvfp4; final eight FFNs, attention/GDN high
+                        classes, and lm_head=mxfp8; the same protected classes
+                        stay bf16. Plain affine keeps legacy Dynamic 2.0.
                         "nvidia" is a data-free MXFP4 port of NVIDIA modelopt's
                         recipe (dense qwen3_5 + MoE qwen3_5_moe): FFN + lm_head
                         =mxfp4 4/32, attn q/k/v/o + GDN in_proj_qkv/z/out_proj
@@ -139,6 +147,7 @@ Examples:
   mlx convert -i .cache/models/qwen3.5-9b -o ./models/qwen35-recipe -q --q-recipe qwen3_5 -m qwen3_5
   mlx convert -i model-BF16.gguf -o ./models/awq-4bit -q --q-recipe unsloth --imatrix-path imatrix.gguf
   mlx convert -i .cache/models/Qwen3.5-27B -o ./models/qwen3.5-unsloth -q --q-recipe unsloth --imatrix-path imatrix.gguf
+  mlx convert -i .cache/models/Qwen3.5-27B -o ./models/qwen3.5-unsloth-mxfp4 -q --q-recipe unsloth --q-mxfp --imatrix-path imatrix.gguf
 `);
 }
 
@@ -272,7 +281,7 @@ export async function run(argv: string[]) {
     // in_proj_a/in_proj_b at 8-bit affine for MTP/AR T=0 bit-exactness).
     // Based on Unsloth's per-tensor KLD analysis. Requires imatrix for AWQ correction
     // on the attention/SSM projections.
-    if (quantRecipe === 'unsloth' && !args['q-bits'] && quantMode !== 'nvfp4') {
+    if (quantRecipe === 'unsloth' && !args['q-bits'] && quantMode !== 'nvfp4' && !args['q-mxfp']) {
       console.log('Note: unsloth recipe defaults to 3-bit base (override with --q-bits)');
     }
     if (quantRecipe === 'unsloth' && !args['imatrix-path']) {
@@ -321,6 +330,12 @@ export async function run(argv: string[]) {
   // produce an inconsistent checkpoint: top-level bits=3 but per-layer
   // overrides at bits=4 from apply_nvfp4_upgrade, with no failure surface).
   const effectiveQuantBits = quantBits ?? (quantMode === 'nvfp4' ? 4 : quantRecipe === 'unsloth' ? 3 : undefined);
+  const usesOfficialUnslothMxfp = quantRecipe === 'unsloth' && args['q-mxfp'];
+  const usesOfficialUnslothNvfp4 = quantRecipe === 'unsloth' && quantMode === 'nvfp4';
+  const officialUnslothSummary = (lowFormat: 'mxfp4' | 'nvfp4') =>
+    `official Unsloth ${lowFormat === 'nvfp4' ? 'DGX/NVFP4' : 'MXFP'} map (early FFN=${lowFormat}; final 8 FFN + attention/GDN/head=mxfp8; protected classes=bf16)`;
+  const requestedOfficialUnslothSummary = (lowFormat: 'mxfp4' | 'nvfp4') =>
+    `requested ${officialUnslothSummary(lowFormat)}; backend verifies Qwen family/shape`;
 
   // MXFP modes have strict bits/group_size invariants enforced by the MLX
   // backend. Surface the failure here rather than letting it bubble up as a
@@ -409,12 +424,18 @@ export async function run(argv: string[]) {
       const [defaultBits, defaultGs] = QUANT_MODE_DEFAULTS[qMode] ?? [4, 64];
       const qBits = effectiveQuantBits || defaultBits;
       const qGs = quantGroupSize || defaultGs;
-      const qMxfpSuffix = args['q-mxfp']
-        ? ', --q-mxfp: eligible 8b->mxfp8/4b->mxfp4 (protected affine keys stay affine)'
-        : '';
-      console.log(
-        `Quantize:   ${qBits}-bit ${qMode} (group_size=${qGs})${quantRecipe ? `, recipe=${quantRecipe}` : ''}${qMxfpSuffix}`,
-      );
+      if (usesOfficialUnslothMxfp) {
+        console.log(`Quantize:   ${requestedOfficialUnslothSummary('mxfp4')}, recipe=unsloth`);
+      } else if (usesOfficialUnslothNvfp4) {
+        console.log(`Quantize:   ${requestedOfficialUnslothSummary('nvfp4')}, recipe=unsloth`);
+      } else {
+        const qMxfpSuffix = args['q-mxfp']
+          ? ', --q-mxfp: eligible 8b->mxfp8/4b->mxfp4 (protected affine keys stay affine)'
+          : '';
+        console.log(
+          `Quantize:   ${qBits}-bit ${qMode} (group_size=${qGs})${quantRecipe ? `, recipe=${quantRecipe}` : ''}${qMxfpSuffix}`,
+        );
+      }
     }
     if (imatrixPath) {
       console.log(`imatrix:    ${imatrixPath}`);
@@ -573,13 +594,23 @@ export async function run(argv: string[]) {
     const [defaultBits, defaultGs] = QUANT_MODE_DEFAULTS[qMode] ?? [4, 64];
     const qBits = effectiveQuantBits || defaultBits;
     const qGs = quantGroupSize || defaultGs;
-    const qMxfpSuffix = args['q-mxfp']
-      ? ', --q-mxfp: eligible 8b->mxfp8/4b->mxfp4 (protected affine keys stay affine)'
-      : '';
     const qGsLabel = qMode === 'sym8' ? 'per-output-channel' : `group_size=${qGs}`;
-    console.log(
-      `Quantize:   ${qBits}-bit ${qMode} (${qGsLabel})${quantRecipe ? `, recipe=${quantRecipe}` : ''}${qMxfpSuffix}${quantMtp !== 'off' ? `, mtp=${quantMtp}` : ''}`,
-    );
+    if (usesOfficialUnslothMxfp) {
+      console.log(
+        `Quantize:   ${requestedOfficialUnslothSummary('mxfp4')}, recipe=unsloth${quantMtp !== 'off' ? `, mtp=${quantMtp}` : ''}`,
+      );
+    } else if (usesOfficialUnslothNvfp4) {
+      console.log(
+        `Quantize:   ${requestedOfficialUnslothSummary('nvfp4')}, recipe=unsloth${quantMtp !== 'off' ? `, mtp=${quantMtp}` : ''}`,
+      );
+    } else {
+      const qMxfpSuffix = args['q-mxfp']
+        ? ', --q-mxfp: eligible 8b->mxfp8/4b->mxfp4 (protected affine keys stay affine)'
+        : '';
+      console.log(
+        `Quantize:   ${qBits}-bit ${qMode} (${qGsLabel})${quantRecipe ? `, recipe=${quantRecipe}` : ''}${qMxfpSuffix}${quantMtp !== 'off' ? `, mtp=${quantMtp}` : ''}`,
+      );
+    }
   }
   if (imatrixPath) {
     console.log(`imatrix:    ${imatrixPath}`);


### PR DESCRIPTION
## Summary

- add the official Unsloth float-class maps for verified Qwen3.5/Qwen3.6 hybrid checkpoints
- translate the Apple path from NVFP4/FP8 to MXFP4/MXFP8 while retaining NVFP4 for the DGX path
- share the family/shape-gated selector across SafeTensors and GGUF conversion
- preserve legacy Dynamic 2.0 behavior for plain affine and non-Qwen/ambiguous inputs
- document both commands and report pre-conversion selection as pending backend family/shape verification

## Recipe maps

- `--q-recipe unsloth --q-mxfp`: early FFNs use MXFP4 4/32
- `--q-recipe unsloth --q-mode nvfp4`: early FFNs use NVFP4 4/16
- both: final eight FFNs, attention q/k/v/o, GDN qkv/z/out, and `lm_head` use MXFP8 8/32
- both: embeddings, routers, GDN a/b, vision, MTP, norms, and recurrent parameters remain BF16
- AWQ imatrix pre-scaling is unchanged

This follows the [official Unsloth Qwen3.6 NVFP4 class map](https://unsloth.ai/docs/models/qwen3.6#nvfp4), substituting MXFP4/MXFP8 only for the Apple-oriented path.

## Root cause

The previous `--q-mxfp` path mechanically upgraded legacy Dynamic 2.0 affine decisions, leaving several sensitive classes as 5/6/8-bit affine instead of applying the official float-class map. The existing DGX path similarly promoted only legacy 4-bit decisions to NVFP4. Both entry points also needed an explicit Qwen family-and-shape gate so Qwen-specific MXFP heads could not be emitted for incompatible model families.

## Validation

- `cargo test -p mlx-core --lib convert::tests` — 141 passed, 1 ignored
- GGUF recipe tests — 8 passed
- CLI conversion tests — 14 passed
- `cargo clippy -p mlx-core --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

Local generated artifacts (not committed):

- Qwen3.5 35B-A3B MoE MXFP: 192 MXFP4 + 179 MXFP8 tensors; load and one-token smoke passed
- Qwen3.6 27B NVIDIA: 193 MXFP4 + 208 MXFP8 + 96 affine8 tensors; load and one-token smoke passed
- Qwen3.6 27B DGX: 168 NVFP4 + 233 MXFP8 tensors; load and one-token smoke passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quantization outputs for Unsloth + `--q-mxfp`/`nvfp4` on Qwen hybrids; gating limits blast radius, but wrong gate logic could mis-quantize or leave sensitive layers in unexpected formats.
> 
> **Overview**
> Adds **official Unsloth float-class quantization** for verified Qwen3.5/Qwen3.6 hybrid checkpoints when using `--q-recipe unsloth` with either `--q-mxfp` (early FFNs → MXFP4, high classes → MXFP8) or `--q-mode nvfp4` (early FFNs → NVFP4 4/16, same MXFP8/BF16 split). This replaces the prior path that only **mechanically upgraded** legacy Dynamic 2.0 affine decisions.
> 
> **Gating:** Activation requires matching config family, requested model type, and hybrid tensor shape (full attention + GDN keys). Non-Qwen, mismatched, or plain affine Unsloth inputs still use Dynamic 2.0 plus `apply_mxfp_upgrade` / `apply_nvfp4_upgrade`.
> 
> **Scope:** The new predicate covers layer-depth rules (final eight FFNs MXFP8), MoE/shared experts, `lm_head` MXFP8, and BF16 exclusions (embeddings, routers, GDN a/b, vision, MTP). The same selector is wired in **SafeTensors** (`convert.rs`) and **GGUF** (`is_qwen35_hybrid_gguf`).
> 
> **CLI/docs:** Help and convert logs describe the official maps as **requested** until the backend verifies family/shape; tests cover messaging and flag forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d75264f8aca1eec7ba736568b66f6a36fe1659f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->