### PR TITLE
fix(convert): stop pinning dense sources through quantization

### DIFF
--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -6857,13 +6857,9 @@ const QUANTIZE_TILE_THRESHOLD_NUM_EXPERTS: i64 = 32;
 
 /// Dense source bytes the quantize loop may retire between allocator flushes.
 ///
-/// Complements the legacy every-50-tensors cadence, which is size-blind: on a
-/// 27B MoE checkpoint fifty expert stacks is tens of GB of freed-but-cached
-/// buffers, and holding that until the 50th tensor is what pushes a 36 GB box
-/// into swap. 1 GiB is small enough to keep the allocator's high-water mark
-/// near a single tensor's working set and large enough that the full
-/// `mlx_synchronize` stall stays amortized (a few hundred flushes across a
-/// whole checkpoint, not one per tensor).
+/// The every-50-tensors cadence alone is size-blind: fifty MoE expert stacks
+/// and fifty small projections differ by orders of magnitude, so it cannot
+/// bound the high-water mark. A byte budget can.
 const QUANTIZE_FLUSH_BYTE_BUDGET: usize = 1 << 30;
 
 /// Quantize a plain per-output-channel E4M3 weight, tiling large 3-D expert
@@ -8225,12 +8221,6 @@ fn quantize_weights_inner(
 
     let mut per_layer_overrides = preexisting_overrides;
     let mut count = 0;
-    // Dense source bytes released since the last allocator flush. The old
-    // `count % 50` cadence is size-blind — 50 MoE expert stacks is tens of GB
-    // of transients while 50 small projections is a few hundred MB — so it
-    // cannot bound peak RSS on a big checkpoint. Flushing on a byte budget as
-    // well keeps the ceiling independent of tensor size, which is what lets an
-    // AWQ-prescaled 27B convert finish on a 36 GB machine.
     let mut bytes_since_flush: usize = 0;
 
     for entry in &entries {
@@ -8247,11 +8237,8 @@ fn quantize_weights_inner(
             continue;
         }
 
-        // Eval to materialize (prevents lazy graph OOM). With AWQ pre-scaling
-        // upstream this is also where the tensor's pre-scale graph
-        // (`weight * s`, and for `up_proj` an additional `/ s'`) is finally
-        // executed — one tensor at a time, instead of the whole checkpoint at
-        // once. See `apply_awq_prescaling`'s materialization contract.
+        // Eval to materialize (prevents lazy graph OOM). This is also where an
+        // AWQ pre-scale graph gets executed, one tensor at a time.
         array.eval();
         let source_bytes = array.nbytes();
 
@@ -8279,20 +8266,17 @@ fn quantize_weights_inner(
                 )?
             };
 
-        // Materialize the quantized triplet BEFORE releasing the dense source.
-        // `mlx_quantize` (and the fp8/sym8 helpers on their non-tiled paths)
-        // return LAZY arrays whose graph still holds `array` alive. Inserting
-        // them un-evaluated pins every dense bf16 input until the safetensors
-        // writer finally evaluates it — i.e. the entire checkpoint resident at
-        // once, which is exactly the OOM this pass is supposed to avoid.
-        // Evaluating here severs that edge so the `drop(array)` below actually
-        // frees the bf16 buffer. eval() cannot change values, so the emitted
-        // bytes are identical to the lazy path.
-        q_weight.eval();
-        q_scales.eval();
+        // Materialize the triplet BEFORE releasing the dense source.
+        // `mlx_quantize` returns LAZY arrays whose graph still holds `array`
+        // alive, so storing them un-evaluated pins every dense input until the
+        // safetensors writer finally evaluates it. Fallible on purpose: the
+        // writer used to own this materialization and could report an OOM, so
+        // taking it over here must not swallow one.
+        let mut triplet: Vec<&MxArray> = vec![&q_weight, &q_scales];
         if let Some(b) = &q_biases {
-            b.eval();
+            triplet.push(b);
         }
+        MxArray::eval_arrays_with_context(&triplet, &format!("quantize '{}'", entry.key))?;
         drop(array);
 
         let prefix = entry.key.strip_suffix(".weight").unwrap_or(&entry.key);
@@ -8527,85 +8511,21 @@ pub(crate) fn reject_awq_for_prequantized_body(weights: &HashMap<String, MxArray
 /// come from attention/GDN computation, not from a norm layer. These tensors should
 /// be kept at bf16 or quantized without AWQ correction.
 ///
-/// Memory: see [`AwqMaterialization`]. The default is
-/// [`AwqMaterialization::Streaming`], which never holds more than one layer's
-/// fold targets at a time.
+/// The rewritten tensors are left LAZY on return. See the tail of the function.
 pub(crate) fn apply_awq_prescaling(
     weights: &mut HashMap<String, MxArray>,
     imatrix: &crate::utils::imatrix::ImatrixData,
     ratio: f32,
     num_layers: usize,
 ) -> Result<usize> {
-    apply_awq_prescaling_with(
-        weights,
-        imatrix,
-        ratio,
-        num_layers,
-        AwqMaterialization::Streaming,
-    )
-}
-
-/// How [`apply_awq_prescaling_with`] turns the AWQ reparametrization graphs
-/// into buffers.
-///
-/// The math is identical either way — this only decides *when* MLX executes
-/// the graphs, and therefore how much bf16 is resident at the peak.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum AwqMaterialization {
-    /// Legacy behavior: after every group of every layer is built, walk the
-    /// WHOLE weight map and `eval()` each entry. That forces the entire
-    /// checkpoint — including tensors AWQ never touched — into RAM as bf16
-    /// before quantization gets a chance to shrink anything (~41.6 GiB for
-    /// Qwen3.6-27B, which is what froze 36 GB machines).
-    ///
-    /// Retained only so tests can prove the streaming path is byte-identical.
-    #[cfg_attr(not(test), allow(dead_code))]
-    EagerAll,
-    /// Bounded behavior. Per layer, only the *fold targets* — the 1-D norm
-    /// vectors, a few KB each — are materialized, which also releases that
-    /// layer's scale vectors. The 2-D/3-D projection graphs are deliberately
-    /// left LAZY: `quantize_weights_inner` (and, for tensors it skips, the
-    /// safetensors writer) already materializes one tensor at a time and drops
-    /// it immediately, so the pre-scale multiply happens inside that streaming
-    /// loop instead of all at once here. Peak bf16 is therefore one projection
-    /// (plus its single intermediate), not the checkpoint.
-    Streaming,
-}
-
-/// Byte size at or below which [`AwqMaterialization::Streaming`] materializes
-/// an AWQ output inside the layer loop rather than leaving it lazy.
-///
-/// Sized to cover norm vectors (`hidden_size` f32/bf16 — 20 KB even at
-/// hidden_size=5120) and nothing else, so no projection weight can slip
-/// through and start accumulating.
-const AWQ_INLINE_MATERIALIZE_MAX_BYTES: usize = 1 << 20;
-
-/// Layers between allocator flushes on the streaming path. Each layer only
-/// retires a handful of KB of norm/scale buffers, so flushing every layer
-/// would pay a full `mlx_synchronize` stall for nothing.
-const AWQ_FLUSH_INTERVAL_LAYERS: usize = 16;
-
-/// Implementation behind [`apply_awq_prescaling`], parameterized by
-/// materialization strategy so tests can A/B the legacy and bounded paths.
-pub(crate) fn apply_awq_prescaling_with(
-    weights: &mut HashMap<String, MxArray>,
-    imatrix: &crate::utils::imatrix::ImatrixData,
-    ratio: f32,
-    num_layers: usize,
-    materialization: AwqMaterialization,
-) -> Result<usize> {
     info!(
-        "Applying AWQ pre-scaling: {} layers, ratio={}, {} imatrix entries, mode={:?}",
+        "Applying AWQ pre-scaling: {} layers, ratio={}, {} imatrix entries",
         num_layers,
         ratio,
-        imatrix.importance.len(),
-        materialization
+        imatrix.importance.len()
     );
 
     let mut modified = 0usize;
-    // Keys this layer's four groups rewrote. Reused across iterations so the
-    // pass allocates once, not once per layer.
-    let mut layer_touched: Vec<String> = Vec::new();
 
     // Auto-detect key prefix: sanitized VLM models use "language_model.model.layers",
     // standard HF/GGUF models use "model.layers".
@@ -8619,7 +8539,6 @@ pub(crate) fn apply_awq_prescaling_with(
     };
 
     for i in 0..num_layers {
-        layer_touched.clear();
         let prefix = format!("{layer_prefix}.{i}");
 
         // ── Group A: norm → gate_proj + up_proj ──
@@ -8642,14 +8561,12 @@ pub(crate) fn apply_awq_prescaling_with(
             // gate_proj.weight *= scales (broadcast over columns: [out, in] * [1, in])
             if let Some(gate) = weights.remove(&gate_key) {
                 let scaled = scale_columns(&gate, &scales)?;
-                layer_touched.push(gate_key.clone());
                 weights.insert(gate_key, scaled);
                 modified += 1;
             }
             // up_proj.weight *= scales (broadcast over columns)
             if let Some(up) = weights.remove(&up_key) {
                 let scaled = scale_columns(&up, &scales)?;
-                layer_touched.push(up_key.clone());
                 weights.insert(up_key.clone(), scaled);
                 modified += 1;
             }
@@ -8657,7 +8574,6 @@ pub(crate) fn apply_awq_prescaling_with(
             if let Some(norm) = weights.remove(&norm_key) {
                 let inv = invert_scales(&scales)?.astype(norm.dtype()?)?;
                 let scaled = norm.mul(&inv)?;
-                layer_touched.push(norm_key.clone());
                 weights.insert(norm_key, scaled);
                 modified += 1;
             }
@@ -8670,7 +8586,6 @@ pub(crate) fn apply_awq_prescaling_with(
             // down_proj.weight *= scales (broadcast over columns: [out, in] * [1, in])
             if let Some(down) = weights.remove(&down_key) {
                 let scaled = scale_columns(&down, &scales)?;
-                layer_touched.push(down_key.clone());
                 weights.insert(down_key, scaled);
                 modified += 1;
             }
@@ -8678,7 +8593,6 @@ pub(crate) fn apply_awq_prescaling_with(
             if let Some(up) = weights.remove(&up_key) {
                 let inv = invert_scales(&scales)?;
                 let scaled = scale_rows(&up, &inv)?;
-                layer_touched.push(up_key.clone());
                 weights.insert(up_key, scaled);
                 modified += 1;
             }
@@ -8699,7 +8613,6 @@ pub(crate) fn apply_awq_prescaling_with(
             for proj_key in [&q_key, &k_key, &v_key] {
                 if let Some(proj) = weights.remove(proj_key) {
                     let scaled = scale_columns(&proj, &scales)?;
-                    layer_touched.push(proj_key.to_string());
                     weights.insert(proj_key.to_string(), scaled);
                     modified += 1;
                 }
@@ -8708,7 +8621,6 @@ pub(crate) fn apply_awq_prescaling_with(
             if let Some(norm) = weights.remove(&input_norm_key) {
                 let inv = invert_scales(&scales)?.astype(norm.dtype()?)?;
                 let scaled = norm.mul(&inv)?;
-                layer_touched.push(input_norm_key.clone());
                 weights.insert(input_norm_key.clone(), scaled);
                 modified += 1;
             } else {
@@ -8745,7 +8657,6 @@ pub(crate) fn apply_awq_prescaling_with(
             for proj_key in [&qkv_key, &z_key, &a_key, &b_key] {
                 if let Some(proj) = weights.remove(proj_key) {
                     let scaled = scale_columns(&proj, &scales)?;
-                    layer_touched.push(proj_key.to_string());
                     weights.insert(proj_key.to_string(), scaled);
                     modified += 1;
                 }
@@ -8756,7 +8667,6 @@ pub(crate) fn apply_awq_prescaling_with(
             if let Some(norm) = weights.remove(&input_norm_key) {
                 let inv = invert_scales(&scales)?.astype(norm.dtype()?)?;
                 let scaled = norm.mul(&inv)?;
-                layer_touched.push(input_norm_key.clone());
                 weights.insert(input_norm_key, scaled);
                 modified += 1;
             } else {
@@ -8767,43 +8677,15 @@ pub(crate) fn apply_awq_prescaling_with(
                 );
             }
         }
-
-        // ── End of this layer's dependency groups ──
-        //
-        // Groups A–D only ever touch tensors of layer `i`; nothing later reads
-        // back a tensor of an earlier layer. So this is the point at which the
-        // layer's intermediates can be retired.
-        if materialization == AwqMaterialization::Streaming {
-            for key in &layer_touched {
-                let Some(array) = weights.get(key) else {
-                    continue;
-                };
-                // Materialize the small fold targets (the 1-D norm vectors)
-                // now: they are a few KB each, they are NOT quantized later,
-                // and evaluating them here is what drops this layer's scale /
-                // inverse-scale vectors. The projection weights are left LAZY
-                // on purpose — `quantize_weights_inner` and the safetensors
-                // writer both materialize-and-release one tensor at a time, so
-                // executing `weight * s` there keeps peak bf16 at a single
-                // tensor instead of the whole checkpoint.
-                if array.nbytes() <= AWQ_INLINE_MATERIALIZE_MAX_BYTES {
-                    array.eval();
-                }
-            }
-            if (i + 1) % AWQ_FLUSH_INTERVAL_LAYERS == 0 {
-                crate::array::memory::synchronize_and_clear_cache();
-            }
-        }
     }
 
-    if materialization == AwqMaterialization::EagerAll {
-        // Legacy: force the ENTIRE map resident as bf16 before quantization.
-        // Kept only as the comparison arm for the byte-equality tests.
-        for w in weights.values() {
-            w.eval();
-        }
-    }
-    crate::array::memory::synchronize_and_clear_cache();
+    // No eval here on purpose. The rewritten tensors stay lazy, so a checkpoint
+    // that fits on disk does not have to fit in RAM as bf16 before quantization
+    // shrinks it. `quantize_weights_inner` materializes and drops one tensor at
+    // a time, and the safetensors writer does the same for the tensors it
+    // skips, so the pre-scale multiply runs there at a bounded peak.
+    // `awq_prescaling_survives_lazy_materialization` pins the emitted bytes
+    // against the eval-everything-first ordering.
 
     info!(
         "AWQ pre-scaling complete: modified {} weight tensors",
@@ -9337,15 +9219,6 @@ mod tests {
         }
     }
 
-    // ── Bounded-memory AWQ: streaming vs. legacy eager materialization ────
-    //
-    // `AwqMaterialization` only decides WHEN MLX executes the reparametrization
-    // graphs, never what they compute. These tests pin that: same fixture, both
-    // arms, byte-for-byte equality of the pre-scaled tensors AND of the packed
-    // quantized triplets that follow. A regression that reorders the math (or
-    // that evaluates against a stale/partially-applied graph) shows up as a
-    // byte diff, not as a silently worse model.
-
     /// Deterministic LCG — both arms of an A/B run must see bit-identical
     /// inputs, and pulling in a RNG crate for that is not worth it.
     fn awq_lcg(seed: u64, n: usize) -> Vec<f32> {
@@ -9361,9 +9234,8 @@ mod tests {
             .collect()
     }
 
-    /// bf16 tensor of `shape` filled from `seed` — bf16 because that is the
-    /// dtype the 27B checkpoint actually carries, and the rounding it applies
-    /// is part of what must match between the two arms.
+    /// bf16 tensor of `shape` filled from `seed`. bf16 because the rounding it
+    /// applies is part of what must match between the two arms.
     fn awq_bf16(seed: u64, shape: &[i64]) -> MxArray {
         let numel: usize = shape.iter().product::<i64>() as usize;
         MxArray::from_float32(&awq_lcg(seed, numel), shape)
@@ -9453,7 +9325,7 @@ mod tests {
     /// Shapes are quantizable at group_size=64 and include tensors AWQ must
     /// leave alone (`o_proj`, `embed_tokens`) so an over-broad change is
     /// caught too.
-    fn awq_streaming_fixture() -> (HashMap<String, MxArray>, crate::utils::imatrix::ImatrixData) {
+    fn awq_fixture() -> (HashMap<String, MxArray>, crate::utils::imatrix::ImatrixData) {
         use crate::utils::imatrix::ImatrixData;
 
         const K: i64 = 128; // input features
@@ -9559,31 +9431,25 @@ mod tests {
         )
     }
 
-    /// The bounded path must reproduce the legacy eval-the-whole-map path
-    /// exactly. This is the guard on "preserve the current AWQ math".
+    /// `apply_awq_prescaling` leaves its rewritten tensors lazy, so the
+    /// pre-scale multiply is executed inside `quantize_weights_inner` instead
+    /// of before it. Moving where MLX runs a graph must not move a bit: one arm
+    /// materializes the whole map first (what this pass used to do), the other
+    /// does not, and the packed weights, scales, biases and per-layer overrides
+    /// must agree exactly. This is a guard on MLX's evaluation order, not on
+    /// our own call sites — it holds today with or without the quantize loop's
+    /// `array.eval()`.
     #[test]
-    fn awq_streaming_materialization_matches_eager_bitwise() {
-        let (mut eager, imatrix) = awq_streaming_fixture();
-        let (mut streaming, _) = awq_streaming_fixture();
+    fn awq_prescaling_survives_lazy_materialization() {
+        let (mut eager, imatrix) = awq_fixture();
+        let (mut lazy, _) = awq_fixture();
         let num_layers = infer_num_layers_from_weights(&eager);
         assert_eq!(num_layers, 2, "fixture must present two layers");
 
-        let eager_modified = apply_awq_prescaling_with(
-            &mut eager,
-            &imatrix,
-            0.5,
-            num_layers,
-            AwqMaterialization::EagerAll,
-        )
-        .expect("eager AWQ");
-        let streaming_modified = apply_awq_prescaling_with(
-            &mut streaming,
-            &imatrix,
-            0.5,
-            num_layers,
-            AwqMaterialization::Streaming,
-        )
-        .expect("streaming AWQ");
+        let eager_modified =
+            apply_awq_prescaling(&mut eager, &imatrix, 0.5, num_layers).expect("eager AWQ");
+        let lazy_modified =
+            apply_awq_prescaling(&mut lazy, &imatrix, 0.5, num_layers).expect("lazy AWQ");
 
         // Group A (gate+up+norm) ×2, Group B (down+up) ×2, Group C (q+k+v+norm),
         // Group D (qkv+z+a+b+norm) = 6 + 4 + 4 + 5 = 19.
@@ -9591,42 +9457,21 @@ mod tests {
             eager_modified, 19,
             "fixture must exercise all four AWQ groups"
         );
-        assert_eq!(
-            eager_modified, streaming_modified,
-            "materialization strategy must not change how many tensors are rewritten"
-        );
-        assert_weight_maps_bitwise_equal(&eager, &streaming);
-    }
+        assert_eq!(lazy_modified, 19, "both arms rewrite the same tensors");
 
-    /// End of the real pipeline: AWQ pre-scaling followed by quantization must
-    /// emit identical packed weights, scales, biases and per-layer overrides
-    /// under both materialization strategies. This is the guard on "preserve
-    /// the Unsloth quantization output" — the streaming path's whole point is
-    /// that the multiply now runs inside the quantizer's per-tensor loop, and
-    /// if that changed a single packed nibble it would show here.
-    #[test]
-    fn awq_then_quantize_matches_eager_bitwise() {
-        let (mut eager, imatrix) = awq_streaming_fixture();
-        let (mut streaming, _) = awq_streaming_fixture();
-
-        apply_awq_prescaling_with(&mut eager, &imatrix, 0.5, 2, AwqMaterialization::EagerAll)
-            .expect("eager AWQ");
-        apply_awq_prescaling_with(
-            &mut streaming,
-            &imatrix,
-            0.5,
-            2,
-            AwqMaterialization::Streaming,
-        )
-        .expect("streaming AWQ");
+        // The arm the quantizer must reproduce: everything resident up front,
+        // which is what this pass used to do for the whole map.
+        for w in eager.values() {
+            w.eval();
+        }
 
         let eager_overrides =
             quantize_weights_pub(&mut eager, 4, 64, "affine", false).expect("eager quantize");
-        let streaming_overrides = quantize_weights_pub(&mut streaming, 4, 64, "affine", false)
-            .expect("streaming quantize");
+        let lazy_overrides =
+            quantize_weights_pub(&mut lazy, 4, 64, "affine", false).expect("lazy quantize");
 
         assert_eq!(
-            eager_overrides, streaming_overrides,
+            eager_overrides, lazy_overrides,
             "per-layer quantization overrides must match"
         );
         assert!(
@@ -9636,14 +9481,13 @@ mod tests {
             "fixture must actually reach the quantizer"
         );
         assert!(
-            eager.contains_key("model.embed_tokens.weight")
-                && eager
-                    .get("model.embed_tokens.weight")
-                    .map(|a| a.dtype().expect("dtype") == DType::BFloat16)
-                    .unwrap_or(false),
+            eager
+                .get("model.embed_tokens.weight")
+                .map(|a| a.dtype().expect("dtype") == DType::BFloat16)
+                .unwrap_or(false),
             "embed_tokens must stay dense bf16 at embed_quantizable=false"
         );
-        assert_weight_maps_bitwise_equal(&eager, &streaming);
+        assert_weight_maps_bitwise_equal(&eager, &lazy);
     }
 
     /// The quantized triplet must not keep its dense bf16 input alive.
@@ -9658,9 +9502,10 @@ mod tests {
     fn quantize_releases_dense_sources_instead_of_pinning_them() {
         use crate::array::memory::{get_active_memory, synchronize_and_clear_cache};
 
-        // 24 × [1024, 4096] bf16 = 8 MiB each, 192 MiB dense in total. Large
-        // enough that any concurrently-running test in this crate (all of which
-        // use kilobyte-scale fixtures) cannot move the comparison.
+        // 24 × [1024, 4096] bf16 = 8 MiB each, 192 MiB dense in total.
+        // `get_active_memory` is process-wide, so this measurement depends on
+        // `RUST_TEST_THREADS = "1"` in `.cargo/config.toml` — other tests in
+        // this binary do allocate tens of MB.
         const TENSORS: usize = 24;
         const ROWS: i64 = 1024;
         const COLS: i64 = 4096;
@@ -9700,12 +9545,25 @@ mod tests {
         synchronize_and_clear_cache();
         let after = get_active_memory();
 
-        // 4-bit affine output is ~25% of the bf16 input plus scales/biases
-        // (~28% all in). Anything at or above half the dense footprint means
-        // the sources are still pinned.
+        // A quantize that emitted nothing would also free the sources, and
+        // would pass the assertion below for the wrong reason.
+        assert_eq!(
+            weights.keys().filter(|k| k.ends_with(".scales")).count(),
+            TENSORS,
+            "every source must have been quantized"
+        );
+
+        // 4-bit affine output is ~25% of the bf16 input plus scales/biases,
+        // ~28% all in. Above half the dense footprint means the sources are
+        // still pinned; below a sixth means the outputs went missing too.
         assert!(
             after - baseline < total_dense * 0.5,
             "dense bf16 sources still resident after quantization: \
+             baseline={baseline}, with_dense={with_dense}, after={after}, dense={total_dense}"
+        );
+        assert!(
+            after - baseline > total_dense * 0.15,
+            "quantized outputs are not resident either: \
              baseline={baseline}, with_dense={with_dense}, after={after}, dense={total_dense}"
         );
     }

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -6855,6 +6855,17 @@ const QUANTIZE_TILE_NUM_EXPERTS: i64 = 32;
 /// remainder (256 → 8 tiles of 32; 128 → 4; 64 → 2; 32 → 1).
 const QUANTIZE_TILE_THRESHOLD_NUM_EXPERTS: i64 = 32;
 
+/// Dense source bytes the quantize loop may retire between allocator flushes.
+///
+/// Complements the legacy every-50-tensors cadence, which is size-blind: on a
+/// 27B MoE checkpoint fifty expert stacks is tens of GB of freed-but-cached
+/// buffers, and holding that until the 50th tensor is what pushes a 36 GB box
+/// into swap. 1 GiB is small enough to keep the allocator's high-water mark
+/// near a single tensor's working set and large enough that the full
+/// `mlx_synchronize` stall stays amortized (a few hundred flushes across a
+/// whole checkpoint, not one per tensor).
+const QUANTIZE_FLUSH_BYTE_BUDGET: usize = 1 << 30;
+
 /// Quantize a plain per-output-channel E4M3 weight, tiling large 3-D expert
 /// stacks along axis 0. This mirrors [`quantize_with_optional_tiling`]'s
 /// watchdog discipline: each expert tile is evaluated and synchronized before
@@ -8214,6 +8225,13 @@ fn quantize_weights_inner(
 
     let mut per_layer_overrides = preexisting_overrides;
     let mut count = 0;
+    // Dense source bytes released since the last allocator flush. The old
+    // `count % 50` cadence is size-blind — 50 MoE expert stacks is tens of GB
+    // of transients while 50 small projections is a few hundred MB — so it
+    // cannot bound peak RSS on a big checkpoint. Flushing on a byte budget as
+    // well keeps the ceiling independent of tensor size, which is what lets an
+    // AWQ-prescaled 27B convert finish on a 36 GB machine.
+    let mut bytes_since_flush: usize = 0;
 
     for entry in &entries {
         let array = match weights.remove(&entry.key) {
@@ -8229,8 +8247,13 @@ fn quantize_weights_inner(
             continue;
         }
 
-        // Eval to materialize (prevents lazy graph OOM)
+        // Eval to materialize (prevents lazy graph OOM). With AWQ pre-scaling
+        // upstream this is also where the tensor's pre-scale graph
+        // (`weight * s`, and for `up_proj` an additional `/ s'`) is finally
+        // executed — one tensor at a time, instead of the whole checkpoint at
+        // once. See `apply_awq_prescaling`'s materialization contract.
         array.eval();
+        let source_bytes = array.nbytes();
 
         let (q_weight, q_scales, q_biases) =
             if entry.mode == crate::quant::fp8_weight::FP8_E4M3_MODE {
@@ -8256,6 +8279,22 @@ fn quantize_weights_inner(
                 )?
             };
 
+        // Materialize the quantized triplet BEFORE releasing the dense source.
+        // `mlx_quantize` (and the fp8/sym8 helpers on their non-tiled paths)
+        // return LAZY arrays whose graph still holds `array` alive. Inserting
+        // them un-evaluated pins every dense bf16 input until the safetensors
+        // writer finally evaluates it — i.e. the entire checkpoint resident at
+        // once, which is exactly the OOM this pass is supposed to avoid.
+        // Evaluating here severs that edge so the `drop(array)` below actually
+        // frees the bf16 buffer. eval() cannot change values, so the emitted
+        // bytes are identical to the lazy path.
+        q_weight.eval();
+        q_scales.eval();
+        if let Some(b) = &q_biases {
+            b.eval();
+        }
+        drop(array);
+
         let prefix = entry.key.strip_suffix(".weight").unwrap_or(&entry.key);
         weights.insert(format!("{}.weight", prefix), q_weight);
         weights.insert(format!("{}.scales", prefix), q_scales);
@@ -8278,9 +8317,11 @@ fn quantize_weights_inner(
         );
 
         count += 1;
+        bytes_since_flush += source_bytes;
 
-        if count % 50 == 0 {
+        if bytes_since_flush >= QUANTIZE_FLUSH_BYTE_BUDGET || count % 50 == 0 {
             crate::array::memory::synchronize_and_clear_cache();
+            bytes_since_flush = 0;
             info!("  Quantized {}/{} tensors...", count, entries.len());
         }
     }
@@ -8485,20 +8526,86 @@ pub(crate) fn reject_awq_for_prequantized_body(weights: &HashMap<String, MxArray
 /// Note: self_attn.o_proj and linear_attn.out_proj are NOT covered — their inputs
 /// come from attention/GDN computation, not from a norm layer. These tensors should
 /// be kept at bf16 or quantized without AWQ correction.
+///
+/// Memory: see [`AwqMaterialization`]. The default is
+/// [`AwqMaterialization::Streaming`], which never holds more than one layer's
+/// fold targets at a time.
 pub(crate) fn apply_awq_prescaling(
     weights: &mut HashMap<String, MxArray>,
     imatrix: &crate::utils::imatrix::ImatrixData,
     ratio: f32,
     num_layers: usize,
 ) -> Result<usize> {
+    apply_awq_prescaling_with(
+        weights,
+        imatrix,
+        ratio,
+        num_layers,
+        AwqMaterialization::Streaming,
+    )
+}
+
+/// How [`apply_awq_prescaling_with`] turns the AWQ reparametrization graphs
+/// into buffers.
+///
+/// The math is identical either way — this only decides *when* MLX executes
+/// the graphs, and therefore how much bf16 is resident at the peak.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AwqMaterialization {
+    /// Legacy behavior: after every group of every layer is built, walk the
+    /// WHOLE weight map and `eval()` each entry. That forces the entire
+    /// checkpoint — including tensors AWQ never touched — into RAM as bf16
+    /// before quantization gets a chance to shrink anything (~41.6 GiB for
+    /// Qwen3.6-27B, which is what froze 36 GB machines).
+    ///
+    /// Retained only so tests can prove the streaming path is byte-identical.
+    #[cfg_attr(not(test), allow(dead_code))]
+    EagerAll,
+    /// Bounded behavior. Per layer, only the *fold targets* — the 1-D norm
+    /// vectors, a few KB each — are materialized, which also releases that
+    /// layer's scale vectors. The 2-D/3-D projection graphs are deliberately
+    /// left LAZY: `quantize_weights_inner` (and, for tensors it skips, the
+    /// safetensors writer) already materializes one tensor at a time and drops
+    /// it immediately, so the pre-scale multiply happens inside that streaming
+    /// loop instead of all at once here. Peak bf16 is therefore one projection
+    /// (plus its single intermediate), not the checkpoint.
+    Streaming,
+}
+
+/// Byte size at or below which [`AwqMaterialization::Streaming`] materializes
+/// an AWQ output inside the layer loop rather than leaving it lazy.
+///
+/// Sized to cover norm vectors (`hidden_size` f32/bf16 — 20 KB even at
+/// hidden_size=5120) and nothing else, so no projection weight can slip
+/// through and start accumulating.
+const AWQ_INLINE_MATERIALIZE_MAX_BYTES: usize = 1 << 20;
+
+/// Layers between allocator flushes on the streaming path. Each layer only
+/// retires a handful of KB of norm/scale buffers, so flushing every layer
+/// would pay a full `mlx_synchronize` stall for nothing.
+const AWQ_FLUSH_INTERVAL_LAYERS: usize = 16;
+
+/// Implementation behind [`apply_awq_prescaling`], parameterized by
+/// materialization strategy so tests can A/B the legacy and bounded paths.
+pub(crate) fn apply_awq_prescaling_with(
+    weights: &mut HashMap<String, MxArray>,
+    imatrix: &crate::utils::imatrix::ImatrixData,
+    ratio: f32,
+    num_layers: usize,
+    materialization: AwqMaterialization,
+) -> Result<usize> {
     info!(
-        "Applying AWQ pre-scaling: {} layers, ratio={}, {} imatrix entries",
+        "Applying AWQ pre-scaling: {} layers, ratio={}, {} imatrix entries, mode={:?}",
         num_layers,
         ratio,
-        imatrix.importance.len()
+        imatrix.importance.len(),
+        materialization
     );
 
     let mut modified = 0usize;
+    // Keys this layer's four groups rewrote. Reused across iterations so the
+    // pass allocates once, not once per layer.
+    let mut layer_touched: Vec<String> = Vec::new();
 
     // Auto-detect key prefix: sanitized VLM models use "language_model.model.layers",
     // standard HF/GGUF models use "model.layers".
@@ -8512,6 +8619,7 @@ pub(crate) fn apply_awq_prescaling(
     };
 
     for i in 0..num_layers {
+        layer_touched.clear();
         let prefix = format!("{layer_prefix}.{i}");
 
         // ── Group A: norm → gate_proj + up_proj ──
@@ -8534,12 +8642,14 @@ pub(crate) fn apply_awq_prescaling(
             // gate_proj.weight *= scales (broadcast over columns: [out, in] * [1, in])
             if let Some(gate) = weights.remove(&gate_key) {
                 let scaled = scale_columns(&gate, &scales)?;
+                layer_touched.push(gate_key.clone());
                 weights.insert(gate_key, scaled);
                 modified += 1;
             }
             // up_proj.weight *= scales (broadcast over columns)
             if let Some(up) = weights.remove(&up_key) {
                 let scaled = scale_columns(&up, &scales)?;
+                layer_touched.push(up_key.clone());
                 weights.insert(up_key.clone(), scaled);
                 modified += 1;
             }
@@ -8547,6 +8657,7 @@ pub(crate) fn apply_awq_prescaling(
             if let Some(norm) = weights.remove(&norm_key) {
                 let inv = invert_scales(&scales)?.astype(norm.dtype()?)?;
                 let scaled = norm.mul(&inv)?;
+                layer_touched.push(norm_key.clone());
                 weights.insert(norm_key, scaled);
                 modified += 1;
             }
@@ -8559,6 +8670,7 @@ pub(crate) fn apply_awq_prescaling(
             // down_proj.weight *= scales (broadcast over columns: [out, in] * [1, in])
             if let Some(down) = weights.remove(&down_key) {
                 let scaled = scale_columns(&down, &scales)?;
+                layer_touched.push(down_key.clone());
                 weights.insert(down_key, scaled);
                 modified += 1;
             }
@@ -8566,6 +8678,7 @@ pub(crate) fn apply_awq_prescaling(
             if let Some(up) = weights.remove(&up_key) {
                 let inv = invert_scales(&scales)?;
                 let scaled = scale_rows(&up, &inv)?;
+                layer_touched.push(up_key.clone());
                 weights.insert(up_key, scaled);
                 modified += 1;
             }
@@ -8586,6 +8699,7 @@ pub(crate) fn apply_awq_prescaling(
             for proj_key in [&q_key, &k_key, &v_key] {
                 if let Some(proj) = weights.remove(proj_key) {
                     let scaled = scale_columns(&proj, &scales)?;
+                    layer_touched.push(proj_key.to_string());
                     weights.insert(proj_key.to_string(), scaled);
                     modified += 1;
                 }
@@ -8594,6 +8708,7 @@ pub(crate) fn apply_awq_prescaling(
             if let Some(norm) = weights.remove(&input_norm_key) {
                 let inv = invert_scales(&scales)?.astype(norm.dtype()?)?;
                 let scaled = norm.mul(&inv)?;
+                layer_touched.push(input_norm_key.clone());
                 weights.insert(input_norm_key.clone(), scaled);
                 modified += 1;
             } else {
@@ -8630,6 +8745,7 @@ pub(crate) fn apply_awq_prescaling(
             for proj_key in [&qkv_key, &z_key, &a_key, &b_key] {
                 if let Some(proj) = weights.remove(proj_key) {
                     let scaled = scale_columns(&proj, &scales)?;
+                    layer_touched.push(proj_key.to_string());
                     weights.insert(proj_key.to_string(), scaled);
                     modified += 1;
                 }
@@ -8640,6 +8756,7 @@ pub(crate) fn apply_awq_prescaling(
             if let Some(norm) = weights.remove(&input_norm_key) {
                 let inv = invert_scales(&scales)?.astype(norm.dtype()?)?;
                 let scaled = norm.mul(&inv)?;
+                layer_touched.push(input_norm_key.clone());
                 weights.insert(input_norm_key, scaled);
                 modified += 1;
             } else {
@@ -8650,12 +8767,43 @@ pub(crate) fn apply_awq_prescaling(
                 );
             }
         }
+
+        // ── End of this layer's dependency groups ──
+        //
+        // Groups A–D only ever touch tensors of layer `i`; nothing later reads
+        // back a tensor of an earlier layer. So this is the point at which the
+        // layer's intermediates can be retired.
+        if materialization == AwqMaterialization::Streaming {
+            for key in &layer_touched {
+                let Some(array) = weights.get(key) else {
+                    continue;
+                };
+                // Materialize the small fold targets (the 1-D norm vectors)
+                // now: they are a few KB each, they are NOT quantized later,
+                // and evaluating them here is what drops this layer's scale /
+                // inverse-scale vectors. The projection weights are left LAZY
+                // on purpose — `quantize_weights_inner` and the safetensors
+                // writer both materialize-and-release one tensor at a time, so
+                // executing `weight * s` there keeps peak bf16 at a single
+                // tensor instead of the whole checkpoint.
+                if array.nbytes() <= AWQ_INLINE_MATERIALIZE_MAX_BYTES {
+                    array.eval();
+                }
+            }
+            if (i + 1) % AWQ_FLUSH_INTERVAL_LAYERS == 0 {
+                crate::array::memory::synchronize_and_clear_cache();
+            }
+        }
     }
 
-    // Eval all modified weights to materialize
-    for w in weights.values() {
-        w.eval();
+    if materialization == AwqMaterialization::EagerAll {
+        // Legacy: force the ENTIRE map resident as bf16 before quantization.
+        // Kept only as the comparison arm for the byte-equality tests.
+        for w in weights.values() {
+            w.eval();
+        }
     }
+    crate::array::memory::synchronize_and_clear_cache();
 
     info!(
         "AWQ pre-scaling complete: modified {} weight tensors",
@@ -9187,6 +9335,379 @@ mod tests {
                 "layer 0 gate[{j}] × pre_ffn_norm[{j}] = {prod}, fold must be balanced"
             );
         }
+    }
+
+    // ── Bounded-memory AWQ: streaming vs. legacy eager materialization ────
+    //
+    // `AwqMaterialization` only decides WHEN MLX executes the reparametrization
+    // graphs, never what they compute. These tests pin that: same fixture, both
+    // arms, byte-for-byte equality of the pre-scaled tensors AND of the packed
+    // quantized triplets that follow. A regression that reorders the math (or
+    // that evaluates against a stale/partially-applied graph) shows up as a
+    // byte diff, not as a silently worse model.
+
+    /// Deterministic LCG — both arms of an A/B run must see bit-identical
+    /// inputs, and pulling in a RNG crate for that is not worth it.
+    fn awq_lcg(seed: u64, n: usize) -> Vec<f32> {
+        let mut s = seed | 1;
+        (0..n)
+            .map(|_| {
+                s = s
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                // 24 random bits → [-1.0, 1.0)
+                ((s >> 40) as f32 / (1u32 << 23) as f32) - 1.0
+            })
+            .collect()
+    }
+
+    /// bf16 tensor of `shape` filled from `seed` — bf16 because that is the
+    /// dtype the 27B checkpoint actually carries, and the rounding it applies
+    /// is part of what must match between the two arms.
+    fn awq_bf16(seed: u64, shape: &[i64]) -> MxArray {
+        let numel: usize = shape.iter().product::<i64>() as usize;
+        MxArray::from_float32(&awq_lcg(seed, numel), shape)
+            .expect("from_float32")
+            .astype(DType::BFloat16)
+            .expect("astype bfloat16")
+    }
+
+    /// Strictly positive importance vector (AWQ clamps at 1e-8 and raises to
+    /// `ratio`, so a zero would flatten the group and hide ordering bugs).
+    fn awq_importance(seed: u64, n: usize) -> Vec<f32> {
+        awq_lcg(seed, n)
+            .into_iter()
+            .map(|v| v.abs() + 0.25)
+            .collect()
+    }
+
+    /// Exact byte image of a tensor, dtype-faithful.
+    ///
+    /// Packed `Uint32` weights MUST go through `to_uint32`: routing them
+    /// through f32 loses every value above 2^24, which would let a real
+    /// divergence in the packed nibbles compare equal.
+    fn awq_tensor_bytes(array: &MxArray) -> Vec<u8> {
+        array.eval();
+        match array.dtype().expect("dtype") {
+            DType::Uint32 => array
+                .to_uint32()
+                .expect("to_uint32")
+                .iter()
+                .flat_map(|v| v.to_le_bytes())
+                .collect(),
+            DType::Float16 | DType::BFloat16 => array
+                .to_uint16_native()
+                .expect("to_uint16_native")
+                .iter()
+                .flat_map(|v| v.to_le_bytes())
+                .collect(),
+            DType::Int32 => array
+                .to_int32()
+                .expect("to_int32")
+                .iter()
+                .flat_map(|v| v.to_le_bytes())
+                .collect(),
+            // f32, u8 and i8 all round-trip through f32 without loss.
+            _ => array
+                .to_float32()
+                .expect("to_float32")
+                .iter()
+                .flat_map(|v| v.to_bits().to_le_bytes())
+                .collect(),
+        }
+    }
+
+    fn assert_weight_maps_bitwise_equal(
+        left: &HashMap<String, MxArray>,
+        right: &HashMap<String, MxArray>,
+    ) {
+        let mut left_keys: Vec<&String> = left.keys().collect();
+        let mut right_keys: Vec<&String> = right.keys().collect();
+        left_keys.sort();
+        right_keys.sort();
+        assert_eq!(left_keys, right_keys, "key sets must match");
+
+        for key in left_keys {
+            let (a, b) = (&left[key], &right[key]);
+            assert_eq!(
+                a.dtype().expect("dtype"),
+                b.dtype().expect("dtype"),
+                "dtype differs for {key}"
+            );
+            let a_shape = a.shape().expect("shape");
+            let b_shape = b.shape().expect("shape");
+            let a_dims: &[i64] = a_shape.as_ref();
+            let b_dims: &[i64] = b_shape.as_ref();
+            assert_eq!(a_dims, b_dims, "shape differs for {key}");
+            assert_eq!(
+                awq_tensor_bytes(a),
+                awq_tensor_bytes(b),
+                "bytes differ for {key}"
+            );
+        }
+    }
+
+    /// Two-layer synthetic checkpoint that exercises every AWQ group:
+    /// layer 0 is a GatedDeltaNet layer (Group D) and layer 1 is a
+    /// full-attention layer (Group C); both carry an MLP (Groups A and B).
+    /// Shapes are quantizable at group_size=64 and include tensors AWQ must
+    /// leave alone (`o_proj`, `embed_tokens`) so an over-broad change is
+    /// caught too.
+    fn awq_streaming_fixture() -> (HashMap<String, MxArray>, crate::utils::imatrix::ImatrixData) {
+        use crate::utils::imatrix::ImatrixData;
+
+        const K: i64 = 128; // input features
+        const N: i64 = 64; // output features
+
+        let mut weights: HashMap<String, MxArray> = HashMap::new();
+        let mut importance: HashMap<String, Vec<f32>> = HashMap::new();
+        let mut seed = 1u64;
+        let mut next_seed = || {
+            seed += 1;
+            seed
+        };
+
+        // Layer 0 — GatedDeltaNet (Group D).
+        for key in [
+            "model.layers.0.linear_attn.in_proj_qkv.weight",
+            "model.layers.0.linear_attn.in_proj_z.weight",
+            "model.layers.0.linear_attn.in_proj_a.weight",
+            "model.layers.0.linear_attn.in_proj_b.weight",
+        ] {
+            weights.insert(key.into(), awq_bf16(next_seed(), &[N, K]));
+        }
+        // Group D derives its scale from qkv + z only.
+        for key in [
+            "model.layers.0.linear_attn.in_proj_qkv.weight",
+            "model.layers.0.linear_attn.in_proj_z.weight",
+        ] {
+            importance.insert(key.into(), awq_importance(next_seed(), K as usize));
+        }
+        weights.insert(
+            "model.layers.0.linear_attn.out_proj.weight".into(),
+            awq_bf16(next_seed(), &[K, N]),
+        );
+
+        // Layer 1 — full attention (Group C).
+        for key in [
+            "model.layers.1.self_attn.q_proj.weight",
+            "model.layers.1.self_attn.k_proj.weight",
+            "model.layers.1.self_attn.v_proj.weight",
+        ] {
+            weights.insert(key.into(), awq_bf16(next_seed(), &[N, K]));
+            importance.insert(key.into(), awq_importance(next_seed(), K as usize));
+        }
+        // o_proj reads attention output, not a norm — AWQ must not touch it,
+        // and no importance entry is registered for it.
+        weights.insert(
+            "model.layers.1.self_attn.o_proj.weight".into(),
+            awq_bf16(next_seed(), &[K, N]),
+        );
+
+        // Shared per-layer structure: MLP (Groups A + B) and both norms.
+        for layer in 0..2 {
+            weights.insert(
+                format!("model.layers.{layer}.mlp.gate_proj.weight"),
+                awq_bf16(next_seed(), &[N, K]),
+            );
+            weights.insert(
+                format!("model.layers.{layer}.mlp.up_proj.weight"),
+                awq_bf16(next_seed(), &[N, K]),
+            );
+            // down_proj is [out=K, in=N]; Group B's scale length is its INPUT
+            // dim, which is also up_proj's output dim — that is the coupling
+            // the two groups share through up_proj.
+            weights.insert(
+                format!("model.layers.{layer}.mlp.down_proj.weight"),
+                awq_bf16(next_seed(), &[K, N]),
+            );
+            importance.insert(
+                format!("model.layers.{layer}.mlp.gate_proj.weight"),
+                awq_importance(next_seed(), K as usize),
+            );
+            importance.insert(
+                format!("model.layers.{layer}.mlp.up_proj.weight"),
+                awq_importance(next_seed(), K as usize),
+            );
+            importance.insert(
+                format!("model.layers.{layer}.mlp.down_proj.weight"),
+                awq_importance(next_seed(), N as usize),
+            );
+            weights.insert(
+                format!("model.layers.{layer}.input_layernorm.weight"),
+                awq_bf16(next_seed(), &[K]),
+            );
+            weights.insert(
+                format!("model.layers.{layer}.post_attention_layernorm.weight"),
+                awq_bf16(next_seed(), &[K]),
+            );
+        }
+
+        // Never AWQ-scaled, never quantized at embed_quantizable=false.
+        weights.insert(
+            "model.embed_tokens.weight".into(),
+            awq_bf16(next_seed(), &[256, K]),
+        );
+
+        (
+            weights,
+            ImatrixData {
+                importance,
+                chunk_count: 1,
+                chunk_size: 1,
+            },
+        )
+    }
+
+    /// The bounded path must reproduce the legacy eval-the-whole-map path
+    /// exactly. This is the guard on "preserve the current AWQ math".
+    #[test]
+    fn awq_streaming_materialization_matches_eager_bitwise() {
+        let (mut eager, imatrix) = awq_streaming_fixture();
+        let (mut streaming, _) = awq_streaming_fixture();
+        let num_layers = infer_num_layers_from_weights(&eager);
+        assert_eq!(num_layers, 2, "fixture must present two layers");
+
+        let eager_modified = apply_awq_prescaling_with(
+            &mut eager,
+            &imatrix,
+            0.5,
+            num_layers,
+            AwqMaterialization::EagerAll,
+        )
+        .expect("eager AWQ");
+        let streaming_modified = apply_awq_prescaling_with(
+            &mut streaming,
+            &imatrix,
+            0.5,
+            num_layers,
+            AwqMaterialization::Streaming,
+        )
+        .expect("streaming AWQ");
+
+        // Group A (gate+up+norm) ×2, Group B (down+up) ×2, Group C (q+k+v+norm),
+        // Group D (qkv+z+a+b+norm) = 6 + 4 + 4 + 5 = 19.
+        assert_eq!(
+            eager_modified, 19,
+            "fixture must exercise all four AWQ groups"
+        );
+        assert_eq!(
+            eager_modified, streaming_modified,
+            "materialization strategy must not change how many tensors are rewritten"
+        );
+        assert_weight_maps_bitwise_equal(&eager, &streaming);
+    }
+
+    /// End of the real pipeline: AWQ pre-scaling followed by quantization must
+    /// emit identical packed weights, scales, biases and per-layer overrides
+    /// under both materialization strategies. This is the guard on "preserve
+    /// the Unsloth quantization output" — the streaming path's whole point is
+    /// that the multiply now runs inside the quantizer's per-tensor loop, and
+    /// if that changed a single packed nibble it would show here.
+    #[test]
+    fn awq_then_quantize_matches_eager_bitwise() {
+        let (mut eager, imatrix) = awq_streaming_fixture();
+        let (mut streaming, _) = awq_streaming_fixture();
+
+        apply_awq_prescaling_with(&mut eager, &imatrix, 0.5, 2, AwqMaterialization::EagerAll)
+            .expect("eager AWQ");
+        apply_awq_prescaling_with(
+            &mut streaming,
+            &imatrix,
+            0.5,
+            2,
+            AwqMaterialization::Streaming,
+        )
+        .expect("streaming AWQ");
+
+        let eager_overrides =
+            quantize_weights_pub(&mut eager, 4, 64, "affine", false).expect("eager quantize");
+        let streaming_overrides = quantize_weights_pub(&mut streaming, 4, 64, "affine", false)
+            .expect("streaming quantize");
+
+        assert_eq!(
+            eager_overrides, streaming_overrides,
+            "per-layer quantization overrides must match"
+        );
+        assert!(
+            eager
+                .keys()
+                .any(|k| k == "model.layers.1.self_attn.q_proj.scales"),
+            "fixture must actually reach the quantizer"
+        );
+        assert!(
+            eager.contains_key("model.embed_tokens.weight")
+                && eager
+                    .get("model.embed_tokens.weight")
+                    .map(|a| a.dtype().expect("dtype") == DType::BFloat16)
+                    .unwrap_or(false),
+            "embed_tokens must stay dense bf16 at embed_quantizable=false"
+        );
+        assert_weight_maps_bitwise_equal(&eager, &streaming);
+    }
+
+    /// The quantized triplet must not keep its dense bf16 input alive.
+    ///
+    /// `mlx_quantize` returns lazy arrays whose graph references the source
+    /// weight; if they are stored un-evaluated, every dense input stays
+    /// resident until the safetensors writer finally evaluates it — the whole
+    /// checkpoint at once, which is the OOM this change exists to fix. Measured
+    /// through MLX's own allocator rather than RSS so page-cache noise cannot
+    /// mask it.
+    #[test]
+    fn quantize_releases_dense_sources_instead_of_pinning_them() {
+        use crate::array::memory::{get_active_memory, synchronize_and_clear_cache};
+
+        // 24 × [1024, 4096] bf16 = 8 MiB each, 192 MiB dense in total. Large
+        // enough that any concurrently-running test in this crate (all of which
+        // use kilobyte-scale fixtures) cannot move the comparison.
+        const TENSORS: usize = 24;
+        const ROWS: i64 = 1024;
+        const COLS: i64 = 4096;
+        let total_dense = (ROWS * COLS) as f64 * 2.0 * TENSORS as f64;
+
+        synchronize_and_clear_cache();
+        let baseline = get_active_memory();
+
+        // One filler buffer reused for every tensor: `from_float32` copies into
+        // a fresh MLX allocation each time, so the tensors are still distinct
+        // buffers — this only avoids regenerating 100M pseudo-random floats.
+        let filler = vec![0.125f32; (ROWS * COLS) as usize];
+        let mut weights: HashMap<String, MxArray> = HashMap::new();
+        for i in 0..TENSORS {
+            let array = MxArray::from_float32(&filler, &[ROWS, COLS])
+                .expect("from_float32")
+                .astype(DType::BFloat16)
+                .expect("astype bfloat16");
+            array.eval();
+            weights.insert(format!("model.layers.{i}.self_attn.q_proj.weight"), array);
+        }
+        synchronize_and_clear_cache();
+        let with_dense = get_active_memory();
+
+        // Hosts whose MLX build reports no allocator statistics (the accessor
+        // returns 0 on a caught exception) cannot support this assertion.
+        // Skip rather than fail — the bitwise tests above still cover
+        // correctness.
+        if with_dense - baseline < total_dense * 0.5 {
+            eprintln!(
+                "skipping: MLX allocator stats unusable (baseline={baseline}, with_dense={with_dense})"
+            );
+            return;
+        }
+
+        quantize_weights_pub(&mut weights, 4, 64, "affine", false).expect("quantize");
+        synchronize_and_clear_cache();
+        let after = get_active_memory();
+
+        // 4-bit affine output is ~25% of the bf16 input plus scales/biases
+        // (~28% all in). Anything at or above half the dense footprint means
+        // the sources are still pinned.
+        assert!(
+            after - baseline < total_dense * 0.5,
+            "dense bf16 sources still resident after quantization: \
+             baseline={baseline}, with_dense={with_dense}, after={after}, dense={total_dense}"
+        );
     }
 
     /// Registry-consistency gate: for the exhaustive set of supported

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -4262,14 +4262,15 @@ async fn convert_model_inner(options: ConversionOptions) -> Result<ConversionRes
         HashMap::new();
     if !source_by_handle.is_empty() {
         for (dest_name, array) in converted_tensors.iter() {
-            if let Some(prov) = source_by_handle.get(&(array.as_raw_ptr() as usize)) {
+            if let Some(prov) = source_by_handle.get(&(array.as_raw_ptr() as usize))
+                && prov.matches(array)
+            {
                 dest_passthrough.insert(dest_name.clone(), prov.source.clone());
             }
         }
     }
-    // Release the pinned source handles before the streaming save drains
-    // `converted_tensors` — `dest_passthrough` carries only file locations, no
-    // arrays, so the keep-alive clones are no longer needed.
+    // `dest_passthrough` now carries every file location still needed, and the
+    // map holds no arrays, so this just releases the entries.
     drop(source_by_handle);
 
     let save_start = std::time::Instant::now();

--- a/crates/mlx-core/src/utils/safetensors.rs
+++ b/crates/mlx-core/src/utils/safetensors.rs
@@ -408,18 +408,14 @@ pub struct SourceProvenance {
 /// on-disk bytes are a pure little-endian bit layout byte-identical to what the
 /// MLX writer emits. Other dtypes are excluded conservatively.
 ///
-/// Tensors below [`raw_passthrough_threshold_bytes`] are ALSO excluded, because
-/// each recorded entry pins its source array alive (see `_keep_alive`) for the
-/// whole conversion. The writer's raw path is gated on
-/// `dest_len >= raw_threshold`, so an entry below it can never be consulted —
-/// recording one buys nothing and costs the tensor's full resident footprint
-/// once something materializes it. On an AWQ run that is the difference between
-/// holding two tensors and holding the entire bf16 checkpoint: AWQ pre-scaling
-/// forces each source to materialize, and a pinned clone then keeps every one
-/// of them resident. Excluding a tensor cannot reintroduce the ABA hazard the
-/// pin defends against — an entry that was never inserted has no pointer for a
-/// recycled address to collide with, and the entries that remain are still
-/// pinned.
+/// Tensors below [`raw_passthrough_threshold_bytes`] are also excluded. The
+/// writer's raw path demands `dest_len >= raw_threshold` AND
+/// `src.byte_len == dest_len`, so a smaller entry can never be consulted, while
+/// `_keep_alive` still pins its source for the whole convert — the quantize
+/// loop then materializes that source and the pin holds the dense bytes to the
+/// end. Excluding a tensor cannot reintroduce the ABA hazard the pin defends
+/// against: an entry that was never inserted has no pointer for a recycled
+/// address to collide with, and every retained entry is still pinned.
 pub fn record_passthrough_sources<P: AsRef<Path>>(
     source_file: P,
     loaded: &HashMap<String, MxArray>,
@@ -431,9 +427,9 @@ pub fn record_passthrough_sources<P: AsRef<Path>>(
 /// [`record_passthrough_sources`] with the size gate lifted into an argument.
 ///
 /// The threshold is a parameter purely so it is assertable without
-/// `std::env::set_var`: that is `unsafe` and races every other test thread in
-/// this binary, and several tests here call [`save_safetensors`], which reads
-/// the same variable on its own raw path.
+/// `std::env::set_var`, which is `unsafe` against any concurrent `getenv` and
+/// would also reach the sibling tests that call [`save_safetensors`], since the
+/// writer resolves the same variable on its own raw path.
 pub(crate) fn record_passthrough_sources_with<P: AsRef<Path>>(
     source_file: P,
     loaded: &HashMap<String, MxArray>,
@@ -453,9 +449,8 @@ pub(crate) fn record_passthrough_sources_with<P: AsRef<Path>>(
             _ => continue,
         };
         let byte_len = info.data_offsets[1] - info.data_offsets[0];
-        // Below the writer's raw-path size gate this entry is unusable, and the
-        // `_keep_alive` clone below would pin the source for the whole convert
-        // for nothing. See fn doc.
+        // Unusable below the writer's size gate, and the pin below is not free.
+        // See fn doc.
         if (byte_len as u64) < raw_threshold {
             continue;
         }
@@ -1286,10 +1281,7 @@ mod tests {
         let small_ptr = loaded.get("small").unwrap().as_raw_ptr() as usize;
         let big_ptr = loaded.get("big").unwrap().as_raw_ptr() as usize;
 
-        // Threshold between the two (512 B > 100 ≥ 32 B), passed directly.
-        // Setting MLX_CONVERT_RAW_THRESHOLD_BYTES here instead would be
-        // `unsafe` and would race the sibling tests that call
-        // `save_safetensors`, which reads that variable.
+        // Threshold between the two: 512 B >= 100 > 32 B.
         let mut out = HashMap::new();
         record_passthrough_sources_with(&path, &loaded, &mut out, 100).unwrap();
 

--- a/crates/mlx-core/src/utils/safetensors.rs
+++ b/crates/mlx-core/src/utils/safetensors.rs
@@ -407,10 +407,38 @@ pub struct SourceProvenance {
 /// Only 2-byte float source tensors (bf16/f16) are recorded — their safetensors
 /// on-disk bytes are a pure little-endian bit layout byte-identical to what the
 /// MLX writer emits. Other dtypes are excluded conservatively.
+///
+/// Tensors below [`raw_passthrough_threshold_bytes`] are ALSO excluded, because
+/// each recorded entry pins its source array alive (see `_keep_alive`) for the
+/// whole conversion. The writer's raw path is gated on
+/// `dest_len >= raw_threshold`, so an entry below it can never be consulted —
+/// recording one buys nothing and costs the tensor's full resident footprint
+/// once something materializes it. On an AWQ run that is the difference between
+/// holding two tensors and holding the entire bf16 checkpoint: AWQ pre-scaling
+/// forces each source to materialize, and a pinned clone then keeps every one
+/// of them resident. Excluding a tensor cannot reintroduce the ABA hazard the
+/// pin defends against — an entry that was never inserted has no pointer for a
+/// recycled address to collide with, and the entries that remain are still
+/// pinned.
 pub fn record_passthrough_sources<P: AsRef<Path>>(
     source_file: P,
     loaded: &HashMap<String, MxArray>,
     out: &mut HashMap<usize, SourceProvenance>,
+) -> Result<()> {
+    record_passthrough_sources_with(source_file, loaded, out, raw_passthrough_threshold_bytes())
+}
+
+/// [`record_passthrough_sources`] with the size gate lifted into an argument.
+///
+/// The threshold is a parameter purely so it is assertable without
+/// `std::env::set_var`: that is `unsafe` and races every other test thread in
+/// this binary, and several tests here call [`save_safetensors`], which reads
+/// the same variable on its own raw path.
+pub(crate) fn record_passthrough_sources_with<P: AsRef<Path>>(
+    source_file: P,
+    loaded: &HashMap<String, MxArray>,
+    out: &mut HashMap<usize, SourceProvenance>,
+    raw_threshold: u64,
 ) -> Result<()> {
     let path = source_file.as_ref();
     let st = SafeTensorsFile::load(path)?;
@@ -425,6 +453,12 @@ pub fn record_passthrough_sources<P: AsRef<Path>>(
             _ => continue,
         };
         let byte_len = info.data_offsets[1] - info.data_offsets[0];
+        // Below the writer's raw-path size gate this entry is unusable, and the
+        // `_keep_alive` clone below would pin the source for the whole convert
+        // for nothing. See fn doc.
+        if (byte_len as u64) < raw_threshold {
+            continue;
+        }
         let file_offset = (st.data_offset + info.data_offsets[0]) as u64;
         // Keep the source array alive (clone shares the `Arc<MxHandle>`) so its
         // raw handle pointer is PINNED for the whole convert. This closes an ABA
@@ -1223,6 +1257,57 @@ mod tests {
         // And both must equal the original little-endian u16 input.
         let expected: Vec<u8> = bits.iter().flat_map(|&x| x.to_le_bytes()).collect();
         assert_eq!(raw_bytes, expected);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Provenance must only be recorded for tensors the writer's raw path can
+    /// actually use, because every recorded entry pins its source array alive
+    /// for the whole conversion. Recording sub-threshold tensors is what kept
+    /// an entire AWQ-prescaled bf16 checkpoint resident.
+    #[test]
+    fn passthrough_provenance_skips_tensors_below_the_raw_threshold() {
+        let dir = std::env::temp_dir().join(format!("st_prov_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.safetensors");
+
+        // Two bf16 tensors: "small" at 32 B, "big" at 512 B.
+        let small = MxArray::from_bfloat16(&[0x3F80u16; 16], &[4, 4]).unwrap();
+        let big = MxArray::from_bfloat16(&[0x4000u16; 256], &[16, 16]).unwrap();
+        let mut tensors = HashMap::new();
+        tensors.insert("small".to_string(), small);
+        tensors.insert("big".to_string(), big);
+        save_safetensors(&path, &mut tensors, None).unwrap();
+
+        let loaded = SafeTensorsFile::load(&path)
+            .unwrap()
+            .load_tensors(&path)
+            .unwrap();
+        let small_ptr = loaded.get("small").unwrap().as_raw_ptr() as usize;
+        let big_ptr = loaded.get("big").unwrap().as_raw_ptr() as usize;
+
+        // Threshold between the two (512 B > 100 ≥ 32 B), passed directly.
+        // Setting MLX_CONVERT_RAW_THRESHOLD_BYTES here instead would be
+        // `unsafe` and would race the sibling tests that call
+        // `save_safetensors`, which reads that variable.
+        let mut out = HashMap::new();
+        record_passthrough_sources_with(&path, &loaded, &mut out, 100).unwrap();
+
+        assert!(
+            out.contains_key(&big_ptr),
+            "a tensor at or above the raw threshold must keep its provenance"
+        );
+        assert!(
+            !out.contains_key(&small_ptr),
+            "a sub-threshold tensor must NOT be recorded: the writer could never \
+             use the entry and the pinned clone would hold the source resident"
+        );
+        assert_eq!(
+            out.len(),
+            1,
+            "exactly one entry expected, got {}",
+            out.len()
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/mlx-core/src/utils/safetensors.rs
+++ b/crates/mlx-core/src/utils/safetensors.rs
@@ -23,11 +23,12 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
+use std::sync::{Arc, Weak};
 
 use napi::bindgen_prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::array::{DType, MxArray};
+use crate::array::{DType, MxArray, MxHandle};
 
 /// Supported tensor data types in SafeTensors format
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -382,15 +383,27 @@ pub struct PassthroughSource {
 /// A recorded source tensor's provenance, keyed during convert by the loaded
 /// MLX array's raw handle pointer.
 ///
-/// `_keep_alive` pins the source `MxArray` (a clone shares the `Arc<MxHandle>`)
-/// for the whole convert so its handle pointer can never be freed and reused by
-/// a later allocation — without this, a dropped source's address could be
-/// recycled by an `astype`/quantize result and falsely match as a passthrough.
-/// The clone is a lazy handle (no materialized data), so the memory cost is just
-/// the handle structs.
+/// `alive` is weak on purpose. It still proves identity — an entry whose source
+/// was dropped fails to upgrade, so a recycled handle address can never match as
+/// a false passthrough — but it does not keep the source resident. A strong
+/// clone did: this map lives until immediately before the save, so any recorded
+/// tensor that convert later transforms or quantizes had its dense bytes pinned
+/// for the whole run.
 pub struct SourceProvenance {
-    _keep_alive: MxArray,
+    alive: Weak<MxHandle>,
     pub source: PassthroughSource,
+}
+
+impl SourceProvenance {
+    /// True when `dest` is the very array this entry was recorded for.
+    ///
+    /// A failed upgrade means the source is gone, which is exactly when its
+    /// handle address may have been recycled by a later allocation.
+    pub fn matches(&self, dest: &MxArray) -> bool {
+        self.alive
+            .upgrade()
+            .is_some_and(|handle| Arc::ptr_eq(&handle, &dest.handle))
+    }
 }
 
 /// For one SOURCE safetensors file, record the on-disk location of every tensor
@@ -410,12 +423,9 @@ pub struct SourceProvenance {
 ///
 /// Tensors below [`raw_passthrough_threshold_bytes`] are also excluded. The
 /// writer's raw path demands `dest_len >= raw_threshold` AND
-/// `src.byte_len == dest_len`, so a smaller entry can never be consulted, while
-/// `_keep_alive` still pins its source for the whole convert — the quantize
-/// loop then materializes that source and the pin holds the dense bytes to the
-/// end. Excluding a tensor cannot reintroduce the ABA hazard the pin defends
-/// against: an entry that was never inserted has no pointer for a recycled
-/// address to collide with, and every retained entry is still pinned.
+/// `src.byte_len == dest_len`, so a smaller entry can never be consulted.
+/// Excluding a tensor cannot produce a false passthrough: an entry that was
+/// never inserted has no pointer for a recycled address to collide with.
 pub fn record_passthrough_sources<P: AsRef<Path>>(
     source_file: P,
     loaded: &HashMap<String, MxArray>,
@@ -449,23 +459,16 @@ pub(crate) fn record_passthrough_sources_with<P: AsRef<Path>>(
             _ => continue,
         };
         let byte_len = info.data_offsets[1] - info.data_offsets[0];
-        // Unusable below the writer's size gate, and the pin below is not free.
-        // See fn doc.
+        // Unusable below the writer's size gate. See fn doc.
         if (byte_len as u64) < raw_threshold {
             continue;
         }
         let file_offset = (st.data_offset + info.data_offsets[0]) as u64;
-        // Keep the source array alive (clone shares the `Arc<MxHandle>`) so its
-        // raw handle pointer is PINNED for the whole convert. This closes an ABA
-        // hazard: if a source array were dropped and its MLX buffer freed, a
-        // later `astype`/quantize allocation could reuse the same address and
-        // collide with a stale entry — a false passthrough = corrupt output.
-        // Pinning the handle guarantees no other array can ever hold this
-        // pointer, so a dest handle match is genuinely the same array.
+        // Weak, not a clone: see `SourceProvenance`.
         out.insert(
             array.as_raw_ptr() as usize,
             SourceProvenance {
-                _keep_alive: array.clone(),
+                alive: Arc::downgrade(&array.handle),
                 source: PassthroughSource {
                     file_path: path.to_path_buf(),
                     file_offset,
@@ -1256,10 +1259,8 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// Provenance must only be recorded for tensors the writer's raw path can
-    /// actually use, because every recorded entry pins its source array alive
-    /// for the whole conversion. Recording sub-threshold tensors is what kept
-    /// an entire AWQ-prescaled bf16 checkpoint resident.
+    /// Provenance is only recorded for tensors the writer's raw path can
+    /// actually use: below the threshold the writer never consults the entry.
     #[test]
     fn passthrough_provenance_skips_tensors_below_the_raw_threshold() {
         let dir = std::env::temp_dir().join(format!("st_prov_{}", std::process::id()));
@@ -1292,13 +1293,139 @@ mod tests {
         assert!(
             !out.contains_key(&small_ptr),
             "a sub-threshold tensor must NOT be recorded: the writer could never \
-             use the entry and the pinned clone would hold the source resident"
+             use the entry"
         );
         assert_eq!(
             out.len(),
             1,
             "exactly one entry expected, got {}",
             out.len()
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Writes one bf16 tensor of `rows × cols` to a fresh temp dir and returns
+    /// the dir plus the file path. Caller removes the dir.
+    fn write_one_bf16_tensor(
+        tag: &str,
+        name: &str,
+        rows: i64,
+        cols: i64,
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
+        let dir = std::env::temp_dir().join(format!("st_prov_{tag}_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("model.safetensors");
+        let arr = MxArray::from_bfloat16(&vec![0x3F80u16; (rows * cols) as usize], &[rows, cols])
+            .unwrap();
+        let mut tensors = HashMap::new();
+        tensors.insert(name.to_string(), arr);
+        save_safetensors(&path, &mut tensors, None).unwrap();
+        (dir, path)
+    }
+
+    /// The recorded entry must not own its source. Convert holds this map until
+    /// immediately before the save, so a strong clone would keep every recorded
+    /// tensor's dense bytes resident for the whole run.
+    #[test]
+    fn provenance_does_not_keep_its_source_resident() {
+        use crate::array::memory::{get_active_memory, synchronize_and_clear_cache};
+
+        // [4096, 8192] bf16 = 64 MiB. `get_active_memory` is process-wide, so
+        // this measurement depends on `RUST_TEST_THREADS = "1"` in
+        // `.cargo/config.toml`.
+        const ROWS: i64 = 4096;
+        const COLS: i64 = 8192;
+        let dense = (ROWS * COLS) as f64 * 2.0;
+        let (dir, path) = write_one_bf16_tensor("resident", "big", ROWS, COLS);
+
+        synchronize_and_clear_cache();
+        let baseline = get_active_memory();
+
+        let loaded = SafeTensorsFile::load(&path)
+            .unwrap()
+            .load_tensors(&path)
+            .unwrap();
+        loaded.get("big").unwrap().eval();
+
+        let mut out = HashMap::new();
+        record_passthrough_sources_with(&path, &loaded, &mut out, 1).unwrap();
+        // A recording that dropped the tensor would also free it, and would pass
+        // the assertion below for the wrong reason.
+        assert_eq!(out.len(), 1, "the tensor must have been recorded");
+
+        synchronize_and_clear_cache();
+        let with_dense = get_active_memory();
+
+        // Instrument the control first: if the source never became resident,
+        // the drop below would prove nothing.
+        assert!(
+            with_dense - baseline > dense * 0.5,
+            "the source is not resident, so this test cannot measure a release: \
+             baseline={baseline}, with_dense={with_dense}, dense={dense}"
+        );
+
+        // `out` is still alive: it is now the only thing that could hold the
+        // source.
+        drop(loaded);
+        synchronize_and_clear_cache();
+        let after = get_active_memory();
+
+        assert!(
+            after - baseline < dense * 0.25,
+            "provenance kept the dense source resident: \
+             baseline={baseline}, with_dense={with_dense}, after={after}, dense={dense}"
+        );
+        assert_eq!(out.len(), 1, "the entry must still be present");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Once the source is gone its handle address may be recycled by a later
+    /// allocation, so a dead entry must never match.
+    #[test]
+    fn provenance_entry_stops_matching_when_its_source_dies() {
+        let (dir, path) = write_one_bf16_tensor("dead", "big", 16, 16);
+
+        let loaded = SafeTensorsFile::load(&path)
+            .unwrap()
+            .load_tensors(&path)
+            .unwrap();
+        let mut out = HashMap::new();
+        record_passthrough_sources_with(&path, &loaded, &mut out, 1).unwrap();
+        assert_eq!(out.len(), 1);
+
+        drop(loaded);
+
+        let other = MxArray::from_bfloat16(&[0x4000u16; 256], &[16, 16]).unwrap();
+        let prov = out.values().next().unwrap();
+        assert!(
+            !prov.matches(&other),
+            "an entry whose source is gone must never match"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn provenance_matches_only_the_array_it_recorded() {
+        let (dir, path) = write_one_bf16_tensor("identity", "big", 16, 16);
+
+        let loaded = SafeTensorsFile::load(&path)
+            .unwrap()
+            .load_tensors(&path)
+            .unwrap();
+        let recorded = loaded.get("big").unwrap();
+        let mut out = HashMap::new();
+        record_passthrough_sources_with(&path, &loaded, &mut out, 1).unwrap();
+
+        let prov = out.get(&(recorded.as_raw_ptr() as usize)).unwrap();
+        assert!(prov.matches(recorded), "the recorded array must match");
+
+        let other = MxArray::from_bfloat16(&[0x4000u16; 256], &[16, 16]).unwrap();
+        assert!(
+            !prov.matches(&other),
+            "a different live array must not match"
         );
 
         std::fs::remove_dir_all(&dir).ok();


### PR DESCRIPTION
## Problem

`mlx convert --quantize` holds every quantized bf16 source resident for the whole conversion, so the lazy SafeTensors load upstream of it buys nothing. Add `--imatrix-path` and AWQ pre-scaling also materializes the tensors it never touched. Converting Qwen3.8-27B (55.6 GB bf16 source) exhausts a 36 GB machine.

Two coupled retention paths. Neither one alone is enough, and neither is specific to AWQ.

### 1. Passthrough provenance pinned every bf16 source

`record_passthrough_sources` kept a `_keep_alive` clone of **every** bf16/f16 source tensor so a recycled handle address could never be mistaken for a passthrough. The clone is free while the array stays lazy — but `quantize_weights_inner` has always called `array.eval()` on its input, and the pin then held the dense bytes until `drop(source_by_handle)`, just before the save.

Two changes close it.

**Sub-threshold tensors are no longer recorded.** The writer's raw path is gated on `dest_len >= raw_threshold` (2 GiB) **and** `src.byte_len == dest_len`, so an entry below the threshold can never be consulted. It only pinned.

**The entry no longer owns its source.** `_keep_alive: MxArray` becomes `alive: Weak<MxHandle>`, and the lookup guards on `SourceProvenance::matches`. Without this the pin still held every recorded tensor that convert later transforms or quantizes — which is the *largest* tensors, not the smallest, and the eval-then-drop below cannot help while a second owner exists. Worst case on a plain `--quantize`: Qwen3.5-122B-A10B stores each layer's `mlp.experts.gate_up_proj` as bf16 `[256, 2048, 3072]` = 3.000 GiB, over the gate, and `normalize_qwen35_prestacked_experts` splits it with `slice_axis` — so all 48 entries are dead and pin 144 GiB. Under any `--q-recipe` the 2.4–4.4 GiB `embed_tokens` / `lm_head` tables go the same way, because the recipe predicates quantize keys `should_quantize` would have skipped.

Neither change can produce a false passthrough. An entry that was never inserted has no pointer for a recycled address to collide with; a weak reference that fails to upgrade is exactly the freed-and-recycled case; and a successful upgrade plus `Arc::ptr_eq` is exact identity, stricter than the address match the pin allowed.

### 2. Quantized outputs pinned their dense inputs

`mlx_quantize` returns **lazy** arrays whose graph holds the bf16 source alive. Storing them un-evaluated meant `drop(array)` freed nothing, and the cost reappeared in the writer:

```
Quantizing 274 weights (3-bit affine, group_size=64)
  Quantized 50/274 tensors...      <- 0.9 ms for all of them
Quantization complete: 249 tensors quantized
shard written ... shard_ms=6400 mlx_peak_mb=15056
```

The triplet is now materialized before the source is dropped. The allocator flush also gains a 1 GiB byte budget alongside the existing every-50-tensors cadence, which is size-blind.

### And AWQ made it worse

`apply_awq_prescaling` ended with `for w in weights.values() { w.eval(); }` — the **whole** map, including tensors AWQ never touched. That eval is gone. The rewritten tensors stay lazy, and the pre-scale multiply runs inside the quantizer's existing per-tensor loop; tensors the quantizer skips are materialized one at a time by the writer instead. The same function serves the GGUF path (`utils/gguf.rs`), so both entry points are covered.

## Output is unchanged

Reported by @ivibes and not re-run since the review pass; the unit tests below are what CI checks.

- **`model.safetensors` is byte-identical** (sha256 `0670e78c…`) between patched and unpatched on Qwen3.5-4B with a real Unsloth imatrix.
- `config.json` is canonically identical. Its key order varies run to run from `HashMap` iteration in `build_quantization_object` — this predates the change; two *unpatched* runs also differ from each other.
- `eval()` schedules, it does not rewrite arithmetic.

## Measurements

@ivibes, on a 38.7 GB M3 Max. Not reproduced on the review machine.

Qwen3.5-4B (9.32 GB bf16), 3-bit affine `--q-recipe unsloth` + imatrix:

| | before | after |
|---|---|---|
| MLX allocator peak | 14.7 GiB | **3.52 GiB** |
| peak RSS | 16.30 GiB | **4.46 GiB** |
| wall time | 12.6 s | 12.2 s |

Qwen3.8-27B (55.6 GB bf16) on a 38.7 GB M3 Max, previously not completable:

| | peak RSS | time |
|---|---|---|
| Q4 | 21.3 GiB | 81 s |
| Q5 | 22.2 GiB | 91 s |
| Q6 | 16.6 GiB | 119 s |

Peak RSS is the measured bound. Swap traffic is **not** claimed: an earlier revision of this PR carried a `swaps` column reading 0, which came from `vm.swapins`/`vm.swapouts` sysctls that do not exist on the test machine. A later run of the same code path, measured with `vm_stat`, paged out ~7.9 GiB during a 27B convert. This change bounds what MLX allocates; it does not make a 27B convert swap-free on a 36 GB machine.

Total time is unchanged — the work moves out of the writer and into the quantize loop rather than being added.

## Tests

- `quantize_releases_dense_sources_instead_of_pinning_them` — allocator assertion that dense sources are released. Verified against its mutation: with the eval-then-drop hunk reverted it fails with `after=201326592`, all 192 MiB still resident.
- `awq_prescaling_survives_lazy_materialization` — AWQ then quantize, bytewise, one arm materialized up front and one left lazy, across all four AWQ dependency groups.
- `passthrough_provenance_skips_tensors_below_the_raw_threshold` — the threshold gate, with the threshold passed in rather than set in the environment.
- `provenance_does_not_keep_its_source_resident` — allocator assertion that a recorded entry releases its source. Mutation-verified: restore the strong clone and it fails with `after=67108864`, the full 64 MiB still resident.
- `provenance_entry_stops_matching_when_its_source_dies` and `provenance_matches_only_the_array_it_recorded` — the identity guard. Dropping `Arc::ptr_eq`, or making `matches` return `true`, each kills one of them.

`cargo test -p mlx-core --lib`, `cargo fmt`, `cargo clippy --all-targets` clean.

## Known limits

- Releasing the pin turns the MoE case from an unconditional 144 GiB into an **order-dependent** peak, not a strict one-tensor working set. `slice_axis` returns a view sharing the parent buffer, so a fused expert tensor stays resident until *both* halves are quantized, and `quantize_weights_inner` builds its work list from `weights.keys()` unsorted (`convert.rs:8005`). Bounding that means changing quantization order or forcing a contiguous copy in the sanitizer — a different function and a different tradeoff.
- Exercised end to end on **dense `qwen3_5` only**. MoE expert stacks and `--q-mtp split` are covered by unit tests and reasoning, not by a full conversion.
- `QUANTIZE_FLUSH_BYTE_BUDGET` (1 GiB) is reasoned, not swept.

## Review notes

Revised from the original submission:

- The AWQ change is reduced to deleting the whole-map eval. The `AwqMaterialization` enum, `apply_awq_prescaling_with`, the per-layer `layer_touched` retire loop and its two tuning constants are gone: measured against the graphs they retire, that machinery bounded roughly 100 KB per layer — under 10 MB on a 27B — against a 21 GiB peak.
- The two byte-equality tests collapse into one. The eager arm is reproduced inside the test with `values().for_each(eval)`, so no production code exists only for tests. Note the honest limit: with the quantize loop's own `array.eval()` mutated away, that test still passes, so it guards MLX's evaluation order, not our call site.
- The provenance test no longer calls `std::env::set_var` — @ivibes landed that independently while this review was running, and their `record_passthrough_sources_with` is what shipped.
- The new triplet materialization is fallible (`eval_arrays_with_context`). The writer used to own it and could report an OOM; taking it over must not swallow one.
- The problem statement is corrected: the pin has held every quantized source since #70, so this is not an AWQ-only fix. Two provenance comments asserting the AWQ-only story are fixed with it.
- `SourceProvenance` no longer pins its source. Codex flagged the residual as P1 on `c6f69d3a`; the mechanism is real but its stated path is not — `apply_awq_prescaling` matches only exact dense `mlp.*` / `self_attn.*` / `linear_attn.*` literals and can never touch an MoE projection. The reachable path is `sanitize`, and it is worse than the finding claimed.

The review commit is separate, so `git diff baf4dbe8..HEAD` shows exactly what it changed.

