### PR TITLE
feat: add Gemma4 Unsloth tensor-class recipes

### DIFF
--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -2807,6 +2807,10 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
             }
             _ => None,
         };
+        if let Some(kind) = official_unsloth_kind {
+            validate_gemma4_official_unsloth_shapes(&converted_tensors, kind)
+                .map_err(Error::from_reason)?;
+        }
 
         if is_privacy_filter {
             // Privacy-filter has a dedicated predicate: quantize attention
@@ -4349,14 +4353,22 @@ fn is_qwen35_hybrid_checkpoint(
         && has_qwen35_hybrid_weight_shape(weight_keys)
 }
 
-/// Which fixed Unsloth tensor-class map to emit. Apple translates the source
-/// classes to MXFP4/MXFP8; DGX preserves NVFP4 and plain per-output E4M3 FP8.
+/// Which verified fixed Unsloth tensor-class map to emit.
+///
+/// The family is part of the variant so the builder cannot accidentally apply
+/// Qwen's final-eight FFN promotion to Gemma4. Apple translates the upstream
+/// NVFP4/FP8 classes to MXFP4/MXFP8; DGX preserves NVFP4 and plain per-output
+/// E4M3 FP8.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OfficialUnslothRecipeKind {
-    /// Translate the upstream NVFP4 class to MLX MXFP4 (4/32).
-    Mxfp,
-    /// Preserve the DGX NVFP4 (4/16) + plain E4M3 FP8 weight classes.
-    Nvfp4,
+    /// Qwen3.5/3.6 hybrid map, translated to MXFP4/MXFP8.
+    QwenMxfp,
+    /// Qwen3.5/3.6 hybrid map, preserving NVFP4/plain E4M3 FP8.
+    QwenNvfp4,
+    /// Gemma4 MoE map, translated to MXFP4/MXFP8.
+    Gemma4MoeMxfp,
+    /// Gemma4 MoE map, preserving NVFP4/plain E4M3 FP8.
+    Gemma4MoeNvfp4,
 }
 
 /// User-facing warning for a verified fixed Unsloth map without calibration.
@@ -4403,9 +4415,10 @@ pub(crate) fn validate_unsloth_imatrix_after_selection(
     }
     Err(
         "unsloth without --imatrix-path is supported only for a verified Qwen3.5/Qwen3.6 \
-         hybrid checkpoint using the fixed --q-mxfp or --q-mode nvfp4 class map; \
-         family/shape validation did not select a fixed map, so refusing to fall back \
-         to legacy Dynamic 2.0 without AWQ calibration"
+         hybrid or Gemma4 MoE SafeTensors checkpoint using the fixed --q-mxfp or \
+         --q-mode nvfp4 class map; family/requested-model/shape validation did not \
+         select a fixed map, so refusing to fall back to legacy Dynamic 2.0 without \
+         AWQ calibration"
             .to_string(),
     )
 }
@@ -4423,12 +4436,84 @@ pub(crate) fn select_official_unsloth_recipe(
         return None;
     }
     if quant_mxfp {
-        Some(OfficialUnslothRecipeKind::Mxfp)
+        Some(OfficialUnslothRecipeKind::QwenMxfp)
     } else if quant_mode == "nvfp4" {
-        Some(OfficialUnslothRecipeKind::Nvfp4)
+        Some(OfficialUnslothRecipeKind::QwenNvfp4)
     } else {
         None
     }
+}
+
+/// Require the post-sanitize tensor classes of the verified
+/// `unsloth/gemma-4-26B-A4B-it-NVFP4` recipe: standard attention, the dense
+/// language-model MLP, split/stacked Gemma experts, and the router.
+///
+/// Gemma4's `attention_k_eq_v` layers legitimately omit some `v_proj`
+/// tensors, so q/k/o are the mandatory attention signature and v is mapped
+/// when present.
+pub(crate) fn has_gemma4_moe_weight_shape(weight_keys: &[String]) -> bool {
+    let language_layer_keys = weight_keys.iter().filter(|key| {
+        key.strip_prefix("language_model.model.layers.")
+            .and_then(|rest| rest.split_once('.'))
+            .is_some_and(|(layer, _)| layer.parse::<usize>().is_ok_and(|layer| layer < 30))
+    });
+    let count = |suffixes: &[&str]| {
+        language_layer_keys
+            .clone()
+            .filter(|key| suffixes.iter().any(|suffix| key.ends_with(suffix)))
+            .count()
+    };
+
+    count(&[".self_attn.q_proj.weight"]) == 30
+        && count(&[".self_attn.k_proj.weight"]) == 30
+        && count(&[".self_attn.v_proj.weight"]) == 25
+        && count(&[".self_attn.o_proj.weight"]) == 30
+        && count(&[".mlp.gate_proj.weight"]) == 30
+        && count(&[".mlp.up_proj.weight"]) == 30
+        && count(&[".mlp.down_proj.weight"]) == 30
+        && count(&[".experts.switch_glu.gate_proj.weight"]) == 30
+        && count(&[".experts.switch_glu.up_proj.weight"]) == 30
+        && count(&[".experts.switch_glu.down_proj.weight"]) == 30
+        && count(&[".router.proj.weight"]) == 30
+}
+
+/// Verify the exact SafeTensors Gemma4 MoE family supported by the upstream
+/// recipe. Root config, nested text config, requested sanitizer, MoE flag, and
+/// sanitized tensor inventory must all agree. Unified/audio and text-only
+/// wrappers are intentionally not inferred from aliases: the published recipe
+/// this map mirrors is the `gemma4` conditional-generation checkpoint.
+fn is_gemma4_moe_checkpoint(
+    config: &serde_json::Value,
+    requested_model_type: Option<&str>,
+    weight_keys: &[String],
+) -> bool {
+    let config_family = config.get("model_type").and_then(|value| value.as_str());
+    let text_family = config
+        .get("text_config")
+        .and_then(|value| value.get("model_type"))
+        .and_then(|value| value.as_str());
+    let is_moe = crate::engine::persistence::get_config_bool(
+        config,
+        config.get("text_config"),
+        &["enable_moe_block"],
+        false,
+    );
+    let text_config = config.get("text_config");
+    let exact_published_shape = text_config.is_some_and(|text| {
+        text.get("num_hidden_layers").and_then(|v| v.as_i64()) == Some(30)
+            && text.get("num_experts").and_then(|v| v.as_i64()) == Some(128)
+            && text.get("hidden_size").and_then(|v| v.as_i64()) == Some(2816)
+            && text.get("intermediate_size").and_then(|v| v.as_i64()) == Some(2112)
+            && text.get("moe_intermediate_size").and_then(|v| v.as_i64()) == Some(704)
+            && text.get("attention_k_eq_v").and_then(|v| v.as_bool()) == Some(true)
+    });
+
+    config_family == Some("gemma4")
+        && text_family == Some("gemma4_text")
+        && requested_model_type == Some("gemma4")
+        && is_moe
+        && exact_published_shape
+        && has_gemma4_moe_weight_shape(weight_keys)
 }
 
 /// Select and validate the SafeTensors fixed Unsloth class map from the input
@@ -4448,25 +4533,52 @@ fn select_and_validate_official_unsloth_recipe(
     weight_keys: &[String],
 ) -> std::result::Result<Option<OfficialUnslothRecipeKind>, String> {
     let is_qwen35_hybrid = is_qwen35_hybrid_checkpoint(config, requested_model_type, weight_keys);
-    let official_kind =
-        select_official_unsloth_recipe(recipe, quant_mxfp, quant_mode, is_qwen35_hybrid);
+    let is_gemma4_moe = is_gemma4_moe_checkpoint(config, requested_model_type, weight_keys);
+    let requests_fixed_map = recipe == "unsloth" && (quant_mxfp || quant_mode == "nvfp4");
+    let config_declares_gemma4 =
+        config.get("model_type").and_then(|value| value.as_str()) == Some("gemma4");
+    let requested_gemma4 = requested_model_type == Some("gemma4");
+    if requests_fixed_map
+        && (config_declares_gemma4 || requested_gemma4)
+        && !is_gemma4_moe
+        && !is_qwen35_hybrid
+    {
+        return Err(
+            "Gemma4 fixed Unsloth map validation failed: only the verified \
+             gemma-4-26B-A4B MoE SafeTensors shape is supported, and input config, \
+             requested --model-type gemma4, MoE dimensions, and the complete sanitized \
+             180-MLP/115-attention/30-router tensor inventory must agree. Refusing to \
+             fall back to the legacy Qwen Dynamic 2.0 predicate even though an imatrix \
+             was provided."
+                .to_string(),
+        );
+    }
+    let official_kind = if is_qwen35_hybrid {
+        select_official_unsloth_recipe(recipe, quant_mxfp, quant_mode, true)
+    } else if recipe == "unsloth" && is_gemma4_moe && quant_mxfp {
+        Some(OfficialUnslothRecipeKind::Gemma4MoeMxfp)
+    } else if recipe == "unsloth" && is_gemma4_moe && quant_mode == "nvfp4" {
+        Some(OfficialUnslothRecipeKind::Gemma4MoeNvfp4)
+    } else {
+        None
+    };
     validate_unsloth_imatrix_after_selection(recipe, imatrix_path, official_kind)?;
     Ok(official_kind)
 }
 
-/// Build the fixed Unsloth tensor-class map for Qwen3.5 hybrid models.
+/// Build a verified fixed Unsloth tensor-class map.
 ///
-/// Selected for verified Qwen hybrids under either `--q-mxfp` (early FFNs use
-/// MXFP4) or `--q-mode nvfp4` (early FFNs use NVFP4). The existing
+/// Selected for verified Qwen hybrids or Gemma4 MoE SafeTensors under either
+/// `--q-mxfp` or `--q-mode nvfp4`. The existing
 /// [`build_unsloth_recipe`] remains unchanged for plain affine and as the safe
-/// fallback for non-Qwen/ambiguous inputs. AWQ pre-scaling is unchanged.
+/// fallback for unverified/ambiguous inputs. AWQ pre-scaling is unchanged.
 ///
