### PR TITLE
fix(desktop): surface control panel on launch

### DIFF
--- a/packages/dashboard/__test__/boot-screen.test.ts
+++ b/packages/dashboard/__test__/boot-screen.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vite-plus/test';
+
+const html = readFileSync(new URL('../ui/index.html', import.meta.url), 'utf8');
+const entry = readFileSync(new URL('../ui/src/main.tsx', import.meta.url), 'utf8');
+
+describe('Control Panel boot screen', () => {
+  it('paints visible status before the JavaScript bundle runs', () => {
+    expect(html).toContain('class="mlx-boot"');
+    expect(html).toContain('role="status"');
+    expect(html).toContain('Starting mlx-node…');
+  });
+
+  it('keeps the loader mounted while waiting for the runtime port', () => {
+    expect(entry).toContain('className="mlx-boot"');
+    expect(entry).toContain('Starting mlx-node…');
+  });
+});

--- a/packages/dashboard/ui/index.html
+++ b/packages/dashboard/ui/index.html
@@ -4,9 +4,59 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>mlx-node Control Panel</title>
+    <style>
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        background: #101014;
+        color: #d7d7df;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+
+      .mlx-boot {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        height: 100%;
+        justify-content: center;
+        letter-spacing: 0.01em;
+      }
+
+      .mlx-boot__spinner {
+        animation: mlx-boot-spin 0.8s linear infinite;
+        border: 2px solid rgba(215, 215, 223, 0.2);
+        border-radius: 50%;
+        border-top-color: #8aa4ff;
+        height: 26px;
+        width: 26px;
+      }
+
+      @keyframes mlx-boot-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .mlx-boot__spinner {
+          animation: none;
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="mlx-boot" role="status" aria-live="polite">
+        <span class="mlx-boot__spinner" aria-hidden="true"></span>
+        <span>Starting mlx-node…</span>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/dashboard/ui/src/main.tsx
+++ b/packages/dashboard/ui/src/main.tsx
@@ -52,5 +52,11 @@ window.addEventListener('message', (event: MessageEvent) => {
 });
 
 // Rendering the app before the port lands would make every page's first fetch
-// fail; this placeholder is what the window shows for the few ms in between.
-root.render(<div className="text-muted-foreground p-6 text-sm">Connecting to the mlx runtime…</div>);
+// fail. Keep the same screen index.html paints before this bundle executes, so
+// startup never flashes from a loader to an empty/unstyled placeholder.
+root.render(
+  <div className="mlx-boot" role="status" aria-live="polite">
+    <span className="mlx-boot__spinner" aria-hidden="true" />
+    <span>Starting mlx-node…</span>
+  </div>,
+);

--- a/packages/desktop/__test__/launch-visibility.test.ts
+++ b/packages/desktop/__test__/launch-visibility.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+import { createLaunchVisibility } from '../src/main/launch-visibility.js';
+
+describe('launch visibility', () => {
+  it('opens the Control Panel when a new app process becomes ready', () => {
+    const show = vi.fn();
+    createLaunchVisibility().ready({ show });
+    expect(show).toHaveBeenCalledOnce();
+  });
+
+  it('does not lose an activation that arrives before async bootstrap', () => {
+    const visibility = createLaunchVisibility();
+    const show = vi.fn();
+    visibility.activate();
+    visibility.activate();
+    visibility.ready({ show });
+    expect(show).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces every activation after bootstrap', () => {
+    const visibility = createLaunchVisibility();
+    const show = vi.fn();
+    visibility.ready({ show });
+    show.mockClear();
+
+    visibility.activate();
+    visibility.activate();
+    expect(show).toHaveBeenCalledTimes(2);
+  });
+
+  it('carries an open request across graceful shutdown', () => {
+    const visibility = createLaunchVisibility();
+    const show = vi.fn();
+    visibility.ready({ show });
+    show.mockClear();
+
+    visibility.beginShutdown();
+    visibility.activate();
+    expect(show).not.toHaveBeenCalled();
+    expect(visibility.takeRelaunchRequest()).toBe(true);
+    expect(visibility.takeRelaunchRequest()).toBe(false);
+  });
+});

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -23,6 +23,7 @@ import { DESKTOP_QUIT_DEADLINE_MS } from '../control-panel/shutdown-timings.js';
 import { createControlPanelBroker, type ControlPanelBroker } from './broker.js';
 import { controlPanelEnvOverrides, sidecarEnvOverrides } from './child-env.js';
 import { electronBrokerDeps } from './control-panel-child.js';
+import { createLaunchVisibility } from './launch-visibility.js';
 import { resolveAppPaths, type AppPaths } from './paths.js';
 import { installAppProtocol, registerAppScheme } from './protocol.js';
 import {
@@ -53,6 +54,7 @@ let supervisor: Supervisor | null = null;
 let tray: TrayController | null = null;
 let controlPanel: ControlPanelWindowManager | null = null;
 let broker: ControlPanelBroker<WebContents> | null = null;
+const launchVisibility = createLaunchVisibility();
 
 /**
  * "The app is exiting", as opposed to "a window is closing". Without the
@@ -108,7 +110,7 @@ function wire(): void {
     });
 
   app.on('second-instance', () => {
-    controlPanel?.show();
+    launchVisibility.activate();
   });
 
   // This handler must exist and must NOT quit. Electron's default, when nothing
@@ -120,12 +122,11 @@ function wire(): void {
   });
 
   app.on('activate', () => {
-    // With no Dock icon there is no gesture that produces this event, so the one
-    // activation that still arrives is the app's own launch — and popping the
-    // window open on every launch is not what a menubar app does. With a Dock
-    // icon, clicking it must reopen the window, which is exactly this.
-    if (!settings.showInDock) return;
-    controlPanel?.show();
+    // Finder re-activates an already-running accessory app rather than spawning
+    // a second instance. Ignoring this when the Dock icon is hidden leaves a live
+    // process with no window and no way for the user's explicit open gesture to
+    // succeed.
+    launchVisibility.activate();
   });
 
   app.on('before-quit', (event) => {
@@ -133,6 +134,7 @@ function wire(): void {
     // through is what actually exits.
     if (shuttingDown) return;
     shuttingDown = true;
+    launchVisibility.beginShutdown();
     // Set BEFORE any window is asked to close, so the Control Panel window's close
     // handler knows this one is real.
     quitting = true;
@@ -142,6 +144,7 @@ function wire(): void {
         console.error('[mlx] shutdown failed:', error);
       })
       .finally(() => {
+        if (launchVisibility.takeRelaunchRequest()) app.relaunch();
         app.quit();
       });
   });
@@ -262,6 +265,7 @@ async function bootstrap(): Promise<void> {
       broker?.recover(contents, expectedGeneration);
     },
   });
+  launchVisibility.ready(controlPanel);
 
   const copyClientCommand = (build: (endpoint: string, token: string) => string): void => {
     const endpoint = supervisor?.snapshot().url;
@@ -305,15 +309,9 @@ async function bootstrap(): Promise<void> {
   if (settings.autoStartInference) {
     void supervisor.start().catch(reportInferenceFailure);
   }
-  // Only on the very first launch. Otherwise a menubar app that reopens its
-  // window on every start is indistinguishable from one that ignores the close
-  // button — and without it, a first-time user gets a menubar icon they have no
-  // reason to look for.
-  if (loaded.source === 'missing') controlPanel.show();
-
-  // Materialise the file whenever we did not read one. Without this "first run"
-  // never ends — nothing else writes settings until the user moves the window or
-  // toggles something, so the window would reopen on every single launch.
+  // Materialise defaults whenever there was no usable file. Otherwise settings
+  // exist only in memory until the user happens to move the window or toggle a
+  // preference, and a crash before then silently loses the recovered state.
   // `unreadable` is excluded on purpose: we could not read that file, so we do
   // not get to replace it.
   if (loaded.source === 'missing' || loaded.source === 'corrupt') scheduleSave();

--- a/packages/desktop/src/main/launch-visibility.ts
+++ b/packages/desktop/src/main/launch-visibility.ts
@@ -1,0 +1,64 @@
+/**
+ * Turn macOS launch/activation events into a visible Control Panel.
+ *
+ * LaunchServices normally re-activates an already-running accessory app instead
+ * of starting a second process. The target is installed only after async
+ * bootstrap, though, so an activation that arrives first has to be remembered
+ * rather than dropped. A process launch is itself an open request: the app may
+ * rest in the tray after the user closes the window, but explicitly opening it
+ * must never produce an invisible process.
+ */
+
+export interface LaunchSurface {
+  show(): void;
+}
+
+export interface LaunchVisibility {
+  /** Record a Finder/Dock/second-instance request and surface it when possible. */
+  activate(): void;
+  /** Install the Control Panel created by bootstrap and satisfy any pending launch. */
+  ready(surface: LaunchSurface): void;
+  /** Stop surfacing windows; a later activation now means "open again after quit". */
+  beginShutdown(): void;
+  /** Consume the relaunch request, once, immediately before the process exits. */
+  takeRelaunchRequest(): boolean;
+}
+
+export function createLaunchVisibility(): LaunchVisibility {
+  let surface: LaunchSurface | null = null;
+  // Starting the process means the user opened the app. Do not infer intent from
+  // the presence of a settings file: another build may already have created it.
+  let pending = true;
+  let shuttingDown = false;
+  let relaunchRequested = false;
+
+  return {
+    activate(): void {
+      if (shuttingDown) {
+        // The new process loses the singleton race and exits. Carry its intent
+        // across our graceful shutdown instead of leaving no process behind.
+        relaunchRequested = true;
+        return;
+      }
+      if (surface === null) {
+        pending = true;
+        return;
+      }
+      surface.show();
+    },
+    ready(next): void {
+      surface = next;
+      if (!pending) return;
+      pending = false;
+      next.show();
+    },
+    beginShutdown(): void {
+      shuttingDown = true;
+    },
+    takeRelaunchRequest(): boolean {
+      const requested = relaunchRequested;
+      relaunchRequested = false;
+      return requested;
+    },
+  };
+}

--- a/packages/desktop/src/main/window.ts
+++ b/packages/desktop/src/main/window.ts
@@ -86,6 +86,16 @@ export function createControlPanelWindowManager(options: ControlPanelWindowOptio
   let boundsTimer: NodeJS.Timeout | null = null;
   let disposed = false;
 
+  function reveal(target: BrowserWindow): void {
+    if (target.isMinimized()) target.restore();
+    target.show();
+    target.focus();
+    // An accessory app has no Dock presence to activate it. Every caller of
+    // manager.show() represents an explicit launch, activation, or tray action,
+    // so bringing the requested window forward is the expected behaviour.
+    app.focus({ steal: true });
+  }
+
   const onReady = (event: IpcMainEvent): void => {
     // Any renderer can send on a channel; only ours may be answered. There is
     // one window today, so this is cheap insurance rather than a live threat —
@@ -100,11 +110,7 @@ export function createControlPanelWindowManager(options: ControlPanelWindowOptio
     // The generation is also an authority boundary: malformed input and a
     // delayed report for a retired channel must never be resolved against the
     // process that happens to be current now.
-    if (
-      typeof expectedGeneration !== 'number' ||
-      !Number.isSafeInteger(expectedGeneration) ||
-      expectedGeneration < 1
-    ) {
+    if (typeof expectedGeneration !== 'number' || !Number.isSafeInteger(expectedGeneration) || expectedGeneration < 1) {
       return;
     }
     options.onControlPanelUnresponsive?.(event.sender, expectedGeneration);
@@ -156,7 +162,7 @@ export function createControlPanelWindowManager(options: ControlPanelWindowOptio
     });
 
     created.once('ready-to-show', () => {
-      created.show();
+      reveal(created);
     });
 
     created.on('resize', persistBounds);
@@ -213,14 +219,7 @@ export function createControlPanelWindowManager(options: ControlPanelWindowOptio
         win = create();
         return;
       }
-      if (win.isMinimized()) win.restore();
-      win.show();
-      win.focus();
-      // With the Dock icon hidden the app is an "accessory" and showing a window
-      // does not bring it forward on its own. This only runs from an explicit
-      // user action — the tray menu, a second launch — so stealing focus is what
-      // was asked for.
-      app.focus({ steal: true });
+      reveal(win);
     },
     current(): BrowserWindow | null {
       return win !== null && !win.isDestroyed() ? win : null;


### PR DESCRIPTION
## Summary
- open and foreground the Control Panel on process launch, Finder/Dock activation, and second-instance requests
- carry a reopen request across graceful shutdown instead of losing it to the singleton lock
- paint an accessible loading screen before the dashboard bundle/runtime connection is ready

## Root cause
The app inferred “first launch” from a missing settings file and ignored macOS `activate` events when `showInDock` was false. A prior build could create settings before the real install, and LaunchServices reactivates an existing accessory app instead of spawning a second Electron instance. That left a live process with neither a Control Panel nor a reliable way to surface it. Reopens during graceful shutdown could also be swallowed by the singleton lock.

## Validation
- `yarn test packages/desktop/__test__/launch-visibility.test.ts packages/desktop/__test__/window-policy.test.ts packages/desktop/__test__/settings.test.ts packages/dashboard/__test__/boot-screen.test.ts` (44 tests)
- `yarn build:ts`
- targeted `vp lint` and `vp fmt --check` on changed files
- packaged Electron smoke test with isolated user data: CoreGraphics confirmed the `mlx-node Control Panel` window onscreen on first launch and after reopening an existing singleton

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS Electron lifecycle (activate, singleton, relaunch) and default window-on-launch behavior, but logic is isolated and covered by new unit tests.
> 
> **Overview**
> Fixes cases where mlx-node stayed running with **no visible Control Panel** after launch, Finder/Dock open, or a second-instance attempt.
> 
> Desktop launch handling is centralized in **`createLaunchVisibility`**: every process start is treated as an open request (no more inferring “first launch” from a missing settings file), **`activate`** and **`second-instance`** always route through it (including when the Dock icon is hidden), early activations before async bootstrap are queued, and reopen intent during graceful shutdown is preserved via **`app.relaunch()`** instead of being lost to the singleton lock. **`window.ts`** consolidates show/restore/focus/`app.focus({ steal: true })` in a shared **`reveal`** path for first paint and later activations.
> 
> The dashboard adds an **accessible boot screen** in **`index.html`** (inline styles + “Starting mlx-node…” before JS runs) and matches that placeholder in **`main.tsx`** while waiting for the runtime port, avoiding a flash to an unstyled connecting message. New tests cover launch visibility and the boot screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a363a09ccc7464b38f01f95ae5c478e4c1d29e8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->