### PR TITLE
fix(agent): contextualize cached prefill metrics

### DIFF
--- a/packages/agent/__test__/performance-status.test.ts
+++ b/packages/agent/__test__/performance-status.test.ts
@@ -5,7 +5,10 @@ import { describe, expect, it } from 'vite-plus/test';
 
 import { PerformanceStatus } from '../src/provider/performance-status.js';
 
-const MESSAGE = { role: 'assistant' } as AssistantMessage;
+const MESSAGE = {
+  role: 'assistant',
+  usage: { input: 1234, cacheRead: 0 },
+} as AssistantMessage;
 const METRICS: PerformanceMetrics = {
   ttftMs: 125,
   prefillTokensPerSecond: 1234.56,
@@ -46,11 +49,57 @@ describe('PerformanceStatus', () => {
     status.showMessage(messageEnd(), ctx);
 
     expect(statuses).toEqual([
-      ['mlx-performance', '[dim]mlx · prefill 1,234.6 tok/s · decode 42.3 tok/s'],
+      ['mlx-performance', '[dim]mlx · TTFT 125.0 ms · input 1.2k · prefill 1,234.6 tok/s · decode 42.3 tok/s'],
     ]);
   });
 
-  it('does not show another message\'s metrics or write outside TUI mode', () => {
+  it('makes a tiny cached suffix explicit instead of presenting it like bulk prefill', () => {
+    const status = new PerformanceStatus();
+    const message = {
+      role: 'assistant',
+      usage: { input: 42, cacheRead: 114556 },
+    } as AssistantMessage;
+    const { ctx, statuses } = makeContext();
+    status.record(message, {
+      ttftMs: 561.677,
+      prefillTokensPerSecond: 74.776,
+      decodeTokensPerSecond: 42.514,
+    });
+
+    status.showMessage(messageEnd(message), ctx);
+
+    expect(statuses).toEqual([
+      [
+        'mlx-performance',
+        '[dim]mlx · TTFT 561.7 ms · input 42 new + 114.6k cached · prefill 74.8 tok/s · decode 42.5 tok/s',
+      ],
+    ]);
+  });
+
+  it('keeps bulk cached-prefill throughput in context', () => {
+    const status = new PerformanceStatus();
+    const message = {
+      role: 'assistant',
+      usage: { input: 4460, cacheRead: 114640 },
+    } as AssistantMessage;
+    const { ctx, statuses } = makeContext();
+    status.record(message, {
+      ttftMs: 5330.159,
+      prefillTokensPerSecond: 836.748,
+      decodeTokensPerSecond: 42.728,
+    });
+
+    status.showMessage(messageEnd(message), ctx);
+
+    expect(statuses).toEqual([
+      [
+        'mlx-performance',
+        '[dim]mlx · TTFT 5.33 s · input 4.5k new + 114.6k cached · prefill 836.7 tok/s · decode 42.7 tok/s',
+      ],
+    ]);
+  });
+
+  it("does not show another message's metrics or write outside TUI mode", () => {
     const status = new PerformanceStatus();
     status.record(MESSAGE, METRICS);
     const other = { role: 'assistant' } as AssistantMessage;
@@ -73,8 +122,22 @@ describe('PerformanceStatus', () => {
     status.showMessage(messageEnd({ role: 'toolResult' }), ctx);
 
     expect(statuses).toEqual([
-      ['mlx-performance', '[dim]mlx · prefill 1,234.6 tok/s · decode 42.3 tok/s'],
+      ['mlx-performance', '[dim]mlx · TTFT 125.0 ms · input 1.2k · prefill 1,234.6 tok/s · decode 42.3 tok/s'],
     ]);
+  });
+
+  it('falls back to valid throughput when usage or TTFT metadata is malformed', () => {
+    const status = new PerformanceStatus();
+    const message = {
+      role: 'assistant',
+      usage: { input: Number.NaN, cacheRead: -1 },
+    } as AssistantMessage;
+    const { ctx, statuses } = makeContext();
+    status.record(message, { ...METRICS, ttftMs: Number.POSITIVE_INFINITY });
+
+    status.showMessage(messageEnd(message), ctx);
+
+    expect(statuses).toEqual([['mlx-performance', '[dim]mlx · prefill 1,234.6 tok/s · decode 42.3 tok/s']]);
   });
 
   it.each([

--- a/packages/agent/__test__/stream-adapter.test.ts
+++ b/packages/agent/__test__/stream-adapter.test.ts
@@ -471,6 +471,7 @@ describe('makeMlxStreamSimple', () => {
 
     expect(record).toHaveBeenCalledOnce();
     expect(record).toHaveBeenCalledWith(message, performance);
+    expect(message.usage).toMatchObject({ input: 12, cacheRead: 8 });
     expect(session.configSeen?.reportPerformance).toBe(true);
   });
 

--- a/packages/agent/src/provider/performance-status.ts
+++ b/packages/agent/src/provider/performance-status.ts
@@ -15,8 +15,11 @@ import type { PerformanceMetrics } from '@mlx-node/lm';
 const STATUS_KEY = 'mlx-performance';
 
 interface ThroughputSample {
+  ttftMs?: number;
   prefillTokensPerSecond: number;
   decodeTokensPerSecond: number;
+  inputTokens?: number;
+  cachedTokens?: number;
 }
 
 interface MessageEndLike {
@@ -27,6 +30,10 @@ function finiteRate(value: number): number | undefined {
   return Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
+function finiteTokenCount(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
 function formatRate(value: number): string {
   return value.toLocaleString('en-US', {
     minimumFractionDigits: 1,
@@ -34,9 +41,38 @@ function formatRate(value: number): string {
   });
 }
 
+function formatDuration(ttftMs: number): string {
+  if (ttftMs < 1000) return `${formatRate(ttftMs)} ms`;
+  return `${(ttftMs / 1000).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} s`;
+}
+
+function formatTokenCount(value: number): string {
+  if (value < 1000) return value.toLocaleString('en-US');
+  const [divisor, suffix] = value < 1_000_000 ? [1000, 'k'] : [1_000_000, 'm'];
+  return `${(value / divisor).toLocaleString('en-US', { maximumFractionDigits: 1 })}${suffix}`;
+}
+
+function formatContext(sample: ThroughputSample): string {
+  let context = '';
+  if (sample.ttftMs !== undefined) context += ` · TTFT ${formatDuration(sample.ttftMs)}`;
+  if (sample.inputTokens !== undefined && sample.cachedTokens !== undefined) {
+    if (sample.cachedTokens > 0) {
+      context +=
+        ` · input ${formatTokenCount(sample.inputTokens)} new` + ` + ${formatTokenCount(sample.cachedTokens)} cached`;
+    } else {
+      context += ` · input ${formatTokenCount(sample.inputTokens)}`;
+    }
+  }
+  return context;
+}
+
 function formatSample(sample: ThroughputSample): string {
   return (
-    `mlx · prefill ${formatRate(sample.prefillTokensPerSecond)} tok/s` +
+    `mlx${formatContext(sample)}` +
+    ` · prefill ${formatRate(sample.prefillTokensPerSecond)} tok/s` +
     ` · decode ${formatRate(sample.decodeTokensPerSecond)} tok/s`
   );
 }
@@ -49,7 +85,16 @@ export class PerformanceStatus {
     const prefillTokensPerSecond = finiteRate(performance.prefillTokensPerSecond);
     const decodeTokensPerSecond = finiteRate(performance.decodeTokensPerSecond);
     if (prefillTokensPerSecond === undefined || decodeTokensPerSecond === undefined) return;
-    this.byMessage.set(message, { prefillTokensPerSecond, decodeTokensPerSecond });
+    const sample: ThroughputSample = { prefillTokensPerSecond, decodeTokensPerSecond };
+    const ttftMs = finiteRate(performance.ttftMs);
+    if (ttftMs !== undefined) sample.ttftMs = ttftMs;
+    const inputTokens = finiteTokenCount(message.usage?.input);
+    const cachedTokens = finiteTokenCount(message.usage?.cacheRead);
+    if (inputTokens !== undefined && cachedTokens !== undefined) {
+      sample.inputTokens = inputTokens;
+      sample.cachedTokens = cachedTokens;
+    }
+    this.byMessage.set(message, sample);
   };
 
   /** Render the successful mlx inference associated with this exact Pi message. */


### PR DESCRIPTION
## Summary

- show TTFT and per-turn input/cache context alongside prefill and decode throughput
- distinguish tiny warm-cache suffixes from comparable bulk-prefill measurements
- preserve the original rate-only footer when optional context metadata is malformed

## Root cause

The agent footer retained only the native prefill and decode rates. On a warm Qwen session, prefill throughput is measured over the fresh suffix while TTFT also includes cache restoration and long-context first-token work. A small suffix such as 42 new tokens over a 114.6K-token cached prefix could therefore display `74.8 tok/s` with no indication that it was not a bulk-prefill benchmark.

The completed Pi message already contains the fresh input and cache-read counts, so this change adds that existing context without changing native metrics or public schemas.

Example:

```text
mlx · TTFT 561.7 ms · input 42 new + 114.6k cached · prefill 74.8 tok/s · decode 42.5 tok/s
```

## Validation

- `yarn vp test packages/agent/__test__/performance-status.test.ts packages/agent/__test__/stream-adapter.test.ts packages/agent/__test__/events.test.ts` (69 passed)
- `yarn exec tsc -b packages/agent/tsconfig.json --pretty false`
- `yarn vp lint packages/agent/src/provider/performance-status.ts packages/agent/__test__/performance-status.test.ts packages/agent/__test__/stream-adapter.test.ts`
- `yarn vp fmt --check packages/agent/src/provider/performance-status.ts packages/agent/__test__/performance-status.test.ts packages/agent/__test__/stream-adapter.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only TUI status formatting with defensive validation; no auth, persistence, or inference behavior changes beyond what is shown in the footer.
> 
> **Overview**
> The agent TUI **mlx performance footer** now adds **TTFT** and **per-turn input context** (fresh vs cached tokens) next to the existing prefill/decode throughput, so warm-cache turns do not look like bulk-prefill benchmarks when only a small suffix was prefilled.
> 
> `PerformanceStatus.record` pulls optional **TTFT** from native metrics and **input/cacheRead** from the completed assistant message’s usage; formatting distinguishes **“N new + M cached”** when `cacheRead > 0`, otherwise a single input count. If TTFT or usage counts are invalid, the footer **falls back** to the previous rate-only line.
> 
> Tests cover tiny vs bulk cached suffixes, malformed metadata fallback, and assert the stream adapter still attaches **usage** (`input` / `cacheRead`) on the Pi assistant message used for recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c851da82f07fd38657e4dda80687ee2425b56cc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->