-/// The language-model depth is inferred from the weight keys. FFNs in the final
-/// eight transformer layers use the selected high format: MXFP8 for `Mxfp`,
-/// plain per-output E4M3 FP8 for `Nvfp4`. Earlier FFNs use MXFP4 or NVFP4,
-/// respectively. Attention, GDN qkv/z/out, and lm_head use the same selected
-/// high format at every depth. Embeddings, router gates, split GDN a/b, vision,
-/// MTP, norms, and recurrent parameters remain BF16.
+/// Qwen keeps its final-eight FFN promotion. Gemma mirrors the published
+/// `unsloth/gemma-4-26B-A4B-it-NVFP4` class map instead: every language-model
+/// attention q/k/v/o projection uses the high format; every dense MLP and
+/// sanitized `experts.switch_glu` gate/up/down projection uses the low format
+/// at every depth. Gemma router, embeddings, vision/audio, norms, head, and all
+/// other tensors remain BF16.
 pub(crate) fn build_official_unsloth_recipe(
     weight_keys: &[String],
     kind: OfficialUnslothRecipeKind,
@@ -4486,6 +4598,14 @@ pub(crate) fn build_official_unsloth_recipe(
         .map(|max_layer| max_layer + 1)
         .unwrap_or(0);
     let final_eight_start = num_layers.saturating_sub(8);
+    let is_qwen = matches!(
+        kind,
+        OfficialUnslothRecipeKind::QwenMxfp | OfficialUnslothRecipeKind::QwenNvfp4
+    );
+    let use_mxfp = matches!(
+        kind,
+        OfficialUnslothRecipeKind::QwenMxfp | OfficialUnslothRecipeKind::Gemma4MoeMxfp
+    );
 
     Box::new(move |key: &str| -> QuantDecision {
         let mxfp8 = || QuantDecision::Custom {
@@ -4508,14 +4628,42 @@ pub(crate) fn build_official_unsloth_recipe(
             group_size: 16,
             mode: "nvfp4".to_string(),
         };
-        let low_ffn = || match kind {
-            OfficialUnslothRecipeKind::Mxfp => mxfp4(),
-            OfficialUnslothRecipeKind::Nvfp4 => nvfp4(),
-        };
-        let high = || match kind {
-            OfficialUnslothRecipeKind::Mxfp => mxfp8(),
-            OfficialUnslothRecipeKind::Nvfp4 => fp8_e4m3(),
-        };
+        let low_ffn = || if use_mxfp { mxfp4() } else { nvfp4() };
+        let high = || if use_mxfp { mxfp8() } else { fp8_e4m3() };
+
+        if !is_qwen {
+            // Gemma's fixed map is language-model-only. Requiring the exact
+            // post-sanitize prefix prevents identically named vision/audio
+            // projections from being swept into the recipe.
+            if !key.starts_with("language_model.model.layers.") {
+                return QuantDecision::Skip;
+            }
+            if !should_quantize(key, /* embed_quantizable */ false) || is_router_gate(key) {
+                return QuantDecision::Skip;
+            }
+
+            let is_attention = key.contains(".self_attn.q_proj")
+                || key.contains(".self_attn.k_proj")
+                || key.contains(".self_attn.v_proj")
+                || key.contains(".self_attn.o_proj");
+            if is_attention {
+                return high();
+            }
+
+            let is_dense_mlp = key.contains(".mlp.")
+                && (key.contains("gate_proj")
+                    || key.contains("up_proj")
+                    || key.contains("down_proj"));
+            let is_expert = key.contains(".experts.switch_glu.")
+                && (key.contains("gate_proj")
+                    || key.contains("up_proj")
+                    || key.contains("down_proj"));
+            if is_dense_mlp || is_expert {
+                return low_ffn();
+            }
+
+            return QuantDecision::Skip;
+        }
 
         // Fail closed for side modules and embeddings, even when a nested key
         // contains a projection name that would otherwise match below.
@@ -4572,6 +4720,69 @@ pub(crate) fn build_official_unsloth_recipe(
 
         QuantDecision::Skip
     })
+}
+
+/// Validate the physical tensor geometry of the published Gemma4 MoE class
+/// map before quantization starts. Name/config gates alone are insufficient:
+/// a wrong-rank expert or an unaligned input dimension would otherwise be
+/// silently skipped by the generic emission gate, producing a mixed checkpoint
+/// that no longer matches the claimed fixed recipe.
+fn validate_gemma4_official_unsloth_shapes(
+    weights: &HashMap<String, MxArray>,
+    kind: OfficialUnslothRecipeKind,
+) -> std::result::Result<(), String> {
+    if !matches!(
+        kind,
+        OfficialUnslothRecipeKind::Gemma4MoeMxfp | OfficialUnslothRecipeKind::Gemma4MoeNvfp4
+    ) {
+        return Ok(());
+    }
+
+    let weight_keys = weights.keys().cloned().collect::<Vec<_>>();
+    let predicate = build_official_unsloth_recipe(&weight_keys, kind);
+    let mut low_count = 0usize;
+    let mut high_count = 0usize;
+    for (key, weight) in weights {
+        let QuantDecision::Custom { mode, .. } = predicate(key) else {
+            continue;
+        };
+        let is_expert = key.contains(".experts.switch_glu.");
+        let expected_rank = if is_expert { 3 } else { 2 };
+        let rank = weight
+            .ndim()
+            .map_err(|error| format!("failed to inspect Gemma4 tensor '{key}': {error}"))?;
+        if rank != expected_rank {
+            return Err(format!(
+                "Gemma4 fixed Unsloth map tensor '{key}' must be rank {expected_rank}, got rank \
+                 {rank}; refusing to emit a partial fixed-map checkpoint"
+            ));
+        }
+        let shape = weight
+            .shape()
+            .map_err(|error| format!("failed to inspect Gemma4 tensor '{key}': {error}"))?;
+        let input_dim = *shape
+            .last()
+            .ok_or_else(|| format!("Gemma4 fixed Unsloth map tensor '{key}' has an empty shape"))?;
+        if input_dim <= 0 || input_dim % 32 != 0 {
+            return Err(format!(
+                "Gemma4 fixed Unsloth map tensor '{key}' has input dimension {input_dim}; \
+                 the verified MXFP4/NVFP4 recipe requires K % 32 == 0"
+            ));
+        }
+
+        if mode == "mxfp4" || mode == "nvfp4" {
+            low_count += 1;
+        } else if mode == "mxfp8" || mode == crate::quant::fp8_weight::FP8_E4M3_MODE {
+            high_count += 1;
+        }
+    }
+    if (low_count, high_count) != (180, 115) {
+        return Err(format!(
+            "Gemma4 fixed Unsloth map selected {low_count} low-format and {high_count} \
+             high-format tensors; expected exactly 180 MLP/expert and 115 attention tensors"
+        ));
+    }
+    Ok(())
 }
 
 /// Build the "nvidia" quantization recipe for Qwen3.5/3.6 hybrid models.
@@ -9881,7 +10092,7 @@ mod tests {
         ]);
         let weight_keys = weights.keys().cloned().collect::<Vec<_>>();
         let predicate =
-            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::Nvfp4);
+            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::QwenNvfp4);
 
         let first_overrides =
             quantize_weights_with_recipe_pub(&mut weights, 4, 16, "nvfp4", &*predicate, false)
