### PR TITLE
feat(convert): allow fixed Unsloth maps without imatrix

### DIFF
--- a/__test__/trainers/grpo-optimizer-roundtrip.test.ts
+++ b/__test__/trainers/grpo-optimizer-roundtrip.test.ts
@@ -1,98 +1,14 @@
 /**
- * GRPO checkpoint + optimizer state round-trip integration test.
+ * GRPO checkpoint + optimizer state round-trip integration tests.
  *
- * Exercises the full `saveCheckpoint` → `GRPOTrainer.create({ resumeFromCheckpoint })`
- * chain for a loaded Qwen3 model. This is the user-visible guarantee that
- * matters: save a checkpoint mid-training, restart the process, resume, and
- * keep training without a crash and without losing step state.
- *
- * Specifically this test guards two fairly recent regressions:
- *
- *   - `f281143` — `Qwen3Model::save_model` used to touch weight MxArrays off
- *     the dedicated model thread, which crashed on loaded (thread-backed)
- *     models. `saveCheckpoint` now routes the save through the model thread.
- *     Before the fix, step 2 below aborted with a foreign exception.
- *
- *   - `9eff18a` — `GrpoTrainingEngine::save_optimizer_state` /
- *     `load_optimizer_state` were silent `warn!` no-op stubs after the Phase 3
- *     training-thread refactor. `GRPOTrainer` was calling them on every
- *     checkpoint and on resume, but the AdamW moment tensors and step counter
- *     silently failed to round-trip. Both entry points now go through the
- *     dedicated model thread via `SaveOptimizerState` / `LoadOptimizerState`
- *     commands. Step 2 below writes `optimizer_state.safetensors` through
- *     that command, and step 3 below consumes it via `LoadOptimizerState`.
- *
- * ---------------------------------------------------------------------------
- * Making the AdamW state map actually populate on a tiny random-weight Qwen3
- * ---------------------------------------------------------------------------
- *
- * A naive version of this test (short `maxCompletionLength`, default sampling,
- * constant rewards) silently degrades into a no-op: the engine's degenerate-
- * completion filter kills every rollout (`finish_reason="length"` +
- * `tokens >= 0.9 * max_completion_length`), `train_step_grpo_sync` is never
- * called, the optimizer state map stays empty, and
- * `save_optimizer_state_sync` takes the `keys.is_empty()` early return
- * without writing a file. In this scenario the optimizer-state round-trip
- * is not exercised at all.
- *
- * After task H3 (fix saveCheckpoint hasOptimizerState lie), `saveCheckpoint`
- * checks whether the safetensors file actually exists on disk after
- * `saveOptimizerState` returns and only sets `hasOptimizerState=true` when a
- * file is present. So if this test accidentally degrades into the no-op
- * path, the `expect(stateJson.hasOptimizerState).toBe(true)` assertion below
- * will fail loudly instead of vacuously passing. The resume path in
- * `GRPOTrainer.create` also no longer swallows a missing optimizer file —
- * if `hasOptimizerState` is true and the file is missing, resume throws
- * immediately. A separate test case below (`does not claim hasOptimizerState
- * when no training step has run`) pins the no-op path so the fix stays
- * fixed.
- *
- * To force the pipeline to actually populate optimizer state we need three
- * things:
- *
- *   1. The engine's degenerate-completion filter to let at least one
- *      completion through per step. The filter only rejects
- *      `finish_reason == "length"` with `tokens >= 0.9 * max`. So we need
- *      generation to finish via EOS or the repetition cutoff before hitting
- *      the length limit. The GRPO engine hardcodes `max_consecutive_tokens:
- *      16`, `max_ngram_repeats: 8`, and `ngram_size: 3` in its generation
- *      config (crates/mlx-core/src/grpo/engine.rs build_gen_config).
- *      Combined with `repetitionPenalty: 0.05` (< 1 REWARDS previously-
- *      sampled tokens — it divides positive logits by the penalty, which
- *      with 0.05 multiplies them by 20) and greedy decoding, the model
- *      collapses into a short repeating cycle within a few dozen tokens on
- *      almost every attempt. A small retry loop tolerates the rare attempt
- *      that escapes the cutoff.
- *
- *   2. The optimizer state map on the model thread to become non-empty.
- *      This happens as a side effect of `AdamW::update_batch` calling
- *      `init_state` the first time it sees each parameter name — regardless
- *      of the actual gradient values. So as long as ONE train step makes it
- *      past the degenerate-completion filter and runs
- *      `train_step_grpo_sync`'s optimizer-update branch, the state map is
- *      populated and `save_optimizer_state_sync` will write a real file
- *      instead of taking the empty-keys early return.
- *
- *   3. `save_model` to succeed at checkpoint time, which means the model
- *      weights must not contain any NaN/Inf values. We guarantee this by
- *      combining `learningRate: 0` with a CONSTANT reward function: with
- *      constant rewards the group-normalized advantages are exactly 0, so
- *      the policy gradient is exactly 0, so AdamW computes `new_m = 0,
- *      new_v = 0, update = 0 / (0 + eps) = 0, lr_update = 0`, and the
- *      parameter update is an identity no-op. This avoids the IEEE
- *      floating-point footgun where `lr=0 * update=inf = NaN` poisons the
- *      weights — a non-hypothetical risk even with `gradientClipNorm` +
- *      element-wise clipping, because the update denominator can get very
- *      small in bf16 on the first real gradient of a random-init model.
- *
- * We deliberately run in the same TINY_TEST_CONFIG the other GRPO trainer
- * tests use — this combination of head_dim / hidden_size / num_heads has
- * been verified to work on the Metal autograd backward path elsewhere
- * (see `grpo-autograd-integration.test.ts`, which runs a full autograd
- * train step on exactly this shape with `maxCompletionLength: 256`).
+ * The first test seeds a tiny checkpoint with deterministic AdamW moments,
+ * then exercises load -> save -> load -> save through the model thread. This
+ * covers both optimizer dispatch directions and thread-backed model saving
+ * without depending on random generation to reach an optimizer update.
  */
 
 import {
+  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -110,32 +26,10 @@ import { loadModel } from '@mlx-node/lm';
 import { GRPOTrainer, type RewardOutput } from '@mlx-node/trl';
 import { afterAll, describe, expect, it } from 'vite-plus/test';
 
-import { createTempModel } from '../test-model-utils';
+import { createTempModel, TINY_TEST_CONFIG } from '../test-model-utils';
 
-// Constant reward: every completion gets the same score. Group normalization
-// turns these into advantages of exactly 0, so the policy gradient is exactly
-// 0 everywhere. This is intentional — we want to populate AdamW moment state
-// (which happens via `init_state` the moment `update_batch` is called on a
-// previously-unseen param) WITHOUT actually perturbing the weights.
-//
-// With zero gradients:
-//   new_m = β1*0 + (1-β1)*0 = 0
-//   new_v = β2*0 + (1-β2)*0 = 0
-//   update = 0 / (sqrt(0) + eps) = 0
-//   new_param = param - lr*0 = param  (exactly, no FP drama)
-//
-// So weights stay pristine (saveable), but the optimizer state map has been
-// populated by `init_state`, so `get_state_keys()` is non-empty and
-// `save_optimizer_state_sync` writes a real safetensors file instead of
-// taking the empty-keys early return. That's exactly what the round-trip
-// test needs.
-//
-// Note: group normalization on constant rewards could hit a 0/0 if std is
-// measured as exactly 0; the engine's `compute_advantages` handles that by
-// clamping std to a small epsilon, producing finite (zero) advantages. This
-// has been verified empirically — the train step returns `gradientsApplied
-// === true` with this reward as long as the engine's degenerate-completion
-// filter lets the completions through (see commentary further below).
+// The remaining no-op checkpoint tests never train, but keep a reward function
+// configured so their trainer setup mirrors normal GRPO construction.
 const constantReward = (outputs: RewardOutput[]): Float32Array => Float32Array.from(outputs.map(() => 1.0));
 
 interface TrainingStateJson {
@@ -145,11 +39,99 @@ interface TrainingStateJson {
   hasOptimizerState: boolean;
 }
 
+interface SafeTensorEntry {
+  dtype: string;
+  shape: number[];
+  data_offsets: [number, number];
+}
+
+const OPTIMIZER_PARAM = 'final_norm.weight';
+const OPTIMIZER_STEP = 7;
+const MOMENT_LENGTH = TINY_TEST_CONFIG.hiddenSize;
+const FIRST_MOMENT = 0.125;
+const SECOND_MOMENT = 0.25;
+
+/** Write a minimal, standards-compliant AdamW SafeTensors fixture. */
+function writeDeterministicOptimizerState(path: string): void {
+  const tensorBytes = MOMENT_LENGTH * Float32Array.BYTES_PER_ELEMENT;
+  const header = {
+    __metadata__: {
+      step: String(OPTIMIZER_STEP),
+      format: 'adamw_optimizer_state',
+    },
+    [`${OPTIMIZER_PARAM}.m`]: {
+      dtype: 'F32',
+      shape: [MOMENT_LENGTH],
+      data_offsets: [0, tensorBytes],
+    },
+    [`${OPTIMIZER_PARAM}.v`]: {
+      dtype: 'F32',
+      shape: [MOMENT_LENGTH],
+      data_offsets: [tensorBytes, tensorBytes * 2],
+    },
+  };
+
+  const rawHeader = Buffer.from(JSON.stringify(header), 'utf8');
+  const headerLength = Math.ceil(rawHeader.length / 8) * 8;
+  const file = Buffer.alloc(8 + headerLength + tensorBytes * 2, 0x20);
+  file.writeBigUInt64LE(BigInt(headerLength), 0);
+  rawHeader.copy(file, 8);
+
+  const dataOffset = 8 + headerLength;
+  for (let i = 0; i < MOMENT_LENGTH; i++) {
+    file.writeFloatLE(FIRST_MOMENT, dataOffset + i * Float32Array.BYTES_PER_ELEMENT);
+    file.writeFloatLE(SECOND_MOMENT, dataOffset + tensorBytes + i * Float32Array.BYTES_PER_ELEMENT);
+  }
+  writeFileSync(path, file);
+}
+
+/** Read enough of an AdamW SafeTensors file to verify exact round-trip data. */
+function readOptimizerState(path: string): {
+  metadata: Record<string, string>;
+  firstMoment: number[];
+  secondMoment: number[];
+} {
+  const file = readFileSync(path);
+  const headerLength = Number(file.readBigUInt64LE(0));
+  const header = JSON.parse(
+    file
+      .subarray(8, 8 + headerLength)
+      .toString('utf8')
+      .trimEnd(),
+  ) as Record<string, SafeTensorEntry | Record<string, string>>;
+  const dataOffset = 8 + headerLength;
+
+  const readTensor = (name: string): number[] => {
+    const entry = header[name] as SafeTensorEntry;
+    expect(entry.dtype).toBe('F32');
+    expect(entry.shape).toEqual([MOMENT_LENGTH]);
+    const [start, end] = entry.data_offsets;
+    expect(end - start).toBe(MOMENT_LENGTH * Float32Array.BYTES_PER_ELEMENT);
+    return Array.from({ length: MOMENT_LENGTH }, (_, index) =>
+      file.readFloatLE(dataOffset + start + index * Float32Array.BYTES_PER_ELEMENT),
+    );
+  };
+
+  return {
+    metadata: header.__metadata__ as Record<string, string>,
+    firstMoment: readTensor(`${OPTIMIZER_PARAM}.m`),
+    secondMoment: readTensor(`${OPTIMIZER_PARAM}.v`),
+  };
+}
+
+function expectDeterministicOptimizerState(path: string): void {
+  const state = readOptimizerState(path);
+  expect(state.metadata).toMatchObject({
+    step: String(OPTIMIZER_STEP),
+    format: 'adamw_optimizer_state',
+  });
+  expect(state.firstMoment).toEqual(Array(MOMENT_LENGTH).fill(FIRST_MOMENT));
+  expect(state.secondMoment).toEqual(Array(MOMENT_LENGTH).fill(SECOND_MOMENT));
+}
+
 describe.sequential('GRPOTrainer checkpoint + optimizer state round-trip', () => {
-  // Resources created *inside* `runOnce` are tracked here so the outer
-  // retry loop and `afterAll` can clean up across attempts. We hold these
-  // at describe scope rather than `beforeAll` because some attempts may
-  // need to discard a poisoned random-init model and create a fresh one.
+  // Track every temp model/checkpoint directory at describe scope so cleanup
+  // still runs when an assertion or checkpoint load fails partway through.
   const cleanups: Array<() => void> = [];
 
   afterAll(() => {
@@ -162,16 +144,7 @@ describe.sequential('GRPOTrainer checkpoint + optimizer state round-trip', () =>
     }
   });
 
-  /**
-   * Single attempt at the full round-trip. Throws on any assertion or
-   * numerical failure; the outer loop in `it(...)` catches those and
-   * re-runs with a fresh random-init model. We isolate per-attempt state
-   * (model, checkpoint dir, trainers) inside this helper so a failed
-   * attempt can't leak an MxArray or checkpoint path into the next.
-   *
-   * Returns the final `m4.loss` on success for the outer loop's logging.
-   */
-  async function runOnce(): Promise<{ attempts: number; finalLoss: number }> {
+  it('round-trips AdamW moments through model-thread checkpoint save and resume', async () => {
     const tempModel = await createTempModel();
     const checkpointDir = mkdtempSync(join(tmpdir(), 'mlx-grpo-opt-roundtrip-'));
     cleanups.push(() => {
@@ -189,269 +162,81 @@ describe.sequential('GRPOTrainer checkpoint + optimizer state round-trip', () =>
       }
     });
 
-    // --- Phase 1: initial trainer, run a few steps ------------------------
-    const loadedA = await loadModel(tempModel.modelPath);
-    expect(loadedA).toBeInstanceOf(Qwen3Model);
-    const modelA = loadedA as unknown as Qwen3Model;
+    // Build a real resumable checkpoint without running generation. The moment
+    // tensors use final_norm.weight's actual shape in TINY_TEST_CONFIG.
+    const seedCheckpointPath = join(checkpointDir, 'seed-checkpoint');
+    cpSync(tempModel.modelPath, seedCheckpointPath, { recursive: true });
+    const seedState: TrainingStateJson = {
+      step: OPTIMIZER_STEP,
+      epoch: 0,
+      timestamp: new Date(0).toISOString(),
+      hasOptimizerState: true,
+    };
+    writeFileSync(join(seedCheckpointPath, 'training_state.json'), JSON.stringify(seedState, null, 2));
+    writeDeterministicOptimizerState(join(seedCheckpointPath, 'optimizer_state.safetensors'));
+    expectDeterministicOptimizerState(join(seedCheckpointPath, 'optimizer_state.safetensors'));
 
-    const sharedTrainerOptions = {
+    const trainerOptions = {
       modelName: 'qwen3-tiny-roundtrip',
-      modelPath: tempModel.modelPath, // so saveCheckpoint can find tokenizer.json
+      modelPath: tempModel.modelPath,
       groupSize: 2,
-      // maxCompletionLength large enough to give the repetition cutoff
-      // room to fire before we hit the length limit. The GRPO engine's
-      // generation config hardcodes `max_consecutive_tokens: 16`,
-      // `max_ngram_repeats: 8`, and `ngram_size: 3`
-      // (crates/mlx-core/src/grpo/engine.rs build_gen_config), so the
-      // consecutive-same cutoff fires after 16 identical tokens in a row
-      // and the ngram cutoff fires after 16 tokens of an ABAB pattern or
-      // 24 tokens of an ABCABC pattern. With `repetitionPenalty: 0.05`
-      // below, we strongly bias the model toward re-picking previously
-      // sampled tokens, so one of those cutoffs fires well before the
-      // 0.9 * 128 = 115 length threshold.
-      maxCompletionLength: 128,
-      // topK=1 + tiny temperature ≈ greedy argmax. Combined with a strong
-      // bonus for previously-sampled tokens via repetitionPenalty<1 (see
-      // below), the model collapses into a short repeating cycle within a
-      // few dozen tokens.
-      temperature: 0.01,
-      topK: 1,
-      topP: 1.0,
-      // repetitionPenalty < 1 REWARDS previously-sampled tokens instead of
-      // penalizing them — `apply_repetition_penalty` divides positive
-      // logits by `penalty`, so penalty=0.05 multiplies them by 20. On a
-      // tiny random-weight model with already-near-uniform logits that's
-      // enough to force the sampler to keep picking the same handful of
-      // tokens, which in turn triggers the 16-consecutive-token and/or
-      // ngram-repeat cutoffs hardcoded in the GRPO engine's gen config.
-      // Without this the random-weight Qwen3 wanders in a long cycle and
-      // all completions finish with reason="length", which the engine's
-      // degenerate-completion filter rejects (see engine.rs ~1000).
-      repetitionPenalty: 0.05,
-      // Zero learning rate + constant rewards = deterministic no-op weight
-      // update. Constant rewards produce zero advantages (see `constantReward`
-      // above), which make all policy gradients exactly zero. With zero
-      // gradients AdamW's `update_single_at_step` computes
-      //   new_m = 0.9*0 + 0.1*0 = 0
-      //   new_v = 0.999*0 + 0.001*0 = 0
-      //   update = 0 / (sqrt(0) + eps) = 0
-      //   new_param = param - 0*update = param
-      // exactly — no bf16/IEEE floating-point edge cases. The state map
-      // is still populated (via `init_state` on each param's first visit),
-      // so `get_state_keys()` is non-empty and `save_optimizer_state_sync`
-      // writes a real file. The weights stay pristine, so `save_model`'s
-      // NaN/Inf validation passes.
-      //
-      // NOTE: `lr=0` alone (with non-zero gradients) is NOT enough, because
-      // of an IEEE floating-point footgun: if `update = corrected_m /
-      // (sqrt(corrected_v) + eps)` ever contains `inf` (possible in bf16
-      // with extreme gradients), then `update * 0 = NaN`, which poisons
-      // the weight through `new_param = param - NaN`. Zero gradients are
-      // the only numerically safe path.
       learningRate: 0,
-      gradientClipNorm: 1.0,
       rewardFunction: constantReward,
       logConsole: false,
       outputDir: checkpointDir,
     } as const;
 
-    const trainerA = new GRPOTrainer(modelA, sharedTrainerOptions);
+    let trainerA: GRPOTrainer | undefined;
+    let trainerB: GRPOTrainer | undefined;
+    try {
+      // First load proves LoadOptimizerState accepts and installs the seeded
+      // moments. The following save can only write a file if that load was
+      // real rather than the historical silent no-op.
+      trainerA = await GRPOTrainer.create({
+        ...trainerOptions,
+        resumeFromCheckpoint: seedCheckpointPath,
+      });
+      expect(trainerA.getStep()).toBe(OPTIMIZER_STEP);
 
-    const prompts = [[{ role: 'user' as const, content: 'hi' }]];
+      const checkpointA = await trainerA.saveCheckpoint('roundtrip-a');
+      expect(checkpointA).toBe(join(checkpointDir, 'roundtrip-a'));
+      const stateA: TrainingStateJson = JSON.parse(readFileSync(join(checkpointA, 'training_state.json'), 'utf8'));
+      expect(stateA).toMatchObject({
+        step: OPTIMIZER_STEP,
+        epoch: 0,
+        hasOptimizerState: true,
+      });
+      expect(readdirSync(checkpointA)).toContain('config.json');
+      expect(
+        readdirSync(checkpointA).some((name: string) => name === 'weights.safetensors' || name === 'weights.mlx'),
+      ).toBe(true);
+      const optimizerA = join(checkpointA, 'optimizer_state.safetensors');
+      expect(existsSync(optimizerA)).toBe(true);
+      expect(statSync(optimizerA).size).toBeGreaterThan(128);
+      expectDeterministicOptimizerState(optimizerA);
 
-    // Run training steps in a retry loop until we see at least one step that
-    // actually applied gradients. We need a successful gradient application
-    // for `save_optimizer_state_sync` to produce a non-empty file — it
-    // short-circuits with `Ok(())` when AdamW's state map is empty (via
-    // `get_state_keys().is_empty()`), and the state map only becomes
-    // non-empty once `update_batch` has been called at least once (it calls
-    // `init_state` the first time each param name is seen).
-    //
-    // Why retry instead of running a fixed number of steps: on a tiny random-
-    // weight Qwen3 (2 layers, hidden_size=64), the GRPO engine's degenerate-
-    // completion filter occasionally rejects every rollout in a step
-    // (when the random sampling path happens to avoid both the 16-consecutive-
-    // token cutoff AND the ABAB/ABCABC ngram-repeat cutoffs and generation
-    // runs right up to `maxCompletionLength`). When all completions are
-    // filtered, the engine early-returns with `gradients_applied=false`
-    // *before* ever calling `train_step_grpo_sync`, so the optimizer never
-    // sees a gradient and `init_state` is never called. Retrying a few
-    // times lets the sampler re-roll until it hits the repetition cutoff
-    // (empirically this almost always happens within the first 1–2 attempts
-    // with `repetitionPenalty: 0.05`).
-    //
-    // Why only ONE successful step before save: on a tiny random-weight
-    // model the first GRPO loss is huge and even with `lr=0` + `grad_clip`
-    // there are floating-point edge cases in the AdamW update path
-    // (`update * 0 = NaN` when `update` momentarily contains `inf` from
-    // `corrected_m / (sqrt(corrected_v) + eps)`) that can occasionally
-    // corrupt weights. Constant rewards keep advantages (and therefore
-    // gradients) at exactly zero, which avoids this problem entirely —
-    // but we still stop after the first success to minimize exposure.
-    const maxTrainStepAttempts = 20;
-    let gradientsAppliedCount = 0;
-    let lastFiniteGradAppliedLoss = Number.NaN;
-    const metricsLog: Array<{
-      attempt: number;
-      step: number | null;
-      loss: number | null;
-      gradientsApplied: boolean;
-      error?: string;
-    }> = [];
-    for (let attempt = 0; attempt < maxTrainStepAttempts; attempt++) {
-      try {
-        const m = await trainerA.trainStep(prompts);
-        metricsLog.push({
-          attempt,
-          step: m.step,
-          loss: m.loss,
-          gradientsApplied: m.gradientsApplied ?? false,
-        });
-        if (m.gradientsApplied === true && Number.isFinite(m.loss)) {
-          gradientsAppliedCount += 1;
-          lastFiniteGradAppliedLoss = m.loss;
-          // Stop as soon as we have one successful gradient application.
-          // Running additional steps only increases the risk of cumulative
-          // numerical drift corrupting the weights before we get to save.
-          break;
-        }
-      } catch (err) {
-        metricsLog.push({
-          attempt,
-          step: null,
-          loss: null,
-          gradientsApplied: false,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        // Keep retrying — a transient NaN in a previous step should not
-        // fail the test; the retry will use fresh samples.
-      }
-    }
+      // Load the freshly-saved checkpoint, then save once more. The second
+      // output proves the resume path restored the exact moments into a fresh
+      // model thread instead of merely validating the first file on disk.
+      trainerB = await GRPOTrainer.create({
+        ...trainerOptions,
+        resumeFromCheckpoint: checkpointA,
+      });
+      expect(trainerB.getStep()).toBe(OPTIMIZER_STEP);
 
-    expect(
-      gradientsAppliedCount,
-      `expected at least one pre-save step to actually apply gradients so AdamW moments are populated; metrics: ${JSON.stringify(metricsLog)}`,
-    ).toBeGreaterThan(0);
-    expect(Number.isFinite(lastFiniteGradAppliedLoss)).toBe(true);
-
-    // Record the exact step count after the loop so downstream assertions
-    // match whatever the retry loop produced (could be > 1 if early attempts
-    // were filtered, even though we break on the first gradient-applied step).
-    const stepsBeforeSave = trainerA.getStep();
-    expect(stepsBeforeSave).toBeGreaterThan(0);
-
-    // --- Phase 2: save checkpoint -----------------------------------------
-    // `saveCheckpoint(name)` writes to `join(outputDir, name)`. Before
-    // f281143 this aborted the process on a loaded (thread-backed) model
-    // because `Qwen3Model::save_model` touched weight MxArrays off-thread.
-    const checkpointName = `checkpoint-${stepsBeforeSave}`;
-    const checkpointPath = await trainerA.saveCheckpoint(checkpointName);
-    expect(checkpointPath).toBe(join(checkpointDir, checkpointName));
-
-    // Sanity-check the checkpoint layout: weights, tokenizer, config, the
-    // JSON blob the resume path reads, AND the optimizer-state safetensors.
-    // The optimizer file is the load-bearing check for commit 9eff18a —
-    // without a real SaveOptimizerState command wired through the model
-    // thread this file would not exist.
-    const checkpointFiles = readdirSync(checkpointPath);
-    expect(checkpointFiles).toContain('training_state.json');
-    expect(checkpointFiles).toContain('config.json');
-    expect(checkpointFiles).toContain('tokenizer.json');
-    expect(checkpointFiles.some((name: string) => name === 'weights.safetensors' || name === 'weights.mlx')).toBe(true);
-
-    const optimizerStatePath = join(checkpointPath, 'optimizer_state.safetensors');
-    expect(
-      existsSync(optimizerStatePath),
-      'optimizer_state.safetensors must exist on disk after saveCheckpoint — if this fails it means the train steps never populated AdamW moments and save_optimizer_state_sync took the empty-keys early return',
-    ).toBe(true);
-    // And it should be non-trivial in size (real tensor data, not just
-    // metadata headers) — catches a regression where SaveOptimizerState
-    // silently becomes a no-op again.
-    expect(statSync(optimizerStatePath).size).toBeGreaterThan(128);
-
-    const stateJson: TrainingStateJson = JSON.parse(readFileSync(join(checkpointPath, 'training_state.json'), 'utf-8'));
-    expect(stateJson.step).toBe(stepsBeforeSave);
-    expect(stateJson.epoch).toBe(0);
-    expect(stateJson.hasOptimizerState).toBe(true);
-
-    // --- Phase 3: construct a fresh trainer via resumeFromCheckpoint ------
-    // This is the user-visible surface of commit 9eff18a: internally
-    // `GRPOTrainer.create` calls `engine.loadOptimizerState(...)`, which
-    // used to be a silent `warn!` no-op and now dispatches through the
-    // dedicated model thread via the `LoadOptimizerState` command.
-    const trainerB = await GRPOTrainer.create({
-      ...sharedTrainerOptions,
-      resumeFromCheckpoint: checkpointPath,
-    });
-
-    // The JS-side step counter is restored from training_state.json before
-    // any new trainStep runs.
-    expect(trainerB.getStep()).toBe(stepsBeforeSave);
-
-    // --- Phase 4: run one more step on the resumed trainer ----------------
-    // The fresh trainer must still be able to run a training step — proves
-    // the model thread is live and `loadOptimizerState` rehydrated the
-    // AdamW moment tensors without leaving the engine in a broken state.
-    const m4 = await trainerB.trainStep(prompts);
-    expect(typeof m4.loss).toBe('number');
-    expect(Number.isFinite(m4.loss)).toBe(true);
-    // Step counter advances by exactly one: stepsBeforeSave → stepsBeforeSave + 1.
-    expect(trainerB.getStep()).toBe(stepsBeforeSave + 1);
-
-    // Loose order-of-magnitude check: if the optimizer state round-trip
-    // utterly broke the model (e.g. moment tensors corrupted on load), the
-    // post-resume loss would explode relative to the pre-save value. We
-    // bound it very loosely because the GRPO loss on a tiny random-weight
-    // model varies enormously between steps (different completions every
-    // call, very sensitive initial logprobs), so anything tighter would be
-    // flaky. The point of this check is to fail loud if the AdamW state
-    // load left the optimizer in a corrupt state that then corrupts the
-    // next forward.
-    const preSaveScale = Math.max(Math.abs(lastFiniteGradAppliedLoss), 1.0);
-    expect(
-      Math.abs(m4.loss),
-      `post-resume loss ${m4.loss} exploded relative to pre-save loss ${lastFiniteGradAppliedLoss}`,
-    ).toBeLessThan(preSaveScale * 1000 + 1e6);
-
-    return { attempts: stepsBeforeSave, finalLoss: m4.loss };
-  }
-
-  it('populates AdamW moments, saves them through the model thread, and restores them on resume', async () => {
-    // Outer retry loop: the pre-save training step can fail deterministically
-    // on certain random-weight initializations — specifically when the tiny
-    // 2-layer Qwen3 produces logits extreme enough that the first forward
-    // pass emits a ±inf per-token log-probability somewhere, which then turns
-    // `log_ratio = new_logp - old_logp` into NaN in `grpo_loss` (both logps
-    // are -inf, so `(-inf) - (-inf) = NaN`). That NaN short-circuits
-    // `train_step_grpo_sync` via the `if loss_value.is_nan()` path BEFORE
-    // the optimizer is ever called, and since the failure is driven by the
-    // (fixed) random weights, retrying with the same model always produces
-    // the same NaN. The only way to escape is to re-create the model with
-    // a fresh random initialization.
-    //
-    // Empirically fewer than ~10% of random inits trigger the extreme-logit
-    // path on TINY_TEST_CONFIG, so a 4-attempt budget is comfortably above
-    // any realistic flake rate while keeping worst-case runtime bounded.
-    const maxOuterAttempts = 4;
-    const attemptErrors: string[] = [];
-    let lastResult: { attempts: number; finalLoss: number } | null = null;
-    for (let outer = 0; outer < maxOuterAttempts; outer++) {
-      try {
-        lastResult = await runOnce();
-        break;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        attemptErrors.push(`attempt ${outer}: ${msg}`);
-        // Keep going on any failure — either a deterministic NaN from a
-        // bad random init (recoverable with a fresh model) or a transient
-        // numerical issue (recoverable on retry).
-      }
-    }
-    if (lastResult === null) {
-      throw new Error(
-        `GRPO optimizer round-trip failed after ${maxOuterAttempts} attempts with fresh random-init models:\n` +
-          attemptErrors.join('\n'),
-      );
+      const checkpointB = await trainerB.saveCheckpoint('roundtrip-b');
+      const stateB: TrainingStateJson = JSON.parse(readFileSync(join(checkpointB, 'training_state.json'), 'utf8'));
+      expect(stateB).toMatchObject({
+        step: OPTIMIZER_STEP,
+        epoch: 0,
+        hasOptimizerState: true,
+      });
+      expectDeterministicOptimizerState(join(checkpointB, 'optimizer_state.safetensors'));
+    } finally {
+      // Drop model-thread optimizer tensors promptly; the temp directories are
+      // removed by afterAll once every assertion has finished reading them.
+      trainerB?.reset();
+      trainerA?.reset();
     }
   });
 

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -1865,14 +1865,12 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
         if quant_mode == "nvfp4" {
             validate_nvfp4_recipe(recipe).map_err(Error::from_reason)?;
         }
-        // Unsloth recipe requires imatrix for near-lossless attention/SSM quantization
-        if recipe == "unsloth" && imatrix_path.is_none() {
-            return Err(Error::from_reason(
-                "unsloth recipe requires --imatrix-path: imatrix calibration data is needed \
-                 for near-lossless quantization of attention/SSM layers"
-                    .to_string(),
-            ));
-        }
+        // Legacy Dynamic 2.0 relies on AWQ calibration. The fixed official
+        // Qwen maps may defer this check until family + sanitized tensor-shape
+        // selection below; that late gate prevents a caller which bypasses the
+        // CLI from silently falling back to the legacy predicate without AWQ.
+        validate_unsloth_imatrix_selector(recipe, imatrix_path.as_deref(), quant_mxfp, &quant_mode)
+            .map_err(Error::from_reason)?;
     }
 
     // Validate input directory
@@ -2562,6 +2560,15 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
                 is_qwen35_hybrid_checkpoint(&config, model_type.as_deref(), &weight_keys);
             let official_unsloth_kind =
                 select_official_unsloth_recipe(recipe, quant_mxfp, &quant_mode, is_qwen35_hybrid);
+            validate_unsloth_imatrix_after_selection(
+                recipe,
+                imatrix_path.as_deref(),
+                official_unsloth_kind,
+            )
+            .map_err(Error::from_reason)?;
+            if recipe == "unsloth" && imatrix_path.is_none() {
+                warn!("{}", UNSLOTH_NO_IMATRIX_WARNING);
+            }
             let predicate = match official_unsloth_kind {
                 Some(kind) => build_official_unsloth_recipe(&weight_keys, kind),
                 None => build_predicate_for_recipe(recipe, &weight_keys, quant_bits, recipe_gs)
@@ -4055,6 +4062,57 @@ pub(crate) enum OfficialUnslothRecipeKind {
     Nvfp4,
 }
 
+/// User-facing warning for a verified fixed Unsloth map without calibration.
+/// The tensor-class assignment is deterministic and remains identical; only
+/// the optional AWQ weight reparameterization is absent.
+pub(crate) const UNSLOTH_NO_IMATRIX_WARNING: &str = "Unsloth fixed class map selected without --imatrix-path: AWQ pre-scaling is skipped; \
+     the MXFP4/MXFP8 or NVFP4/MXFP8 class map is unchanged, but quantization quality may be lower.";
+
+/// Early imatrix policy gate, before model loading or MLX initialization.
+///
+/// Plain affine Unsloth is the legacy Dynamic 2.0 recipe and still requires
+/// calibration. `--q-mxfp` and `--q-mode nvfp4` merely defer the decision:
+/// only a later, independently verified official Qwen class-map selection may
+/// actually proceed without an imatrix.
+pub(crate) fn validate_unsloth_imatrix_selector(
+    recipe: &str,
+    imatrix_path: Option<&str>,
+    quant_mxfp: bool,
+    quant_mode: &str,
+) -> std::result::Result<(), String> {
+    if recipe != "unsloth" || imatrix_path.is_some() || quant_mxfp || quant_mode == "nvfp4" {
+        return Ok(());
+    }
+    Err(
+        "legacy affine unsloth recipe requires --imatrix-path for AWQ pre-scaling; \
+         without calibration, only the fixed official maps selected by --q-mxfp or \
+         --q-mode nvfp4 are supported"
+            .to_string(),
+    )
+}
+
+/// Late fail-closed gate after family + sanitized tensor-shape selection.
+///
+/// A no-imatrix request is valid only if it selected one of the official fixed
+/// maps. This prevents the SafeTensors and GGUF backends from falling through
+/// to the family-agnostic legacy predicate when callers bypass CLI validation.
+pub(crate) fn validate_unsloth_imatrix_after_selection(
+    recipe: &str,
+    imatrix_path: Option<&str>,
+    official_kind: Option<OfficialUnslothRecipeKind>,
+) -> std::result::Result<(), String> {
+    if recipe != "unsloth" || imatrix_path.is_some() || official_kind.is_some() {
+        return Ok(());
+    }
+    Err(
+        "unsloth without --imatrix-path is supported only for a verified Qwen3.5/Qwen3.6 \
+         hybrid checkpoint using the fixed official --q-mxfp or --q-mode nvfp4 class map; \
+         family/shape validation did not select an official map, so refusing to fall back \
+         to legacy Dynamic 2.0 without AWQ calibration"
+            .to_string(),
+    )
+}
+
 /// Select an official class map only for a verified Qwen3.5/Qwen3.6 hybrid
 /// checkpoint. Plain affine and non-Qwen/ambiguous inputs continue through the
 /// legacy Dynamic 2.0 predicate and its existing upgrade wrappers.
@@ -4733,7 +4791,8 @@ pub(crate) const NVFP4_NO_RECIPE_ERROR: &str = "--q-mode nvfp4 requires --q-reci
      Pure NVFP4 corrupts sensitivity-critical tensors (linear_attn.out_proj, \
      self_attn.o_proj, mlp.down_proj, in_proj_qkv/z, q/k/v_proj) without a \
      recipe's per-tensor affine fallbacks. 'qwen3_5' works without an \
-     imatrix; 'unsloth' is the gold-standard but requires --imatrix-path.";
+     imatrix; 'unsloth' may omit it only when family/shape validation selects \
+     the fixed official Qwen class map.";
 
 /// Recipe predicates drive per-key `QuantDecision`s that bypass every
 /// sym8-scoped guard in the legacy (no-recipe) path: the `sym8_eligible`
@@ -8090,7 +8149,7 @@ mod tests {
         );
         assert!(
             NVFP4_NO_RECIPE_ERROR.contains("unsloth"),
-            "error must mention 'unsloth' as the imatrix-required recipe, got: {NVFP4_NO_RECIPE_ERROR}"
+            "error must mention 'unsloth' and its calibrated/fixed-map path, got: {NVFP4_NO_RECIPE_ERROR}"
         );
     }
 
@@ -11191,6 +11250,49 @@ mod tests {
             select_official_unsloth_recipe("nvidia", true, "affine", true),
             None
         );
+    }
+
+    #[test]
+    fn unsloth_no_imatrix_selector_keeps_plain_affine_fail_closed() {
+        let err = validate_unsloth_imatrix_selector("unsloth", None, false, "affine")
+            .expect_err("legacy affine Unsloth must still require AWQ calibration");
+        assert!(err.contains("legacy affine"), "unexpected error: {err}");
+        assert!(err.contains("--imatrix-path"), "unexpected error: {err}");
+
+        validate_unsloth_imatrix_selector("unsloth", Some("imatrix.gguf"), false, "affine")
+            .expect("legacy affine with an imatrix must remain accepted");
+    }
+
+    #[test]
+    fn unsloth_no_imatrix_fixed_selectors_defer_to_verified_map_gate() {
+        validate_unsloth_imatrix_selector("unsloth", None, true, "affine")
+            .expect("--q-mxfp may defer to official-map verification");
+        validate_unsloth_imatrix_selector("unsloth", None, false, "nvfp4")
+            .expect("--q-mode nvfp4 may defer to official-map verification");
+    }
+
+    #[test]
+    fn unsloth_no_imatrix_late_gate_requires_an_official_map() {
+        let err = validate_unsloth_imatrix_after_selection("unsloth", None, None)
+            .expect_err("an unverified no-imatrix request must not use the legacy fallback");
+        assert!(
+            err.contains("verified Qwen3.5/Qwen3.6"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("refusing to fall back"),
+            "unexpected error: {err}"
+        );
+
+        for kind in [
+            OfficialUnslothRecipeKind::Mxfp,
+            OfficialUnslothRecipeKind::Nvfp4,
+        ] {
+            validate_unsloth_imatrix_after_selection("unsloth", None, Some(kind))
+                .expect("a verified fixed official map may run without an imatrix");
+        }
+        validate_unsloth_imatrix_after_selection("unsloth", Some("imatrix.gguf"), None)
+            .expect("an imatrix keeps the existing fallback behavior available");
     }
 
     fn qwen35_hybrid_test_keys() -> Vec<String> {

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -2477,6 +2477,33 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
             }
         );
 
+        // Resolve and validate the fixed Unsloth map before dispatching to a
+        // model-specific quantization branch. Most recipes use the generic
+        // branch below, but privacy-filter owns a dedicated predicate and
+        // would otherwise bypass the late no-imatrix fail-closed gate.
+        let recipe_weight_keys = quant_recipe
+            .as_ref()
+            .map(|_| converted_tensors.keys().cloned().collect::<Vec<_>>());
+        let official_unsloth_kind = match (quant_recipe.as_deref(), recipe_weight_keys.as_deref()) {
+            (Some(recipe), Some(weight_keys)) => {
+                let kind = select_and_validate_official_unsloth_recipe(
+                    recipe,
+                    imatrix_path.as_deref(),
+                    quant_mxfp,
+                    &quant_mode,
+                    &config,
+                    model_type.as_deref(),
+                    weight_keys,
+                )
+                .map_err(Error::from_reason)?;
+                if recipe == "unsloth" && imatrix_path.is_none() {
+                    warn!("{}", UNSLOTH_NO_IMATRIX_WARNING);
+                }
+                kind
+            }
+            _ => None,
+        };
+
         if is_privacy_filter {
             // Privacy-filter has a dedicated predicate: quantize attention
             // projections (q/k/v/o) and MoE experts (gate_up_proj, down_proj);
@@ -2533,7 +2560,9 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
                 );
             }
         } else if let Some(ref recipe) = quant_recipe {
-            let weight_keys: Vec<String> = converted_tensors.keys().cloned().collect();
+            let weight_keys = recipe_weight_keys
+                .as_deref()
+                .expect("recipe keys are collected whenever quant_recipe is present");
             // Recipes emit affine `Custom` decisions for protected tensors
             // (lm_head, AWQ-corrected attn/SSM projections, etc). Affine
             // quantize only supports group_size ∈ {32, 64, 128}, so when the
@@ -2547,31 +2576,9 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
             } else {
                 quant_group_size
             };
-            // Verified Qwen hybrids use Unsloth's official float class map:
-            // `--q-mxfp` translates FP8/NVFP4 to MXFP8/MXFP4, while
-            // `--q-mode nvfp4` preserves NVFP4 for the low FFN class and uses
-            // MXFP8 for the high class. This is not a mechanical rewrite of
-            // the legacy Dynamic 2.0 affine decisions.
-            // The official map is Qwen3.5/Qwen3.6-hybrid-specific. Gate on the
-            // input config (ground truth), the requested sanitizer family, and
-            // the sanitized weight shape. If any of those are unavailable or
-            // disagree, preserve the legacy family-agnostic upgrade wrappers.
-            let is_qwen35_hybrid =
-                is_qwen35_hybrid_checkpoint(&config, model_type.as_deref(), &weight_keys);
-            let official_unsloth_kind =
-                select_official_unsloth_recipe(recipe, quant_mxfp, &quant_mode, is_qwen35_hybrid);
-            validate_unsloth_imatrix_after_selection(
-                recipe,
-                imatrix_path.as_deref(),
-                official_unsloth_kind,
-            )
-            .map_err(Error::from_reason)?;
-            if recipe == "unsloth" && imatrix_path.is_none() {
-                warn!("{}", UNSLOTH_NO_IMATRIX_WARNING);
-            }
             let predicate = match official_unsloth_kind {
-                Some(kind) => build_official_unsloth_recipe(&weight_keys, kind),
-                None => build_predicate_for_recipe(recipe, &weight_keys, quant_bits, recipe_gs)
+                Some(kind) => build_official_unsloth_recipe(weight_keys, kind),
+                None => build_predicate_for_recipe(recipe, weight_keys, quant_bits, recipe_gs)
                     .map_err(Error::from_reason)?,
             };
             let predicate: Box<dyn Fn(&str) -> QuantDecision + Send + Sync> =
@@ -4132,6 +4139,29 @@ pub(crate) fn select_official_unsloth_recipe(
     } else {
         None
     }
+}
+
+/// Select and validate the SafeTensors fixed Unsloth class map from the input
+/// config, requested sanitizer family, and sanitized tensor inventory.
+///
+/// This helper is deliberately called before model-specific quantization
+/// dispatch. A sanitizer-managed branch (currently privacy-filter) must not be
+/// able to bypass the late no-imatrix gate merely because it uses a dedicated
+/// predicate instead of [`build_predicate_for_recipe`].
+fn select_and_validate_official_unsloth_recipe(
+    recipe: &str,
+    imatrix_path: Option<&str>,
+    quant_mxfp: bool,
+    quant_mode: &str,
+    config: &serde_json::Value,
+    requested_model_type: Option<&str>,
+    weight_keys: &[String],
+) -> std::result::Result<Option<OfficialUnslothRecipeKind>, String> {
+    let is_qwen35_hybrid = is_qwen35_hybrid_checkpoint(config, requested_model_type, weight_keys);
+    let official_kind =
+        select_official_unsloth_recipe(recipe, quant_mxfp, quant_mode, is_qwen35_hybrid);
+    validate_unsloth_imatrix_after_selection(recipe, imatrix_path, official_kind)?;
+    Ok(official_kind)
 }
 
 /// Build the official Unsloth float class map for Qwen3.5 hybrid models.
@@ -11293,6 +11323,56 @@ mod tests {
         }
         validate_unsloth_imatrix_after_selection("unsloth", Some("imatrix.gguf"), None)
             .expect("an imatrix keeps the existing fallback behavior available");
+    }
+
+    #[test]
+    fn unsloth_no_imatrix_privacy_filter_is_rejected_before_dedicated_quantization() {
+        let config = serde_json::json!({
+            "model_type": "privacy-filter",
+            "tie_word_embeddings": false,
+        });
+        let weight_keys = [
+            "model.layers.0.self_attn.q_proj.weight",
+            "model.layers.0.self_attn.k_proj.weight",
+            "model.layers.0.self_attn.v_proj.weight",
+            "model.layers.0.self_attn.o_proj.weight",
+            "model.layers.0.mlp.experts.gate_up_proj.weight",
+            "model.layers.0.mlp.experts.down_proj.weight",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+        for (quant_mxfp, quant_mode) in [(true, "affine"), (false, "nvfp4")] {
+            let err = select_and_validate_official_unsloth_recipe(
+                "unsloth",
+                None,
+                quant_mxfp,
+                quant_mode,
+                &config,
+                Some("privacy-filter"),
+                &weight_keys,
+            )
+            .expect_err("privacy-filter must not bypass no-imatrix official-map validation");
+            assert!(
+                err.contains("verified Qwen3.5/Qwen3.6"),
+                "unexpected error for mode={quant_mode}, q_mxfp={quant_mxfp}: {err}"
+            );
+        }
+
+        assert_eq!(
+            select_and_validate_official_unsloth_recipe(
+                "unsloth",
+                Some("imatrix.gguf"),
+                true,
+                "affine",
+                &config,
+                Some("privacy-filter"),
+                &weight_keys,
+            )
+            .expect("calibrated privacy-filter behavior must remain available"),
+            None,
+        );
     }
 
     fn qwen35_hybrid_test_keys() -> Vec<String> {

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -1689,6 +1689,19 @@ pub async fn convert_gguf_to_safetensors(
         )));
     }
 
+    // Match the SafeTensors entry point's early policy gate. Plain affine
+    // Unsloth cannot run without AWQ calibration; fixed-map selectors defer
+    // the decision until GGUF architecture + remapped hybrid shape are known.
+    if let Some(ref recipe) = options.quant_recipe {
+        crate::convert::validate_unsloth_imatrix_selector(
+            recipe,
+            options.imatrix_path.as_deref(),
+            options.quant_mxfp.unwrap_or(false),
+            options.quant_mode.as_deref().unwrap_or("affine"),
+        )
+        .map_err(Error::from_reason)?;
+    }
+
     // The nvidia recipe is documented + validated only for qwen3_5 /
     // qwen3_5_moe and is a data-free port with a fixed format map. Reject an
     // unsupported model type + the flags that would silently alter or
@@ -1946,6 +1959,15 @@ pub async fn convert_gguf_to_safetensors(
                 &quant_mode_str,
                 is_qwen35_hybrid,
             );
+            crate::convert::validate_unsloth_imatrix_after_selection(
+                recipe,
+                options.imatrix_path.as_deref(),
+                official_unsloth_kind,
+            )
+            .map_err(Error::from_reason)?;
+            if recipe == "unsloth" && options.imatrix_path.is_none() {
+                warn!("{}", crate::convert::UNSLOTH_NO_IMATRIX_WARNING);
+            }
             let predicate = match official_unsloth_kind {
                 Some(kind) => crate::convert::build_official_unsloth_recipe(&weight_keys, kind),
                 None => crate::convert::build_predicate_for_recipe(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,17 +52,19 @@ mlx convert --input ./model --output ./model-q --quantize --q-recipe mixed_4_6
 For verified dense and MoE Qwen3.5/Qwen3.6-family checkpoints, the fixed
 [official Unsloth class map](https://unsloth.ai/docs/models/qwen3.6#nvfp4) is
 available in two forms. Both keep FP8-class weights as MXFP8 and use the same
-AWQ imatrix pre-scaling:
+AWQ imatrix pre-scaling when calibration is provided. The imatrix is optional
+for these fixed maps: without it, AWQ pre-scaling is skipped and quality may be
+lower, while the class map remains unchanged. Plain affine Unsloth still
+requires an imatrix. Matching calibration remains preferred when available;
+add `--imatrix-path ./imatrix_unsloth.gguf_file` to either command below.
 
 ```bash
 # Apple MXFP variant: replace NVFP4 with MXFP4
 mlx convert -m qwen3_5_moe -q --q-recipe unsloth --q-mxfp \
-  --imatrix-path ./imatrix_unsloth.gguf_file \
   -i ./qwen3.5-35b-a3b -o ./qwen3.5-35b-a3b-unsloth-mxfp4-mlx
 
 # Official DGX variant: retain NVFP4
 mlx convert -m qwen3_5_moe -q --q-mode nvfp4 --q-recipe unsloth \
-  --imatrix-path ./imatrix_unsloth.gguf_file \
   -i ./qwen3.5-35b-a3b -o ./qwen3.5-35b-a3b-unsloth-nvfp4-mlx
 ```
 

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -430,10 +430,12 @@ The Qwen3.5 GDN recurrence uses the **per-step** kernel by default on **every** 
 
 - mlx-lm-style mixed-bit: `mixed_2_6`, `mixed_3_4`, `mixed_3_6`, `mixed_4_6`
 - `qwen3_5` — Qwen3.5-tuned recipe
-- `unsloth` — requires imatrix calibration. `--q-mxfp` selects the official map
-  translated from NVFP4/FP8 to MXFP4/MXFP8; `--q-mode nvfp4` selects the
-  official DGX map with NVFP4/MXFP8. Both use the final-eight FFN split and the
-  same BF16 exclusions. Plain affine alone keeps the legacy Dynamic 2.0 map.
+- `unsloth` — legacy affine requires imatrix calibration. `--q-mxfp` selects
+  the official map translated from NVFP4/FP8 to MXFP4/MXFP8; `--q-mode nvfp4`
+  selects the official DGX map with NVFP4/MXFP8. These fixed maps may omit the
+  imatrix; AWQ pre-scaling is then skipped and quality may be lower, while the
+  class map remains unchanged. Both use the final-eight FFN split and the same
+  BF16 exclusions. Plain affine alone keeps the legacy Dynamic 2.0 map.
 
 AWQ-style imatrix pre-scaling is supported for improved low-bit quality.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -110,7 +110,7 @@ mlx convert --input ./model --output ./model-unsloth --quantize --q-recipe unslo
 
 # Qwen3.5 family: official Unsloth map translated to MXFP4/MXFP8
 mlx convert --input ./model --output ./model-unsloth-mxfp4 --quantize \
-  --q-recipe unsloth --q-mxfp --imatrix-path ./imatrix.gguf
+  --q-recipe unsloth --q-mxfp
 
 # Qwen3.6 with MTPLX-style MTP sidecar
 mlx convert \
@@ -166,7 +166,7 @@ Auto-detected from `config.json` when not specified:
 
 #### Unsloth Recipe
 
-MLX affine equivalent of [Unsloth Dynamic 2.0](https://unsloth.ai/docs/models/qwen3.5/gguf-benchmarks) (UD) GGUF quantization. Designed for Qwen3.5's hybrid GatedDeltaNet + full attention architecture. Requires imatrix for AWQ pre-scaling of attention/SSM weights.
+MLX affine equivalent of [Unsloth Dynamic 2.0](https://unsloth.ai/docs/models/qwen3.5/gguf-benchmarks) (UD) GGUF quantization. Designed for Qwen3.5's hybrid GatedDeltaNet + full attention architecture. Legacy affine requires an imatrix for AWQ pre-scaling of attention/SSM weights.
 
 ```bash
 # UD-Q3_K_XL equivalent (~17 GB for 35B-A3B)
@@ -179,15 +179,19 @@ mlx convert -i ./model -o ./model-q4 -q --q-bits 4 --q-recipe unsloth --imatrix-
 For verified Qwen3.5/Qwen3.6-family checkpoints, select the fixed [official
 Unsloth class map](https://unsloth.ai/docs/models/qwen3.6#nvfp4) with either
 `--q-mxfp` (NVFP4 → MXFP4, FP8 → MXFP8) or `--q-mode nvfp4` (the official DGX
-map, retaining NVFP4 and using MXFP8 for FP8 classes). AWQ imatrix pre-scaling
-is the same for both. Plain affine Unsloth alone keeps legacy Dynamic 2.0.
+map, retaining NVFP4 and using MXFP8 for FP8 classes). An imatrix is optional
+for these two fixed maps: when omitted, AWQ pre-scaling is skipped and quality
+may be lower, while the class map stays unchanged. Plain affine Unsloth alone
+keeps legacy Dynamic 2.0 and still requires an imatrix. A matching imatrix
+remains preferred for the fixed maps when calibration data is available; add
+`--imatrix-path ./imatrix.gguf` to either command below.
 
 ```bash
 mlx convert -i ./model -o ./model-unsloth-mxfp4 -q \
-  --q-recipe unsloth --q-mxfp --imatrix-path ./imatrix.gguf
+  --q-recipe unsloth --q-mxfp
 
 mlx convert -i ./model -o ./model-unsloth-nvfp4 -q \
-  --q-recipe unsloth --q-mode nvfp4 --imatrix-path ./imatrix.gguf
+  --q-recipe unsloth --q-mode nvfp4
 ```
 
 The two official maps share the high-precision and BF16 classes:

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -196,6 +196,102 @@ describe('mlx convert Unsloth MXFP messaging', () => {
     expect(help).not.toContain('Recommended combo: --q-recipe unsloth --q-bits 4 --q-mxfp');
   });
 
+  it('still rejects legacy affine Unsloth without an imatrix', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+
+    await expect(
+      runConvert([
+        '--input',
+        tmp,
+        '--output',
+        join(tmp, 'out'),
+        '--model-type',
+        'qwen3_5_moe',
+        '--quantize',
+        '--q-recipe',
+        'unsloth',
+      ]),
+    ).rejects.toThrow('process.exit(1)');
+
+    const errors = errSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(errors).toContain('legacy affine --q-recipe unsloth requires --imatrix-path');
+    expect(errors).toContain('--q-mxfp or --q-mode nvfp4');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(convertModel).not.toHaveBeenCalled();
+  });
+
+  it('allows the requested fixed MXFP map without an imatrix and warns about skipped AWQ', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeFileSync(join(tmp, 'config.json'), JSON.stringify({ model_type: 'qwen3_5_moe' }));
+
+    await runConvert([
+      '--input',
+      tmp,
+      '--output',
+      join(tmp, 'out'),
+      '--model-type',
+      'qwen3_5_moe',
+      '--quantize',
+      '--q-recipe',
+      'unsloth',
+      '--q-mxfp',
+    ]);
+
+    const warnings = warnSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(warnings).toContain('If backend Qwen family/shape validation selects');
+    expect(warnings).toContain('AWQ pre-scaling will be skipped');
+    expect(warnings).toContain('quality may be lower');
+    expect(warnings).toContain('unsupported inputs will be rejected');
+    expect(convertModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quantRecipe: 'unsloth',
+        quantMxfp: true,
+        imatrixPath: undefined,
+      }),
+    );
+  });
+
+  it('allows the requested fixed DGX map without an imatrix and warns about skipped AWQ', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    writeFileSync(join(tmp, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
+
+    await runConvert([
+      '--input',
+      tmp,
+      '--output',
+      join(tmp, 'out'),
+      '--model-type',
+      'qwen3_5',
+      '--quantize',
+      '--q-mode',
+      'nvfp4',
+      '--q-recipe',
+      'unsloth',
+    ]);
+
+    const warnings = warnSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(warnings).toContain('If backend Qwen family/shape validation selects');
+    expect(warnings).toContain('AWQ pre-scaling will be skipped');
+    expect(warnings).toContain('quality may be lower');
+    expect(warnings).toContain('unsupported inputs will be rejected');
+    expect(convertModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quantRecipe: 'unsloth',
+        quantMode: 'nvfp4',
+        quantMxfp: false,
+        imatrixPath: undefined,
+      }),
+    );
+  });
+
   it('reports the requested DGX map and forwards it without replacing its NVFP4 FFNs', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -29,7 +29,7 @@ vi.mock('@mlx-node/core', () => ({
   })),
 }));
 
-import { convertModel, convertGgufToSafetensors } from '@mlx-node/core';
+import { convertModel, convertForeignWeights, convertGgufToSafetensors } from '@mlx-node/core';
 
 import { run as runConvert } from '../src/commands/convert.js';
 
@@ -180,6 +180,43 @@ describe('mlx convert model-type auto-detection', () => {
       'gemma4_unified',
     );
   });
+});
+
+describe('mlx convert foreign-weight quantization validation', () => {
+  it.each([
+    ['pp-lcnet-ori', ['--q-recipe', 'unsloth', '--q-mxfp']],
+    ['uvdoc', ['--q-recipe', 'unsloth', '--q-mode', 'nvfp4']],
+  ])(
+    'rejects the fixed Unsloth map for %s before the non-quantizing foreign converter',
+    async (modelType, quantArgs) => {
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+        throw new Error(`process.exit(${code})`);
+      }) as never);
+
+      await expect(
+        runConvert([
+          '--input',
+          tmp,
+          '--output',
+          join(tmp, 'out'),
+          '--model-type',
+          modelType,
+          '--quantize',
+          ...quantArgs,
+        ]),
+      ).rejects.toThrow('process.exit(1)');
+
+      const errors = errSpy.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(errors).toContain(`--quantize is not supported for foreign model type '${modelType}'`);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(convertForeignWeights).not.toHaveBeenCalled();
+      expect(convertModel).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe('mlx convert Unsloth MXFP messaging', () => {

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -60,8 +60,9 @@ Quantization Arguments:
                         attention q/k/v/o, GDN qkv/z/out, and lm_head=mxfp8;
                         embeddings, routers, GDN a/b, vision, MTP, norms, and
                         recurrent tensors stay bf16. AWQ imatrix pre-scaling
-                        remains enabled. --q-bits/--q-group-size do not alter
-                        this fixed map.
+                        is applied when --imatrix-path is provided. Without it,
+                        the fixed class map is unchanged but quality may be
+                        lower. --q-bits/--q-group-size do not alter this map.
 
                         With other recipes (or no recipe), applies after the
                         recipe predicate: any 8-bit affine decision becomes
@@ -86,7 +87,10 @@ Quantization Arguments:
                         "unsloth" defaults to 3-bit base (gate/up=3b, down=4b,
                         embed=5b, lm_head=6b, attn q/k/v=5b+AWQ,
                         o_proj/out_proj/in_proj_a/in_proj_b=8b affine)
-                        "unsloth" requires --imatrix-path for quality
+                        "unsloth" legacy affine requires --imatrix-path.
+                        The fixed --q-mxfp / --q-mode nvfp4 maps may omit it;
+                        AWQ pre-scaling is then skipped and quality may be lower.
+                        A matching imatrix remains preferred when available.
                         Add --q-mxfp for the official Qwen3.5 MXFP class map
                         (NVFP4 translated to MXFP4, FP8 translated to MXFP8).
                         Use --q-mode nvfp4 for the official DGX map: early
@@ -120,7 +124,9 @@ Quantization Arguments:
                         require --quantize/--q-recipe.
   --imatrix-path <path> imatrix GGUF file for AWQ-style pre-scaling
                         Improves quantization quality using calibration data
-                        Required for "unsloth" recipe
+                        Required for legacy affine "unsloth". Optional for its
+                        fixed --q-mxfp / --q-mode nvfp4 maps, but preferred
+                        when matching calibration data is available.
 
 Model Types:
   (default)             SafeTensors dtype conversion (HuggingFace models)
@@ -282,16 +288,27 @@ export async function run(argv: string[]) {
     // embed_tokens at 5-bit, lm_head at 6-bit, attn q/k/v + SSM in_proj_qkv/z at
     // 5-bit with AWQ pre-scaling via input_layernorm, o_proj/out_proj and split
     // in_proj_a/in_proj_b at 8-bit affine for MTP/AR T=0 bit-exactness).
-    // Based on Unsloth's per-tensor KLD analysis. Requires imatrix for AWQ correction
-    // on the attention/SSM projections.
+    // Based on Unsloth's per-tensor KLD analysis. Legacy affine requires an
+    // imatrix for AWQ correction on attention/SSM projections. The fixed
+    // official --q-mxfp / --q-mode nvfp4 maps may run data-free, but the
+    // backend must still verify the Qwen family + hybrid tensor shape before
+    // it is allowed to skip AWQ rather than fall back to Dynamic 2.0.
     if (quantRecipe === 'unsloth' && !args['q-bits'] && quantMode !== 'nvfp4' && !args['q-mxfp']) {
       console.log('Note: unsloth recipe defaults to 3-bit base (override with --q-bits)');
     }
     if (quantRecipe === 'unsloth' && !args['imatrix-path']) {
-      console.error('Error: --q-recipe unsloth requires --imatrix-path for AWQ pre-scaling');
-      console.error('       imatrix calibration data is needed for near-lossless attention/SSM quantization');
-      console.error('       Generate with: llama-imatrix -m model.gguf -f calibration.txt -o imatrix.gguf');
-      process.exit(1);
+      const requestsFixedOfficialMap = args['q-mxfp'] || quantMode === 'nvfp4';
+      if (!requestsFixedOfficialMap) {
+        console.error('Error: legacy affine --q-recipe unsloth requires --imatrix-path for AWQ pre-scaling');
+        console.error(
+          '       without calibration, only the fixed official maps selected by --q-mxfp or --q-mode nvfp4 are supported',
+        );
+        console.error('       Generate with: llama-imatrix -m model.gguf -f calibration.txt -o imatrix.gguf');
+        process.exit(1);
+      }
+      console.warn(
+        'Warning: no --imatrix-path was provided. If backend Qwen family/shape validation selects the requested fixed MXFP4/MXFP8 or NVFP4/MXFP8 map, AWQ pre-scaling will be skipped and quality may be lower; unsupported inputs will be rejected.',
+      );
     }
     // The nvidia recipe is a data-free port with a fixed format map: it reads
     // no imatrix, emits mxfp4/mxfp8 per-layer directly (so --q-mxfp is

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -211,6 +211,17 @@ export async function run(argv: string[]) {
   const quantMode = args['q-mode'];
   const quantMtp = args['q-mtp'] ?? 'off';
 
+  // The foreign-weight converter only remaps Paddle/PyTorch tensors into
+  // unquantized SafeTensors and accepts no quantization options. Reject the
+  // request before recipe-specific messaging can promise backend validation
+  // that this conversion path never invokes.
+  if ((args['model-type'] === 'pp-lcnet-ori' || args['model-type'] === 'uvdoc') && args.quantize) {
+    console.error(
+      `Error: --quantize is not supported for foreign model type '${args['model-type']}'; foreign conversion only emits unquantized SafeTensors`,
+    );
+    process.exit(1);
+  }
+
   const validQuantModes = ['affine', 'mxfp4', 'mxfp8', 'nvfp4', 'sym8'];
   if (quantMode !== undefined && !validQuantModes.includes(quantMode)) {
     console.error(`Error: --q-mode must be one of ${validQuantModes.join(', ')}`);


### PR DESCRIPTION
## Summary

- allow the verified official Qwen3.5/Qwen3.6 MXFP4/MXFP8 and NVFP4/MXFP8 class maps to run without an imatrix
- keep legacy affine Unsloth fail-closed and require `--imatrix-path`
- verify the model family and sanitized hybrid tensor shape before allowing a no-imatrix request, in both SafeTensors and direct GGUF conversion paths
- warn that AWQ pre-scaling is skipped and quantization quality may be lower while preserving the fixed class map
- update CLI help, documentation, and regression coverage

## Why

The fixed Unsloth class maps are deterministic, but the converter previously rejected every Unsloth invocation without an imatrix. That blocked compatible checkpoints which do not publish calibration data. Simply removing the early check would be unsafe because unsupported or ambiguous inputs could silently fall back to the legacy Dynamic 2.0 predicate without AWQ calibration.

This change only defers the imatrix requirement for `--q-mxfp` and `--q-mode nvfp4`, then requires the backend's existing Qwen family and hybrid-shape verification to select an official map. All other no-imatrix Unsloth requests still fail.

## Validation

- `yarn vp test packages/cli/__test__/convert-cmd.test.ts --run` — 19 passed
- `cargo test -p mlx-core unsloth_no_imatrix --lib` — 3 passed
- `yarn typecheck`
- `cargo fmt --all -- --check`
- `git diff --check`
- converted Ornith-1.0-35B through both no-imatrix paths:
  - MXFP variant: 192 MXFP4 + 179 MXFP8 tensors
  - DGX variant: 192 NVFP4 + 179 MXFP8 tensors
  - both outputs: 1,437 indexed tensors, 371 scales, zero affine biases, five shards

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quantization validation and conversion entry points across Rust and CLI; incorrect gating could reject valid converts or allow low-quality legacy Unsloth without calibration, but scope is limited to convert tooling rather than runtime inference or auth.
> 
> **Overview**
> **Unsloth without calibration** is now allowed only for the verified official Qwen3.5/Qwen3.6 fixed class maps (`--q-mxfp` or `--q-mode nvfp4`). Legacy affine `--q-recipe unsloth` still **requires** `--imatrix-path`.
> 
> The converter adds **early** and **late** imatrix gates in `convert.rs` (shared by SafeTensors and GGUF): defer fixed-map requests at the CLI, then **fail closed** if family/shape verification does not select an official map—so callers cannot silently fall back to legacy Dynamic 2.0 without AWQ. Official-map selection runs **before** model-specific branches (e.g. privacy-filter) so dedicated predicates cannot skip that check. A warning is emitted when AWQ pre-scaling is skipped.
> 
> **CLI and docs** mirror the policy: optional imatrix for fixed maps, warnings on no-imatrix runs, and tests for legacy rejection vs allowed MXFP/NVFP paths. **`mlx convert`** rejects `--quantize` on foreign types `pp-lcnet-ori` and `uvdoc` before backend conversion.
> 
> The **GRPO optimizer round-trip test** is rewritten to seed a deterministic AdamW SafeTensors fixture and exercise load → save → load → save on the model thread, replacing flaky GRPO training/retry logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4d9536d4272b8b3581a11bc792a4f32a7f1e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->