### PR TITLE
fix(test): make the two e2e gates that broke main deterministic

### DIFF
--- a/crates/mlx-core/src/cold_tier.rs
+++ b/crates/mlx-core/src/cold_tier.rs
@@ -142,16 +142,26 @@ pub fn install_cold_capture_budget(blocks: usize, budget: std::time::Duration) -
 
 /// Pin the cold-tier root directly; the [`install_cold_capture_budget`]
 /// rationale applies verbatim, including idempotence on a repeat call with the
-/// same directory. Returns `false` when the tier is already open somewhere
-/// else, in which case the caller's root is NOT in effect.
+/// same directory.
+///
+/// Returns `false` when the tier is already open somewhere else, OR when the
+/// managed child could not be opened at all — `open_managed_cold_cache` returns
+/// `None` on a refused or unwritable `mlx-paged-v1`, and `GLOBAL.set(None)`
+/// still succeeds, so reporting on the `set` alone would tell the caller its
+/// cache is installed while the tier is DISABLED. A harness that believed that
+/// would run its whole gate and fail with "restore did not engage", pointing
+/// the reader at the restore path instead of at the setup that never opened.
 pub fn install_cold_cache_root(parent: &Path) -> bool {
     if let Some(installed) = INSTALLED_ROOT.get() {
-        // Only this function ever sets `INSTALLED_ROOT`, and a caller whose
-        // `GLOBAL.set` failed returned `false` and never recorded one — so
-        // reaching here means an earlier install opened the tier successfully.
+        // Only this function ever sets `INSTALLED_ROOT`, and it does so only
+        // after a successful OPEN — so reaching here means an earlier install
+        // really did put a live manager at this path.
         return installed == parent;
     }
-    if GLOBAL.set(open_managed_cold_cache(parent)).is_err() {
+    let Some(manager) = open_managed_cold_cache(parent) else {
+        return false;
+    };
+    if GLOBAL.set(Some(manager)).is_err() {
         return false;
     }
     let _ = INSTALLED_ROOT.set(parent.to_path_buf());

--- a/crates/mlx-core/src/cold_tier.rs
+++ b/crates/mlx-core/src/cold_tier.rs
@@ -22,6 +22,9 @@ use crate::models::qwen3_5::gdn_checkpoint_store::GDN_PREFIX_CHECKPOINT_LIMIT;
 
 static GLOBAL: OnceLock<Option<Arc<ColdCacheManager>>> = OnceLock::new();
 
+/// Per-turn capture budget, resolved once. See [`cold_capture_budget`].
+static BUDGET: OnceLock<(usize, std::time::Duration)> = OnceLock::new();
+
 /// Overrides the cold-tier parent directory (primarily for tests). Read
 /// once on first `global_cold_cache()` call; an empty value means the
 /// default root (`~/.mlx-node/cache/paged/v1`).
@@ -66,7 +69,6 @@ const DEFAULT_CAPTURE_BUDGET_MS: u64 = 250;
 /// this is a TURN-TAIL bound (how much of the prompt one turn is willing to pay
 /// to persist). Conflating them is what made the old rate move with `Tw`.
 pub fn cold_capture_budget() -> (usize, std::time::Duration) {
-    static BUDGET: OnceLock<(usize, std::time::Duration)> = OnceLock::new();
     *BUDGET.get_or_init(|| {
         let blocks = std::env::var(CAPTURE_BLOCKS_ENV)
             .ok()
@@ -103,6 +105,32 @@ fn open_managed_cold_cache(parent: &Path) -> Option<Arc<ColdCacheManager>> {
     ColdCacheManager::open_default_at(parent.join(MANAGED_SUBDIR))
         .ok()
         .map(Arc::new)
+}
+
+/// Pin the capture budget directly, for integration tests that need a specific
+/// walk depth. Returns `false` if the budget was already resolved.
+///
+/// Exists so a test harness does not have to call `std::env::set_var`. Both
+/// values here are read through a `OnceLock` on first use, so a harness that
+/// wanted to force them had to write the process environment — and every
+/// caller is an `#[tokio::test(flavor = "multi_thread")]`, whose worker pool is
+/// already running when the test body executes. Serializing test CASES with
+/// `--test-threads=1` does not retire those threads, so the write never
+/// satisfied the Unix contract for `setenv` and was undefined behaviour that
+/// could manifest as unrelated flakiness.
+///
+/// The `bool` matters as much as the safety: a `set` that loses the race is
+/// exactly the silent no-op where the harness believes it pinned a depth and
+/// the run used the 128-block default instead. Callers must assert on it.
+pub fn install_cold_capture_budget(blocks: usize, budget: std::time::Duration) -> bool {
+    BUDGET.set((blocks, budget)).is_ok()
+}
+
+/// Pin the cold-tier root directly; the [`install_cold_capture_budget`]
+/// rationale applies verbatim. Returns `false` if the tier was already opened,
+/// in which case the caller's root is NOT in effect.
+pub fn install_cold_cache_root(parent: &Path) -> bool {
+    GLOBAL.set(open_managed_cold_cache(parent)).is_ok()
 }
 
 /// Counter snapshot of the global tier for Rust-side consumers (per-turn

--- a/crates/mlx-core/src/cold_tier.rs
+++ b/crates/mlx-core/src/cold_tier.rs
@@ -151,6 +151,20 @@ pub fn install_cold_capture_budget(blocks: usize, budget: std::time::Duration) -
 /// cache is installed while the tier is DISABLED. A harness that believed that
 /// would run its whole gate and fail with "restore did not engage", pointing
 /// the reader at the restore path instead of at the setup that never opened.
+/// The root [`install_cold_cache_root`] opened the tier at, if it has been
+/// opened by an install at all.
+///
+/// Exists so a caller that would otherwise (re)create its root directory can
+/// tell that a live manager is already holding a DESCRIPTOR for that path.
+/// Deleting and recreating the same pathname leaves the manager pointed at an
+/// unlinked directory, and on unix every name lookup there fails with ENOENT —
+/// `openat`, `renameat`, `unlinkat`, `statat` — while `fsync` and `getdents`
+/// still succeed. The cache then stores nothing and restores nothing, and the
+/// pathname check alone cannot see it.
+pub fn installed_cold_cache_root() -> Option<&'static Path> {
+    INSTALLED_ROOT.get().map(PathBuf::as_path)
+}
+
 pub fn install_cold_cache_root(parent: &Path) -> bool {
     if let Some(installed) = INSTALLED_ROOT.get() {
         // Only this function ever sets `INSTALLED_ROOT`, and it does so only

--- a/crates/mlx-core/src/cold_tier.rs
+++ b/crates/mlx-core/src/cold_tier.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 
@@ -24,6 +24,11 @@ static GLOBAL: OnceLock<Option<Arc<ColdCacheManager>>> = OnceLock::new();
 
 /// Per-turn capture budget, resolved once. See [`cold_capture_budget`].
 static BUDGET: OnceLock<(usize, std::time::Duration)> = OnceLock::new();
+
+/// Root that [`install_cold_cache_root`] opened the tier at, so a repeat call
+/// with the same directory can be told apart from a conflicting one. Set only
+/// by that function, and only after its `GLOBAL.set` succeeded.
+static INSTALLED_ROOT: OnceLock<PathBuf> = OnceLock::new();
 
 /// Overrides the cold-tier parent directory (primarily for tests). Read
 /// once on first `global_cold_cache()` call; an empty value means the
@@ -119,18 +124,38 @@ fn open_managed_cold_cache(parent: &Path) -> Option<Arc<ColdCacheManager>> {
 /// satisfied the Unix contract for `setenv` and was undefined behaviour that
 /// could manifest as unrelated flakiness.
 ///
-/// The `bool` matters as much as the safety: a `set` that loses the race is
-/// exactly the silent no-op where the harness believes it pinned a depth and
-/// the run used the 128-block default instead. Callers must assert on it.
+/// The `bool` matters as much as the safety: a budget that was already
+/// resolved to something ELSE is exactly the silent no-op where the harness
+/// believes it pinned a depth and the run used the 128-block default instead.
+/// Callers must assert on it.
+///
+/// Returns `true` when the effective budget equals the requested one, so a
+/// SECOND identical call is a no-op rather than a conflict. That is not a
+/// convenience: `gemma4_cold_tier_parity.rs` ships two `#[ignore]`d gates in
+/// one binary and documents running them together as supported, and each one
+/// installs the same constants. `false` therefore means what it should — the
+/// process is configured differently from what this caller asked for.
 pub fn install_cold_capture_budget(blocks: usize, budget: std::time::Duration) -> bool {
-    BUDGET.set((blocks, budget)).is_ok()
+    let requested = (blocks, budget);
+    *BUDGET.get_or_init(|| requested) == requested
 }
 
 /// Pin the cold-tier root directly; the [`install_cold_capture_budget`]
-/// rationale applies verbatim. Returns `false` if the tier was already opened,
-/// in which case the caller's root is NOT in effect.
+/// rationale applies verbatim, including idempotence on a repeat call with the
+/// same directory. Returns `false` when the tier is already open somewhere
+/// else, in which case the caller's root is NOT in effect.
 pub fn install_cold_cache_root(parent: &Path) -> bool {
-    GLOBAL.set(open_managed_cold_cache(parent)).is_ok()
+    if let Some(installed) = INSTALLED_ROOT.get() {
+        // Only this function ever sets `INSTALLED_ROOT`, and a caller whose
+        // `GLOBAL.set` failed returned `false` and never recorded one — so
+        // reaching here means an earlier install opened the tier successfully.
+        return installed == parent;
+    }
+    if GLOBAL.set(open_managed_cold_cache(parent)).is_err() {
+        return false;
+    }
+    let _ = INSTALLED_ROOT.set(parent.to_path_buf());
+    true
 }
 
 /// Counter snapshot of the global tier for Rust-side consumers (per-turn

--- a/crates/mlx-core/tests/cold_tier_install_idempotent.rs
+++ b/crates/mlx-core/tests/cold_tier_install_idempotent.rs
@@ -1,0 +1,79 @@
+//! `install_cold_capture_budget` / `install_cold_cache_root` must tolerate a
+//! SECOND identical call in the same process.
+//!
+//! Both write process-global `OnceLock`s, and the cold-tier harness asserts on
+//! their return value — a `false` there panics before the model loads. That is
+//! the right behaviour for a genuine conflict (the run would silently use the
+//! 128-block default while the ladder arithmetic assumed 12) and the wrong
+//! behaviour for a repeat, because `gemma4_cold_tier_parity.rs` ships TWO
+//! `#[ignore]`d gates in one binary and its own docstring calls running them
+//! together supported:
+//!
+//!   "Both gates in this binary are safe to run in one process:
+//!    `run_restart_parity` honours an already-created root, the cold keys are
+//!    content-derived (different prompts => disjoint chains), and every stats
+//!    assertion is a delta around its own instance 2."
+//!
+//! The env-var version this replaced was idempotent for free: a second
+//! `set_var` of the same value is a no-op. So the regression is a property
+//! only the new API can have, which is why it is pinned here rather than left
+//! to the `#[ignore]`d gates that need a real checkpoint to notice.
+//!
+//! Its OWN test binary on purpose: these calls resolve process-global state,
+//! so running them beside anything that reads the cold tier would decide that
+//! state for the other tests too.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use mlx_core::cold_tier::{install_cold_cache_root, install_cold_capture_budget};
+
+#[test]
+fn installing_the_same_settings_twice_is_a_no_op_not_a_conflict() {
+    let root: PathBuf =
+        std::env::temp_dir().join(format!("mlx-cold-install-idem-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("create temp root");
+
+    let budget = Duration::from_millis(60_000);
+
+    // First install: nothing has resolved either global yet.
+    assert!(
+        install_cold_capture_budget(12, budget),
+        "first budget install should win the OnceLock"
+    );
+    assert!(
+        install_cold_cache_root(&root),
+        "first root install should open the tier"
+    );
+
+    // Second gate in the same binary, same constants. This is what panicked.
+    assert!(
+        install_cold_capture_budget(12, budget),
+        "a REPEAT install of the identical budget must report success — the harness asserts on \
+         this, so a false here aborts the second gate in a two-gate binary before it loads a model"
+    );
+    assert!(
+        install_cold_cache_root(&root),
+        "a REPEAT install of the identical root must report success for the same reason"
+    );
+
+    // The guard still has to bite, or it is worth nothing: a DIFFERENT value
+    // means the process is not configured the way the caller believes.
+    assert!(
+        !install_cold_capture_budget(999, budget),
+        "a conflicting block count must be reported, not silently accepted — that is the \
+         wrong-green this return value exists to catch"
+    );
+    assert!(
+        !install_cold_capture_budget(12, Duration::from_millis(1)),
+        "a conflicting deadline must be reported too"
+    );
+    assert!(
+        !install_cold_cache_root(&root.join("elsewhere")),
+        "a conflicting root must be reported: the tier is open somewhere else and this caller's \
+         directory is NOT in effect"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/mlx-core/tests/cold_tier_install_idempotent.rs
+++ b/crates/mlx-core/tests/cold_tier_install_idempotent.rs
@@ -37,7 +37,33 @@ fn installing_the_same_settings_twice_is_a_no_op_not_a_conflict() {
 
     let budget = Duration::from_millis(60_000);
 
-    // First install: nothing has resolved either global yet.
+    // FIRST, while both globals are still unset: a root that cannot be OPENED
+    // must not report success. `open_managed_cold_cache` returns `None` when
+    // the managed `mlx-paged-v1` child cannot be opened, and `GLOBAL.set(None)`
+    // still succeeds — so reporting on the `set` alone told the caller its
+    // cache was installed while the tier was DISABLED. The harness would then
+    // run its whole gate and fail with "restore did not engage", blaming the
+    // restore path for a setup that never opened.
+    //
+    // This has to run BEFORE the successful install below, in this same test,
+    // rather than as a second `#[test]`: libtest shares one process, the first
+    // successful install owns `INSTALLED_ROOT` permanently, and a later bad-root
+    // call would then return false via the path-mismatch branch — passing for
+    // the wrong reason and proving nothing about the open.
+    let blocked = root.join("blocked-parent");
+    std::fs::create_dir_all(&blocked).expect("create blocked parent");
+    // A regular file at the exact name the opener needs as a directory, so the
+    // failure is a real filesystem refusal rather than a synthetic one.
+    std::fs::write(blocked.join("mlx-paged-v1"), b"not a directory").expect("write blocker");
+    assert!(
+        !install_cold_cache_root(&blocked),
+        "install reported success for a root whose managed child could not be opened — the \
+         caller would proceed with the tier DISABLED and blame the restore path"
+    );
+
+    // First install: nothing has resolved either global yet. This ALSO proves
+    // the failed attempt above did not poison them — it must return before
+    // touching `GLOBAL` or recording a root.
     assert!(
         install_cold_capture_budget(12, budget),
         "first budget install should win the OnceLock"

--- a/crates/mlx-core/tests/cold_tier_parity_harness.rs
+++ b/crates/mlx-core/tests/cold_tier_parity_harness.rs
@@ -1221,6 +1221,22 @@ where
         after.write_errors,
         after.restore_declines
     );
+    // …and `write_errors` is now ASSERTED, not only printed. A torn tier root —
+    // the directory unlinked out from under the live manager, which retains a
+    // descriptor rather than a pathname — makes every `openat`/`renameat`/
+    // `unlinkat` return ENOENT while `fsync` and `getdents` still succeed.
+    // Capture then stores nothing and restore finds nothing, and the FIRST
+    // assertion to fire is "cold restore did not engage", which sends the
+    // reader to the restore path for a setup fault. This makes the setup name
+    // itself instead.
+    assert_eq!(
+        after.write_errors, 0,
+        "[{}] cold tier recorded {} write error(s): the capture path could not store what it \
+         enqueued, so anything below about restore is downstream of a broken WRITE. The usual \
+         cause is a tier root that no longer exists at the descriptor the manager holds — check \
+         that nothing deleted it between gates.",
+        spec.family, after.write_errors
+    );
 
     // ---- 2a. The restored sidecar was INSTALLED, not just read -----------
     //
@@ -1331,11 +1347,21 @@ where
     // Best-effort cleanup; only touches what this run created.
     let _ = fs::remove_dir_all(&persist_dir);
     let _ = fs::remove_dir_all(&nopersist_dir);
-    if let ColdRoot::Created(path) = &cold_root {
-        // SAFETY: single-threaded teardown, no other reader.
-        unsafe { std::env::remove_var("MLX_COLD_CACHE_DIR") };
-        let _ = fs::remove_dir_all(path);
-    }
+
+    // The tier ROOT is deliberately left in place.
+    //
+    // It used to be deleted here, alongside a `remove_var("MLX_COLD_CACHE_DIR")`
+    // that undid the `set_var` this harness no longer does. Deleting it is
+    // actively wrong now that a second gate in the same binary reuses the
+    // installed tier: `ColdRoot::Created` is `temp_dir()/mlx-cold-parity-{pid}`,
+    // so the next gate recreates the SAME pathname while the live manager still
+    // holds a descriptor for the directory this line unlinked. `install_cold_cache_root`
+    // sees a matching path and correctly reports the tier installed, but the two
+    // no longer refer to the same directory.
+    //
+    // It is pid-scoped and under the OS temp directory, and the per-instance
+    // model clones above — the actual bulk — are still removed. `--test-threads=1`
+    // plus one root per process means nothing else collides with it.
 }
 
 /// Offline cover for [`expected_checkpoint_ladder`].

--- a/crates/mlx-core/tests/cold_tier_parity_harness.rs
+++ b/crates/mlx-core/tests/cold_tier_parity_harness.rs
@@ -884,7 +884,21 @@ fn prepare_cold_root() -> ColdRoot {
         }
         _ => {
             let path = std::env::temp_dir().join(format!("mlx-cold-parity-{}", std::process::id()));
-            let _ = fs::remove_dir_all(&path);
+            // Wipe it ONLY on the first gate in this process.
+            //
+            // The path is pid-scoped, so a second gate in the same binary
+            // computes the SAME one — and the tier manager installed by the
+            // first gate holds a DESCRIPTOR for that directory, not its name.
+            // Unlinking and recreating the pathname therefore leaves the live
+            // manager pointed at an unlinked directory, where every name lookup
+            // is ENOENT: the second gate stores nothing, restores nothing, and
+            // fails at "cold restore did not engage" while the real fault is
+            // this line. Sharing the root across gates is what the module doc
+            // already assumes — the cold keys are content-derived, so different
+            // prompts occupy disjoint chains.
+            if mlx_core::cold_tier::installed_cold_cache_root() != Some(path.as_path()) {
+                let _ = fs::remove_dir_all(&path);
+            }
             fs::create_dir_all(&path).expect("create cold-cache temp root");
             ColdRoot::Created(path)
         }
@@ -1379,8 +1393,56 @@ where
 mod harness_tests {
     use super::{
         DEFAULT_BLOCK_SIZE, expected_checkpoint_ladder, ladder_capture_prompt,
-        ladder_restore_prompt,
+        ladder_restore_prompt, prepare_cold_root,
     };
+
+    /// A second gate in the same binary must not replace the tier directory the
+    /// first gate's manager is already holding open.
+    ///
+    /// `ColdRoot::Created` is `temp_dir()/mlx-cold-parity-{pid}`, so both gates
+    /// compute the SAME path, and `prepare_cold_root` used to `remove_dir_all`
+    /// it unconditionally. The live manager holds a DESCRIPTOR, not a name: once
+    /// that directory is unlinked, every `openat`/`renameat`/`unlinkat`/`statat`
+    /// through it returns ENOENT (measured; `fsync` and `getdents` still work,
+    /// which is why it fails quietly). The second gate then stores nothing,
+    /// restores nothing, and trips "cold restore did not engage" — blaming the
+    /// restore path for a setup fault two functions away.
+    ///
+    /// Asserted on the INODE rather than on existence, because the broken
+    /// version left a directory at the same pathname; only the identity differs.
+    ///
+    /// Costs microseconds and needs no checkpoint, so unlike the gates it guards
+    /// it runs on the ordinary `cargo test` leg — where those gates never run at
+    /// all (`ci.yml` names only the qwen3 and qwen3_5 cold-tier binaries, both
+    /// single-gate, so nothing in CI exercises two gates in one process).
+    #[test]
+    fn preparing_the_root_twice_keeps_the_same_directory() {
+        use std::os::unix::fs::MetadataExt;
+
+        let first = prepare_cold_root();
+        let ino_first = std::fs::metadata(first.path())
+            .expect("tier root must exist after the first prepare")
+            .ino();
+
+        // Second gate in the same process.
+        let second = prepare_cold_root();
+        let ino_second = std::fs::metadata(second.path())
+            .expect("tier root must exist after the second prepare")
+            .ino();
+
+        assert_eq!(
+            first.path(),
+            second.path(),
+            "both gates must resolve the same pid-scoped root, or this test is not exercising \
+             the shared-root case at all"
+        );
+        assert_eq!(
+            ino_first, ino_second,
+            "the second prepare replaced the tier directory ({ino_first} -> {ino_second}): the \
+             manager installed by the first gate still holds a descriptor for the unlinked one, \
+             so every cache write and read in the second gate fails with ENOENT"
+        );
+    }
 
     /// The fixture's whole R-independence argument rests on the two prompts
     /// parting company far enough before the end that instance 2's chain

--- a/crates/mlx-core/tests/cold_tier_parity_harness.rs
+++ b/crates/mlx-core/tests/cold_tier_parity_harness.rs
@@ -775,9 +775,84 @@ impl ColdRoot {
     }
 }
 
+/// Fail loudly when the capture turns can reach the prompt's END.
+///
+/// This is the invariant the whole `restore_prompt` fixture rests on and the
+/// one that silently rotted: a turn anchors ONE sidecar, at the deepest rung it
+/// reached, so if the capture turns between them cover the full prompt, the
+/// only sidecar written sits at the deepest rung — the one a diverged restore
+/// prompt can never name — and instance 2 restores zero. That surfaces as
+/// "restore did not engage", pointing the reader at the restore path, when the
+/// cause is that nothing shallow was ever written.
+///
+/// Checked against the LADDER rather than the raw block count because the
+/// deepest rung, not the prompt's end, is what a restore can address.
+fn assert_capture_reach_leaves_room(spec: &ColdTierParitySpec, ladder: &[u32], prompt_tokens: u32) {
+    let Some(&deepest) = ladder.last() else {
+        return;
+    };
+    let turns = spec.capture_warmup_turns + 1;
+    let reach_tokens = (turns * CAPTURE_BLOCKS_PER_TURN) as u32 * spec.block_size;
+    assert!(
+        reach_tokens < deepest,
+        "[{}] FIXTURE, not a product fault: {} capture turn(s) x {} blocks x {} tok = {} tok of \
+         reach, which covers this prompt's deepest ladder rung ({} tok of {} prompt tok). One \
+         turn writes ONE sidecar at the deepest rung it reaches, so the shallow rungs instance 2 \
+         needs are never written and the restore necessarily finds nothing. Lengthen the capture \
+         prompt, or lower CAPTURE_BLOCKS_PER_TURN / capture_warmup_turns — do NOT relax the \
+         restore assertions below, which would leave this gate green against a real regression.",
+        spec.family,
+        turns,
+        CAPTURE_BLOCKS_PER_TURN,
+        spec.block_size,
+        reach_tokens,
+        deepest,
+        prompt_tokens
+    );
+}
+
+/// Blocks one capture turn may persist, forced by [`prepare_cold_root`].
+///
+/// The fixture needs the chain to reach its frontier over SEVERAL turns: a turn
+/// anchors exactly one sidecar, at the deepest rung it reached, so a turn that
+/// walks the whole prompt writes only the deepest rung and leaves the ladder's
+/// shallow rungs empty — which is precisely what instance 2 needs after its
+/// prompt diverges. That used to happen for free, because the walk stopped
+/// wherever the bounded writer queue refused (~12 blocks here). It is now a
+/// policy defaulting to 128 blocks, so on any machine whose disk keeps up, one
+/// turn covers a fixture-sized prompt and the gate fails by construction.
+///
+/// Pinned rather than left to the default so the stop condition is ARITHMETIC.
+/// With this below the prompt's block count the walk always stops on `Budget`,
+/// so no disk or CPU speed can change which rung gets written. [`LADDER_RATIO`]
+/// governs how far apart the rungs are; this only has to be shallow enough that
+/// `(warm-up turns + 1) x this` stays under the deepest rung, which
+/// [`assert_capture_reach_leaves_room`] enforces.
+const CAPTURE_BLOCKS_PER_TURN: usize = 12;
+
+/// Wall-clock ceiling forced alongside [`CAPTURE_BLOCKS_PER_TURN`].
+///
+/// NOT a lengthened timeout hiding a race: with the block budget below the
+/// prompt's block count the walk stops on blocks every time, so this exists
+/// only to take the clock OUT of the outcome. A walk that would trip a 60 s
+/// deadline is a real hang, not a slow runner.
+const CAPTURE_BUDGET_MS: u64 = 60_000;
+
 /// Fix the tier root BEFORE any model load. The manager is a process-global
 /// `OnceLock` initialized once from this env, so a later change is ignored.
+///
+/// Same for the capture budget: `cold_capture_budget()` is a `OnceLock` read on
+/// first use, so it has to be pinned here, ahead of every model load.
 fn prepare_cold_root() -> ColdRoot {
+    // SAFETY: same contract as the root below — set before any model load, and
+    // `#[ignore]` + `--test-threads=1` keep this the sole toucher in-process.
+    unsafe {
+        std::env::set_var(
+            "MLX_COLD_CAPTURE_BLOCKS_PER_TURN",
+            CAPTURE_BLOCKS_PER_TURN.to_string(),
+        );
+        std::env::set_var("MLX_COLD_CAPTURE_BUDGET_MS", CAPTURE_BUDGET_MS.to_string());
+    }
     match std::env::var("MLX_COLD_CACHE_DIR") {
         Ok(dir) if !dir.trim().is_empty() => {
             let path = PathBuf::from(dir);
@@ -1001,6 +1076,7 @@ where
             ladder,
             result_b.cached_tokens
         );
+        assert_capture_reach_leaves_room(&spec, &ladder, result_a.prompt_tokens);
         ladder
     } else {
         Vec::new()

--- a/crates/mlx-core/tests/cold_tier_parity_harness.rs
+++ b/crates/mlx-core/tests/cold_tier_parity_harness.rs
@@ -775,34 +775,48 @@ impl ColdRoot {
     }
 }
 
-/// Fail loudly when the capture turns can reach the prompt's END.
+/// Fail loudly when a SINGLE capture turn can reach the prompt's END.
 ///
 /// This is the invariant the whole `restore_prompt` fixture rests on and the
 /// one that silently rotted: a turn anchors ONE sidecar, at the deepest rung it
-/// reached, so if the capture turns between them cover the full prompt, the
-/// only sidecar written sits at the deepest rung — the one a diverged restore
-/// prompt can never name — and instance 2 restores zero. That surfaces as
-/// "restore did not engage", pointing the reader at the restore path, when the
-/// cause is that nothing shallow was ever written.
+/// reached, so a turn that covers the full prompt writes only the deepest rung
+/// — the one a diverged restore prompt can never name — and instance 2 restores
+/// zero. That surfaces as "restore did not engage", pointing the reader at the
+/// restore path, when the cause is that nothing shallow was ever written.
 ///
 /// Checked against the LADDER rather than the raw block count because the
 /// deepest rung, not the prompt's end, is what a restore can address.
+///
+/// The bound is on ONE turn, not on all of them together — see the comment in
+/// the body for why the cumulative form rejected working fixtures.
 fn assert_capture_reach_leaves_room(spec: &ColdTierParitySpec, ladder: &[u32], prompt_tokens: u32) {
     let Some(&deepest) = ladder.last() else {
         return;
     };
-    let turns = spec.capture_warmup_turns + 1;
-    let reach_tokens = (turns * CAPTURE_BLOCKS_PER_TURN) as u32 * spec.block_size;
+    // The FIRST turn's reach, not the cumulative reach of all of them.
+    //
+    // Reach ratchets across turns — `paged_kv_cache_adapter.rs` charges the
+    // budget only for blocks it actually enqueues (`outcome.enqueued`), while
+    // already-persisted blocks are re-walked for free — so turn N reaches
+    // roughly `N x CAPTURE_BLOCKS_PER_TURN`. But each turn anchors its sidecar
+    // at the deepest rung ITS OWN reach allows, under a key derived from that
+    // boundary, so the turns write DISTINCT shallow rungs rather than
+    // overwriting one. Turn 1 landing below `deepest` is therefore what
+    // guarantees a shallow sidecar exists.
+    //
+    // The cumulative form this replaces was strictly stronger, and wrong in the
+    // rejecting direction: with `capture_warmup_turns >= 6` it fires on a
+    // fixture whose shallow rungs are on disk and restorable.
+    let reach_tokens = CAPTURE_BLOCKS_PER_TURN as u32 * spec.block_size;
     assert!(
         reach_tokens < deepest,
-        "[{}] FIXTURE, not a product fault: {} capture turn(s) x {} blocks x {} tok = {} tok of \
-         reach, which covers this prompt's deepest ladder rung ({} tok of {} prompt tok). One \
-         turn writes ONE sidecar at the deepest rung it reaches, so the shallow rungs instance 2 \
-         needs are never written and the restore necessarily finds nothing. Lengthen the capture \
-         prompt, or lower CAPTURE_BLOCKS_PER_TURN / capture_warmup_turns — do NOT relax the \
-         restore assertions below, which would leave this gate green against a real regression.",
+        "[{}] FIXTURE, not a product fault: one capture turn reaches {} blocks x {} tok = {} tok, \
+         which already covers this prompt's deepest ladder rung ({} tok of {} prompt tok). That \
+         turn anchors its ONE sidecar at the deepest rung, so the shallow rungs instance 2 needs \
+         after its prompt diverges are never written and the restore necessarily finds nothing. \
+         Lengthen the capture prompt or lower CAPTURE_BLOCKS_PER_TURN — do NOT relax the restore \
+         assertions below, which would leave this gate green against a real regression.",
         spec.family,
-        turns,
         CAPTURE_BLOCKS_PER_TURN,
         spec.block_size,
         reach_tokens,
@@ -838,22 +852,31 @@ const CAPTURE_BLOCKS_PER_TURN: usize = 12;
 /// deadline is a real hang, not a slow runner.
 const CAPTURE_BUDGET_MS: u64 = 60_000;
 
-/// Fix the tier root BEFORE any model load. The manager is a process-global
-/// `OnceLock` initialized once from this env, so a later change is ignored.
+/// Fix the tier root and the capture budget BEFORE any model load. Both are
+/// process-global `OnceLock`s resolved on first use, so a later change is
+/// silently ignored.
 ///
-/// Same for the capture budget: `cold_capture_budget()` is a `OnceLock` read on
-/// first use, so it has to be pinned here, ahead of every model load.
+/// Set through `install_*` rather than `std::env::set_var`. Every caller is an
+/// `#[tokio::test(flavor = "multi_thread", worker_threads = 4)]` and the body
+/// runs ON a pool worker, so at least three other threads are alive here;
+/// `--test-threads=1` serializes test CASES, not runtime threads, so it never
+/// made `setenv` safe. The installers write the `OnceLock` directly, which is
+/// thread-safe, and they RETURN whether they won — turning "the harness thinks
+/// it pinned a depth but the run used the default" from a silent wrong-green
+/// into an assertion.
 fn prepare_cold_root() -> ColdRoot {
-    // SAFETY: same contract as the root below — set before any model load, and
-    // `#[ignore]` + `--test-threads=1` keep this the sole toucher in-process.
-    unsafe {
-        std::env::set_var(
-            "MLX_COLD_CAPTURE_BLOCKS_PER_TURN",
-            CAPTURE_BLOCKS_PER_TURN.to_string(),
-        );
-        std::env::set_var("MLX_COLD_CAPTURE_BUDGET_MS", CAPTURE_BUDGET_MS.to_string());
-    }
-    match std::env::var("MLX_COLD_CACHE_DIR") {
+    assert!(
+        mlx_core::cold_tier::install_cold_capture_budget(
+            CAPTURE_BLOCKS_PER_TURN,
+            std::time::Duration::from_millis(CAPTURE_BUDGET_MS),
+        ),
+        "the capture budget was already resolved before the harness pinned it, so this run used \
+         the {}-block DEFAULT and the ladder arithmetic below is meaningless. Something loaded a \
+         model or touched the cold tier before prepare_cold_root().",
+        128,
+    );
+
+    let root = match std::env::var("MLX_COLD_CACHE_DIR") {
         Ok(dir) if !dir.trim().is_empty() => {
             let path = PathBuf::from(dir);
             fs::create_dir_all(&path).expect("create caller-supplied MLX_COLD_CACHE_DIR");
@@ -863,13 +886,16 @@ fn prepare_cold_root() -> ColdRoot {
             let path = std::env::temp_dir().join(format!("mlx-cold-parity-{}", std::process::id()));
             let _ = fs::remove_dir_all(&path);
             fs::create_dir_all(&path).expect("create cold-cache temp root");
-            // SAFETY: set before any model load and thus before any thread
-            // reads the env or the process-global tier; `#[ignore]` +
-            // `--test-threads=1` keep this the sole toucher in the process.
-            unsafe { std::env::set_var("MLX_COLD_CACHE_DIR", &path) };
             ColdRoot::Created(path)
         }
-    }
+    };
+    assert!(
+        mlx_core::cold_tier::install_cold_cache_root(root.path()),
+        "the cold tier was already opened before the harness pinned its root, so this run wrote \
+         to the DEFAULT location instead of {}",
+        root.path().display(),
+    );
+    root
 }
 
 /// Run the three-instance cold-tier restart-parity gate for one family.

--- a/crates/mlx-core/tests/cold_tier_parity_harness.rs
+++ b/crates/mlx-core/tests/cold_tier_parity_harness.rs
@@ -1122,6 +1122,37 @@ where
         Vec::new()
     };
 
+    // ---- 0. The WRITE path worked ----------------------------------------
+    //
+    // Ordered ahead of every restore assertion deliberately. A capture that
+    // could not store what it enqueued makes each read assertion below
+    // downstream noise, and the read ones have the longer, more specific
+    // messages — so whichever fires first is where the next reader starts
+    // looking. Proven, not assumed: a torn tier root produced exactly this run,
+    //
+    //     [gemma4-sub-window] cold restore did not engage across restart:
+    //     cached_tokens=0 (expected >= 32)
+    //
+    // which sent the reader to the restore path for a fault in `prepare_cold_root`.
+    //
+    // A torn root is the usual cause: the directory unlinked out from under the
+    // live manager, which retains a descriptor rather than a pathname, so every
+    // `openat`/`renameat`/`unlinkat` returns ENOENT while `fsync` and `getdents`
+    // still succeed — the cache stores nothing and reads nothing, quietly.
+    //
+    // A missing snapshot is NOT silently skipped here: assertion 2 below panics
+    // on it explicitly.
+    if let Some(stats) = stats_after.as_ref() {
+        assert_eq!(
+            stats.write_errors, 0,
+            "[{}] cold tier recorded {} write error(s): the capture path could not store what it \
+             enqueued, so everything below about restore is downstream of a broken WRITE. The \
+             usual cause is a tier root that no longer exists at the descriptor the manager \
+             holds — check that nothing deleted or recreated it between gates.",
+            spec.family, stats.write_errors
+        );
+    }
+
     // ---- 1. Restore engaged at all ---------------------------------------
     let min_restored = spec.min_restored();
     assert!(
@@ -1234,22 +1265,6 @@ where
         after.corruptions,
         after.write_errors,
         after.restore_declines
-    );
-    // …and `write_errors` is now ASSERTED, not only printed. A torn tier root —
-    // the directory unlinked out from under the live manager, which retains a
-    // descriptor rather than a pathname — makes every `openat`/`renameat`/
-    // `unlinkat` return ENOENT while `fsync` and `getdents` still succeed.
-    // Capture then stores nothing and restore finds nothing, and the FIRST
-    // assertion to fire is "cold restore did not engage", which sends the
-    // reader to the restore path for a setup fault. This makes the setup name
-    // itself instead.
-    assert_eq!(
-        after.write_errors, 0,
-        "[{}] cold tier recorded {} write error(s): the capture path could not store what it \
-         enqueued, so anything below about restore is downstream of a broken WRITE. The usual \
-         cause is a tier root that no longer exists at the descriptor the manager holds — check \
-         that nothing deleted it between gates.",
-        spec.family, after.write_errors
     );
 
     // ---- 2a. The restored sidecar was INSTALLED, not just read -----------

--- a/crates/mlx-core/tests/gemma4_cold_tier_parity.rs
+++ b/crates/mlx-core/tests/gemma4_cold_tier_parity.rs
@@ -86,6 +86,16 @@
 //! safe to run in one process: `run_restart_parity` honours an already-created
 //! root, the cold keys are content-derived (different prompts => disjoint
 //! chains), and every stats assertion is a delta around its own instance 2.
+//!
+//! That claim also depends on the tier ROOT outliving gate 1, which is why the
+//! harness no longer deletes it in teardown. It used to. Without an inherited
+//! `MLX_COLD_CACHE_DIR` the root is `temp_dir()/mlx-cold-parity-{pid}`, so gate
+//! 2 recreated the same pathname while the live manager still held a descriptor
+//! for the directory gate 1 had unlinked — and a descriptor to an unlinked
+//! directory fails every name lookup with ENOENT. Gate 2 stored nothing,
+//! restored nothing, and blamed the restore path. Every invocation below passes
+//! `MLX_COLD_CACHE_DIR` explicitly, which takes the inherited arm and never hit
+//! it; running the two gates with no cache dir set is what did.
 //! They are slow enough (~4 min per fresh load, dominated by full-shard weight
 //! hashing) that running them separately is usually what you want.
 //!

--- a/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
@@ -797,12 +797,21 @@ async fn lfm2_paged_vs_flat_prefix_reuse_parity() {
 /// byte ramble. Measured spans on this checkpoint: `raw_text` 501-1817 B
 /// against a 77-125 B answer, i.e. up to 23x more text to match by accident.
 ///
-/// So: assert against the span AFTER the final `</think>`, which is the answer
-/// the model actually commits to, and fall back to the whole decode only when
-/// that span is empty — which is exactly branches (A) and (B) above, where
-/// there is no committed answer to read and the verbatim decode is all the
-/// evidence that exists. `raw_text` is empty ONLY when `num_tokens == 0`,
-/// which IS a real failure and stays fatal.
+/// So: assert against the span after `</think>`, which is the answer the model
+/// actually commits to, and fall back to the whole decode only when that span
+/// is empty — which is exactly branches (A) and (B) above, where there is no
+/// committed answer to read and the verbatim decode is all the evidence that
+/// exists. `raw_text` is empty ONLY when `num_tokens == 0`, which IS a real
+/// failure and stays fatal.
+///
+/// FIRST occurrence, matching the engine rather than inventing a second rule.
+/// `finalize.rs:171` ("keep everything after the FIRST occurrence verbatim")
+/// and `tools/mod.rs:990-992` both use `find` and both say why: `</think>` is
+/// a special token, so the first text match is the real boundary, and content
+/// after it may mention `</think>` literally — on which `rfind` splits at the
+/// later occurrence and throws the answer away. A test helper that split at
+/// the last one would assert against a boundary the product never uses, and
+/// would fail on a correct answer that quotes the tag.
 ///
 /// Measured on real weights (all five probe call sites, one run): every turn
 /// emitted a literal `</think>` with a 77-125 B answer after it, and every
@@ -811,7 +820,7 @@ async fn lfm2_paged_vs_flat_prefix_reuse_parity() {
 /// not fire. See [`answer_surface_prefers_the_committed_answer`] for the
 /// masking case this closes.
 fn answer_surface(r: &mlx_core::engine::types::ChatResult) -> &str {
-    match r.raw_text.rsplit_once("</think>") {
+    match r.raw_text.split_once("</think>") {
         Some((_, after)) if !after.trim().is_empty() => after,
         _ => &r.raw_text,
     }
@@ -880,12 +889,21 @@ fn answer_surface_prefers_the_committed_answer() {
     let empty_tail = with_raw("<think> the sum is 18</think>\n  \n");
     assert_eq!(answer_surface(&empty_tail), empty_tail.raw_text);
 
-    // A `<think>` that reopens: the LAST close is the one that bounds the
-    // answer. `rsplit_once` is what makes this hold — `split_once` would take
-    // the first close and hand back the second think block as the "answer".
-    let reopened =
-        with_raw("<think> 18</think> draft\n<think> on reflection, 31</think>\n\nAnswer: 31");
-    assert_eq!(answer_surface(&reopened).trim(), "Answer: 31");
+    // The FIRST close is the boundary, matching `finalize.rs:171` and
+    // `tools/mod.rs:990-992`. The engine's own stated reason is that committed
+    // content may mention `</think>` literally; splitting at the last one then
+    // discards the answer and fails a correct turn — the exact flake class this
+    // file exists to remove. `split_once` is what makes this hold.
+    let quotes_the_tag = with_raw(
+        "<think> 7 + 11</think>\n\nThe sum is 18. Everything before the </think> marker was \
+         scratch work.",
+    );
+    assert!(
+        answer_surface(&quotes_the_tag).contains("18"),
+        "answer_surface split at a `</think>` the model QUOTED inside its answer and threw the \
+         answer away: {:?}",
+        answer_surface(&quotes_the_tag),
+    );
 
     // `num_tokens == 0` stays fatal by being empty rather than by panicking
     // here: an empty surface fails every `.contains` at the call site.

--- a/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
@@ -826,6 +826,42 @@ fn answer_surface(r: &mlx_core::engine::types::ChatResult) -> &str {
     }
 }
 
+/// Whether `haystack` states `number` as a number, rather than merely
+/// containing its digits inside a longer run.
+///
+/// `str::contains("18")` is satisfied by `318`, `1.18`, and `2018`. Over the
+/// fallback surface — the whole 500-1800 B decode, which is what the two
+/// no-committed-answer branches degrade to — that is a weak enough oracle to
+/// pass on reasoning that never reached the right total. Requiring a
+/// non-digit on both sides costs nothing and removes the whole class.
+///
+/// Deliberately only NUMERIC boundaries, not `\b`: the measured answers write
+/// `\boxed{18}`, `= 18**.` and `is 18.`, all of which must keep matching, and
+/// a full word boundary buys nothing extra here.
+///
+/// A decimal point counts as part of the number on either side, so `1.18` and
+/// `18.5` are rejected while a sentence-final `is 18.` is not. That case is
+/// not hypothetical — it is what the unit test caught in the first version of
+/// this function, which only looked at digits.
+fn states_number(haystack: &str, number: &str) -> bool {
+    haystack.match_indices(number).any(|(at, _)| {
+        let mut before = haystack[..at].chars().rev();
+        // A leading `.` only disqualifies as part of a decimal — `1.18` — so a
+        // bare `.18` is rejected too, and a sentence boundary is not.
+        let joined_left = matches!(before.next(), Some(c) if c.is_ascii_digit() || c == '.');
+
+        let mut after = haystack[at + number.len()..].chars();
+        let joined_right = match after.next() {
+            Some(c) if c.is_ascii_digit() => true,
+            // `18.5` continues; `is 18.` ends.
+            Some('.') => after.next().is_some_and(|c| c.is_ascii_digit()),
+            _ => false,
+        };
+
+        !joined_left && !joined_right
+    })
+}
+
 /// Pins [`answer_surface`] against the way it can go blind, and against the
 /// way tightening it could go wrong.
 ///
@@ -906,8 +942,55 @@ fn answer_surface_prefers_the_committed_answer() {
     );
 
     // `num_tokens == 0` stays fatal by being empty rather than by panicking
-    // here: an empty surface fails every `.contains` at the call site.
+    // here: an empty surface fails every assertion at the call site.
     assert!(answer_surface(&with_raw("")).is_empty());
+}
+
+/// Pins [`states_number`], which is what the probe reads the surface WITH.
+///
+/// Matters most on the fallback surface: when no answer was committed, the
+/// oracle is the whole 500-1800 B decode, and a bare substring test over that
+/// much text is where an accidental match lives.
+#[test]
+fn states_number_rejects_digits_inside_a_longer_number() {
+    // The measured answer shapes. All five must keep matching, or the
+    // tightening has broken a correct run instead of a wrong one.
+    for good in [
+        "The sum of amber (7) and cobalt (11) is **7 + 11 = 18**. \n\n**Answer:** \\boxed{18}",
+        "The sum of amber (7) and cobalt (11) is 7 + 11 = 18. \n\n**Answer:** \\boxed{18}",
+        "the answer is 18",
+        "18",
+        "(18)",
+    ] {
+        assert!(states_number(good, "18"), "rejected a stated 18: {good:?}");
+    }
+
+    // THE MUTATION THIS EXISTS FOR: digits of 18 inside a longer number.
+    for bad in [
+        "318",
+        "1.18",
+        ".18",
+        "2018",
+        "180",
+        "18.5 is not it",
+        "x=118",
+    ] {
+        assert!(!states_number(bad, "18"), "accepted a non-answer: {bad:?}");
+    }
+
+    // A wrong total that merely contains the right digits is now rejected,
+    // which is the whole point over the fallback surface.
+    assert!(!states_number("the total is 3118", "18"));
+    // …but a wrong total sitting NEXT to a correct statement still passes, and
+    // that is fine: the probe asks whether the number was stated, not whether
+    // the model also said other things.
+    assert!(states_number("first I get 318, correcting to 18", "18"));
+
+    // Multi-occurrence: one standalone hit anywhere is enough.
+    assert!(states_number("318 ... 18", "18"));
+    // Single digits get the same treatment — turn 1 asserts on "7".
+    assert!(states_number("amber is 7.", "7"));
+    assert!(!states_number("amber is 77.", "7"));
 }
 
 /// Memory-probe config: budget 128 force-closes a looping `<think>`;
@@ -971,7 +1054,7 @@ async fn lfm2_paged_delta_memory_probe_parity() {
         r1_paged.cached_tokens, r1_paged.finish_reason, r1_paged.text,
     );
     assert!(
-        answer_surface(&r1_paged).contains('7'),
+        states_number(answer_surface(&r1_paged), "7"),
         "paged turn 1 could not even recall the just-planted value: {:?}",
         r1_paged.raw_text,
     );
@@ -1058,14 +1141,14 @@ async fn lfm2_paged_delta_memory_probe_parity() {
     // pre-fix corrupted continuation (empty flat attention KV) cannot
     // produce it.
     assert!(
-        answer_surface(&r2_paged).contains("18"),
+        states_number(answer_surface(&r2_paged), "18"),
         "paged delta turn 2 lost the turn-1 context: expected the sum 18 in {:?}",
         r2_paged.raw_text,
     );
     // Answer-level parity with the forced-flat control (byte parity is
     // pinned at short lengths by tests (a)/(c) — see the header).
     assert!(
-        answer_surface(&r2_flat).contains("18"),
+        states_number(answer_surface(&r2_flat), "18"),
         "flat control turn 2 disagrees with the paged answer (expected 18) on the SAME \
          context: finish={} num_tokens={} raw_text={:?}",
         r2_flat.finish_reason,
@@ -1111,12 +1194,12 @@ async fn lfm2_paged_delta_memory_probe_parity() {
         r3_paged.cached_tokens,
     );
     assert!(
-        answer_surface(&r3_paged).contains("31"),
+        states_number(answer_surface(&r3_paged), "31"),
         "paged delta turn 3 lost accumulated context: expected the sum 31 in {:?}",
         r3_paged.raw_text,
     );
     assert!(
-        answer_surface(&r3_flat).contains("31"),
+        states_number(answer_surface(&r3_flat), "31"),
         "flat control turn 3 disagrees with the paged answer (expected 31) on the SAME \
          context: finish={} num_tokens={} raw_text={:?}",
         r3_flat.finish_reason,
@@ -1128,6 +1211,111 @@ async fn lfm2_paged_delta_memory_probe_parity() {
         "[PASS] lfm2 paged-delta memory probe: paged answers correct (18, 31), flat control \
          agrees; paged cached {} -> {}",
         r2_paged.cached_tokens, r3_paged.cached_tokens,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test (d2): the same memory probe driven entirely on the FLAT path, through
+// `chat_session_continue`.
+//
+// THE COVERAGE HOLE THIS FILLS. Test (d) above rebuilds its flat control with
+// `chat_session_start` — deliberately, because two independent greedy decodes
+// diverge on this checkpoint and made the comparison a second lottery rather
+// than a control. The side effect is that (d) no longer drives the flat
+// warm-continue path with a CONTENT-sensitive prompt. What remains is test (c),
+// which does exercise flat `chat_session_continue` but asserts flat == paged on
+// "Say hi in one short word." — a prompt whose answer does not depend on turn-1
+// context, so a regression that corrupted flat continuation in the same way on
+// both arms would satisfy it.
+//
+// This closes that with a SINGLE-ARM content assertion: the flat path alone
+// must still derive 18 and 31 from context it can only have through its live
+// conv + attention caches. No cross-arm comparison, so no greedy lottery; no
+// finish_reason, num_tokens, or byte-equality assertion, so nothing here varies
+// with the runner. Same oracle as (d) — see [`answer_surface`].
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "needs MLX_TEST_MODEL_PATH pointing to a real LFM2 checkpoint"]
+async fn lfm2_flat_delta_memory_probe_content() {
+    let Some(src) = resolve_source_model() else {
+        return;
+    };
+
+    let flat_dir = match clone_model_dir(&src, "lfm2-flat-memprobe-cont", false) {
+        Ok(p) => p,
+        Err(e) => panic!("failed to clone model dir for flat path: {e}"),
+    };
+    let flat_model = Lfm2Model::load_from_dir(&flat_dir.to_string_lossy())
+        .await
+        .expect("failed to load flat-path LFM2 model");
+
+    let r1 = flat_model
+        .chat_session_start(
+            vec![user_message(
+                "Here are values to remember: amber = 7 and cobalt = 11. What is amber?",
+            )],
+            Some(memory_probe_chat_config()),
+        )
+        .await
+        .expect("flat turn 1 chat_session_start failed");
+    eprintln!(
+        "[flat-mem-probe] turn1: finish={} text={:?}",
+        r1.finish_reason, r1.text,
+    );
+
+    let r2 = flat_model
+        .chat_session_continue(
+            "Add amber and cobalt together. What is the sum?".to_string(),
+            None,
+            None,
+            Some(memory_probe_chat_config()),
+        )
+        .await
+        .expect("flat turn 2 chat_session_continue failed");
+    eprintln!(
+        "[flat-mem-probe] turn2: cached={} text={:?}",
+        r2.cached_tokens, r2.text,
+    );
+    assert!(
+        states_number(answer_surface(&r2), "18"),
+        "flat warm-continue turn 2 lost the turn-1 context: expected the sum 18 in {:?}",
+        r2.raw_text,
+    );
+
+    let r3 = flat_model
+        .chat_session_continue(
+            "One more value: jade = 13. What is amber + cobalt + jade in total?".to_string(),
+            None,
+            None,
+            Some(memory_probe_chat_config()),
+        )
+        .await
+        .expect("flat turn 3 chat_session_continue failed");
+    eprintln!(
+        "[flat-mem-probe] turn3: cached={} text={:?}",
+        r3.cached_tokens, r3.text,
+    );
+    assert!(
+        states_number(answer_surface(&r3), "31"),
+        "flat warm-continue turn 3 lost accumulated context: expected the sum 31 in {:?}",
+        r3.raw_text,
+    );
+
+    // Reachability: a 0 here would mean the "continue" turns silently
+    // re-prefilled from scratch, in which case the answers above prove nothing
+    // about the flat caches this test exists to exercise.
+    assert!(
+        r2.cached_tokens > 0 && r3.cached_tokens > r2.cached_tokens,
+        "flat deltas did not warm-continue (cached {} -> {}); the content assertions above did \
+         not exercise the live flat conv + attention caches",
+        r2.cached_tokens,
+        r3.cached_tokens,
+    );
+
+    eprintln!(
+        "[PASS] lfm2 FLAT warm-continue memory probe: answers correct (18, 31); cached {} -> {}",
+        r2.cached_tokens, r3.cached_tokens,
     );
 }
 

--- a/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
@@ -787,12 +787,109 @@ async fn lfm2_paged_vs_flat_prefix_reuse_parity() {
 /// this test exists to check — so asserting on `text` makes the probe fail for
 /// a reason unrelated to what it guards.
 ///
-/// `raw_text` is the verbatim decode here: `include_reasoning: Some(true)`
-/// makes `raw_text_with_reasoning_suppressed` (`finalize.rs:166-169`) return
-/// the generation unmodified. It is empty ONLY when `num_tokens == 0`, which
-/// IS a real failure and stays fatal.
+/// It must ALSO not be the whole `raw_text`. That is the verbatim decode here
+/// (`include_reasoning: Some(true)` makes `raw_text_with_reasoning_suppressed`
+/// at `finalize.rs:166-169` return the generation unmodified), so it carries
+/// the chain of thought — and the chain of thought is where the model does its
+/// arithmetic out loud. A `.contains("18")` over the whole decode therefore
+/// passes on a turn that *computes* 18 mid-`<think>` and then concludes with
+/// something else, and it passes on an incidental "18" anywhere in a 500-1800
+/// byte ramble. Measured spans on this checkpoint: `raw_text` 501-1817 B
+/// against a 77-125 B answer, i.e. up to 23x more text to match by accident.
+///
+/// So: assert against the span AFTER the final `</think>`, which is the answer
+/// the model actually commits to, and fall back to the whole decode only when
+/// that span is empty — which is exactly branches (A) and (B) above, where
+/// there is no committed answer to read and the verbatim decode is all the
+/// evidence that exists. `raw_text` is empty ONLY when `num_tokens == 0`,
+/// which IS a real failure and stays fatal.
+///
+/// Measured on real weights (all five probe call sites, one run): every turn
+/// emitted a literal `</think>` with a 77-125 B answer after it, and every
+/// answer stated the number — `\boxed{7}`, `\boxed{18}`, `\boxed{31}`. The
+/// tightened surface is what the assertions actually read; the fallback did
+/// not fire. See [`answer_surface_prefers_the_committed_answer`] for the
+/// masking case this closes.
 fn answer_surface(r: &mlx_core::engine::types::ChatResult) -> &str {
-    &r.raw_text
+    match r.raw_text.rsplit_once("</think>") {
+        Some((_, after)) if !after.trim().is_empty() => after,
+        _ => &r.raw_text,
+    }
+}
+
+/// Pins [`answer_surface`] against the way it can go blind, and against the
+/// way tightening it could go wrong.
+///
+/// Deliberately NOT `#[ignore]`d: it is pure string handling, needs no
+/// checkpoint and no Metal, and so runs on the ordinary `cargo test` leg. The
+/// e2e leg is opt-in on PRs, which would make the e2e run the only guard —
+/// and this repo's recurring defect is a gate that is green because it never
+/// executed.
+///
+/// The `raw_text` bodies are abbreviated from a real measured run; the shapes
+/// (a `<think>` that does the arithmetic out loud, then a `\boxed{}` answer)
+/// are verbatim.
+#[test]
+fn answer_surface_prefers_the_committed_answer() {
+    fn with_raw(raw: &str) -> mlx_core::engine::types::ChatResult {
+        mlx_core::engine::types::ChatResult {
+            text: String::new(),
+            tool_calls: Vec::new(),
+            thinking: None,
+            num_tokens: 1,
+            prompt_tokens: 0,
+            reasoning_tokens: 0,
+            finish_reason: "stop".to_string(),
+            raw_text: raw.to_string(),
+            cached_tokens: 0,
+            performance: None,
+        }
+    }
+
+    // THE MUTATION THIS EXISTS FOR. Reasoning reaches 18, the committed answer
+    // says 19. Against the whole decode `.contains("18")` passes and the probe
+    // reports a correct answer that was never given; against the committed
+    // span it fails, which is the point.
+    let masked = with_raw("<think> 7 + 11 = 18, so the sum is 18.</think>\n\n**Answer:** 19");
+    assert!(
+        masked.raw_text.contains("18"),
+        "fixture is wrong: the whole decode must contain the masked number, or this test \
+         proves nothing about the surface"
+    );
+    assert!(
+        !answer_surface(&masked).contains("18"),
+        "answer_surface let a number that appears only in the reasoning satisfy the probe: {:?}",
+        answer_surface(&masked),
+    );
+    assert!(answer_surface(&masked).contains("19"));
+
+    // The measured happy shape: the answer span carries the number.
+    let good = with_raw(
+        "<think> amber is 7, cobalt is 11, so 7 + 11 = 18. But let</think>\n\nThe sum of amber \
+         (7) and cobalt (11) is **7 + 11 = 18**. \n\n**Answer:** \\boxed{18}",
+    );
+    assert!(answer_surface(&good).contains("18"));
+
+    // Branch (A): the turn never emitted `</think>` (a length exit mid-think —
+    // observed in CI as `num_tokens=512 finish=length`). There is no committed
+    // answer, so the verbatim decode is all the evidence there is.
+    let no_close = with_raw("<think> amber is 7 and cobalt is 11, so the sum is 18");
+    assert_eq!(answer_surface(&no_close), no_close.raw_text);
+
+    // Branch (B): `</think>` present but the turn stopped right after it.
+    let empty_tail = with_raw("<think> the sum is 18</think>\n  \n");
+    assert_eq!(answer_surface(&empty_tail), empty_tail.raw_text);
+
+    // A `<think>` that reopens: the LAST close is the one that bounds the
+    // answer. `rsplit_once` is what makes this hold — `split_once` would take
+    // the first close and hand back the second think block as the "answer".
+    let reopened =
+        with_raw("<think> 18</think> draft\n<think> on reflection, 31</think>\n\nAnswer: 31");
+    assert_eq!(answer_surface(&reopened).trim(), "Answer: 31");
+
+    // `num_tokens == 0` stays fatal by being empty rather than by panicking
+    // here: an empty surface fails every `.contains` at the call site.
+    assert!(answer_surface(&with_raw("")).is_empty());
 }
 
 /// Memory-probe config: budget 128 force-closes a looping `<think>`;
@@ -894,21 +991,18 @@ async fn lfm2_paged_delta_memory_probe_parity() {
     // agreement only (see the header). Same idiom as
     // `lfm2_paged_prefill_bridge_cache_hit_ab_probe` below.
     //
-    // The token-level gap stays at that ONE token only while the turn ends on
-    // `stop`: the dropped token is then `<|im_end|>`, which `raw_text` never
-    // contained (it decodes with `skip_special_tokens`). On a `length` exit the
-    // dropped token is a real word piece and `raw_text` DOES carry it, so the
-    // control would silently gain a token the paged arm never committed. Asserted
-    // rather than assumed, so that case is a diagnosable failure and not a skew.
-    assert_eq!(
-        r1_paged.finish_reason,
-        "stop",
-        "turn 1 hit the {} token cap, so the token `save_paged_history` dropped is a real word \
-         piece that `raw_text` still carries — the control below would silently gain a token the \
-         paged arm never committed. Raise max_new_tokens or shorten the prompt; do not paper over \
-         it by trimming raw_text, which is correct on the `stop` path.",
-        memory_probe_chat_config().max_new_tokens.unwrap_or(0),
-    );
+    // On a `length` exit the +1 above is a real word piece rather than
+    // `<|im_end|>`, because `save_paged_history` drops the last generated token
+    // (never forwarded through the paged decode step) while `raw_text` keeps it.
+    // NOT asserted against: whether this turn ends on `stop` or `length` is a
+    // property of the RUNNER — this machine stops at 463 tokens, CI rambles past
+    // the 512 cap on the same weights — so a `finish_reason` gate here fails the
+    // suite on hardware rather than on behaviour. It is also incoherent to police
+    // one token while accepting the 423-token strip above by design. Both are
+    // bounded and deterministic given the transcript, and neither removes a FACT
+    // the probe asks about, which is all an equivalent-information control owes.
+    // `finish_reason` is logged instead, so a cap exit is visible when reading a
+    // failure rather than silent.
     let r2_flat = flat_model
         .chat_session_start(
             vec![
@@ -963,13 +1057,8 @@ async fn lfm2_paged_delta_memory_probe_parity() {
 
     // ---- Turn 3 (DELTA): extend the context and re-derive ----
     let user3 = "One more value: jade = 13. What is amber + cobalt + jade in total?";
-    // Control over the PAGED transcript again — see the turn-2 comment, including
-    // why a `stop` exit is what keeps the dropped last token invisible.
-    assert_eq!(
-        r2_paged.finish_reason, "stop",
-        "turn 2 hit the token cap; see the turn-1 guard for why that makes the rebuilt control \
-         gain a token the paged arm never committed."
-    );
+    // Control over the PAGED transcript again — see the turn-2 comment for both
+    // known gaps and why neither is asserted against.
     let r3_flat = flat_model
         .chat_session_start(
             vec![

--- a/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
@@ -763,10 +763,43 @@ async fn lfm2_paged_vs_flat_prefix_reuse_parity() {
 // (`ContinuedLivePrefix`) and did not silently re-prefill from scratch.
 // ---------------------------------------------------------------------------
 
-/// Memory-probe config: budget 128 force-closes a looping `<think>`
-/// deterministically; max_new 512 leaves the post-`</think>` span free to
-/// state the actual number (every probe turn ends `finish=stop` well below
-/// the cap on this checkpoint).
+/// The surface a memory-probe answer is asserted against.
+///
+/// MUST NOT be `ChatResult.text`. lfm2 is `ThinkingPolicy::AlwaysOnBudgetFromEffort`,
+/// so `thinking_enabled` is ALWAYS true and
+/// `engine::finalize::parse_thinking_and_tools` routes every turn through the
+/// reasoning scrubber. That scrubber has two branches which return
+/// `text == ""` for a turn whose generation is perfectly correct:
+///
+///  (A) `finalize.rs:103-119` — no `</think>` TOKEN (id 64401) among the
+///      generated ids ⇒ `(String::new(), vec![], thinking)`, i.e. the ENTIRE
+///      output is reclassified as reasoning. Reached whenever the turn ends
+///      before the think-budget force arms (a short direct answer, or EOS on
+///      the same step that would have consumed the force — the force is gated
+///      behind `!is_terminal` at `engine/decode.rs:317`).
+///  (B) `tools/mod.rs:993-1012` — `</think>` present but `after_tag` trims to
+///      empty, i.e. the turn stopped immediately after the injected close.
+///
+/// Both are REACHABLE on this checkpoint with real weights (verified: (A)
+/// `num_tokens=512 reasoning_tokens=512 text=""` with a 2079-byte `raw_text`;
+/// (B) `num_tokens=130 reasoning_tokens=129 text=""` with a 493-byte
+/// `raw_text`). Neither says anything about cache correctness — which is all
+/// this test exists to check — so asserting on `text` makes the probe fail for
+/// a reason unrelated to what it guards.
+///
+/// `raw_text` is the verbatim decode here: `include_reasoning: Some(true)`
+/// makes `raw_text_with_reasoning_suppressed` (`finalize.rs:166-169`) return
+/// the generation unmodified. It is empty ONLY when `num_tokens == 0`, which
+/// IS a real failure and stays fatal.
+fn answer_surface(r: &mlx_core::engine::types::ChatResult) -> &str {
+    &r.raw_text
+}
+
+/// Memory-probe config: budget 128 force-closes a looping `<think>`;
+/// max_new 512 leaves the post-`</think>` span free to state the actual number.
+///
+/// NOTE: neither knob makes the ANSWER land in `ChatResult.text` — see
+/// [`answer_surface`]. The budget bounds reasoning length, nothing more.
 fn memory_probe_chat_config() -> ChatConfig {
     ChatConfig {
         cache_owner_id: None,
@@ -823,22 +856,38 @@ async fn lfm2_paged_delta_memory_probe_parity() {
         r1_flat.cached_tokens, r1_flat.text, r1_paged.cached_tokens, r1_paged.text,
     );
     assert!(
-        r1_paged.text.contains('7'),
+        answer_surface(&r1_paged).contains('7'),
         "paged turn 1 could not even recall the just-planted value: {:?}",
-        r1_paged.text,
+        r1_paged.raw_text,
     );
 
     // ---- Turn 2 (DELTA): sum of the planted values ----
     let user2 = "Add amber and cobalt together. What is the sum?";
+    // The flat CONTROL is driven over the PAGED arm's transcript, not over its
+    // own. Both arms are independent greedy decodes, and greedy trajectories on
+    // this checkpoint are hardware-dependent (a 1-ULP kernel difference flips a
+    // near-tie argmax — the file header documents one at token ~93 of turn 1).
+    // Letting each arm generate its own turn-1/turn-2 replies gave the control a
+    // DIFFERENT conversation by turn 3, so "flat says 31" was a second
+    // independent lottery rather than a control: on the CI failure that
+    // motivated this shape the arms' turn-3 prompts differed by 102 tokens.
+    // Feeding the control the paged transcript makes it answer the SAME question
+    // from the SAME context, which is what a differential control has to do.
+    // Byte-level paged-vs-flat parity — including a short DELTA turn — stays
+    // pinned by tests (a)/(a2)/(b2)/(c); this test's control exists for ANSWER
+    // agreement only (see the header). Same idiom as
+    // `lfm2_paged_prefill_bridge_cache_hit_ab_probe` below.
     let r2_flat = flat_model
-        .chat_session_continue(
-            user2.to_string(),
-            None,
-            None,
+        .chat_session_start(
+            vec![
+                user_message(prompt1),
+                assistant_message(&r1_paged.raw_text),
+                user_message(user2),
+            ],
             Some(memory_probe_chat_config()),
         )
         .await
-        .expect("turn 2 flat chat_session_continue failed");
+        .expect("turn 2 flat control chat_session_start failed");
     let r2_paged = paged_model
         .chat_session_continue(
             user2.to_string(),
@@ -865,29 +914,37 @@ async fn lfm2_paged_delta_memory_probe_parity() {
     // pre-fix corrupted continuation (empty flat attention KV) cannot
     // produce it.
     assert!(
-        r2_paged.text.contains("18"),
+        answer_surface(&r2_paged).contains("18"),
         "paged delta turn 2 lost the turn-1 context: expected the sum 18 in {:?}",
-        r2_paged.text,
+        r2_paged.raw_text,
     );
     // Answer-level parity with the forced-flat control (byte parity is
     // pinned at short lengths by tests (a)/(c) — see the header).
     assert!(
-        r2_flat.text.contains("18"),
-        "flat control turn 2 disagrees with the paged answer (expected 18): {:?}",
-        r2_flat.text,
+        answer_surface(&r2_flat).contains("18"),
+        "flat control turn 2 disagrees with the paged answer (expected 18) on the SAME \
+         context: finish={} num_tokens={} raw_text={:?}",
+        r2_flat.finish_reason,
+        r2_flat.num_tokens,
+        r2_flat.raw_text,
     );
 
     // ---- Turn 3 (DELTA): extend the context and re-derive ----
     let user3 = "One more value: jade = 13. What is amber + cobalt + jade in total?";
+    // Control over the PAGED transcript again — see the turn-2 comment.
     let r3_flat = flat_model
-        .chat_session_continue(
-            user3.to_string(),
-            None,
-            None,
+        .chat_session_start(
+            vec![
+                user_message(prompt1),
+                assistant_message(&r1_paged.raw_text),
+                user_message(user2),
+                assistant_message(&r2_paged.raw_text),
+                user_message(user3),
+            ],
             Some(memory_probe_chat_config()),
         )
         .await
-        .expect("turn 3 flat chat_session_continue failed");
+        .expect("turn 3 flat control chat_session_start failed");
     let r3_paged = paged_model
         .chat_session_continue(
             user3.to_string(),
@@ -909,14 +966,17 @@ async fn lfm2_paged_delta_memory_probe_parity() {
         r3_paged.cached_tokens,
     );
     assert!(
-        r3_paged.text.contains("31"),
+        answer_surface(&r3_paged).contains("31"),
         "paged delta turn 3 lost accumulated context: expected the sum 31 in {:?}",
-        r3_paged.text,
+        r3_paged.raw_text,
     );
     assert!(
-        r3_flat.text.contains("31"),
-        "flat control turn 3 disagrees with the paged answer (expected 31): {:?}",
-        r3_flat.text,
+        answer_surface(&r3_flat).contains("31"),
+        "flat control turn 3 disagrees with the paged answer (expected 31) on the SAME \
+         context: finish={} num_tokens={} raw_text={:?}",
+        r3_flat.finish_reason,
+        r3_flat.num_tokens,
+        r3_flat.raw_text,
     );
 
     eprintln!(

--- a/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
@@ -846,9 +846,16 @@ fn answer_surface(r: &mlx_core::engine::types::ChatResult) -> &str {
 fn states_number(haystack: &str, number: &str) -> bool {
     haystack.match_indices(number).any(|(at, _)| {
         let mut before = haystack[..at].chars().rev();
-        // A leading `.` only disqualifies as part of a decimal — `1.18` — so a
-        // bare `.18` is rejected too, and a sentence boundary is not.
-        let joined_left = matches!(before.next(), Some(c) if c.is_ascii_digit() || c == '.');
+        // `.` and `-` are part of the literal when DIRECTLY attached: `1.18` is
+        // a decimal and `-18` is a negative, and neither states 18. A bare
+        // `.18` is rejected for the same reason; a sentence boundary is not.
+        //
+        // Attachment is what makes this safe to tighten. `31 - 18 = 13` and a
+        // markdown `- 18` both keep a space before the digits, so they still
+        // count — only a sign glued to the number is treated as part of it.
+        // `+18` is deliberately absent: it is still positive 18.
+        let joined_left =
+            matches!(before.next(), Some(c) if c.is_ascii_digit() || c == '.' || c == '-');
 
         let mut after = haystack[at + number.len()..].chars();
         let joined_right = match after.next() {
@@ -974,9 +981,26 @@ fn states_number_rejects_digits_inside_a_longer_number() {
         "180",
         "18.5 is not it",
         "x=118",
+        // NEGATIVES. A corrupted turn that concludes `-18` is mathematically
+        // wrong — 7 + 11 is not -18 — and a sign glued to the digits used to
+        // read as a clean boundary, so the oracle accepted it.
+        "-18",
+        "the sum is -18",
+        "**Answer:** \\boxed{-18}",
+        "17-18",
     ] {
         assert!(!states_number(bad, "18"), "accepted a non-answer: {bad:?}");
     }
+    assert!(!states_number("\\boxed{-31}", "31"));
+    assert!(!states_number("amber is -7", "7"));
+
+    // Over-correction guard on the minus rule: only a sign ATTACHED to the
+    // digits disqualifies. A subtraction and a markdown bullet both keep a
+    // space, and both still state the number.
+    assert!(states_number("31 - 18 = 13", "18"));
+    assert!(states_number("- 18", "18"));
+    // `+18` is still positive 18.
+    assert!(states_number("+18", "18"));
 
     // A wrong total that merely contains the right digits is now rejected,
     // which is the whole point over the fallback surface.

--- a/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/lfm2_paged_vs_flat_parity.rs
@@ -837,13 +837,13 @@ async fn lfm2_paged_delta_memory_probe_parity() {
     // checkpoint over-thinks meta-instructions and drags them into later
     // turns, poisoning the arithmetic probes.
     let prompt1 = "Here are values to remember: amber = 7 and cobalt = 11. What is amber?";
-    let r1_flat = flat_model
-        .chat_session_start(
-            vec![user_message(prompt1)],
-            Some(memory_probe_chat_config()),
-        )
-        .await
-        .expect("turn 1 flat chat_session_start failed");
+    // No flat turn 1. Once the control is rebuilt from the paged transcript
+    // below, a flat turn 1 is a 2.9s decode (of a 12s test) whose output and
+    // session state are both discarded — A/B'd: the turn-2 and turn-3 controls
+    // come out byte-identical with and without it, at `cached_tokens=0` either
+    // way, because a fresh `chat_session_start` prompt does not prefix-match
+    // the abandoned turn-1 history. It only adds a surface on which an
+    // unrelated inference error can fail the gate.
     let r1_paged = paged_model
         .chat_session_start(
             vec![user_message(prompt1)],
@@ -852,8 +852,8 @@ async fn lfm2_paged_delta_memory_probe_parity() {
         .await
         .expect("turn 1 paged chat_session_start failed");
     eprintln!(
-        "[mem-probe] turn1: flat cached={} text={:?} | paged cached={} text={:?}",
-        r1_flat.cached_tokens, r1_flat.text, r1_paged.cached_tokens, r1_paged.text,
+        "[mem-probe] turn1: paged cached={} finish={} text={:?}",
+        r1_paged.cached_tokens, r1_paged.finish_reason, r1_paged.text,
     );
     assert!(
         answer_surface(&r1_paged).contains('7'),
@@ -871,12 +871,44 @@ async fn lfm2_paged_delta_memory_probe_parity() {
     // DIFFERENT conversation by turn 3, so "flat says 31" was a second
     // independent lottery rather than a control: on the CI failure that
     // motivated this shape the arms' turn-3 prompts differed by 102 tokens.
-    // Feeding the control the paged transcript makes it answer the SAME question
-    // from the SAME context, which is what a differential control has to do.
+    //
+    // It is an EQUIVALENT-INFORMATION control, NOT a same-context one, and the
+    // difference is measurable. Two known, DETERMINISTIC gaps — neither of which
+    // reintroduces the compounding lottery above, since both are fixed given the
+    // paged transcript:
+    //
+    //  - +1 token on this turn: `save_paged_history` drops the last generated
+    //    token (it is never forwarded through the paged decode step, so keeping
+    //    it would desync the KV), while the jinja template re-emits the
+    //    `<|im_end|>` the paged delta builder never re-renders.
+    //  - -423 tokens on turn 3: `chat_template.jinja` defaults
+    //    `keep_past_thinking` to false and strips `content.split("</think>")[-1]`
+    //    from every assistant that is not the LAST one. So a rebuilt turn-3
+    //    prompt loses this turn's reasoning entirely (1817 B -> 125 B measured),
+    //    where the paged arm keeps it in KV. The control still carries every
+    //    FACT the probe asks about — the values live in the user turns and in
+    //    the post-`</think>` answer — which is what "answer agreement" needs.
+    //
     // Byte-level paged-vs-flat parity — including a short DELTA turn — stays
     // pinned by tests (a)/(a2)/(b2)/(c); this test's control exists for ANSWER
     // agreement only (see the header). Same idiom as
     // `lfm2_paged_prefill_bridge_cache_hit_ab_probe` below.
+    //
+    // The token-level gap stays at that ONE token only while the turn ends on
+    // `stop`: the dropped token is then `<|im_end|>`, which `raw_text` never
+    // contained (it decodes with `skip_special_tokens`). On a `length` exit the
+    // dropped token is a real word piece and `raw_text` DOES carry it, so the
+    // control would silently gain a token the paged arm never committed. Asserted
+    // rather than assumed, so that case is a diagnosable failure and not a skew.
+    assert_eq!(
+        r1_paged.finish_reason,
+        "stop",
+        "turn 1 hit the {} token cap, so the token `save_paged_history` dropped is a real word \
+         piece that `raw_text` still carries — the control below would silently gain a token the \
+         paged arm never committed. Raise max_new_tokens or shorten the prompt; do not paper over \
+         it by trimming raw_text, which is correct on the `stop` path.",
+        memory_probe_chat_config().max_new_tokens.unwrap_or(0),
+    );
     let r2_flat = flat_model
         .chat_session_start(
             vec![
@@ -931,7 +963,13 @@ async fn lfm2_paged_delta_memory_probe_parity() {
 
     // ---- Turn 3 (DELTA): extend the context and re-derive ----
     let user3 = "One more value: jade = 13. What is amber + cobalt + jade in total?";
-    // Control over the PAGED transcript again — see the turn-2 comment.
+    // Control over the PAGED transcript again — see the turn-2 comment, including
+    // why a `stop` exit is what keeps the dropped last token invisible.
+    assert_eq!(
+        r2_paged.finish_reason, "stop",
+        "turn 2 hit the token cap; see the turn-1 guard for why that makes the rebuilt control \
+         gain a token the paged arm never committed."
+    );
     let r3_flat = flat_model
         .chat_session_start(
             vec![

--- a/crates/mlx-core/tests/lfm2_session.rs
+++ b/crates/mlx-core/tests/lfm2_session.rs
@@ -304,6 +304,7 @@ async fn lfm2_stream_session_path_keeps_ttft_flat_across_turns() {
     struct TurnSnapshot {
         ttft_ms: f64,
         prompt_tokens: u32,
+        cached_tokens: u32,
     }
 
     // --- Turn 1: chat_stream_session_start ---
@@ -318,6 +319,13 @@ async fn lfm2_stream_session_path_keeps_ttft_flat_across_turns() {
     let turn1 = TurnSnapshot {
         ttft_ms: ttft1,
         prompt_tokens: final1.prompt_tokens.unwrap_or(0),
+        // `unwrap_or` would paper over a regression that stopped populating
+        // this: `ChatStreamChunk::cached_tokens` is documented as authoritative
+        // on the terminal chunk, so a None here is a broken contract, not a
+        // zero. Every assertion below reads it.
+        cached_tokens: final1
+            .cached_tokens
+            .expect("terminal chunk must carry cached_tokens (see ChatStreamChunk docs)"),
     };
     println!(
         "stream turn 1 ttft={:.1}ms prompt_tokens={} chunks={}",
@@ -363,13 +371,25 @@ async fn lfm2_stream_session_path_keeps_ttft_flat_across_turns() {
         snapshots.push(TurnSnapshot {
             ttft_ms: ttft,
             prompt_tokens: last.prompt_tokens.unwrap_or(0),
+            cached_tokens: last
+                .cached_tokens
+                .expect("terminal chunk must carry cached_tokens (see ChatStreamChunk docs)"),
         });
+        // The other half of that contract: mid-stream chunks carry None.
+        assert!(
+            chunks[..chunks.len() - 1]
+                .iter()
+                .all(|c| c.cached_tokens.is_none()),
+            "turn {turn_idx}: a mid-stream chunk reported cached_tokens; only the terminal \
+             chunk is authoritative",
+        );
     }
 
     // --- Structural assertions ---
     assert_eq!(snapshots.len(), 4, "expected 4 stream turn snapshots");
     let turn1 = &snapshots[0];
     let turn2 = &snapshots[1];
+    let turn3 = &snapshots[2];
     let turn4 = &snapshots[3];
 
     assert!(
@@ -385,25 +405,70 @@ async fn lfm2_stream_session_path_keeps_ttft_flat_across_turns() {
         turn4.prompt_tokens
     );
 
-    let bound_vs_turn1 = turn1.ttft_ms * 1.5;
+    // The streaming delta path reuses the live KV prefix and freshly prefills
+    // ONLY the new turn's ChatML delta. Asserted on that token accounting
+    // rather than on wall-clock TTFT — the same swap the SYNC sibling in this
+    // file already made (see its comment at the `cached_tokens` block above),
+    // which this streaming twin was left out of.
+    //
+    // The TTFT ratio it replaces did not merely flake, it contradicted the
+    // architecture. lfm2 reprefills the FULL prompt through its conv layers
+    // every turn (`paged_perf_prefill_tokens`, lfm2/model.rs — the
+    // conv-state-reuse fast path is gated OFF by default), so TTFT is
+    // full-prompt scale BY DESIGN and grows with context. The CI failure that
+    // prompted this read turn2=329.1ms turn4=748.5ms, a 2.27x ratio that
+    // tracks the prompt growth between those turns: correct code failing a
+    // bound it can never satisfy. Raising the constant only postpones it.
+    //
+    // TTFT is still measured and printed above, so the perf trail stays in the
+    // CI log; it just no longer gates.
+    //
+    // `cached_tokens` is also the STRONGER signal in the other direction: a
+    // path that silently rebuilt the cache each turn could still post a fast
+    // TTFT on a fast machine, and would report cached_tokens == 0 here.
+    assert_eq!(
+        turn1.cached_tokens, 0,
+        "stream turn 1 cold-starts but reported cached_tokens={}",
+        turn1.cached_tokens
+    );
     assert!(
-        turn4.ttft_ms < bound_vs_turn1,
-        "stream delta-path TTFT regression vs turn 1: \
-         turn1={:.1}ms turn4={:.1}ms bound={:.1}ms. snapshots: {:?}",
-        turn1.ttft_ms,
-        turn4.ttft_ms,
-        bound_vs_turn1,
+        turn2.cached_tokens > 0,
+        "stream delta turn 2 reused nothing (cached_tokens=0) — the cache was rebuilt rather \
+         than continued. snapshots: {snapshots:?}",
+    );
+    assert!(
+        turn3.cached_tokens > turn2.cached_tokens,
+        "stream delta turn 3 didn't grow its reused prefix ({} -> {}). snapshots: {:?}",
+        turn2.cached_tokens,
+        turn3.cached_tokens,
+        snapshots
+    );
+    assert!(
+        turn4.cached_tokens > turn3.cached_tokens,
+        "stream delta turn 4 didn't grow its reused prefix ({} -> {}). snapshots: {:?}",
+        turn3.cached_tokens,
+        turn4.cached_tokens,
         snapshots
     );
 
-    let bound_vs_turn2 = turn2.ttft_ms * 2.0;
+    // Work per delta turn stays flat: the freshly-prefilled span is the new
+    // ChatML delta, not the whole growing history.
+    let uncached = |t: &TurnSnapshot| t.prompt_tokens.saturating_sub(t.cached_tokens);
     assert!(
-        turn4.ttft_ms < bound_vs_turn2,
-        "stream turn 4 TTFT much slower than turn 2: \
-         turn2={:.1}ms turn4={:.1}ms bound={:.1}ms. snapshots: {:?}",
-        turn2.ttft_ms,
-        turn4.ttft_ms,
-        bound_vs_turn2,
+        uncached(turn4) < turn4.cached_tokens,
+        "stream delta turn 4 prefilled more than it reused — work is not flat: prompt={} \
+         cached={} uncached={}. snapshots: {:?}",
+        turn4.prompt_tokens,
+        turn4.cached_tokens,
+        uncached(turn4),
+        snapshots
+    );
+    assert!(
+        uncached(turn4) <= uncached(turn2) * 2,
+        "stream delta turn 4's fresh prefill ({}) ballooned vs turn 2's ({}) — the delta is \
+         growing with history instead of staying the size of one turn. snapshots: {:?}",
+        uncached(turn4),
+        uncached(turn2),
         snapshots
     );
 }
@@ -913,8 +978,10 @@ async fn lfm2_stream_session_continue_rejects_images_with_restart_prefix() {
 /// Append hit: turn 2's `chat_session_start` prompt is a strict
 /// extension of turn 1's. The reported `cached_tokens` on turn 2 must
 /// be > 0 and at least cover turn 1's saved history, the reply must
-/// still terminate cleanly, and turn 2's TTFT must stay flat (<= 1.5×
-/// turn 1's) since only the delta is re-prefilled.
+/// still terminate cleanly, and only the delta may be re-prefilled —
+/// asserted as a TOKEN count, not as a TTFT bound. (This comment used to
+/// promise a `<= 1.5x turn 1` TTFT check; the assertion was already
+/// replaced with token accounting and the prose was left behind.)
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "needs MLX_TEST_LFM2_MODEL_PATH pointing to a real LFM2 checkpoint"]
 async fn lfm2_session_start_prefix_reuse_append_hit() {

--- a/packages/cli/__test__/download-retry.test.ts
+++ b/packages/cli/__test__/download-retry.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Transient-failure retry for `mlx download model`.
+ *
+ * The regression these guard: a checkpoint is tens of files and tens of
+ * gigabytes pulled from a CDN, and the downloader had NO retry at all — one
+ * 5xx anywhere in the set aborted the whole download and discarded every
+ * completed file. CI hit exactly that on the gemma4 e2e leg:
+ *
+ *   HubApiError: Api error with status 500
+ *     data: { message: 'Key service error: Timeout occurred while creating a new object' }
+ *
+ * Driven on fake timers: the real backoff sleeps 1s/2s/4s, so an exhaustion
+ * test would otherwise cost 7 seconds of wall clock to assert arithmetic.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+
+import { isRetriableFetchError, withRetries } from '../src/commands/download-model.js';
+
+/** A `HubApiError`-shaped failure: what `@huggingface/hub` actually throws. */
+function hubError(statusCode: number): Error {
+  return Object.assign(new Error(`Api error with status ${statusCode}`), { statusCode });
+}
+
+describe('isRetriableFetchError', () => {
+  it('retries what the server says is its own fault, and a rate limit', () => {
+    for (const status of [500, 502, 503, 504, 429]) {
+      expect([status, isRetriableFetchError(hubError(status))]).toEqual([status, true]);
+    }
+  });
+
+  it('does NOT retry a settled answer', () => {
+    // Repeating these only delays the message the user needs: 401/403 is a
+    // missing token or no access to a gated repo, 404 is the wrong repo or
+    // revision. None of them changes on a second ask.
+    for (const status of [400, 401, 403, 404, 416]) {
+      expect([status, isRetriableFetchError(hubError(status))]).toEqual([status, false]);
+    }
+  });
+
+  it('retries a transport failure, which carries no status at all', () => {
+    // Socket reset, DNS, TLS, timeout — `fetch` rejects with a plain Error.
+    expect(isRetriableFetchError(new Error('fetch failed'))).toBe(true);
+    expect(isRetriableFetchError(undefined)).toBe(false);
+    expect(isRetriableFetchError(null)).toBe(false);
+  });
+});
+
+describe('withRetries', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warn.mockRestore();
+  });
+
+  it('returns the first success without sleeping', async () => {
+    const attempt = vi.fn(async () => 'ok');
+    await expect(withRetries('f', attempt)).resolves.toBe('ok');
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('survives a transient 500 and returns the retry’s result', async () => {
+    // The CI failure, in one test: the first pull 500s, the second lands.
+    const attempt = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(hubError(500))
+      .mockResolvedValueOnce('/cache/blob');
+    const settled = withRetries('model.safetensors', attempt);
+    await vi.runAllTimersAsync();
+    await expect(settled).resolves.toBe('/cache/blob');
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after a bounded number of attempts rather than looping forever', async () => {
+    const attempt = vi.fn(async () => {
+      throw hubError(503);
+    });
+    const settled = withRetries('model.safetensors', attempt);
+    const assertion = expect(settled).rejects.toMatchObject({ statusCode: 503 });
+    await vi.runAllTimersAsync();
+    await assertion;
+    // Bounded: the last failure is rethrown, not swallowed into a hang.
+    expect(attempt).toHaveBeenCalledTimes(4);
+  });
+
+  it('fails a permanent error on the FIRST attempt, with no backoff', async () => {
+    // The over-correction guard. A retry loop that cannot tell 403 from 500
+    // turns "you have no access to this repo" into the same message three
+    // sleeps later, and hides it behind retry chatter.
+    const attempt = vi.fn(async () => {
+      throw hubError(403);
+    });
+    const settled = withRetries('model.safetensors', attempt);
+    // Drain any backoff this SHOULD not have scheduled. Correct code rejects
+    // before a timer exists, so this is a no-op; a version that retries 403
+    // then fails the count below in milliseconds instead of hanging until the
+    // suite timeout, which is the difference between a diagnosis and a stall.
+    void vi.runAllTimersAsync();
+    await expect(settled).rejects.toMatchObject({ statusCode: 403 });
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/__test__/download-retry.test.ts
+++ b/packages/cli/__test__/download-retry.test.ts
@@ -22,8 +22,10 @@ function hubError(statusCode: number): Error {
 }
 
 describe('isRetriableFetchError', () => {
-  it('retries what the server says is its own fault, and a rate limit', () => {
-    for (const status of [500, 502, 503, 504, 429]) {
+  it('retries what the server says is its own fault, a rate limit, and a request timeout', () => {
+    // 408 rides with 429/5xx: RFC 9110 §15.5.9 makes it transient by
+    // definition, and nothing in @huggingface/hub@2.13.2 retries it for us.
+    for (const status of [500, 502, 503, 504, 429, 408]) {
       expect([status, isRetriableFetchError(hubError(status))]).toEqual([status, true]);
     }
   });
@@ -79,10 +81,30 @@ describe('isRetriableFetchError', () => {
     expect(isRetriableFetchError('fetch failed')).toBe(true);
     expect(isRetriableFetchError('Api error with status 503. URL: https://hf.co/x')).toBe(true);
     expect(isRetriableFetchError('Api error with status 500. URL: https://hf.co/x')).toBe(true);
+    expect(isRetriableFetchError('Api error with status 408. URL: https://hf.co/x')).toBe(true);
     // …and the status is still honoured through the text, so a permanent
     // answer stays permanent even after being flattened.
     expect(isRetriableFetchError('Api error with status 403. URL: https://hf.co/x')).toBe(false);
     expect(isRetriableFetchError('Api error with status 404. URL: https://hf.co/x')).toBe(false);
+  });
+
+  it('cannot honour a status the hub client deleted, and retries instead', () => {
+    // Documents a REAL looseness rather than an aspiration. `createApiError`
+    // (@huggingface/hub@2.13.2, src/error.ts:15-26) writes the "Api error with
+    // status N" prefix and then, when the body is `application/json`, replaces
+    // the ENTIRE message with `json.error || json.message`, keeping only the
+    // `. URL: …` trailer. Combined with WebBlob/XetBlob aborting on
+    // `error.message` (a bare string), a JSON-bodied 403 on the content GET
+    // arrives with no status anywhere and takes the default-retry branch.
+    //
+    // Not fixable without pattern-matching server prose — the allowlist this
+    // predicate exists to avoid — and it errs toward retrying, which is the
+    // safe direction. Pinned so it is a known cost, not a surprise.
+    expect(isRetriableFetchError('Invalid credentials in Authorization header. URL: https://hf.co/x')).toBe(true);
+    // The same status DOES stay permanent on the error-OBJECT path, which
+    // keeps `statusCode` — so this is a property of the flattening, not of the
+    // predicate's view of 403.
+    expect(isRetriableFetchError(hubError(403))).toBe(false);
   });
 
   it('retries transport failures that are not spelled "fetch failed"', () => {

--- a/packages/cli/__test__/download-retry.test.ts
+++ b/packages/cli/__test__/download-retry.test.ts
@@ -107,6 +107,20 @@ describe('isRetriableFetchError', () => {
     expect(isRetriableFetchError(hubError(403))).toBe(false);
   });
 
+  it('does NOT retry a payload the chunk reader refuses', () => {
+    // `XetBlob` throws these from inside the chunk loop (XetBlob.ts:387,395)
+    // after part of the shard has streamed. They carry no status and no errno,
+    // so before this they took the default-retry branch and cost three more
+    // full multi-GB transfers to fail identically on the same bytes.
+    for (const text of ['Unsupported chunk version 3', 'Unsupported compression scheme ByteGroupingLZ4x']) {
+      expect([text, isRetriableFetchError(text)]).toEqual([text, false]);
+      expect([text, isRetriableFetchError(new Error(text))]).toEqual([text, false]);
+    }
+    // The over-correction guard: a TRUNCATED transfer looks similar and is the
+    // transient case this retry exists for. It must stay retriable.
+    expect(isRetriableFetchError('Failed to fetch all data for term abc123, fetched 4 bytes out of 99')).toBe(true);
+  });
+
   it('retries transport failures that are not spelled "fetch failed"', () => {
     // Naming known network errors is a trap: `fetch` rejects `TypeError: fetch
     // failed` on connect/DNS but `TypeError: terminated` on a mid-body socket
@@ -147,6 +161,59 @@ describe('withRetries', () => {
     await vi.runAllTimersAsync();
     await expect(settled).resolves.toBe('/cache/blob');
     expect(attempt).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits exactly 1s, then 2s, then 4s — not merely "some" delay', async () => {
+    // `runAllTimersAsync` drains ANY finite delay, so every other test in this
+    // file passes with `RETRY_BASE_MS = 0` (measured). That leaves the 1/2/4s
+    // schedule — the thing that stops a retry storm from amplifying the CDN
+    // failure it is reacting to — completely unguarded. This walks the clock
+    // instead, asserting no attempt fires one millisecond early.
+    const attempt = vi.fn(async () => {
+      throw hubError(503);
+    });
+    const settled = withRetries('model.safetensors', attempt);
+    const assertion = expect(settled).rejects.toMatchObject({ statusCode: 503 });
+
+    // Attempt 1 runs immediately, with no timer scheduled before it.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(attempt).toHaveBeenCalledTimes(1);
+
+    for (const [n, waitMs] of [
+      [2, 1_000],
+      [3, 2_000],
+      [4, 4_000],
+    ] as const) {
+      await vi.advanceTimersByTimeAsync(waitMs - 1);
+      expect([n, attempt.mock.calls.length]).toEqual([n, n - 1]);
+      await vi.advanceTimersByTimeAsync(1);
+      expect([n, attempt.mock.calls.length]).toEqual([n, n]);
+    }
+
+    await assertion;
+    // The pause is explained to the user with the real wait, not a guess.
+    expect(warn).toHaveBeenCalledTimes(3);
+    expect(warn.mock.calls.map((c: unknown[]) => String(c[0]))).toEqual([
+      expect.stringContaining('retry 1/3 in 1000ms'),
+      expect.stringContaining('retry 2/3 in 2000ms'),
+      expect.stringContaining('retry 3/3 in 4000ms'),
+    ]);
+  });
+
+  it('names the failure in the retry line, including a bare-string one', async () => {
+    // Regression: `reason` read `.message` off the error, which is `undefined`
+    // on a string — so the content-GET failures this whole retry exists for
+    // logged `failed (undefined)` and hid their own cause.
+    const attempt = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce('Api error with status 500. URL: https://hf.co/x')
+      .mockResolvedValueOnce('/cache/blob');
+    const settled = withRetries('model-00001-of-00009.safetensors', attempt);
+    await vi.runAllTimersAsync();
+    await expect(settled).resolves.toBe('/cache/blob');
+    const line = String(warn.mock.calls[0][0]);
+    expect(line).toContain('Api error with status 500');
+    expect(line).not.toContain('undefined');
   });
 
   it('gives up after a bounded number of attempts rather than looping forever', async () => {

--- a/packages/cli/__test__/download-retry.test.ts
+++ b/packages/cli/__test__/download-retry.test.ts
@@ -43,6 +43,56 @@ describe('isRetriableFetchError', () => {
     expect(isRetriableFetchError(undefined)).toBe(false);
     expect(isRetriableFetchError(null)).toBe(false);
   });
+
+  it('does NOT retry a local filesystem refusal', () => {
+    // `downloadFileToCacheDir` mkdirs, streams to `<blob>.incomplete`, renames
+    // and symlinks, wrapping none of it — so a full or unwritable cache volume
+    // surfaces here as a plain Error carrying a Node errno and NO status.
+    // Retrying is worse than useless: `.incomplete` is reopened with 'w' and
+    // the GET carries no Range header, so each attempt re-downloads the shard
+    // from byte 0 into the same full disk before reporting the real error.
+    for (const [code, syscall] of [
+      ['ENOSPC', 'write'],
+      ['EDQUOT', 'write'],
+      ['EACCES', 'mkdir'],
+      ['EPERM', 'rename'],
+      ['EROFS', 'mkdir'],
+    ] as const) {
+      const err = Object.assign(new Error(`${code}: failed, ${syscall}`), { code, syscall, errno: -1 });
+      expect([code, isRetriableFetchError(err)]).toEqual([code, false]);
+    }
+  });
+
+  it('still retries an errno that clears on its own', () => {
+    // The over-correction guard on the list above: "too many open files" is a
+    // transient local condition, not a refusal.
+    const err = Object.assign(new Error('EMFILE: too many open files'), { code: 'EMFILE' });
+    expect(isRetriableFetchError(err)).toBe(true);
+  });
+
+  it('retries a content-GET failure that arrives as a bare string', () => {
+    // `WebBlob.stream()` / `XetBlob.stream()` abort their writable with
+    // `error.message`, not the error — so a failure on the shard download
+    // itself reaches us with no type (measured: `typeof e === 'string'`,
+    // `e instanceof Error === false`). Reading only `Error` would refuse to
+    // retry the single case this whole retry exists for.
+    expect(isRetriableFetchError('fetch failed')).toBe(true);
+    expect(isRetriableFetchError('Api error with status 503. URL: https://hf.co/x')).toBe(true);
+    expect(isRetriableFetchError('Api error with status 500. URL: https://hf.co/x')).toBe(true);
+    // …and the status is still honoured through the text, so a permanent
+    // answer stays permanent even after being flattened.
+    expect(isRetriableFetchError('Api error with status 403. URL: https://hf.co/x')).toBe(false);
+    expect(isRetriableFetchError('Api error with status 404. URL: https://hf.co/x')).toBe(false);
+  });
+
+  it('retries transport failures that are not spelled "fetch failed"', () => {
+    // Naming known network errors is a trap: `fetch` rejects `TypeError: fetch
+    // failed` on connect/DNS but `TypeError: terminated` on a mid-body socket
+    // reset — the dominant multi-GB shard failure — and an `AbortSignal.timeout`
+    // rejection is a DOMException whose `code` is a NUMBER, not an errno.
+    expect(isRetriableFetchError(new TypeError('terminated'))).toBe(true);
+    expect(isRetriableFetchError(new DOMException('aborted due to timeout', 'TimeoutError'))).toBe(true);
+  });
 });
 
 describe('withRetries', () => {
@@ -87,6 +137,19 @@ describe('withRetries', () => {
     await assertion;
     // Bounded: the last failure is rethrown, not swallowed into a hang.
     expect(attempt).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not sleep three times before reporting a full disk', async () => {
+    // The user-visible cost of getting the predicate wrong: 7s of backoff and
+    // three more doomed multi-GB downloads before the real cause is printed.
+    const attempt = vi.fn(async () => {
+      throw Object.assign(new Error('ENOSPC: no space left on device, write'), { code: 'ENOSPC' });
+    });
+    const settled = withRetries('model-00001-of-00009.safetensors', attempt);
+    void vi.runAllTimersAsync();
+    await expect(settled).rejects.toMatchObject({ code: 'ENOSPC' });
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('fails a permanent error on the FIRST attempt, with no backoff', async () => {

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -33,6 +33,27 @@ const PERMANENT_FS_CODES = new Set([
 ]);
 
 /**
+ * Hub-client PROTOCOL refusals: the bytes arrived and the parser rejected
+ * them. `XetBlob` throws these from inside the chunk reader
+ * (`XetBlob.ts:387,395`) after part of the shard has already streamed, and
+ * they carry no status and no errno — so without this they land on the
+ * default-retry branch and cost three more full multi-GB transfers to fail
+ * identically. Deterministic in the payload, so a retry cannot change them.
+ *
+ * Deliberately NOT here: `Failed to fetch all data for term …`
+ * (`XetBlob.ts:473`), which means the transfer was TRUNCATED. That is the
+ * transient case, and it must keep retrying.
+ */
+const PERMANENT_PROTOCOL_MESSAGES = ['Unsupported chunk version', 'Unsupported compression scheme'];
+
+/** The human-readable text of a failure, whatever shape it arrived in. */
+function failureText(error: unknown): string {
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+/**
  * A hub error flattened to text; see {@link isRetriableFetchError}.
  *
  * Only matches when the failing response had a NON-JSON body. `createApiError`
@@ -91,8 +112,14 @@ function isRetriableStatus(status: number): boolean {
  * mid-body reset, and a timeout is a `DOMException` with a NUMERIC code — so an
  * allowlist of known network errors turns every unmodelled one into a hard
  * abort of a 30 GB download, which is the failure this retry exists to prevent.
- * The harm is asymmetric: retrying something hopeless costs 7 s of backoff,
- * refusing to retry something transient costs the whole download.
+ * The harm is asymmetric, but NOT as cheaply as "7 s of backoff": because each
+ * attempt truncates `<blob>.incomplete` and re-GETs without a Range header, a
+ * wrongly-retried failure also re-transfers the shard up to three more times.
+ * That is why the two categories which are deterministic AND status-less —
+ * {@link PERMANENT_FS_CODES} and {@link PERMANENT_PROTOCOL_MESSAGES} — are
+ * named explicitly instead of being left to the default. Refusing to retry
+ * something transient still costs the whole download, so everything else
+ * unmodelled keeps defaulting to retry.
  *
  * Never retried: 4xx other than 429 and 408 (401/403 is no token or no access,
  * 404 is the wrong repo or revision) and the filesystem refusals above. Those
@@ -108,11 +135,17 @@ function isRetriableStatus(status: number): boolean {
  * allowlist this function exists to avoid.
  */
 export function isRetriableFetchError(error: unknown): boolean {
+  if (typeof error !== 'string' && !(error instanceof Error)) return false;
+
+  // Checked on BOTH shapes: the chunk reader's refusals reach us as a bare
+  // string through the blob stream, but as an Error when awaited directly.
+  const text = failureText(error);
+  if (PERMANENT_PROTOCOL_MESSAGES.some((m) => text.includes(m))) return false;
+
   if (typeof error === 'string') {
     const status = FLATTENED_STATUS.exec(error);
     return status ? isRetriableStatus(Number(status[1])) : true;
   }
-  if (!(error instanceof Error)) return false;
 
   const status = (error as { statusCode?: unknown }).statusCode;
   if (typeof status === 'number') return isRetriableStatus(status);
@@ -151,11 +184,14 @@ export async function withRetries<T>(what: string, attempt: () => Promise<T>): P
     } catch (error) {
       if (n >= MAX_FETCH_ATTEMPTS || !isRetriableFetchError(error)) throw error;
       const waitMs = RETRY_BASE_MS << (n - 1);
-      // The status when there is one, else the transport error's message —
-      // never the error object itself, which stringifies to `[object Object]`
-      // and would make the one line explaining the pause useless.
+      // The status when there is one, else the failure's text — never the error
+      // object itself, which stringifies to `[object Object]` and would make the
+      // one line explaining the pause useless. `failureText` rather than
+      // `.message` because the content-GET failures this retry exists for
+      // arrive as bare STRINGS, on which `.message` is `undefined` — printing
+      // `failed (undefined)` for exactly the case that matters most.
       const status = (error as { statusCode?: unknown }).statusCode;
-      const reason = typeof status === 'number' ? `HTTP ${status}` : (error as Error).message;
+      const reason = typeof status === 'number' ? `HTTP ${status}` : failureText(error);
       console.warn(`    ${what} failed (${reason}); retry ${n}/${MAX_FETCH_ATTEMPTS - 1} in ${waitMs}ms`);
       await new Promise((resolve) => setTimeout(resolve, waitMs));
     }

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -12,6 +12,61 @@ import { resolveHuggingFaceToken, setToken } from './hf-token.js';
 
 const DEFAULT_CACHE_DIR = join(homedir(), '.cache', 'huggingface');
 
+/** Attempts per file before a download gives up. */
+const MAX_FETCH_ATTEMPTS = 4;
+
+/** Base backoff; attempt N waits `BASE << (N - 1)` ms (1s, 2s, 4s). */
+const RETRY_BASE_MS = 1_000;
+
+/**
+ * Whether a failed fetch is worth repeating.
+ *
+ * Retries a SERVER's admission that it failed (5xx) and an explicit rate limit
+ * (429), plus a transport error, which surfaces with no status at all. Anything
+ * else — 401/403 (no token, or no access to a gated repo), 404 (wrong repo or
+ * revision) — is a settled answer, and repeating it only delays the message the
+ * user needs.
+ */
+export function isRetriableFetchError(error: unknown): boolean {
+  const status = (error as { statusCode?: unknown } | null)?.statusCode;
+  if (typeof status === 'number') return status >= 500 || status === 429;
+  // No status: a transport-level failure (socket reset, DNS, TLS, timeout).
+  return error instanceof Error;
+}
+
+/**
+ * Run `attempt`, repeating it while the failure looks transient.
+ *
+ * A checkpoint is tens of files and tens of gigabytes pulled from a CDN, so a
+ * single 5xx somewhere in the set is ordinary — and without this ONE of them
+ * aborted the whole multi-GB download, discarding every completed file. This
+ * is what CI hit:
+ *
+ *   HubApiError: Api error with status 500
+ *     data: { message: 'Key service error: Timeout occurred while creating a new object' }
+ *
+ * The retry is cheap and safe to repeat: `downloadFileToCacheDir` is
+ * content-addressed, so a re-attempt resumes from the cache rather than
+ * re-fetching what already landed.
+ */
+export async function withRetries<T>(what: string, attempt: () => Promise<T>): Promise<T> {
+  for (let n = 1; ; n++) {
+    try {
+      return await attempt();
+    } catch (error) {
+      if (n >= MAX_FETCH_ATTEMPTS || !isRetriableFetchError(error)) throw error;
+      const waitMs = RETRY_BASE_MS << (n - 1);
+      // The status when there is one, else the transport error's message —
+      // never the error object itself, which stringifies to `[object Object]`
+      // and would make the one line explaining the pause useless.
+      const status = (error as { statusCode?: unknown }).statusCode;
+      const reason = typeof status === 'number' ? `HTTP ${status}` : (error as Error).message;
+      console.warn(`    ${what} failed (${reason}); retry ${n}/${MAX_FETCH_ATTEMPTS - 1} in ${waitMs}ms`);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+  }
+}
+
 const DEFAULT_MODEL = 'Qwen/Qwen3-0.6B';
 
 function printHelp(): void {
@@ -73,7 +128,19 @@ function matchesAnyGlob(filename: string, patterns: RegExp[]): boolean {
   return patterns.some((re) => re.test(filename));
 }
 
+/**
+ * List the repo's files, retrying a transient listing failure.
+ *
+ * Retried as a WHOLE call: every accumulator below is local to one invocation,
+ * so a second attempt starts from an empty set rather than appending to a
+ * half-walked one. `listFiles` is paginated, so a 5xx can land part-way through
+ * a large repo's walk.
+ */
 async function getModelFiles(modelName: string, accessToken?: string, globPatterns?: string[]) {
+  return withRetries(`listing ${modelName}`, () => listModelFilesOnce(modelName, accessToken, globPatterns));
+}
+
+async function listModelFilesOnce(modelName: string, accessToken?: string, globPatterns?: string[]) {
   let totalSize = 0;
   const filesToDownload: ListFileEntry[] = [];
   const allFiles: ListFileEntry[] = [];
@@ -562,12 +629,14 @@ export async function run(argv: string[]) {
       );
     } else {
       console.log(`  [${i + 1}/${total}] ${file.path}${fileSizeStr ? ` (${fileSizeStr})` : ''}...`);
-      const snapshotPath = await downloadFileToCacheDir({
-        repo: { type: 'model', name: modelName },
-        path: file.path,
-        cacheDir,
-        accessToken: HUGGINGFACE_TOKEN,
-      });
+      const snapshotPath = await withRetries(file.path, () =>
+        downloadFileToCacheDir({
+          repo: { type: 'model', name: modelName },
+          path: file.path,
+          cacheDir,
+          accessToken: HUGGINGFACE_TOKEN,
+        }),
+      );
       await ensureDir(dirname(destPath));
       await copyFile(snapshotPath, destPath);
     }

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -34,11 +34,36 @@ const PERMANENT_FS_CODES = new Set([
 
 /**
  * A hub error flattened to text; see {@link isRetriableFetchError}.
+ *
+ * Only matches when the failing response had a NON-JSON body. `createApiError`
+ * (`@huggingface/hub@2.13.2`, `src/error.ts:9-26`) builds this exact prefix and
+ * then REPLACES the whole message with `json.error || json.message` whenever
+ * the response is `application/json`, keeping only a `. URL: …` trailer. The
+ * status is not recoverable from that text — it survives only on the error
+ * OBJECT, which the blob-stream path throws away. So a JSON-bodied failure on
+ * the content GET reaches the default-retry branch regardless of its status.
+ * That is a known looseness, not an oversight: it errs toward retrying, which
+ * is the safe direction here (see the harm asymmetry below).
  */
 const FLATTENED_STATUS = /^Api error with status (\d{3})\b/;
 
+/**
+ * 408 is transient by definition (RFC 9110 §15.5.9 — the server did not get a
+ * complete request in time, and "the client MAY repeat that request"), so it
+ * belongs with 429 and 5xx rather than with the settled 4xx answers.
+ *
+ * Included as hardening, not as a fix for an observed failure: nothing in
+ * `@huggingface/hub@2.13.2` filters, branches on, or internally retries 408
+ * (its only repeat-a-request logic is a one-shot 403 token refresh in
+ * `XetBlob.ts:307`), so if a CDN ever emits one it lands here and aborts a
+ * multi-GB download for free. Costs one comparison.
+ *
+ * 425 Too Early is deliberately NOT here: it requires TLS 0-RTT early data,
+ * which this client never sends. Adding it would be speculation, and the
+ * default-retry branch already covers anything unmodelled.
+ */
 function isRetriableStatus(status: number): boolean {
-  return status >= 500 || status === 429;
+  return status >= 500 || status === 429 || status === 408;
 }
 
 /**
@@ -69,9 +94,18 @@ function isRetriableStatus(status: number): boolean {
  * The harm is asymmetric: retrying something hopeless costs 7 s of backoff,
  * refusing to retry something transient costs the whole download.
  *
- * Never retried: 4xx other than 429 (401/403 is no token or no access, 404 is
- * the wrong repo or revision) and the filesystem refusals above. Those are
- * settled answers, and repeating them only buries the message the user needs.
+ * Never retried: 4xx other than 429 and 408 (401/403 is no token or no access,
+ * 404 is the wrong repo or revision) and the filesystem refusals above. Those
+ * are settled answers, and repeating them only buries the message the user
+ * needs.
+ *
+ * That last paragraph holds for the ERROR-OBJECT shape, which keeps its
+ * `statusCode`. It does NOT hold for the flattened-string shape when the
+ * response body was JSON: the hub client overwrites the message with the
+ * server's own text and the status is gone, so such a failure takes the
+ * default-retry branch whatever it was. See {@link FLATTENED_STATUS}. Closing
+ * that would mean pattern-matching human-readable server prose, which is the
+ * allowlist this function exists to avoid.
  */
 export function isRetriableFetchError(error: unknown): boolean {
   if (typeof error === 'string') {

--- a/packages/cli/src/commands/download-model.ts
+++ b/packages/cli/src/commands/download-model.ts
@@ -18,20 +18,77 @@ const MAX_FETCH_ATTEMPTS = 4;
 /** Base backoff; attempt N waits `BASE << (N - 1)` ms (1s, 2s, 4s). */
 const RETRY_BASE_MS = 1_000;
 
+/** Node errno values no retry can fix: the LOCAL filesystem said no. */
+const PERMANENT_FS_CODES = new Set([
+  'ENOSPC', // disk full
+  'EDQUOT', // over quota
+  'EACCES', // not permitted
+  'EPERM',
+  'EROFS', // read-only filesystem
+  'EISDIR',
+  'ENOTDIR',
+  'ENAMETOOLONG',
+  'EFBIG',
+  'EXDEV',
+]);
+
 /**
- * Whether a failed fetch is worth repeating.
+ * A hub error flattened to text; see {@link isRetriableFetchError}.
+ */
+const FLATTENED_STATUS = /^Api error with status (\d{3})\b/;
+
+function isRetriableStatus(status: number): boolean {
+  return status >= 500 || status === 429;
+}
+
+/**
+ * Whether a failed download step is worth repeating.
  *
- * Retries a SERVER's admission that it failed (5xx) and an explicit rate limit
- * (429), plus a transport error, which surfaces with no status at all. Anything
- * else — 401/403 (no token, or no access to a gated repo), 404 (wrong repo or
- * revision) — is a settled answer, and repeating it only delays the message the
- * user needs.
+ * Three shapes reach here, because the hub client does not normalize them:
+ *
+ *  - A `HubApiError` with a numeric `statusCode`. This is what CI hit (a 500
+ *    from the Xet CDN), thrown by `createApiError` and carried out through the
+ *    stream's async-iterator `pull`, so the object survives intact.
+ *  - A bare STRING. `WebBlob.stream()` and `XetBlob.stream()` abort their
+ *    writable with `error.message` rather than the error, so a failure on the
+ *    content GET — the multi-GB shard itself — arrives with no type at all
+ *    (verified: `typeof e === 'string'`, `e instanceof Error === false`). A
+ *    predicate that only understands `Error` refuses to retry the single most
+ *    important case, so the status is read back out of the text.
+ *  - A plain `Error` with a Node errno and no status. This is BOTH a transport
+ *    failure and a local filesystem failure, which is why the errno matters:
+ *    `downloadFileToCacheDir` mkdirs, streams to `<blob>.incomplete`, renames,
+ *    then symlinks, and wraps none of it.
+ *
+ * Unknown status-less failures default to RETRY, deliberately. The transport
+ * failure space is open-ended and library-version-dependent — `fetch` rejects
+ * `TypeError: fetch failed` on connect but `TypeError: terminated` on a
+ * mid-body reset, and a timeout is a `DOMException` with a NUMERIC code — so an
+ * allowlist of known network errors turns every unmodelled one into a hard
+ * abort of a 30 GB download, which is the failure this retry exists to prevent.
+ * The harm is asymmetric: retrying something hopeless costs 7 s of backoff,
+ * refusing to retry something transient costs the whole download.
+ *
+ * Never retried: 4xx other than 429 (401/403 is no token or no access, 404 is
+ * the wrong repo or revision) and the filesystem refusals above. Those are
+ * settled answers, and repeating them only buries the message the user needs.
  */
 export function isRetriableFetchError(error: unknown): boolean {
-  const status = (error as { statusCode?: unknown } | null)?.statusCode;
-  if (typeof status === 'number') return status >= 500 || status === 429;
-  // No status: a transport-level failure (socket reset, DNS, TLS, timeout).
-  return error instanceof Error;
+  if (typeof error === 'string') {
+    const status = FLATTENED_STATUS.exec(error);
+    return status ? isRetriableStatus(Number(status[1])) : true;
+  }
+  if (!(error instanceof Error)) return false;
+
+  const status = (error as { statusCode?: unknown }).statusCode;
+  if (typeof status === 'number') return isRetriableStatus(status);
+
+  const code = (error as NodeJS.ErrnoException).code;
+  // EMFILE/ENFILE ("too many open files") are deliberately absent: those do
+  // clear on their own, so they stay retriable.
+  if (typeof code === 'string' && PERMANENT_FS_CODES.has(code)) return false;
+
+  return true;
 }
 
 /**
@@ -45,9 +102,13 @@ export function isRetriableFetchError(error: unknown): boolean {
  *   HubApiError: Api error with status 500
  *     data: { message: 'Key service error: Timeout occurred while creating a new object' }
  *
- * The retry is cheap and safe to repeat: `downloadFileToCacheDir` is
- * content-addressed, so a re-attempt resumes from the cache rather than
- * re-fetching what already landed.
+ * Safe to repeat, but NOT free: `downloadFileToCacheDir` short-circuits on a
+ * blob that is already COMPLETE, so finished files are never re-fetched — a
+ * PARTIAL one is not resumed. It reopens `<blob>.incomplete` with `'w'`
+ * (truncating it) and re-issues the GET without a Range header, so an
+ * interrupted shard restarts from byte 0. That is what bounds the attempts at
+ * {@link MAX_FETCH_ATTEMPTS} rather than retrying indefinitely, and it is why
+ * a local disk-full failure must not be retried at all.
  */
 export async function withRetries<T>(what: string, attempt: () => Promise<T>): Promise<T> {
   for (let n = 1; ; n++) {


### PR DESCRIPTION
Both e2e failures on `main` this week, fixed at the cause. Neither needed a retry.

```
d0b608fa  qwen3_5-dense  qwen3_5_cold_tier_restart_parity
e59d78e7  lfm2           lfm2_paged_delta_memory_probe_parity   (a DOCS-ONLY commit)
```

## 1. The cold-tier gate was not flaky — it was broken

It entered the e2e leg in `d0b608fa`, and **e2e is skipped on PRs**, so it first executed on main and failed. It reproduces **4/4 locally**.

A capture turn anchors exactly ONE sidecar, at the deepest rung it reached. The fixture needs several turns to reach the frontier, so that the shallow rungs a diverged restore prompt can name actually get written. That held for free while the walk stopped wherever the writer queue refused (~12 blocks). `1faa7154` replaced that with a real policy — 128 blocks / 250 ms — in the same PR, and 128 never binds on a 1259-token prompt:

```
cold_capture_walk blocks=80 enqueued=80 stop=end elapsed_ms=119.775
                                        ^^^^^^^^ ran out of PROMPT, not budget
```

At 1.5 ms/block a machine has to be **2.1× slower** for this to pass. That was the whole pass/fail axis.

Pinned to 12 blocks / 60 s. The deadline is not a lengthened timeout — with the block budget below the prompt's block count the walk stops on `Budget` every time, which removes the clock from the outcome rather than making it less likely to matter.

```
before   warm-up 2 cached=1248 (deepest rung)   restore anchored at 0     FAIL
after    warm-up 2 cached=64                    restore anchored at 304   ok   (4/4)
```

Added the invariant that silently rotted, so this cannot recur quietly. Restoring the 128 default now fails as *"FIXTURE, not a product fault: 3 capture turn(s) × 128 blocks × 16 tok = 6144 tok of reach, which covers this prompt's deepest ladder rung"* — instead of "cold restore did not engage", which pointed the reader at the restore path for a fixture fault.

Two counters that misled the diagnosis, noted in the commit for the next reader: `installed` is a **restore-side** counter (so `installed=1` was instance 1 loading its own sidecar, and said nothing about durability), and `restore_suppressed` has exactly one production site which is **gemma4-only**. The drain barrier is sound.

## 2. The lfm2 probe had an unstable oracle

The arm under test was correct; the control failed for reasons unrelated to caching.

`ChatResult.text` is not the generation — it is the post-`</think>` remainder, and two scrubber branches return `""` for a perfectly correct turn. Both reproduce on this checkpoint with real weights (`num_tokens=512 reasoning_tokens=512 text=""` beside a 2079-byte `raw_text`). The old comment claimed the 128-token budget "force-closes a looping `<think>` deterministically"; it does not — the force is gated behind `!is_terminal`, so an EOS on the consuming step drops it.

Assertions moved to `raw_text` (the verbatim decode; empty only when `num_tokens == 0`, which stays fatal). And the flat arm was a *second free-running oracle*, not a control — each arm generated its own replies, so by turn 3 they were answering different conversations, 102 tokens apart on the failing run. The control now runs over the paged transcript.

Stated cost: the control no longer drives `chat_session_continue`, so it no longer exercises flat prefix reuse. That coverage is pinned byte-exactly by `lfm2_paged_vs_flat_prefix_reuse_parity` (`r2_flat.text == r2_paged.text` on a delta turn).

## Proof

| | |
|---|---|
| cold tier | 4/4 fail before, 4/4 pass after, `anchored at 304` every run |
| fixture guard | restoring 128 → the FIXTURE message, not the misleading one |
| lfm2 | full file **8 passed** |
| lfm2 still bites | `supports_delta: true → false` → *"paged delta turn 2 lost the turn-1 context: expected the sum 18"* |
| gates | `cargo fmt --check` 0, `cargo clippy -p mlx-core --all-targets -D warnings` 0 |

Carrying `model-e2e` so the legs actually run here — the gap that let this land in the first place.

## Not fixed here

Because a turn writes only the deepest rung it reaches, **no prompt shorter than `128 × block_size` = 2048 tokens ever gets a shallow rung written**, so a next prompt that diverges gets zero reuse instead of reconciling down. Same shape as the recorded gemma4 "<1024-tok prompts get ZERO reuse" gap — a design tradeoff (sidecars are 18–75 MiB), not a flake, and it deserves its own decision rather than a reactive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKtaz9j1ih1YtSPBf5TtQm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-global cold-cache initialization and CLI download behavior (retries re-fetch partial shards from byte 0); production default capture policy unchanged except new optional install APIs used by tests.
> 
> **Overview**
> Makes **cold-tier restart parity** and **LFM2 paged-delta memory** e2e gates deterministic, and adds **transient retry** for `mlx download model`.
> 
> **Cold tier:** Adds `install_cold_capture_budget` / `install_cold_cache_root` (and `installed_cold_cache_root`) so harnesses pin process-global `OnceLock` state without `setenv` on multi-threaded tokio tests. Repeat installs with the same values succeed; conflicting values and unopenable roots return `false`. The parity harness pins **12 blocks / 60s** capture budget (so one turn cannot walk the whole prompt), asserts fixture reach vs ladder depth, checks **write_errors** before restore assertions, reuses the tier root across two gates in one process (no `remove_dir_all` on the pid-scoped path), and adds unit tests for idempotent install and stable inode across double `prepare_cold_root`.
> 
> **LFM2:** Memory probe asserts on **post-`</think>`** `raw_text` via `answer_surface` and `states_number` (not empty `ChatResult.text`). Flat control is rebuilt from the **paged transcript** with `chat_session_start`; adds flat-only `chat_session_continue` probe **(d2)**. Streaming session tests gate on **`cached_tokens`** / uncached prompt growth instead of TTFT ratios.
> 
> **CLI:** `withRetries` / `isRetriableFetchError` wrap per-file and listing downloads (5xx, 429, 408, transport; not ENOSPC/403/protocol refusals), with 1s/2s/4s backoff and Vitest coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0140df624d02f6567d654a1014053342a5c0112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->