@@ -13087,11 +13298,11 @@ mod tests {
     fn official_unsloth_selector_is_exact() {
         assert_eq!(
             select_official_unsloth_recipe("unsloth", true, "affine", true),
-            Some(OfficialUnslothRecipeKind::Mxfp)
+            Some(OfficialUnslothRecipeKind::QwenMxfp)
         );
         assert_eq!(
             select_official_unsloth_recipe("unsloth", false, "nvfp4", true),
-            Some(OfficialUnslothRecipeKind::Nvfp4)
+            Some(OfficialUnslothRecipeKind::QwenNvfp4)
         );
         assert_eq!(
             select_official_unsloth_recipe("unsloth", false, "affine", true),
@@ -13148,8 +13359,10 @@ mod tests {
         );
 
         for kind in [
-            OfficialUnslothRecipeKind::Mxfp,
-            OfficialUnslothRecipeKind::Nvfp4,
+            OfficialUnslothRecipeKind::QwenMxfp,
+            OfficialUnslothRecipeKind::QwenNvfp4,
+            OfficialUnslothRecipeKind::Gemma4MoeMxfp,
+            OfficialUnslothRecipeKind::Gemma4MoeNvfp4,
         ] {
             validate_unsloth_imatrix_after_selection("unsloth", None, Some(kind))
                 .expect("a verified fixed map may run without an imatrix");
@@ -13273,6 +13486,272 @@ mod tests {
         ));
     }
 
+    fn gemma4_moe_test_config() -> serde_json::Value {
+        serde_json::json!({
+            "model_type": "gemma4",
+            "text_config": {
+                "model_type": "gemma4_text",
+                "enable_moe_block": true,
+                "num_hidden_layers": 30,
+                "num_experts": 128,
+                "hidden_size": 2816,
+                "intermediate_size": 2112,
+                "moe_intermediate_size": 704,
+                "attention_k_eq_v": true
+            }
+        })
+    }
+
+    fn gemma4_moe_test_keys() -> Vec<String> {
+        let mut keys = Vec::new();
+        for layer in 0..30 {
+            for proj in ["gate_proj", "up_proj", "down_proj"] {
+                keys.push(format!(
+                    "language_model.model.layers.{layer}.mlp.{proj}.weight"
+                ));
+                keys.push(format!(
+                    "language_model.model.layers.{layer}.experts.switch_glu.{proj}.weight"
+                ));
+            }
+            for proj in ["q_proj", "k_proj", "o_proj"] {
+                keys.push(format!(
+                    "language_model.model.layers.{layer}.self_attn.{proj}.weight"
+                ));
+            }
+            if layer < 25 {
+                keys.push(format!(
+                    "language_model.model.layers.{layer}.self_attn.v_proj.weight"
+                ));
+            }
+            keys.push(format!(
+                "language_model.model.layers.{layer}.router.proj.weight"
+            ));
+        }
+        keys
+    }
+
+    #[test]
+    fn unsloth_gemma4_moe_selector_requires_config_requested_model_and_shape_agreement() {
+        let config = gemma4_moe_test_config();
+        let keys = gemma4_moe_test_keys();
+        assert!(has_gemma4_moe_weight_shape(&keys));
+        assert!(is_gemma4_moe_checkpoint(&config, Some("gemma4"), &keys));
+
+        assert_eq!(
+            select_and_validate_official_unsloth_recipe(
+                "unsloth",
+                None,
+                true,
+                "affine",
+                &config,
+                Some("gemma4"),
+                &keys,
+            )
+            .expect("verified Gemma4 MoE MXFP selector"),
+            Some(OfficialUnslothRecipeKind::Gemma4MoeMxfp),
+        );
+        assert_eq!(
+            select_and_validate_official_unsloth_recipe(
+                "unsloth",
+                None,
+                false,
+                "nvfp4",
+                &config,
+                Some("gemma4"),
+                &keys,
+            )
+            .expect("verified Gemma4 MoE DGX selector"),
+            Some(OfficialUnslothRecipeKind::Gemma4MoeNvfp4),
+        );
+
+        let dense_config = serde_json::json!({
+            "model_type": "gemma4",
+            "text_config": {
+                "model_type": "gemma4_text",
+                "enable_moe_block": false,
+                "num_hidden_layers": 30,
+                "num_experts": 128,
+                "hidden_size": 2816,
+                "intermediate_size": 2112,
+                "moe_intermediate_size": 704,
+                "attention_k_eq_v": true
+            }
+        });
+        let unified_config = serde_json::json!({
+            "model_type": "gemma4_unified",
+            "text_config": {
+                "model_type": "gemma4_text",
+                "enable_moe_block": true,
+                "num_hidden_layers": 30,
+                "num_experts": 128,
+                "hidden_size": 2816,
+                "intermediate_size": 2112,
+                "moe_intermediate_size": 704,
+                "attention_k_eq_v": true
+            }
+        });
+        let mut incomplete = keys.clone();
+        incomplete.retain(|key| !key.contains("experts.switch_glu.up_proj"));
+
+        for (bad_config, requested, bad_keys) in [
+            (&dense_config, Some("gemma4"), keys.as_slice()),
+            (&unified_config, Some("gemma4_unified"), keys.as_slice()),
+            (&config, Some("qwen3_5_moe"), keys.as_slice()),
+            (&config, None, keys.as_slice()),
+            (&config, Some("gemma4"), incomplete.as_slice()),
+        ] {
+            assert!(
+                !is_gemma4_moe_checkpoint(bad_config, requested, bad_keys),
+                "mismatched Gemma4 selector inputs must fail closed: \
+                 config={bad_config}, requested={requested:?}"
+            );
+            let err = select_and_validate_official_unsloth_recipe(
+                "unsloth",
+                Some("imatrix.gguf"),
+                true,
+                "affine",
+                bad_config,
+                requested,
+                bad_keys,
+            )
+            .expect_err("an imatrix must not authorize Gemma's legacy Qwen fallback");
+            assert!(
+                err.contains("Gemma4 fixed Unsloth map validation failed"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn unsloth_gemma4_moe_fixed_maps_emit_exact_upstream_module_classes() {
+        // The verified 30-layer 26B-A4B inventory has:
+        // - 90 dense MLP + 90 sanitized expert projections = 180 low modules;
+        // - q/k/o in all 30 layers + v in 25 (k_eq_v omits five) = 115 high.
+        let mut weight_keys = Vec::new();
+        for layer in 0..30 {
+            for proj in ["gate_proj", "up_proj", "down_proj"] {
+                weight_keys.push(format!(
+                    "language_model.model.layers.{layer}.mlp.{proj}.weight"
+                ));
+                weight_keys.push(format!(
+                    "language_model.model.layers.{layer}.experts.switch_glu.{proj}.weight"
+                ));
+            }
+            for proj in ["q_proj", "k_proj", "o_proj"] {
+                weight_keys.push(format!(
+                    "language_model.model.layers.{layer}.self_attn.{proj}.weight"
+                ));
+            }
+            if layer < 25 {
+                weight_keys.push(format!(
+                    "language_model.model.layers.{layer}.self_attn.v_proj.weight"
+                ));
+            }
+            weight_keys.push(format!(
+                "language_model.model.layers.{layer}.router.proj.weight"
+            ));
+            weight_keys.push(format!(
+                "language_model.model.layers.{layer}.input_layernorm.weight"
+            ));
+        }
+        weight_keys.extend(
+            [
+                "language_model.model.embed_tokens.weight",
+                "language_model.lm_head.weight",
+                "vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight",
+                "embed_vision.embedding_projection.weight",
+            ]
+            .into_iter()
+            .map(str::to_string),
+        );
+
+        for (kind, low_mode, high_mode) in [
+            (OfficialUnslothRecipeKind::Gemma4MoeMxfp, "mxfp4", "mxfp8"),
+            (
+                OfficialUnslothRecipeKind::Gemma4MoeNvfp4,
+                "nvfp4",
+                crate::quant::fp8_weight::FP8_E4M3_MODE,
+            ),
+        ] {
+            let predicate = build_official_unsloth_recipe(&weight_keys, kind);
+            let mut low = 0;
+            let mut high = 0;
+            let mut skipped = 0;
+            for key in &weight_keys {
+                match predicate(key) {
+                    QuantDecision::Custom { mode, .. } if mode == low_mode => low += 1,
+                    QuantDecision::Custom { mode, .. } if mode == high_mode => high += 1,
+                    QuantDecision::Skip => skipped += 1,
+                    other => panic!("{kind:?}: unexpected decision for {key}: {other:?}"),
+                }
+            }
+            assert_eq!(low, 180, "{kind:?}: all dense/expert MLPs stay low");
+            assert_eq!(high, 115, "{kind:?}: only q/k/v/o attention is high");
+            assert_eq!(
+                skipped, 64,
+                "{kind:?}: routers/norms/side modules stay bf16"
+            );
+
+            // Unlike Qwen, Gemma has no final-eight promotion.
+            assert!(
+                matches!(
+                    predicate("language_model.model.layers.29.mlp.down_proj.weight"),
+                    QuantDecision::Custom { mode, .. } if mode == low_mode
+                ),
+                "{kind:?}: final Gemma FFN must remain in the low class"
+            );
+        }
+    }
+
+    fn gemma4_moe_shape_test_weights() -> HashMap<String, MxArray> {
+        gemma4_moe_test_keys()
+            .into_iter()
+            .filter(|key| !key.ends_with(".router.proj.weight"))
+            .map(|key| {
+                let shape: &[i64] = if key.contains(".experts.switch_glu.") {
+                    &[2, 3, 32]
+                } else {
+                    &[3, 32]
+                };
+                (
+                    key,
+                    MxArray::zeros(shape, Some(DType::BFloat16))
+                        .expect("synthetic Gemma4 recipe weight"),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn unsloth_gemma4_moe_shape_preflight_rejects_rank_or_alignment_mismatch() {
+        for kind in [
+            OfficialUnslothRecipeKind::Gemma4MoeMxfp,
+            OfficialUnslothRecipeKind::Gemma4MoeNvfp4,
+        ] {
+            let good = gemma4_moe_shape_test_weights();
+            validate_gemma4_official_unsloth_shapes(&good, kind)
+                .expect("published Gemma4 module ranks and K alignment must pass");
+
+            let mut bad_rank = gemma4_moe_shape_test_weights();
+            bad_rank.insert(
+                "language_model.model.layers.0.experts.switch_glu.gate_proj.weight".into(),
+                MxArray::zeros(&[3, 32], Some(DType::BFloat16)).unwrap(),
+            );
+            let err = validate_gemma4_official_unsloth_shapes(&bad_rank, kind)
+                .expect_err("2-D expert storage must reject");
+            assert!(err.contains("must be rank 3"), "{err}");
+
+            let mut bad_alignment = gemma4_moe_shape_test_weights();
+            bad_alignment.insert(
+                "language_model.model.layers.0.self_attn.q_proj.weight".into(),
+                MxArray::zeros(&[3, 48], Some(DType::BFloat16)).unwrap(),
+            );
+            let err = validate_gemma4_official_unsloth_shapes(&bad_alignment, kind)
+                .expect_err("K % 32 mismatch must reject");
+            assert!(err.contains("K % 32"), "{err}");
+        }
+    }
+
     #[test]
     fn non_qwen_unsloth_mxfp_preserves_legacy_affine_only_head() {
         let is_qwen35_hybrid = is_qwen35_hybrid_checkpoint(
@@ -13313,7 +13792,7 @@ mod tests {
         .map(str::to_string)
         .collect::<Vec<_>>();
         let predicate =
-            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::Mxfp);
+            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::QwenMxfp);
 
         let mxfp4 = || QuantDecision::Custom {
             bits: 4,
@@ -13377,7 +13856,7 @@ mod tests {
         .map(str::to_string)
         .collect::<Vec<_>>();
         let predicate =
-            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::Mxfp);
+            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::QwenMxfp);
 
         for family in ["switch_mlp", "experts", "shared_expert"] {
             for suffix in ["gate_proj", "up_proj", "down_proj"] {
@@ -13427,7 +13906,7 @@ mod tests {
         .map(str::to_string)
         .collect::<Vec<_>>();
         let predicate =
-            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::Nvfp4);
+            build_official_unsloth_recipe(&weight_keys, OfficialUnslothRecipeKind::QwenNvfp4);
 
         let nvfp4 = || QuantDecision::Custom {
             bits: 4,

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -13595,7 +13595,6 @@ mod tests {
 
         for (bad_config, requested, bad_keys) in [
             (&dense_config, Some("gemma4"), keys.as_slice()),
-            (&unified_config, Some("gemma4_unified"), keys.as_slice()),
             (&config, Some("qwen3_5_moe"), keys.as_slice()),
             (&config, None, keys.as_slice()),
             (&config, Some("gemma4"), incomplete.as_slice()),
@@ -13620,6 +13619,34 @@ mod tests {
                 "unexpected error: {err}"
             );
         }
+
+        assert_eq!(
+            select_and_validate_official_unsloth_recipe(
+                "unsloth",
+                Some("imatrix.gguf"),
+                true,
+                "affine",
+                &unified_config,
+                Some("gemma4_unified"),
+                &keys,
+            )
+            .expect("calibrated Gemma4 unified must retain the legacy fallback"),
+            None,
+        );
+        let err = select_and_validate_official_unsloth_recipe(
+            "unsloth",
+            None,
+            true,
+            "affine",
+            &unified_config,
+            Some("gemma4_unified"),
+            &keys,
+        )
+        .expect_err("unverified Gemma4 unified must not bypass the no-imatrix gate");
+        assert!(
+            err.contains("family/requested-model/shape validation did not select a fixed map"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -1421,7 +1421,7 @@ fn apply_weights(
     quant_group_size: i32,
     top_level_mode: Option<PerLayerMode>,
     per_layer_quant: &HashMap<String, PerLayerQuant>,
-) -> Result<()> {
+) -> Result<u64> {
     let is_quantized = is_quantized_checkpoint(params);
     let is_mxfp8 = is_mxfp8_checkpoint(params);
     let default_mode = resolve_default_mode(top_level_mode, is_mxfp8);
@@ -1455,9 +1455,18 @@ fn apply_weights(
     // validation-scope choice on its own path (sym8 there is validated on
     // the flat path only; paged is simply unvalidated) — a rationale that
     // does not transfer here.
+    let reconstructed_fp8_weight_bytes = std::cell::Cell::new(0u64);
     let try_build_ql = |prefix: &str| -> Result<Option<super::quantized_linear::QuantizedLinear>> {
         let plq = per_layer_quant.get(prefix).copied().unwrap_or(default_plq);
-        build_gemma_ql(params, prefix, plq)
+        let quantized = build_gemma_ql(params, prefix, plq)?;
+        if let Some(linear) = quantized.as_ref() {
+            reconstructed_fp8_weight_bytes.set(
+                reconstructed_fp8_weight_bytes
+                    .get()
+                    .saturating_add(linear.reconstructed_fp8_weight_bytes()),
+            );
+        }
+        Ok(quantized)
     };
     // Helper for expert-batched (switch) quantized linears used by MoE layers.
     let try_build_qsl =
@@ -1925,7 +1934,7 @@ fn apply_weights(
     }
 
     info!("All weights applied successfully");
-    Ok(())
+    Ok(reconstructed_fp8_weight_bytes.get())
 }
 
 /// Apply vision weights to the inner model's vision tower and multimodal embedder.
@@ -2322,11 +2331,12 @@ impl Gemma4Inner {
     ///
     /// All weight loading happens synchronously (designed to run on the model thread).
     ///
-    /// Returns the constructed inner alongside a deterministic
-    /// weight-byte total (`sum(params.values().nbytes())`) for the
-    /// cache-limit coordinator. See `cache_limit.rs` module docs for
-    /// why this deterministic measurement is preferred over a
-    /// process-wide `get_active_memory()` delta.
+    /// Returns the constructed inner alongside a deterministic model-owned
+    /// weight-byte total for the cache-limit coordinator: checkpoint-backed
+    /// arrays plus any additional load-time weight reconstructions retained by
+    /// the model. See `cache_limit.rs` module docs for why this deterministic
+    /// measurement is preferred over a process-wide `get_active_memory()`
+    /// delta.
     ///
     /// `draft_model_path` optionally points at a draft checkpoint directory
     /// (DSpark or assistant — probed from its config.json) loaded alongside
@@ -2603,7 +2613,7 @@ impl Gemma4Inner {
         maybe_shard_ple_embedding(&mut inner, &mut params, path)?;
 
         // Apply weights
-        apply_weights(
+        let reconstructed_fp8_weight_bytes = apply_weights(
             &mut inner,
             &params,
             &config,
@@ -2763,15 +2773,20 @@ impl Gemma4Inner {
             inner.draft = Some(draft);
         }
 
-        // Deterministic weight-byte total for the cache-limit
-        // coordinator. Computed from the still-live `params` map
-        // before it is dropped at end-of-function.
-        // `saturating_add` guards against overflow on a corrupted
-        // checkpoint.
+        // Deterministic weight-byte total for the cache-limit coordinator.
+        // Start with the still-live checkpoint-backed `params` map before it
+        // is dropped at end-of-function, then fold in model-owned arrays that
+        // were created or moved outside that map. `saturating_add` guards
+        // against overflow on a corrupted checkpoint.
         let mut weight_bytes: u64 = params
             .values()
             .map(|a| a.nbytes() as u64)
             .fold(0u64, |acc, v| acc.saturating_add(v));
+        // Plain E4M3 linears retain their serialized Uint8 weight + scales
+        // (already counted through `params`) and also own a reconstructed BF16
+        // weight for the A16 matmul fallback. Count that additional resident
+        // array exactly once for every successfully installed linear.
+        weight_bytes = weight_bytes.saturating_add(reconstructed_fp8_weight_bytes);
         // The PLE shards were removed from `params` (their oversized source key
         // is gone) but are still model-owned resident weights. Count them too,
         // mirroring the materialize pass above; omitting their ~4GB would
@@ -4635,7 +4650,7 @@ mod tests {
         let assert_int8_rejected = |params: &HashMap<String, MxArray>, key: &str| {
             let err = match run(params) {
                 Err(e) => e,
-                Ok(()) => panic!("int8 '{key}' on a dense route must fail loud"),
+                Ok(_) => panic!("int8 '{key}' on a dense route must fail loud"),
             };
             let msg = format!("{err}");
             assert!(
@@ -4680,6 +4695,77 @@ mod tests {
         );
         params.insert("layers.0.router.proj.weight".into(), bf16_w(&[2, 16]));
         run(&params).expect("dense bf16 MoE weights must keep loading");
+    }
+
+    /// Plain E4M3 linears keep both their serialized Uint8 checkpoint tensors
+    /// and a reconstructed BF16 weight for the correctness fallback. The
+    /// loader must report the latter as an additional model-owned resident
+    /// allocation so cache-limit registration cannot over-grant the freelist.
+    #[test]
+    fn apply_weights_reports_plain_fp8_reconstruction_bytes() {
+        let config: Gemma4Config = serde_json::from_value(serde_json::json!({
+            "vocab_size": 8,
+            "hidden_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 64,
+            "intermediate_size": 64,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 64,
+            "use_block_paged_cache": false,
+        }))
+        .expect("minimal Gemma4Config");
+        let source = MxArray::from_float32(&vec![0.25f32; 64 * 64], &[64, 64])
+            .expect("from_float32")
+            .astype(DType::BFloat16)
+            .expect("bf16");
+        let expected_reconstruction_bytes = source.nbytes() as u64;
+        let (weight, scales) = crate::quant::fp8_weight::quantize_per_output_channel(
+            &source,
+            "layers.0.self_attn.q_proj",
+        )
+        .expect("plain FP8 fixture");
+        let params = HashMap::from([
+            ("layers.0.self_attn.q_proj.weight".to_string(), weight),
+            ("layers.0.self_attn.q_proj.scales".to_string(), scales),
+        ]);
+        let per_layer_quant = HashMap::from([(
+            "layers.0.self_attn.q_proj".to_string(),
+            PerLayerQuant {
+                bits: crate::quant::fp8_weight::FP8_E4M3_BITS,
+                group_size: crate::quant::fp8_weight::FP8_E4M3_GROUP_SIZE,
+                mode: PerLayerMode::Fp8E4m3,
+                input_amax: None,
+            },
+        )]);
+
+        let mut inner = Gemma4Inner::new(config.clone()).expect("Gemma4Inner::new");
+        let reported = apply_weights(&mut inner, &params, &config, 4, 64, None, &per_layer_quant)
+            .expect("plain FP8 attention must load");
+        assert_eq!(
+            reported, expected_reconstruction_bytes,
+            "apply_weights must report the model-owned BF16 reconstruction"
+        );
+
+        let dense_params =
+            HashMap::from([("layers.0.self_attn.q_proj.weight".to_string(), source)]);
+        let mut dense_inner = Gemma4Inner::new(config.clone()).expect("Gemma4Inner::new");
+        assert_eq!(
+            apply_weights(
+                &mut dense_inner,
+                &dense_params,
+                &config,
+                4,
+                64,
+                None,
+                &HashMap::new(),
+            )
+            .expect("dense attention must load"),
+            0,
+            "checkpoint-backed dense weights must not be counted as extra allocations"
+        );
     }
 
     /// A quantized `lm_head` (2-bit affine, untied) must be installed as

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -26,11 +26,12 @@ use super::model::{Gemma4Draft, Gemma4Inner, Gemma4Model, warmup_forward};
 use super::quantized_linear::{
     DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, MXFP8_BITS, MXFP8_GROUP_SIZE, MXFP8_MODE,
     PerLayerMode, PerLayerQuant, is_mxfp8_checkpoint, is_quantized_checkpoint,
-    try_build_kquant_quantized_linear, try_build_kquant_quantized_switch_linear,
-    try_build_mxfp4_quantized_linear, try_build_mxfp4_quantized_switch_linear,
-    try_build_mxfp8_quantized_linear, try_build_mxfp8_quantized_switch_linear,
-    try_build_nvfp4_quantized_linear, try_build_nvfp4_quantized_switch_linear,
-    try_build_quantized_linear, try_build_quantized_switch_linear, try_build_sym8_quantized_linear,
+    try_build_fp8_e4m3_quantized_linear, try_build_kquant_quantized_linear,
+    try_build_kquant_quantized_switch_linear, try_build_mxfp4_quantized_linear,
+    try_build_mxfp4_quantized_switch_linear, try_build_mxfp8_quantized_linear,
+    try_build_mxfp8_quantized_switch_linear, try_build_nvfp4_quantized_linear,
+    try_build_nvfp4_quantized_switch_linear, try_build_quantized_linear,
+    try_build_quantized_switch_linear, try_build_sym8_quantized_linear,
 };
 
 /// Conventional in-checkpoint location for an external Gemma4 speculative
@@ -1365,12 +1366,7 @@ fn build_gemma_ql(
         PerLayerMode::Mxfp4 => try_build_mxfp4_quantized_linear(params, prefix),
         PerLayerMode::Mxfp8 => try_build_mxfp8_quantized_linear(params, prefix),
         PerLayerMode::Nvfp4 => try_build_nvfp4_quantized_linear(params, prefix),
-        PerLayerMode::Fp8E4m3 => {
-            return Err(Error::from_reason(format!(
-                "gemma4 layer '{prefix}' resolved to fp8_e4m3, but plain per-output \
-                 E4M3 storage is supported only by Qwen3.5 DGX artifacts"
-            )));
-        }
+        PerLayerMode::Fp8E4m3 => try_build_fp8_e4m3_quantized_linear(params, prefix)?,
         PerLayerMode::Affine => {
             try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
         }
@@ -1397,7 +1393,8 @@ fn build_gemma_qsl(
         PerLayerMode::Fp8E4m3 => {
             return Err(Error::from_reason(format!(
                 "gemma4 expert layer '{prefix}' resolved to fp8_e4m3, but plain \
-                 per-output E4M3 storage is supported only by Qwen3.5 DGX artifacts"
+                 per-output E4M3 storage is supported only for 2-D attention/linear \
+                 tensors; Gemma4 experts must use the upstream NVFP4 low class"
             )));
         }
         PerLayerMode::Affine => {
@@ -5494,7 +5491,7 @@ mod tests {
     }
 
     #[test]
-    fn gemma_ql_and_qsl_reject_plain_fp8_storage_before_packed_dispatch() {
+    fn gemma_ql_accepts_plain_fp8_while_qsl_keeps_experts_fail_closed() {
         let dense_prefix = "layers.0.self_attn.q_proj";
         let dense_params = HashMap::from([
             (
@@ -5527,14 +5524,11 @@ mod tests {
             mode: PerLayerMode::Fp8E4m3,
             input_amax: None,
         };
-        let err = build_gemma_ql(&dense_params, dense_prefix, explicit_fp8)
-            .err()
-            .expect("Gemma plain-FP8 QL is unsupported");
-        assert!(
-            err.reason.contains("supported only by Qwen3.5"),
-            "{}",
-            err.reason
-        );
+        let ql = build_gemma_ql(&dense_params, dense_prefix, explicit_fp8)
+            .expect("well-formed Gemma plain-FP8 QL must load")
+            .expect("plain-FP8 sidecars must build a QL");
+        assert_eq!(ql.mode(), crate::quant::fp8_weight::FP8_E4M3_MODE);
+        assert_eq!(ql.get_weight().dtype().unwrap(), DType::Uint8);
 
         let expert_prefix = "layers.0.experts.gate_up_proj";
         let expert_params = HashMap::from([
@@ -5557,9 +5551,9 @@ mod tests {
         );
         let err = build_gemma_qsl(&expert_params, expert_prefix, explicit_fp8)
             .err()
-            .expect("Gemma plain-FP8 QSL is unsupported");
+            .expect("Gemma expert plain-FP8 QSL must remain unsupported");
         assert!(
-            err.reason.contains("supported only by Qwen3.5"),
+            err.reason.contains("experts must use the upstream NVFP4"),
             "{}",
             err.reason
         );

--- a/crates/mlx-core/src/models/gemma4/quantized_linear.rs
+++ b/crates/mlx-core/src/models/gemma4/quantized_linear.rs
@@ -833,6 +833,18 @@ impl QuantizedLinear {
         &self.mode
     }
 
+    /// Additional model-owned bytes created by the plain-E4M3 correctness
+    /// fallback and not represented by the serialized checkpoint tensors.
+    ///
+    /// The raw Uint8 weight and BF16 scales are already counted through the
+    /// loader's params map; only the reconstructed BF16 weight is extra.
+    pub(crate) fn reconstructed_fp8_weight_bytes(&self) -> u64 {
+        self.fp8_dequant_weight
+            .as_ref()
+            .map(|weight| weight.nbytes() as u64)
+            .unwrap_or(0)
+    }
+
     /// Test-scope accessor for the sym8 operands
     /// `(w_nk [N,K] checkpoint, w_kn [K,N] kernel operand, s_w [N])`.
     /// Used by the routing/parity unit tests to call the reference kernels with
@@ -876,6 +888,11 @@ mod plain_fp8_weight_tests {
             .unwrap();
         assert_eq!(ql.mode(), crate::quant::fp8_weight::FP8_E4M3_MODE);
         assert_eq!(ql.get_weight().dtype().unwrap(), DType::Uint8);
+        assert_eq!(
+            ql.reconstructed_fp8_weight_bytes(),
+            3 * 4 * std::mem::size_of::<u16>() as u64,
+            "the resident-byte delta must count the reconstructed BF16 weight"
+        );
 
         let x = MxArray::from_float32(&[1.0, -0.5, 0.25, 2.0], &[1, 4])
             .unwrap()

--- a/crates/mlx-core/src/models/gemma4/quantized_linear.rs
+++ b/crates/mlx-core/src/models/gemma4/quantized_linear.rs
@@ -378,6 +378,50 @@ pub fn try_build_nvfp4_quantized_linear(
     ))
 }
 
+/// Build the plain per-output E4M3 correctness fallback used by the fixed
+/// Gemma4 DGX attention map.
+///
+/// Storage is strict: Uint8 `[N,K]` E4M3 bytes + floating `[N,1]` dequant
+/// scales, with no affine `.biases`. The weight is reconstructed to BF16 once
+/// at load and forward uses ordinary A16 matmul. Experts deliberately do not
+/// use this path; their upstream class is NVFP4.
+pub fn try_build_fp8_e4m3_quantized_linear(
+    params: &HashMap<String, MxArray>,
+    key_prefix: &str,
+) -> Result<Option<QuantizedLinear>> {
+    let weight_key = format!("{key_prefix}.weight");
+    let scales_key = format!("{key_prefix}.scales");
+    let weight = params.get(&weight_key);
+    let scales = params.get(&scales_key);
+    let (weight, scales) = match (weight, scales) {
+        (None, None) => return Ok(None),
+        (Some(_), None) => {
+            return Err(Error::from_reason(format!(
+                "plain FP8 layer '{key_prefix}': .weight present but mandatory .scales missing"
+            )));
+        }
+        (None, Some(_)) => {
+            return Err(Error::from_reason(format!(
+                "plain FP8 layer '{key_prefix}': .scales present but .weight missing"
+            )));
+        }
+        (Some(weight), Some(scales)) => (weight, scales),
+    };
+    if params.contains_key(&format!("{key_prefix}.biases")) {
+        return Err(Error::from_reason(format!(
+            "plain FP8 layer '{key_prefix}': unexpected .biases sidecar"
+        )));
+    }
+    let dequant_weight =
+        crate::quant::fp8_weight::validate_and_dequantize(weight, scales, 2, key_prefix)?;
+    Ok(Some(QuantizedLinear::new_fp8_e4m3(
+        weight.clone(),
+        scales.clone(),
+        dequant_weight,
+        None,
+    )))
+}
+
 /// Try to build an affine QuantizedLinear from weight/scales/biases keys.
 pub fn try_build_quantized_linear(
     params: &HashMap<String, MxArray>,
@@ -541,7 +585,7 @@ pub fn try_build_kquant_quantized_linear(
     )))
 }
 
-/// QuantizedLinear: Linear layer using quantized_matmul for efficient inference.
+/// Linear layer backed by a serialized quantized weight format.
 ///
 /// The sym8 surface (fields `w_i8`/`s_w`, `new_sym8`, `forward_sym8`, the
 /// `mode == "sym8"` dispatch) is a gemma4-local copy of the dense Qwen3.5
@@ -549,6 +593,8 @@ pub fn try_build_kquant_quantized_linear(
 /// calling the same family-agnostic `int8_gemm` kernels. The two copies MUST
 /// NOT drift: same M-boundary (M <= 2 -> W8A16 qmv, M >= 3 -> W8A8 gemm),
 /// linear bias added AFTER the kernel, result narrowed to bf16 inside C++.
+/// Plain `fp8_e4m3` is the non-native exception: it keeps raw Uint8 checkpoint
+/// storage, reconstructs BF16 once at load, and uses ordinary A16 matmul.
 pub struct QuantizedLinear {
     weight: MxArray,
     scales: MxArray,
@@ -557,6 +603,9 @@ pub struct QuantizedLinear {
     group_size: i32,
     bits: i32,
     mode: String,
+    // Reconstructed BF16 `[N,K]` weight for the plain E4M3 correctness
+    // fallback. `Some` iff mode == fp8_e4m3.
+    fp8_dequant_weight: Option<MxArray>,
     // sym8 kernel operands (`Some` iff `mode == "sym8"`): `w_i8` is the opaque
     // contiguous [K,N] int8 weight (pre-transposed at load), `s_w` is the f32
     // [N] per-output-channel scale. Consumed by `int8_w8a16_qmv` (M <= 2,
@@ -607,6 +656,30 @@ impl QuantizedLinear {
             group_size,
             bits,
             mode,
+            fp8_dequant_weight: None,
+            w_i8: None,
+            s_w: None,
+        }
+    }
+
+    /// Construct a plain E4M3 storage-backed linear with a load-time BF16
+    /// reconstruction. The raw Uint8 tensor remains visible through
+    /// `get_weight()` so storage identity is never confused with MXFP8.
+    pub fn new_fp8_e4m3(
+        weight: MxArray,
+        scales: MxArray,
+        dequant_weight: MxArray,
+        bias: Option<MxArray>,
+    ) -> Self {
+        Self {
+            weight,
+            scales,
+            biases: None,
+            bias,
+            group_size: crate::quant::fp8_weight::FP8_E4M3_GROUP_SIZE,
+            bits: crate::quant::fp8_weight::FP8_E4M3_BITS,
+            mode: crate::quant::fp8_weight::FP8_E4M3_MODE.to_string(),
+            fp8_dequant_weight: Some(dequant_weight),
             w_i8: None,
             s_w: None,
         }
@@ -629,6 +702,7 @@ impl QuantizedLinear {
             group_size: SYM8_GROUP_SIZE,
             bits: SYM8_BITS,
             mode: SYM8_MODE.to_string(),
+            fp8_dequant_weight: None,
             w_i8: Some(w_kn),
             s_w: Some(s_w),
         }
@@ -726,6 +800,19 @@ impl QuantizedLinear {
             return self.forward_sym8(x);
         }
 
+        if self.mode == crate::quant::fp8_weight::FP8_E4M3_MODE {
+            let weight = self.fp8_dequant_weight.as_ref().ok_or_else(|| {
+                Error::from_reason(
+                    "plain FP8 QuantizedLinear missing load-time BF16 reconstruction",
+                )
+            })?;
+            let mut result = x.matmul(&weight.transpose(Some(&[1, 0]))?)?;
+            if let Some(ref b) = self.bias {
+                result = result.add(b)?;
+            }
+            return Ok(result);
+        }
+
         // MLX promotes affine QMM to FP32 when a BF16 activation is paired
         // with GGUF Q4_0's sidecars (including their exact load-time FP32
         // widening). Restore the model's activation dtype at the projection
@@ -741,7 +828,7 @@ impl QuantizedLinear {
     }
 
     /// Quantization mode discriminator string ("affine", "mxfp8", "mxfp4",
-    /// "nvfp4", or "sym8").
+    /// "nvfp4", "fp8_e4m3", or "sym8").
     pub fn mode(&self) -> &str {
         &self.mode
     }
@@ -756,6 +843,82 @@ impl QuantizedLinear {
             (Some(w), Some(s)) => Some((&self.weight, w, s)),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod plain_fp8_weight_tests {
+    use super::*;
+
+    fn params(prefix: &str) -> HashMap<String, MxArray> {
+        let source = MxArray::from_float32(
+            &[
+                0.0, 0.5, -1.0, 2.0, -0.25, 1.5, 0.75, -2.5, 1.0, -0.5, 0.25, 3.0,
+            ],
+            &[3, 4],
+        )
+        .unwrap()
+        .astype(DType::BFloat16)
+        .unwrap();
+        let (weight, scales) =
+            crate::quant::fp8_weight::quantize_per_output_channel(&source, prefix).unwrap();
+        HashMap::from([
+            (format!("{prefix}.weight"), weight),
+            (format!("{prefix}.scales"), scales),
+        ])
+    }
+
+    #[test]
+    fn plain_fp8_builder_reconstructs_bf16_and_forward_is_a16_matmul() {
+        let p = params("proj");
+        let ql = try_build_fp8_e4m3_quantized_linear(&p, "proj")
+            .unwrap()
+            .unwrap();
+        assert_eq!(ql.mode(), crate::quant::fp8_weight::FP8_E4M3_MODE);
+        assert_eq!(ql.get_weight().dtype().unwrap(), DType::Uint8);
+
+        let x = MxArray::from_float32(&[1.0, -0.5, 0.25, 2.0], &[1, 4])
+            .unwrap()
+            .astype(DType::BFloat16)
+            .unwrap();
+        let got = ql.forward(&x).unwrap();
+        let dequant = crate::quant::fp8_weight::validate_and_dequantize(
+            p.get("proj.weight").unwrap(),
+            p.get("proj.scales").unwrap(),
+            2,
+            "proj",
+        )
+        .unwrap();
+        let want = x
+            .matmul(&dequant.transpose(Some(&[1, 0])).unwrap())
+            .unwrap();
+        got.eval();
+        want.eval();
+        assert_eq!(
+            got.to_uint16_native().unwrap(),
+            want.to_uint16_native().unwrap()
+        );
+    }
+
+    #[test]
+    fn plain_fp8_builder_fails_loud_on_incomplete_or_malformed_storage() {
+        let mut missing_scales = params("proj");
+        missing_scales.remove("proj.scales");
+        assert!(try_build_fp8_e4m3_quantized_linear(&missing_scales, "proj").is_err());
+
+        let mut wrong_weight_dtype = params("proj");
+        let bad = wrong_weight_dtype["proj.weight"]
+            .from_fp8(DType::BFloat16)
+            .unwrap();
+        wrong_weight_dtype.insert("proj.weight".into(), bad);
+        assert!(try_build_fp8_e4m3_quantized_linear(&wrong_weight_dtype, "proj").is_err());
+
+        let mut wrong_scale_shape = params("proj");
+        wrong_scale_shape.insert(
+            "proj.scales".into(),
+            MxArray::from_float32(&[1.0, 1.0, 1.0], &[3]).unwrap(),
+        );
+        assert!(try_build_fp8_e4m3_quantized_linear(&wrong_scale_shape, "proj").is_err());
     }
 }
 

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -6068,7 +6068,7 @@ mod tests {
                     "affine",
                     is_qwen35_hybrid,
                 ),
-                Some(crate::convert::OfficialUnslothRecipeKind::Mxfp)
+                Some(crate::convert::OfficialUnslothRecipeKind::QwenMxfp)
             );
             assert_eq!(
                 crate::convert::select_official_unsloth_recipe(
@@ -6077,7 +6077,7 @@ mod tests {
                     "nvfp4",
                     is_qwen35_hybrid,
                 ),
-                Some(crate::convert::OfficialUnslothRecipeKind::Nvfp4)
+                Some(crate::convert::OfficialUnslothRecipeKind::QwenNvfp4)
             );
         }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,9 +47,10 @@ mlx convert --input ./model --output ./model-bf16 --dtype bf16
 mlx convert --input ./model --output ./model-q --quantize --q-recipe mixed_4_6
 ```
 
-### Unsloth MXFP and DGX tensor-class recipes for Qwen3.5
+### Unsloth MXFP and DGX tensor-class recipes for Qwen3.5 and SafeTensors Gemma4 MoE
 
-For verified dense and MoE Qwen3.5/Qwen3.6-family checkpoints, the fixed
+For verified dense and MoE Qwen3.5/Qwen3.6-family checkpoints and the exact
+SafeTensors Gemma-4-26B-A4B MoE shape, the fixed
 [Unsloth class map](https://unsloth.ai/docs/models/qwen3.6#nvfp4) is
 available in two forms. The Apple map translates FP8-class weights to MXFP8;
 the DGX map retains NVFP4 weight storage and stores plain E4M3 FP8 weights with
@@ -68,20 +69,31 @@ mlx convert -m qwen3_5_moe -q --q-recipe unsloth --q-mxfp \
 # DGX weight variant: retain NVFP4
 mlx convert -m qwen3_5_moe -q --q-mode nvfp4 --q-recipe unsloth \
   -i ./qwen3.5-35b-a3b -o ./qwen3.5-35b-a3b-unsloth-nvfp4-mlx
+
+# Gemma4 MoE Apple MXFP variant
+mlx convert -m gemma4 -q --q-recipe unsloth --q-mxfp \
+  -i ./gemma-4-26b-a4b-it -o ./gemma-4-26b-a4b-it-unsloth-mxfp4-mlx
+
+# Gemma4 MoE DGX weight variant
+mlx convert -m gemma4 -q --q-mode nvfp4 --q-recipe unsloth \
+  -i ./gemma-4-26b-a4b-it -o ./gemma-4-26b-a4b-it-unsloth-nvfp4-mlx
 ```
 
-Early FFNs use MXFP4 4/32 with `--q-mxfp`, or NVFP4 4/16 with
-`--q-mode nvfp4`. The final eight FFNs, attention q/k/v/o, GDN qkv/z/out, and
-`lm_head` use MXFP8 8/32 on Apple and `fp8_e4m3` (raw E4M3 `[N,K]` weights +
-BF16 `[N,1]` dequant scales, extended to `[E,N,K]` / `[E,N,1]` for experts) in
-the DGX artifact. Runtime activations remain A16 for both DGX weight classes:
+For Qwen, early FFNs use the low class; the final eight FFNs, attention
+q/k/v/o, GDN qkv/z/out, and `lm_head` use the high class. For Gemma4 MoE, every
+dense and expert FFN uses the low class, attention q/k/v/o uses the high class,
+and there is no final-eight or `lm_head` exception. The low class is MXFP4 4/32
+with `--q-mxfp`, or NVFP4 4/16 with `--q-mode nvfp4`; the high class is MXFP8
+8/32 on Apple or `fp8_e4m3` (raw E4M3 `[N,K]` weights + BF16 `[N,1]` dequant
+scales) in the DGX artifact. Runtime activations remain A16 for both DGX weight classes:
 NVFP4 uses standard MLX weight-only quantized matmul, while plain FP8 weights
 are reconstructed to BF16 once at load. This is a data-free tensor-class and
 serialized-weight-format port when no imatrix is supplied. It does not include
 Unsloth's calibrated NVFP4 global scales, W4A4/W8A8 activation execution, or
 calibrated FP8 KV-cache scales, and it does not claim upstream numerical or
-performance parity. Embeddings, routers, GDN a/b, vision, MTP,
-norms, and recurrent parameters remain BF16. Plain affine Unsloth alone keeps
+performance parity. Embeddings, routers, GDN a/b, vision/audio, MTP,
+norms, recurrent parameters, and other unmatched tensors remain BF16. Gemma
+expert imatrix pre-scaling is not inferred from flat GGUF statistics. Plain affine Unsloth alone keeps
 the legacy Dynamic 2.0 recipe.
 
 ### NVIDIA modelopt recipe (data-free MXFP4 port)

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -419,9 +419,9 @@ The Qwen3.5 GDN recurrence uses the **per-step** kernel by default on **every** 
 | Scheme       | How it's invoked                                                                                                                                         |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 4-bit affine | `mlx_quantized_matmul` (mode `affine`, configurable group size and bits)                                                                                 |
-| MXFP4        | `--q-mode mxfp4`, or the early-FFN class in `--q-recipe unsloth --q-mxfp`; 4-bit microscaling with group size 32                                         |
+| MXFP4        | `--q-mode mxfp4`, or the low FFN class in `--q-recipe unsloth --q-mxfp`; 4-bit microscaling with group size 32                                           |
 | MXFP8        | `mlx_gather_qmm` with `mode="mxfp8"` (used for MoE expert routing); returns `[quantized, scales]`                                                        |
-| NVFP4        | `--q-recipe unsloth --q-mode nvfp4`; early FFNs use NVFP4 4/16 weight storage with standard MLX A16 quantized matmul in the fixed DGX class map           |
+| NVFP4        | `--q-recipe unsloth --q-mode nvfp4`; low-class FFNs use NVFP4 4/16 weight storage with standard MLX A16 quantized matmul in the fixed DGX class map        |
 | FP8 E4M3 import | Source `.weight_scale_inv` checkpoints are dequantized **before** expert stacking; no re-quantization after stacking                              |
 | Plain FP8 weights | Unsloth DGX high class: `fp8_e4m3` raw U8 weights + per-output BF16 scales; current runtime dequantizes once to BF16 and runs A16 matmul/gather-mm (not native W8A8) |
 | FP8 KV cache | Paged-adapter only — `KVCacheDType::Fp8` with per-layer scale management via `KvScaleManager`. FP8 KV is intentionally rejected by the flat-path attach. |
@@ -465,8 +465,11 @@ K-quant prefill is routed onto the NAX tensor op through a `nax_supports_mode()`
   the fixed tensor-class map translated from NVFP4/FP8 to MXFP4/MXFP8;
   `--q-mode nvfp4` selects the DGX weight map with NVFP4/plain per-output E4M3 FP8. These fixed maps may omit the
   imatrix; AWQ pre-scaling is then skipped and quality may be lower, while the
-  class map remains unchanged. Both use the final-eight FFN split and the same
-  BF16 exclusions. DGX runtime remains A16 for both weight classes and does not
+  class map remains unchanged. Qwen uses its final-eight FFN split; exact
+  Gemma-4-26B-A4B MoE checkpoints keep all dense/expert FFNs low, attention
+  q/k/v/o high, and all other tensors BF16, with no final-eight or head
+  exception. Flat GGUF imatrix statistics are not promoted into an invented
+  expert-axis calibration rule. DGX runtime remains A16 for both weight classes and does not
   preserve Unsloth's calibrated global scales, W4A4/W8A8 activation execution,
   or calibrated FP8 KV-cache scales; no upstream numerical or performance
   parity is claimed. Plain affine alone keeps the legacy Dynamic 2.0 map.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -178,8 +178,9 @@ mlx convert -i ./model -o ./model-q3 -q --q-bits 3 --q-recipe unsloth --imatrix-
 mlx convert -i ./model -o ./model-q4 -q --q-bits 4 --q-recipe unsloth --imatrix-path ./imatrix.gguf
 ```
 
-For verified Qwen3.5/Qwen3.6-family checkpoints, select the fixed [Unsloth
-class map](https://unsloth.ai/docs/models/qwen3.6#nvfp4) with either
+For verified Qwen3.5/Qwen3.6-family checkpoints or the exact SafeTensors
+Gemma-4-26B-A4B MoE shape, select the fixed [Unsloth class
+map](https://unsloth.ai/docs/models/qwen3.6#nvfp4) with either
 `--q-mxfp` (NVFP4 → MXFP4, FP8 → MXFP8) or `--q-mode nvfp4` (the DGX
 weight map, retaining NVFP4 and storing FP8 classes as plain per-output E4M3). An imatrix is optional
 for these two fixed maps: when omitted, AWQ pre-scaling is skipped and quality
@@ -194,6 +195,14 @@ mlx convert -i ./model -o ./model-unsloth-mxfp4 -q \
 
 mlx convert -i ./model -o ./model-unsloth-nvfp4 -q \
   --q-recipe unsloth --q-mode nvfp4
+
+mlx convert -m gemma4 -i ./gemma-4-26b-a4b-it \
+  -o ./gemma-4-26b-a4b-it-unsloth-mxfp4 -q \
+  --q-recipe unsloth --q-mxfp
+
+mlx convert -m gemma4 -i ./gemma-4-26b-a4b-it \
+  -o ./gemma-4-26b-a4b-it-unsloth-nvfp4 -q \
+  --q-recipe unsloth --q-mode nvfp4
 ```
 
 The two fixed maps share tensor-class boundaries but preserve different weight
@@ -207,11 +216,16 @@ does not include Unsloth's calibrated NVFP4 global scales, W4A4/W8A8 activation
 execution, or calibrated FP8 KV-cache scales, and does not claim upstream
 numerical or performance parity.
 
-| Weight class                                                                     | `--q-mxfp` | `--q-mode nvfp4` |
-| -------------------------------------------------------------------------------- | ---------- | ---------------- |
-| FFN `gate_proj` / `up_proj` / `down_proj`, except the final 8 transformer layers | MXFP4 4/32 | NVFP4 4/16       |
-| Final 8 FFNs; attention q/k/v/o; GDN qkv/z/out; `lm_head`                        | MXFP8 8/32 | E4M3 FP8 + per-output BF16 scale |
-| Embeddings; routers; GDN a/b; vision; MTP; norms; recurrent parameters           | BF16       | BF16             |
+| Weight class                                                                                | `--q-mxfp` | `--q-mode nvfp4`                 |
+| ------------------------------------------------------------------------------------------- | ---------- | -------------------------------- |
+| Qwen FFNs except the final 8; all Gemma4 dense/expert FFNs                                  | MXFP4 4/32 | NVFP4 4/16                       |
+| Qwen final 8 FFNs, attention, GDN qkv/z/out, head; Gemma4 attention q/k/v/o                | MXFP8 8/32 | E4M3 FP8 + per-output BF16 scale |
+| Embeddings; routers; Qwen GDN a/b; vision/audio; MTP; norms; recurrent and unmatched tensors | BF16       | BF16                             |
+
+Gemma4 has no final-eight or `lm_head` exception. Its stacked experts remain
+in the low NVFP4/MXFP4 class; plain FP8 is accepted only for the rank-2
+attention weights. Flat GGUF imatrix statistics are not treated as an invented
+expert-axis calibration rule.
 
 Per-tensor bit assignments (N = `--q-bits`):
 

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -298,9 +298,13 @@ describe('mlx convert Unsloth MXFP messaging', () => {
 
     const help = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
     expect(help).toContain('--config-dir <path>');
-    expect(help).toContain('Qwen3.5 MXFP map: early FFNs=mxfp4');
+    expect(help).toContain('Qwen3.5/3.6:');
+    expect(help).toContain('early FFNs=mxfp4');
+    expect(help).toContain('Gemma-4-26B-A4B MoE:');
+    expect(help).toContain('all dense/expert FFNs=mxfp4');
     expect(help).toContain('Use --q-mode nvfp4 for the fixed DGX weight map');
-    expect(help).toContain('lm_head=fp8_e4m3');
+    expect(help).toContain('attention/GDN/head=fp8_e4m3');
+    expect(help).toContain('q/k/v/o=fp8_e4m3');
     expect(help).toContain("preserve Unsloth's calibrated W4A4/W8A8 execution");
     expect(help).toContain('calibrated FP8 KV cache');
     expect(help).toContain('Plain affine keeps legacy Dynamic 2.0');
@@ -355,7 +359,9 @@ describe('mlx convert Unsloth MXFP messaging', () => {
     ]);
 
     const warnings = warnSpy.mock.calls.map((call) => String(call[0])).join('\n');
-    expect(warnings).toContain('If backend Qwen family/shape validation selects');
+    expect(warnings).toContain(
+      'backend validation selects the requested fixed Qwen hybrid or exact SafeTensors Gemma4 MoE',
+    );
     expect(warnings).toContain('NVFP4/plain-FP8');
     expect(warnings).toContain('AWQ pre-scaling will be skipped');
     expect(warnings).toContain('quality may be lower');
@@ -390,7 +396,9 @@ describe('mlx convert Unsloth MXFP messaging', () => {
     ]);
 
     const warnings = warnSpy.mock.calls.map((call) => String(call[0])).join('\n');
-    expect(warnings).toContain('If backend Qwen family/shape validation selects');
+    expect(warnings).toContain(
+      'backend validation selects the requested fixed Qwen hybrid or exact SafeTensors Gemma4 MoE',
+    );
     expect(warnings).toContain('AWQ pre-scaling will be skipped');
     expect(warnings).toContain('quality may be lower');
     expect(warnings).toContain('unsupported inputs will be rejected');
@@ -429,9 +437,13 @@ describe('mlx convert Unsloth MXFP messaging', () => {
 
     const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
     expect(logs).toContain('requested fixed Unsloth DGX/NVFP4 weight map');
-    expect(logs).toContain('backend verifies Qwen family/shape');
+    expect(logs).toContain(
+      'backend verifies Qwen hybrid or exact SafeTensors Gemma4 MoE family/shape',
+    );
     expect(logs).toContain('early FFN=nvfp4');
     expect(logs).toContain('final 8 FFN + attention/GDN/head=fp8_e4m3');
+    expect(logs).toContain('all dense/expert FFN=nvfp4');
+    expect(logs).toContain('attention q/k/v/o=fp8_e4m3');
     expect(logs).not.toContain('final 8 FFN + attention/GDN/head=mxfp8');
     expect(logs).not.toContain('early FFN=mxfp4');
     expect(logs).not.toContain('Quantize:   fixed Unsloth DGX/NVFP4 weight map');
@@ -470,9 +482,13 @@ describe('mlx convert Unsloth MXFP messaging', () => {
 
     const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
     expect(logs).toContain('requested fixed Unsloth MXFP map');
-    expect(logs).toContain('backend verifies Qwen family/shape');
+    expect(logs).toContain(
+      'backend verifies Qwen hybrid or exact SafeTensors Gemma4 MoE family/shape',
+    );
     expect(logs).toContain('early FFN=mxfp4');
     expect(logs).toContain('final 8 FFN + attention/GDN/head=mxfp8');
+    expect(logs).toContain('all dense/expert FFN=mxfp4');
+    expect(logs).toContain('attention q/k/v/o=mxfp8');
     expect(logs).not.toContain('fp8_e4m3');
     expect(logs).not.toContain('unsloth recipe defaults to 3-bit base');
     expect(logs).not.toContain('eligible 8b->mxfp8/4b->mxfp4');
@@ -549,7 +565,9 @@ describe('mlx convert Unsloth MXFP messaging', () => {
 
     const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
     expect(logs).toContain('requested fixed Unsloth MXFP map');
-    expect(logs).toContain('backend verifies Qwen family/shape');
+    expect(logs).toContain(
+      'backend verifies Qwen hybrid or exact SafeTensors Gemma4 MoE family/shape',
+    );
     expect(logs).not.toContain('Quantize:   fixed Unsloth MXFP map');
   });
 
@@ -574,7 +592,9 @@ describe('mlx convert Unsloth MXFP messaging', () => {
 
     const logs = logSpy.mock.calls.map((call) => String(call[0])).join('\n');
     expect(logs).toContain('requested fixed Unsloth MXFP map');
-    expect(logs).toContain('backend verifies Qwen family/shape');
+    expect(logs).toContain(
+      'backend verifies Qwen hybrid or exact SafeTensors Gemma4 MoE family/shape',
+    );
     expect(logs).not.toContain('Quantize:   fixed Unsloth MXFP map');
     expect(vi.mocked(convertGgufToSafetensors)).toHaveBeenCalledWith(
       expect.objectContaining({ quantRecipe: 'unsloth', quantMxfp: true, imatrixPath }),

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -109,7 +109,7 @@ describe('mlx convert GGUF validation', () => {
   it('rejects --gguf-kquant combined with --imatrix-path for .gguf input upfront', async () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(console, 'log').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    const _exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`process.exit(${code})`);
     }) as never);
 

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -56,13 +56,17 @@ Quantization Arguments:
                         with per-layer overrides. NOT mlx-lm-loadable.
   --q-mxfp              Upgrade quantization to micro-scaling FP (mxfp4 / mxfp8).
                         With --q-recipe unsloth, selects the fixed Unsloth
-                        Qwen3.5 MXFP map: early FFNs=mxfp4; final eight FFNs,
-                        attention q/k/v/o, GDN qkv/z/out, and lm_head=mxfp8;
-                        embeddings, routers, GDN a/b, vision, MTP, norms, and
-                        recurrent tensors stay bf16. AWQ imatrix pre-scaling
-                        is applied when --imatrix-path is provided. Without it,
-                        the fixed class map is unchanged but quality may be
-                        lower. --q-bits/--q-group-size do not alter this map.
+                        family map after backend validation. Qwen3.5/3.6:
+                        early FFNs=mxfp4; final eight FFNs, attention q/k/v/o,
+                        GDN qkv/z/out, and lm_head=mxfp8. SafeTensors
+                        Gemma-4-26B-A4B MoE:
+                        all dense/expert FFNs=mxfp4 and attention q/k/v/o=mxfp8.
+                        Gemma routers, embeddings/head, vision, norms, and all
+                        other tensors stay bf16. AWQ imatrix pre-scaling is
+                        applied when --imatrix-path is provided; it does not
+                        invent expert AWQ. Without it, the fixed class map is
+                        unchanged but quality may be lower. --q-bits/
+                        --q-group-size do not alter this map.
 
                         With other recipes (or no recipe), applies after the
                         recipe predicate: any 8-bit affine decision becomes
@@ -91,13 +95,15 @@ Quantization Arguments:
                         The fixed --q-mxfp / --q-mode nvfp4 maps may omit it;
                         AWQ pre-scaling is then skipped and quality may be lower.
                         A matching imatrix remains preferred when available.
-                        Add --q-mxfp for the fixed Qwen3.5 MXFP class map
+                        Add --q-mxfp for the verified Qwen hybrid or SafeTensors
+                        Gemma4 MoE fixed class map
                         (NVFP4 translated to MXFP4, FP8 translated to MXFP8).
-                        Use --q-mode nvfp4 for the fixed DGX weight map: early
-                        FFNs=nvfp4; final eight FFNs, attention/GDN high
-                        classes, and lm_head=fp8_e4m3 (raw E4M3 weights with
-                        per-output float scales); the same protected classes
-                        stay bf16. Both DGX classes run with A16 activations:
+                        Use --q-mode nvfp4 for the fixed DGX weight map. Qwen
+                        uses early FFNs=nvfp4 and final-eight FFNs +
+                        attention/GDN/head=fp8_e4m3; Gemma4 MoE uses every
+                        dense/expert FFN=nvfp4 and only attention
+                        q/k/v/o=fp8_e4m3. Protected classes stay bf16. Both DGX
+                        classes run with A16 activations:
                         NVFP4 uses standard MLX weight-only quantized matmul;
                         plain FP8 reconstructs bf16 weights at load. This does
                         not preserve Unsloth's calibrated W4A4/W8A8 execution,
@@ -338,7 +344,7 @@ export async function run(argv: string[]) {
         process.exit(1);
       }
       console.warn(
-        'Warning: no --imatrix-path was provided. If backend Qwen family/shape validation selects the requested fixed MXFP4/MXFP8 or NVFP4/plain-FP8 map, AWQ pre-scaling will be skipped and quality may be lower; unsupported inputs will be rejected.',
+        'Warning: no --imatrix-path was provided. If backend validation selects the requested fixed Qwen hybrid or exact SafeTensors Gemma4 MoE MXFP4/MXFP8 or NVFP4/plain-FP8 map, AWQ pre-scaling will be skipped and quality may be lower; unsupported inputs will be rejected.',
       );
     }
     // The nvidia recipe is a data-free port with a fixed format map: it reads
@@ -385,10 +391,10 @@ export async function run(argv: string[]) {
   const usesOfficialUnslothNvfp4 = quantRecipe === 'unsloth' && quantMode === 'nvfp4';
   const fixedUnslothSummary = (lowFormat: 'mxfp4' | 'nvfp4') => {
     const highFormat = lowFormat === 'nvfp4' ? 'fp8_e4m3' : 'mxfp8';
-    return `fixed Unsloth ${lowFormat === 'nvfp4' ? 'DGX/NVFP4 weight' : 'MXFP'} map (early FFN=${lowFormat}; final 8 FFN + attention/GDN/head=${highFormat}; protected classes=bf16)`;
+    return `fixed Unsloth ${lowFormat === 'nvfp4' ? 'DGX/NVFP4 weight' : 'MXFP'} map (Qwen: early FFN=${lowFormat}, final 8 FFN + attention/GDN/head=${highFormat}; Gemma4 MoE: all dense/expert FFN=${lowFormat}, attention q/k/v/o=${highFormat}; protected classes=bf16)`;
   };
   const requestedFixedUnslothSummary = (lowFormat: 'mxfp4' | 'nvfp4') =>
-    `requested ${fixedUnslothSummary(lowFormat)}; backend verifies Qwen family/shape`;
+    `requested ${fixedUnslothSummary(lowFormat)}; backend verifies Qwen hybrid or exact SafeTensors Gemma4 MoE family/shape`;
   // Render the `Quantize:` line body shared by the GGUF and SafeTensors paths.
   // `qGsLabel` carries the group-size text (the GGUF path never reaches sym8,
   // so it always passes `group_size=N`); `mtp` is `'off'` on the GGUF path,


### PR DESCRIPTION
## What changed

- add a fail-closed fixed Unsloth selector for the exact SafeTensors Gemma 4 26B-A4B MoE shape
- emit 180 MXFP4/NVFP4 dense and expert FFN modules plus 115 MXFP8/plain-E4M3 attention modules
- keep routers, embeddings/head, norms, vision/audio, and unmatched tensors in BF16
- add Gemma rank-2 plain E4M3 loading via one-time BF16 reconstruction while keeping stacked experts fail-closed
- include plain-E4M3 BF16 reconstructions in cache-limit weight accounting (2,220,359,680 bytes for the published map)
- preserve the calibrated legacy fallback for unsupported Gemma4 wrappers while rejecting uncalibrated fallback
- update CLI messaging and docs to distinguish the existing Qwen final-eight policy from Gemma's all-low-FFN policy

## Why

The CLI accepted `--q-recipe unsloth --q-mxfp` and `--q-mode nvfp4` for Gemma, but the backend only selected the verified Qwen map. Gemma therefore fell back to the legacy Dynamic 2.0 predicate, and its loader rejected the plain E4M3 attention weights required by the DGX class map.

## Validation

- `cargo check -p mlx-core --lib`
- `yarn vp test packages/cli/__test__/convert-cmd.test.ts` (25/25)
- `yarn build:ts`
- `cargo fmt --all -- --check`
- `git diff --check`
- GitHub Actions at `8c8b270e`: Build, Rust Lint, full `cargo test`, TypeScript build/tests, and Publish all passed
- regression coverage pins the exact reconstructed-BF16 byte delta and a dense zero-delta control
- rebuilt the release native addon
- converted the real `google/gemma-4-26B-A4B-it` checkpoint with matching Unsloth imatrix into both maps
- audited exact 180 low / 115 high classes and SafeTensors index closure
- loaded both artifacts and generated deterministic one-token `OK`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quantization recipe selection, conversion validation, and Gemma4 weight loading/memory accounting; wrong gates could reject valid checkpoints or mis-classify tensors, but behavior is heavily gated and covered by new tests.
> 
> **Overview**
> Extends the verified **fixed Unsloth** path beyond Qwen hybrids to the exact SafeTensors **Gemma 4 26B-A4B MoE** checkpoint (`--q-mxfp` / `--q-mode nvfp4`). `OfficialUnslothRecipeKind` is split into Qwen vs Gemma4 variants so Gemma never inherits Qwen’s final-eight FFN promotion.
> 
> **Conversion (`convert.rs`):** Strict gates on config, `--model-type gemma4`, MoE dims, and a 180-MLP / 115-attention tensor inventory; near-miss Gemma inputs **fail closed** instead of falling back to legacy Dynamic 2.0. Gemma’s map keeps all dense/expert FFNs low, attention q/k/v/o high, and everything else BF16. A pre-quant **shape preflight** enforces ranks, K%32, and the 180/115 class counts.
> 
> **Runtime (Gemma4):** Rank-2 **plain E4M3** attention weights load via one-time BF16 reconstruction and A16 matmul; experts stay NVFP4-only. Reconstructed FP8 weight bytes are folded into cache-limit accounting.
> 
> **CLI/docs/tests:** Help text and docs describe Qwen vs Gemma policies; CLI tests updated for the new messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c8b270eb3de1ce259da1e9ddaaa5f63b88659e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->