### PR TITLE
feat(muse_glimmer): add Q4_K runtime, MTP, batching, and SSD restore

### DIFF
--- a/__test__/models/model-loader-registry.test.ts
+++ b/__test__/models/model-loader-registry.test.ts
@@ -2,12 +2,20 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { detectModelType, Gemma4Model, loadModel, loadSession, type ModelType } from '@mlx-node/lm';
+import {
+  detectModelType,
+  Gemma4Model,
+  loadModel,
+  loadSession,
+  MuseGlimmerModel,
+  type ModelType,
+} from '@mlx-node/lm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 const RAW_MODEL_TYPE_ALIASES = {
   harrier: ['harrier'],
   gemma4: ['gemma4', 'gemma4_text', 'gemma4_unified'],
+  muse_glimmer: ['muse_glimmer', 'muse_glimmer_text'],
   qwen3: ['qwen3'],
   qwen3_5: ['qwen3_5'],
   qwen3_5_moe: ['qwen3_5_moe'],
@@ -77,6 +85,11 @@ describe.sequential('declarative model loader registry', () => {
 
     await writeConfig({ architectures: 'Qwen3Model' });
     await expect(detectModelType(tempDir)).resolves.toBe('harrier');
+  });
+
+  it('detects Muse-Glimmer from its authoritative architecture', async () => {
+    await writeConfig({ model_type: 'unknown', architectures: ['MuseGlimmerForConditionalGeneration'] });
+    await expect(detectModelType(tempDir)).resolves.toBe('muse_glimmer');
   });
 
   it('fails closed for an unknown model_type', async () => {
@@ -174,5 +187,14 @@ describe.sequential('declarative model loader registry', () => {
     await expect(loadModel(tempDir, { draftModelPath: '/tmp/draft' })).resolves.toBe(loadedModel);
     expect(loadSpy).toHaveBeenCalledOnce();
     expect(loadSpy).toHaveBeenCalledWith(tempDir, { draftModelPath: '/tmp/draft' });
+  });
+
+  it('loads Muse-Glimmer through its streaming wrapper', async () => {
+    await writeConfig({ model_type: 'muse_glimmer' });
+    const loadedModel = { model: 'muse_glimmer' };
+    const loadSpy = vi.spyOn(MuseGlimmerModel, 'load').mockResolvedValue(loadedModel as never);
+
+    await expect(loadModel(tempDir)).resolves.toBe(loadedModel);
+    expect(loadSpy).toHaveBeenCalledWith(tempDir);
   });
 });

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -650,6 +650,91 @@ export declare class Lfm2Model {
   ): Promise<ChatStreamHandle>;
 }
 
+export declare class MuseGlimmerModel {
+  static load(modelPath: string): Promise<MuseGlimmerModel>;
+  hasMtpWeights(): boolean;
+  autoEnablesMtp(): boolean;
+  hasBlockPagedCache(): boolean;
+  maxConcurrentSequences(): number;
+  schedulerStats(): Promise<SchedulerStats>;
+  /**
+   * Reset all caches and clear cached token history. Async so a reset
+   * queued behind an in-flight turn parks a tokio future, never the
+   * Node event loop (H1: a dead prefill used to freeze all HTTP traffic).
+   */
+  resetCaches(): Promise<void>;
+  /**
+   * Release scheduler-owned KV/history state for one logical
+   * session owner without purging content-addressed prefix blocks.
+   */
+  releaseCacheOwner(ownerId: string): Promise<void>;
+  /**
+   * Start a new chat session.
+   *
+   * Renders the complete conversation through the loaded chat
+   * template, decodes until the family's session stop token, and
+   * preserves the resulting KV state for exact-prefix reuse.
+   */
+  chatSessionStart(messages: Array<ChatMessage>, config?: ChatConfig | undefined | null): Promise<ChatResult>;
+  /**
+   * Internal operation bridge for `chatSessionStart` (H2). Resolves
+   * IMMEDIATELY with a `ChatSessionCall` whose `cancel()`
+   * can cancel the queued/running turn; the reply arrives via
+   * `call.result()`. A cancelled turn rejects `result()` with
+   * the exact string `"chat session cancelled"`. The LM wrapper
+   * keeps this two-phase operation private and exposes cancellation
+   * through the ordinary method's `AbortSignal` argument.
+   */
+  beginChatSessionStart(messages: Array<ChatMessage>, config?: ChatConfig | undefined | null): Promise<ChatSessionCall>;
+  /**
+   * Continue an existing chat session from the complete
+   * structured conversation. The loaded model template is the
+   * sole authority for the rendered suffix; native cache reuse
+   * occurs only after the completed structured history is verified
+   * against the saved token history.
+   */
+  chatSessionContinue(messages: Array<ChatMessage>, config?: ChatConfig | undefined | null): Promise<ChatResult>;
+  /**
+   * Internal operation bridge for `chatSessionContinue` (H2). Same
+   * contract as `beginChatSessionStart`.
+   */
+  beginChatSessionContinue(
+    messages: Array<ChatMessage>,
+    config?: ChatConfig | undefined | null,
+  ): Promise<ChatSessionCall>;
+  /**
+   * Continue an existing chat session from a complete
+   * structured conversation ending in a tool-role message.
+   */
+  chatSessionContinueTool(messages: Array<ChatMessage>, config?: ChatConfig | undefined | null): Promise<ChatResult>;
+  /**
+   * Internal operation bridge for `chatSessionContinueTool` (H2). Same
+   * contract as `beginChatSessionStart`.
+   */
+  beginChatSessionContinueTool(
+    messages: Array<ChatMessage>,
+    config?: ChatConfig | undefined | null,
+  ): Promise<ChatSessionCall>;
+  /** Streaming variant of `chatSessionStart`. */
+  chatStreamSessionStart(
+    messages: ChatMessage[],
+    config: ChatConfig | null,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ): Promise<ChatStreamHandle>;
+  /** Streaming variant of `chatSessionContinue`. */
+  chatStreamSessionContinue(
+    messages: ChatMessage[],
+    config: ChatConfig | null,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ): Promise<ChatStreamHandle>;
+  /** Streaming variant of `chatSessionContinueTool`. */
+  chatStreamSessionContinueTool(
+    messages: ChatMessage[],
+    config: ChatConfig | null,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ): Promise<ChatStreamHandle>;
+}
+
 export declare class MxArray {
   equal(other: MxArray): MxArray;
   notEqual(other: MxArray): MxArray;
@@ -2518,6 +2603,10 @@ export interface ChatConfig {
    * - Assistant (Google `gemma-4-*-it-assistant`): an unset `mtpDepth`
    *   drafts 3 tokens per cycle (`ASSISTANT_DEFAULT_DEPTH`), and an
    *   explicit `mtpDepth` clamps to `[1, 8]` (`ASSISTANT_MAX_DEPTH`).
+   * - Muse-Glimmer DFlash follows DSpark's external-draft rules: unset
+   *   uses the checkpoint block size (16 for Muse-Glimmer-30B), while an
+   *   explicit value clamps to `[1, block_size]` and pins that depth unless
+   *   `mtpAdaptiveDepth: true` explicitly enables the break-even guard.
    *
    * `mtpAdaptiveDepth` is ignored for the Gemma4 assistant variant.
    */
@@ -2532,9 +2621,9 @@ export interface ChatConfig {
    * `MLX_MTP_EV_ALLOW_DEEPEN=0` to pin the base depth.
    * When false, the loop pins `mtpDepth` for every cycle.
    *
-   * Default: false, except Gemma4 DSpark enables its measured break-even
-   * guard when both this field and `mtpDepth` are unset. An explicit value
-   * always wins over the family default.
+   * Default: false, except Gemma4 DSpark and Muse-Glimmer DFlash enable the
+   * measured break-even guard when both this field and `mtpDepth` are unset.
+   * An explicit value always wins over the family default.
    */
   mtpAdaptiveDepth?: boolean | undefined;
 }

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -4292,6 +4292,12 @@ export interface PhaseProfile {
 }
 
 /**
+ * Header-only DFlash validation for the CLI's transactional ordering. This
+ * runs before the primary conversion touches its output directory.
+ */
+export declare function preflightMuseDflashGguf(inputPath: string, targetConfigDir: string): void;
+
+/**
  * Per-call Viterbi calibration overrides.
  *
  * Any field set to `Some(_)` overrides the corresponding bias from the

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -656,6 +656,12 @@ export declare class MuseGlimmerModel {
   autoEnablesMtp(): boolean;
   hasBlockPagedCache(): boolean;
   maxConcurrentSequences(): number;
+  /**
+   * Conservative model-wide context snapshot used by higher layers for
+   * compaction. It includes the paged AR limit even when DFlash is present,
+   * because DFlash is opt-in per request and can be disabled by the caller.
+   */
+  contextLimits(): MuseGlimmerContextLimits;
   schedulerStats(): Promise<SchedulerStats>;
   /**
    * Reset all caches and clear cached token history. Async so a reset
@@ -4100,6 +4106,19 @@ export interface ModelConfig {
 export declare const enum MultimodalContentOrder {
   TextThenMedia = 'textThenMedia',
   ImagesThenText = 'imagesThenText',
+}
+
+/**
+ * Trained and physically available active-context limits for one loaded
+ * Muse-Glimmer model. The effective window is conservative across both
+ * execution modes: DFlash may use the flat cache, but callers can disable it
+ * per request and fall back to the paged AR scheduler.
+ */
+export interface MuseGlimmerContextLimits {
+  trainedWindowTokens: number;
+  effectiveWindowTokens: number;
+  pagedBlockCapacity: number;
+  pagedBlockSize: number;
 }
 
 /** Result from document orientation classification. */

--- a/crates/mlx-core/src/cold_tier.rs
+++ b/crates/mlx-core/src/cold_tier.rs
@@ -436,6 +436,9 @@ pub(crate) fn sidecar_counter_test_lock() -> std::sync::MutexGuard<'static, ()> 
 ///    The full-attention chain is the authority; a `ColdGroup::SlidingWindow`
 ///    sidecar stores every sliding group at the same exact block boundary. A
 ///    restore installs every group atomically or discards the candidate.
+///  * `muse_glimmer` uses the same grouped hybrid contract: its 13 full layers
+///    own the persisted K/V chain and one sidecar restores all 39 sliding
+///    layers at the reconciled boundary.
 ///  * `qwen3_5` (dense) sizes its pool over the full-attention layers only, but
 ///    persists its out-of-pool GDN recurrent state (conv + recurrent) as a
 ///    `ColdGroup::GdnState` sidecar (`crate::models::qwen3_5::gdn_sidecar`). A
@@ -465,6 +468,7 @@ const COLD_RESTORE_FAMILIES: &[&str] = &[
     "qwen3_5",
     "qwen3_5_moe",
     "gemma4",
+    "muse_glimmer",
     "lfm2",
     "lfm2_moe",
 ];
@@ -1350,6 +1354,8 @@ mod tests {
         // Gemma4 restores full and sliding groups at one exact boundary.
         assert!(cold_restore_supported("gemma4"));
         assert!(resolve_persist_cold("gemma4", Some("1"), Some(true)));
+        assert!(cold_restore_supported("muse_glimmer"));
+        assert!(resolve_persist_cold("muse_glimmer", Some("1"), Some(true)));
         // Hybrid, admitted only because its out-of-pool GDN recurrent state is
         // persisted as a `ColdGroup::GdnState` sidecar AND its restart-parity
         // gate passes on real weights
@@ -1374,6 +1380,8 @@ mod tests {
             "qwen3_5 ",
             "Gemma4",
             "gemma4_text",
+            "Muse_Glimmer",
+            "muse_glimmer_text",
             "",
         ] {
             assert!(
@@ -1390,6 +1398,7 @@ mod tests {
                 "qwen3_5".to_string(),
                 "qwen3_5_moe".to_string(),
                 "gemma4".to_string(),
+                "muse_glimmer".to_string(),
                 "lfm2".to_string(),
                 "lfm2_moe".to_string()
             ]

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -1848,6 +1848,24 @@ pub(crate) mod recipe {
             let mut skipped = 0usize;
 
             for (source_key, array) in weights {
+                // Canonical HF Muse stores the four sandwich-norm parameters
+                // centered around zero and applies them as `(1 + weight)`.
+                // SafeTensors conversion emits `format: mlx`, so bake the
+                // offset exactly once while the source namespace still tells
+                // raw HF (`model.language_model.*`) from an already-sanitized
+                // `language_model.model.*` artifact.
+                let shift_sandwich_norm = source_key
+                    .strip_prefix("model.language_model.layers.")
+                    .is_some_and(|rest| {
+                        [
+                            ".input_layernorm.weight",
+                            ".post_attention_layernorm.weight",
+                            ".pre_feedforward_layernorm.weight",
+                            ".post_feedforward_layernorm.weight",
+                        ]
+                        .iter()
+                        .any(|suffix| rest.ends_with(suffix))
+                    });
                 let key = if let Some(rest) = source_key.strip_prefix("model.language_model.") {
                     format!("language_model.model.{rest}")
                 } else if source_key.starts_with("language_model.model.") {
@@ -1862,6 +1880,11 @@ pub(crate) mod recipe {
                     rest.to_string()
                 } else {
                     source_key.clone()
+                };
+                let array = if shift_sandwich_norm {
+                    array.add_scalar(1.0)?
+                } else {
+                    array
                 };
 
                 if sanitized.insert(key.clone(), array).is_some() {
@@ -14767,6 +14790,14 @@ mod tests {
                 "model.vision_tower.layers.0.attn.q_proj.weight".to_string(),
                 weight(),
             ),
+            (
+                "model.language_model.layers.0.input_layernorm.weight".to_string(),
+                MxArray::from_float32(&[0.25], &[1]).expect("centered norm"),
+            ),
+            (
+                "model.language_model.norm.weight".to_string(),
+                MxArray::from_float32(&[0.5], &[1]).expect("final norm"),
+            ),
         ]);
         let recipe = recipe::MuseGlimmerRecipe;
         let once = recipe
@@ -14776,16 +14807,34 @@ mod tests {
         assert!(once.contains_key("language_model.model.lm_head.weight"));
         assert!(once.contains_key("vision_adapter.fc1.weight"));
         assert!(once.contains_key("vision_tower.layers.0.attn.q_proj.weight"));
+        assert_eq!(
+            once["language_model.model.layers.0.input_layernorm.weight"]
+                .item_at_float32(0)
+                .expect("shifted norm"),
+            1.25
+        );
+        assert_eq!(
+            once["language_model.model.norm.weight"]
+                .item_at_float32(0)
+                .expect("unchanged final norm"),
+            0.5
+        );
 
         let twice = recipe
             .sanitize(once, &serde_json::json!({}), "bfloat16", false, false)
             .expect("second sanitize");
         assert_eq!(
             twice.len(),
-            4,
+            6,
             "canonical keys must not grow another prefix"
         );
         assert!(twice.contains_key("language_model.model.layers.0.self_attn.q_proj.weight"));
+        assert_eq!(
+            twice["language_model.model.layers.0.input_layernorm.weight"]
+                .item_at_float32(0)
+                .expect("idempotent norm"),
+            1.25
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -222,6 +222,18 @@ impl ChunkSink for crate::model_thread::StreamTx<ChatStreamChunk> {
 /// the done-chunk carrying `text: ""` and the parser-accumulated
 /// `tool_calls()` / `thinking()` instead of `result.text`.
 pub(crate) trait StreamEmitter {
+    /// Observe a committed token before the decode loop schedules any
+    /// subsequent model work. Family protocol guards may return `true` to
+    /// terminate the turn at this token; ordinary text emitters keep the
+    /// default `false` behavior.
+    ///
+    /// The later [`Self::on_token_id`] call remains responsible for sending
+    /// chunks. Keeping observation separate lets speculative loops clamp and
+    /// commit the exact accepted prefix before exposing it to the sink.
+    fn observe_token_id(&mut self, _token_id: u32) -> bool {
+        false
+    }
+
     /// Token-aware entry point. The default preserves the historical text-only
     /// emitter contract; protocol parsers that require special-token
     /// provenance override this method.
@@ -1806,6 +1818,17 @@ pub(crate) trait DsparkStepper {
     /// unconditionally kept); the cycle's boundary token has NO K/V slot —
     /// it becomes the next cycle's anchor.
     fn commit(&mut self, keep: usize, total_written: usize) -> Result<()>;
+
+    /// Publish model-private state retained by a successful speculative turn.
+    /// Most steppers keep all persistent state behind their backend and need
+    /// no action. Draft models with a turn-local context owner can move it
+    /// back into the backend here for the next live-session continuation.
+    fn finish(self) -> Result<()>
+    where
+        Self: Sized,
+    {
+        Ok(())
+    }
 
     /// Schedule async eval for the boundary token that becomes the next
     /// cycle's anchor. `&self` — schedules only, no mutation. Called at the

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -222,18 +222,6 @@ impl ChunkSink for crate::model_thread::StreamTx<ChatStreamChunk> {
 /// the done-chunk carrying `text: ""` and the parser-accumulated
 /// `tool_calls()` / `thinking()` instead of `result.text`.
 pub(crate) trait StreamEmitter {
-    /// Observe a committed token before the decode loop schedules any
-    /// subsequent model work. Family protocol guards may return `true` to
-    /// terminate the turn at this token; ordinary text emitters keep the
-    /// default `false` behavior.
-    ///
-    /// The later [`Self::on_token_id`] call remains responsible for sending
-    /// chunks. Keeping observation separate lets speculative loops clamp and
-    /// commit the exact accepted prefix before exposing it to the sink.
-    fn observe_token_id(&mut self, _token_id: u32) -> bool {
-        false
-    }
-
     /// Token-aware entry point. The default preserves the historical text-only
     /// emitter contract; protocol parsers that require special-token
     /// provenance override this method.
@@ -281,6 +269,22 @@ pub(crate) trait StreamEmitter {
     /// family-controlled end to end: a family's finalize override feeds
     /// its own parse into its emitter's terminal chunk.
     fn finish(&mut self, result: &ChatResult, sink: &dyn ChunkSink);
+}
+
+/// Per-turn protocol observer, independent of whether the caller requested a
+/// streaming sink.
+///
+/// Families with token-level turn boundaries use this hook to stop generation
+/// before another forward is scheduled. Keeping it separate from
+/// [`StreamEmitter`] ensures synchronous turns stop and persist the same token
+/// prefix as streaming turns, while speculative loops can clamp before commit.
+pub(crate) trait TurnTokenObserver {
+    /// Observe one committed token. Return `true` when it terminates the turn.
+    fn observe_token_id(&mut self, token_id: u32) -> bool;
+
+    /// Rewind the most recently observed non-terminal token when a recoverable
+    /// scheduler allocation failure rolls that token back for replay.
+    fn rollback_last_token(&mut self) {}
 }
 
 /// Default [`StreamEmitter`]: the raw ChatML streaming emission — raw
@@ -980,6 +984,13 @@ pub(crate) trait ChatBackend {
     /// for the full mapping).
     fn stream_emitter(&self) -> Box<dyn StreamEmitter> {
         Box::new(DefaultStreamEmitter)
+    }
+
+    /// Build the turn-local token protocol observer, when the family needs
+    /// boundaries beyond the ordinary EOS token set. Called for both
+    /// synchronous and streaming turns.
+    fn turn_token_observer(&self) -> Option<Box<dyn TurnTokenObserver>> {
+        None
     }
 
     /// Byte budget for the turn's `WiredLimitContext`, or `None` for NO

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -222,6 +222,20 @@ impl ChunkSink for crate::model_thread::StreamTx<ChatStreamChunk> {
 /// the done-chunk carrying `text: ""` and the parser-accumulated
 /// `tool_calls()` / `thinking()` instead of `result.text`.
 pub(crate) trait StreamEmitter {
+    /// Token-aware entry point. The default preserves the historical text-only
+    /// emitter contract; protocol parsers that require special-token
+    /// provenance override this method.
+    fn on_token_id(
+        &mut self,
+        _token_id: u32,
+        token_text: &str,
+        is_reasoning: bool,
+        include_reasoning: bool,
+        sink: &dyn ChunkSink,
+    ) {
+        self.on_token_text(token_text, is_reasoning, include_reasoning, sink);
+    }
+
     /// One committed token's incremental detokenized text (may be empty
     /// for partial-grapheme steps). `is_reasoning` is the
     /// [`crate::engine::penalties::ReasoningTracker`] tag for this

--- a/crates/mlx-core/src/engine/decode.rs
+++ b/crates/mlx-core/src/engine/decode.rs
@@ -494,8 +494,13 @@ pub(crate) fn run_decode_loop<S: DecodeStep>(
             // emitter applies the gate then emits the chunk). Detokenize +
             // length-advance above stay OUTSIDE the emitter so
             // DecodeStream sees every token.
-            s.emitter
-                .on_token_text(&token_text, is_reasoning, p.include_reasoning, s.callback);
+            s.emitter.on_token_id(
+                token_id,
+                &token_text,
+                is_reasoning,
+                p.include_reasoning,
+                s.callback,
+            );
         } else if cancelled {
             // NON-streaming cancel break (H2): same snapshot, same
             // position in the iteration as the ChatML streaming

--- a/crates/mlx-core/src/engine/decode.rs
+++ b/crates/mlx-core/src/engine/decode.rs
@@ -307,7 +307,16 @@ pub(crate) fn run_decode_loop<S: DecodeStep>(
             p.max_ngram_repeats,
             p.ngram_size,
         );
-        let is_terminal = stops_at_eos || cancelled || repetition.is_some();
+        // Protocol-aware emitters must inspect the current token before a
+        // subsequent forward is scheduled. For Muse-Glimmer this catches a
+        // StreamGuard terminator/self-play boundary even when it is not in
+        // the model's ordinary EOS set.
+        let emitter_stopped = !cancelled
+            && !(eos_before_emit && stops_at_eos)
+            && streaming
+                .as_mut()
+                .is_some_and(|s| s.emitter.observe_token_id(token_id));
+        let is_terminal = stops_at_eos || cancelled || repetition.is_some() || emitter_stopped;
 
         // This loop builds the next forward HERE — before the streaming
         // emit block further down — whereas origin/main's paged loop
@@ -501,6 +510,10 @@ pub(crate) fn run_decode_loop<S: DecodeStep>(
                 p.include_reasoning,
                 s.callback,
             );
+            if emitter_stopped {
+                *finish_reason = String::from("stop");
+                break;
+            }
         } else if cancelled {
             // NON-streaming cancel break (H2): same snapshot, same
             // position in the iteration as the ChatML streaming
@@ -1489,6 +1502,67 @@ mod run_decode_loop_tests {
         fn finish(&mut self, _result: &ChatResult, _sink: &dyn ChunkSink) {
             self.finished += 1;
         }
+    }
+
+    struct StoppingEmitter {
+        stop_id: u32,
+        seen: Vec<String>,
+    }
+
+    impl StreamEmitter for StoppingEmitter {
+        fn observe_token_id(&mut self, token_id: u32) -> bool {
+            token_id == self.stop_id
+        }
+
+        fn on_token_text(
+            &mut self,
+            token_text: &str,
+            _is_reasoning: bool,
+            _include_reasoning: bool,
+            _sink: &dyn ChunkSink,
+        ) {
+            self.seen.push(token_text.to_string());
+        }
+
+        fn on_residual(
+            &mut self,
+            _residual: &str,
+            _is_reasoning: bool,
+            _include_reasoning: bool,
+            _sink: &dyn ChunkSink,
+        ) {
+        }
+
+        fn finish(&mut self, _result: &ChatResult, _sink: &dyn ChunkSink) {}
+    }
+
+    #[test]
+    fn emitter_terminal_token_stops_before_the_next_forward() {
+        let params = greedy_params(|_| {});
+        let mut tracker = ReasoningTracker::new(false, None, None);
+        let mut step = MockStep::new(vec![3, 4], 7);
+        let mut emitter = StoppingEmitter {
+            stop_id: 3,
+            seen: Vec::new(),
+        };
+
+        let (generated, finish, chunks) = drive_streaming(
+            &mut step,
+            1,
+            &params,
+            &mut tracker,
+            5,
+            &[],
+            false,
+            &mut emitter,
+            false,
+        );
+
+        assert_eq!(generated, vec![1, 3]);
+        assert_eq!(finish, "stop");
+        assert_eq!(step.forward_calls, 1, "no forward after emitter stop");
+        assert_eq!(emitter.seen, vec![String::from("t1"), String::from(" c3")]);
+        assert!(chunks.is_empty(), "the custom emitter owns the sink");
     }
 
     #[test]

--- a/crates/mlx-core/src/engine/decode.rs
+++ b/crates/mlx-core/src/engine/decode.rs
@@ -20,7 +20,7 @@ use napi::bindgen_prelude::*;
 
 use crate::array::MxArray;
 use crate::decode_profiler::DecodeProfiler;
-use crate::engine::backend::{ChunkSink, DecodeStep, StreamEmitter};
+use crate::engine::backend::{ChunkSink, DecodeStep, StreamEmitter, TurnTokenObserver};
 use crate::engine::params::ChatParams;
 use crate::engine::penalties::{ReasoningTracker, apply_all_penalties};
 use crate::stream::{Stream, StreamContext};
@@ -144,6 +144,10 @@ pub(crate) struct DecodeLoopArgs<'a> {
     pub first_token_instant: &'a mut Option<Instant>,
     pub report_perf: bool,
     pub generation_stream: Stream,
+    /// Optional family protocol guard. Unlike streaming emission, this is
+    /// present on synchronous turns too, so token-level boundaries stop the
+    /// next forward and the persisted cache at the same prefix.
+    pub turn_token_observer: Option<Box<dyn TurnTokenObserver>>,
     /// Whole-turn cooperative cancel flag, populated for BOTH sync and
     /// streaming turns (H2). Streaming callers pass the SAME atomic that
     /// backs [`StreamingCtx::cancelled`], so the per-step snapshot below
@@ -231,6 +235,7 @@ pub(crate) fn run_decode_loop<S: DecodeStep>(
         report_perf,
         generation_stream,
         cancel_flag,
+        mut turn_token_observer,
     } = args;
 
     for step_idx in 0..max_new_tokens {
@@ -311,12 +316,12 @@ pub(crate) fn run_decode_loop<S: DecodeStep>(
         // subsequent forward is scheduled. For Muse-Glimmer this catches a
         // StreamGuard terminator/self-play boundary even when it is not in
         // the model's ordinary EOS set.
-        let emitter_stopped = !cancelled
+        let observer_stopped = !cancelled
             && !(eos_before_emit && stops_at_eos)
-            && streaming
-                .as_mut()
-                .is_some_and(|s| s.emitter.observe_token_id(token_id));
-        let is_terminal = stops_at_eos || cancelled || repetition.is_some() || emitter_stopped;
+            && turn_token_observer
+                .as_deref_mut()
+                .is_some_and(|observer| observer.observe_token_id(token_id));
+        let is_terminal = stops_at_eos || cancelled || repetition.is_some() || observer_stopped;
 
         // This loop builds the next forward HERE — before the streaming
         // emit block further down — whereas origin/main's paged loop
@@ -510,10 +515,6 @@ pub(crate) fn run_decode_loop<S: DecodeStep>(
                 p.include_reasoning,
                 s.callback,
             );
-            if emitter_stopped {
-                *finish_reason = String::from("stop");
-                break;
-            }
         } else if cancelled {
             // NON-streaming cancel break (H2): same snapshot, same
             // position in the iteration as the ChatML streaming
@@ -524,6 +525,11 @@ pub(crate) fn run_decode_loop<S: DecodeStep>(
             // here). The sync session wrapper maps this finish_reason to
             // the distinguished `"chat session cancelled"` rejection.
             *finish_reason = String::from("cancelled");
+            break;
+        }
+
+        if observer_stopped {
+            *finish_reason = String::from("stop");
             break;
         }
 
@@ -564,7 +570,9 @@ mod run_decode_loop_tests {
     use super::{DecodeLoopArgs, StreamingCtx, run_decode_loop};
     use crate::array::MxArray;
     use crate::decode_profiler::DecodeProfiler;
-    use crate::engine::backend::{ChunkSink, DecodeStep, DefaultStreamEmitter, StreamEmitter};
+    use crate::engine::backend::{
+        ChunkSink, DecodeStep, DefaultStreamEmitter, StreamEmitter, TurnTokenObserver,
+    };
     use crate::engine::params::{ChatParams, extract_chat_params};
     use crate::engine::penalties::ReasoningTracker;
     use crate::engine::types::{ChatConfig, ChatResult, ChatStreamChunk};
@@ -676,6 +684,29 @@ mod run_decode_loop_tests {
         eos_id: u32,
         extra_eos_ids: &[u32],
     ) -> Result<LoopOutcome> {
+        drive_with_observer(
+            step,
+            first_token,
+            params,
+            tracker,
+            max_new_tokens,
+            eos_id,
+            extra_eos_ids,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn drive_with_observer(
+        step: &mut MockStep,
+        first_token: u32,
+        params: &ChatParams,
+        tracker: &mut ReasoningTracker,
+        max_new_tokens: i32,
+        eos_id: u32,
+        extra_eos_ids: &[u32],
+        turn_token_observer: Option<Box<dyn TurnTokenObserver>>,
+    ) -> Result<LoopOutcome> {
         let y = MxArray::from_int32(&[first_token as i32], &[1])?;
         let mut profiler = DecodeProfiler::new("test", "mock");
         let mut generated_tokens: Vec<u32> = Vec::new();
@@ -702,6 +733,7 @@ mod run_decode_loop_tests {
                 report_perf: false,
                 generation_stream,
                 cancel_flag: None,
+                turn_token_observer,
             },
             None,
         )?;
@@ -928,6 +960,7 @@ mod run_decode_loop_tests {
                 report_perf: false,
                 generation_stream,
                 cancel_flag: Some(&cancelled),
+                turn_token_observer: None,
             },
             Some(StreamingCtx {
                 callback: &sink,
@@ -1016,6 +1049,7 @@ mod run_decode_loop_tests {
                 report_perf: false,
                 generation_stream,
                 cancel_flag: Some(&cancelled),
+                turn_token_observer: None,
             },
             Some(StreamingCtx {
                 callback: &sink,
@@ -1175,6 +1209,7 @@ mod run_decode_loop_tests {
                 report_perf: false,
                 generation_stream,
                 cancel_flag: Some(&cancelled),
+                turn_token_observer: None,
             },
             Some(StreamingCtx {
                 callback: &sink,
@@ -1273,6 +1308,7 @@ mod run_decode_loop_tests {
                     report_perf: false,
                     generation_stream,
                     cancel_flag: wire_flag.then_some(&cancelled),
+                    turn_token_observer: None,
                 },
                 None,
             )
@@ -1308,6 +1344,7 @@ mod run_decode_loop_tests {
         extra_eos_ids: &[u32],
         eos_before_emit: bool,
         emitter: &mut dyn StreamEmitter,
+        turn_token_observer: Option<Box<dyn TurnTokenObserver>>,
         cancelled_pre_set: bool,
     ) -> (Vec<u32>, String, Vec<ChatStreamChunk>) {
         let tokenizer = tiny_tokenizer();
@@ -1346,6 +1383,7 @@ mod run_decode_loop_tests {
                 report_perf: false,
                 generation_stream,
                 cancel_flag: Some(&cancelled),
+                turn_token_observer,
             },
             Some(StreamingCtx {
                 callback: &sink,
@@ -1422,6 +1460,7 @@ mod run_decode_loop_tests {
                 &[],
                 eos_before_emit,
                 &mut emitter,
+                None,
                 false,
             );
 
@@ -1458,6 +1497,7 @@ mod run_decode_loop_tests {
                 &[],
                 eos_before_emit,
                 &mut emitter,
+                None,
                 true, // cancellation already pending
             );
 
@@ -1504,47 +1544,22 @@ mod run_decode_loop_tests {
         }
     }
 
-    struct StoppingEmitter {
+    struct StoppingObserver {
         stop_id: u32,
-        seen: Vec<String>,
     }
 
-    impl StreamEmitter for StoppingEmitter {
+    impl TurnTokenObserver for StoppingObserver {
         fn observe_token_id(&mut self, token_id: u32) -> bool {
             token_id == self.stop_id
         }
-
-        fn on_token_text(
-            &mut self,
-            token_text: &str,
-            _is_reasoning: bool,
-            _include_reasoning: bool,
-            _sink: &dyn ChunkSink,
-        ) {
-            self.seen.push(token_text.to_string());
-        }
-
-        fn on_residual(
-            &mut self,
-            _residual: &str,
-            _is_reasoning: bool,
-            _include_reasoning: bool,
-            _sink: &dyn ChunkSink,
-        ) {
-        }
-
-        fn finish(&mut self, _result: &ChatResult, _sink: &dyn ChunkSink) {}
     }
 
     #[test]
-    fn emitter_terminal_token_stops_before_the_next_forward() {
+    fn turn_observer_stops_streaming_before_the_next_forward() {
         let params = greedy_params(|_| {});
         let mut tracker = ReasoningTracker::new(false, None, None);
         let mut step = MockStep::new(vec![3, 4], 7);
-        let mut emitter = StoppingEmitter {
-            stop_id: 3,
-            seen: Vec::new(),
-        };
+        let mut emitter = DefaultStreamEmitter;
 
         let (generated, finish, chunks) = drive_streaming(
             &mut step,
@@ -1555,14 +1570,38 @@ mod run_decode_loop_tests {
             &[],
             false,
             &mut emitter,
+            Some(Box::new(StoppingObserver { stop_id: 3 })),
             false,
         );
 
         assert_eq!(generated, vec![1, 3]);
         assert_eq!(finish, "stop");
-        assert_eq!(step.forward_calls, 1, "no forward after emitter stop");
-        assert_eq!(emitter.seen, vec![String::from("t1"), String::from(" c3")]);
-        assert!(chunks.is_empty(), "the custom emitter owns the sink");
+        assert_eq!(step.forward_calls, 1, "no forward after observer stop");
+        let texts: Vec<&str> = chunks.iter().map(|chunk| chunk.text.as_str()).collect();
+        assert_eq!(texts, vec!["t1", " c3"]);
+    }
+
+    #[test]
+    fn turn_observer_stops_synchronous_before_the_next_forward() {
+        let params = greedy_params(|_| {});
+        let mut tracker = ReasoningTracker::new(false, None, None);
+        let mut step = MockStep::new(vec![3, 4], 7);
+
+        let out = drive_with_observer(
+            &mut step,
+            1,
+            &params,
+            &mut tracker,
+            10,
+            5,
+            &[],
+            Some(Box::new(StoppingObserver { stop_id: 3 })),
+        )
+        .unwrap_or_else(|e| panic!("loop failed: {}", e.reason));
+
+        assert_eq!(out.generated, vec![1, 3]);
+        assert_eq!(out.finish_reason, "stop");
+        assert_eq!(step.forward_calls, 1, "no forward after observer stop");
     }
 
     #[test]
@@ -1592,6 +1631,7 @@ mod run_decode_loop_tests {
             &[],
             false,
             &mut emitter,
+            None,
             false,
         );
 
@@ -1682,6 +1722,7 @@ mod run_decode_loop_tests {
                 report_perf: false,
                 generation_stream,
                 cancel_flag: None,
+                turn_token_observer: None,
             },
             None,
         )

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -299,6 +299,7 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
     // the last cached token is the prompt's last token, which IS in cache.
     let mut last_in_cache = true;
     let mut last_clear_at: usize = generated.len();
+    let mut emitter_stopped = false;
 
     // Same nonpositive-budget clamp as `run_mtp_turn` (see its PARITY-FIX
     // comment): a negative `max` must behave as 0, not wrap to a huge usize.
@@ -323,6 +324,7 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
         if let Some(s) = streaming.as_mut() {
             *s.last_is_reasoning = _is_reasoning;
             if !s.cancelled.load(Ordering::Relaxed) {
+                emitter_stopped = s.emitter.observe_token_id(initial_token_id);
                 let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                     s.decode_stream,
                     s.tokenizer,
@@ -396,6 +398,11 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
     // gemma4 has no post-commit heal path, so a mid-emit cancel must never
     // be observed AFTER the cycle's commit already kept its slots.
     loop {
+        if emitter_stopped {
+            *reason = String::from("stop");
+            break;
+        }
+
         // Pre-cycle stop checks — `run_mtp_turn`'s exact order and reason
         // strings: zero budget → EOS/extra-EOS → cancel → repetition → max.
         if max_as_usize == 0 {
@@ -681,6 +688,13 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
                     stop = Some(CycleStop::Cancelled);
                     break;
                 }
+                if streaming
+                    .as_mut()
+                    .is_some_and(|s| s.emitter.observe_token_id(tok))
+                {
+                    stop = Some(CycleStop::Stop);
+                    break;
+                }
                 if tok == eos_id || p.extra_eos_ids.contains(&tok) {
                     stop = Some(CycleStop::Stop);
                     break;
@@ -870,6 +884,7 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
         step.eval_boundary(&y_arr);
     }
 
+    step.finish()?;
     profiler.snapshot_memory_after();
     profiler.report();
 
@@ -899,7 +914,7 @@ mod tests {
     use crate::decode_profiler::DecodeProfiler;
     use crate::engine::backend::{
         ChatBackend, ChunkSink, DefaultStreamEmitter, DsparkBackend, DsparkProposal, DsparkStepper,
-        DsparkVerifyOutput, FinalizeArgs, ResetScope, SaveStateArgs, TurnSetup,
+        DsparkVerifyOutput, FinalizeArgs, ResetScope, SaveStateArgs, StreamEmitter, TurnSetup,
     };
     use crate::engine::decode::StreamingCtx;
     use crate::engine::params::ChatParams;
@@ -2161,13 +2176,14 @@ mod tests {
     /// Drive the STREAMING turn over the scripted backend. `pre_cancelled`
     /// sets the cancel flag before the turn starts; the backend's
     /// `cancel_on_verify` can flip it mid-cycle instead.
-    fn drive_streaming_turn(
+    fn drive_streaming_turn_with_emitter(
         backend: &mut MockDsparkBackend,
         params: ChatParams,
         first_token: u32,
         eos_id: u32,
         block_size: usize,
         cancelled: Arc<AtomicBool>,
+        emitter: &mut dyn crate::engine::backend::StreamEmitter,
     ) -> StreamOut {
         let mut tracker = ReasoningTracker::new(false, None, None);
         let mut profiler = DecodeProfiler::new("dspark_stream_test", "test");
@@ -2188,8 +2204,6 @@ mod tests {
         };
         let mut streamed_text_len = 0usize;
         let mut last_is_reasoning = false;
-        let mut emitter = DefaultStreamEmitter;
-
         let outcome = run_dspark_turn(
             backend,
             &mut rng,
@@ -2219,7 +2233,7 @@ mod tests {
                 tokenizer: &tokenizer,
                 streamed_text_len: &mut streamed_text_len,
                 last_is_reasoning: &mut last_is_reasoning,
-                emitter: &mut emitter,
+                emitter,
             }),
         )
         .unwrap_or_else(|e| panic!("run_dspark_turn (streaming) failed: {}", e.reason));
@@ -2240,6 +2254,26 @@ mod tests {
             ledger: backend.ledger_snapshot(),
             streamed_text_len,
         }
+    }
+
+    fn drive_streaming_turn(
+        backend: &mut MockDsparkBackend,
+        params: ChatParams,
+        first_token: u32,
+        eos_id: u32,
+        block_size: usize,
+        cancelled: Arc<AtomicBool>,
+    ) -> StreamOut {
+        let mut emitter = DefaultStreamEmitter;
+        drive_streaming_turn_with_emitter(
+            backend,
+            params,
+            first_token,
+            eos_id,
+            block_size,
+            cancelled,
+            &mut emitter,
+        )
     }
 
     /// The residual the whole-turn core's post-loop flush would emit:
@@ -2300,6 +2334,76 @@ mod tests {
             residual_of(&streamed),
             "",
             "an uncancelled turn leaves nothing for the residual flush"
+        );
+    }
+
+    struct StoppingEmitter {
+        stop_id: u32,
+        inner: DefaultStreamEmitter,
+    }
+
+    impl StreamEmitter for StoppingEmitter {
+        fn observe_token_id(&mut self, token_id: u32) -> bool {
+            token_id == self.stop_id
+        }
+
+        fn on_token_text(
+            &mut self,
+            token_text: &str,
+            is_reasoning: bool,
+            include_reasoning: bool,
+            sink: &dyn ChunkSink,
+        ) {
+            self.inner
+                .on_token_text(token_text, is_reasoning, include_reasoning, sink);
+        }
+
+        fn on_residual(
+            &mut self,
+            residual: &str,
+            is_reasoning: bool,
+            include_reasoning: bool,
+            sink: &dyn ChunkSink,
+        ) {
+            self.inner
+                .on_residual(residual, is_reasoning, include_reasoning, sink);
+        }
+
+        fn finish(&mut self, result: &ChatResult, sink: &dyn ChunkSink) {
+            self.inner.finish(result, sink);
+        }
+    }
+
+    #[test]
+    fn dspark_emitter_stop_clamps_before_commit() {
+        let mut backend =
+            MockDsparkBackend::greedy(7, vec![CycleScript::greedy(vec![1, 3], vec![1, 3, 4])]);
+        let mut emitter = StoppingEmitter {
+            stop_id: 3,
+            inner: DefaultStreamEmitter,
+        };
+        let out = drive_streaming_turn_with_emitter(
+            &mut backend,
+            greedy_params(),
+            0,
+            5,
+            2,
+            Arc::new(AtomicBool::new(false)),
+            &mut emitter,
+        );
+
+        assert_eq!(out.generated, vec![0, 1, 3]);
+        assert_eq!(out.finish_reason, "stop");
+        assert!(!out.last_in_cache, "the stopping token is not persisted");
+        assert_eq!(out.chunks, vec!["t0", " t1", " c3"]);
+        assert_eq!(commits(&out.ledger), vec![(2, 3)]);
+        assert_eq!(
+            count(&out.ledger, |call| matches!(
+                call,
+                Call::EvalBoundary { .. }
+            )),
+            0,
+            "no next speculative cycle is scheduled"
         );
     }
 

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -331,7 +331,8 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
                     *s.streamed_text_len,
                 );
                 *s.streamed_text_len += token_text.len();
-                s.emitter.on_token_text(
+                s.emitter.on_token_id(
+                    initial_token_id,
                     &token_text,
                     _is_reasoning,
                     p.include_reasoning,
@@ -824,7 +825,8 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
                     *s.streamed_text_len,
                 );
                 *s.streamed_text_len += token_text.len();
-                s.emitter.on_token_text(
+                s.emitter.on_token_id(
+                    tok_id,
                     &token_text,
                     _is_reasoning,
                     p.include_reasoning,

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -19,7 +19,7 @@ use napi::bindgen_prelude::*;
 
 use crate::array::{DType, MxArray};
 use crate::decode_profiler::DecodeProfiler;
-use crate::engine::backend::{DsparkBackend, DsparkProposal, DsparkStepper};
+use crate::engine::backend::{DsparkBackend, DsparkProposal, DsparkStepper, TurnTokenObserver};
 use crate::engine::decode::StreamingCtx;
 use crate::engine::params::ChatParams;
 use crate::engine::penalties::{ReasoningTracker, apply_all_penalties};
@@ -59,6 +59,8 @@ pub(crate) struct DsparkTurnArgs<'a> {
     /// Streaming turns carry the SAME flag in `StreamingCtx.cancelled`;
     /// the polls are idempotent, so double-polling is harmless.
     pub cancel_flag: Option<&'a AtomicBool>,
+    /// Family protocol guard, present independently of a streaming sink.
+    pub turn_token_observer: Option<Box<dyn TurnTokenObserver>>,
 }
 
 /// Terminal outs of [`run_dspark_turn`] the caller threads into its save /
@@ -283,6 +285,7 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
         report_perf: report,
         generation_stream,
         cancel_flag,
+        mut turn_token_observer,
     } = args;
     // One closure for every cancel snapshot point below — sync turns poll
     // `cancel_flag` directly; streaming turns pass the same flag, so a
@@ -299,7 +302,7 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
     // the last cached token is the prompt's last token, which IS in cache.
     let mut last_in_cache = true;
     let mut last_clear_at: usize = generated.len();
-    let mut emitter_stopped = false;
+    let mut observer_stopped = false;
 
     // Same nonpositive-budget clamp as `run_mtp_turn` (see its PARITY-FIX
     // comment): a negative `max` must behave as 0, not wrap to a huge usize.
@@ -321,10 +324,14 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
         hist.push(initial_token_id);
         profiler.step();
         let _is_reasoning = tracker.observe_token(initial_token_id);
+        if !turn_cancelled() {
+            observer_stopped = turn_token_observer
+                .as_deref_mut()
+                .is_some_and(|observer| observer.observe_token_id(initial_token_id));
+        }
         if let Some(s) = streaming.as_mut() {
             *s.last_is_reasoning = _is_reasoning;
             if !s.cancelled.load(Ordering::Relaxed) {
-                emitter_stopped = s.emitter.observe_token_id(initial_token_id);
                 let token_text = crate::tokenizer::Qwen3Tokenizer::step_decode_stream(
                     s.decode_stream,
                     s.tokenizer,
@@ -398,7 +405,7 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
     // gemma4 has no post-commit heal path, so a mid-emit cancel must never
     // be observed AFTER the cycle's commit already kept its slots.
     loop {
-        if emitter_stopped {
+        if observer_stopped {
             *reason = String::from("stop");
             break;
         }
@@ -688,9 +695,9 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
                     stop = Some(CycleStop::Cancelled);
                     break;
                 }
-                if streaming
-                    .as_mut()
-                    .is_some_and(|s| s.emitter.observe_token_id(tok))
+                if turn_token_observer
+                    .as_deref_mut()
+                    .is_some_and(|observer| observer.observe_token_id(tok))
                 {
                     stop = Some(CycleStop::Stop);
                     break;
@@ -914,7 +921,7 @@ mod tests {
     use crate::decode_profiler::DecodeProfiler;
     use crate::engine::backend::{
         ChatBackend, ChunkSink, DefaultStreamEmitter, DsparkBackend, DsparkProposal, DsparkStepper,
-        DsparkVerifyOutput, FinalizeArgs, ResetScope, SaveStateArgs, StreamEmitter, TurnSetup,
+        DsparkVerifyOutput, FinalizeArgs, ResetScope, SaveStateArgs, TurnSetup, TurnTokenObserver,
     };
     use crate::engine::decode::StreamingCtx;
     use crate::engine::params::ChatParams;
@@ -1437,7 +1444,16 @@ mod tests {
         block_size: usize,
         rng: &mut R,
     ) -> RawTurnOut {
-        drive_turn_raw_with_cancel(backend, params, first_token, eos_id, block_size, rng, None)
+        drive_turn_raw_with_cancel(
+            backend,
+            params,
+            first_token,
+            eos_id,
+            block_size,
+            rng,
+            None,
+            None,
+        )
     }
 
     /// [`drive_turn_raw`] with an H2 sync cancel flag threaded into
@@ -1451,6 +1467,7 @@ mod tests {
         block_size: usize,
         rng: &mut R,
         cancel_flag: Option<&AtomicBool>,
+        turn_token_observer: Option<Box<dyn TurnTokenObserver>>,
     ) -> RawTurnOut {
         let mut tracker = ReasoningTracker::new(false, None, None);
         let mut profiler = DecodeProfiler::new("dspark_turn_test", "test");
@@ -1481,6 +1498,7 @@ mod tests {
                 report_perf: false,
                 generation_stream,
                 cancel_flag,
+                turn_token_observer,
             },
             None,
         );
@@ -2184,6 +2202,7 @@ mod tests {
         block_size: usize,
         cancelled: Arc<AtomicBool>,
         emitter: &mut dyn crate::engine::backend::StreamEmitter,
+        turn_token_observer: Option<Box<dyn TurnTokenObserver>>,
     ) -> StreamOut {
         let mut tracker = ReasoningTracker::new(false, None, None);
         let mut profiler = DecodeProfiler::new("dspark_stream_test", "test");
@@ -2225,6 +2244,7 @@ mod tests {
                 // isolation — production (gemma4 `draft_chat_turn`) also
                 // wires the same flag here.
                 cancel_flag: None,
+                turn_token_observer,
             },
             Some(StreamingCtx {
                 callback: &sink,
@@ -2273,6 +2293,7 @@ mod tests {
             block_size,
             cancelled,
             &mut emitter,
+            None,
         )
     }
 
@@ -2337,51 +2358,21 @@ mod tests {
         );
     }
 
-    struct StoppingEmitter {
+    struct StoppingObserver {
         stop_id: u32,
-        inner: DefaultStreamEmitter,
     }
 
-    impl StreamEmitter for StoppingEmitter {
+    impl TurnTokenObserver for StoppingObserver {
         fn observe_token_id(&mut self, token_id: u32) -> bool {
             token_id == self.stop_id
-        }
-
-        fn on_token_text(
-            &mut self,
-            token_text: &str,
-            is_reasoning: bool,
-            include_reasoning: bool,
-            sink: &dyn ChunkSink,
-        ) {
-            self.inner
-                .on_token_text(token_text, is_reasoning, include_reasoning, sink);
-        }
-
-        fn on_residual(
-            &mut self,
-            residual: &str,
-            is_reasoning: bool,
-            include_reasoning: bool,
-            sink: &dyn ChunkSink,
-        ) {
-            self.inner
-                .on_residual(residual, is_reasoning, include_reasoning, sink);
-        }
-
-        fn finish(&mut self, result: &ChatResult, sink: &dyn ChunkSink) {
-            self.inner.finish(result, sink);
         }
     }
 
     #[test]
-    fn dspark_emitter_stop_clamps_before_commit() {
+    fn dspark_streaming_observer_stop_clamps_before_commit() {
         let mut backend =
             MockDsparkBackend::greedy(7, vec![CycleScript::greedy(vec![1, 3], vec![1, 3, 4])]);
-        let mut emitter = StoppingEmitter {
-            stop_id: 3,
-            inner: DefaultStreamEmitter,
-        };
+        let mut emitter = DefaultStreamEmitter;
         let out = drive_streaming_turn_with_emitter(
             &mut backend,
             greedy_params(),
@@ -2390,6 +2381,7 @@ mod tests {
             2,
             Arc::new(AtomicBool::new(false)),
             &mut emitter,
+            Some(Box::new(StoppingObserver { stop_id: 3 })),
         );
 
         assert_eq!(out.generated, vec![0, 1, 3]);
@@ -2405,6 +2397,34 @@ mod tests {
             0,
             "no next speculative cycle is scheduled"
         );
+    }
+
+    #[test]
+    fn dspark_sync_observer_stop_clamps_before_commit() {
+        let mut backend =
+            MockDsparkBackend::greedy(7, vec![CycleScript::greedy(vec![1, 3], vec![1, 3, 4])]);
+        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(0xD5_9A2B_C0DE);
+        let raw = drive_turn_raw_with_cancel(
+            &mut backend,
+            greedy_params(),
+            0,
+            5,
+            2,
+            &mut rng,
+            None,
+            Some(Box::new(StoppingObserver { stop_id: 3 })),
+        );
+        let outcome = raw
+            .result
+            .unwrap_or_else(|e| panic!("run_dspark_turn failed: {}", e.reason));
+
+        assert_eq!(raw.generated, vec![0, 1, 3]);
+        assert_eq!(raw.finish_reason, "stop");
+        assert!(
+            !outcome.last_in_cache,
+            "the stopping token is not persisted"
+        );
+        assert_eq!(commits(&backend.ledger_snapshot()), vec![(2, 3)]);
     }
 
     #[test]
@@ -2520,6 +2540,7 @@ mod tests {
             2,
             &mut rng,
             Some(cancel.as_ref()),
+            None,
         );
         let outcome = raw
             .result
@@ -2559,6 +2580,7 @@ mod tests {
             2,
             &mut rng,
             Some(cancel.as_ref()),
+            None,
         );
         let outcome = raw
             .result

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -545,7 +545,13 @@ impl<B: HybridSchedulerBackend> HybridStepExecutor<'_, B> {
         };
         payload.streamed_text_len = payload.streamed_text_len.saturating_add(text.len());
         if let (Some(sink), Some(emitter)) = (payload.response.sink(), payload.emitter.as_mut()) {
-            emitter.on_token_text(&text, is_reasoning, payload.params.include_reasoning, sink);
+            emitter.on_token_id(
+                token_id,
+                &text,
+                is_reasoning,
+                payload.params.include_reasoning,
+                sink,
+            );
         }
     }
 
@@ -1953,7 +1959,7 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             Ok(Some(snapshot)) => snapshot.bytes_per_block,
             Ok(None) => 1,
             Err(error) => {
-                self.fail_preempted(turn, error.reason);
+                self.fail_preempted(turn, error.reason.clone());
                 return;
             }
         };
@@ -1969,7 +1975,7 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
         self.inner.release_scheduled_recurrent_for(turn.seq_id);
         if let Err(error) = lifecycle {
             let _ = self.inner.release_scheduled_cache(turn.seq_id);
-            self.fail_preempted(turn, error.reason);
+            self.fail_preempted(turn, error.reason.clone());
             return;
         }
         turn.payload.preemption_replay = Some(replay);
@@ -1992,7 +1998,7 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
         let cache_snapshot = match self.inner.scheduler_cache_snapshot() {
             Ok(snapshot) => snapshot,
             Err(error) => {
-                self.fail_preempted(turn, error.reason);
+                self.fail_preempted(turn, error.reason.clone());
                 return;
             }
         };
@@ -2043,7 +2049,7 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             turn.payload.params.cache_root_owner_id.as_deref(),
         );
         if let Err(error) = self.inner.activate_scheduled_recurrent(turn.seq_id) {
-            self.fail_preempted(turn, error.reason);
+            self.fail_preempted(turn, error.reason.clone());
             return;
         }
         let prefix_admission = match self.inner.prepare_scheduled_prefix(
@@ -2067,7 +2073,7 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             Err(error) => {
                 let _ = self.inner.release_scheduled_cache(turn.seq_id);
                 self.inner.release_scheduled_recurrent_for(turn.seq_id);
-                self.fail_preempted(turn, error.reason);
+                self.fail_preempted(turn, error.reason.clone());
                 return;
             }
         };

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -447,6 +447,7 @@ struct PreparedDecodeRow {
     stops_at_eos: bool,
     cancelled: bool,
     repetition: Option<&'static str>,
+    emitter_stopped: bool,
     batch_index: Option<usize>,
 }
 
@@ -724,7 +725,7 @@ impl<B: HybridSchedulerBackend> HybridStepExecutor<'_, B> {
             if turn.payload.response.sink().is_some() {
                 Self::stream_token(turn, row.token_id, is_reasoning);
             }
-            if row.stops_at_eos {
+            if row.emitter_stopped || row.stops_at_eos {
                 turn.payload.finish_reason = String::from("stop");
             } else if let Some(reason) = row.repetition {
                 turn.payload.finish_reason = reason.to_string();
@@ -808,7 +809,16 @@ impl<B: HybridSchedulerBackend> HybridStepExecutor<'_, B> {
                 turn.payload.params.max_ngram_repeats,
                 turn.payload.params.ngram_size,
             );
-            let terminal = stops_at_eos || planned.cancel_snapshot || repetition.is_some();
+            let emitter_stopped = !planned.cancel_snapshot
+                && !(stops_at_eos && !B::STREAM_EOS_TOKEN)
+                && turn.payload.response.sink().is_some()
+                && turn
+                    .payload
+                    .emitter
+                    .as_mut()
+                    .is_some_and(|emitter| emitter.observe_token_id(token_id));
+            let terminal =
+                stops_at_eos || planned.cancel_snapshot || repetition.is_some() || emitter_stopped;
             let at_length = turn.payload.generated_tokens.len()
                 >= turn.payload.params.max_new_tokens.max(0) as usize;
             // GDN state is not rewindable. A terminal/length token is never
@@ -827,6 +837,7 @@ impl<B: HybridSchedulerBackend> HybridStepExecutor<'_, B> {
                 stops_at_eos,
                 cancelled: planned.cancel_snapshot,
                 repetition,
+                emitter_stopped,
                 batch_index,
             });
         }

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -16,6 +16,7 @@ use crate::array::MxArray;
 use crate::decode_profiler::DecodeProfiler;
 use crate::engine::backend::{
     ChunkSink, PagedBackend, PagedPrefix, StreamEmitter, ThinkingSetup, TurnOutput,
+    TurnTokenObserver,
 };
 use crate::engine::cmd::{ChatCmd, FromChatCmd};
 use crate::engine::scheduler::{
@@ -416,6 +417,7 @@ pub(crate) struct ScheduledTurn<P> {
     pub(crate) generation_stream: Stream,
     pub(crate) profiler: crate::decode_profiler::DecodeProfiler,
     pub(crate) emitter: Option<Box<dyn StreamEmitter>>,
+    pub(crate) turn_token_observer: Option<Box<dyn TurnTokenObserver>>,
     pub(crate) stream_skip_special: bool,
     pub(crate) decode_ids: Vec<u32>,
     pub(crate) decode_prefix: String,
@@ -447,7 +449,7 @@ struct PreparedDecodeRow {
     stops_at_eos: bool,
     cancelled: bool,
     repetition: Option<&'static str>,
-    emitter_stopped: bool,
+    observer_stopped: bool,
     batch_index: Option<usize>,
 }
 
@@ -725,7 +727,7 @@ impl<B: HybridSchedulerBackend> HybridStepExecutor<'_, B> {
             if turn.payload.response.sink().is_some() {
                 Self::stream_token(turn, row.token_id, is_reasoning);
             }
-            if row.emitter_stopped || row.stops_at_eos {
+            if row.observer_stopped || row.stops_at_eos {
                 turn.payload.finish_reason = String::from("stop");
             } else if let Some(reason) = row.repetition {
                 turn.payload.finish_reason = reason.to_string();
@@ -809,16 +811,15 @@ impl<B: HybridSchedulerBackend> HybridStepExecutor<'_, B> {
                 turn.payload.params.max_ngram_repeats,
                 turn.payload.params.ngram_size,
             );
-            let emitter_stopped = !planned.cancel_snapshot
+            let observer_stopped = !planned.cancel_snapshot
                 && !(stops_at_eos && !B::STREAM_EOS_TOKEN)
-                && turn.payload.response.sink().is_some()
                 && turn
                     .payload
-                    .emitter
+                    .turn_token_observer
                     .as_mut()
-                    .is_some_and(|emitter| emitter.observe_token_id(token_id));
+                    .is_some_and(|observer| observer.observe_token_id(token_id));
             let terminal =
-                stops_at_eos || planned.cancel_snapshot || repetition.is_some() || emitter_stopped;
+                stops_at_eos || planned.cancel_snapshot || repetition.is_some() || observer_stopped;
             let at_length = turn.payload.generated_tokens.len()
                 >= turn.payload.params.max_new_tokens.max(0) as usize;
             // GDN state is not rewindable. A terminal/length token is never
@@ -837,7 +838,7 @@ impl<B: HybridSchedulerBackend> HybridStepExecutor<'_, B> {
                 stops_at_eos,
                 cancelled: planned.cancel_snapshot,
                 repetition,
-                emitter_stopped,
+                observer_stopped,
                 batch_index,
             });
         }
@@ -963,6 +964,11 @@ impl<B: HybridSchedulerBackend> HybridStepExecutor<'_, B> {
                 (Err(error), Some(_)) if is_paged_allocation_blocked(&error.reason) => {
                     let rolled_back = turn.payload.generated_tokens.pop();
                     debug_assert_eq!(rolled_back, Some(row.token_id));
+                    if rolled_back.is_some()
+                        && let Some(observer) = turn.payload.turn_token_observer.as_mut()
+                    {
+                        observer.rollback_last_token();
+                    }
                     results.push((row.plan_index, Self::blocked(planned)));
                     continue;
                 }
@@ -1751,6 +1757,7 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             generation_stream,
             profiler,
             emitter: is_streaming.then(|| self.inner.stream_emitter()),
+            turn_token_observer: self.inner.turn_token_observer(),
             stream_skip_special: self.inner.stream_skip_special_tokens(),
             decode_ids: Vec::new(),
             decode_prefix: String::new(),

--- a/crates/mlx-core/src/engine/mtp_turn.rs
+++ b/crates/mlx-core/src/engine/mtp_turn.rs
@@ -1438,7 +1438,8 @@ pub(crate) fn run_mtp_turn<B: MtpBackend, R: rand::Rng>(
                     *s.streamed_text_len,
                 );
                 *s.streamed_text_len += token_text.len();
-                s.emitter.on_token_text(
+                s.emitter.on_token_id(
+                    initial_token_id,
                     &token_text,
                     _is_reasoning,
                     p.include_reasoning,
@@ -1637,7 +1638,8 @@ pub(crate) fn run_mtp_turn<B: MtpBackend, R: rand::Rng>(
                     *s.streamed_text_len,
                 );
                 *s.streamed_text_len += token_text.len();
-                s.emitter.on_token_text(
+                s.emitter.on_token_id(
+                    token_id,
                     &token_text,
                     _is_reasoning,
                     p.include_reasoning,
@@ -1946,7 +1948,8 @@ pub(crate) fn run_mtp_turn<B: MtpBackend, R: rand::Rng>(
                     *s.streamed_text_len,
                 );
                 *s.streamed_text_len += token_text.len();
-                s.emitter.on_token_text(
+                s.emitter.on_token_id(
+                    tok_id,
                     &token_text,
                     _is_reasoning,
                     p.include_reasoning,

--- a/crates/mlx-core/src/engine/paged_turn.rs
+++ b/crates/mlx-core/src/engine/paged_turn.rs
@@ -255,6 +255,7 @@ pub(crate) fn run_paged_turn<B: PagedBackend>(
     let mut streamed_text_len = 0usize;
     let mut last_is_reasoning = thinking.enabled;
     let mut emitter: Option<Box<dyn StreamEmitter>> = args.sink.map(|_| backend.stream_emitter());
+    let turn_token_observer = backend.turn_token_observer();
 
     // ---- prefill ----
     // ABORT-ON-ERROR: every fallible step from here through `end_decode`
@@ -349,6 +350,7 @@ pub(crate) fn run_paged_turn<B: PagedBackend>(
                 // turns too — the engine passes it via
                 // `WholeTurnArgs::cancelled` regardless of sink presence.
                 cancel_flag: args.cancelled,
+                turn_token_observer,
             },
             streaming_ctx,
         )?;

--- a/crates/mlx-core/src/engine/params.rs
+++ b/crates/mlx-core/src/engine/params.rs
@@ -202,8 +202,9 @@ pub(crate) struct ChatParams {
     ///     `mtpAdaptiveDepth=true` explicitly to enable the adaptive
     ///     policy.
     ///
-    /// Families may post-resolve this generic default. Gemma4 DSpark enables
-    /// its measured target-AR break-even guard when both raw fields are unset.
+    /// Families may post-resolve this generic default. Gemma4 DSpark and
+    /// Muse-Glimmer DFlash enable their measured target-AR break-even guard
+    /// when both raw fields are unset.
     pub mtp_adaptive_depth: bool,
 }
 

--- a/crates/mlx-core/src/engine/session.rs
+++ b/crates/mlx-core/src/engine/session.rs
@@ -1195,6 +1195,7 @@ fn chat_turn_core<B: ChatBackend>(
     // `begin_decode` takes the long &mut borrow of the backend.
     let mut emitter: Option<Box<dyn StreamEmitter>> =
         streaming.as_ref().map(|_| backend.stream_emitter());
+    let turn_token_observer = backend.turn_token_observer();
 
     // From prefill onward, every fallible operation runs inside one error
     // boundary. The temporary closure ensures a decode stepper borrowing the
@@ -1265,6 +1266,7 @@ fn chat_turn_core<B: ChatBackend>(
                     report_perf,
                     generation_stream,
                     cancel_flag: turn_cancel,
+                    turn_token_observer,
                 },
                 streaming_ctx,
             )?;

--- a/crates/mlx-core/src/engine/types.rs
+++ b/crates/mlx-core/src/engine/types.rs
@@ -147,6 +147,10 @@ pub struct ChatConfig {
     /// - Assistant (Google `gemma-4-*-it-assistant`): an unset `mtpDepth`
     ///   drafts 3 tokens per cycle (`ASSISTANT_DEFAULT_DEPTH`), and an
     ///   explicit `mtpDepth` clamps to `[1, 8]` (`ASSISTANT_MAX_DEPTH`).
+    /// - Muse-Glimmer DFlash follows DSpark's external-draft rules: unset
+    ///   uses the checkpoint block size (16 for Muse-Glimmer-30B), while an
+    ///   explicit value clamps to `[1, block_size]` and pins that depth unless
+    ///   `mtpAdaptiveDepth: true` explicitly enables the break-even guard.
     ///
     /// `mtpAdaptiveDepth` is ignored for the Gemma4 assistant variant.
     #[napi(ts_type = "number | undefined")]
@@ -160,9 +164,9 @@ pub struct ChatConfig {
     /// `MLX_MTP_EV_ALLOW_DEEPEN=0` to pin the base depth.
     /// When false, the loop pins `mtpDepth` for every cycle.
     ///
-    /// Default: false, except Gemma4 DSpark enables its measured break-even
-    /// guard when both this field and `mtpDepth` are unset. An explicit value
-    /// always wins over the family default.
+    /// Default: false, except Gemma4 DSpark and Muse-Glimmer DFlash enable the
+    /// measured break-even guard when both this field and `mtpDepth` are unset.
+    /// An explicit value always wins over the family default.
     #[napi(ts_type = "boolean | undefined")]
     pub mtp_adaptive_depth: Option<bool>,
 }

--- a/crates/mlx-core/src/models/gemma4/dspark_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark_decode.rs
@@ -782,6 +782,7 @@ impl Gemma4Inner {
                     // streaming turns it is the SAME flag StreamingCtx
                     // carries — the polls are idempotent.
                     cancel_flag: args.cancelled,
+                    turn_token_observer: None,
                 },
                 streaming_ctx,
             );

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -107,7 +107,7 @@ pub(crate) struct Gemma4KVCacheCoordinator {
 }
 
 impl Gemma4KVCacheCoordinator {
-    fn new(
+    pub(crate) fn new(
         specs: &[LayerKVCacheSpec],
         groups: Vec<KVCacheGroup>,
         adapters: Vec<PagedKVCacheAdapter>,
@@ -158,11 +158,11 @@ impl Gemma4KVCacheCoordinator {
         })
     }
 
-    fn routes(&self) -> &[LayerKVCacheRoute] {
+    pub(crate) fn routes(&self) -> &[LayerKVCacheRoute] {
         self.inner.routes()
     }
 
-    fn sliding_capacity_summary(&self) -> (usize, u32, u32) {
+    pub(crate) fn sliding_capacity_summary(&self) -> (usize, u32, u32) {
         self.inner
             .groups()
             .iter()
@@ -199,7 +199,7 @@ impl Gemma4KVCacheCoordinator {
         })
     }
 
-    fn prepare_scheduled_request(
+    pub(crate) fn prepare_scheduled_request(
         &mut self,
         seq_id: u32,
         tokens: &[u32],
@@ -211,7 +211,10 @@ impl Gemma4KVCacheCoordinator {
         Ok(0)
     }
 
-    fn reset_scheduled_request(&mut self, seq_id: u32) -> std::result::Result<(), String> {
+    pub(crate) fn reset_scheduled_request(
+        &mut self,
+        seq_id: u32,
+    ) -> std::result::Result<(), String> {
         let _ = self.release_request_all(seq_id);
         for group_id in 0..self.inner.groups().len() {
             let result = self.adapter_mut(group_id)?.begin_request(seq_id);
@@ -225,7 +228,10 @@ impl Gemma4KVCacheCoordinator {
         Ok(())
     }
 
-    fn reset_sliding_requests(&mut self, seq_id: u32) -> std::result::Result<(), String> {
+    pub(crate) fn reset_sliding_requests(
+        &mut self,
+        seq_id: u32,
+    ) -> std::result::Result<(), String> {
         for group_id in 0..self.inner.groups().len() {
             if let Some(Gemma4KVCacheGroupManager::SlidingWindow { adapter, .. }) =
                 self.inner.manager_mut(group_id)
@@ -237,7 +243,7 @@ impl Gemma4KVCacheCoordinator {
         Ok(())
     }
 
-    fn restore_sliding_groups(
+    pub(crate) fn restore_sliding_groups(
         &mut self,
         seq_id: u32,
         prompt_tokens: &[u32],
@@ -268,7 +274,7 @@ impl Gemma4KVCacheCoordinator {
         Ok(())
     }
 
-    fn read_sliding_groups_at(
+    pub(crate) fn read_sliding_groups_at(
         &mut self,
         seq_id: u32,
         boundary: u32,
@@ -302,7 +308,10 @@ impl Gemma4KVCacheCoordinator {
         Ok(Some(layer_kv))
     }
 
-    fn adapter(&self, group_id: usize) -> std::result::Result<&PagedKVCacheAdapter, String> {
+    pub(crate) fn adapter(
+        &self,
+        group_id: usize,
+    ) -> std::result::Result<&PagedKVCacheAdapter, String> {
         if group_id == self.full_group_id {
             return Ok(&self.full_adapter);
         }
@@ -316,7 +325,7 @@ impl Gemma4KVCacheCoordinator {
         }
     }
 
-    fn adapter_mut(
+    pub(crate) fn adapter_mut(
         &mut self,
         group_id: usize,
     ) -> std::result::Result<&mut PagedKVCacheAdapter, String> {
@@ -344,14 +353,14 @@ impl Gemma4KVCacheCoordinator {
         Ok(())
     }
 
-    fn activate_request_all(&mut self, seq_id: u32) -> std::result::Result<(), String> {
+    pub(crate) fn activate_request_all(&mut self, seq_id: u32) -> std::result::Result<(), String> {
         for group_id in 0..self.inner.groups().len() {
             self.adapter_mut(group_id)?.activate_request(seq_id)?;
         }
         Ok(())
     }
 
-    fn can_continue_all(&self, seq_id: u32, prompt_tokens: &[u32]) -> bool {
+    pub(crate) fn can_continue_all(&self, seq_id: u32, prompt_tokens: &[u32]) -> bool {
         (0..self.inner.groups().len()).all(|group_id| {
             let Ok(adapter) = self.adapter(group_id) else {
                 return false;
@@ -363,14 +372,14 @@ impl Gemma4KVCacheCoordinator {
         })
     }
 
-    fn is_live_all(&self, seq_id: u32) -> bool {
+    pub(crate) fn is_live_all(&self, seq_id: u32) -> bool {
         (0..self.inner.groups().len()).all(|group_id| {
             self.adapter(group_id)
                 .is_ok_and(|adapter| adapter.is_live_for_continue_for(seq_id))
         })
     }
 
-    fn request_token_count_all(&self, seq_id: u32) -> std::result::Result<u32, String> {
+    pub(crate) fn request_token_count_all(&self, seq_id: u32) -> std::result::Result<u32, String> {
         let mut count = None;
         for group_id in 0..self.inner.groups().len() {
             let adapter = self.adapter(group_id)?;
@@ -390,7 +399,7 @@ impl Gemma4KVCacheCoordinator {
         count.ok_or_else(|| "Gemma4 hybrid KV coordinator has no groups".to_string())
     }
 
-    fn continue_turn_all(
+    pub(crate) fn continue_turn_all(
         &mut self,
         seq_id: u32,
         prompt_tokens: &[u32],
@@ -413,7 +422,7 @@ impl Gemma4KVCacheCoordinator {
         Ok(boundary.unwrap_or(0))
     }
 
-    fn continue_sliding_all(
+    pub(crate) fn continue_sliding_all(
         &mut self,
         seq_id: u32,
         prompt_tokens: &[u32],
@@ -437,7 +446,7 @@ impl Gemma4KVCacheCoordinator {
         Ok(())
     }
 
-    fn record_tokens_all(
+    pub(crate) fn record_tokens_all(
         &mut self,
         seq_id: u32,
         tokens: &[u32],
@@ -459,7 +468,7 @@ impl Gemma4KVCacheCoordinator {
         Ok(())
     }
 
-    fn prune_sliding_all(&mut self, seq_id: u32) -> std::result::Result<u32, String> {
+    pub(crate) fn prune_sliding_all(&mut self, seq_id: u32) -> std::result::Result<u32, String> {
         let mut released = 0u32;
         for group_id in 0..self.inner.groups().len() {
             released = released.saturating_add(
@@ -470,14 +479,14 @@ impl Gemma4KVCacheCoordinator {
         Ok(released)
     }
 
-    fn eval_pending_pool_writes_all(&mut self) -> std::result::Result<(), String> {
+    pub(crate) fn eval_pending_pool_writes_all(&mut self) -> std::result::Result<(), String> {
         for group_id in 0..self.inner.groups().len() {
             self.adapter_mut(group_id)?.eval_pending_pool_writes()?;
         }
         Ok(())
     }
 
-    fn finalize_keep_live_all(
+    pub(crate) fn finalize_keep_live_all(
         &mut self,
         seq_id: u32,
         extra_keys_per_block: &[Vec<u64>],
@@ -496,7 +505,7 @@ impl Gemma4KVCacheCoordinator {
         Ok(())
     }
 
-    fn register_full_for_cold_capture(
+    pub(crate) fn register_full_for_cold_capture(
         &mut self,
         seq_id: u32,
         extra_keys_per_block: &[Vec<u64>],
@@ -509,7 +518,7 @@ impl Gemma4KVCacheCoordinator {
             .map(|_| ())
     }
 
-    fn rollback_last_tokens_all(
+    pub(crate) fn rollback_last_tokens_all(
         &mut self,
         seq_id: u32,
         token_count: u32,
@@ -526,7 +535,7 @@ impl Gemma4KVCacheCoordinator {
         first_error.map_or(Ok(()), Err)
     }
 
-    fn release_request_all(&mut self, seq_id: u32) -> std::result::Result<u32, String> {
+    pub(crate) fn release_request_all(&mut self, seq_id: u32) -> std::result::Result<u32, String> {
         let mut released = 0u32;
         let mut first_error = None;
         for group_id in 0..self.inner.groups().len() {
@@ -540,7 +549,7 @@ impl Gemma4KVCacheCoordinator {
         first_error.map_or(Ok(released), Err)
     }
 
-    fn release_all_and_purge(&mut self) -> std::result::Result<u32, String> {
+    pub(crate) fn release_all_and_purge(&mut self) -> std::result::Result<u32, String> {
         let mut released = 0u32;
         let mut first_error = None;
         for group_id in 0..self.inner.groups().len() {
@@ -6344,7 +6353,7 @@ impl DecodeStep for Gemma4PagedDecode<'_> {
         if self.pending_cache_error.is_none() {
             let seq_id = self.inner.active_paged_seq;
             if let Err(error) = self.inner.settle_grouped_kv_step(seq_id) {
-                self.pending_cache_error = Some(error.reason);
+                self.pending_cache_error = Some(error.reason.clone());
             }
         }
         // Paged cadence — the per-step
@@ -6356,7 +6365,7 @@ impl DecodeStep for Gemma4PagedDecode<'_> {
         if self.pending_cache_error.is_none() {
             let seq_id = self.inner.active_paged_seq;
             if let Err(error) = self.inner.settle_grouped_kv_step(seq_id) {
-                self.pending_cache_error = Some(error.reason);
+                self.pending_cache_error = Some(error.reason.clone());
             }
         }
         self.pending_cache_error

--- a/crates/mlx-core/src/models/gemma4/sliding_sidecar.rs
+++ b/crates/mlx-core/src/models/gemma4/sliding_sidecar.rs
@@ -247,7 +247,14 @@ fn layout_carrying(
 /// every `b > 0`.
 pub(crate) fn policy(config: &Gemma4Config) -> Option<ColdSidecarPolicy> {
     let geo = geometry(config)?;
-    ColdSidecarPolicy::new_boundary_scaled(template_layout(&geo), 2).ok()
+    policy_for_geometry(&geo)
+}
+
+/// Build the same exact-boundary policy for another hybrid family using this
+/// codec. Keeping the constructor beside the codec prevents its template from
+/// drifting from [`layout_at`].
+pub(crate) fn policy_for_geometry(geo: &SlidingSidecarGeometry) -> Option<ColdSidecarPolicy> {
+    ColdSidecarPolicy::new_boundary_scaled(template_layout(geo), 2).ok()
 }
 
 /// Encode the live K/V suffix read from a paged sliding-group adapter.

--- a/crates/mlx-core/src/models/muse_glimmer/attention.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/attention.rs
@@ -290,6 +290,7 @@ impl MuseGlimmerAttention {
         paged_idx: u32,
         rows: &[(SeqId, u32)],
         window: PagedWindowSlot,
+        preserve_singleton_projection_graphs: bool,
     ) -> Result<MxArray> {
         let shape = x.shape()?;
         if rows.is_empty()
@@ -321,18 +322,28 @@ impl MuseGlimmerAttention {
             .collect::<Result<Vec<_>>>()?;
         let offsets = MxArray::from_int32(&offsets, &[batch])?;
         let seq_ids = rows.iter().map(|&(seq_id, _)| seq_id).collect::<Vec<_>>();
-        let q = self
-            .q_proj
-            .forward(x)?
-            .reshape(&[batch, 1, self.num_heads, self.head_dim])?;
-        let k = self
-            .k_proj
-            .forward(x)?
-            .reshape(&[batch, 1, self.num_kv_heads, self.head_dim])?;
-        let v = self
-            .v_proj
-            .forward(x)?
-            .reshape(&[batch, 1, self.num_kv_heads, self.head_dim])?;
+        // Keep packed affine/K-quant matmuls on their established singleton
+        // graph. Metal can choose a different reduction path for `B > 1`,
+        // changing greedy tokens near ties. K/V writes and attention below
+        // remain one genuine paged batch.
+        let (q, k, v, gate) = if preserve_singleton_projection_graphs {
+            (
+                super::row_exact::forward_rows_independently(x, |row| self.q_proj.forward(row))?,
+                super::row_exact::forward_rows_independently(x, |row| self.k_proj.forward(row))?,
+                super::row_exact::forward_rows_independently(x, |row| self.v_proj.forward(row))?,
+                super::row_exact::forward_rows_independently(x, |row| self.gate_proj.forward(row))?,
+            )
+        } else {
+            (
+                self.q_proj.forward(x)?,
+                self.k_proj.forward(x)?,
+                self.v_proj.forward(x)?,
+                self.gate_proj.forward(x)?,
+            )
+        };
+        let q = q.reshape(&[batch, 1, self.num_heads, self.head_dim])?;
+        let k = k.reshape(&[batch, 1, self.num_kv_heads, self.head_dim])?;
+        let v = v.reshape(&[batch, 1, self.num_kv_heads, self.head_dim])?;
         let q = self
             .scaleless_rms_norm(&q)?
             .mul_scalar(self.qk_scale_factor)?
@@ -360,7 +371,11 @@ impl MuseGlimmerAttention {
             .map_err(Error::from_reason)?
             .astype(x.dtype()?)?
             .reshape(&[batch, 1, self.num_heads * self.head_dim])?;
-        let gate = Activations::sigmoid(&self.gate_proj.forward(x)?)?;
-        self.o_proj.forward(&attended.mul(&gate)?)
+        let output = attended.mul(&Activations::sigmoid(&gate)?)?;
+        if preserve_singleton_projection_graphs {
+            super::row_exact::forward_rows_independently(&output, |row| self.o_proj.forward(row))
+        } else {
+            self.o_proj.forward(&output)
+        }
     }
 }

--- a/crates/mlx-core/src/models/muse_glimmer/attention.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/attention.rs
@@ -1,0 +1,366 @@
+use crate::array::MxArray;
+use crate::array::attention::{scaled_dot_product_attention, scaled_dot_product_attention_causal};
+use crate::array::mask::create_causal_mask;
+use crate::models::gemma4::layer_cache::Gemma4LayerCache;
+use crate::models::gemma4::quantized_linear::LinearProj;
+use crate::nn::{Activations, RoPE};
+use crate::transformer::paged_kv_cache_adapter::{PagedKVCacheAdapter, SeqId};
+use napi::bindgen_prelude::*;
+
+use super::config::{LayerKind, MuseGlimmerTextConfig};
+use super::kv_cache::{PagedWindowSlot, WindowCarrier};
+
+/// Muse-Glimmer's gated GQA attention. Q/K normalization is weightless in the
+/// HF model; the official GGUF synthesizes scale tensors, which the converter
+/// deliberately omits and represents through `qk_scale_factor` here.
+pub struct MuseGlimmerAttention {
+    q_proj: LinearProj,
+    k_proj: LinearProj,
+    v_proj: LinearProj,
+    o_proj: LinearProj,
+    gate_proj: LinearProj,
+    num_heads: i64,
+    num_kv_heads: i64,
+    head_dim: i64,
+    qk_scale_factor: f64,
+    qk_norm_eps: f32,
+    sliding_window: Option<i32>,
+    rope: Option<RoPE>,
+}
+
+impl MuseGlimmerAttention {
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_projections(
+        config: &MuseGlimmerTextConfig,
+        layer_index: usize,
+        rope_traditional: bool,
+        q_proj: LinearProj,
+        k_proj: LinearProj,
+        v_proj: LinearProj,
+        o_proj: LinearProj,
+        gate_proj: LinearProj,
+    ) -> Result<Self> {
+        let kind = config.layer_kinds[layer_index];
+        let rope = config.rope_theta_for(layer_index).map(|theta| {
+            RoPE::new(
+                config.head_dim as i32,
+                Some(rope_traditional),
+                Some(theta as f64),
+                None,
+            )
+        });
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            gate_proj,
+            num_heads: config.num_attention_heads as i64,
+            num_kv_heads: config.num_key_value_heads as i64,
+            head_dim: config.head_dim as i64,
+            qk_scale_factor: config.qk_scale_factor as f64,
+            qk_norm_eps: config.rms_norm_eps,
+            sliding_window: (kind == LayerKind::Sliding).then_some(
+                i32::try_from(config.sliding_window).map_err(|_| {
+                    Error::from_reason("Muse-Glimmer sliding window exceeds i32::MAX")
+                })?,
+            ),
+            rope,
+        })
+    }
+
+    fn scaleless_rms_norm(&self, x: &MxArray) -> Result<MxArray> {
+        let handle = unsafe {
+            mlx_sys::mlx_fast_rms_norm(x.as_raw_ptr(), std::ptr::null_mut(), self.qk_norm_eps)
+        };
+        MxArray::from_handle(handle, "muse_glimmer_qk_rms_norm")
+    }
+
+    pub fn forward(&self, x: &MxArray, cache: &mut Gemma4LayerCache) -> Result<MxArray> {
+        let shape = x.shape()?;
+        if shape.len() != 3 {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer attention expects [B,T,H], got {:?}",
+                shape.as_ref()
+            )));
+        }
+        let (batch, seq_len) = (shape[0], shape[1]);
+        let offset = cache.get_offset();
+
+        let q =
+            self.q_proj
+                .forward(x)?
+                .reshape(&[batch, seq_len, self.num_heads, self.head_dim])?;
+        let k =
+            self.k_proj
+                .forward(x)?
+                .reshape(&[batch, seq_len, self.num_kv_heads, self.head_dim])?;
+        let v =
+            self.v_proj
+                .forward(x)?
+                .reshape(&[batch, seq_len, self.num_kv_heads, self.head_dim])?;
+
+        let q = self
+            .scaleless_rms_norm(&q)?
+            .mul_scalar(self.qk_scale_factor)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let k = self
+            .scaleless_rms_norm(&k)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let v = v.transpose(Some(&[0, 2, 1, 3]))?;
+        let (q, k) = match self.rope.as_ref() {
+            Some(rope) => (
+                rope.forward(&q, Some(offset))?,
+                rope.forward(&k, Some(offset))?,
+            ),
+            None => (q, k),
+        };
+        let (k, v) = cache.update_and_fetch(&k, &v)?;
+
+        let mask = if seq_len > 1 {
+            let full = create_causal_mask(seq_len as i32, Some(offset), self.sliding_window)?;
+            let kv_len = k.shape_at(2)?;
+            let full_len = full.shape_at(1)?;
+            Some(if kv_len < full_len {
+                full.slice_axis(1, full_len - kv_len, full_len)?
+            } else {
+                full
+            })
+        } else {
+            None
+        };
+        let attended = scaled_dot_product_attention(
+            &q,
+            &k,
+            &v,
+            1.0 / (self.head_dim as f64).sqrt(),
+            mask.as_ref(),
+        )?
+        .transpose(Some(&[0, 2, 1, 3]))?
+        .reshape(&[batch, seq_len, self.num_heads * self.head_dim])?;
+
+        let gate = Activations::sigmoid(&self.gate_proj.forward(x)?)?;
+        self.o_proj.forward(&attended.mul(&gate)?)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn forward_paged(
+        &self,
+        x: &MxArray,
+        adapter: &mut PagedKVCacheAdapter,
+        paged_idx: u32,
+        first_logical_position: u32,
+        cached_prefix_len: u32,
+        is_prefill: bool,
+        window: PagedWindowSlot,
+    ) -> Result<MxArray> {
+        let shape = x.shape()?;
+        if shape.as_ref().len() != 3 || shape[0] != 1 {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer paged attention expects [1,T,H], got {:?}",
+                shape.as_ref()
+            )));
+        }
+        let seq_len = shape[1];
+        let q = self
+            .q_proj
+            .forward(x)?
+            .reshape(&[1, seq_len, self.num_heads, self.head_dim])?;
+        let k = self
+            .k_proj
+            .forward(x)?
+            .reshape(&[1, seq_len, self.num_kv_heads, self.head_dim])?;
+        let v = self
+            .v_proj
+            .forward(x)?
+            .reshape(&[1, seq_len, self.num_kv_heads, self.head_dim])?;
+        let q = self
+            .scaleless_rms_norm(&q)?
+            .mul_scalar(self.qk_scale_factor)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let k = self
+            .scaleless_rms_norm(&k)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let v = v.transpose(Some(&[0, 2, 1, 3]))?;
+        let (q, k) = match self.rope.as_ref() {
+            Some(rope) => (
+                rope.forward(&q, Some(first_logical_position as i32))?,
+                rope.forward(&k, Some(first_logical_position as i32))?,
+            ),
+            None => (q, k),
+        };
+        let k_paged = k.transpose(Some(&[0, 2, 1, 3]))?.reshape(&[
+            seq_len,
+            self.num_kv_heads,
+            self.head_dim,
+        ])?;
+        let v_paged = v.transpose(Some(&[0, 2, 1, 3]))?.reshape(&[
+            seq_len,
+            self.num_kv_heads,
+            self.head_dim,
+        ])?;
+        if let Err(error) =
+            adapter.update_keys_values_native(paged_idx, &k_paged, &v_paged, first_logical_position)
+        {
+            adapter
+                .update_keys_values(paged_idx, &k_paged, &v_paged, first_logical_position)
+                .map_err(|fallback| {
+                    Error::from_reason(format!(
+                        "Muse-Glimmer paged K/V write failed: {error}; fallback failed: {fallback}"
+                    ))
+                })?;
+        }
+
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+        let attended = if is_prefill {
+            if window.carrier() != WindowCarrier::ExplicitMask {
+                return Err(Error::from_reason(
+                    "Muse-Glimmer paged prefill requires an admitted explicit-mask window slot",
+                ));
+            }
+            let (keys, values) = if cached_prefix_len == 0 {
+                (k, v)
+            } else {
+                let total_context = cached_prefix_len.saturating_add(seq_len as u32);
+                let (keys, values, adapter_window) = adapter
+                    .gather_kv_for_dense_cache_hit_prefill(paged_idx, total_context)
+                    .map_err(Error::from_reason)?;
+                let expected = window.mask_window().unwrap_or(0) as u32;
+                if adapter_window.tokens() != expected {
+                    return Err(Error::from_reason(format!(
+                        "Muse-Glimmer paged prefill window mismatch: admitted {expected}, adapter {}",
+                        adapter_window.tokens()
+                    )));
+                }
+                (keys, values)
+            };
+            let mask = window
+                .mask_window()
+                .map(|width| {
+                    create_causal_mask(
+                        seq_len as i32,
+                        (first_logical_position != 0).then_some(first_logical_position as i32),
+                        Some(width),
+                    )
+                })
+                .transpose()?;
+            if mask.is_none() && cached_prefix_len == 0 {
+                scaled_dot_product_attention_causal(&q, &keys, &values, scale)?
+            } else {
+                let mask = match mask {
+                    Some(mask) => mask,
+                    None => create_causal_mask(
+                        seq_len as i32,
+                        Some(first_logical_position as i32),
+                        None,
+                    )?,
+                };
+                scaled_dot_product_attention(&q, &keys, &values, scale, Some(&mask))?
+            }
+        } else {
+            if window.carrier() != WindowCarrier::KernelArgument {
+                return Err(Error::from_reason(
+                    "Muse-Glimmer paged decode requires an admitted kernel-window slot",
+                ));
+            }
+            let query = q.squeeze(Some(&[2]))?;
+            adapter
+                .gather_kv_for_decode_graph(paged_idx, &query, scale as f32, 1.0)
+                .or_else(|_| {
+                    adapter
+                        .gather_kv_for_decode(paged_idx, &query, scale as f32, 1.0)
+                        .map_err(Error::from_reason)
+                })?
+                .astype(x.dtype()?)?
+                .reshape(&[1, self.num_heads, 1, self.head_dim])?
+        };
+        let attended = attended.transpose(Some(&[0, 2, 1, 3]))?.reshape(&[
+            1,
+            seq_len,
+            self.num_heads * self.head_dim,
+        ])?;
+        let gate = Activations::sigmoid(&self.gate_proj.forward(x)?)?;
+        self.o_proj.forward(&attended.mul(&gate)?)
+    }
+
+    pub(crate) fn forward_paged_batched(
+        &self,
+        x: &MxArray,
+        adapter: &mut PagedKVCacheAdapter,
+        paged_idx: u32,
+        rows: &[(SeqId, u32)],
+        window: PagedWindowSlot,
+    ) -> Result<MxArray> {
+        let shape = x.shape()?;
+        if rows.is_empty()
+            || shape.as_ref().len() != 3
+            || shape[0] != rows.len() as i64
+            || shape[1] != 1
+        {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer batched paged attention expects [N,1,H] for {} rows, got {:?}",
+                rows.len(),
+                shape.as_ref()
+            )));
+        }
+        if window.carrier() != WindowCarrier::KernelArgument {
+            return Err(Error::from_reason(
+                "Muse-Glimmer batched decode requires an admitted kernel-window slot",
+            ));
+        }
+        let batch = rows.len() as i64;
+        let offsets = rows
+            .iter()
+            .map(|&(seq_id, position)| {
+                i32::try_from(position).map_err(|_| {
+                    Error::from_reason(format!(
+                        "Muse-Glimmer sequence {seq_id} position {position} exceeds i32::MAX"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let offsets = MxArray::from_int32(&offsets, &[batch])?;
+        let seq_ids = rows.iter().map(|&(seq_id, _)| seq_id).collect::<Vec<_>>();
+        let q = self
+            .q_proj
+            .forward(x)?
+            .reshape(&[batch, 1, self.num_heads, self.head_dim])?;
+        let k = self
+            .k_proj
+            .forward(x)?
+            .reshape(&[batch, 1, self.num_kv_heads, self.head_dim])?;
+        let v = self
+            .v_proj
+            .forward(x)?
+            .reshape(&[batch, 1, self.num_kv_heads, self.head_dim])?;
+        let q = self
+            .scaleless_rms_norm(&q)?
+            .mul_scalar(self.qk_scale_factor)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let k = self
+            .scaleless_rms_norm(&k)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let v = v.transpose(Some(&[0, 2, 1, 3]))?;
+        let (q, k) = match self.rope.as_ref() {
+            Some(rope) => (
+                rope.forward_with_offsets(&q, &offsets)?,
+                rope.forward_with_offsets(&k, &offsets)?,
+            ),
+            None => (q, k),
+        };
+        let q = q.squeeze(Some(&[2]))?;
+        let k = k.squeeze(Some(&[2]))?;
+        let v = v.squeeze(Some(&[2]))?;
+        adapter
+            .update_keys_values_native_batched(paged_idx, &k, &v, rows)
+            .map_err(Error::from_reason)?;
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+        let attended = adapter
+            .gather_kv_for_decode_graph_batched(paged_idx, &q, &seq_ids, scale as f32, 1.0)
+            .map_err(Error::from_reason)?
+            .astype(x.dtype()?)?
+            .reshape(&[batch, 1, self.num_heads * self.head_dim])?;
+        let gate = Activations::sigmoid(&self.gate_proj.forward(x)?)?;
+        self.o_proj.forward(&attended.mul(&gate)?)
+    }
+}

--- a/crates/mlx-core/src/models/muse_glimmer/cold_sidecar.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/cold_sidecar.rs
@@ -1,0 +1,121 @@
+//! SSD sidecar identity for Muse-Glimmer's paged sliding-attention group.
+//!
+//! The full-attention group owns the content-addressed K/V chain. A restore is
+//! usable only when the sliding group has state at the same boundary, so its
+//! live window is persisted as a co-keyed `SlidingWindow` sidecar.
+
+use mlx_paged_attn::{ColdCacheFingerprint, ColdCacheKey, ColdGroup, ColdSidecarPolicy};
+
+use crate::models::gemma4::sliding_sidecar::{SlidingSidecarGeometry, policy_for_geometry};
+
+use super::config::{LayerKind, MuseGlimmerConfig};
+
+const ANCHOR_RATIO: u32 = 4;
+const MAX_ANCHORS: usize = 5;
+
+pub(crate) fn geometry(config: &MuseGlimmerConfig) -> Option<SlidingSidecarGeometry> {
+    let physical_layers = u32::try_from(
+        config
+            .text_config
+            .layer_kinds
+            .iter()
+            .filter(|kind| **kind == LayerKind::Sliding)
+            .count(),
+    )
+    .ok()?;
+    let window = u32::try_from(config.text_config.sliding_window).ok()?;
+    let kv_heads = u32::try_from(config.text_config.num_key_value_heads).ok()?;
+    let head_dim = u32::try_from(config.text_config.head_dim).ok()?;
+    if physical_layers == 0 || window == 0 || kv_heads == 0 || head_dim == 0 {
+        return None;
+    }
+    Some(SlidingSidecarGeometry {
+        window,
+        physical_layers,
+        kv_heads,
+        head_dim,
+    })
+}
+
+pub(crate) fn policy(config: &MuseGlimmerConfig) -> Option<ColdSidecarPolicy> {
+    policy_for_geometry(&geometry(config)?)
+}
+
+/// Stable block-aligned checkpoints retained while a turn is live.
+///
+/// Anchoring the ladder at zero makes the same sidecar reusable by later
+/// prompts that share the prefix. Including the first block lets short chat
+/// prompts benefit; deeper rungs cover the 128-block default SSD capture walk.
+pub(crate) fn anchor_rungs(block_size: u32) -> Vec<u32> {
+    if block_size == 0 {
+        return Vec::new();
+    }
+    let mut rungs = Vec::with_capacity(MAX_ANCHORS);
+    let mut rung = block_size;
+    for _ in 0..MAX_ANCHORS {
+        rungs.push(rung);
+        let Some(next) = rung.checked_mul(ANCHOR_RATIO) else {
+            break;
+        };
+        rung = next;
+    }
+    rungs
+}
+
+/// Derive the sidecar key using the same parent-linked block chain as the K/V
+/// restore walk, but under the `SlidingWindow` domain tag.
+pub(crate) fn chain_key(
+    fingerprint: ColdCacheFingerprint,
+    request_tokens: &[u32],
+    extra_keys_per_block: &[Vec<u64>],
+    block_size: u32,
+    boundary: u32,
+    cache_salt: u64,
+) -> Option<ColdCacheKey> {
+    if block_size == 0 || boundary == 0 || !boundary.is_multiple_of(block_size) {
+        return None;
+    }
+    let blocks = boundary as usize / block_size as usize;
+    let mut parent = None;
+    for index in 0..blocks {
+        let extra_keys = extra_keys_per_block.get(index)?;
+        let start = index.checked_mul(block_size as usize)?;
+        let end = start.checked_add(block_size as usize)?;
+        let tokens = request_tokens.get(start..end)?;
+        parent = Some(ColdCacheKey::chain(
+            ColdGroup::SlidingWindow,
+            fingerprint,
+            parent,
+            tokens,
+            extra_keys,
+            cache_salt,
+            index,
+        ));
+    }
+    parent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::muse_glimmer::config::MuseGlimmerConfig;
+    use crate::models::muse_glimmer::config::fixtures::{config_json, text_config_json};
+
+    #[test]
+    fn checkpoint_geometry_covers_every_sliding_layer() {
+        let config = MuseGlimmerConfig::from_json_str(&config_json(&text_config_json(52)))
+            .expect("checkpoint config");
+        let geometry = geometry(&config).expect("hybrid sidecar geometry");
+        assert_eq!(geometry.window, 2048);
+        assert_eq!(geometry.physical_layers, 39);
+        assert_eq!(geometry.kv_heads, 2);
+        assert_eq!(geometry.head_dim, 128);
+        assert!(policy(&config).is_some());
+    }
+
+    #[test]
+    fn anchor_ladder_is_stable_and_block_aligned() {
+        assert_eq!(anchor_rungs(16), vec![16, 64, 256, 1024, 4096]);
+        assert!(anchor_rungs(0).is_empty());
+    }
+}

--- a/crates/mlx-core/src/models/muse_glimmer/config.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/config.rs
@@ -90,6 +90,41 @@ struct RawConfig {
     projector_hidden_act: String,
     text_config: RawTextConfig,
     vision_config: MuseGlimmerVisionConfig,
+    #[serde(default)]
+    muse_glimmer_gguf_rope_layout: Option<String>,
+    #[serde(default)]
+    dflash_config: Option<MuseGlimmerDFlashConfig>,
+    #[serde(default)]
+    use_block_paged_cache: Option<bool>,
+    #[serde(default)]
+    paged_block_size: Option<u32>,
+    #[serde(default)]
+    paged_cache_memory_mb: Option<u32>,
+    #[serde(default)]
+    persist_paged_cache: Option<bool>,
+}
+
+/// Configuration written from Meta's companion DFlash GGUF header.
+///
+/// The draft intentionally shares the target embedding and LM head, so these
+/// are the complete independent geometry and protocol fields needed to build
+/// it from `draft.safetensors`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MuseGlimmerDFlashConfig {
+    pub num_hidden_layers: usize,
+    pub block_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub sliding_window: usize,
+    pub max_position_embeddings: usize,
+    pub rms_norm_eps: f32,
+    pub rope_theta: f32,
+    pub target_layers: Vec<usize>,
+    pub mask_token_id: usize,
+    pub causal: bool,
 }
 
 /// Vision tower geometry.
@@ -182,6 +217,96 @@ pub struct MuseGlimmerConfig {
     pub projector_hidden_act: String,
     pub text_config: MuseGlimmerTextConfig,
     pub vision_config: MuseGlimmerVisionConfig,
+    /// Official llama.cpp GGUFs store decoder and vision Q/K rows in
+    /// interleaved RoPE layout. Base SafeTensors keep HF's half-split layout.
+    pub rope_traditional: bool,
+    pub dflash_config: Option<MuseGlimmerDFlashConfig>,
+    /// Block-paged KV is enabled by default on Metal. `false` is an explicit
+    /// flat-cache opt-out for diagnostics and parity checks.
+    pub use_block_paged_cache: Option<bool>,
+    pub paged_block_size: Option<u32>,
+    pub paged_cache_memory_mb: Option<u32>,
+    /// Persist full-attention blocks plus the exact-boundary sliding sidecar
+    /// to the process-global SSD cold tier.
+    pub persist_paged_cache: Option<bool>,
+}
+
+impl MuseGlimmerDFlashConfig {
+    fn validate(&self, target: &RawTextConfig) -> Result<()> {
+        for (name, value) in [
+            ("num_hidden_layers", self.num_hidden_layers),
+            ("block_size", self.block_size),
+            ("hidden_size", self.hidden_size),
+            ("intermediate_size", self.intermediate_size),
+            ("num_attention_heads", self.num_attention_heads),
+            ("num_key_value_heads", self.num_key_value_heads),
+            ("head_dim", self.head_dim),
+            ("sliding_window", self.sliding_window),
+            ("max_position_embeddings", self.max_position_embeddings),
+        ] {
+            if value == 0 {
+                return Err(Error::from_reason(format!(
+                    "muse_glimmer: dflash_config.{name} must be non-zero"
+                )));
+            }
+        }
+        if self.hidden_size != target.hidden_size {
+            return Err(Error::from_reason(format!(
+                "muse_glimmer: DFlash hidden_size {} does not match target hidden_size {}",
+                self.hidden_size, target.hidden_size
+            )));
+        }
+        if !self
+            .num_attention_heads
+            .is_multiple_of(self.num_key_value_heads)
+        {
+            return Err(Error::from_reason(format!(
+                "muse_glimmer: DFlash num_key_value_heads {} must divide num_attention_heads {}",
+                self.num_key_value_heads, self.num_attention_heads
+            )));
+        }
+        if self.target_layers.is_empty() {
+            return Err(Error::from_reason(
+                "muse_glimmer: DFlash target_layers must not be empty",
+            ));
+        }
+        let mut previous = None;
+        for &layer in &self.target_layers {
+            if layer >= target.num_hidden_layers.saturating_sub(1) {
+                return Err(Error::from_reason(format!(
+                    "muse_glimmer: DFlash target layer {layer} is not a non-final target layer"
+                )));
+            }
+            if previous.is_some_and(|prior| layer <= prior) {
+                return Err(Error::from_reason(
+                    "muse_glimmer: DFlash target_layers must be strictly ascending",
+                ));
+            }
+            previous = Some(layer);
+        }
+        if self.mask_token_id >= target.vocab_size {
+            return Err(Error::from_reason(format!(
+                "muse_glimmer: DFlash mask_token_id {} is outside target vocab_size {}",
+                self.mask_token_id, target.vocab_size
+            )));
+        }
+        if !self.rms_norm_eps.is_finite() || self.rms_norm_eps <= 0.0 {
+            return Err(Error::from_reason(
+                "muse_glimmer: DFlash rms_norm_eps must be finite and positive",
+            ));
+        }
+        if !self.rope_theta.is_finite() || self.rope_theta <= 0.0 {
+            return Err(Error::from_reason(
+                "muse_glimmer: DFlash rope_theta must be finite and positive",
+            ));
+        }
+        if self.causal {
+            return Err(Error::from_reason(
+                "muse_glimmer: Meta's DFlash companion must use non-causal query attention",
+            ));
+        }
+        Ok(())
+    }
 }
 
 impl MuseGlimmerVisionConfig {
@@ -304,6 +429,9 @@ impl MuseGlimmerConfig {
         let raw: RawConfig = serde_json::from_str(json)
             .map_err(|e| Error::from_reason(format!("muse_glimmer: invalid config.json: {e}")))?;
         let text = raw.text_config;
+        if let Some(dflash) = raw.dflash_config.as_ref() {
+            dflash.validate(&text)?;
+        }
         let layers = text.num_hidden_layers;
 
         // Resolve the layer kinds first so an unrecognized span names itself.
@@ -709,6 +837,16 @@ impl MuseGlimmerConfig {
             }
         }
 
+        let rope_traditional = match raw.muse_glimmer_gguf_rope_layout.as_deref() {
+            None | Some("half_split") => false,
+            Some("interleaved") => true,
+            Some(layout) => {
+                return Err(Error::from_reason(format!(
+                    "muse_glimmer: unsupported muse_glimmer_gguf_rope_layout '{layout}'"
+                )));
+            }
+        };
+
         Ok(Self {
             image_token_id: raw.image_token_id,
             video_token_id: raw.video_token_id,
@@ -735,6 +873,12 @@ impl MuseGlimmerConfig {
                 layer_rope_theta: text.layer_rope_theta,
             },
             vision_config: raw.vision_config,
+            rope_traditional,
+            dflash_config: raw.dflash_config,
+            use_block_paged_cache: raw.use_block_paged_cache,
+            paged_block_size: raw.paged_block_size,
+            paged_cache_memory_mb: raw.paged_cache_memory_mb,
+            persist_paged_cache: raw.persist_paged_cache,
         })
     }
 }

--- a/crates/mlx-core/src/models/muse_glimmer/decoder_layer.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/decoder_layer.rs
@@ -82,6 +82,7 @@ impl MuseGlimmerDecoderLayer {
         paged_idx: u32,
         rows: &[(SeqId, u32)],
         window: PagedWindowSlot,
+        preserve_singleton_projection_graphs: bool,
     ) -> Result<MxArray> {
         let attn = self.attention.forward_paged_batched(
             &self.input_layernorm.forward(x)?,
@@ -89,11 +90,15 @@ impl MuseGlimmerDecoderLayer {
             paged_idx,
             rows,
             window,
+            preserve_singleton_projection_graphs,
         )?;
         let h = x.add(&self.post_attention_layernorm.forward(&attn)?)?;
-        let ffn = self
-            .mlp
-            .forward(&self.pre_feedforward_layernorm.forward(&h)?)?;
+        let normed = self.pre_feedforward_layernorm.forward(&h)?;
+        let ffn = if preserve_singleton_projection_graphs {
+            super::row_exact::forward_rows_independently(&normed, |row| self.mlp.forward(row))?
+        } else {
+            self.mlp.forward(&normed)?
+        };
         h.add(&self.post_feedforward_layernorm.forward(&ffn)?)
     }
 }

--- a/crates/mlx-core/src/models/muse_glimmer/decoder_layer.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/decoder_layer.rs
@@ -1,0 +1,99 @@
+use crate::array::MxArray;
+use crate::models::gemma4::layer_cache::Gemma4LayerCache;
+use crate::nn::RMSNorm;
+use crate::transformer::paged_kv_cache_adapter::{PagedKVCacheAdapter, SeqId};
+use napi::bindgen_prelude::*;
+
+use super::attention::MuseGlimmerAttention;
+use super::kv_cache::PagedWindowSlot;
+use super::mlp::MuseGlimmerMlp;
+
+pub struct MuseGlimmerDecoderLayer {
+    pub attention: MuseGlimmerAttention,
+    pub mlp: MuseGlimmerMlp,
+    input_layernorm: RMSNorm,
+    post_attention_layernorm: RMSNorm,
+    pre_feedforward_layernorm: RMSNorm,
+    post_feedforward_layernorm: RMSNorm,
+}
+
+impl MuseGlimmerDecoderLayer {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        attention: MuseGlimmerAttention,
+        mlp: MuseGlimmerMlp,
+        input_layernorm: RMSNorm,
+        post_attention_layernorm: RMSNorm,
+        pre_feedforward_layernorm: RMSNorm,
+        post_feedforward_layernorm: RMSNorm,
+    ) -> Self {
+        Self {
+            attention,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+            pre_feedforward_layernorm,
+            post_feedforward_layernorm,
+        }
+    }
+
+    pub fn forward(&self, x: &MxArray, cache: &mut Gemma4LayerCache) -> Result<MxArray> {
+        let attn = self
+            .attention
+            .forward(&self.input_layernorm.forward(x)?, cache)?;
+        let h = x.add(&self.post_attention_layernorm.forward(&attn)?)?;
+        let ffn = self
+            .mlp
+            .forward(&self.pre_feedforward_layernorm.forward(&h)?)?;
+        h.add(&self.post_feedforward_layernorm.forward(&ffn)?)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn forward_paged(
+        &self,
+        x: &MxArray,
+        adapter: &mut PagedKVCacheAdapter,
+        paged_idx: u32,
+        first_logical_position: u32,
+        cached_prefix_len: u32,
+        is_prefill: bool,
+        window: PagedWindowSlot,
+    ) -> Result<MxArray> {
+        let attn = self.attention.forward_paged(
+            &self.input_layernorm.forward(x)?,
+            adapter,
+            paged_idx,
+            first_logical_position,
+            cached_prefix_len,
+            is_prefill,
+            window,
+        )?;
+        let h = x.add(&self.post_attention_layernorm.forward(&attn)?)?;
+        let ffn = self
+            .mlp
+            .forward(&self.pre_feedforward_layernorm.forward(&h)?)?;
+        h.add(&self.post_feedforward_layernorm.forward(&ffn)?)
+    }
+
+    pub(crate) fn forward_paged_batched(
+        &self,
+        x: &MxArray,
+        adapter: &mut PagedKVCacheAdapter,
+        paged_idx: u32,
+        rows: &[(SeqId, u32)],
+        window: PagedWindowSlot,
+    ) -> Result<MxArray> {
+        let attn = self.attention.forward_paged_batched(
+            &self.input_layernorm.forward(x)?,
+            adapter,
+            paged_idx,
+            rows,
+            window,
+        )?;
+        let h = x.add(&self.post_attention_layernorm.forward(&attn)?)?;
+        let ffn = self
+            .mlp
+            .forward(&self.pre_feedforward_layernorm.forward(&h)?)?;
+        h.add(&self.post_feedforward_layernorm.forward(&ffn)?)
+    }
+}

--- a/crates/mlx-core/src/models/muse_glimmer/dflash.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/dflash.rs
@@ -1,0 +1,417 @@
+//! Meta DFlash companion for Muse-Glimmer.
+//!
+//! The drafter consumes five post-layer target residuals, projects them into a
+//! context stream, and predicts a 16-token block in one non-causal forward.
+//! It shares the target token embedding and LM head.
+
+use napi::bindgen_prelude::*;
+use rand::{Rng, RngExt};
+
+use crate::array::attention::scaled_dot_product_attention;
+use crate::array::{DType, MxArray};
+use crate::models::gemma4::layer_cache::Gemma4LayerCache;
+use crate::models::gemma4::quantized_linear::LinearProj;
+use crate::nn::{Embedding, RMSNorm, RoPE};
+use crate::sampling::{SamplingConfig, is_greedy_temperature, sampling_distribution};
+
+use super::config::{MuseGlimmerDFlashConfig, MuseGlimmerTextConfig};
+use super::mlp::MuseGlimmerMlp;
+
+fn sample_index<R: Rng + ?Sized>(probs: &[f32], rng: &mut R) -> Result<i32> {
+    let total: f64 = probs
+        .iter()
+        .filter(|prob| prob.is_finite() && **prob > 0.0)
+        .map(|&prob| f64::from(prob))
+        .sum();
+    if !total.is_finite() || total <= 0.0 {
+        return Err(Error::from_reason(
+            "Muse-Glimmer DFlash distribution has no positive probability mass",
+        ));
+    }
+    let draw = rng.random::<f64>() * total;
+    let mut cumulative = 0.0;
+    let mut last = None;
+    for (index, &prob) in probs.iter().enumerate() {
+        if !prob.is_finite() || prob <= 0.0 {
+            continue;
+        }
+        cumulative += f64::from(prob);
+        last = Some(index);
+        if draw < cumulative {
+            return Ok(index as i32);
+        }
+    }
+    last.map(|index| index as i32).ok_or_else(|| {
+        Error::from_reason("Muse-Glimmer DFlash distribution has no sampleable token")
+    })
+}
+
+fn parallel_query_ids(anchor: u32, mask: usize, draft_len: usize) -> Vec<i32> {
+    let mut ids = Vec::with_capacity(draft_len.saturating_add(1));
+    ids.push(anchor as i32);
+    ids.resize(draft_len.saturating_add(1), mask as i32);
+    ids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parallel_query_ids;
+
+    #[test]
+    fn block_sixteen_has_one_anchor_and_sixteen_sampled_mask_rows() {
+        let ids = parallel_query_ids(7, 201_818, 16);
+        assert_eq!(ids.len(), 17);
+        assert_eq!(ids[0], 7);
+        assert!(ids[1..].iter().all(|&id| id == 201_818));
+    }
+}
+
+fn non_causal_sliding_mask(
+    query_base: i32,
+    query_len: i64,
+    key_base: i32,
+    key_len: i64,
+    window: i64,
+) -> Result<Option<MxArray>> {
+    if key_len <= window {
+        return Ok(None);
+    }
+    let queries = MxArray::arange(
+        f64::from(query_base),
+        f64::from(query_base) + query_len as f64,
+        None,
+        None,
+    )?
+    .reshape(&[query_len, 1])?;
+    let keys = MxArray::arange(
+        f64::from(key_base),
+        f64::from(key_base) + key_len as f64,
+        None,
+        None,
+    )?
+    .reshape(&[1, key_len])?;
+    let distance = queries.sub(&keys)?;
+    let window = MxArray::scalar_int(window as i32)?;
+    Ok(Some(
+        distance
+            .less(&window)?
+            .reshape(&[1, 1, query_len, key_len])?,
+    ))
+}
+
+pub(crate) struct DFlashAttention {
+    q_proj: LinearProj,
+    k_proj: LinearProj,
+    v_proj: LinearProj,
+    o_proj: LinearProj,
+    q_norm: RMSNorm,
+    k_norm: RMSNorm,
+    rope: RoPE,
+    num_heads: i64,
+    num_kv_heads: i64,
+    head_dim: i64,
+    sliding_window: i64,
+}
+
+impl DFlashAttention {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        config: &MuseGlimmerDFlashConfig,
+        q_proj: LinearProj,
+        k_proj: LinearProj,
+        v_proj: LinearProj,
+        o_proj: LinearProj,
+        q_norm: RMSNorm,
+        k_norm: RMSNorm,
+    ) -> Self {
+        Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            // The official DFlash GGUF intentionally keeps HF's half-split
+            // Q/K rows; unlike the target GGUF it is not unpermuted.
+            rope: RoPE::new(
+                config.head_dim as i32,
+                Some(false),
+                Some(config.rope_theta as f64),
+                None,
+            ),
+            num_heads: config.num_attention_heads as i64,
+            num_kv_heads: config.num_key_value_heads as i64,
+            head_dim: config.head_dim as i64,
+            sliding_window: config.sliding_window as i64,
+        }
+    }
+
+    fn project_context(&self, x: &MxArray, base: i32) -> Result<(MxArray, MxArray)> {
+        let batch = x.shape_at(0)?;
+        let seq = x.shape_at(1)?;
+        let keys =
+            self.k_proj
+                .forward(x)?
+                .reshape(&[batch, seq, self.num_kv_heads, self.head_dim])?;
+        let keys = self.k_norm.forward(&keys)?.transpose(Some(&[0, 2, 1, 3]))?;
+        let keys = self.rope.forward(&keys, Some(base))?;
+        let values = self
+            .v_proj
+            .forward(x)?
+            .reshape(&[batch, seq, self.num_kv_heads, self.head_dim])?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        Ok((keys, values))
+    }
+
+    fn forward(
+        &self,
+        x: &MxArray,
+        context: Option<&(MxArray, MxArray)>,
+        context_base: i32,
+        query_base: i32,
+    ) -> Result<MxArray> {
+        let batch = x.shape_at(0)?;
+        let seq = x.shape_at(1)?;
+        let queries =
+            self.q_proj
+                .forward(x)?
+                .reshape(&[batch, seq, self.num_heads, self.head_dim])?;
+        let queries = self
+            .q_norm
+            .forward(&queries)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let queries = self.rope.forward(&queries, Some(query_base))?;
+        let (block_keys, block_values) = self.project_context(x, query_base)?;
+        let (keys, values, key_base) = match context {
+            Some((context_keys, context_values)) => (
+                MxArray::concatenate(context_keys, &block_keys, 2)?,
+                MxArray::concatenate(context_values, &block_values, 2)?,
+                context_base,
+            ),
+            None => (block_keys, block_values, query_base),
+        };
+        let key_len = keys.shape_at(2)?;
+        let mask =
+            non_causal_sliding_mask(query_base, seq, key_base, key_len, self.sliding_window)?;
+        let attended = scaled_dot_product_attention(
+            &queries,
+            &keys,
+            &values,
+            1.0 / (self.head_dim as f64).sqrt(),
+            mask.as_ref(),
+        )?
+        .transpose(Some(&[0, 2, 1, 3]))?
+        .reshape(&[batch, seq, self.num_heads * self.head_dim])?;
+        self.o_proj.forward(&attended)
+    }
+}
+
+pub(crate) struct DFlashLayer {
+    attention: DFlashAttention,
+    mlp: MuseGlimmerMlp,
+    input_norm: RMSNorm,
+    post_attention_norm: RMSNorm,
+}
+
+impl DFlashLayer {
+    pub(crate) fn new(
+        attention: DFlashAttention,
+        mlp: MuseGlimmerMlp,
+        input_norm: RMSNorm,
+        post_attention_norm: RMSNorm,
+    ) -> Self {
+        Self {
+            attention,
+            mlp,
+            input_norm,
+            post_attention_norm,
+        }
+    }
+
+    fn forward(
+        &self,
+        x: &MxArray,
+        context: Option<&(MxArray, MxArray)>,
+        context_base: i32,
+        query_base: i32,
+    ) -> Result<MxArray> {
+        let attention = self.attention.forward(
+            &self.input_norm.forward(x)?,
+            context,
+            context_base,
+            query_base,
+        )?;
+        let hidden = x.add(&attention)?;
+        let mlp = self
+            .mlp
+            .forward(&self.post_attention_norm.forward(&hidden)?)?;
+        hidden.add(&mlp)
+    }
+}
+
+pub(crate) struct DFlashContextCache {
+    layers: Vec<Gemma4LayerCache>,
+    logical_len: i32,
+}
+
+impl DFlashContextCache {
+    pub(crate) fn new_at(config: &MuseGlimmerDFlashConfig, logical_len: i32) -> Self {
+        Self {
+            layers: (0..config.num_hidden_layers)
+                .map(|_| Gemma4LayerCache::new_sliding(config.sliding_window as i32))
+                .collect(),
+            logical_len,
+        }
+    }
+
+    pub(crate) fn append(
+        &mut self,
+        model: &DFlashModel,
+        fused_context: &MxArray,
+        base: i32,
+    ) -> Result<()> {
+        if base != self.logical_len {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer DFlash context append starts at {base}, expected {}",
+                self.logical_len
+            )));
+        }
+        let rows = fused_context.shape_at(1)? as i32;
+        for (layer, cache) in model.layers.iter().zip(self.layers.iter_mut()) {
+            let (keys, values) = layer.attention.project_context(fused_context, base)?;
+            let _ = cache.update_and_fetch(&keys, &values)?;
+        }
+        self.logical_len = self.logical_len.saturating_add(rows);
+        Ok(())
+    }
+
+    pub(crate) fn eval(&self) -> Result<()> {
+        let mut arrays = Vec::new();
+        for cache in &self.layers {
+            cache.collect_cache_arrays(&mut arrays);
+        }
+        if arrays.is_empty() {
+            Ok(())
+        } else {
+            MxArray::eval_arrays(&arrays)
+        }
+    }
+}
+
+pub(crate) struct DFlashModel {
+    pub(crate) config: MuseGlimmerDFlashConfig,
+    fc: LinearProj,
+    hidden_norm: RMSNorm,
+    layers: Vec<DFlashLayer>,
+    norm: RMSNorm,
+}
+
+impl DFlashModel {
+    pub(crate) fn from_loaded(
+        config: MuseGlimmerDFlashConfig,
+        fc: LinearProj,
+        hidden_norm: RMSNorm,
+        layers: Vec<DFlashLayer>,
+        norm: RMSNorm,
+    ) -> Self {
+        Self {
+            config,
+            fc,
+            hidden_norm,
+            layers,
+            norm,
+        }
+    }
+
+    pub(crate) fn fuse_context(&self, taps: &[MxArray]) -> Result<MxArray> {
+        if taps.len() != self.config.target_layers.len() || taps.is_empty() {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer DFlash expects {} target taps, got {}",
+                self.config.target_layers.len(),
+                taps.len()
+            )));
+        }
+        let refs = taps.iter().collect::<Vec<_>>();
+        let concatenated = MxArray::concatenate_many(refs, Some(2))?;
+        self.hidden_norm.forward(&self.fc.forward(&concatenated)?)
+    }
+
+    pub(crate) fn forward_block(
+        &self,
+        target_embedding: &Embedding,
+        target_lm_head: &LinearProj,
+        target_config: &MuseGlimmerTextConfig,
+        block_ids: &MxArray,
+        query_base: i32,
+        context: &DFlashContextCache,
+    ) -> Result<MxArray> {
+        let mut hidden = target_embedding.forward(block_ids)?;
+        let context_len = context.logical_len;
+        for (index, layer) in self.layers.iter().enumerate() {
+            let cached = context.layers[index].get_cached_kv();
+            let live_len = cached
+                .as_ref()
+                .map(|(keys, _)| keys.shape_at(2))
+                .transpose()?
+                .unwrap_or(0) as i32;
+            let context_base = context_len.saturating_sub(live_len);
+            hidden = layer.forward(&hidden, cached.as_ref(), context_base, query_base)?;
+        }
+        let hidden = self.norm.forward(&hidden)?;
+        let logits = target_lm_head
+            .forward(&hidden)?
+            .mul_scalar(target_config.output_multiplier as f64)?;
+        let cap = target_config.final_logit_softcapping as f64;
+        logits.div_scalar(cap)?.tanh()?.mul_scalar(cap)
+    }
+
+    pub(crate) fn propose<R: Rng + ?Sized>(
+        &self,
+        target_embedding: &Embedding,
+        target_lm_head: &LinearProj,
+        target_config: &MuseGlimmerTextConfig,
+        context: &DFlashContextCache,
+        anchor: u32,
+        max_len: usize,
+        sampling: &SamplingConfig,
+        rng: &mut R,
+    ) -> Result<(Vec<i32>, Vec<MxArray>)> {
+        // DFlash is parallel infill, not an autoregressive draft. The query
+        // contains one bonus/anchor token followed by K mask tokens, and only
+        // the K mask rows are projected to draft distributions. Sampling the
+        // anchor row shifts every proposal by one: position zero can still
+        // look plausible, but every later acceptance collapses to zero.
+        let ids = parallel_query_ids(anchor, self.config.mask_token_id, max_len);
+        let block = MxArray::from_int32(&ids, &[1, ids.len() as i64])?;
+        let logits = self.forward_block(
+            target_embedding,
+            target_lm_head,
+            target_config,
+            &block,
+            context.logical_len,
+            context,
+        )?;
+        let greedy = is_greedy_temperature(sampling.temperature.unwrap_or(1.0));
+        let vocab = target_config.vocab_size as i64;
+        let mut draft_ids = Vec::with_capacity(max_len);
+        let mut distributions = Vec::with_capacity(if greedy { 0 } else { max_len });
+        for position in 0..max_len {
+            let query_row = position as i64 + 1;
+            let row = logits
+                .slice_axis(1, query_row, query_row + 1)?
+                .reshape(&[vocab])?;
+            if greedy {
+                let token = row.argmax(0, Some(false))?.astype(DType::Int32)?;
+                token.eval();
+                draft_ids.push(token.item_at_int32(0)?);
+            } else {
+                let distribution =
+                    sampling_distribution(&row, Some(*sampling))?.astype(DType::Float32)?;
+                distribution.eval();
+                draft_ids.push(sample_index(&distribution.to_float32()?, rng)?);
+                distributions.push(distribution);
+            }
+        }
+        Ok((draft_ids, distributions))
+    }
+}

--- a/crates/mlx-core/src/models/muse_glimmer/dflash.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/dflash.rs
@@ -53,19 +53,6 @@ fn parallel_query_ids(anchor: u32, mask: usize, draft_len: usize) -> Vec<i32> {
     ids
 }
 
-#[cfg(test)]
-mod tests {
-    use super::parallel_query_ids;
-
-    #[test]
-    fn block_sixteen_has_one_anchor_and_sixteen_sampled_mask_rows() {
-        let ids = parallel_query_ids(7, 201_818, 16);
-        assert_eq!(ids.len(), 17);
-        assert_eq!(ids[0], 7);
-        assert!(ids[1..].iter().all(|&id| id == 201_818));
-    }
-}
-
 fn non_causal_sliding_mask(
     query_base: i32,
     query_len: i64,
@@ -339,7 +326,7 @@ impl DFlashModel {
     pub(crate) fn forward_block(
         &self,
         target_embedding: &Embedding,
-        target_lm_head: &LinearProj,
+        target_lm_head: Option<&LinearProj>,
         target_config: &MuseGlimmerTextConfig,
         block_ids: &MxArray,
         query_base: i32,
@@ -358,9 +345,11 @@ impl DFlashModel {
             hidden = layer.forward(&hidden, cached.as_ref(), context_base, query_base)?;
         }
         let hidden = self.norm.forward(&hidden)?;
-        let logits = target_lm_head
-            .forward(&hidden)?
-            .mul_scalar(target_config.output_multiplier as f64)?;
+        let logits = match target_lm_head {
+            Some(lm_head) => lm_head.forward(&hidden)?,
+            None => target_embedding.as_linear(&hidden)?,
+        }
+        .mul_scalar(target_config.output_multiplier as f64)?;
         let cap = target_config.final_logit_softcapping as f64;
         logits.div_scalar(cap)?.tanh()?.mul_scalar(cap)
     }
@@ -368,7 +357,7 @@ impl DFlashModel {
     pub(crate) fn propose<R: Rng + ?Sized>(
         &self,
         target_embedding: &Embedding,
-        target_lm_head: &LinearProj,
+        target_lm_head: Option<&LinearProj>,
         target_config: &MuseGlimmerTextConfig,
         context: &DFlashContextCache,
         anchor: u32,
@@ -413,5 +402,18 @@ impl DFlashModel {
             }
         }
         Ok((draft_ids, distributions))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parallel_query_ids;
+
+    #[test]
+    fn block_sixteen_has_one_anchor_and_sixteen_sampled_mask_rows() {
+        let ids = parallel_query_ids(7, 201_818, 16);
+        assert_eq!(ids.len(), 17);
+        assert_eq!(ids[0], 7);
+        assert!(ids[1..].iter().all(|&id| id == 201_818));
     }
 }

--- a/crates/mlx-core/src/models/muse_glimmer/dflash.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/dflash.rs
@@ -272,6 +272,10 @@ impl DFlashContextCache {
         Ok(())
     }
 
+    pub(crate) fn logical_len(&self) -> i32 {
+        self.logical_len
+    }
+
     pub(crate) fn eval(&self) -> Result<()> {
         let mut arrays = Vec::new();
         for cache in &self.layers {

--- a/crates/mlx-core/src/models/muse_glimmer/dflash_decode.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/dflash_decode.rs
@@ -37,6 +37,26 @@ pub(crate) struct MuseGlimmerDFlashStepper<'a> {
     tapped: Option<Vec<MxArray>>,
 }
 
+fn reusable_dflash_prefix(
+    is_delta: bool,
+    token_len: usize,
+    prior_cached: usize,
+    verified_hit: usize,
+    retained_context_len: Option<i32>,
+) -> usize {
+    let candidate = if is_delta { prior_cached } else { verified_hit };
+    if candidate > 0
+        && candidate < token_len
+        && i32::try_from(candidate)
+            .ok()
+            .is_some_and(|candidate| retained_context_len == Some(candidate))
+    {
+        candidate
+    } else {
+        0
+    }
+}
+
 impl MuseGlimmerDFlashStepper<'_> {
     fn ensure_clean(&self, operation: &str) -> Result<()> {
         if self.rollback.is_some() || self.tapped.is_some() {
@@ -77,16 +97,7 @@ impl DsparkStepper for MuseGlimmerDFlashStepper<'_> {
     }
 
     fn enter_ar_fallback(&mut self) -> Result<()> {
-        self.ensure_clean("AR fallback")?;
-        let config = self
-            .inner
-            .dflash
-            .as_ref()
-            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?
-            .config
-            .clone();
-        self.context = DFlashContextCache::new_at(&config, self.next_position);
-        Ok(())
+        self.ensure_clean("AR fallback")
     }
 
     fn materialize_adaptive_state(&self) -> Result<()> {
@@ -170,6 +181,11 @@ impl DsparkStepper for MuseGlimmerDFlashStepper<'_> {
         self.append_tapped(&tapped, keep)
     }
 
+    fn finish(self) -> Result<()> {
+        self.inner.dflash_context = Some(self.context);
+        Ok(())
+    }
+
     fn eval_boundary(&self, token: &MxArray) {
         MxArray::async_eval_arrays(&[token]);
     }
@@ -231,7 +247,22 @@ impl MuseGlimmerInner {
             .as_ref()
             .ok_or_else(|| Error::from_reason("Muse-Glimmer has no loaded DFlash companion"))?;
         let tap_layers = draft.config.target_layers.clone();
-        let mut context = DFlashContextCache::new_at(&draft.config, position_base);
+        let draft_config = draft.config.clone();
+        let mut context = match self.dflash_context.take() {
+            Some(context) if context.logical_len() == position_base => context,
+            Some(context) => {
+                return Err(Error::from_reason(format!(
+                    "Muse-Glimmer DFlash context length {} does not match cached prefix {position_base}",
+                    context.logical_len()
+                )));
+            }
+            None if position_base == 0 => DFlashContextCache::new_at(&draft_config, 0),
+            None => {
+                return Err(Error::from_reason(format!(
+                    "Muse-Glimmer DFlash cached prefix {position_base} has no retained draft context"
+                )));
+            }
+        };
         let mut offset = 0usize;
         let mut last_logits = None;
         while offset < tokens.len() {
@@ -284,9 +315,32 @@ impl MuseGlimmerInner {
     }
 
     fn dflash_materialize_final(&mut self, token: u32, stream: Stream) -> Result<()> {
+        let tap_layers = self
+            .dflash
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?
+            .config
+            .target_layers
+            .clone();
         let input = MxArray::from_int32(&[token as i32], &[1, 1])?;
         let _stream = StreamContext::new(stream);
-        let _ = self.forward(&input)?;
+        let (_, taps) = self.forward_with_taps(&input, &tap_layers)?;
+        let fused = self
+            .dflash
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?
+            .fuse_context(&taps)?;
+        let mut context = self.dflash_context.take().ok_or_else(|| {
+            Error::from_reason("Muse-Glimmer DFlash final token has no retained draft context")
+        })?;
+        let base = context.logical_len();
+        let append_result = self
+            .dflash
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))
+            .and_then(|draft| context.append(draft, &fused, base));
+        self.dflash_context = Some(context);
+        append_result?;
         self.eval_caches()
     }
 
@@ -302,16 +356,27 @@ impl MuseGlimmerInner {
         } else {
             0
         };
-        let (prefill, cached_prefix) = if is_delta {
-            (tokens[prior_cached..].to_vec(), prior_cached)
+        let retained_context_len = self
+            .dflash_context
+            .as_ref()
+            .map(DFlashContextCache::logical_len);
+        let verified_hit = if is_delta {
+            0
         } else {
-            let hit = ChatBackend::verify_cache_prefix(self, &tokens, params.reuse_cache);
-            if hit > 0 && hit < tokens.len() {
-                (tokens[hit..].to_vec(), hit)
-            } else {
-                ChatBackend::reset_caches(self, ResetScope::PrefixMiss)?;
-                (tokens.clone(), 0)
-            }
+            ChatBackend::verify_cache_prefix(self, &tokens, params.reuse_cache)
+        };
+        let cached_prefix = reusable_dflash_prefix(
+            is_delta,
+            tokens.len(),
+            prior_cached,
+            verified_hit,
+            retained_context_len,
+        );
+        let prefill = if cached_prefix > 0 {
+            tokens[cached_prefix..].to_vec()
+        } else {
+            ChatBackend::reset_caches(self, ResetScope::PrefixMiss)?;
+            tokens.clone()
         };
 
         let generation_stream = Stream::new(DeviceType::Gpu);
@@ -471,5 +536,19 @@ impl MuseGlimmerInner {
         } else {
             Ok(TurnOutput::Complete(Box::new(result)))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reusable_dflash_prefix;
+
+    #[test]
+    fn continuation_reuses_only_a_matching_retained_dflash_context() {
+        assert_eq!(reusable_dflash_prefix(true, 14, 10, 0, Some(10)), 10);
+        assert_eq!(reusable_dflash_prefix(true, 14, 10, 0, None), 0);
+        assert_eq!(reusable_dflash_prefix(true, 14, 10, 0, Some(9)), 0);
+        assert_eq!(reusable_dflash_prefix(false, 14, 0, 10, Some(10)), 10);
+        assert_eq!(reusable_dflash_prefix(false, 14, 0, 10, Some(9)), 0);
     }
 }

--- a/crates/mlx-core/src/models/muse_glimmer/dflash_decode.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/dflash_decode.rs
@@ -420,6 +420,7 @@ impl MuseGlimmerInner {
         let mut last_is_reasoning = args.thinking.enabled;
         let mut emitter: Option<Box<dyn StreamEmitter>> =
             args.sink.map(|_| ChatBackend::stream_emitter(self));
+        let turn_token_observer = ChatBackend::turn_token_observer(self);
         let block_size = self
             .dflash
             .as_ref()
@@ -458,6 +459,7 @@ impl MuseGlimmerInner {
                     report_perf: report_performance,
                     generation_stream,
                     cancel_flag: args.cancelled,
+                    turn_token_observer,
                 },
                 streaming,
             )

--- a/crates/mlx-core/src/models/muse_glimmer/dflash_decode.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/dflash_decode.rs
@@ -122,7 +122,7 @@ impl DsparkStepper for MuseGlimmerDFlashStepper<'_> {
         let sampling = params.sampling_config.unwrap_or_default();
         let (draft_ids, draft_dists) = draft.propose(
             &self.inner.embed_tokens,
-            &self.inner.lm_head,
+            self.inner.lm_head.as_ref(),
             &self.inner.config.text_config,
             &self.context,
             anchor_id,

--- a/crates/mlx-core/src/models/muse_glimmer/dflash_decode.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/dflash_decode.rs
@@ -1,0 +1,475 @@
+//! DFlash speculative-turn integration for Muse-Glimmer.
+
+use std::time::Instant;
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::decode_profiler::DecodeProfiler;
+use crate::engine::backend::{
+    ChatBackend, DsparkBackend, DsparkProposal, DsparkStepper, DsparkVerifyOutput, FinalizeArgs,
+    ResetScope, StreamEmitter, TurnOutput, WholeTurnArgs,
+};
+use crate::engine::decode::StreamingCtx;
+use crate::engine::dspark_turn::{DsparkTurnArgs, run_dspark_turn};
+use crate::engine::finalize::compute_performance_metrics;
+use crate::engine::params::generated_capacity_hint;
+use crate::engine::penalties::{ReasoningTracker, apply_all_penalties};
+use crate::models::gemma4::layer_cache::{
+    Gemma4VerifyRollback, commit_after_verify, snapshot_before_verify,
+};
+use crate::stream::{DeviceType, Stream, StreamContext};
+
+use super::dflash::DFlashContextCache;
+use super::model::MuseGlimmerInner;
+
+pub(crate) struct DFlashTurnState {
+    context: DFlashContextCache,
+    next_position: i32,
+}
+
+pub(crate) struct MuseGlimmerDFlashStepper<'a> {
+    inner: &'a mut MuseGlimmerInner,
+    context: DFlashContextCache,
+    next_position: i32,
+    tap_layers: Vec<usize>,
+    rollback: Option<Gemma4VerifyRollback>,
+    tapped: Option<Vec<MxArray>>,
+}
+
+impl MuseGlimmerDFlashStepper<'_> {
+    fn ensure_clean(&self, operation: &str) -> Result<()> {
+        if self.rollback.is_some() || self.tapped.is_some() {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer DFlash {operation}: prior verify was not committed"
+            )));
+        }
+        Ok(())
+    }
+
+    fn target_forward(&mut self, ids: &[u32]) -> Result<(MxArray, Vec<MxArray>)> {
+        let ids = ids.iter().map(|&id| id as i32).collect::<Vec<_>>();
+        let input = MxArray::from_int32(&ids, &[1, ids.len() as i64])?;
+        self.inner
+            .forward_with_taps_mode(&input, &self.tap_layers, false)
+    }
+
+    fn append_tapped(&mut self, tapped: &[MxArray], keep: usize) -> Result<()> {
+        let mut kept = Vec::with_capacity(tapped.len());
+        for hidden in tapped {
+            kept.push(hidden.slice_axis(1, 0, keep as i64)?);
+        }
+        let draft = self
+            .inner
+            .dflash
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?;
+        let fused = draft.fuse_context(&kept)?;
+        self.context.append(draft, &fused, self.next_position)?;
+        self.next_position = self.next_position.saturating_add(keep as i32);
+        Ok(())
+    }
+}
+
+impl DsparkStepper for MuseGlimmerDFlashStepper<'_> {
+    fn supports_adaptive_ar_fallback(&self) -> bool {
+        true
+    }
+
+    fn enter_ar_fallback(&mut self) -> Result<()> {
+        self.ensure_clean("AR fallback")?;
+        let config = self
+            .inner
+            .dflash
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?
+            .config
+            .clone();
+        self.context = DFlashContextCache::new_at(&config, self.next_position);
+        Ok(())
+    }
+
+    fn materialize_adaptive_state(&self) -> Result<()> {
+        self.context.eval()
+    }
+
+    fn verify_ar_probe(&mut self, anchor_id: u32) -> Result<DsparkVerifyOutput> {
+        self.ensure_clean("AR probe")?;
+        let (logits, tapped) = self.target_forward(&[anchor_id])?;
+        self.tapped = Some(tapped);
+        Ok(DsparkVerifyOutput { logits })
+    }
+
+    fn commit_ar_probe(&mut self) -> Result<()> {
+        let tapped = self.tapped.take().ok_or_else(|| {
+            Error::from_reason("Muse-Glimmer DFlash AR probe has no tapped target state")
+        })?;
+        self.append_tapped(&tapped, 1)
+    }
+
+    fn propose(
+        &mut self,
+        anchor_id: u32,
+        max_len: usize,
+        params: &crate::engine::params::ChatParams,
+        rng: &mut dyn rand::Rng,
+    ) -> Result<DsparkProposal> {
+        let draft = self
+            .inner
+            .dflash
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?;
+        let sampling = params.sampling_config.unwrap_or_default();
+        let (draft_ids, draft_dists) = draft.propose(
+            &self.inner.embed_tokens,
+            &self.inner.lm_head,
+            &self.inner.config.text_config,
+            &self.context,
+            anchor_id,
+            max_len,
+            &sampling,
+            rng,
+        )?;
+        Ok(DsparkProposal {
+            draft_ids,
+            draft_dists,
+        })
+    }
+
+    fn verify(&mut self, verify_ids: &[u32]) -> Result<DsparkVerifyOutput> {
+        if verify_ids.is_empty() {
+            return Err(Error::from_reason(
+                "Muse-Glimmer DFlash verify block must not be empty",
+            ));
+        }
+        self.ensure_clean("verify")?;
+        let rollback = snapshot_before_verify(
+            &self.inner.caches,
+            verify_ids.len(),
+            &vec![false; self.inner.caches.len()],
+        )?;
+        let (logits, tapped) = self.target_forward(verify_ids)?;
+        self.rollback = Some(rollback);
+        self.tapped = Some(tapped);
+        Ok(DsparkVerifyOutput { logits })
+    }
+
+    fn commit(&mut self, keep: usize, total_written: usize) -> Result<()> {
+        if keep == 0 || keep > total_written {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer DFlash invalid commit keep={keep}, total={total_written}"
+            )));
+        }
+        let rollback = self.rollback.take().ok_or_else(|| {
+            Error::from_reason("Muse-Glimmer DFlash commit has no pending target rollback")
+        })?;
+        let tapped = self.tapped.take().ok_or_else(|| {
+            Error::from_reason("Muse-Glimmer DFlash commit has no pending target taps")
+        })?;
+        commit_after_verify(&mut self.inner.caches, &rollback, keep)?;
+        self.append_tapped(&tapped, keep)
+    }
+
+    fn eval_boundary(&self, token: &MxArray) {
+        MxArray::async_eval_arrays(&[token]);
+    }
+}
+
+impl DsparkBackend for MuseGlimmerInner {
+    type DsparkDecode<'a>
+        = MuseGlimmerDFlashStepper<'a>
+    where
+        Self: 'a;
+
+    fn begin_dspark_decode(&mut self, block_size: usize) -> Result<Self::DsparkDecode<'_>> {
+        let expected = self
+            .dflash
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer has no loaded DFlash companion"))?
+            .config
+            .block_size;
+        if block_size != expected {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer DFlash block size {block_size} does not match checkpoint {expected}"
+            )));
+        }
+        let state = self.dflash_turn_state.take().ok_or_else(|| {
+            Error::from_reason("Muse-Glimmer DFlash decode requires tapped prefill state")
+        })?;
+        let tap_layers = self
+            .dflash
+            .as_ref()
+            .expect("checked DFlash companion")
+            .config
+            .target_layers
+            .clone();
+        Ok(MuseGlimmerDFlashStepper {
+            inner: self,
+            context: state.context,
+            next_position: state.next_position,
+            tap_layers,
+            rollback: None,
+            tapped: None,
+        })
+    }
+}
+
+impl MuseGlimmerInner {
+    fn dflash_prefill(
+        &mut self,
+        tokens: &[u32],
+        position_base: i32,
+        stream: Stream,
+    ) -> Result<(MxArray, DFlashTurnState)> {
+        if tokens.is_empty() {
+            return Err(Error::from_reason(
+                "Muse-Glimmer DFlash requires at least one prefill token",
+            ));
+        }
+        let draft = self
+            .dflash
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer has no loaded DFlash companion"))?;
+        let tap_layers = draft.config.target_layers.clone();
+        let mut context = DFlashContextCache::new_at(&draft.config, position_base);
+        let mut offset = 0usize;
+        let mut last_logits = None;
+        while offset < tokens.len() {
+            if offset > 0
+                && self
+                    .turn_cancel
+                    .as_ref()
+                    .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Relaxed))
+            {
+                return Err(Error::from_reason("prefill cancelled"));
+            }
+            let end = (offset + super::model::PREFILL_STEP_SIZE as usize).min(tokens.len());
+            let chunk = tokens[offset..end]
+                .iter()
+                .map(|&id| id as i32)
+                .collect::<Vec<_>>();
+            let input = MxArray::from_int32(&chunk, &[1, chunk.len() as i64])?;
+            let (logits, taps) = {
+                let _stream = StreamContext::new(stream);
+                self.forward_with_taps(&input, &tap_layers)?
+            };
+            let draft = self
+                .dflash
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?;
+            let fused = draft.fuse_context(&taps)?;
+            context.append(draft, &fused, position_base + offset as i32)?;
+            last_logits = Some(logits);
+            if end < tokens.len() {
+                self.eval_caches()?;
+                crate::array::clear_cache();
+            }
+            offset = end;
+        }
+        Ok((
+            last_logits
+                .expect("non-empty prefill")
+                .squeeze(Some(&[1]))?,
+            DFlashTurnState {
+                context,
+                next_position: position_base.saturating_add(tokens.len() as i32),
+            },
+        ))
+    }
+
+    fn dflash_fail_closed(&mut self, error: Error) -> Error {
+        let _ = ChatBackend::reset_caches(self, ResetScope::PrefixMiss);
+        self.dflash_turn_state = None;
+        error
+    }
+
+    fn dflash_materialize_final(&mut self, token: u32, stream: Stream) -> Result<()> {
+        let input = MxArray::from_int32(&[token as i32], &[1, 1])?;
+        let _stream = StreamContext::new(stream);
+        let _ = self.forward(&input)?;
+        self.eval_caches()
+    }
+
+    pub(crate) fn dflash_chat_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
+        let tokenizer = args.tokenizer.clone();
+        let tokens = args.tokens.to_vec();
+        let is_delta = args.plan.is_delta;
+        let is_streaming = args.sink.is_some();
+        let mut params = ChatBackend::resolve_params(self, args.config);
+        params.extra_eos_ids = ChatBackend::extra_eos_ids(self);
+        let prior_cached = if is_delta {
+            self.cached_token_history.len()
+        } else {
+            0
+        };
+        let (prefill, cached_prefix) = if is_delta {
+            (tokens[prior_cached..].to_vec(), prior_cached)
+        } else {
+            let hit = ChatBackend::verify_cache_prefix(self, &tokens, params.reuse_cache);
+            if hit > 0 && hit < tokens.len() {
+                (tokens[hit..].to_vec(), hit)
+            } else {
+                ChatBackend::reset_caches(self, ResetScope::PrefixMiss)?;
+                (tokens.clone(), 0)
+            }
+        };
+
+        let generation_stream = Stream::new(DeviceType::Gpu);
+        let report_performance = params.report_performance;
+        let generation_start = report_performance.then(Instant::now);
+        let mut first_token_instant = None;
+        let mut profiler = DecodeProfiler::new(
+            ChatBackend::profiler_label(self, is_delta, is_streaming),
+            ChatBackend::family_name(self),
+        );
+        profiler.set_prompt_tokens(prefill.len() as u32);
+        profiler.snapshot_memory_before();
+        profiler.begin_prefill();
+        let (last_logits, state) =
+            match self.dflash_prefill(&prefill, cached_prefix as i32, generation_stream) {
+                Ok(value) => value,
+                Err(error) => return Err(self.dflash_fail_closed(error)),
+            };
+        profiler.end_prefill();
+
+        let mut token_history = tokens.clone();
+        let y = match apply_all_penalties(last_logits, &token_history, &params)
+            .and_then(|logits| crate::sampling::sample(&logits, params.sampling_config))
+        {
+            Ok(token) => token,
+            Err(error) => return Err(self.dflash_fail_closed(error)),
+        };
+        y.eval();
+        self.eval_caches()?;
+        if report_performance {
+            first_token_instant = Some(Instant::now());
+        }
+        self.dflash_turn_state = Some(state);
+
+        let mut generated = Vec::with_capacity(generated_capacity_hint(params.max_new_tokens));
+        let mut finish_reason = String::from("length");
+        let mut reasoning = ReasoningTracker::from_setup(&args.thinking, tokenizer.think_end_id());
+        let stream_skip_special = ChatBackend::stream_skip_special_tokens(self);
+        let mut decode_stream = tokenizer.inner().decode_stream(stream_skip_special);
+        let mut streamed_text_len = 0usize;
+        let mut last_is_reasoning = args.thinking.enabled;
+        let mut emitter: Option<Box<dyn StreamEmitter>> =
+            args.sink.map(|_| ChatBackend::stream_emitter(self));
+        let block_size = self
+            .dflash
+            .as_ref()
+            .expect("loaded DFlash companion")
+            .config
+            .block_size;
+        let mut rng = rand::rng();
+        let outcome = {
+            let streaming = match (args.sink, args.cancelled, emitter.as_mut()) {
+                (Some(callback), Some(cancelled), Some(emitter)) => Some(StreamingCtx {
+                    callback,
+                    cancelled,
+                    decode_stream: &mut decode_stream,
+                    tokenizer: tokenizer.inner(),
+                    streamed_text_len: &mut streamed_text_len,
+                    last_is_reasoning: &mut last_is_reasoning,
+                    emitter: emitter.as_mut(),
+                }),
+                _ => None,
+            };
+            run_dspark_turn(
+                self,
+                &mut rng,
+                DsparkTurnArgs {
+                    y,
+                    block_size,
+                    params: &params,
+                    reasoning_tracker: &mut reasoning,
+                    profiler: &mut profiler,
+                    max_new_tokens: params.max_new_tokens,
+                    eos_id: args.eos_id,
+                    generated_tokens: &mut generated,
+                    token_history: &mut token_history,
+                    finish_reason: &mut finish_reason,
+                    first_token_instant: &mut first_token_instant,
+                    report_perf: report_performance,
+                    generation_stream,
+                    cancel_flag: args.cancelled,
+                },
+                streaming,
+            )
+        };
+        let mut last_in_cache = match outcome {
+            Ok(outcome) => outcome.last_in_cache,
+            Err(error) => return Err(self.dflash_fail_closed(error)),
+        };
+        if finish_reason == "length"
+            && !last_in_cache
+            && let Some(&last) = generated.last()
+        {
+            self.dflash_materialize_final(last, generation_stream)?;
+            last_in_cache = true;
+        }
+        let saved_generated = if !last_in_cache && !generated.is_empty() {
+            &generated[..generated.len() - 1]
+        } else {
+            generated.as_slice()
+        };
+        let mut history = tokens.clone();
+        history.extend_from_slice(saved_generated);
+        self.cached_token_history = history;
+
+        let performance = if report_performance {
+            compute_performance_metrics(
+                generation_start,
+                first_token_instant,
+                prefill.len(),
+                generated.len(),
+            )
+            .map(|mut metrics| {
+                ChatBackend::augment_performance(self, &profiler, &mut metrics);
+                metrics
+            })
+        } else {
+            None
+        };
+        if let (Some(sink), Some(emitter)) = (args.sink, emitter.as_mut()) {
+            let decoded = tokenizer
+                .decode_sync(&generated, stream_skip_special)
+                .unwrap_or_default();
+            if decoded.len() > streamed_text_len {
+                emitter.on_residual(
+                    &decoded[streamed_text_len..],
+                    last_is_reasoning,
+                    params.include_reasoning,
+                    sink,
+                );
+            }
+        }
+        let prompt_tokens = if is_delta && is_streaming {
+            ChatBackend::stream_delta_prompt_tokens(self, tokens.len(), tokens.len() - prior_cached)
+        } else {
+            tokens.len() as u32
+        };
+        let mut result = ChatBackend::finalize_turn(
+            self,
+            FinalizeArgs {
+                tokenizer: &tokenizer,
+                generated_tokens: &generated,
+                finish_reason,
+                think_end_id: tokenizer.think_end_id(),
+                think_end_str: tokenizer.think_end_str(),
+                performance,
+                include_reasoning: params.include_reasoning,
+                thinking_enabled: args.thinking.enabled,
+                prompt_tokens,
+                reasoning_tokens: reasoning.reasoning_token_count(),
+            },
+        )?;
+        result.cached_tokens = cached_prefix as u32;
+        if let (Some(sink), Some(emitter)) = (args.sink, emitter.as_mut()) {
+            emitter.finish(&result, sink);
+            Ok(TurnOutput::Streamed)
+        } else {
+            Ok(TurnOutput::Complete(Box::new(result)))
+        }
+    }
+}

--- a/crates/mlx-core/src/models/muse_glimmer/kv_cache.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/kv_cache.rs
@@ -2112,7 +2112,7 @@ mod tests {
         // `AttentionKind::SlidingWindow` or `sliding_window`, which this seam
         // itself talks about constantly.
         const WIRING_MARKERS: [&str; 6] = [
-            "new_sliding",
+            "PagedKVCacheAdapter::new_sliding",
             "mlx_paged_attention",
             "gather_kv_for_prefill",
             "read_kv_range",
@@ -2191,7 +2191,7 @@ mod tests {
         // scan still reaches everything" can be checked at all, since a scan
         // that silently stopped descending would otherwise just report fewer
         // files and still pass a loose floor.
-        const FAMILY_FILES: usize = 5; // config, kv_cache, mod, output_parser, stream_guard
+        const FAMILY_FILES: usize = 14;
         assert!(
             checked >= FAMILY_FILES,
             "the tripwire scanned only {checked} file(s), fewer than the {FAMILY_FILES} this \

--- a/crates/mlx-core/src/models/muse_glimmer/kv_cache.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/kv_cache.rs
@@ -2191,7 +2191,7 @@ mod tests {
         // scan still reaches everything" can be checked at all, since a scan
         // that silently stopped descending would otherwise just report fewer
         // files and still pass a loose floor.
-        const FAMILY_FILES: usize = 14;
+        const FAMILY_FILES: usize = 15;
         assert!(
             checked >= FAMILY_FILES,
             "the tripwire scanned only {checked} file(s), fewer than the {FAMILY_FILES} this \

--- a/crates/mlx-core/src/models/muse_glimmer/mlp.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/mlp.rs
@@ -1,0 +1,26 @@
+use crate::array::MxArray;
+use crate::models::gemma4::quantized_linear::LinearProj;
+use crate::nn::Activations;
+use napi::bindgen_prelude::*;
+
+pub struct MuseGlimmerMlp {
+    gate_proj: LinearProj,
+    up_proj: LinearProj,
+    down_proj: LinearProj,
+}
+
+impl MuseGlimmerMlp {
+    pub fn new(gate_proj: LinearProj, up_proj: LinearProj, down_proj: LinearProj) -> Self {
+        Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+        }
+    }
+
+    pub fn forward(&self, x: &MxArray) -> Result<MxArray> {
+        let gate = Activations::silu(&self.gate_proj.forward(x)?)?;
+        let up = self.up_proj.forward(x)?;
+        self.down_proj.forward(&gate.mul(&up)?)
+    }
+}

--- a/crates/mlx-core/src/models/muse_glimmer/mod.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/mod.rs
@@ -12,6 +12,7 @@ pub mod mlp;
 pub mod model;
 pub mod output_parser;
 pub mod persistence;
+mod row_exact;
 pub mod stream_guard;
 
 pub use model::MuseGlimmerModel;

--- a/crates/mlx-core/src/models/muse_glimmer/mod.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/mod.rs
@@ -1,7 +1,17 @@
 //! Muse-Glimmer-30B: windowed vision tower + 3-stage projector + hybrid text
 //! decoder ([slide,slide,slide,full] x13, NoPE on the full layers).
 
+pub mod attention;
+pub(crate) mod cold_sidecar;
 pub mod config;
+pub mod decoder_layer;
+pub(crate) mod dflash;
+pub(crate) mod dflash_decode;
 pub mod kv_cache;
+pub mod mlp;
+pub mod model;
 pub mod output_parser;
+pub mod persistence;
 pub mod stream_guard;
+
+pub use model::MuseGlimmerModel;

--- a/crates/mlx-core/src/models/muse_glimmer/model.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/model.rs
@@ -76,6 +76,85 @@ pub(crate) struct MusePagedRuntime {
     pub(crate) decode_windows: Vec<PagedWindowSlot>,
 }
 
+/// Trained and physically available active-context limits for one loaded
+/// Muse-Glimmer model. The effective window is conservative across both
+/// execution modes: DFlash may use the flat cache, but callers can disable it
+/// per request and fall back to the paged AR scheduler.
+#[napi(object)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MuseGlimmerContextLimits {
+    pub trained_window_tokens: u32,
+    pub effective_window_tokens: u32,
+    pub paged_block_capacity: u32,
+    pub paged_block_size: u32,
+}
+
+impl MuseGlimmerContextLimits {
+    fn from_parts(
+        trained_window_tokens: u32,
+        scheduler_window_tokens: u32,
+        paged: Option<(u32, u32, u32)>,
+    ) -> Self {
+        let Some((paged_window_tokens, paged_block_capacity, paged_block_size)) = paged else {
+            return Self {
+                trained_window_tokens,
+                effective_window_tokens: trained_window_tokens,
+                paged_block_capacity: 0,
+                paged_block_size: 0,
+            };
+        };
+        Self {
+            trained_window_tokens,
+            effective_window_tokens: trained_window_tokens
+                .min(scheduler_window_tokens)
+                .min(paged_window_tokens),
+            paged_block_capacity,
+            paged_block_size,
+        }
+    }
+
+    pub(crate) fn from_inner(inner: &MuseGlimmerInner) -> Self {
+        let trained = u32::try_from(inner.config.text_config.max_position_embeddings)
+            .expect("validated Muse-Glimmer context fits u32");
+        let paged = inner.paged.as_ref().map(|runtime| {
+            let adapter = runtime.coordinator.full_adapter();
+            (
+                adapter.max_capacity_tokens(),
+                adapter.block_capacity(),
+                adapter.block_size(),
+            )
+        });
+        Self::from_parts(
+            trained,
+            crate::engine::hybrid_scheduler::scheduler_per_seq_context(),
+            paged,
+        )
+    }
+}
+
+#[cfg(test)]
+mod context_limit_tests {
+    use super::MuseGlimmerContextLimits;
+
+    #[test]
+    fn paged_ar_limit_is_published_even_when_dflash_can_use_the_trained_window() {
+        let limits =
+            MuseGlimmerContextLimits::from_parts(131_072, 32_768, Some((131_072, 8_192, 16)));
+        assert_eq!(limits.trained_window_tokens, 131_072);
+        assert_eq!(limits.effective_window_tokens, 32_768);
+        assert_eq!(limits.paged_block_capacity, 8_192);
+        assert_eq!(limits.paged_block_size, 16);
+    }
+
+    #[test]
+    fn a_flat_only_runtime_publishes_the_trained_window() {
+        let limits = MuseGlimmerContextLimits::from_parts(131_072, 32_768, None);
+        assert_eq!(limits.effective_window_tokens, 131_072);
+        assert_eq!(limits.paged_block_capacity, 0);
+        assert_eq!(limits.paged_block_size, 0);
+    }
+}
+
 #[derive(Clone)]
 struct MuseSlidingColdCheckpoint {
     boundary: u32,
@@ -1447,6 +1526,7 @@ pub struct MuseGlimmerModel {
     pub(crate) has_dflash: bool,
     pub(crate) paged_active: bool,
     pub(crate) max_concurrent_sequences: u32,
+    pub(crate) context_limits: MuseGlimmerContextLimits,
     pub(crate) _cache_limit_guard: crate::cache_limit::CacheLimitGuard,
     pub(crate) _pool_cache_limit_guard: Option<crate::cache_limit::PoolCacheLimitGuard>,
 }
@@ -1480,6 +1560,14 @@ impl MuseGlimmerModel {
         } else {
             1
         }
+    }
+
+    /// Conservative model-wide context snapshot used by higher layers for
+    /// compaction. It includes the paged AR limit even when DFlash is present,
+    /// because DFlash is opt-in per request and can be disabled by the caller.
+    #[napi]
+    pub fn context_limits(&self) -> MuseGlimmerContextLimits {
+        self.context_limits.clone()
     }
 
     #[napi]

--- a/crates/mlx-core/src/models/muse_glimmer/model.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/model.rs
@@ -1,0 +1,1439 @@
+use std::collections::{HashMap, VecDeque};
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+use crate::array::MxArray;
+use crate::engine::ThinkingPolicy;
+use crate::engine::backend::{
+    ChatBackend, ChunkSink, DecodeStep, FinalizeArgs, PagedBackend, PagedPrefix, ResetScope,
+    SaveStateArgs, StreamEmitter, TurnOutput, TurnSetup, WholeTurnArgs,
+};
+use crate::engine::cmd::{ChatCmd, FromChatCmd};
+use crate::engine::params::ChatParams;
+use crate::engine::plan::{
+    ExecutionPlan, MediaPlan, PagedAttentionPlan, SpeculativeKind, SpeculativePlan,
+};
+use crate::engine::types::{ChatConfig, ChatResult, ChatStreamChunk};
+use crate::model_thread::ModelThread;
+use crate::model_thread::ResponseTx;
+use crate::models::gemma4::layer_cache::Gemma4LayerCache;
+use crate::models::gemma4::model::Gemma4KVCacheCoordinator;
+use crate::models::gemma4::quantized_linear::LinearProj;
+use crate::nn::{Embedding, RMSNorm};
+use crate::stream::{Stream, StreamContext};
+use crate::tokenizer::Qwen3Tokenizer;
+use crate::tools::ToolCallResult;
+use crate::transformer::LayerKVCacheRoute;
+use crate::transformer::paged_kv_cache_adapter::ColdTierContext;
+use crate::transformer::paged_kv_cache_adapter::SeqId;
+
+use super::config::{LayerKind, MuseGlimmerConfig};
+use super::decoder_layer::MuseGlimmerDecoderLayer;
+use super::dflash::DFlashModel;
+use super::kv_cache::PagedWindowSlot;
+use super::output_parser::ResponseTemplate;
+use super::stream_guard::{GuardOutcome, StreamGuard};
+
+#[path = "scheduler.rs"]
+mod scheduler;
+pub(crate) use scheduler::MuseSchedulerState;
+
+pub(super) const PREFILL_STEP_SIZE: i64 = 512;
+
+fn resolve_dflash_schedule(
+    requested_depth: Option<i32>,
+    requested_adaptive: Option<bool>,
+    block_size: usize,
+) -> (usize, bool) {
+    let depth = requested_depth
+        .map(|value| (value.max(1) as usize).min(block_size))
+        .unwrap_or(block_size);
+    let adaptive = requested_adaptive.unwrap_or(requested_depth.is_none());
+    (depth, adaptive)
+}
+
+#[cfg(test)]
+mod dflash_schedule_tests {
+    use super::resolve_dflash_schedule;
+
+    #[test]
+    fn external_dflash_uses_the_checkpoint_block_instead_of_the_mtp_head_clamp() {
+        assert_eq!(resolve_dflash_schedule(None, None, 16), (16, true));
+        assert_eq!(resolve_dflash_schedule(Some(16), None, 16), (16, false));
+        assert_eq!(resolve_dflash_schedule(Some(99), None, 16), (16, false));
+        assert_eq!(resolve_dflash_schedule(Some(-1), Some(true), 16), (1, true));
+    }
+}
+
+pub(crate) struct MusePagedRuntime {
+    pub(crate) coordinator: Gemma4KVCacheCoordinator,
+    pub(crate) routes: Vec<LayerKVCacheRoute>,
+    pub(crate) prefill_windows: Vec<PagedWindowSlot>,
+    pub(crate) decode_windows: Vec<PagedWindowSlot>,
+}
+
+#[derive(Clone)]
+struct MuseSlidingColdCheckpoint {
+    boundary: u32,
+    tokens: Vec<u32>,
+    layer_kv: Vec<(MxArray, MxArray)>,
+}
+
+pub(crate) enum MuseGlimmerCmd {
+    Chat(Box<ChatCmd>),
+    SchedulerStats {
+        reply: ResponseTx<crate::engine::SchedulerStatsJs>,
+    },
+}
+
+impl FromChatCmd for MuseGlimmerCmd {
+    fn from_chat(cmd: ChatCmd) -> Self {
+        Self::Chat(Box::new(cmd))
+    }
+}
+
+pub(crate) struct MuseGlimmerInner {
+    pub(crate) config: MuseGlimmerConfig,
+    pub(crate) embed_tokens: Embedding,
+    pub(crate) layers: Vec<MuseGlimmerDecoderLayer>,
+    pub(crate) final_norm: RMSNorm,
+    pub(crate) lm_head: LinearProj,
+    pub(crate) caches: Vec<Gemma4LayerCache>,
+    pub(crate) tokenizer: Option<Arc<Qwen3Tokenizer>>,
+    pub(crate) response_template: Arc<ResponseTemplate>,
+    pub(crate) cached_token_history: Vec<u32>,
+    pub(crate) turn_cancel: Option<Arc<AtomicBool>>,
+    pub(crate) gen_defaults: crate::engine::ModelGenerationDefaults,
+    pub(crate) dflash: Option<DFlashModel>,
+    pub(crate) dflash_turn_state: Option<super::dflash_decode::DFlashTurnState>,
+    pub(crate) paged: Option<MusePagedRuntime>,
+    pub(crate) active_paged_seq: u32,
+    pub(crate) active_flat_session: bool,
+    sliding_cold_checkpoints: HashMap<SeqId, VecDeque<MuseSlidingColdCheckpoint>>,
+}
+
+fn init_caches(config: &MuseGlimmerConfig) -> Vec<Gemma4LayerCache> {
+    config
+        .text_config
+        .layer_kinds
+        .iter()
+        .map(|kind| match kind {
+            LayerKind::Sliding => Gemma4LayerCache::new_sliding(
+                i32::try_from(config.text_config.sliding_window)
+                    .expect("validated Muse-Glimmer sliding window"),
+            ),
+            LayerKind::Full => Gemma4LayerCache::new_global(),
+        })
+        .collect()
+}
+
+impl MuseGlimmerInner {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_loaded(
+        config: MuseGlimmerConfig,
+        embed_tokens: Embedding,
+        layers: Vec<MuseGlimmerDecoderLayer>,
+        final_norm: RMSNorm,
+        lm_head: LinearProj,
+        tokenizer: Arc<Qwen3Tokenizer>,
+        response_template: ResponseTemplate,
+        gen_defaults: crate::engine::ModelGenerationDefaults,
+        dflash: Option<DFlashModel>,
+        paged: Option<MusePagedRuntime>,
+    ) -> Self {
+        let caches = init_caches(&config);
+        Self {
+            config,
+            embed_tokens,
+            layers,
+            final_norm,
+            lm_head,
+            caches,
+            tokenizer: Some(tokenizer),
+            response_template: Arc::new(response_template),
+            cached_token_history: Vec::new(),
+            turn_cancel: None,
+            gen_defaults,
+            dflash,
+            dflash_turn_state: None,
+            paged,
+            active_paged_seq: 0,
+            active_flat_session: false,
+            sliding_cold_checkpoints: HashMap::new(),
+        }
+    }
+
+    fn cold_anchor_rungs(&self) -> Vec<u32> {
+        let Some(full) = self
+            .paged
+            .as_ref()
+            .map(|paged| paged.coordinator.full_adapter())
+        else {
+            return Vec::new();
+        };
+        let has_sliding_sidecar = full
+            .cold_tier()
+            .and_then(|cold| cold.sidecar_policy.as_ref())
+            .is_some_and(|policy| policy.group() == mlx_paged_attn::ColdGroup::SlidingWindow);
+        if has_sliding_sidecar {
+            super::cold_sidecar::anchor_rungs(full.block_size())
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Build, but do not attach, the content-addressed SSD tier for this exact
+    /// target checkpoint and hybrid cache geometry.
+    pub(crate) fn build_cold_tier_context(
+        &self,
+        model_path: &str,
+        weights: &crate::array::memory::WeightsResident,
+    ) -> Option<ColdTierContext> {
+        let coordinator = self.paged.as_ref().map(|paged| &paged.coordinator)?;
+        let manager = crate::cold_tier::global_cold_cache()?;
+        let geometry = super::cold_sidecar::geometry(&self.config)?;
+        let sidecar_policy = super::cold_sidecar::policy(&self.config)?;
+        let mut config_json = std::fs::read(Path::new(model_path).join("config.json")).ok()?;
+        config_json.extend_from_slice(&geometry.fingerprint_component());
+        let pool = coordinator.full_adapter().layer_kv_pool();
+        let pool_geometry = crate::cold_tier::ColdTierGeometry {
+            block_size: pool.block_size() as u64,
+            num_layers: pool.num_layers() as u64,
+            num_kv_heads: pool.config().num_kv_heads as u64,
+            head_size: pool.config().head_size as u64,
+            cache_dtype: format!("{:?}", pool.cache_dtype()),
+        };
+        match crate::cold_tier::build_model_fingerprint(
+            "muse_glimmer",
+            model_path,
+            Some(&config_json),
+            &pool_geometry,
+            weights,
+        ) {
+            Some(fingerprint) => Some(ColdTierContext {
+                manager,
+                fingerprint,
+                sidecar_policy: Some(sidecar_policy),
+            }),
+            None => {
+                tracing::warn!(
+                    "cold-tier persistence disabled for {model_path}: could not establish a complete model fingerprint"
+                );
+                None
+            }
+        }
+    }
+
+    pub(crate) fn attach_cold_tier(
+        &mut self,
+        context: ColdTierContext,
+        _weights: &crate::array::memory::WeightsResident,
+    ) {
+        if let Some(paged) = self.paged.as_mut() {
+            paged.coordinator.full_adapter_mut().set_cold_tier(context);
+        }
+    }
+
+    /// Prepare one common full/sliding prefix boundary. The full group owns
+    /// the hot/SSD lookup, while the sidecar is the joint commit record for the
+    /// sliding group. A missing or invalid sidecar restarts every group at zero.
+    pub(crate) fn prepare_paged_text_request(
+        &mut self,
+        seq_id: SeqId,
+        tokens: &[u32],
+        cache_salt: u64,
+        reuse_cache: bool,
+    ) -> Result<u32> {
+        self.set_active_paged_owner(seq_id);
+        let total_budget = tokens.len() as u32;
+        let geometry = super::cold_sidecar::geometry(&self.config);
+        let (block_size, plan) = {
+            let coordinator = &mut self
+                .paged
+                .as_mut()
+                .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime is unavailable"))?
+                .coordinator;
+            let block_size = coordinator.full_adapter().block_size();
+            let extra_keys = crate::engine::build_paged_extra_keys(tokens.len(), block_size, &[]);
+            let plan = coordinator
+                .full_adapter_mut()
+                .prepare_turn_per_block_with_max_cache_hit_tokens(
+                    seq_id,
+                    tokens,
+                    total_budget,
+                    reuse_cache,
+                    &extra_keys,
+                    cache_salt,
+                    false,
+                    total_budget.saturating_sub(1),
+                )
+                .map_err(Error::from_reason)?;
+            (block_size, plan)
+        };
+
+        if plan.continued_live_prefix {
+            let continued = self
+                .paged
+                .as_mut()
+                .expect("checked Muse paged runtime")
+                .coordinator
+                .continue_sliding_all(seq_id, tokens, total_budget, plan.cached_prefix_len);
+            if continued.is_ok() {
+                return Ok(plan.cached_prefix_len);
+            }
+            tracing::warn!(
+                target: "mlx_core::muse_glimmer::paged",
+                "Muse-Glimmer hybrid live continuation disagreed across groups; restarting cold"
+            );
+            let extra_keys = crate::engine::build_paged_extra_keys(tokens.len(), block_size, &[]);
+            let coordinator = &mut self
+                .paged
+                .as_mut()
+                .expect("checked Muse paged runtime")
+                .coordinator;
+            coordinator
+                .full_adapter_mut()
+                .restart_prepared_turn_cold_per_block(
+                    seq_id,
+                    tokens,
+                    total_budget,
+                    &extra_keys,
+                    cache_salt,
+                )
+                .map_err(Error::from_reason)?;
+            coordinator
+                .reset_sliding_requests(seq_id)
+                .map_err(Error::from_reason)?;
+            self.sliding_cold_checkpoints.remove(&seq_id);
+            return Ok(0);
+        }
+
+        self.sliding_cold_checkpoints.remove(&seq_id);
+        if plan.cached_prefix_len == 0 {
+            self.paged
+                .as_mut()
+                .expect("checked Muse paged runtime")
+                .coordinator
+                .reset_sliding_requests(seq_id)
+                .map_err(Error::from_reason)?;
+            return Ok(0);
+        }
+
+        let restored = self
+            .paged
+            .as_mut()
+            .expect("checked Muse paged runtime")
+            .coordinator
+            .full_adapter_mut()
+            .take_restored_sidecar();
+        let installed = if let Some(geometry) = geometry.as_ref() {
+            let expected =
+                crate::models::gemma4::sliding_sidecar::layout_at(geometry, plan.cached_prefix_len);
+            crate::cold_tier::try_install_cold_sidecar(restored, &expected, |tensors, boundary| {
+                let Some(layer_kv) = crate::models::gemma4::sliding_sidecar::decode_layer_kv(
+                    geometry, tensors, boundary,
+                )?
+                else {
+                    return Ok(None);
+                };
+                let coordinator = &mut self
+                    .paged
+                    .as_mut()
+                    .expect("checked Muse paged runtime")
+                    .coordinator;
+                if coordinator
+                    .restore_sliding_groups(seq_id, tokens, boundary, &layer_kv)
+                    .is_err()
+                {
+                    return Ok(None);
+                }
+                Ok(Some(boundary))
+            })?
+        } else {
+            None
+        };
+        if let Some(boundary) = installed {
+            return Ok(boundary);
+        }
+
+        let extra_keys = crate::engine::build_paged_extra_keys(tokens.len(), block_size, &[]);
+        let coordinator = &mut self
+            .paged
+            .as_mut()
+            .expect("checked Muse paged runtime")
+            .coordinator;
+        coordinator
+            .full_adapter_mut()
+            .restart_prepared_turn_cold_per_block(
+                seq_id,
+                tokens,
+                total_budget,
+                &extra_keys,
+                cache_salt,
+            )
+            .map_err(Error::from_reason)?;
+        coordinator
+            .reset_sliding_requests(seq_id)
+            .map_err(Error::from_reason)?;
+        Ok(0)
+    }
+
+    pub(crate) fn remember_sliding_cold_checkpoints(&mut self, seq_id: SeqId) -> Result<()> {
+        let candidates = {
+            let Some(paged) = self.paged.as_ref() else {
+                return Ok(());
+            };
+            let full = paged.coordinator.full_adapter();
+            let anchors = self.cold_anchor_rungs();
+            if anchors.is_empty() {
+                return Ok(());
+            }
+            let Some(recorded) = full.current_token_count_for(seq_id) else {
+                return Ok(());
+            };
+            let Some(tokens) = full.request_tokens_for(seq_id) else {
+                return Ok(());
+            };
+            anchors
+                .iter()
+                .copied()
+                .filter(|boundary| *boundary <= recorded)
+                .filter_map(|boundary| {
+                    tokens
+                        .get(..boundary as usize)
+                        .map(|prefix| (boundary, prefix.to_vec(), anchors.len()))
+                })
+                .collect::<Vec<_>>()
+        };
+        for (boundary, tokens, limit) in candidates {
+            if self
+                .sliding_cold_checkpoints
+                .get(&seq_id)
+                .is_some_and(|entries| {
+                    entries
+                        .iter()
+                        .any(|entry| entry.boundary == boundary && entry.tokens == tokens)
+                })
+            {
+                continue;
+            }
+            let Some(layer_kv) = self
+                .paged
+                .as_mut()
+                .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime disappeared"))?
+                .coordinator
+                .read_sliding_groups_at(seq_id, boundary)
+                .map_err(Error::from_reason)?
+            else {
+                continue;
+            };
+            let entries = self.sliding_cold_checkpoints.entry(seq_id).or_default();
+            entries.push_back(MuseSlidingColdCheckpoint {
+                boundary,
+                tokens,
+                layer_kv,
+            });
+            while entries.len() > limit.max(1) {
+                entries.pop_front();
+            }
+        }
+        Ok(())
+    }
+
+    fn discard_sliding_checkpoints_through(&mut self, seq_id: SeqId, boundary: u32) {
+        if let Some(entries) = self.sliding_cold_checkpoints.get_mut(&seq_id) {
+            entries.retain(|entry| entry.boundary > boundary);
+            if entries.is_empty() {
+                self.sliding_cold_checkpoints.remove(&seq_id);
+            }
+        }
+    }
+
+    fn capture_sliding_cold_sidecar(
+        &mut self,
+        seq_id: SeqId,
+        extra_keys_per_block: &[Vec<u64>],
+        cache_salt: u64,
+    ) {
+        crate::cold_tier::cold_sidecar_counters().record_capture_reached();
+        let Some((block_size, frontier, request_tokens, anchors, manager, fingerprint, budget)) =
+            self.paged.as_ref().and_then(|paged| {
+                let full = paged.coordinator.full_adapter();
+                let cold = full.cold_tier()?;
+                if cold
+                    .sidecar_policy
+                    .as_ref()
+                    .is_none_or(|policy| policy.group() != mlx_paged_attn::ColdGroup::SlidingWindow)
+                {
+                    return None;
+                }
+                Some((
+                    full.block_size(),
+                    full.cold_captured_blocks()
+                        .saturating_mul(full.block_size()),
+                    full.request_tokens_for(seq_id)?.to_vec(),
+                    super::cold_sidecar::anchor_rungs(full.block_size()),
+                    Arc::clone(&cold.manager),
+                    cold.fingerprint,
+                    full.cold_capture_budget(),
+                ))
+            })
+        else {
+            return;
+        };
+        let checkpoint = self
+            .sliding_cold_checkpoints
+            .get(&seq_id)
+            .and_then(|entries| {
+                entries.iter().rev().find(|entry| {
+                    entry.boundary <= frontier
+                        && request_tokens
+                            .get(..entry.boundary as usize)
+                            .is_some_and(|tokens| tokens == entry.tokens)
+                })
+            })
+            .cloned()
+            .or_else(|| {
+                let boundary = anchors
+                    .iter()
+                    .rev()
+                    .copied()
+                    .find(|boundary| *boundary <= frontier)?;
+                let layer_kv = self
+                    .paged
+                    .as_mut()?
+                    .coordinator
+                    .read_sliding_groups_at(seq_id, boundary)
+                    .ok()??;
+                let tokens = request_tokens.get(..boundary as usize)?.to_vec();
+                Some(MuseSlidingColdCheckpoint {
+                    boundary,
+                    tokens,
+                    layer_kv,
+                })
+            });
+        let Some(checkpoint) = checkpoint else {
+            crate::cold_tier::cold_sidecar_counters().record_boundary_skip();
+            return;
+        };
+        let Some(key) = super::cold_sidecar::chain_key(
+            fingerprint,
+            &request_tokens,
+            extra_keys_per_block,
+            block_size,
+            checkpoint.boundary,
+            cache_salt,
+        ) else {
+            return;
+        };
+        if manager.contains_in(&key, mlx_paged_attn::ColdGroup::SlidingWindow) {
+            crate::cold_tier::cold_sidecar_counters().record_already_persisted();
+            self.discard_sliding_checkpoints_through(seq_id, checkpoint.boundary);
+            return;
+        }
+        let refs = checkpoint
+            .layer_kv
+            .iter()
+            .flat_map(|(keys, values)| [keys, values])
+            .collect::<Vec<_>>();
+        if MxArray::eval_arrays(&refs).is_err() {
+            return;
+        }
+        let Some(geometry) = super::cold_sidecar::geometry(&self.config) else {
+            return;
+        };
+        let Ok(Some(tensors)) = crate::models::gemma4::sliding_sidecar::encode_layer_kv(
+            &geometry,
+            &checkpoint.layer_kv,
+            checkpoint.boundary,
+        ) else {
+            return;
+        };
+        let sidecar = mlx_paged_attn::ColdSidecar {
+            key,
+            fingerprint,
+            layout: crate::models::gemma4::sliding_sidecar::layout_at(
+                &geometry,
+                checkpoint.boundary,
+            ),
+            tensors,
+        };
+        let deadline = std::time::Instant::now() + budget.max_walk;
+        match manager.enqueue_sidecar_before(sidecar, deadline) {
+            Ok(true) => {
+                crate::cold_tier::cold_sidecar_counters().record_enqueued();
+                self.discard_sliding_checkpoints_through(seq_id, checkpoint.boundary);
+            }
+            Ok(false) => crate::cold_tier::cold_sidecar_counters().record_queue_drop(),
+            Err(error) => tracing::debug!(
+                target: "mlx_core::muse_glimmer::paged",
+                "Muse-Glimmer sliding sidecar enqueue failed: {error}"
+            ),
+        }
+    }
+
+    pub(crate) fn release_paged_request(
+        &mut self,
+        seq_id: SeqId,
+    ) -> std::result::Result<u32, String> {
+        self.sliding_cold_checkpoints.remove(&seq_id);
+        self.paged
+            .as_mut()
+            .map_or(Ok(0), |paged| paged.coordinator.release_request_all(seq_id))
+    }
+
+    fn scaleless_rms_norm(&self, x: &MxArray) -> Result<MxArray> {
+        let handle = unsafe {
+            mlx_sys::mlx_fast_rms_norm(
+                x.as_raw_ptr(),
+                std::ptr::null_mut(),
+                self.config.text_config.rms_norm_eps,
+            )
+        };
+        MxArray::from_handle(handle, "muse_glimmer_embedding_norm")
+    }
+
+    fn project_logits(&self, hidden: &MxArray, last_only: bool) -> Result<MxArray> {
+        let hidden = if last_only {
+            let seq_len = hidden.shape_at(1)?;
+            hidden.slice_axis(1, seq_len - 1, seq_len)?
+        } else {
+            hidden.clone()
+        };
+        let normed = self.final_norm.forward(&hidden)?;
+        let logits = self
+            .lm_head
+            .forward(&normed)?
+            .mul_scalar(self.config.text_config.output_multiplier as f64)?;
+        let cap = self.config.text_config.final_logit_softcapping as f64;
+        logits.div_scalar(cap)?.tanh()?.mul_scalar(cap)
+    }
+
+    /// Target forward with optional post-layer hidden taps for DFlash.
+    pub(crate) fn forward_with_taps_mode(
+        &mut self,
+        input_ids: &MxArray,
+        tap_layers: &[usize],
+        last_only: bool,
+    ) -> Result<(MxArray, Vec<MxArray>)> {
+        let mut h = self.scaleless_rms_norm(&self.embed_tokens.forward(input_ids)?)?;
+        let mut taps = Vec::with_capacity(tap_layers.len());
+        for (index, layer) in self.layers.iter().enumerate() {
+            h = layer.forward(&h, &mut self.caches[index])?;
+            if tap_layers.contains(&index) {
+                taps.push(h.clone());
+            }
+        }
+
+        let logits = self.project_logits(&h, last_only)?;
+        Ok((logits, taps))
+    }
+
+    pub(crate) fn forward_with_taps(
+        &mut self,
+        input_ids: &MxArray,
+        tap_layers: &[usize],
+    ) -> Result<(MxArray, Vec<MxArray>)> {
+        self.forward_with_taps_mode(input_ids, tap_layers, true)
+    }
+
+    pub(crate) fn forward(&mut self, input_ids: &MxArray) -> Result<MxArray> {
+        self.forward_with_taps_mode(input_ids, &[], true)
+            .map(|(logits, _)| logits)
+    }
+
+    fn chunked_prefill(&mut self, prompt: &MxArray, stream: Stream) -> Result<MxArray> {
+        let total = prompt.shape_at(1)?;
+        let mut offset = 0;
+        while total - offset > PREFILL_STEP_SIZE {
+            if self
+                .turn_cancel
+                .as_ref()
+                .is_some_and(|flag| flag.load(Ordering::Relaxed))
+            {
+                return Err(Error::from_reason("prefill cancelled"));
+            }
+            let chunk = prompt.slice_axis(1, offset, offset + PREFILL_STEP_SIZE)?;
+            {
+                let _stream = StreamContext::new(stream);
+                let _ = self.forward(&chunk)?;
+            }
+            self.eval_caches()?;
+            crate::array::clear_cache();
+            offset += PREFILL_STEP_SIZE;
+        }
+        let remaining = prompt.slice_axis(1, offset, total)?;
+        let _stream = StreamContext::new(stream);
+        self.forward(&remaining)
+    }
+
+    pub(crate) fn set_active_paged_owner(&mut self, seq_id: SeqId) {
+        self.active_paged_seq = seq_id;
+        self.active_flat_session = false;
+    }
+
+    pub(crate) fn install_flat_owner_caches(&mut self, caches: Option<Vec<Gemma4LayerCache>>) {
+        self.active_paged_seq = 0;
+        self.active_flat_session = true;
+        self.caches = caches.unwrap_or_else(|| init_caches(&self.config));
+    }
+
+    pub(crate) fn take_flat_owner_caches(&mut self) -> Vec<Gemma4LayerCache> {
+        std::mem::replace(&mut self.caches, init_caches(&self.config))
+    }
+
+    pub(crate) fn select_ownerless_lane(&mut self, flat: bool) {
+        self.active_paged_seq = 0;
+        self.active_flat_session = flat;
+    }
+
+    fn run_paged_layer_loop(
+        &mut self,
+        tokens: &[u32],
+        first_logical_position: u32,
+        is_prefill: bool,
+    ) -> Result<MxArray> {
+        if tokens.is_empty() {
+            return Err(Error::from_reason(
+                "Muse-Glimmer paged forward requires at least one token",
+            ));
+        }
+        self.paged
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime is unavailable"))?
+            .coordinator
+            .record_tokens_all(self.active_paged_seq, tokens)
+            .map_err(Error::from_reason)?;
+        let ids = MxArray::from_uint32(tokens, &[1, tokens.len() as i64])?;
+        let mut hidden = self.scaleless_rms_norm(&self.embed_tokens.forward(&ids)?)?;
+        for index in 0..self.layers.len() {
+            let layer: &MuseGlimmerDecoderLayer = unsafe { &*self.layers.as_ptr().add(index) };
+            let (route, window) = {
+                let paged = self
+                    .paged
+                    .as_ref()
+                    .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime disappeared"))?;
+                let route = paged.routes.get(index).ok_or_else(|| {
+                    Error::from_reason(format!("Muse-Glimmer paged route missing layer {index}"))
+                })?;
+                let windows = if is_prefill {
+                    &paged.prefill_windows
+                } else {
+                    &paged.decode_windows
+                };
+                let window = *windows.get(route.group_id).ok_or_else(|| {
+                    Error::from_reason(format!(
+                        "Muse-Glimmer paged window missing group {}",
+                        route.group_id
+                    ))
+                })?;
+                (route.clone(), window)
+            };
+            let adapter = self
+                .paged
+                .as_mut()
+                .expect("checked Muse paged runtime")
+                .coordinator
+                .adapter_mut(route.group_id)
+                .map_err(Error::from_reason)?;
+            hidden = layer.forward_paged(
+                &hidden,
+                adapter,
+                u32::try_from(route.physical_layer_ordinal).map_err(|_| {
+                    Error::from_reason("Muse-Glimmer paged layer ordinal exceeds u32::MAX")
+                })?,
+                first_logical_position,
+                first_logical_position,
+                is_prefill,
+                window,
+            )?;
+            crate::array::maybe_eval_clear_for_paged_prefill_layer(index, &hidden)?;
+        }
+        self.paged
+            .as_mut()
+            .expect("checked Muse paged runtime")
+            .coordinator
+            .eval_pending_pool_writes_all()
+            .map_err(Error::from_reason)?;
+        self.remember_sliding_cold_checkpoints(self.active_paged_seq)?;
+        self.paged
+            .as_mut()
+            .expect("checked Muse paged runtime")
+            .coordinator
+            .prune_sliding_all(self.active_paged_seq)
+            .map_err(Error::from_reason)?;
+        Ok(hidden)
+    }
+
+    fn run_paged_prefill_slice(
+        &mut self,
+        tokens: &[u32],
+        first_logical_position: u32,
+    ) -> Result<MxArray> {
+        let hidden = self.run_paged_layer_loop(tokens, first_logical_position, true)?;
+        self.project_logits(&hidden, true)?.squeeze(Some(&[0, 1]))
+    }
+
+    fn run_paged_decode_step_for(&mut self, seq_id: SeqId, token: u32) -> Result<MxArray> {
+        self.set_active_paged_owner(seq_id);
+        let position = self
+            .paged
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime is unavailable"))?
+            .coordinator
+            .request_token_count_all(seq_id)
+            .map_err(Error::from_reason)?;
+        let hidden = self.run_paged_layer_loop(&[token], position, false)?;
+        self.project_logits(&hidden, false)
+    }
+
+    pub(crate) fn run_paged_decode_step_batched(
+        &mut self,
+        rows: &[(SeqId, u32)],
+    ) -> Result<MxArray> {
+        if rows.is_empty() {
+            return Err(Error::from_reason(
+                "Muse-Glimmer batched decode requires at least one row",
+            ));
+        }
+        let planned = {
+            let paged = self
+                .paged
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime is unavailable"))?;
+            rows.iter()
+                .map(|&(seq_id, _)| {
+                    paged
+                        .coordinator
+                        .request_token_count_all(seq_id)
+                        .map(|position| (seq_id, position))
+                        .map_err(Error::from_reason)
+                })
+                .collect::<Result<Vec<_>>>()?
+        };
+        let mut recorded = Vec::new();
+        for &(seq_id, token) in rows {
+            let result = self
+                .paged
+                .as_mut()
+                .expect("checked Muse paged runtime")
+                .coordinator
+                .record_tokens_all(seq_id, &[token]);
+            if let Err(error) = result {
+                for recorded_seq in recorded.into_iter().rev() {
+                    let _ = self
+                        .paged
+                        .as_mut()
+                        .expect("checked Muse paged runtime")
+                        .coordinator
+                        .rollback_last_tokens_all(recorded_seq, 1);
+                }
+                return Err(Error::from_reason(format!(
+                    "Muse-Glimmer batched token record failed for sequence {seq_id}: {error}"
+                )));
+            }
+            recorded.push(seq_id);
+        }
+        let ids = rows.iter().map(|&(_, token)| token).collect::<Vec<_>>();
+        let input = MxArray::from_uint32(&ids, &[rows.len() as i64, 1])?;
+        let mut hidden = self.scaleless_rms_norm(&self.embed_tokens.forward(&input)?)?;
+        for index in 0..self.layers.len() {
+            let layer: &MuseGlimmerDecoderLayer = unsafe { &*self.layers.as_ptr().add(index) };
+            let (route, window) = {
+                let paged = self.paged.as_ref().expect("checked Muse paged runtime");
+                let route = paged.routes[index].clone();
+                (route.clone(), paged.decode_windows[route.group_id])
+            };
+            let adapter = self
+                .paged
+                .as_mut()
+                .expect("checked Muse paged runtime")
+                .coordinator
+                .adapter_mut(route.group_id)
+                .map_err(Error::from_reason)?;
+            hidden = layer.forward_paged_batched(
+                &hidden,
+                adapter,
+                u32::try_from(route.physical_layer_ordinal).map_err(|_| {
+                    Error::from_reason("Muse-Glimmer paged layer ordinal exceeds u32::MAX")
+                })?,
+                &planned,
+                window,
+            )?;
+        }
+        self.project_logits(&hidden, false)
+    }
+}
+
+pub(crate) struct MusePagedDecode<'a> {
+    inner: &'a mut MuseGlimmerInner,
+}
+
+impl DecodeStep for MusePagedDecode<'_> {
+    fn forward_with_token(
+        &mut self,
+        _input_ids: &MxArray,
+        token_id: u32,
+    ) -> Result<(MxArray, bool)> {
+        Ok((
+            self.inner
+                .run_paged_decode_step_for(self.inner.active_paged_seq, token_id)?
+                .squeeze(Some(&[1]))?,
+            false,
+        ))
+    }
+
+    fn forward(&mut self, input_ids: &MxArray) -> Result<(MxArray, bool)> {
+        self.forward_with_token(input_ids, input_ids.item_at_int32(0)? as u32)
+    }
+
+    fn eval_step(&mut self, next_token: &MxArray, logits: &MxArray, _budget_forced: bool) {
+        MxArray::async_eval_arrays(&[next_token, logits]);
+    }
+
+    fn materialize_final(&mut self, token_id: u32) -> Result<()> {
+        let _ = self
+            .inner
+            .run_paged_decode_step_for(self.inner.active_paged_seq, token_id)?;
+        Ok(())
+    }
+}
+
+pub(crate) struct MusePrefixState {
+    effective_cached_prefix_len: usize,
+    suffix_len: usize,
+}
+
+impl PagedPrefix for MusePrefixState {
+    fn effective_cached_prefix_len(&self) -> usize {
+        self.effective_cached_prefix_len
+    }
+
+    fn suffix_len(&self) -> usize {
+        self.suffix_len
+    }
+}
+
+pub(crate) struct MuseGlimmerDecode<'a> {
+    inner: &'a mut MuseGlimmerInner,
+}
+
+impl DecodeStep for MuseGlimmerDecode<'_> {
+    fn forward(&mut self, input_ids: &MxArray) -> Result<(MxArray, bool)> {
+        Ok((self.inner.forward(input_ids)?, true))
+    }
+
+    fn eval_step(&mut self, next_token: &MxArray, _logits: &MxArray, _budget_forced: bool) {
+        MxArray::async_eval_arrays(&[next_token]);
+    }
+}
+
+struct MuseGlimmerEmitter {
+    guard: StreamGuard,
+}
+
+impl MuseGlimmerEmitter {
+    fn emit(text: String, sink: &dyn ChunkSink) {
+        if text.is_empty() {
+            return;
+        }
+        sink.send(Ok(ChatStreamChunk {
+            text,
+            done: false,
+            finish_reason: None,
+            tool_calls: None,
+            thinking: None,
+            thinking_enabled: None,
+            num_tokens: None,
+            prompt_tokens: None,
+            reasoning_tokens: None,
+            raw_text: None,
+            public_raw_text: None,
+            text_authoritative: None,
+            cached_tokens: None,
+            performance: None,
+            is_reasoning: Some(false),
+        }));
+    }
+}
+
+impl StreamEmitter for MuseGlimmerEmitter {
+    fn on_token_id(
+        &mut self,
+        token_id: u32,
+        _token_text: &str,
+        _is_reasoning: bool,
+        _include_reasoning: bool,
+        sink: &dyn ChunkSink,
+    ) {
+        if let GuardOutcome::Emit(text) = self.guard.push_id(token_id) {
+            Self::emit(text, sink);
+        }
+    }
+
+    fn on_token_text(
+        &mut self,
+        _token_text: &str,
+        _is_reasoning: bool,
+        _include_reasoning: bool,
+        _sink: &dyn ChunkSink,
+    ) {
+    }
+
+    fn on_residual(
+        &mut self,
+        _residual: &str,
+        _is_reasoning: bool,
+        _include_reasoning: bool,
+        _sink: &dyn ChunkSink,
+    ) {
+        // StreamGuard owns stateful detokenization; the generic detokenizer's
+        // residual would duplicate bytes here.
+    }
+
+    fn finish(&mut self, result: &ChatResult, sink: &dyn ChunkSink) {
+        Self::emit(self.guard.flush(), sink);
+        sink.send(Ok(ChatStreamChunk {
+            text: String::new(),
+            done: true,
+            finish_reason: Some(result.finish_reason.clone()),
+            tool_calls: Some(result.tool_calls.clone()),
+            thinking: result.thinking.clone(),
+            thinking_enabled: Some(result.thinking_enabled),
+            num_tokens: Some(result.num_tokens),
+            prompt_tokens: Some(result.prompt_tokens),
+            reasoning_tokens: Some(result.reasoning_tokens),
+            raw_text: Some(result.raw_text.clone()),
+            public_raw_text: result.public_raw_text.clone(),
+            text_authoritative: Some(false),
+            cached_tokens: Some(result.cached_tokens),
+            performance: result.performance.clone(),
+            is_reasoning: None,
+        }));
+    }
+}
+
+impl PagedBackend for MuseGlimmerInner {
+    type PagedDecode<'a>
+        = MusePagedDecode<'a>
+    where
+        Self: 'a;
+    type PrefixState = MusePrefixState;
+
+    fn prime_prefix_state(
+        &mut self,
+        plan: &[u32],
+        reuse_cache: bool,
+        _block_size: usize,
+        _extra_keys: &[u64],
+        cache_salt: u64,
+    ) -> Result<Self::PrefixState> {
+        let seq_id = self.active_paged_seq;
+        let cached = self.prepare_paged_text_request(seq_id, plan, cache_salt, reuse_cache)?;
+        let cached = if cached < plan.len() as u32 {
+            cached
+        } else {
+            self.paged
+                .as_mut()
+                .expect("checked Muse paged runtime")
+                .coordinator
+                .reset_scheduled_request(seq_id)
+                .map_err(Error::from_reason)?;
+            0
+        };
+        Ok(MusePrefixState {
+            effective_cached_prefix_len: cached as usize,
+            suffix_len: plan.len().saturating_sub(cached as usize),
+        })
+    }
+
+    fn paged_prefill(
+        &mut self,
+        suffix_tokens: &[u32],
+        prefix: &Self::PrefixState,
+        _stream: Stream,
+    ) -> Result<MxArray> {
+        self.run_paged_prefill_slice(suffix_tokens, prefix.effective_cached_prefix_len as u32)
+    }
+
+    fn begin_paged_decode(&mut self) -> Result<Self::PagedDecode<'_>> {
+        Ok(MusePagedDecode { inner: self })
+    }
+
+    fn finalize_paged_turn(&mut self, reuse_cache: bool, cache_salt: u64) {
+        let seq_id = self.active_paged_seq;
+        if self.paged.is_none() {
+            return;
+        }
+        let result = (|| -> std::result::Result<Vec<Vec<u64>>, String> {
+            let paged = self.paged.as_mut().expect("checked Muse paged runtime");
+            paged.coordinator.activate_request_all(seq_id)?;
+            paged.coordinator.eval_pending_pool_writes_all()?;
+            let full = paged.coordinator.full_adapter();
+            let extra = crate::engine::build_paged_extra_keys(
+                full.request_tokens().len(),
+                full.block_size(),
+                &[],
+            );
+            if reuse_cache {
+                paged
+                    .coordinator
+                    .finalize_keep_live_all(seq_id, &extra, cache_salt)?;
+            } else {
+                paged
+                    .coordinator
+                    .register_full_for_cold_capture(seq_id, &extra, cache_salt)?;
+            }
+            Ok(extra)
+        })();
+        if let Ok(extra) = result.as_ref() {
+            self.capture_sliding_cold_sidecar(seq_id, extra, cache_salt);
+            if !reuse_cache && let Err(error) = self.release_paged_request(seq_id) {
+                tracing::warn!("Muse-Glimmer paged release after cold capture failed: {error}");
+            }
+        }
+        if let Err(error) = result {
+            tracing::warn!("Muse-Glimmer paged finalize failed: {error}");
+            let _ = self.release_paged_request(seq_id);
+            self.cached_token_history.clear();
+        }
+    }
+
+    fn abort_paged_turn(&mut self) {
+        let _ = self.release_paged_request(self.active_paged_seq);
+        self.cached_token_history.clear();
+    }
+
+    fn save_paged_history(
+        &mut self,
+        save_tokens: &[u32],
+        generated: &[u32],
+        keep_all: bool,
+        reuse_cache: bool,
+    ) -> Result<()> {
+        if reuse_cache {
+            let mut history = save_tokens.to_vec();
+            let generated = if keep_all || generated.is_empty() {
+                generated
+            } else {
+                &generated[..generated.len() - 1]
+            };
+            history.extend_from_slice(generated);
+            self.cached_token_history = history;
+        } else {
+            self.cached_token_history.clear();
+        }
+        Ok(())
+    }
+
+    fn reconcile_paged_request_tokens(
+        &mut self,
+        prompt_len: usize,
+        generated: &[u32],
+        keep_all: bool,
+    ) -> bool {
+        let generated_len = if keep_all || generated.is_empty() {
+            generated.len()
+        } else {
+            generated.len() - 1
+        };
+        let target = prompt_len.saturating_add(generated_len);
+        let Some(paged) = self.paged.as_mut() else {
+            return false;
+        };
+        let Ok(current) = paged
+            .coordinator
+            .request_token_count_all(self.active_paged_seq)
+        else {
+            return false;
+        };
+        let surplus = (current as usize).saturating_sub(target);
+        surplus == 0
+            || paged
+                .coordinator
+                .rollback_last_tokens_all(self.active_paged_seq, surplus as u32)
+                .is_ok()
+    }
+}
+
+impl ChatBackend for MuseGlimmerInner {
+    fn tokenizer(&self) -> Result<Arc<Qwen3Tokenizer>> {
+        self.tokenizer
+            .clone()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer tokenizer not loaded"))
+    }
+
+    fn family_name(&self) -> &'static str {
+        "muse_glimmer"
+    }
+
+    fn set_turn_cancel_flag(&mut self, flag: Option<Arc<AtomicBool>>) {
+        self.turn_cancel = flag;
+    }
+
+    fn session_eos_id(&self, tok: &Qwen3Tokenizer) -> Result<u32> {
+        tok.token_to_id("<|eot|>".to_string()).ok_or_else(|| {
+            Error::from_reason("Muse-Glimmer tokenizer is missing the <|eot|> stop token")
+        })
+    }
+
+    fn policy(&self) -> ThinkingPolicy {
+        ThinkingPolicy::AlwaysOnBudgetFromEffort
+    }
+
+    fn resolve_params(&self, config: &ChatConfig) -> ChatParams {
+        let mut params = crate::engine::extract_chat_params(config);
+        if let Some(dflash) = self.dflash.as_ref() {
+            let (depth, adaptive) = resolve_dflash_schedule(
+                config.mtp_depth,
+                config.mtp_adaptive_depth,
+                dflash.config.block_size,
+            );
+            params.mtp_depth = depth;
+            params.mtp_adaptive_depth = adaptive;
+        }
+        params
+    }
+
+    fn generation_defaults(&self) -> Option<&crate::engine::ModelGenerationDefaults> {
+        Some(&self.gen_defaults)
+    }
+
+    fn extra_eos_ids(&self) -> Vec<u32> {
+        self.gen_defaults.eos_token_ids.clone()
+    }
+
+    fn cached_token_history(&self) -> &[u32] {
+        &self.cached_token_history
+    }
+
+    fn reset_caches(&mut self, _scope: ResetScope) -> Result<()> {
+        self.caches = init_caches(&self.config);
+        self.cached_token_history.clear();
+        if let Some(paged) = self.paged.as_mut()
+            && _scope == ResetScope::Command
+        {
+            paged
+                .coordinator
+                .release_all_and_purge()
+                .map_err(Error::from_reason)?;
+        }
+        Ok(())
+    }
+
+    fn verify_cache_prefix(&self, tokens: &[u32], reuse_cache: bool) -> usize {
+        if reuse_cache
+            && !self.cached_token_history.is_empty()
+            && tokens.len() > self.cached_token_history.len()
+            && tokens.starts_with(&self.cached_token_history)
+        {
+            self.cached_token_history.len()
+        } else {
+            0
+        }
+    }
+
+    fn save_cache_state(&mut self, args: SaveStateArgs<'_>) {
+        if args.is_delta || args.reuse_cache {
+            let mut history = args.save_tokens.to_vec();
+            if !args.generated_tokens.is_empty() {
+                history.extend_from_slice(
+                    &args.generated_tokens[..args.generated_tokens.len().saturating_sub(1)],
+                );
+            }
+            self.cached_token_history = history;
+        } else {
+            self.caches = init_caches(&self.config);
+            self.cached_token_history.clear();
+        }
+    }
+
+    fn eval_caches(&self) -> Result<()> {
+        let mut arrays = Vec::new();
+        for cache in &self.caches {
+            if let Some((k, v)) = cache.get_cached_kv() {
+                arrays.push(k);
+                arrays.push(v);
+            }
+        }
+        let refs: Vec<&MxArray> = arrays.iter().collect();
+        if !refs.is_empty() {
+            MxArray::eval_arrays(&refs)?;
+        }
+        Ok(())
+    }
+
+    fn prefill(&mut self, prompt_tokens: &[u32], stream: Stream) -> Result<MxArray> {
+        let tokens: Vec<i32> = prompt_tokens.iter().map(|&id| id as i32).collect();
+        let prompt = MxArray::from_int32(&tokens, &[1, tokens.len() as i64])?;
+        self.chunked_prefill(&prompt, stream)?.squeeze(Some(&[1]))
+    }
+
+    type Decode<'a>
+        = MuseGlimmerDecode<'a>
+    where
+        Self: 'a;
+
+    fn begin_decode(&mut self, _turn: &TurnSetup<'_>) -> Result<Self::Decode<'_>> {
+        Ok(MuseGlimmerDecode { inner: self })
+    }
+
+    fn finalize_turn(&self, args: FinalizeArgs<'_>) -> Result<ChatResult> {
+        let mut guard = StreamGuard::new(
+            args.tokenizer.inner_arc(),
+            1024,
+            args.generated_tokens.len().max(1),
+            4096,
+        );
+        let _ = guard.push_ids(args.generated_tokens);
+        let _ = guard.flush();
+        let parsed = self.response_template.parse(guard.generated_turn());
+        let raw_text = guard.raw_turn().0.to_string();
+        let tool_calls: Vec<ToolCallResult> = parsed
+            .tool_calls
+            .into_iter()
+            .map(|call| {
+                let raw = call.arguments.to_string();
+                ToolCallResult::ok(call.name, call.arguments, raw)
+            })
+            .collect();
+        let finish_reason = if tool_calls.is_empty() {
+            args.finish_reason
+        } else {
+            "tool_calls".to_string()
+        };
+        Ok(ChatResult {
+            text: parsed.content.unwrap_or_default(),
+            tool_calls,
+            thinking: args.include_reasoning.then_some(parsed.reasoning).flatten(),
+            thinking_enabled: args.thinking_enabled,
+            num_tokens: args.generated_tokens.len() as u32,
+            prompt_tokens: args.prompt_tokens,
+            reasoning_tokens: args.reasoning_tokens,
+            finish_reason,
+            raw_text,
+            public_raw_text: None,
+            cached_tokens: 0,
+            performance: args.performance,
+        })
+    }
+
+    fn stream_skip_special_tokens(&self) -> bool {
+        false
+    }
+
+    fn stream_emitter(&self) -> Box<dyn StreamEmitter> {
+        let tokenizer = self
+            .tokenizer
+            .as_ref()
+            .expect("loaded Muse-Glimmer tokenizer")
+            .inner_arc();
+        Box::new(MuseGlimmerEmitter {
+            guard: StreamGuard::new(tokenizer, 1024, usize::MAX, 4096),
+        })
+    }
+
+    fn eos_before_emit(&self) -> bool {
+        true
+    }
+
+    fn execution_plan(&self) -> ExecutionPlan {
+        let paged_available = self.paged.is_some() && !self.active_flat_session;
+        ExecutionPlan {
+            media: MediaPlan::NONE,
+            paged_attention: paged_available.then_some(PagedAttentionPlan {
+                supports_delta: true,
+            }),
+            speculative: self.dflash.as_ref().map(|_| SpeculativePlan {
+                kind: SpeculativeKind::DraftModel,
+                supported_input_media: crate::engine::plan::MediaCapabilities::NONE,
+                supported_context_media: crate::engine::plan::MediaCapabilities::NONE,
+                supports_paged_attention: false,
+            }),
+        }
+    }
+
+    fn run_speculative_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
+        self.dflash_chat_turn(args)
+    }
+
+    fn run_paged_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
+        crate::engine::paged_turn::run_paged_turn(self, args)
+    }
+
+    fn has_live_session(&self) -> bool {
+        if self.cached_token_history.is_empty() {
+            return false;
+        }
+        if self.active_flat_session {
+            return self.caches.iter().any(|cache| cache.get_offset() > 0);
+        }
+        self.paged
+            .as_ref()
+            .is_some_and(|paged| paged.coordinator.is_live_all(self.active_paged_seq))
+    }
+}
+
+#[napi]
+pub struct MuseGlimmerModel {
+    pub(crate) thread: ModelThread<MuseGlimmerCmd>,
+    pub(crate) has_dflash: bool,
+    pub(crate) paged_active: bool,
+    pub(crate) max_concurrent_sequences: u32,
+    pub(crate) _cache_limit_guard: crate::cache_limit::CacheLimitGuard,
+    pub(crate) _pool_cache_limit_guard: Option<crate::cache_limit::PoolCacheLimitGuard>,
+}
+
+#[napi]
+impl MuseGlimmerModel {
+    #[napi]
+    pub async fn load(model_path: String) -> Result<Self> {
+        super::persistence::load_with_thread(&model_path).await
+    }
+
+    #[napi]
+    pub fn has_mtp_weights(&self) -> bool {
+        self.has_dflash
+    }
+
+    #[napi]
+    pub fn auto_enables_mtp(&self) -> bool {
+        self.has_dflash
+    }
+
+    #[napi]
+    pub fn has_block_paged_cache(&self) -> bool {
+        self.paged_active
+    }
+
+    #[napi]
+    pub fn max_concurrent_sequences(&self) -> u32 {
+        if self.paged_active && !MuseSchedulerState::force_serial() {
+            self.max_concurrent_sequences.max(1)
+        } else {
+            1
+        }
+    }
+
+    #[napi]
+    pub async fn scheduler_stats(&self) -> Result<crate::engine::SchedulerStatsJs> {
+        crate::model_thread::send_and_await(&self.thread, |reply| MuseGlimmerCmd::SchedulerStats {
+            reply,
+        })
+        .await
+    }
+}
+
+crate::models::chat_napi::chat_napi_surface! {
+    class: MuseGlimmerModel,
+    thread_cmd: crate::models::muse_glimmer::model::MuseGlimmerCmd,
+    thread: direct,
+    image_guard: text_only,
+    ts_stream_start: "messages: ChatMessage[], config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void",
+    ts_stream_continue: "messages: ChatMessage[], config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void",
+    ts_stream_continue_tool: "messages: ChatMessage[], config: ChatConfig | null, callback: (err: Error | null, chunk: ChatStreamChunk) => void",
+}

--- a/crates/mlx-core/src/models/muse_glimmer/model.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/model.rs
@@ -101,7 +101,11 @@ pub(crate) struct MuseGlimmerInner {
     pub(crate) embed_tokens: Embedding,
     pub(crate) layers: Vec<MuseGlimmerDecoderLayer>,
     pub(crate) final_norm: RMSNorm,
-    pub(crate) lm_head: LinearProj,
+    /// Explicit output projection for untied checkpoints. Tied checkpoints
+    /// project through `embed_tokens.as_linear()` so packed embeddings remain
+    /// packed-resident and a separate `lm_head.weight` is neither required nor
+    /// consulted.
+    pub(crate) lm_head: Option<LinearProj>,
     pub(crate) caches: Vec<Gemma4LayerCache>,
     pub(crate) tokenizer: Option<Arc<Qwen3Tokenizer>>,
     pub(crate) response_template: Arc<ResponseTemplate>,
@@ -138,7 +142,7 @@ impl MuseGlimmerInner {
         embed_tokens: Embedding,
         layers: Vec<MuseGlimmerDecoderLayer>,
         final_norm: RMSNorm,
-        lm_head: LinearProj,
+        lm_head: Option<LinearProj>,
         tokenizer: Arc<Qwen3Tokenizer>,
         response_template: ResponseTemplate,
         gen_defaults: crate::engine::ModelGenerationDefaults,
@@ -605,10 +609,11 @@ impl MuseGlimmerInner {
             hidden.clone()
         };
         let normed = self.final_norm.forward(&hidden)?;
-        let logits = self
-            .lm_head
-            .forward(&normed)?
-            .mul_scalar(self.config.text_config.output_multiplier as f64)?;
+        let logits = match self.lm_head.as_ref() {
+            Some(lm_head) => lm_head.forward(&normed)?,
+            None => self.embed_tokens.as_linear(&normed)?,
+        }
+        .mul_scalar(self.config.text_config.output_multiplier as f64)?;
         let cap = self.config.text_config.final_logit_softcapping as f64;
         logits.div_scalar(cap)?.tanh()?.mul_scalar(cap)
     }

--- a/crates/mlx-core/src/models/muse_glimmer/model.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/model.rs
@@ -10,7 +10,7 @@ use crate::array::MxArray;
 use crate::engine::ThinkingPolicy;
 use crate::engine::backend::{
     ChatBackend, ChunkSink, DecodeStep, FinalizeArgs, PagedBackend, PagedPrefix, ResetScope,
-    SaveStateArgs, StreamEmitter, TurnOutput, TurnSetup, WholeTurnArgs,
+    SaveStateArgs, StreamEmitter, TurnOutput, TurnSetup, TurnTokenObserver, WholeTurnArgs,
 };
 use crate::engine::cmd::{ChatCmd, FromChatCmd};
 use crate::engine::params::ChatParams;
@@ -941,7 +941,22 @@ impl DecodeStep for MuseGlimmerDecode<'_> {
 
 struct MuseGlimmerEmitter {
     guard: StreamGuard,
-    pending: VecDeque<(u32, Option<String>)>,
+}
+
+struct MuseGlimmerTurnObserver {
+    tokenizer: Arc<tokenizers::Tokenizer>,
+    guard: StreamGuard,
+    observed_tokens: Vec<u32>,
+}
+
+impl MuseGlimmerTurnObserver {
+    fn new(tokenizer: Arc<tokenizers::Tokenizer>) -> Self {
+        Self {
+            guard: StreamGuard::new(tokenizer.clone(), 1024, usize::MAX, 4096),
+            tokenizer,
+            observed_tokens: Vec::new(),
+        }
+    }
 }
 
 impl MuseGlimmerEmitter {
@@ -969,18 +984,20 @@ impl MuseGlimmerEmitter {
     }
 }
 
-impl StreamEmitter for MuseGlimmerEmitter {
+impl TurnTokenObserver for MuseGlimmerTurnObserver {
     fn observe_token_id(&mut self, token_id: u32) -> bool {
-        let outcome = self.guard.push_id(token_id);
-        let ended = matches!(outcome, GuardOutcome::EndTurn);
-        let text = match outcome {
-            GuardOutcome::Emit(text) => Some(text),
-            GuardOutcome::Hold | GuardOutcome::EndTurn => None,
-        };
-        self.pending.push_back((token_id, text));
-        ended
+        self.observed_tokens.push(token_id);
+        matches!(self.guard.push_id(token_id), GuardOutcome::EndTurn)
     }
 
+    fn rollback_last_token(&mut self) {
+        let _ = self.observed_tokens.pop();
+        self.guard = StreamGuard::new(self.tokenizer.clone(), 1024, usize::MAX, 4096);
+        let _ = self.guard.push_ids(&self.observed_tokens);
+    }
+}
+
+impl StreamEmitter for MuseGlimmerEmitter {
     fn on_token_id(
         &mut self,
         token_id: u32,
@@ -989,14 +1006,9 @@ impl StreamEmitter for MuseGlimmerEmitter {
         _include_reasoning: bool,
         sink: &dyn ChunkSink,
     ) {
-        let text = match self.pending.front() {
-            Some((pending_id, _)) if *pending_id == token_id => {
-                self.pending.pop_front().and_then(|(_, text)| text)
-            }
-            _ => match self.guard.push_id(token_id) {
-                GuardOutcome::Emit(text) => Some(text),
-                GuardOutcome::Hold | GuardOutcome::EndTurn => None,
-            },
+        let text = match self.guard.push_id(token_id) {
+            GuardOutcome::Emit(text) => Some(text),
+            GuardOutcome::Hold | GuardOutcome::EndTurn => None,
         };
         if let Some(text) = text {
             Self::emit(text, sink);
@@ -1364,8 +1376,16 @@ impl ChatBackend for MuseGlimmerInner {
             .inner_arc();
         Box::new(MuseGlimmerEmitter {
             guard: StreamGuard::new(tokenizer, 1024, usize::MAX, 4096),
-            pending: VecDeque::new(),
         })
+    }
+
+    fn turn_token_observer(&self) -> Option<Box<dyn TurnTokenObserver>> {
+        let tokenizer = self
+            .tokenizer
+            .as_ref()
+            .expect("loaded Muse-Glimmer tokenizer")
+            .inner_arc();
+        Some(Box::new(MuseGlimmerTurnObserver::new(tokenizer)))
     }
 
     fn eos_before_emit(&self) -> bool {

--- a/crates/mlx-core/src/models/muse_glimmer/model.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/model.rs
@@ -116,6 +116,10 @@ pub(crate) struct MuseGlimmerInner {
     pub(crate) dflash_turn_state: Option<super::dflash_decode::DFlashTurnState>,
     pub(crate) dflash_context: Option<super::dflash::DFlashContextCache>,
     pub(crate) paged: Option<MusePagedRuntime>,
+    /// Affine and GGML K-quant projections can select numerically distinct
+    /// Metal reduction kernels for `B > 1`. Preserve each decode row's
+    /// singleton projection graph while paged attention remains batched.
+    pub(crate) row_exact_decode_projections: bool,
     pub(crate) active_paged_seq: u32,
     pub(crate) active_flat_session: bool,
     sliding_cold_checkpoints: HashMap<SeqId, VecDeque<MuseSlidingColdCheckpoint>>,
@@ -167,6 +171,7 @@ impl MuseGlimmerInner {
             dflash_turn_state: None,
             dflash_context: None,
             paged,
+            row_exact_decode_projections: false,
             active_paged_seq: 0,
             active_flat_session: false,
             sliding_cold_checkpoints: HashMap::new(),
@@ -870,9 +875,16 @@ impl MuseGlimmerInner {
                 })?,
                 &planned,
                 window,
+                self.row_exact_decode_projections,
             )?;
         }
-        self.project_logits(&hidden, false)
+        if self.row_exact_decode_projections && rows.len() > 1 {
+            super::row_exact::forward_rows_independently(&hidden, |row| {
+                self.project_logits(row, false)
+            })
+        } else {
+            self.project_logits(&hidden, false)
+        }
     }
 }
 

--- a/crates/mlx-core/src/models/muse_glimmer/model.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/model.rs
@@ -114,6 +114,7 @@ pub(crate) struct MuseGlimmerInner {
     pub(crate) gen_defaults: crate::engine::ModelGenerationDefaults,
     pub(crate) dflash: Option<DFlashModel>,
     pub(crate) dflash_turn_state: Option<super::dflash_decode::DFlashTurnState>,
+    pub(crate) dflash_context: Option<super::dflash::DFlashContextCache>,
     pub(crate) paged: Option<MusePagedRuntime>,
     pub(crate) active_paged_seq: u32,
     pub(crate) active_flat_session: bool,
@@ -164,6 +165,7 @@ impl MuseGlimmerInner {
             gen_defaults,
             dflash,
             dflash_turn_state: None,
+            dflash_context: None,
             paged,
             active_paged_seq: 0,
             active_flat_session: false,
@@ -939,6 +941,7 @@ impl DecodeStep for MuseGlimmerDecode<'_> {
 
 struct MuseGlimmerEmitter {
     guard: StreamGuard,
+    pending: VecDeque<(u32, Option<String>)>,
 }
 
 impl MuseGlimmerEmitter {
@@ -967,6 +970,17 @@ impl MuseGlimmerEmitter {
 }
 
 impl StreamEmitter for MuseGlimmerEmitter {
+    fn observe_token_id(&mut self, token_id: u32) -> bool {
+        let outcome = self.guard.push_id(token_id);
+        let ended = matches!(outcome, GuardOutcome::EndTurn);
+        let text = match outcome {
+            GuardOutcome::Emit(text) => Some(text),
+            GuardOutcome::Hold | GuardOutcome::EndTurn => None,
+        };
+        self.pending.push_back((token_id, text));
+        ended
+    }
+
     fn on_token_id(
         &mut self,
         token_id: u32,
@@ -975,7 +989,16 @@ impl StreamEmitter for MuseGlimmerEmitter {
         _include_reasoning: bool,
         sink: &dyn ChunkSink,
     ) {
-        if let GuardOutcome::Emit(text) = self.guard.push_id(token_id) {
+        let text = match self.pending.front() {
+            Some((pending_id, _)) if *pending_id == token_id => {
+                self.pending.pop_front().and_then(|(_, text)| text)
+            }
+            _ => match self.guard.push_id(token_id) {
+                GuardOutcome::Emit(text) => Some(text),
+                GuardOutcome::Hold | GuardOutcome::EndTurn => None,
+            },
+        };
+        if let Some(text) = text {
             Self::emit(text, sink);
         }
     }
@@ -1219,6 +1242,8 @@ impl ChatBackend for MuseGlimmerInner {
     fn reset_caches(&mut self, _scope: ResetScope) -> Result<()> {
         self.caches = init_caches(&self.config);
         self.cached_token_history.clear();
+        self.dflash_turn_state = None;
+        self.dflash_context = None;
         if let Some(paged) = self.paged.as_mut()
             && _scope == ResetScope::Command
         {
@@ -1339,6 +1364,7 @@ impl ChatBackend for MuseGlimmerInner {
             .inner_arc();
         Box::new(MuseGlimmerEmitter {
             guard: StreamGuard::new(tokenizer, 1024, usize::MAX, 4096),
+            pending: VecDeque::new(),
         })
     }
 

--- a/crates/mlx-core/src/models/muse_glimmer/persistence.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/persistence.rs
@@ -393,6 +393,13 @@ fn build_paged_runtime(config: &MuseGlimmerConfig) -> Result<Option<MusePagedRun
     }))
 }
 
+fn load_target_safetensors(path: &Path) -> Result<HashMap<String, MxArray>> {
+    // Muse-Glimmer execution is text-only today. Keep the optional
+    // vision.safetensors sidecar out of residency accounting and cold-tier
+    // materialization until a vision forward path consumes it.
+    load_all_safetensors(path, false)
+}
+
 fn load_inner(path: &Path) -> Result<(MuseGlimmerInner, u64)> {
     let config = MuseGlimmerConfig::from_path(path)?;
     let persist_env = std::env::var("MLX_PERSIST_PAGED_CACHE").ok();
@@ -406,7 +413,7 @@ fn load_inner(path: &Path) -> Result<(MuseGlimmerInner, u64)> {
     } else {
         None
     };
-    let params = load_all_safetensors(path, true)?;
+    let params = load_target_safetensors(path)?;
     let shard_snapshot_at_mmap = if persist_cold {
         snapshot_shard_identities(path)
     } else {
@@ -616,10 +623,22 @@ pub(crate) async fn load_with_thread(model_path: &str) -> Result<MuseGlimmerMode
 
 #[cfg(test)]
 mod tests {
-    use super::{load_lm_head, quant_lookup_prefix};
+    use super::{load_lm_head, load_target_safetensors, quant_lookup_prefix};
     use crate::array::MxArray;
     use crate::models::gemma4::quantized_linear::{PerLayerMode, PerLayerQuant};
+    use crate::utils::safetensors::save_safetensors;
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn save_one(path: &std::path::Path, key: &str, value: f32) {
+        let mut tensors = HashMap::from([(
+            key.to_string(),
+            MxArray::from_float32(&[value], &[1]).expect("create test tensor"),
+        )]);
+        save_safetensors(path, &mut tensors, None).expect("save test safetensors");
+    }
 
     #[test]
     fn target_and_dflash_quantization_namespaces_stay_distinct() {
@@ -636,6 +655,25 @@ mod tests {
             "language_model.embed_tokens"
         );
         assert_eq!(quant_lookup_prefix("lm_head"), "lm_head");
+    }
+
+    #[test]
+    fn text_runtime_excludes_the_unused_vision_sidecar() {
+        let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "muse_glimmer_text_weights_{}_{}",
+            std::process::id(),
+            id
+        ));
+        std::fs::create_dir_all(&dir).expect("create model directory");
+        save_one(&dir.join("model.safetensors"), "text.weight", 1.0);
+        save_one(&dir.join("vision.safetensors"), "vision.weight", 2.0);
+
+        let weights = load_target_safetensors(&dir).expect("load Muse target weights");
+        assert!(weights.contains_key("text.weight"));
+        assert!(!weights.contains_key("vision.weight"));
+
+        std::fs::remove_dir_all(dir).ok();
     }
 
     #[test]

--- a/crates/mlx-core/src/models/muse_glimmer/persistence.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/persistence.rs
@@ -123,25 +123,16 @@ fn load_embedding(
     Ok(embedding)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::quant_lookup_prefix;
-
-    #[test]
-    fn target_and_dflash_quantization_namespaces_stay_distinct() {
-        assert_eq!(
-            quant_lookup_prefix("model.language_model.layers.0.self_attn.q_proj"),
-            "language_model.layers.0.self_attn.q_proj"
-        );
-        assert_eq!(
-            quant_lookup_prefix("layers.0.self_attn.q_proj"),
-            "layers.0.self_attn.q_proj"
-        );
-        assert_eq!(
-            quant_lookup_prefix("model.language_model.embed_tokens"),
-            "language_model.embed_tokens"
-        );
-        assert_eq!(quant_lookup_prefix("lm_head"), "lm_head");
+fn load_lm_head(
+    params: &HashMap<String, MxArray>,
+    tie_word_embeddings: bool,
+    default: PerLayerQuant,
+    overrides: &HashMap<String, PerLayerQuant>,
+) -> Result<Option<LinearProj>> {
+    if tie_word_embeddings {
+        Ok(None)
+    } else {
+        build_projection(params, "lm_head", default, overrides).map(Some)
     }
 }
 
@@ -446,7 +437,7 @@ fn load_inner(path: &Path) -> Result<(MuseGlimmerInner, u64)> {
         default,
         &overrides,
     )?;
-    let lm_head = build_projection(&params, "lm_head", default, &overrides)?;
+    let lm_head = load_lm_head(&params, text.tie_word_embeddings, default, &overrides)?;
     let final_norm = norm(
         &params,
         "model.language_model.norm.weight",
@@ -621,4 +612,52 @@ pub(crate) async fn load_with_thread(model_path: &str) -> Result<MuseGlimmerMode
         _cache_limit_guard: cache_limit_guard,
         _pool_cache_limit_guard: pool_cache_limit_guard,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{load_lm_head, quant_lookup_prefix};
+    use crate::array::MxArray;
+    use crate::models::gemma4::quantized_linear::{PerLayerMode, PerLayerQuant};
+    use std::collections::HashMap;
+
+    #[test]
+    fn target_and_dflash_quantization_namespaces_stay_distinct() {
+        assert_eq!(
+            quant_lookup_prefix("model.language_model.layers.0.self_attn.q_proj"),
+            "language_model.layers.0.self_attn.q_proj"
+        );
+        assert_eq!(
+            quant_lookup_prefix("layers.0.self_attn.q_proj"),
+            "layers.0.self_attn.q_proj"
+        );
+        assert_eq!(
+            quant_lookup_prefix("model.language_model.embed_tokens"),
+            "language_model.embed_tokens"
+        );
+        assert_eq!(quant_lookup_prefix("lm_head"), "lm_head");
+    }
+
+    #[test]
+    fn tied_embeddings_do_not_require_an_lm_head_tensor() {
+        let params = HashMap::<String, MxArray>::new();
+        let overrides = HashMap::new();
+        let default = PerLayerQuant {
+            bits: 4,
+            group_size: 64,
+            mode: PerLayerMode::Affine,
+            input_amax: None,
+        };
+
+        assert!(
+            load_lm_head(&params, true, default, &overrides)
+                .expect("tied embedding head")
+                .is_none()
+        );
+        let error = match load_lm_head(&params, false, default, &overrides) {
+            Ok(_) => panic!("untied checkpoint must still require lm_head.weight"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("lm_head.weight"), "{error}");
+    }
 }

--- a/crates/mlx-core/src/models/muse_glimmer/persistence.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/persistence.rs
@@ -485,15 +485,23 @@ fn canonicalize_target_weights(
     Ok(canonical)
 }
 
-fn load_target_safetensors(path: &Path) -> Result<HashMap<String, MxArray>> {
+fn load_target_safetensors(
+    path: &Path,
+    tie_word_embeddings: bool,
+) -> Result<HashMap<String, MxArray>> {
     // Muse-Glimmer execution is text-only today. Keep the optional
     // vision.safetensors sidecar and any vision tensors embedded in the
     // primary shards out of residency accounting and cold-tier materialization
-    // until a vision forward path consumes them.
+    // until a vision forward path consumes them. Tied checkpoints may also
+    // carry a redundant lm_head quantization group; logits use the embedding
+    // table, so exclude the whole unused group before the same accounting.
     let norms_are_direct = primary_safetensor_is_mlx(path)?;
     let mut params =
         canonicalize_target_weights(load_all_safetensors(path, false)?, norms_are_direct)?;
-    params.retain(|key, _| key.starts_with("model.language_model.") || key.starts_with("lm_head."));
+    params.retain(|key, _| {
+        key.starts_with("model.language_model.")
+            || (!tie_word_embeddings && key.starts_with("lm_head."))
+    });
     Ok(params)
 }
 
@@ -521,7 +529,7 @@ fn load_inner(path: &Path) -> Result<(MuseGlimmerInner, u64)> {
     } else {
         None
     };
-    let params = load_target_safetensors(path)?;
+    let params = load_target_safetensors(path, config.text_config.tie_word_embeddings)?;
     let shard_snapshot_at_mmap = if persist_cold {
         snapshot_shard_identities(path)
     } else {
@@ -882,7 +890,7 @@ mod tests {
     }
 
     #[test]
-    fn text_runtime_excludes_inline_vision_weights_and_the_unused_sidecar() {
+    fn text_runtime_excludes_unused_weights_before_residency() {
         let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
         let dir = std::env::temp_dir().join(format!(
             "muse_glimmer_text_weights_{}_{}",
@@ -903,6 +911,18 @@ mod tests {
                 "vision_adapter.fc1.weight".to_string(),
                 MxArray::from_float32(&[3.0], &[1]).expect("create adapter tensor"),
             ),
+            (
+                "language_model.model.lm_head.weight".to_string(),
+                MxArray::from_float32(&[4.0], &[1]).expect("create lm head weight"),
+            ),
+            (
+                "language_model.model.lm_head.scales".to_string(),
+                MxArray::from_float32(&[5.0], &[1]).expect("create lm head scales"),
+            ),
+            (
+                "language_model.model.lm_head.biases".to_string(),
+                MxArray::from_float32(&[6.0], &[1]).expect("create lm head biases"),
+            ),
         ]);
         save_safetensors(
             dir.join("model.safetensors"),
@@ -912,11 +932,21 @@ mod tests {
         .expect("save mixed Muse safetensors");
         save_one(&dir.join("vision.safetensors"), "vision.weight", 2.0);
 
-        let weights = load_target_safetensors(&dir).expect("load Muse target weights");
-        assert!(weights.contains_key("model.language_model.embed_tokens.weight"));
-        assert!(!weights.contains_key("vision_tower.layers.0.attn.q_proj.weight"));
-        assert!(!weights.contains_key("vision_adapter.fc1.weight"));
-        assert!(!weights.contains_key("vision.weight"));
+        let untied = load_target_safetensors(&dir, false).expect("load untied Muse weights");
+        assert!(untied.contains_key("model.language_model.embed_tokens.weight"));
+        assert!(untied.contains_key("lm_head.weight"));
+        assert!(untied.contains_key("lm_head.scales"));
+        assert!(untied.contains_key("lm_head.biases"));
+        assert!(!untied.contains_key("vision_tower.layers.0.attn.q_proj.weight"));
+        assert!(!untied.contains_key("vision_adapter.fc1.weight"));
+        assert!(!untied.contains_key("vision.weight"));
+
+        let tied = load_target_safetensors(&dir, true).expect("load tied Muse weights");
+        assert!(tied.contains_key("model.language_model.embed_tokens.weight"));
+        assert!(!tied.keys().any(|key| key.starts_with("lm_head.")));
+        assert!(!tied.contains_key("vision_tower.layers.0.attn.q_proj.weight"));
+        assert!(!tied.contains_key("vision_adapter.fc1.weight"));
+        assert!(!tied.contains_key("vision.weight"));
 
         std::fs::remove_dir_all(dir).ok();
     }

--- a/crates/mlx-core/src/models/muse_glimmer/persistence.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/persistence.rs
@@ -487,10 +487,14 @@ fn canonicalize_target_weights(
 
 fn load_target_safetensors(path: &Path) -> Result<HashMap<String, MxArray>> {
     // Muse-Glimmer execution is text-only today. Keep the optional
-    // vision.safetensors sidecar out of residency accounting and cold-tier
-    // materialization until a vision forward path consumes it.
+    // vision.safetensors sidecar and any vision tensors embedded in the
+    // primary shards out of residency accounting and cold-tier materialization
+    // until a vision forward path consumes them.
     let norms_are_direct = primary_safetensor_is_mlx(path)?;
-    canonicalize_target_weights(load_all_safetensors(path, false)?, norms_are_direct)
+    let mut params =
+        canonicalize_target_weights(load_all_safetensors(path, false)?, norms_are_direct)?;
+    params.retain(|key, _| key.starts_with("model.language_model.") || key.starts_with("lm_head."));
+    Ok(params)
 }
 
 fn requires_row_exact_decode_projections(
@@ -878,7 +882,7 @@ mod tests {
     }
 
     #[test]
-    fn text_runtime_excludes_the_unused_vision_sidecar() {
+    fn text_runtime_excludes_inline_vision_weights_and_the_unused_sidecar() {
         let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
         let dir = std::env::temp_dir().join(format!(
             "muse_glimmer_text_weights_{}_{}",
@@ -886,11 +890,32 @@ mod tests {
             id
         ));
         std::fs::create_dir_all(&dir).expect("create model directory");
-        save_one(&dir.join("model.safetensors"), "text.weight", 1.0);
+        let mut primary = HashMap::from([
+            (
+                "language_model.model.embed_tokens.weight".to_string(),
+                MxArray::from_float32(&[1.0], &[1]).expect("create text tensor"),
+            ),
+            (
+                "vision_tower.layers.0.attn.q_proj.weight".to_string(),
+                MxArray::from_float32(&[2.0], &[1]).expect("create vision tensor"),
+            ),
+            (
+                "vision_adapter.fc1.weight".to_string(),
+                MxArray::from_float32(&[3.0], &[1]).expect("create adapter tensor"),
+            ),
+        ]);
+        save_safetensors(
+            dir.join("model.safetensors"),
+            &mut primary,
+            Some(serde_json::json!({"format": "mlx"})),
+        )
+        .expect("save mixed Muse safetensors");
         save_one(&dir.join("vision.safetensors"), "vision.weight", 2.0);
 
         let weights = load_target_safetensors(&dir).expect("load Muse target weights");
-        assert!(weights.contains_key("text.weight"));
+        assert!(weights.contains_key("model.language_model.embed_tokens.weight"));
+        assert!(!weights.contains_key("vision_tower.layers.0.attn.q_proj.weight"));
+        assert!(!weights.contains_key("vision_adapter.fc1.weight"));
         assert!(!weights.contains_key("vision.weight"));
 
         std::fs::remove_dir_all(dir).ok();

--- a/crates/mlx-core/src/models/muse_glimmer/persistence.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/persistence.rs
@@ -13,16 +13,16 @@ use crate::models::gemma4::quantized_linear::{
     try_build_nvfp4_quantized_linear, try_build_quantized_linear, try_build_sym8_quantized_linear,
 };
 use crate::models::quant_dispatch::{
-    PerLayerMode, PerLayerQuant, effective_plq_for, ensure_affine_biases_present,
-    ensure_dense_weight_floating, ensure_int8_storage_resolves_sym8,
-    ensure_kquant_storage_resolves_kquant, ensure_plain_fp8_storage_resolves_fp8_e4m3,
-    has_kquant_mode, load_quant_settings_from_disk, mode_to_str, normalize_per_layer_key,
+    PerLayerMode, PerLayerQuant, ensure_affine_biases_present, ensure_dense_weight_floating,
+    ensure_int8_storage_resolves_sym8, ensure_kquant_storage_resolves_kquant,
+    ensure_plain_fp8_storage_resolves_fp8_e4m3, has_kquant_mode, load_quant_settings_from_disk,
+    mode_to_str, normalize_per_layer_key,
 };
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::tokenizer::Qwen3Tokenizer;
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
 use crate::transformer::{AttentionKind, KVCacheDType};
-use crate::utils::safetensors::load_safetensors_lazy;
+use crate::utils::safetensors::{SafeTensorsFile, load_safetensors_lazy};
 
 use super::attention::MuseGlimmerAttention;
 use super::config::MuseGlimmerConfig;
@@ -46,14 +46,27 @@ fn quant_lookup_prefix(prefix: &str) -> String {
     normalize_per_layer_key(&crate::utils::normalize_override_key(prefix))
 }
 
+fn muse_projection_quant(
+    prefix: &str,
+    overrides: &HashMap<String, PerLayerQuant>,
+    default: PerLayerQuant,
+) -> PerLayerQuant {
+    let scoped = quant_lookup_prefix(prefix);
+    let bare = normalize_per_layer_key(prefix);
+    overrides
+        .get(&scoped)
+        .or_else(|| overrides.get(&bare))
+        .copied()
+        .unwrap_or(default)
+}
+
 pub(super) fn build_projection(
     params: &HashMap<String, MxArray>,
     prefix: &str,
     default: PerLayerQuant,
     overrides: &HashMap<String, PerLayerQuant>,
 ) -> Result<LinearProj> {
-    let quant_prefix = quant_lookup_prefix(prefix);
-    let plq = effective_plq_for(&quant_prefix, overrides, default, None);
+    let plq = muse_projection_quant(prefix, overrides, default);
     let scales_key = format!("{prefix}.scales");
     if params.contains_key(&scales_key) {
         ensure_int8_storage_resolves_sym8(params, prefix, plq.mode, "muse_glimmer")?;
@@ -99,8 +112,7 @@ fn load_embedding(
     let mut embedding = Embedding::new_uninitialized(vocab as u32, hidden as u32)?;
     let weight = required(params, &format!("{prefix}.weight"))?;
     if let Some(scales) = params.get(&format!("{prefix}.scales")) {
-        let quant_prefix = quant_lookup_prefix(prefix);
-        let plq = effective_plq_for(&quant_prefix, overrides, default, None);
+        let plq = muse_projection_quant(prefix, overrides, default);
         if matches!(plq.mode, PerLayerMode::Sym8 | PerLayerMode::Fp8E4m3) {
             return Err(Error::from_reason(format!(
                 "Muse-Glimmer embedding '{prefix}' does not support {:?}",
@@ -393,11 +405,92 @@ fn build_paged_runtime(config: &MuseGlimmerConfig) -> Result<Option<MusePagedRun
     }))
 }
 
+fn primary_safetensor_is_mlx(path: &Path) -> Result<bool> {
+    let primary = if path.join("weights.safetensors").is_file() {
+        path.join("weights.safetensors")
+    } else if path.join("model.safetensors").is_file() {
+        path.join("model.safetensors")
+    } else {
+        let mut shards = std::fs::read_dir(path)
+            .map_err(|error| {
+                Error::from_reason(format!(
+                    "Failed to inspect Muse-Glimmer checkpoint directory: {error}"
+                ))
+            })?
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|file| {
+                let name = file
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or_default();
+                (name.starts_with("model-") || name.starts_with("model.safetensors-"))
+                    && name.ends_with(".safetensors")
+                    && name.contains("-of-")
+            })
+            .collect::<Vec<_>>();
+        shards.sort();
+        shards.into_iter().next().ok_or_else(|| {
+            Error::from_reason(format!(
+                "No model SafeTensors file found in {}",
+                path.display()
+            ))
+        })?
+    };
+    Ok(SafeTensorsFile::load(&primary)?
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("format"))
+        .and_then(serde_json::Value::as_str)
+        == Some("mlx"))
+}
+
+fn canonicalize_target_weights(
+    params: HashMap<String, MxArray>,
+    norms_are_direct: bool,
+) -> Result<HashMap<String, MxArray>> {
+    let mut canonical = HashMap::with_capacity(params.len());
+    for (source_key, array) in params {
+        let key = if let Some(rest) = source_key.strip_prefix("language_model.model.lm_head.") {
+            format!("lm_head.{rest}")
+        } else if let Some(rest) = source_key.strip_prefix("language_model.lm_head.") {
+            format!("lm_head.{rest}")
+        } else if let Some(rest) = source_key.strip_prefix("language_model.model.") {
+            format!("model.language_model.{rest}")
+        } else {
+            source_key.clone()
+        };
+        let is_centered_sandwich_norm = key
+            .strip_prefix("model.language_model.layers.")
+            .is_some_and(|rest| {
+                [
+                    ".input_layernorm.weight",
+                    ".post_attention_layernorm.weight",
+                    ".pre_feedforward_layernorm.weight",
+                    ".post_feedforward_layernorm.weight",
+                ]
+                .iter()
+                .any(|suffix| rest.ends_with(suffix))
+            });
+        let array = if !norms_are_direct && is_centered_sandwich_norm {
+            array.add_scalar(1.0)?
+        } else {
+            array
+        };
+        if canonical.insert(key.clone(), array).is_some() {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer checkpoint contains duplicate canonical tensor '{key}'"
+            )));
+        }
+    }
+    Ok(canonical)
+}
+
 fn load_target_safetensors(path: &Path) -> Result<HashMap<String, MxArray>> {
     // Muse-Glimmer execution is text-only today. Keep the optional
     // vision.safetensors sidecar out of residency accounting and cold-tier
     // materialization until a vision forward path consumes it.
-    load_all_safetensors(path, false)
+    let norms_are_direct = primary_safetensor_is_mlx(path)?;
+    canonicalize_target_weights(load_all_safetensors(path, false)?, norms_are_direct)
 }
 
 fn requires_row_exact_decode_projections(
@@ -637,8 +730,8 @@ pub(crate) async fn load_with_thread(model_path: &str) -> Result<MuseGlimmerMode
 #[cfg(test)]
 mod tests {
     use super::{
-        load_lm_head, load_target_safetensors, quant_lookup_prefix,
-        requires_row_exact_decode_projections,
+        canonicalize_target_weights, load_lm_head, load_target_safetensors, muse_projection_quant,
+        primary_safetensor_is_mlx, quant_lookup_prefix, requires_row_exact_decode_projections,
     };
     use crate::array::MxArray;
     use crate::models::gemma4::quantized_linear::{PerLayerMode, PerLayerQuant};
@@ -671,6 +764,113 @@ mod tests {
             "language_model.embed_tokens"
         );
         assert_eq!(quant_lookup_prefix("lm_head"), "lm_head");
+
+        let fallback = PerLayerQuant {
+            bits: 6,
+            group_size: 16,
+            mode: PerLayerMode::Q6K,
+            input_amax: None,
+        };
+        let overrides = HashMap::from([(
+            "layers.0.self_attn.q_proj".to_string(),
+            PerLayerQuant {
+                bits: 4,
+                group_size: 32,
+                mode: PerLayerMode::Q4K,
+                input_amax: None,
+            },
+        )]);
+        assert_eq!(
+            muse_projection_quant(
+                "model.language_model.layers.0.self_attn.q_proj",
+                &overrides,
+                fallback
+            )
+            .mode,
+            PerLayerMode::Q4K,
+            "SafeTensors-converter overrides use the bare target namespace"
+        );
+    }
+
+    #[test]
+    fn converter_namespace_and_centered_hf_norms_reach_one_runtime_form() {
+        let converter = HashMap::from([
+            (
+                "language_model.model.layers.0.input_layernorm.weight".to_string(),
+                MxArray::from_float32(&[1.25], &[1]).expect("direct norm"),
+            ),
+            (
+                "language_model.model.lm_head.weight".to_string(),
+                MxArray::from_float32(&[2.0], &[1]).expect("lm head"),
+            ),
+        ]);
+        let converter = canonicalize_target_weights(converter, true).expect("converter namespace");
+        assert_eq!(
+            converter["model.language_model.layers.0.input_layernorm.weight"]
+                .item_at_float32(0)
+                .expect("direct value"),
+            1.25
+        );
+        assert!(converter.contains_key("lm_head.weight"));
+
+        let mut raw_hf = HashMap::from([(
+            "model.language_model.norm.weight".to_string(),
+            MxArray::from_float32(&[0.5], &[1]).expect("final norm"),
+        )]);
+        for norm in [
+            "input_layernorm",
+            "post_attention_layernorm",
+            "pre_feedforward_layernorm",
+            "post_feedforward_layernorm",
+        ] {
+            raw_hf.insert(
+                format!("model.language_model.layers.0.{norm}.weight"),
+                MxArray::from_float32(&[0.25], &[1]).expect("centered norm"),
+            );
+        }
+        let raw_hf = canonicalize_target_weights(raw_hf, false).expect("raw HF namespace");
+        for norm in [
+            "input_layernorm",
+            "post_attention_layernorm",
+            "pre_feedforward_layernorm",
+            "post_feedforward_layernorm",
+        ] {
+            assert_eq!(
+                raw_hf[&format!("model.language_model.layers.0.{norm}.weight")]
+                    .item_at_float32(0)
+                    .expect("shifted sandwich norm"),
+                1.25
+            );
+        }
+        assert_eq!(
+            raw_hf["model.language_model.norm.weight"]
+                .item_at_float32(0)
+                .expect("unchanged final norm"),
+            0.5
+        );
+    }
+
+    #[test]
+    fn mlx_metadata_marks_direct_norm_weights() {
+        let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "muse_glimmer_norm_metadata_{}_{}",
+            std::process::id(),
+            id
+        ));
+        std::fs::create_dir_all(&dir).expect("create model directory");
+        let mut tensors = HashMap::from([(
+            "weight".to_string(),
+            MxArray::from_float32(&[1.0], &[1]).expect("weight"),
+        )]);
+        save_safetensors(
+            dir.join("model.safetensors"),
+            &mut tensors,
+            Some(serde_json::json!({"format": "mlx"})),
+        )
+        .expect("save MLX checkpoint");
+        assert!(primary_safetensor_is_mlx(&dir).expect("read metadata"));
+        std::fs::remove_dir_all(dir).ok();
     }
 
     #[test]

--- a/crates/mlx-core/src/models/muse_glimmer/persistence.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/persistence.rs
@@ -1,0 +1,624 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use napi::bindgen_prelude::*;
+
+use crate::array::MxArray;
+use crate::cold_tier::{resolve_persist_cold, shard_identities_stable, snapshot_shard_identities};
+use crate::engine::persistence::{load_all_safetensors, parse_generation_defaults};
+use crate::models::gemma4::quantized_linear::{
+    LinearProj, try_build_fp8_e4m3_quantized_linear, try_build_kquant_quantized_linear,
+    try_build_mxfp4_quantized_linear, try_build_mxfp8_quantized_linear,
+    try_build_nvfp4_quantized_linear, try_build_quantized_linear, try_build_sym8_quantized_linear,
+};
+use crate::models::quant_dispatch::{
+    PerLayerMode, PerLayerQuant, effective_plq_for, ensure_affine_biases_present,
+    ensure_dense_weight_floating, ensure_int8_storage_resolves_sym8,
+    ensure_kquant_storage_resolves_kquant, ensure_plain_fp8_storage_resolves_fp8_e4m3,
+    load_quant_settings_from_disk, mode_to_str, normalize_per_layer_key,
+};
+use crate::nn::{Embedding, Linear, RMSNorm};
+use crate::tokenizer::Qwen3Tokenizer;
+use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
+use crate::transformer::{AttentionKind, KVCacheDType};
+use crate::utils::safetensors::load_safetensors_lazy;
+
+use super::attention::MuseGlimmerAttention;
+use super::config::MuseGlimmerConfig;
+use super::decoder_layer::MuseGlimmerDecoderLayer;
+use super::dflash::{DFlashAttention, DFlashLayer, DFlashModel};
+use super::kv_cache::{
+    PagedWindowSlot, WindowCarrier, admit_paged_dispatch_plan, compute_layer_kv_cache_groups,
+    compute_layer_kv_cache_specs, group_reserved_blocks,
+};
+use super::mlp::MuseGlimmerMlp;
+use super::model::{MuseGlimmerInner, MuseGlimmerModel, MusePagedRuntime, MuseSchedulerState};
+use super::output_parser::ResponseTemplate;
+
+fn required<'a>(params: &'a HashMap<String, MxArray>, key: &str) -> Result<&'a MxArray> {
+    params
+        .get(key)
+        .ok_or_else(|| Error::from_reason(format!("Muse-Glimmer checkpoint is missing '{key}'")))
+}
+
+fn quant_lookup_prefix(prefix: &str) -> String {
+    normalize_per_layer_key(&crate::utils::normalize_override_key(prefix))
+}
+
+pub(super) fn build_projection(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    default: PerLayerQuant,
+    overrides: &HashMap<String, PerLayerQuant>,
+) -> Result<LinearProj> {
+    let quant_prefix = quant_lookup_prefix(prefix);
+    let plq = effective_plq_for(&quant_prefix, overrides, default, None);
+    let scales_key = format!("{prefix}.scales");
+    if params.contains_key(&scales_key) {
+        ensure_int8_storage_resolves_sym8(params, prefix, plq.mode, "muse_glimmer")?;
+        ensure_plain_fp8_storage_resolves_fp8_e4m3(params, prefix, plq.mode, "muse_glimmer")?;
+        ensure_kquant_storage_resolves_kquant(params, prefix, plq.mode, "muse_glimmer")?;
+        ensure_affine_biases_present(params, prefix, plq.mode, "muse_glimmer")?;
+        let quantized = match plq.mode {
+            PerLayerMode::Mxfp4 => try_build_mxfp4_quantized_linear(params, prefix),
+            PerLayerMode::Mxfp8 => try_build_mxfp8_quantized_linear(params, prefix),
+            PerLayerMode::Nvfp4 => try_build_nvfp4_quantized_linear(params, prefix),
+            PerLayerMode::Fp8E4m3 => try_build_fp8_e4m3_quantized_linear(params, prefix)?,
+            PerLayerMode::Affine => {
+                try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
+            }
+            PerLayerMode::Sym8 => try_build_sym8_quantized_linear(params, prefix)?,
+            PerLayerMode::Q4K | PerLayerMode::Q5K | PerLayerMode::Q6K => {
+                try_build_kquant_quantized_linear(params, prefix, plq.mode, "muse_glimmer")?
+            }
+        }
+        .ok_or_else(|| {
+            Error::from_reason(format!(
+                "Muse-Glimmer projection '{prefix}' has quant sidecars but no complete quant group"
+            ))
+        })?;
+        return Ok(LinearProj::Quantized(quantized));
+    }
+
+    let weight_key = format!("{prefix}.weight");
+    let weight = required(params, &weight_key)?;
+    ensure_dense_weight_floating(&weight_key, weight)?;
+    let bias = params.get(&format!("{prefix}.bias"));
+    Ok(LinearProj::Standard(Linear::from_weights(weight, bias)?))
+}
+
+fn load_embedding(
+    params: &HashMap<String, MxArray>,
+    prefix: &str,
+    vocab: usize,
+    hidden: usize,
+    default: PerLayerQuant,
+    overrides: &HashMap<String, PerLayerQuant>,
+) -> Result<Embedding> {
+    let mut embedding = Embedding::new_uninitialized(vocab as u32, hidden as u32)?;
+    let weight = required(params, &format!("{prefix}.weight"))?;
+    if let Some(scales) = params.get(&format!("{prefix}.scales")) {
+        let quant_prefix = quant_lookup_prefix(prefix);
+        let plq = effective_plq_for(&quant_prefix, overrides, default, None);
+        if matches!(plq.mode, PerLayerMode::Sym8 | PerLayerMode::Fp8E4m3) {
+            return Err(Error::from_reason(format!(
+                "Muse-Glimmer embedding '{prefix}' does not support {:?}",
+                plq.mode
+            )));
+        }
+        ensure_kquant_storage_resolves_kquant(params, prefix, plq.mode, "muse_glimmer")?;
+        embedding.load_quantized_packed(
+            weight,
+            scales,
+            params.get(&format!("{prefix}.biases")),
+            plq.group_size,
+            plq.bits,
+            mode_to_str(plq.mode),
+        )?;
+    } else {
+        ensure_dense_weight_floating(&format!("{prefix}.weight"), weight)?;
+        embedding.load_weight(weight)?;
+    }
+    Ok(embedding)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quant_lookup_prefix;
+
+    #[test]
+    fn target_and_dflash_quantization_namespaces_stay_distinct() {
+        assert_eq!(
+            quant_lookup_prefix("model.language_model.layers.0.self_attn.q_proj"),
+            "language_model.layers.0.self_attn.q_proj"
+        );
+        assert_eq!(
+            quant_lookup_prefix("layers.0.self_attn.q_proj"),
+            "layers.0.self_attn.q_proj"
+        );
+        assert_eq!(
+            quant_lookup_prefix("model.language_model.embed_tokens"),
+            "language_model.embed_tokens"
+        );
+        assert_eq!(quant_lookup_prefix("lm_head"), "lm_head");
+    }
+}
+
+pub(super) fn norm(params: &HashMap<String, MxArray>, key: &str, eps: f32) -> Result<RMSNorm> {
+    RMSNorm::from_weight(required(params, key)?, Some(eps as f64))
+}
+
+fn load_dflash(
+    path: &Path,
+    config: &MuseGlimmerConfig,
+    default: PerLayerQuant,
+    overrides: &HashMap<String, PerLayerQuant>,
+) -> Result<Option<DFlashModel>> {
+    let draft_path = path.join("draft.safetensors");
+    if !draft_path.is_file() {
+        return Ok(None);
+    }
+    let draft_config = config.dflash_config.clone().ok_or_else(|| {
+        Error::from_reason(
+            "Muse-Glimmer has draft.safetensors but config.json has no dflash_config; reconvert the companion GGUF with --draft",
+        )
+    })?;
+    let params = load_safetensors_lazy(&draft_path)?;
+    let fc = build_projection(&params, "fc", default, overrides)?;
+    let hidden_norm = norm(&params, "hidden_norm.weight", draft_config.rms_norm_eps)?;
+    let final_norm = norm(&params, "norm.weight", draft_config.rms_norm_eps)?;
+    let mut layers = Vec::with_capacity(draft_config.num_hidden_layers);
+    for index in 0..draft_config.num_hidden_layers {
+        let base = format!("layers.{index}");
+        let attention_base = format!("{base}.self_attn");
+        let attention = DFlashAttention::new(
+            &draft_config,
+            build_projection(
+                &params,
+                &format!("{attention_base}.q_proj"),
+                default,
+                overrides,
+            )?,
+            build_projection(
+                &params,
+                &format!("{attention_base}.k_proj"),
+                default,
+                overrides,
+            )?,
+            build_projection(
+                &params,
+                &format!("{attention_base}.v_proj"),
+                default,
+                overrides,
+            )?,
+            build_projection(
+                &params,
+                &format!("{attention_base}.o_proj"),
+                default,
+                overrides,
+            )?,
+            norm(
+                &params,
+                &format!("{attention_base}.q_norm.weight"),
+                draft_config.rms_norm_eps,
+            )?,
+            norm(
+                &params,
+                &format!("{attention_base}.k_norm.weight"),
+                draft_config.rms_norm_eps,
+            )?,
+        );
+        let mlp_base = format!("{base}.mlp");
+        let mlp = MuseGlimmerMlp::new(
+            build_projection(
+                &params,
+                &format!("{mlp_base}.gate_proj"),
+                default,
+                overrides,
+            )?,
+            build_projection(&params, &format!("{mlp_base}.up_proj"), default, overrides)?,
+            build_projection(
+                &params,
+                &format!("{mlp_base}.down_proj"),
+                default,
+                overrides,
+            )?,
+        );
+        layers.push(DFlashLayer::new(
+            attention,
+            mlp,
+            norm(
+                &params,
+                &format!("{base}.input_layernorm.weight"),
+                draft_config.rms_norm_eps,
+            )?,
+            norm(
+                &params,
+                &format!("{base}.post_attention_layernorm.weight"),
+                draft_config.rms_norm_eps,
+            )?,
+        ));
+    }
+    Ok(Some(DFlashModel::from_loaded(
+        draft_config,
+        fc,
+        hidden_norm,
+        layers,
+        final_norm,
+    )))
+}
+
+const BYTES_PER_MIB: u64 = 1024 * 1024;
+const DEFAULT_PAGED_CACHE_MEMORY_MB: u32 = 2048;
+const DEFAULT_PAGED_MAX_SEQUENCES: u32 = 8;
+
+fn build_paged_runtime(config: &MuseGlimmerConfig) -> Result<Option<MusePagedRuntime>> {
+    if config.use_block_paged_cache == Some(false)
+        || !crate::engine::persistence::compiled_forward_backend_available()
+    {
+        return Ok(None);
+    }
+    let block_size = config.paged_block_size.unwrap_or(16);
+    let max_chunk = u32::try_from(super::model::PREFILL_STEP_SIZE)
+        .expect("positive Muse-Glimmer prefill chunk");
+    let specs = compute_layer_kv_cache_specs(config, block_size, KVCacheDType::BFloat16)
+        .map_err(Error::from_reason)?;
+    let groups =
+        compute_layer_kv_cache_groups(config, block_size, KVCacheDType::BFloat16, max_chunk)
+            .map_err(Error::from_reason)?;
+    let max_seq_len = u32::try_from(config.text_config.max_position_embeddings)
+        .map_err(|_| Error::from_reason("Muse-Glimmer max_position_embeddings exceeds u32::MAX"))?;
+    let bytes_per_block = groups
+        .iter()
+        .map(|group| {
+            2u64.saturating_mul(u64::from(group.physical_layout.num_kv_heads))
+                .saturating_mul(u64::from(group.physical_layout.head_size))
+                .saturating_mul(u64::from(block_size))
+                .saturating_mul(2)
+                .saturating_mul(group.physical_layer_indices.len() as u64)
+        })
+        .collect::<Vec<_>>();
+    let required_bytes_for_width = |width: u32| {
+        groups
+            .iter()
+            .zip(&bytes_per_block)
+            .fold(0u64, |sum, (group, bytes)| {
+                sum.saturating_add(
+                    u64::from(group_reserved_blocks(
+                        group.attention_kind,
+                        group.max_admission_blocks,
+                        width,
+                    ))
+                    .saturating_mul(*bytes),
+                )
+            })
+    };
+    let minimum_bytes = required_bytes_for_width(1);
+    let default_memory_mb = minimum_bytes
+        .div_ceil(BYTES_PER_MIB)
+        .max(u64::from(DEFAULT_PAGED_CACHE_MEMORY_MB));
+    let memory_mb = config
+        .paged_cache_memory_mb
+        .unwrap_or_else(|| u32::try_from(default_memory_mb).unwrap_or(u32::MAX));
+    let memory_bytes = u64::from(memory_mb).saturating_mul(BYTES_PER_MIB);
+    if memory_bytes < minimum_bytes {
+        return Err(Error::from_reason(format!(
+            "Muse-Glimmer paged_cache_memory_mb={memory_mb} is below the {} MiB hybrid-cache minimum",
+            minimum_bytes.div_ceil(BYTES_PER_MIB)
+        )));
+    }
+    let mut max_sequences = DEFAULT_PAGED_MAX_SEQUENCES.min(32);
+    while max_sequences > 1 && required_bytes_for_width(max_sequences) > memory_bytes {
+        max_sequences -= 1;
+    }
+    if required_bytes_for_width(max_sequences) > memory_bytes {
+        return Err(Error::from_reason(
+            "Muse-Glimmer paged cache cannot admit one sequence",
+        ));
+    }
+    let reserved_bytes = required_bytes_for_width(max_sequences);
+    let mut unassigned_bytes = memory_bytes.saturating_sub(reserved_bytes);
+    let mut adapters = Vec::with_capacity(groups.len());
+    let mut total_blocks = 0u32;
+    for (group, bytes) in groups.iter().zip(bytes_per_block.iter().copied()) {
+        let mut blocks = group_reserved_blocks(
+            group.attention_kind,
+            group.max_admission_blocks,
+            max_sequences,
+        );
+        if matches!(group.attention_kind, AttentionKind::Full) {
+            let extra = u32::try_from(unassigned_bytes / bytes).unwrap_or(u32::MAX);
+            blocks = blocks.saturating_add(extra);
+            unassigned_bytes =
+                unassigned_bytes.saturating_sub(u64::from(extra).saturating_mul(bytes));
+        }
+        let group_memory_mb = bytes
+            .saturating_mul(u64::from(blocks))
+            .div_ceil(BYTES_PER_MIB)
+            .max(256);
+        let pa_config = mlx_paged_attn::PagedAttentionConfig {
+            block_size,
+            gpu_memory_mb: u32::try_from(group_memory_mb).unwrap_or(u32::MAX),
+            head_size: group.physical_layout.head_size,
+            num_kv_heads: group.physical_layout.num_kv_heads,
+            num_layers: u32::try_from(group.physical_layer_indices.len()).map_err(|_| {
+                Error::from_reason("Muse-Glimmer paged physical layer count exceeds u32::MAX")
+            })?,
+            use_fp8_cache: Some(false),
+            max_seq_len: Some(max_seq_len),
+            max_batch_size: Some(max_sequences),
+        };
+        let allocator = Arc::new(std::sync::Mutex::new(mlx_paged_attn::BlockAllocator::new(
+            blocks, block_size,
+        )));
+        let pool = mlx_paged_attn::LayerKVPool::new(
+            pa_config,
+            blocks,
+            mlx_paged_attn::metal::MetalDtype::BFloat16,
+        )
+        .map_err(|error| {
+            Error::from_reason(format!(
+                "Muse-Glimmer KV group {} pool construction failed: {error}",
+                group.group_id
+            ))
+        })?;
+        let adapter = match group.attention_kind {
+            AttentionKind::Full => PagedKVCacheAdapter::new(allocator, Arc::new(pool), block_size),
+            AttentionKind::SlidingWindow { sliding_window } => PagedKVCacheAdapter::new_sliding(
+                allocator,
+                Arc::new(pool),
+                block_size,
+                sliding_window,
+                max_seq_len,
+            ),
+        }
+        .map_err(Error::from_reason)?;
+        total_blocks = total_blocks.saturating_add(blocks);
+        adapters.push(adapter);
+    }
+    let prefill_windows: Vec<PagedWindowSlot> =
+        admit_paged_dispatch_plan(&groups, &vec![WindowCarrier::ExplicitMask; groups.len()])
+            .map_err(Error::from_reason)?;
+    let decode_windows: Vec<PagedWindowSlot> =
+        admit_paged_dispatch_plan(&groups, &vec![WindowCarrier::KernelArgument; groups.len()])
+            .map_err(Error::from_reason)?;
+    let coordinator = crate::models::gemma4::model::Gemma4KVCacheCoordinator::new(
+        &specs,
+        groups,
+        adapters,
+        max_sequences,
+    )
+    .map_err(Error::from_reason)?;
+    let routes = coordinator.routes().to_vec();
+    tracing::info!(
+        "Muse-Glimmer hybrid paged cache enabled: total_blocks={total_blocks}, block_size={block_size}, memory_mb={memory_mb}, max_sequences={max_sequences}"
+    );
+    Ok(Some(MusePagedRuntime {
+        coordinator,
+        routes,
+        prefill_windows,
+        decode_windows,
+    }))
+}
+
+fn load_inner(path: &Path) -> Result<(MuseGlimmerInner, u64)> {
+    let config = MuseGlimmerConfig::from_path(path)?;
+    let persist_env = std::env::var("MLX_PERSIST_PAGED_CACHE").ok();
+    let persist_cold = resolve_persist_cold(
+        "muse_glimmer",
+        persist_env.as_deref(),
+        config.persist_paged_cache,
+    );
+    let shard_snapshot_before_mmap = if persist_cold {
+        snapshot_shard_identities(path)
+    } else {
+        None
+    };
+    let params = load_all_safetensors(path, true)?;
+    let shard_snapshot_at_mmap = if persist_cold {
+        snapshot_shard_identities(path)
+    } else {
+        None
+    };
+    if persist_cold {
+        crate::engine::persistence::prewarm_checkpoint_pages(path);
+    }
+    let (bits, group_size, top_mode, overrides) = load_quant_settings_from_disk(path, 4, 64)?;
+    let default = PerLayerQuant {
+        bits,
+        group_size,
+        mode: top_mode.unwrap_or(PerLayerMode::Affine),
+        input_amax: None,
+    };
+    if params.keys().any(|key| key.ends_with(".scales")) && top_mode.is_none() {
+        return Err(Error::from_reason(
+            "Muse-Glimmer checkpoint has packed weights but config.json has no quantization mode",
+        ));
+    }
+
+    let text = &config.text_config;
+    let embed_tokens = load_embedding(
+        &params,
+        "model.language_model.embed_tokens",
+        text.vocab_size,
+        text.hidden_size,
+        default,
+        &overrides,
+    )?;
+    let lm_head = build_projection(&params, "lm_head", default, &overrides)?;
+    let final_norm = norm(
+        &params,
+        "model.language_model.norm.weight",
+        text.rms_norm_eps,
+    )?;
+
+    let mut layers = Vec::with_capacity(text.num_hidden_layers);
+    for index in 0..text.num_hidden_layers {
+        let base = format!("model.language_model.layers.{index}");
+        let attn = format!("{base}.self_attn");
+        let attention = MuseGlimmerAttention::from_projections(
+            text,
+            index,
+            config.rope_traditional,
+            build_projection(&params, &format!("{attn}.q_proj"), default, &overrides)?,
+            build_projection(&params, &format!("{attn}.k_proj"), default, &overrides)?,
+            build_projection(&params, &format!("{attn}.v_proj"), default, &overrides)?,
+            build_projection(&params, &format!("{attn}.o_proj"), default, &overrides)?,
+            build_projection(&params, &format!("{attn}.gate_proj"), default, &overrides)?,
+        )?;
+        let mlp_base = format!("{base}.mlp");
+        let mlp = MuseGlimmerMlp::new(
+            build_projection(
+                &params,
+                &format!("{mlp_base}.gate_proj"),
+                default,
+                &overrides,
+            )?,
+            build_projection(&params, &format!("{mlp_base}.up_proj"), default, &overrides)?,
+            build_projection(
+                &params,
+                &format!("{mlp_base}.down_proj"),
+                default,
+                &overrides,
+            )?,
+        );
+        layers.push(MuseGlimmerDecoderLayer::new(
+            attention,
+            mlp,
+            norm(
+                &params,
+                &format!("{base}.input_layernorm.weight"),
+                text.rms_norm_eps,
+            )?,
+            norm(
+                &params,
+                &format!("{base}.post_attention_layernorm.weight"),
+                text.post_norm_eps,
+            )?,
+            norm(
+                &params,
+                &format!("{base}.pre_feedforward_layernorm.weight"),
+                text.rms_norm_eps,
+            )?,
+            norm(
+                &params,
+                &format!("{base}.post_feedforward_layernorm.weight"),
+                text.post_norm_eps,
+            )?,
+        ));
+    }
+
+    let tokenizer_path = path.join("tokenizer.json");
+    let tokenizer = Arc::new(Qwen3Tokenizer::from_file(&tokenizer_path).map_err(|error| {
+        Error::from_reason(format!("Failed to load Muse-Glimmer tokenizer: {error}"))
+    })?);
+    let response_template = ResponseTemplate::from_tokenizer_config(path)?;
+    let gen_defaults = parse_generation_defaults(path);
+    let dflash = load_dflash(path, &config, default, &overrides)?;
+    let paged = build_paged_runtime(&config)?;
+    let has_dflash = dflash.is_some();
+    let weight_bytes = params
+        .values()
+        .map(|array| array.nbytes() as u64)
+        .sum::<u64>()
+        .saturating_add(if has_dflash {
+            std::fs::metadata(path.join("draft.safetensors"))
+                .map(|meta| meta.len())
+                .unwrap_or(0)
+        } else {
+            0
+        });
+    let weights_resident = if persist_cold {
+        let arrays = params.values().collect::<Vec<_>>();
+        Some(crate::array::memory::materialize_weights(&arrays)?)
+    } else {
+        None
+    };
+    let mut inner = MuseGlimmerInner::from_loaded(
+        config,
+        embed_tokens,
+        layers,
+        final_norm,
+        lm_head,
+        tokenizer,
+        response_template,
+        gen_defaults,
+        dflash,
+        paged,
+    );
+    if let Some(weights_resident) = weights_resident.as_ref()
+        && let Some(context) =
+            inner.build_cold_tier_context(&path.to_string_lossy(), weights_resident)
+    {
+        let after_fingerprint = snapshot_shard_identities(path);
+        if shard_identities_stable(
+            &shard_snapshot_before_mmap,
+            &shard_snapshot_at_mmap,
+            &after_fingerprint,
+        ) {
+            inner.attach_cold_tier(context, weights_resident);
+        } else {
+            tracing::warn!(
+                "cold-tier persistence disabled for {}: model directory changed during load; KV persistence stays off",
+                path.display()
+            );
+        }
+    }
+    Ok((inner, weight_bytes))
+}
+
+pub(crate) async fn load_with_thread(model_path: &str) -> Result<MuseGlimmerModel> {
+    let model_path = model_path.to_string();
+    let (thread, init_rx) = crate::model_thread::ModelThread::spawn_with_scheduler(
+        move || {
+            let (inner, weight_bytes) = load_inner(Path::new(&model_path))?;
+            let has_dflash = inner.dflash.is_some();
+            let pool_bytes = inner
+                .paged
+                .as_ref()
+                .map(|paged| paged.coordinator.pool_allocated_bytes())
+                .transpose()
+                .map_err(Error::from_reason)?
+                .unwrap_or(0);
+            let paged_active = inner.paged.is_some();
+            let max_concurrent_sequences =
+                crate::engine::hybrid_scheduler::scheduler_max_num_seqs_for(
+                    inner.paged.as_ref().map_or(1, |paged| {
+                        paged.coordinator.max_concurrent_sequences() as usize
+                    }),
+                ) as u32;
+            let guard = crate::cache_limit::coordinator().register(weight_bytes);
+            let pool_guard = (pool_bytes != 0)
+                .then(|| crate::cache_limit::coordinator().register_pool(pool_bytes));
+            Ok((
+                MuseSchedulerState::new(inner)?,
+                (
+                    has_dflash,
+                    paged_active,
+                    max_concurrent_sequences,
+                    guard,
+                    pool_guard,
+                ),
+            ))
+        },
+        |state, receiver| state.drive(receiver),
+    );
+    let (
+        has_dflash,
+        paged_active,
+        max_concurrent_sequences,
+        cache_limit_guard,
+        pool_cache_limit_guard,
+    ) = init_rx
+        .await
+        .map_err(|_| Error::from_reason("Muse-Glimmer model thread exited during load"))??;
+    Ok(MuseGlimmerModel {
+        thread,
+        has_dflash,
+        paged_active,
+        max_concurrent_sequences,
+        _cache_limit_guard: cache_limit_guard,
+        _pool_cache_limit_guard: pool_cache_limit_guard,
+    })
+}

--- a/crates/mlx-core/src/models/muse_glimmer/persistence.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/persistence.rs
@@ -16,7 +16,7 @@ use crate::models::quant_dispatch::{
     PerLayerMode, PerLayerQuant, effective_plq_for, ensure_affine_biases_present,
     ensure_dense_weight_floating, ensure_int8_storage_resolves_sym8,
     ensure_kquant_storage_resolves_kquant, ensure_plain_fp8_storage_resolves_fp8_e4m3,
-    load_quant_settings_from_disk, mode_to_str, normalize_per_layer_key,
+    has_kquant_mode, load_quant_settings_from_disk, mode_to_str, normalize_per_layer_key,
 };
 use crate::nn::{Embedding, Linear, RMSNorm};
 use crate::tokenizer::Qwen3Tokenizer;
@@ -400,6 +400,17 @@ fn load_target_safetensors(path: &Path) -> Result<HashMap<String, MxArray>> {
     load_all_safetensors(path, false)
 }
 
+fn requires_row_exact_decode_projections(
+    top_mode: Option<PerLayerMode>,
+    overrides: &HashMap<String, PerLayerQuant>,
+) -> bool {
+    has_kquant_mode(top_mode, overrides)
+        || top_mode == Some(PerLayerMode::Affine)
+        || overrides
+            .values()
+            .any(|quant| quant.mode == PerLayerMode::Affine)
+}
+
 fn load_inner(path: &Path) -> Result<(MuseGlimmerInner, u64)> {
     let config = MuseGlimmerConfig::from_path(path)?;
     let persist_env = std::env::var("MLX_PERSIST_PAGED_CACHE").ok();
@@ -545,6 +556,8 @@ fn load_inner(path: &Path) -> Result<(MuseGlimmerInner, u64)> {
         dflash,
         paged,
     );
+    inner.row_exact_decode_projections =
+        requires_row_exact_decode_projections(top_mode, &overrides);
     if let Some(weights_resident) = weights_resident.as_ref()
         && let Some(context) =
             inner.build_cold_tier_context(&path.to_string_lossy(), weights_resident)
@@ -623,7 +636,10 @@ pub(crate) async fn load_with_thread(model_path: &str) -> Result<MuseGlimmerMode
 
 #[cfg(test)]
 mod tests {
-    use super::{load_lm_head, load_target_safetensors, quant_lookup_prefix};
+    use super::{
+        load_lm_head, load_target_safetensors, quant_lookup_prefix,
+        requires_row_exact_decode_projections,
+    };
     use crate::array::MxArray;
     use crate::models::gemma4::quantized_linear::{PerLayerMode, PerLayerQuant};
     use crate::utils::safetensors::save_safetensors;
@@ -674,6 +690,34 @@ mod tests {
         assert!(!weights.contains_key("vision.weight"));
 
         std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn packed_checkpoints_enable_row_exact_concurrent_decode() {
+        let mut overrides = HashMap::new();
+        assert!(requires_row_exact_decode_projections(
+            Some(PerLayerMode::Q4K),
+            &overrides
+        ));
+        assert!(requires_row_exact_decode_projections(
+            Some(PerLayerMode::Affine),
+            &overrides
+        ));
+        assert!(!requires_row_exact_decode_projections(
+            Some(PerLayerMode::Mxfp4),
+            &overrides
+        ));
+
+        overrides.insert(
+            "language_model.layers.0.self_attn.q_proj".to_string(),
+            PerLayerQuant {
+                bits: 5,
+                group_size: 32,
+                mode: PerLayerMode::Q5K,
+                input_amax: None,
+            },
+        );
+        assert!(requires_row_exact_decode_projections(None, &overrides));
     }
 
     #[test]

--- a/crates/mlx-core/src/models/muse_glimmer/persistence.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/persistence.rs
@@ -686,6 +686,7 @@ pub(crate) async fn load_with_thread(model_path: &str) -> Result<MuseGlimmerMode
                 .map_err(Error::from_reason)?
                 .unwrap_or(0);
             let paged_active = inner.paged.is_some();
+            let context_limits = super::model::MuseGlimmerContextLimits::from_inner(&inner);
             let max_concurrent_sequences =
                 crate::engine::hybrid_scheduler::scheduler_max_num_seqs_for(
                     inner.paged.as_ref().map_or(1, |paged| {
@@ -701,6 +702,7 @@ pub(crate) async fn load_with_thread(model_path: &str) -> Result<MuseGlimmerMode
                     has_dflash,
                     paged_active,
                     max_concurrent_sequences,
+                    context_limits,
                     guard,
                     pool_guard,
                 ),
@@ -712,6 +714,7 @@ pub(crate) async fn load_with_thread(model_path: &str) -> Result<MuseGlimmerMode
         has_dflash,
         paged_active,
         max_concurrent_sequences,
+        context_limits,
         cache_limit_guard,
         pool_cache_limit_guard,
     ) = init_rx
@@ -722,6 +725,7 @@ pub(crate) async fn load_with_thread(model_path: &str) -> Result<MuseGlimmerMode
         has_dflash,
         paged_active,
         max_concurrent_sequences,
+        context_limits,
         _cache_limit_guard: cache_limit_guard,
         _pool_cache_limit_guard: pool_cache_limit_guard,
     })

--- a/crates/mlx-core/src/models/muse_glimmer/row_exact.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/row_exact.rs
@@ -1,0 +1,47 @@
+use crate::array::MxArray;
+use napi::bindgen_prelude::*;
+
+/// Apply a decode operation to independent `[1, 1, H]` rows and restore the
+/// scheduler's `[N, 1, H]` layout. Packed projections use this to retain the
+/// same Metal graph as serial inference without serializing paged attention.
+pub(super) fn forward_rows_independently(
+    x: &MxArray,
+    mut forward: impl FnMut(&MxArray) -> Result<MxArray>,
+) -> Result<MxArray> {
+    let batch = usize::try_from(x.shape_at(0)?).map_err(|_| {
+        Error::from_reason("Muse-Glimmer row-exact decode received a negative batch")
+    })?;
+    if batch == 0 {
+        return Err(Error::from_reason(
+            "Muse-Glimmer row-exact decode requires at least one row",
+        ));
+    }
+    if batch == 1 {
+        return forward(x);
+    }
+    let rows = (0..batch)
+        .map(|row| {
+            let row = x.slice_axis(0, row as i64, row as i64 + 1)?;
+            forward(&row)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    MxArray::concatenate_many(rows.iter().collect(), Some(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconstructs_rows_in_scheduler_order() {
+        let input =
+            MxArray::from_float32(&[1.0, 2.0, 3.0, 4.0], &[2, 1, 2]).expect("row-exact input");
+        let output = forward_rows_independently(&input, |row| row.mul_scalar(2.0))
+            .expect("row-exact output");
+        assert_eq!(output.shape().expect("shape").as_ref(), [2, 1, 2]);
+        assert_eq!(
+            output.to_float32().expect("values").as_ref(),
+            [2.0, 4.0, 6.0, 8.0]
+        );
+    }
+}

--- a/crates/mlx-core/src/models/muse_glimmer/scheduler.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/scheduler.rs
@@ -12,6 +12,7 @@ use crate::engine::scheduler::PreemptionMode;
 use crate::engine::types::ChatConfig;
 use crate::model_thread::ResponseTx;
 use crate::models::gemma4::layer_cache::Gemma4LayerCache;
+use crate::models::muse_glimmer::dflash::DFlashContextCache;
 use crate::models::muse_glimmer::kv_cache::PagedWindowSlot;
 use crate::stream::Stream;
 use crate::transformer::paged_kv_cache_adapter::{PagedKVCacheAdapter, SeqId};
@@ -45,6 +46,7 @@ impl HybridSchedulerCommand for MuseGlimmerCmd {
 pub(crate) struct MuseOwnerState {
     history: Vec<u32>,
     flat_caches: Option<Vec<Gemma4LayerCache>>,
+    dflash_context: Option<DFlashContextCache>,
 }
 
 pub(crate) type MuseSchedulerState = HybridSchedulerState<MuseGlimmerInner>;
@@ -212,6 +214,7 @@ impl HybridSchedulerBackend for MuseGlimmerInner {
         MuseOwnerState {
             history: self.cached_token_history.clone(),
             flat_caches: None,
+            dflash_context: None,
         }
     }
 
@@ -354,6 +357,7 @@ impl HybridSchedulerBackend for MuseGlimmerInner {
         let state = owners.owner_states.remove(&owner).unwrap_or_default();
         if flat_lane {
             self.install_flat_owner_caches(state.flat_caches);
+            self.dflash_context = state.dflash_context;
             self.cached_token_history = state.history;
             handle_chat_cmd(self, command);
             if ChatBackend::has_live_session(self) {
@@ -362,6 +366,7 @@ impl HybridSchedulerBackend for MuseGlimmerInner {
                     MuseOwnerState {
                         history: self.cached_token_history.clone(),
                         flat_caches: Some(self.take_flat_owner_caches()),
+                        dflash_context: self.dflash_context.take(),
                     },
                 );
             } else {
@@ -387,6 +392,7 @@ impl HybridSchedulerBackend for MuseGlimmerInner {
                     MuseOwnerState {
                         history: self.cached_token_history.clone(),
                         flat_caches: None,
+                        dflash_context: None,
                     },
                 );
             } else {

--- a/crates/mlx-core/src/models/muse_glimmer/scheduler.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/scheduler.rs
@@ -1,0 +1,397 @@
+use napi::bindgen_prelude::{Error, Result};
+
+use super::{MuseGlimmerCmd, MuseGlimmerInner, MusePrefixState};
+use crate::array::MxArray;
+use crate::engine::backend::ChatBackend;
+use crate::engine::cmd::{ChatCmd, handle_chat_cmd};
+use crate::engine::hybrid_scheduler::{
+    HybridSchedulerBackend, HybridSchedulerCommand, HybridSchedulerState, HybridStepExecutor,
+    NoRestoreTicket, ScheduledPrefixAdmission, ScheduledReply, SchedulerOwnerContext,
+};
+use crate::engine::scheduler::PreemptionMode;
+use crate::engine::types::ChatConfig;
+use crate::model_thread::ResponseTx;
+use crate::models::gemma4::layer_cache::Gemma4LayerCache;
+use crate::models::muse_glimmer::kv_cache::PagedWindowSlot;
+use crate::stream::Stream;
+use crate::transformer::paged_kv_cache_adapter::{PagedKVCacheAdapter, SeqId};
+
+impl HybridSchedulerCommand for MuseGlimmerCmd {
+    fn as_chat(&self) -> Option<&ChatCmd> {
+        match self {
+            Self::Chat(chat) => Some(chat),
+            Self::SchedulerStats { .. } => None,
+        }
+    }
+
+    fn into_chat(self) -> std::result::Result<ChatCmd, Self> {
+        match self {
+            Self::Chat(chat) => Ok(*chat),
+            other => Err(other),
+        }
+    }
+
+    fn into_scheduler_stats(
+        self,
+    ) -> std::result::Result<ResponseTx<crate::engine::SchedulerStatsJs>, Self> {
+        match self {
+            Self::SchedulerStats { reply } => Ok(reply),
+            other => Err(other),
+        }
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct MuseOwnerState {
+    history: Vec<u32>,
+    flat_caches: Option<Vec<Gemma4LayerCache>>,
+}
+
+pub(crate) type MuseSchedulerState = HybridSchedulerState<MuseGlimmerInner>;
+
+fn chat_config(command: &ChatCmd) -> Option<&ChatConfig> {
+    match command {
+        ChatCmd::SessionStart { config, .. }
+        | ChatCmd::SessionContinue { config, .. }
+        | ChatCmd::SessionContinueTool { config, .. }
+        | ChatCmd::StreamSessionStart { config, .. }
+        | ChatCmd::StreamSessionContinue { config, .. }
+        | ChatCmd::StreamSessionContinueTool { config, .. } => Some(config),
+        ChatCmd::ResetCaches { .. } | ChatCmd::ReleaseCacheOwner { .. } => None,
+    }
+}
+
+fn owner_id(command: &ChatCmd) -> Option<&str> {
+    chat_config(command)
+        .and_then(|config| config.cache_owner_id.as_deref())
+        .filter(|owner| !owner.is_empty())
+}
+
+fn is_start(command: &ChatCmd) -> bool {
+    matches!(
+        command,
+        ChatCmd::SessionStart { .. } | ChatCmd::StreamSessionStart { .. }
+    )
+}
+
+fn send_error(command: ChatCmd, error: Error) {
+    match command {
+        ChatCmd::SessionStart {
+            reply, cancelled, ..
+        }
+        | ChatCmd::SessionContinue {
+            reply, cancelled, ..
+        }
+        | ChatCmd::SessionContinueTool {
+            reply, cancelled, ..
+        } => ScheduledReply::Sync(reply).send_error(error, cancelled.as_ref()),
+        ChatCmd::StreamSessionStart {
+            stream_tx,
+            cancelled,
+            ..
+        }
+        | ChatCmd::StreamSessionContinue {
+            stream_tx,
+            cancelled,
+            ..
+        }
+        | ChatCmd::StreamSessionContinueTool {
+            stream_tx,
+            cancelled,
+            ..
+        } => ScheduledReply::Stream(stream_tx).send_error(error, cancelled.as_ref()),
+        ChatCmd::ResetCaches { reply } => {
+            let _ = reply.send(Err(error));
+        }
+        ChatCmd::ReleaseCacheOwner { reply, .. } => {
+            let _ = reply.send(Err(error));
+        }
+    }
+}
+
+impl HybridSchedulerBackend for MuseGlimmerInner {
+    type Command = MuseGlimmerCmd;
+    type RestoreTicket = NoRestoreTicket;
+    type OwnerState = MuseOwnerState;
+    type StepExecutor<'a> = HybridStepExecutor<'a, Self>;
+
+    const SCHEDULER_NAME: &'static str = "Muse-Glimmer";
+
+    fn paged_adapter(&self) -> Option<&PagedKVCacheAdapter> {
+        self.paged.as_ref().map(|paged| {
+            let _admitted_decode_windows: &[PagedWindowSlot] = &paged.decode_windows;
+            paged.coordinator.full_adapter()
+        })
+    }
+
+    fn paged_adapter_mut(&mut self) -> Option<&mut PagedKVCacheAdapter> {
+        self.paged
+            .as_mut()
+            .map(|paged| paged.coordinator.full_adapter_mut())
+    }
+
+    fn scheduler_capacity(&self) -> usize {
+        self.paged.as_ref().map_or(1, |paged| {
+            paged.coordinator.max_concurrent_sequences() as usize
+        })
+    }
+
+    fn scheduler_prefill_slice_tokens(&self) -> u32 {
+        super::PREFILL_STEP_SIZE as u32
+    }
+
+    fn scheduler_has_cold_tier(&self) -> bool {
+        // Like Gemma4, ordinary prefix admission may restore the atomic
+        // full/sliding record. In-flight SSD preemption remains disabled: a
+        // partial turn has not published a matching sliding sidecar yet.
+        false
+    }
+
+    fn reset_owner_on_session_start(&self) -> bool {
+        true
+    }
+
+    fn release_scheduled_cache(&mut self, seq_id: SeqId) -> Result<()> {
+        self.release_paged_request(seq_id)
+            .map(|_| ())
+            .map_err(Error::from_reason)
+    }
+
+    fn preempt_scheduled_cache(
+        &mut self,
+        seq_id: SeqId,
+        _cache_salt: u64,
+        _mode: PreemptionMode,
+    ) -> Result<()> {
+        self.release_scheduled_cache(seq_id)
+    }
+
+    fn release_owner_resources(
+        &mut self,
+        seq_id: Option<SeqId>,
+        _state: Option<&Self::OwnerState>,
+    ) -> Result<()> {
+        if let Some(seq_id) = seq_id {
+            self.release_scheduled_cache(seq_id)?;
+        }
+        Ok(())
+    }
+
+    fn max_position_embeddings(&self) -> i32 {
+        i32::try_from(self.config.text_config.max_position_embeddings).unwrap_or(i32::MAX)
+    }
+
+    fn activate_paged_seq(&mut self, seq_id: SeqId) -> Result<()> {
+        self.set_active_paged_owner(seq_id);
+        self.paged
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime is unavailable"))?
+            .coordinator
+            .activate_request_all(seq_id)
+            .map_err(Error::from_reason)
+    }
+
+    fn run_paged_decode_step_batched(&mut self, rows: &[(SeqId, u32)]) -> Result<MxArray> {
+        MuseGlimmerInner::run_paged_decode_step_batched(self, rows)
+    }
+
+    fn replace_cached_token_history(&mut self, history: Vec<u32>) {
+        self.cached_token_history = history;
+    }
+
+    fn owner_tokens(state: &Self::OwnerState) -> &[u32] {
+        &state.history
+    }
+
+    fn install_owner_state(&mut self, seq_id: SeqId, state: &Self::OwnerState) {
+        self.set_active_paged_owner(seq_id);
+        self.cached_token_history = state.history.clone();
+    }
+
+    fn capture_owner_state(&mut self, _seq_id: SeqId) -> Self::OwnerState {
+        MuseOwnerState {
+            history: self.cached_token_history.clone(),
+            flat_caches: None,
+        }
+    }
+
+    fn build_scheduled_prefix(
+        &self,
+        _base: &Self::PrefixState,
+        effective_cached_prefix_len: usize,
+        suffix_len: usize,
+        _full_tokens: Vec<u32>,
+        _first_chunk: bool,
+    ) -> Self::PrefixState {
+        MusePrefixState {
+            effective_cached_prefix_len,
+            suffix_len,
+        }
+    }
+
+    fn run_scheduled_prefill_slice(
+        &mut self,
+        seq_id: SeqId,
+        source: &[u32],
+        _base: &Self::PrefixState,
+        start: usize,
+        end: usize,
+        _generation_stream: Stream,
+        _first_chunk: bool,
+    ) -> Result<Option<MxArray>> {
+        self.set_active_paged_owner(seq_id);
+        self.run_paged_prefill_slice(&source[start..end], start as u32)
+            .map(Some)
+    }
+
+    fn finish_scheduled_decode_batch(&mut self, rows: &[(SeqId, u32)]) -> Result<()> {
+        let paged = self
+            .paged
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime is unavailable"))?;
+        paged
+            .coordinator
+            .eval_pending_pool_writes_all()
+            .map_err(Error::from_reason)?;
+        for &(seq_id, _) in rows {
+            self.remember_sliding_cold_checkpoints(seq_id)?;
+        }
+        let paged = self
+            .paged
+            .as_mut()
+            .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime is unavailable"))?;
+        for &(seq_id, _) in rows {
+            paged
+                .coordinator
+                .prune_sliding_all(seq_id)
+                .map_err(Error::from_reason)?;
+        }
+        Ok(())
+    }
+
+    fn prepare_scheduled_prefix(
+        &mut self,
+        seq_id: SeqId,
+        tokens: &[u32],
+        _owner_history: &[u32],
+        reuse_cache: bool,
+        cache_salt: u64,
+        _block_size: u32,
+    ) -> Result<ScheduledPrefixAdmission<Self::PrefixState, Self::RestoreTicket>> {
+        let mut cached =
+            self.prepare_paged_text_request(seq_id, tokens, cache_salt, reuse_cache)?;
+        if cached >= tokens.len() as u32 {
+            self.paged
+                .as_mut()
+                .ok_or_else(|| Error::from_reason("Muse-Glimmer paged runtime is unavailable"))?
+                .coordinator
+                .reset_scheduled_request(seq_id)
+                .map_err(Error::from_reason)?;
+            cached = 0;
+        }
+        Ok(ScheduledPrefixAdmission::Ready(MusePrefixState {
+            effective_cached_prefix_len: cached as usize,
+            suffix_len: tokens.len().saturating_sub(cached as usize),
+        }))
+    }
+
+    fn extra_prefill_breaks(&self, _prompt_tokens: u32, _cached_prefix: u32) -> Vec<u32> {
+        self.cold_anchor_rungs()
+    }
+
+    fn step_executor(&mut self) -> Self::StepExecutor<'_> {
+        HybridStepExecutor::new(self)
+    }
+
+    fn execute_barrier(
+        &mut self,
+        command: Self::Command,
+        owners: SchedulerOwnerContext<'_, Self::OwnerState>,
+    ) {
+        let MuseGlimmerCmd::Chat(command) = command else {
+            return;
+        };
+        if matches!(command.as_ref(), ChatCmd::ResetCaches { .. }) {
+            self.select_ownerless_lane(self.paged.is_none());
+            handle_chat_cmd(self, *command);
+            return;
+        }
+        let command = *command;
+        let flat_lane = chat_config(&command).is_some_and(|config| config.enable_mtp == Some(true))
+            || self.paged.is_none();
+        let Some(owner) = owner_id(&command).map(str::to_owned) else {
+            self.select_ownerless_lane(flat_lane);
+            handle_chat_cmd(self, command);
+            return;
+        };
+        if is_start(&command) {
+            if let Some(seq_id) = owners.owner_sequences.remove(&owner)
+                && let Err(error) = self.release_scheduled_cache(seq_id)
+            {
+                send_error(command, error);
+                return;
+            }
+            owners.owner_states.remove(&owner);
+        } else {
+            let state = owners.owner_states.get(&owner);
+            let matching = if flat_lane {
+                state.is_some_and(|state| state.flat_caches.is_some())
+            } else {
+                owners.owner_sequences.contains_key(&owner)
+                    && state.is_some_and(|state| state.flat_caches.is_none())
+            };
+            if !matching {
+                let conflicting = state.is_some() || owners.owner_sequences.contains_key(&owner);
+                let message = if conflicting {
+                    "Muse-Glimmer cannot switch a live cache owner between paged AR and flat DFlash layouts; start a new session"
+                } else {
+                    "chat session continuation requires an initialized cache owner (call chatSessionStart first)"
+                };
+                send_error(command, Error::from_reason(message));
+                return;
+            }
+        }
+        let state = owners.owner_states.remove(&owner).unwrap_or_default();
+        if flat_lane {
+            self.install_flat_owner_caches(state.flat_caches);
+            self.cached_token_history = state.history;
+            handle_chat_cmd(self, command);
+            if ChatBackend::has_live_session(self) {
+                owners.owner_states.insert(
+                    owner,
+                    MuseOwnerState {
+                        history: self.cached_token_history.clone(),
+                        flat_caches: Some(self.take_flat_owner_caches()),
+                    },
+                );
+            } else {
+                owners.owner_sequences.remove(&owner);
+            }
+        } else {
+            let seq_id = owners
+                .owner_sequences
+                .get(&owner)
+                .copied()
+                .unwrap_or_else(|| {
+                    let seq_id = *owners.next_seq_id;
+                    *owners.next_seq_id = owners.next_seq_id.saturating_add(1);
+                    owners.owner_sequences.insert(owner.clone(), seq_id);
+                    seq_id
+                });
+            self.set_active_paged_owner(seq_id);
+            self.cached_token_history = state.history;
+            handle_chat_cmd(self, command);
+            if ChatBackend::has_live_session(self) {
+                owners.owner_states.insert(
+                    owner,
+                    MuseOwnerState {
+                        history: self.cached_token_history.clone(),
+                        flat_caches: None,
+                    },
+                );
+            } else {
+                owners.owner_sequences.remove(&owner);
+            }
+        }
+    }
+}

--- a/crates/mlx-core/src/models/qwen3/model.rs
+++ b/crates/mlx-core/src/models/qwen3/model.rs
@@ -420,7 +420,13 @@ impl QwenStepExecutor<'_> {
         };
         payload.streamed_text_len = payload.streamed_text_len.saturating_add(text.len());
         if let (Some(sink), Some(emitter)) = (payload.response.sink(), payload.emitter.as_mut()) {
-            emitter.on_token_text(&text, is_reasoning, payload.params.include_reasoning, sink);
+            emitter.on_token_id(
+                token_id,
+                &text,
+                is_reasoning,
+                payload.params.include_reasoning,
+                sink,
+            );
         }
     }
 

--- a/crates/mlx-core/src/nn/embedding.rs
+++ b/crates/mlx-core/src/nn/embedding.rs
@@ -81,6 +81,22 @@ pub struct Embedding {
 }
 
 impl Embedding {
+    /// Construct only the embedding metadata plus a tiny placeholder. Loaders
+    /// that immediately install mmap-backed dense or packed weights avoid
+    /// building a checkpoint-sized random initialization graph first.
+    pub(crate) fn new_uninitialized(num_embeddings: u32, embedding_dim: u32) -> Result<Self> {
+        Ok(Self {
+            weight: MxArray::zeros(&[1, 1], None)?,
+            num_embeddings,
+            embedding_dim,
+            is_quantized_flag: false,
+            quantized_packed: None,
+            sharded: None,
+            #[cfg(test)]
+            packed_full_dequant_calls: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+
     /// Create a new Embedding layer
     pub fn new(num_embeddings: u32, embedding_dim: u32) -> Result<Self> {
         // Initialize with normal distribution

--- a/crates/mlx-core/src/tokenizer.rs
+++ b/crates/mlx-core/src/tokenizer.rs
@@ -297,6 +297,12 @@ impl KwargFrame {
 
 #[napi]
 impl Qwen3Tokenizer {
+    /// Internal tokenizers handle for protocol-aware stream parsers that must
+    /// retain special-token provenance. This never crosses N-API.
+    pub(crate) fn inner_arc(&self) -> Arc<Tokenizer> {
+        self.tokenizer.clone()
+    }
+
     /// Load tokenizer from tokenizer.json file
     ///
     /// # Arguments

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -1144,6 +1144,31 @@ fn is_gemma4_mmproj_gguf(metadata: &HashMap<String, GgufMetaValue>) -> bool {
                 == Some("gemma4ua"))
 }
 
+fn is_muse_glimmer_main_gguf(metadata: &HashMap<String, GgufMetaValue>) -> bool {
+    metadata
+        .get("general.architecture")
+        .and_then(GgufMetaValue::as_str)
+        == Some("muse-glimmer")
+}
+
+fn is_muse_glimmer_mmproj_gguf(metadata: &HashMap<String, GgufMetaValue>) -> bool {
+    metadata
+        .get("general.architecture")
+        .and_then(GgufMetaValue::as_str)
+        == Some("clip")
+        && metadata
+            .get("clip.projector_type")
+            .and_then(GgufMetaValue::as_str)
+            == Some("muse-glimmer")
+}
+
+fn is_muse_glimmer_dflash_gguf(metadata: &HashMap<String, GgufMetaValue>) -> bool {
+    metadata
+        .get("general.architecture")
+        .and_then(GgufMetaValue::as_str)
+        == Some("dflash")
+}
+
 /// The three names a quantized tensor group ships under. Both GGUF quant
 /// importers emit the same trio: `load_quantized_tensor` (affine Q4_0/Q4_1/Q8_0)
 /// and `load_kquant_repack` (Q4_K/Q5_K/Q6_K) each write `{base}.weight` plus a
@@ -1249,6 +1274,123 @@ fn gemma4_mmproj_name_to_hf(name: &str) -> Option<String> {
     Some(mapped.to_string())
 }
 
+/// Map the official Meta Muse-Glimmer text GGUF onto the canonical
+/// `MuseGlimmerForConditionalGeneration` SafeTensors namespace.
+///
+/// llama.cpp materializes scale-free Q/K RMSNorms as explicit all-one
+/// tensors. The HF/MLX architecture has no parameters for those operations,
+/// so they are intentionally omitted rather than becoming unused checkpoint
+/// keys. Query pre-scaling remains a config value (`qk_scale_factor`).
+fn muse_glimmer_name_to_hf(name: &str) -> Option<String> {
+    if name.ends_with(".attn_q_norm.weight") || name.ends_with(".attn_k_norm.weight") {
+        return None;
+    }
+    if name == "rope_freqs.weight" {
+        return None;
+    }
+
+    let mut result = name.to_string();
+    if result.starts_with("blk.") {
+        result = result.replacen("blk.", "model.language_model.layers.", 1);
+    }
+    result = result.replace(".attn_q.", ".self_attn.q_proj.");
+    result = result.replace(".attn_k.", ".self_attn.k_proj.");
+    result = result.replace(".attn_v.", ".self_attn.v_proj.");
+    result = result.replace(".attn_output.", ".self_attn.o_proj.");
+    result = result.replace(".attn_gate.", ".self_attn.gate_proj.");
+    result = result.replace(".ffn_gate.", ".mlp.gate_proj.");
+    result = result.replace(".ffn_down.", ".mlp.down_proj.");
+    result = result.replace(".ffn_up.", ".mlp.up_proj.");
+    result = result.replace(".attn_norm.", ".input_layernorm.");
+    result = result.replace(".post_attention_norm.", ".post_attention_layernorm.");
+    result = result.replace(".ffn_norm.", ".pre_feedforward_layernorm.");
+    result = result.replace(".post_ffw_norm.", ".post_feedforward_layernorm.");
+
+    if let Some(renamed) =
+        rename_global_quant_group(&result, "token_embd", "model.language_model.embed_tokens")
+    {
+        result = renamed;
+    } else if result == "output_norm.weight" {
+        result = "model.language_model.norm.weight".to_string();
+    } else if let Some(renamed) = rename_global_quant_group(&result, "output", "lm_head") {
+        result = renamed;
+    }
+    Some(result)
+}
+
+/// Map Meta's separate `mmproj-*.gguf` file onto the same namespace used by
+/// the original Muse-Glimmer SafeTensors release.
+fn muse_glimmer_mmproj_name_to_hf(name: &str) -> Option<String> {
+    let mut result = name.to_string();
+    if result.starts_with("v.blk.") {
+        result = result.replacen("v.blk.", "model.vision_tower.layers.", 1);
+        result = result.replace(".attn_q.", ".attn.q_proj.");
+        result = result.replace(".attn_k.", ".attn.k_proj.");
+        result = result.replace(".attn_v.", ".attn.v_proj.");
+        result = result.replace(".attn_out.", ".attn.proj.");
+        result = result.replace(".ffn_up.", ".mlp.fc1.");
+        result = result.replace(".ffn_down.", ".mlp.fc2.");
+        result = result.replace(".ln1.", ".norm1.");
+        result = result.replace(".ln2.", ".norm2.");
+        return Some(result);
+    }
+
+    for (from, to) in [
+        (
+            "v.patch_embd",
+            "model.vision_tower.patch_embedder.patch_embedding",
+        ),
+        (
+            "v.position_embd",
+            "model.vision_tower.patch_embedder.position_embedding_table",
+        ),
+        ("v.pre_ln", "model.vision_tower.ln_pre"),
+        ("v.post_ln", "model.vision_tower.ln_post"),
+        ("mm.0", "model.vision_adapter.fc1"),
+        ("mm.1", "model.vision_adapter.fc2"),
+        ("mm.2", "model.vision_projection"),
+    ] {
+        if let Some(renamed) = rename_global_quant_group(name, from, to) {
+            return Some(renamed);
+        }
+        if let Some(suffix) = name.strip_prefix(from)
+            && matches!(suffix, ".bias")
+        {
+            return Some(format!("{to}{suffix}"));
+        }
+    }
+    Some(result)
+}
+
+/// Map the companion DFlash GGUF to a compact, self-contained drafter
+/// namespace. The target embedding and lm_head are intentionally absent from
+/// this file: Meta's drafter shares both with the target model.
+fn muse_glimmer_dflash_name_to_hf(name: &str) -> Option<String> {
+    let mut result = name.to_string();
+    if result.starts_with("blk.") {
+        result = result.replacen("blk.", "layers.", 1);
+        result = result.replace(".attn_q.", ".self_attn.q_proj.");
+        result = result.replace(".attn_k.", ".self_attn.k_proj.");
+        result = result.replace(".attn_v.", ".self_attn.v_proj.");
+        result = result.replace(".attn_output.", ".self_attn.o_proj.");
+        result = result.replace(".attn_q_norm.", ".self_attn.q_norm.");
+        result = result.replace(".attn_k_norm.", ".self_attn.k_norm.");
+        result = result.replace(".ffn_gate.", ".mlp.gate_proj.");
+        result = result.replace(".ffn_up.", ".mlp.up_proj.");
+        result = result.replace(".ffn_down.", ".mlp.down_proj.");
+        result = result.replace(".attn_norm.", ".input_layernorm.");
+        result = result.replace(".ffn_norm.", ".post_attention_layernorm.");
+        return Some(result);
+    }
+    if let Some(renamed) = rename_global_quant_group(name, "enc.output_norm", "hidden_norm") {
+        return Some(renamed);
+    }
+    if let Some(renamed) = rename_global_quant_group(name, "output_norm", "norm") {
+        return Some(renamed);
+    }
+    Some(result)
+}
+
 fn gguf_name_to_hf_for_metadata(
     name: &str,
     metadata: &HashMap<String, GgufMetaValue>,
@@ -1257,6 +1399,12 @@ fn gguf_name_to_hf_for_metadata(
         gemma4_name_to_hf(name)
     } else if is_gemma4_mmproj_gguf(metadata) {
         gemma4_mmproj_name_to_hf(name)
+    } else if is_muse_glimmer_main_gguf(metadata) {
+        muse_glimmer_name_to_hf(name)
+    } else if is_muse_glimmer_mmproj_gguf(metadata) {
+        muse_glimmer_mmproj_name_to_hf(name)
+    } else if is_muse_glimmer_dflash_gguf(metadata) {
+        muse_glimmer_dflash_name_to_hf(name)
     } else {
         Some(gguf_name_to_hf(name))
     }
@@ -1900,10 +2048,11 @@ pub fn extract_config(metadata: &HashMap<String, GgufMetaValue>) -> serde_json::
     // with existing Gemma4 K-quant conversions and because neither GGUF value is
     // the whole story there.
     let is_qwen_family = matches!(arch.as_str(), "qwen3" | "qwen35" | "qwen35moe");
+    let has_independent_head_dim = is_qwen_family || arch == "muse-glimmer";
     // A key_length of 0 is not a head dim; fall through to the derivation
     // rather than writing a config that divides by it downstream. Same guard
     // the `heads > 0` arm below applies to the derived value.
-    let key_length = if is_qwen_family {
+    let key_length = if has_independent_head_dim {
         metadata
             .get(&format!("{arch}.attention.key_length"))
             .and_then(|v| v.as_u32())
@@ -2370,30 +2519,9 @@ fn preserved_source_quantization(
     gguf: &GgufFile,
     import_k_quants: bool,
 ) -> Result<Option<serde_json::Value>> {
-    let mut profiles = std::collections::BTreeMap::<String, SourceQuantProfile>::new();
+    let profiles = source_quantization_profiles(gguf, import_k_quants)?;
     let mut profile_counts = HashMap::<SourceQuantProfile, usize>::new();
-
-    for tensor in &gguf.tensors {
-        if !import_k_quants && tensor.tensor_type.k_quant_format().is_some() {
-            continue;
-        }
-        let Some(profile) = SourceQuantProfile::for_gguf_type(tensor.tensor_type) else {
-            continue;
-        };
-        let Some(mapped) = gguf_name_to_hf_for_metadata(&tensor.name, &gguf.metadata) else {
-            continue;
-        };
-        let prefix = mapped.strip_suffix(".weight").unwrap_or(&mapped);
-        let prefix = super::normalize_override_key(prefix);
-        if let Some(previous) = profiles.insert(prefix.clone(), profile)
-            && previous != profile
-        {
-            return Err(Error::from_reason(format!(
-                "GGUF source quantization collision: '{prefix}' resolves to both {} and {} tensors",
-                previous.describe(),
-                profile.describe()
-            )));
-        }
+    for &profile in profiles.values() {
         *profile_counts.entry(profile).or_default() += 1;
     }
 
@@ -2433,6 +2561,136 @@ fn preserved_source_quantization(
         }
     }
     Ok(Some(serde_json::Value::Object(quant)))
+}
+
+fn source_quantization_profiles(
+    gguf: &GgufFile,
+    import_k_quants: bool,
+) -> Result<std::collections::BTreeMap<String, SourceQuantProfile>> {
+    let mut profiles = std::collections::BTreeMap::new();
+    for tensor in &gguf.tensors {
+        if !import_k_quants && tensor.tensor_type.k_quant_format().is_some() {
+            continue;
+        }
+        let Some(profile) = SourceQuantProfile::for_gguf_type(tensor.tensor_type) else {
+            continue;
+        };
+        let Some(mapped) = gguf_name_to_hf_for_metadata(&tensor.name, &gguf.metadata) else {
+            continue;
+        };
+        let prefix = mapped.strip_suffix(".weight").unwrap_or(&mapped);
+        let prefix = super::normalize_override_key(prefix);
+        if let Some(previous) = profiles.insert(prefix.clone(), profile)
+            && previous != profile
+        {
+            return Err(Error::from_reason(format!(
+                "GGUF source quantization collision: '{prefix}' resolves to both {} and {} tensors",
+                previous.describe(),
+                profile.describe()
+            )));
+        }
+    }
+    Ok(profiles)
+}
+
+/// Secondary Muse mmproj files share the target's config.json. Unlike a
+/// uniform affine companion, Meta's file deliberately mixes Q4_K and Q6_K,
+/// so every packed projection needs an explicit mode entry in that shared
+/// config; the text model's top-level default cannot describe both.
+fn merge_muse_secondary_quantization(
+    config_path: &Path,
+    gguf: &GgufFile,
+    import_k_quants: bool,
+) -> Result<()> {
+    let profiles = source_quantization_profiles(gguf, import_k_quants)?;
+    if profiles.is_empty() {
+        return Ok(());
+    }
+    let data = fs::read_to_string(config_path).map_err(|e| {
+        Error::from_reason(format!(
+            "Muse-Glimmer companion GGUF needs the primary model config at {}: {e}",
+            config_path.display()
+        ))
+    })?;
+    let mut config: serde_json::Value = serde_json::from_str(&data).map_err(|e| {
+        Error::from_reason(format!("Failed to parse {}: {e}", config_path.display()))
+    })?;
+
+    for key in ["quantization", "quantization_config"] {
+        let quant = config
+            .get_mut(key)
+            .and_then(serde_json::Value::as_object_mut)
+            .ok_or_else(|| {
+                Error::from_reason(format!(
+                    "Muse-Glimmer companion GGUF is K-quantized but {} has no object-valued '{key}' from the primary GGUF conversion",
+                    config_path.display()
+                ))
+            })?;
+        for (prefix, profile) in &profiles {
+            quant.insert(prefix.clone(), profile.to_json());
+        }
+    }
+
+    if is_muse_glimmer_dflash_gguf(&gguf.metadata) {
+        let read_u32 = |key: &str| -> Result<u32> {
+            gguf.metadata
+                .get(key)
+                .and_then(GgufMetaValue::as_u32)
+                .ok_or_else(|| Error::from_reason(format!("DFlash GGUF is missing '{key}'")))
+        };
+        let target_layers = match gguf.metadata.get("dflash.target_layers") {
+            Some(GgufMetaValue::ArrayU32(values)) => values.clone(),
+            Some(GgufMetaValue::ArrayI32(values)) => values
+                .iter()
+                .map(|&value| u32::try_from(value))
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(|_| {
+                    Error::from_reason("DFlash target_layers contains a negative index")
+                })?,
+            _ => {
+                return Err(Error::from_reason(
+                    "DFlash GGUF is missing its target_layers array",
+                ));
+            }
+        };
+        let target_layers = target_layers
+            .into_iter()
+            .map(|layer| {
+                layer.checked_sub(1).ok_or_else(|| {
+                    Error::from_reason("DFlash target_layers are 1-based and cannot contain 0")
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        config["dflash_config"] = serde_json::json!({
+            "num_hidden_layers": read_u32("dflash.block_count")?,
+            "block_size": read_u32("dflash.block_size")?,
+            "hidden_size": read_u32("dflash.embedding_length")?,
+            "intermediate_size": read_u32("dflash.feed_forward_length")?,
+            "num_attention_heads": read_u32("dflash.attention.head_count")?,
+            "num_key_value_heads": read_u32("dflash.attention.head_count_kv")?,
+            "head_dim": read_u32("dflash.attention.key_length")?,
+            "sliding_window": read_u32("dflash.attention.sliding_window")?,
+            "max_position_embeddings": read_u32("dflash.context_length")?,
+            "rms_norm_eps": gguf.metadata
+                .get("dflash.attention.layer_norm_rms_epsilon")
+                .and_then(GgufMetaValue::as_f32)
+                .ok_or_else(|| Error::from_reason("DFlash GGUF is missing its RMS epsilon"))?,
+            "rope_theta": gguf.metadata
+                .get("dflash.rope.freq_base")
+                .and_then(GgufMetaValue::as_f32)
+                .ok_or_else(|| Error::from_reason("DFlash GGUF is missing its RoPE theta"))?,
+            "target_layers": target_layers,
+            "mask_token_id": read_u32("tokenizer.ggml.mask_token_id")?,
+            "causal": false,
+        });
+    }
+
+    let output = serde_json::to_string_pretty(&config)
+        .map_err(|e| Error::from_reason(format!("Failed to serialize config: {e}")))?;
+    fs::write(config_path, output).map_err(|e| {
+        Error::from_reason(format!("Failed to update {}: {e}", config_path.display()))
+    })?;
+    Ok(())
 }
 
 // ── Dtype Conversion ────────────────────────────────────────────────────────
@@ -2765,6 +3023,8 @@ pub async fn convert_gguf_to_safetensors(
     // Header-only, like the two guards above — `parse_gguf` has read the header,
     // metadata and tensor descriptors and nothing else.
     if !is_primary_model
+        && !is_muse_glimmer_mmproj_gguf(&gguf.metadata)
+        && !is_muse_glimmer_dflash_gguf(&gguf.metadata)
         && let Some((tensor, profile)) = gguf.tensors.iter().find_map(|t| {
             if !import_k_quants && t.tensor_type.k_quant_format().is_some() {
                 return None;
@@ -2806,6 +3066,18 @@ pub async fn convert_gguf_to_safetensors(
     let asset_dir = config_source_dir.clone().unwrap_or(gguf_dir);
     let src_config = asset_dir.join("config.json");
     let synthesized_config = !src_config.exists();
+
+    // The text GGUF contains the decoder geometry, but the runtime contract is
+    // the multimodal HF config: it also carries image/video token IDs, the
+    // projector dimensions, vision layer kinds, and Muse's independent
+    // per-layer RoPE table. Inventing those fields would make a text-only
+    // smoke test pass while producing an artifact that cannot safely attach
+    // Meta's mmproj. Require the authoritative base-model assets instead.
+    if is_primary_model && is_muse_glimmer_main_gguf(&gguf.metadata) && synthesized_config {
+        return Err(Error::from_reason(
+            "Muse-Glimmer GGUF conversion requires the authoritative base-model config and tokenizer assets. Pass --config-dir pointing to meta-models/Muse-Glimmer-30B (or place config.json beside the GGUF); the GGUF header alone does not contain the multimodal token IDs and complete vision layer table.",
+        ));
+    }
 
     // A synthesized config gets its KV head counts from
     // `apply_gemma4_attention_geometry`, which can only tell the sliding count
@@ -3147,7 +3419,7 @@ pub async fn convert_gguf_to_safetensors(
     }
 
     // Remap LLM keys for VLM compatibility when requested
-    if options.vlm_key_prefix.unwrap_or(false) {
+    if options.vlm_key_prefix.unwrap_or(false) && !is_muse_glimmer_main_gguf(&gguf.metadata) {
         let keys: Vec<String> = weights.keys().cloned().collect();
         for key in keys {
             if key.starts_with("model.") || key.starts_with("lm_head.") {
@@ -3241,6 +3513,14 @@ pub async fn convert_gguf_to_safetensors(
             }
         }
 
+        if is_muse_glimmer_main_gguf(&gguf.metadata) {
+            // llama.cpp's official converter unpermutes decoder and vision Q/K
+            // rows into ggml's interleaved RoPE layout before K-quantization.
+            // Reordering packed rows here would violate lossless import.
+            config_json["muse_glimmer_gguf_rope_layout"] =
+                serde_json::Value::String("interleaved".to_string());
+        }
+
         if do_quantize {
             let quant_obj = crate::convert::build_quantization_object(
                 quant_bits,
@@ -3318,6 +3598,16 @@ pub async fn convert_gguf_to_safetensors(
             }
         }
     } else {
+        if is_muse_glimmer_mmproj_gguf(&gguf.metadata)
+            || is_muse_glimmer_dflash_gguf(&gguf.metadata)
+        {
+            merge_muse_secondary_quantization(
+                &output_dir.join("config.json"),
+                &gguf,
+                import_k_quants,
+            )?;
+            info!("Merged Muse-Glimmer companion GGUF metadata into config.json");
+        }
         info!(
             "Skipping config.json and tokenizer writes for secondary output file: {safetensors_filename}"
         );
@@ -4732,6 +5022,126 @@ mod tests {
                 GgufMetaValue::String("gemma4uv".to_string()),
             ),
         ])
+    }
+
+    fn muse_glimmer_metadata() -> HashMap<String, GgufMetaValue> {
+        HashMap::from([(
+            "general.architecture".to_string(),
+            GgufMetaValue::String("muse-glimmer".to_string()),
+        )])
+    }
+
+    fn muse_glimmer_mmproj_metadata() -> HashMap<String, GgufMetaValue> {
+        HashMap::from([
+            (
+                "general.architecture".to_string(),
+                GgufMetaValue::String("clip".to_string()),
+            ),
+            (
+                "clip.projector_type".to_string(),
+                GgufMetaValue::String("muse-glimmer".to_string()),
+            ),
+        ])
+    }
+
+    fn muse_glimmer_dflash_metadata() -> HashMap<String, GgufMetaValue> {
+        HashMap::from([(
+            "general.architecture".to_string(),
+            GgufMetaValue::String("dflash".to_string()),
+        )])
+    }
+
+    #[test]
+    fn muse_glimmer_mapping_matches_canonical_text_checkpoint() {
+        let metadata = muse_glimmer_metadata();
+        let cases = [
+            (
+                "blk.7.attn_gate.weight",
+                Some("model.language_model.layers.7.self_attn.gate_proj.weight"),
+            ),
+            (
+                "blk.7.ffn_norm.weight",
+                Some("model.language_model.layers.7.pre_feedforward_layernorm.weight"),
+            ),
+            (
+                "blk.7.post_ffw_norm.weight",
+                Some("model.language_model.layers.7.post_feedforward_layernorm.weight"),
+            ),
+            (
+                "token_embd.scales",
+                Some("model.language_model.embed_tokens.scales"),
+            ),
+            ("output.weight", Some("lm_head.weight")),
+            (
+                "output_norm.weight",
+                Some("model.language_model.norm.weight"),
+            ),
+            ("blk.7.attn_q_norm.weight", None),
+            ("blk.7.attn_k_norm.weight", None),
+        ];
+        for (source, expected) in cases {
+            assert_eq!(
+                gguf_name_to_hf_for_metadata(source, &metadata).as_deref(),
+                expected,
+                "mapping mismatch for {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn muse_glimmer_mmproj_mapping_matches_canonical_checkpoint() {
+        let metadata = muse_glimmer_mmproj_metadata();
+        let cases = [
+            (
+                "v.blk.4.attn_q.weight",
+                "model.vision_tower.layers.4.attn.q_proj.weight",
+            ),
+            (
+                "v.blk.4.ffn_down.bias",
+                "model.vision_tower.layers.4.mlp.fc2.bias",
+            ),
+            (
+                "v.patch_embd.weight",
+                "model.vision_tower.patch_embedder.patch_embedding.weight",
+            ),
+            ("mm.0.weight", "model.vision_adapter.fc1.weight"),
+            ("mm.1.weight", "model.vision_adapter.fc2.weight"),
+            ("mm.2.weight", "model.vision_projection.weight"),
+        ];
+        for (source, expected) in cases {
+            assert_eq!(
+                gguf_name_to_hf_for_metadata(source, &metadata).as_deref(),
+                Some(expected),
+                "mapping mismatch for {source}"
+            );
+        }
+    }
+
+    #[test]
+    fn muse_glimmer_dflash_mapping_matches_runtime_namespace() {
+        let metadata = muse_glimmer_dflash_metadata();
+        let cases = [
+            ("blk.2.attn_q.weight", "layers.2.self_attn.q_proj.weight"),
+            (
+                "blk.2.attn_q_norm.weight",
+                "layers.2.self_attn.q_norm.weight",
+            ),
+            ("blk.2.ffn_down.weight", "layers.2.mlp.down_proj.weight"),
+            (
+                "blk.2.ffn_norm.weight",
+                "layers.2.post_attention_layernorm.weight",
+            ),
+            ("enc.output_norm.weight", "hidden_norm.weight"),
+            ("output_norm.weight", "norm.weight"),
+            ("fc.weight", "fc.weight"),
+        ];
+        for (source, expected) in cases {
+            assert_eq!(
+                gguf_name_to_hf_for_metadata(source, &metadata).as_deref(),
+                Some(expected),
+                "mapping mismatch for {source}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -2660,6 +2660,97 @@ fn muse_dflash_config_value(gguf: &GgufFile) -> Result<serde_json::Value> {
     }))
 }
 
+fn validate_muse_dflash_tensor_descriptors(
+    gguf: &GgufFile,
+    config: &crate::models::muse_glimmer::config::MuseGlimmerDFlashConfig,
+) -> Result<()> {
+    let dimension = |name: &str, value: usize| {
+        u64::try_from(value).map_err(|_| {
+            Error::from_reason(format!(
+                "DFlash {name} {value} cannot be represented as a GGUF dimension"
+            ))
+        })
+    };
+    let hidden = dimension("hidden_size", config.hidden_size)?;
+    let intermediate = dimension("intermediate_size", config.intermediate_size)?;
+    let head_dim = dimension("head_dim", config.head_dim)?;
+    let query_width = dimension(
+        "query width",
+        config
+            .num_attention_heads
+            .checked_mul(config.head_dim)
+            .ok_or_else(|| Error::from_reason("DFlash query width overflows usize"))?,
+    )?;
+    let kv_width = dimension(
+        "KV width",
+        config
+            .num_key_value_heads
+            .checked_mul(config.head_dim)
+            .ok_or_else(|| Error::from_reason("DFlash KV width overflows usize"))?,
+    )?;
+    let context_width = dimension(
+        "context projection width",
+        config
+            .hidden_size
+            .checked_mul(config.target_layers.len())
+            .ok_or_else(|| Error::from_reason("DFlash context projection width overflows usize"))?,
+    )?;
+
+    let mut required = Vec::<(String, Vec<u64>)>::with_capacity(
+        3usize.saturating_add(config.num_hidden_layers.saturating_mul(11)),
+    );
+    required.push(("fc.weight".to_string(), vec![hidden, context_width]));
+    required.push(("enc.output_norm.weight".to_string(), vec![hidden]));
+    required.push(("output_norm.weight".to_string(), vec![hidden]));
+    for index in 0..config.num_hidden_layers {
+        let base = format!("blk.{index}");
+        required.extend([
+            (format!("{base}.attn_norm.weight"), vec![hidden]),
+            (format!("{base}.ffn_norm.weight"), vec![hidden]),
+            (format!("{base}.attn_q_norm.weight"), vec![head_dim]),
+            (format!("{base}.attn_k_norm.weight"), vec![head_dim]),
+            (format!("{base}.attn_q.weight"), vec![query_width, hidden]),
+            (format!("{base}.attn_k.weight"), vec![kv_width, hidden]),
+            (format!("{base}.attn_v.weight"), vec![kv_width, hidden]),
+            (
+                format!("{base}.attn_output.weight"),
+                vec![hidden, query_width],
+            ),
+            (
+                format!("{base}.ffn_gate.weight"),
+                vec![intermediate, hidden],
+            ),
+            (format!("{base}.ffn_up.weight"), vec![intermediate, hidden]),
+            (
+                format!("{base}.ffn_down.weight"),
+                vec![hidden, intermediate],
+            ),
+        ]);
+    }
+
+    let mut descriptors = HashMap::with_capacity(gguf.tensors.len());
+    for tensor in &gguf.tensors {
+        if descriptors.insert(tensor.name.as_str(), tensor).is_some() {
+            return Err(Error::from_reason(format!(
+                "DFlash GGUF contains duplicate tensor descriptor '{}'",
+                tensor.name
+            )));
+        }
+    }
+    for (name, expected) in required {
+        let tensor = descriptors.get(name.as_str()).ok_or_else(|| {
+            Error::from_reason(format!("DFlash GGUF is missing required tensor '{name}'"))
+        })?;
+        let actual = tensor.dims.iter().rev().copied().collect::<Vec<_>>();
+        if actual != expected {
+            return Err(Error::from_reason(format!(
+                "DFlash GGUF tensor '{name}' has MLX shape {actual:?}; expected {expected:?} from dflash_config"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Secondary Muse mmproj files share the target's config.json. Unlike a
 /// uniform affine companion, Meta's file deliberately mixes Q4_K and Q6_K,
 /// so every packed projection needs an explicit mode entry in that shared
@@ -2740,7 +2831,15 @@ fn prepare_muse_secondary_config(
     let output = serde_json::to_string_pretty(&config)
         .map_err(|e| Error::from_reason(format!("Failed to serialize config: {e}")))?;
     if is_dflash {
-        crate::models::muse_glimmer::config::MuseGlimmerConfig::from_json_str(&output)?;
+        let validated =
+            crate::models::muse_glimmer::config::MuseGlimmerConfig::from_json_str(&output)?;
+        validate_muse_dflash_tensor_descriptors(
+            gguf,
+            validated
+                .dflash_config
+                .as_ref()
+                .expect("validated DFlash config must be present"),
+        )?;
     }
     Ok(Some(output))
 }
@@ -2777,7 +2876,14 @@ pub fn preflight_muse_dflash_gguf(input_path: String, target_config_dir: String)
     let merged = serde_json::to_string(&target).map_err(|error| {
         Error::from_reason(format!("Failed to serialize DFlash preflight: {error}"))
     })?;
-    crate::models::muse_glimmer::config::MuseGlimmerConfig::from_json_str(&merged)?;
+    let validated = crate::models::muse_glimmer::config::MuseGlimmerConfig::from_json_str(&merged)?;
+    validate_muse_dflash_tensor_descriptors(
+        &gguf,
+        validated
+            .dflash_config
+            .as_ref()
+            .expect("validated DFlash config must be present"),
+    )?;
     Ok(())
 }
 
@@ -5172,6 +5278,48 @@ mod tests {
         metadata
     }
 
+    fn dflash_tensor(name: impl Into<String>, mlx_shape: &[u64]) -> GgufTensorInfo {
+        GgufTensorInfo {
+            name: name.into(),
+            n_dims: mlx_shape.len() as u32,
+            dims: mlx_shape.iter().rev().copied().collect(),
+            tensor_type: GgufTensorType::F32,
+            offset: 0,
+        }
+    }
+
+    fn complete_muse_glimmer_dflash_tensors() -> Vec<GgufTensorInfo> {
+        const LAYERS: usize = 5;
+        const HIDDEN: u64 = 6656;
+        const INTERMEDIATE: u64 = 1536;
+        const HEAD_DIM: u64 = 64;
+        const QUERY_WIDTH: u64 = 8 * HEAD_DIM;
+        const KV_WIDTH: u64 = 2 * HEAD_DIM;
+        const CONTEXT_WIDTH: u64 = 3 * HIDDEN;
+
+        let mut tensors = Vec::with_capacity(3 + LAYERS * 11);
+        tensors.push(dflash_tensor("fc.weight", &[HIDDEN, CONTEXT_WIDTH]));
+        tensors.push(dflash_tensor("enc.output_norm.weight", &[HIDDEN]));
+        tensors.push(dflash_tensor("output_norm.weight", &[HIDDEN]));
+        for index in 0..LAYERS {
+            let base = format!("blk.{index}");
+            tensors.extend([
+                dflash_tensor(format!("{base}.attn_norm.weight"), &[HIDDEN]),
+                dflash_tensor(format!("{base}.ffn_norm.weight"), &[HIDDEN]),
+                dflash_tensor(format!("{base}.attn_q_norm.weight"), &[HEAD_DIM]),
+                dflash_tensor(format!("{base}.attn_k_norm.weight"), &[HEAD_DIM]),
+                dflash_tensor(format!("{base}.attn_q.weight"), &[QUERY_WIDTH, HIDDEN]),
+                dflash_tensor(format!("{base}.attn_k.weight"), &[KV_WIDTH, HIDDEN]),
+                dflash_tensor(format!("{base}.attn_v.weight"), &[KV_WIDTH, HIDDEN]),
+                dflash_tensor(format!("{base}.attn_output.weight"), &[HIDDEN, QUERY_WIDTH]),
+                dflash_tensor(format!("{base}.ffn_gate.weight"), &[INTERMEDIATE, HIDDEN]),
+                dflash_tensor(format!("{base}.ffn_up.weight"), &[INTERMEDIATE, HIDDEN]),
+                dflash_tensor(format!("{base}.ffn_down.weight"), &[HIDDEN, INTERMEDIATE]),
+            ]);
+        }
+        tensors
+    }
+
     #[test]
     fn gguf_u32_metadata_conversion_is_checked() {
         assert_eq!(GgufMetaValue::Uint32(u32::MAX).as_u32(), Some(u32::MAX));
@@ -5331,11 +5479,12 @@ mod tests {
 
     #[test]
     fn floating_point_dflash_still_writes_runtime_metadata() {
+        let tensors = complete_muse_glimmer_dflash_tensors();
         let gguf = GgufFile {
             version: GGUF_VERSION_3,
-            tensor_count: 0,
+            tensor_count: tensors.len() as u64,
             metadata: complete_muse_glimmer_dflash_metadata(),
-            tensors: Vec::new(),
+            tensors,
             alignment: GGUF_DEFAULT_ALIGNMENT,
             data_offset: 0,
         };
@@ -5407,18 +5556,84 @@ mod tests {
     }
 
     #[test]
+    fn dflash_descriptor_inventory_matches_runtime_geometry() {
+        let config = crate::models::muse_glimmer::config::MuseGlimmerDFlashConfig {
+            num_hidden_layers: 5,
+            block_size: 16,
+            hidden_size: 6656,
+            intermediate_size: 1536,
+            num_attention_heads: 8,
+            num_key_value_heads: 2,
+            head_dim: 64,
+            sliding_window: 2048,
+            max_position_embeddings: 131_072,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10_000.0,
+            target_layers: vec![0, 7, 15],
+            mask_token_id: 201_818,
+            causal: false,
+        };
+        let gguf_with = |tensors: Vec<GgufTensorInfo>| GgufFile {
+            version: GGUF_VERSION_3,
+            tensor_count: tensors.len() as u64,
+            metadata: complete_muse_glimmer_dflash_metadata(),
+            tensors,
+            alignment: GGUF_DEFAULT_ALIGNMENT,
+            data_offset: 0,
+        };
+
+        validate_muse_dflash_tensor_descriptors(
+            &gguf_with(complete_muse_glimmer_dflash_tensors()),
+            &config,
+        )
+        .expect("complete descriptor inventory");
+
+        let mut missing = complete_muse_glimmer_dflash_tensors();
+        missing.retain(|tensor| tensor.name != "fc.weight");
+        let error = validate_muse_dflash_tensor_descriptors(&gguf_with(missing), &config)
+            .expect_err("missing context projection must fail");
+        assert!(error.reason.contains("missing required tensor 'fc.weight'"));
+
+        let mut wrong_shape = complete_muse_glimmer_dflash_tensors();
+        let output = wrong_shape
+            .iter_mut()
+            .find(|tensor| tensor.name == "blk.2.attn_output.weight")
+            .expect("complete descriptor inventory");
+        output.dims[0] -= 1;
+        let error = validate_muse_dflash_tensor_descriptors(&gguf_with(wrong_shape), &config)
+            .expect_err("wrong output projection shape must fail");
+        assert!(
+            error.reason.contains("blk.2.attn_output.weight")
+                && error.reason.contains("expected [6656, 512]"),
+            "unexpected shape error: {}",
+            error.reason
+        );
+    }
+
+    #[test]
+    #[ignore = "requires the official Muse-Glimmer DFlash GGUF and target config"]
+    fn real_muse_glimmer_dflash_descriptors_pass_preflight() {
+        let input = std::env::var("MLX_TEST_MUSE_GLIMMER_DFLASH_GGUF")
+            .expect("set MLX_TEST_MUSE_GLIMMER_DFLASH_GGUF");
+        let target = std::env::var("MLX_TEST_MUSE_GLIMMER_MODEL_PATH")
+            .expect("set MLX_TEST_MUSE_GLIMMER_MODEL_PATH");
+        preflight_muse_dflash_gguf(input, target)
+            .expect("official DFlash descriptor inventory must pass preflight");
+    }
+
+    #[test]
     fn kquant_dflash_initializes_quantization_for_a_dense_target() {
+        let mut tensors = complete_muse_glimmer_dflash_tensors();
+        tensors
+            .iter_mut()
+            .find(|tensor| tensor.name == "blk.0.attn_q.weight")
+            .expect("complete DFlash tensor inventory")
+            .tensor_type = GgufTensorType::Q4K;
         let gguf = GgufFile {
             version: GGUF_VERSION_3,
-            tensor_count: 1,
+            tensor_count: tensors.len() as u64,
             metadata: complete_muse_glimmer_dflash_metadata(),
-            tensors: vec![GgufTensorInfo {
-                name: "blk.0.attn_q.weight".to_string(),
-                n_dims: 2,
-                dims: vec![256, 1],
-                tensor_type: GgufTensorType::Q4K,
-                offset: 0,
-            }],
+            tensors,
             alignment: GGUF_DEFAULT_ALIGNMENT,
             data_offset: 0,
         };
@@ -5458,17 +5673,17 @@ mod tests {
 
     #[test]
     fn companion_quantization_keeps_target_and_dflash_layers_distinct() {
+        let mut tensors = complete_muse_glimmer_dflash_tensors();
+        tensors
+            .iter_mut()
+            .find(|tensor| tensor.name == "blk.0.attn_q.weight")
+            .expect("complete DFlash tensor inventory")
+            .tensor_type = GgufTensorType::Q4K;
         let gguf = GgufFile {
             version: GGUF_VERSION_3,
-            tensor_count: 1,
+            tensor_count: tensors.len() as u64,
             metadata: complete_muse_glimmer_dflash_metadata(),
-            tensors: vec![GgufTensorInfo {
-                name: "blk.0.attn_q.weight".to_string(),
-                n_dims: 2,
-                dims: vec![256, 1],
-                tensor_type: GgufTensorType::Q4K,
-                offset: 0,
-            }],
+            tensors,
             alignment: GGUF_DEFAULT_ALIGNMENT,
             data_offset: 0,
         };
@@ -5579,6 +5794,103 @@ mod tests {
             fs::read(&sidecar).expect("read preserved sidecar"),
             sentinel,
             "failed companion validation replaced the existing sidecar"
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn incomplete_dflash_inventory_fails_preflight_and_preserves_sidecar() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-muse-dflash-inventory-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after epoch")
+                .as_nanos()
+        ));
+        let output = root.join("output");
+        fs::create_dir_all(&output).expect("create output directory");
+        fs::write(
+            output.join("config.json"),
+            serde_json::to_vec(&valid_muse_target_config()).expect("serialize target config"),
+        )
+        .expect("write primary config");
+        let sidecar = output.join("draft.safetensors");
+        let sentinel = b"previous complete DFlash sidecar";
+        fs::write(&sidecar, sentinel).expect("write sidecar sentinel");
+
+        let scalar = 1.0f32.to_le_bytes();
+        let gguf = build_minimal_gguf(
+            &[
+                (
+                    "general.architecture",
+                    GgufMetaValue::String("dflash".to_string()),
+                ),
+                ("dflash.block_count", GgufMetaValue::Uint32(5)),
+                ("dflash.block_size", GgufMetaValue::Uint32(16)),
+                ("dflash.embedding_length", GgufMetaValue::Uint32(6656)),
+                ("dflash.feed_forward_length", GgufMetaValue::Uint32(1536)),
+                ("dflash.attention.head_count", GgufMetaValue::Uint32(8)),
+                ("dflash.attention.head_count_kv", GgufMetaValue::Uint32(2)),
+                ("dflash.attention.key_length", GgufMetaValue::Uint32(64)),
+                (
+                    "dflash.attention.sliding_window",
+                    GgufMetaValue::Uint32(2048),
+                ),
+                ("dflash.context_length", GgufMetaValue::Uint32(131_072)),
+                (
+                    "dflash.target_layers",
+                    GgufMetaValue::ArrayI32(vec![1, 8, 16]),
+                ),
+                (
+                    "dflash.attention.layer_norm_rms_epsilon",
+                    GgufMetaValue::Float32(1e-6),
+                ),
+                ("dflash.rope.freq_base", GgufMetaValue::Float32(10_000.0)),
+                (
+                    "tokenizer.ggml.mask_token_id",
+                    GgufMetaValue::Uint32(201_818),
+                ),
+            ],
+            &[("output_norm.weight", &[6656], GgufTensorType::F32, &scalar)],
+        );
+        let input = root.join("draft.gguf");
+        fs::write(&input, gguf).expect("write incomplete DFlash GGUF");
+
+        let error = preflight_muse_dflash_gguf(
+            input.to_string_lossy().into_owned(),
+            output.to_string_lossy().into_owned(),
+        )
+        .expect_err("preflight must reject an incomplete tensor inventory");
+        assert!(error.reason.contains("missing required tensor 'fc.weight'"));
+
+        let outcome = convert_gguf_to_safetensors(GgufConversionOptions {
+            input_path: input.to_string_lossy().into_owned(),
+            output_dir: output.to_string_lossy().into_owned(),
+            config_source_dir: None,
+            dtype: None,
+            verbose: Some(false),
+            quantize: Some(false),
+            quant_bits: None,
+            quant_group_size: None,
+            quant_mode: None,
+            quant_recipe: None,
+            imatrix_path: None,
+            output_filename: Some("draft.safetensors".to_string()),
+            vlm_key_prefix: Some(false),
+            quant_mxfp: Some(false),
+            import_k_quants: Some(true),
+        })
+        .await;
+        let error = match outcome {
+            Ok(_) => panic!("direct conversion must reject incomplete DFlash"),
+            Err(error) => error,
+        };
+        assert!(error.reason.contains("missing required tensor 'fc.weight'"));
+        assert_eq!(
+            fs::read(&sidecar).expect("read preserved sidecar"),
+            sentinel,
+            "incomplete companion replaced the existing sidecar"
         );
         fs::remove_dir_all(root).ok();
     }

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -2603,7 +2603,8 @@ fn merge_muse_secondary_quantization(
     import_k_quants: bool,
 ) -> Result<()> {
     let profiles = source_quantization_profiles(gguf, import_k_quants)?;
-    if profiles.is_empty() {
+    let is_dflash = is_muse_glimmer_dflash_gguf(&gguf.metadata);
+    if profiles.is_empty() && !is_dflash {
         return Ok(());
     }
     let data = fs::read_to_string(config_path).map_err(|e| {
@@ -2616,22 +2617,24 @@ fn merge_muse_secondary_quantization(
         Error::from_reason(format!("Failed to parse {}: {e}", config_path.display()))
     })?;
 
-    for key in ["quantization", "quantization_config"] {
-        let quant = config
-            .get_mut(key)
-            .and_then(serde_json::Value::as_object_mut)
-            .ok_or_else(|| {
-                Error::from_reason(format!(
-                    "Muse-Glimmer companion GGUF is K-quantized but {} has no object-valued '{key}' from the primary GGUF conversion",
-                    config_path.display()
-                ))
-            })?;
-        for (prefix, profile) in &profiles {
-            quant.insert(prefix.clone(), profile.to_json());
+    if !profiles.is_empty() {
+        for key in ["quantization", "quantization_config"] {
+            let quant = config
+                .get_mut(key)
+                .and_then(serde_json::Value::as_object_mut)
+                .ok_or_else(|| {
+                    Error::from_reason(format!(
+                        "Muse-Glimmer companion GGUF is K-quantized but {} has no object-valued '{key}' from the primary GGUF conversion",
+                        config_path.display()
+                    ))
+                })?;
+            for (prefix, profile) in &profiles {
+                quant.insert(prefix.clone(), profile.to_json());
+            }
         }
     }
 
-    if is_muse_glimmer_dflash_gguf(&gguf.metadata) {
+    if is_dflash {
         let read_u32 = |key: &str| -> Result<u32> {
             gguf.metadata
                 .get(key)
@@ -5142,6 +5145,69 @@ mod tests {
                 "mapping mismatch for {source}"
             );
         }
+    }
+
+    #[test]
+    fn floating_point_dflash_still_writes_runtime_metadata() {
+        let mut metadata = muse_glimmer_dflash_metadata();
+        for (key, value) in [
+            ("dflash.block_count", 5),
+            ("dflash.block_size", 16),
+            ("dflash.embedding_length", 512),
+            ("dflash.feed_forward_length", 1536),
+            ("dflash.attention.head_count", 8),
+            ("dflash.attention.head_count_kv", 2),
+            ("dflash.attention.key_length", 64),
+            ("dflash.attention.sliding_window", 2048),
+            ("dflash.context_length", 131_072),
+            ("tokenizer.ggml.mask_token_id", 201_818),
+        ] {
+            metadata.insert(key.to_string(), GgufMetaValue::Uint32(value));
+        }
+        metadata.insert(
+            "dflash.target_layers".to_string(),
+            GgufMetaValue::ArrayU32(vec![1, 8, 16]),
+        );
+        metadata.insert(
+            "dflash.attention.layer_norm_rms_epsilon".to_string(),
+            GgufMetaValue::Float32(1e-6),
+        );
+        metadata.insert(
+            "dflash.rope.freq_base".to_string(),
+            GgufMetaValue::Float32(10_000.0),
+        );
+        let gguf = GgufFile {
+            version: GGUF_VERSION_3,
+            tensor_count: 0,
+            metadata,
+            tensors: Vec::new(),
+            alignment: GGUF_DEFAULT_ALIGNMENT,
+            data_offset: 0,
+        };
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_nanos();
+        let config_path = std::env::temp_dir().join(format!(
+            "mlx-node-muse-dflash-{}-{unique}.json",
+            std::process::id()
+        ));
+        fs::write(&config_path, "{}").expect("write primary config");
+
+        merge_muse_secondary_quantization(&config_path, &gguf, true)
+            .expect("merge floating-point DFlash metadata");
+        let config: serde_json::Value =
+            serde_json::from_slice(&fs::read(&config_path).expect("read merged config"))
+                .expect("parse merged config");
+        fs::remove_file(&config_path).ok();
+
+        let dflash = config
+            .get("dflash_config")
+            .expect("floating-point DFlash must still write its config");
+        assert_eq!(dflash["block_size"], 16);
+        assert_eq!(dflash["target_layers"], serde_json::json!([0, 7, 15]));
+        assert_eq!(dflash["mask_token_id"], 201_818);
+        assert!(config.get("quantization").is_none());
     }
 
     #[test]

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -2597,15 +2597,15 @@ fn source_quantization_profiles(
 /// uniform affine companion, Meta's file deliberately mixes Q4_K and Q6_K,
 /// so every packed projection needs an explicit mode entry in that shared
 /// config; the text model's top-level default cannot describe both.
-fn merge_muse_secondary_quantization(
+fn prepare_muse_secondary_config(
     config_path: &Path,
     gguf: &GgufFile,
     import_k_quants: bool,
-) -> Result<()> {
+) -> Result<Option<String>> {
     let profiles = source_quantization_profiles(gguf, import_k_quants)?;
     let is_dflash = is_muse_glimmer_dflash_gguf(&gguf.metadata);
     if profiles.is_empty() && !is_dflash {
-        return Ok(());
+        return Ok(None);
     }
     let data = fs::read_to_string(config_path).map_err(|e| {
         Error::from_reason(format!(
@@ -2628,6 +2628,29 @@ fn merge_muse_secondary_quantization(
                         config_path.display()
                     ))
                 })?;
+            // SafeTensors conversion writes target overrides as
+            // `language_model.model.layers.*`, which the shared parser reduces
+            // to the same bare `layers.*` namespace used by DFlash. Scope the
+            // target entries one wrapper deeper before adding companion
+            // profiles so target and draft layer 0 cannot overwrite each
+            // other. Main-GGUF conversion already emits this scoped form.
+            let target_keys = quant
+                .keys()
+                .filter_map(|entry| {
+                    entry
+                        .strip_prefix("language_model.model.layers.")
+                        .map(|rest| (entry.clone(), rest.to_string()))
+                })
+                .collect::<Vec<_>>();
+            for (source, rest) in target_keys {
+                let value = quant.remove(&source).expect("collected quantization key");
+                let target = format!("language_model.model.language_model.layers.{rest}");
+                if quant.insert(target.clone(), value).is_some() {
+                    return Err(Error::from_reason(format!(
+                        "Muse-Glimmer companion quantization collides with existing scoped target override '{target}'"
+                    )));
+                }
+            }
             for (prefix, profile) in &profiles {
                 quant.insert(prefix.clone(), profile.to_json());
             }
@@ -2690,10 +2713,7 @@ fn merge_muse_secondary_quantization(
 
     let output = serde_json::to_string_pretty(&config)
         .map_err(|e| Error::from_reason(format!("Failed to serialize config: {e}")))?;
-    fs::write(config_path, output).map_err(|e| {
-        Error::from_reason(format!("Failed to update {}: {e}", config_path.display()))
-    })?;
-    Ok(())
+    Ok(Some(output))
 }
 
 // ── Dtype Conversion ────────────────────────────────────────────────────────
@@ -3081,6 +3101,21 @@ pub async fn convert_gguf_to_safetensors(
             "Muse-Glimmer GGUF conversion requires the authoritative base-model config and tokenizer assets. Pass --config-dir pointing to meta-models/Muse-Glimmer-30B (or place config.json beside the GGUF); the GGUF header alone does not contain the multimodal token IDs and complete vision layer table.",
         ));
     }
+
+    // Validate and serialize every companion-driven config mutation before
+    // loading tensor payloads or opening the destination SafeTensors file.
+    // `save_safetensors` truncates an existing sidecar immediately; a missing
+    // primary config or malformed DFlash header must therefore fail here while
+    // the previous `vision.safetensors` / `draft.safetensors` is still intact.
+    let muse_secondary_config_path = output_dir.join("config.json");
+    let prepared_muse_secondary_config = if !is_primary_model
+        && (is_muse_glimmer_mmproj_gguf(&gguf.metadata)
+            || is_muse_glimmer_dflash_gguf(&gguf.metadata))
+    {
+        prepare_muse_secondary_config(&muse_secondary_config_path, &gguf, import_k_quants)?
+    } else {
+        None
+    };
 
     // A synthesized config gets its KV head counts from
     // `apply_gemma4_attention_geometry`, which can only tell the sliding count
@@ -3601,14 +3636,13 @@ pub async fn convert_gguf_to_safetensors(
             }
         }
     } else {
-        if is_muse_glimmer_mmproj_gguf(&gguf.metadata)
-            || is_muse_glimmer_dflash_gguf(&gguf.metadata)
-        {
-            merge_muse_secondary_quantization(
-                &output_dir.join("config.json"),
-                &gguf,
-                import_k_quants,
-            )?;
+        if let Some(config) = prepared_muse_secondary_config {
+            fs::write(&muse_secondary_config_path, config).map_err(|error| {
+                Error::from_reason(format!(
+                    "Failed to update {}: {error}",
+                    muse_secondary_config_path.display()
+                ))
+            })?;
             info!("Merged Muse-Glimmer companion GGUF metadata into config.json");
         }
         info!(
@@ -5054,6 +5088,37 @@ mod tests {
         )])
     }
 
+    fn complete_muse_glimmer_dflash_metadata() -> HashMap<String, GgufMetaValue> {
+        let mut metadata = muse_glimmer_dflash_metadata();
+        for (key, value) in [
+            ("dflash.block_count", 5),
+            ("dflash.block_size", 16),
+            ("dflash.embedding_length", 512),
+            ("dflash.feed_forward_length", 1536),
+            ("dflash.attention.head_count", 8),
+            ("dflash.attention.head_count_kv", 2),
+            ("dflash.attention.key_length", 64),
+            ("dflash.attention.sliding_window", 2048),
+            ("dflash.context_length", 131_072),
+            ("tokenizer.ggml.mask_token_id", 201_818),
+        ] {
+            metadata.insert(key.to_string(), GgufMetaValue::Uint32(value));
+        }
+        metadata.insert(
+            "dflash.target_layers".to_string(),
+            GgufMetaValue::ArrayU32(vec![1, 8, 16]),
+        );
+        metadata.insert(
+            "dflash.attention.layer_norm_rms_epsilon".to_string(),
+            GgufMetaValue::Float32(1e-6),
+        );
+        metadata.insert(
+            "dflash.rope.freq_base".to_string(),
+            GgufMetaValue::Float32(10_000.0),
+        );
+        metadata
+    }
+
     #[test]
     fn muse_glimmer_mapping_matches_canonical_text_checkpoint() {
         let metadata = muse_glimmer_metadata();
@@ -5149,37 +5214,10 @@ mod tests {
 
     #[test]
     fn floating_point_dflash_still_writes_runtime_metadata() {
-        let mut metadata = muse_glimmer_dflash_metadata();
-        for (key, value) in [
-            ("dflash.block_count", 5),
-            ("dflash.block_size", 16),
-            ("dflash.embedding_length", 512),
-            ("dflash.feed_forward_length", 1536),
-            ("dflash.attention.head_count", 8),
-            ("dflash.attention.head_count_kv", 2),
-            ("dflash.attention.key_length", 64),
-            ("dflash.attention.sliding_window", 2048),
-            ("dflash.context_length", 131_072),
-            ("tokenizer.ggml.mask_token_id", 201_818),
-        ] {
-            metadata.insert(key.to_string(), GgufMetaValue::Uint32(value));
-        }
-        metadata.insert(
-            "dflash.target_layers".to_string(),
-            GgufMetaValue::ArrayU32(vec![1, 8, 16]),
-        );
-        metadata.insert(
-            "dflash.attention.layer_norm_rms_epsilon".to_string(),
-            GgufMetaValue::Float32(1e-6),
-        );
-        metadata.insert(
-            "dflash.rope.freq_base".to_string(),
-            GgufMetaValue::Float32(10_000.0),
-        );
         let gguf = GgufFile {
             version: GGUF_VERSION_3,
             tensor_count: 0,
-            metadata,
+            metadata: complete_muse_glimmer_dflash_metadata(),
             tensors: Vec::new(),
             alignment: GGUF_DEFAULT_ALIGNMENT,
             data_offset: 0,
@@ -5194,11 +5232,11 @@ mod tests {
         ));
         fs::write(&config_path, "{}").expect("write primary config");
 
-        merge_muse_secondary_quantization(&config_path, &gguf, true)
-            .expect("merge floating-point DFlash metadata");
+        let prepared = prepare_muse_secondary_config(&config_path, &gguf, true)
+            .expect("prepare floating-point DFlash metadata")
+            .expect("DFlash config update");
         let config: serde_json::Value =
-            serde_json::from_slice(&fs::read(&config_path).expect("read merged config"))
-                .expect("parse merged config");
+            serde_json::from_str(&prepared).expect("parse prepared config");
         fs::remove_file(&config_path).ok();
 
         let dflash = config
@@ -5208,6 +5246,134 @@ mod tests {
         assert_eq!(dflash["target_layers"], serde_json::json!([0, 7, 15]));
         assert_eq!(dflash["mask_token_id"], 201_818);
         assert!(config.get("quantization").is_none());
+    }
+
+    #[test]
+    fn companion_quantization_keeps_target_and_dflash_layers_distinct() {
+        let gguf = GgufFile {
+            version: GGUF_VERSION_3,
+            tensor_count: 1,
+            metadata: complete_muse_glimmer_dflash_metadata(),
+            tensors: vec![GgufTensorInfo {
+                name: "blk.0.attn_q.weight".to_string(),
+                n_dims: 2,
+                dims: vec![256, 1],
+                tensor_type: GgufTensorType::Q4K,
+                offset: 0,
+            }],
+            alignment: GGUF_DEFAULT_ALIGNMENT,
+            data_offset: 0,
+        };
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-muse-quant-scope-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("create config directory");
+        let config_path = root.join("config.json");
+        let target = serde_json::json!({"bits": 6, "group_size": 16, "mode": "q6k"});
+        fs::write(
+            &config_path,
+            serde_json::to_vec(&serde_json::json!({
+                "quantization": {
+                    "bits": 6,
+                    "group_size": 16,
+                    "mode": "q6k",
+                    "language_model.model.layers.0.self_attn.q_proj": target.clone(),
+                },
+                "quantization_config": {
+                    "bits": 6,
+                    "group_size": 16,
+                    "mode": "q6k",
+                    "language_model.model.layers.0.self_attn.q_proj": target,
+                }
+            }))
+            .expect("serialize primary config"),
+        )
+        .expect("write primary config");
+
+        let prepared = prepare_muse_secondary_config(&config_path, &gguf, true)
+            .expect("prepare companion quantization")
+            .expect("companion config update");
+        let config: serde_json::Value =
+            serde_json::from_str(&prepared).expect("parse companion config");
+        for block in ["quantization", "quantization_config"] {
+            assert_eq!(
+                config[block]["language_model.model.language_model.layers.0.self_attn.q_proj"]["mode"],
+                "q6k"
+            );
+            assert_eq!(
+                config[block]["language_model.model.layers.0.self_attn.q_proj"]["mode"],
+                "q4k"
+            );
+        }
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn invalid_dflash_metadata_does_not_replace_an_existing_sidecar() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-muse-dflash-preflight-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after epoch")
+                .as_nanos()
+        ));
+        let output = root.join("output");
+        fs::create_dir_all(&output).expect("create output directory");
+        fs::write(output.join("config.json"), "{}").expect("write primary config");
+        let sidecar = output.join("draft.safetensors");
+        let sentinel = b"previous valid DFlash sidecar";
+        fs::write(&sidecar, sentinel).expect("write sidecar sentinel");
+
+        let scalar = 1.0f32.to_le_bytes();
+        let gguf = build_minimal_gguf(
+            &[(
+                "general.architecture",
+                GgufMetaValue::String("dflash".to_string()),
+            )],
+            &[("output_norm.weight", &[1], GgufTensorType::F32, &scalar)],
+        );
+        let input = root.join("draft.gguf");
+        fs::write(&input, gguf).expect("write malformed DFlash GGUF");
+
+        let outcome = convert_gguf_to_safetensors(GgufConversionOptions {
+            input_path: input.to_string_lossy().into_owned(),
+            output_dir: output.to_string_lossy().into_owned(),
+            config_source_dir: None,
+            dtype: None,
+            verbose: Some(false),
+            quantize: Some(false),
+            quant_bits: None,
+            quant_group_size: None,
+            quant_mode: None,
+            quant_recipe: None,
+            imatrix_path: None,
+            output_filename: Some("draft.safetensors".to_string()),
+            vlm_key_prefix: Some(false),
+            quant_mxfp: Some(false),
+            import_k_quants: Some(true),
+        })
+        .await;
+        let error = match outcome {
+            Ok(_) => panic!("missing DFlash metadata must fail preflight"),
+            Err(error) => error,
+        };
+        assert!(
+            error.reason.contains("target_layers"),
+            "unexpected preflight error: {}",
+            error.reason
+        );
+        assert_eq!(
+            fs::read(&sidecar).expect("read preserved sidecar"),
+            sentinel,
+            "failed companion validation replaced the existing sidecar"
+        );
+        fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -2593,6 +2593,68 @@ fn source_quantization_profiles(
     Ok(profiles)
 }
 
+fn muse_dflash_config_value(gguf: &GgufFile) -> Result<serde_json::Value> {
+    if !is_muse_glimmer_dflash_gguf(&gguf.metadata) {
+        let architecture = gguf
+            .metadata
+            .get("general.architecture")
+            .and_then(GgufMetaValue::as_str)
+            .unwrap_or("<missing>");
+        return Err(Error::from_reason(format!(
+            "Muse-Glimmer --draft requires a DFlash GGUF (general.architecture=dflash), got '{architecture}'"
+        )));
+    }
+    let read_u32 = |key: &str| -> Result<u32> {
+        gguf.metadata
+            .get(key)
+            .and_then(GgufMetaValue::as_u32)
+            .ok_or_else(|| Error::from_reason(format!("DFlash GGUF is missing '{key}'")))
+    };
+    let target_layers = match gguf.metadata.get("dflash.target_layers") {
+        Some(GgufMetaValue::ArrayU32(values)) => values.clone(),
+        Some(GgufMetaValue::ArrayI32(values)) => values
+            .iter()
+            .map(|&value| u32::try_from(value))
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|_| Error::from_reason("DFlash target_layers contains a negative index"))?,
+        _ => {
+            return Err(Error::from_reason(
+                "DFlash GGUF is missing its target_layers array",
+            ));
+        }
+    };
+    let target_layers = target_layers
+        .into_iter()
+        .map(|layer| {
+            layer.checked_sub(1).ok_or_else(|| {
+                Error::from_reason("DFlash target_layers are 1-based and cannot contain 0")
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(serde_json::json!({
+        "num_hidden_layers": read_u32("dflash.block_count")?,
+        "block_size": read_u32("dflash.block_size")?,
+        "hidden_size": read_u32("dflash.embedding_length")?,
+        "intermediate_size": read_u32("dflash.feed_forward_length")?,
+        "num_attention_heads": read_u32("dflash.attention.head_count")?,
+        "num_key_value_heads": read_u32("dflash.attention.head_count_kv")?,
+        "head_dim": read_u32("dflash.attention.key_length")?,
+        "sliding_window": read_u32("dflash.attention.sliding_window")?,
+        "max_position_embeddings": read_u32("dflash.context_length")?,
+        "rms_norm_eps": gguf.metadata
+            .get("dflash.attention.layer_norm_rms_epsilon")
+            .and_then(GgufMetaValue::as_f32)
+            .ok_or_else(|| Error::from_reason("DFlash GGUF is missing its RMS epsilon"))?,
+        "rope_theta": gguf.metadata
+            .get("dflash.rope.freq_base")
+            .and_then(GgufMetaValue::as_f32)
+            .ok_or_else(|| Error::from_reason("DFlash GGUF is missing its RoPE theta"))?,
+        "target_layers": target_layers,
+        "mask_token_id": read_u32("tokenizer.ggml.mask_token_id")?,
+        "causal": false,
+    }))
+}
+
 /// Secondary Muse mmproj files share the target's config.json. Unlike a
 /// uniform affine companion, Meta's file deliberately mixes Q4_K and Q6_K,
 /// so every packed projection needs an explicit mode entry in that shared
@@ -2658,61 +2720,14 @@ fn prepare_muse_secondary_config(
     }
 
     if is_dflash {
-        let read_u32 = |key: &str| -> Result<u32> {
-            gguf.metadata
-                .get(key)
-                .and_then(GgufMetaValue::as_u32)
-                .ok_or_else(|| Error::from_reason(format!("DFlash GGUF is missing '{key}'")))
-        };
-        let target_layers = match gguf.metadata.get("dflash.target_layers") {
-            Some(GgufMetaValue::ArrayU32(values)) => values.clone(),
-            Some(GgufMetaValue::ArrayI32(values)) => values
-                .iter()
-                .map(|&value| u32::try_from(value))
-                .collect::<std::result::Result<Vec<_>, _>>()
-                .map_err(|_| {
-                    Error::from_reason("DFlash target_layers contains a negative index")
-                })?,
-            _ => {
-                return Err(Error::from_reason(
-                    "DFlash GGUF is missing its target_layers array",
-                ));
-            }
-        };
-        let target_layers = target_layers
-            .into_iter()
-            .map(|layer| {
-                layer.checked_sub(1).ok_or_else(|| {
-                    Error::from_reason("DFlash target_layers are 1-based and cannot contain 0")
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-        config["dflash_config"] = serde_json::json!({
-            "num_hidden_layers": read_u32("dflash.block_count")?,
-            "block_size": read_u32("dflash.block_size")?,
-            "hidden_size": read_u32("dflash.embedding_length")?,
-            "intermediate_size": read_u32("dflash.feed_forward_length")?,
-            "num_attention_heads": read_u32("dflash.attention.head_count")?,
-            "num_key_value_heads": read_u32("dflash.attention.head_count_kv")?,
-            "head_dim": read_u32("dflash.attention.key_length")?,
-            "sliding_window": read_u32("dflash.attention.sliding_window")?,
-            "max_position_embeddings": read_u32("dflash.context_length")?,
-            "rms_norm_eps": gguf.metadata
-                .get("dflash.attention.layer_norm_rms_epsilon")
-                .and_then(GgufMetaValue::as_f32)
-                .ok_or_else(|| Error::from_reason("DFlash GGUF is missing its RMS epsilon"))?,
-            "rope_theta": gguf.metadata
-                .get("dflash.rope.freq_base")
-                .and_then(GgufMetaValue::as_f32)
-                .ok_or_else(|| Error::from_reason("DFlash GGUF is missing its RoPE theta"))?,
-            "target_layers": target_layers,
-            "mask_token_id": read_u32("tokenizer.ggml.mask_token_id")?,
-            "causal": false,
-        });
+        config["dflash_config"] = muse_dflash_config_value(gguf)?;
     }
 
     let output = serde_json::to_string_pretty(&config)
         .map_err(|e| Error::from_reason(format!("Failed to serialize config: {e}")))?;
+    if is_dflash {
+        crate::models::muse_glimmer::config::MuseGlimmerConfig::from_json_str(&output)?;
+    }
     Ok(Some(output))
 }
 
@@ -2727,6 +2742,30 @@ fn convert_tensor_dtype(arr: MxArray, target: DType) -> Result<MxArray> {
 }
 
 // ── NAPI Export ──────────────────────────────────────────────────────────────
+
+/// Header-only DFlash validation for the CLI's transactional ordering. This
+/// runs before the primary conversion touches its output directory.
+#[napi]
+pub fn preflight_muse_dflash_gguf(input_path: String, target_config_dir: String) -> Result<()> {
+    let gguf = parse_gguf(&input_path)?;
+    source_quantization_profiles(&gguf, true)?;
+    let mut target: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(Path::new(&target_config_dir).join("config.json")).map_err(
+            |error| {
+                Error::from_reason(format!(
+                    "Muse-Glimmer --draft preflight could not read target config: {error}"
+                ))
+            },
+        )?,
+    )
+    .map_err(|error| Error::from_reason(format!("Invalid Muse-Glimmer target config: {error}")))?;
+    target["dflash_config"] = muse_dflash_config_value(&gguf)?;
+    let merged = serde_json::to_string(&target).map_err(|error| {
+        Error::from_reason(format!("Failed to serialize DFlash preflight: {error}"))
+    })?;
+    crate::models::muse_glimmer::config::MuseGlimmerConfig::from_json_str(&merged)?;
+    Ok(())
+}
 
 #[napi(object)]
 pub struct GgufConversionOptions {
@@ -5093,7 +5132,7 @@ mod tests {
         for (key, value) in [
             ("dflash.block_count", 5),
             ("dflash.block_size", 16),
-            ("dflash.embedding_length", 512),
+            ("dflash.embedding_length", 6656),
             ("dflash.feed_forward_length", 1536),
             ("dflash.attention.head_count", 8),
             ("dflash.attention.head_count_kv", 2),
@@ -5117,6 +5156,14 @@ mod tests {
             GgufMetaValue::Float32(10_000.0),
         );
         metadata
+    }
+
+    fn valid_muse_target_config() -> serde_json::Value {
+        let text = crate::models::muse_glimmer::config::fixtures::text_config_json(52);
+        serde_json::from_str(&crate::models::muse_glimmer::config::fixtures::config_json(
+            &text,
+        ))
+        .expect("parse Muse target fixture")
     }
 
     #[test]
@@ -5230,7 +5277,11 @@ mod tests {
             "mlx-node-muse-dflash-{}-{unique}.json",
             std::process::id()
         ));
-        fs::write(&config_path, "{}").expect("write primary config");
+        fs::write(
+            &config_path,
+            serde_json::to_vec(&valid_muse_target_config()).expect("serialize target config"),
+        )
+        .expect("write primary config");
 
         let prepared = prepare_muse_secondary_config(&config_path, &gguf, true)
             .expect("prepare floating-point DFlash metadata")
@@ -5246,6 +5297,43 @@ mod tests {
         assert_eq!(dflash["target_layers"], serde_json::json!([0, 7, 15]));
         assert_eq!(dflash["mask_token_id"], 201_818);
         assert!(config.get("quantization").is_none());
+    }
+
+    #[test]
+    fn dflash_preflight_rejects_wrong_architecture_and_target_geometry() {
+        let wrong_arch = GgufFile {
+            version: GGUF_VERSION_3,
+            tensor_count: 0,
+            metadata: muse_glimmer_metadata(),
+            tensors: Vec::new(),
+            alignment: GGUF_DEFAULT_ALIGNMENT,
+            data_offset: 0,
+        };
+        let error = muse_dflash_config_value(&wrong_arch)
+            .expect_err("a main-model GGUF cannot be accepted as --draft");
+        assert!(error.reason.contains("requires a DFlash GGUF"));
+
+        let mut metadata = complete_muse_glimmer_dflash_metadata();
+        metadata.insert(
+            "dflash.embedding_length".to_string(),
+            GgufMetaValue::Uint32(1),
+        );
+        let incompatible = GgufFile {
+            version: GGUF_VERSION_3,
+            tensor_count: 0,
+            metadata,
+            tensors: Vec::new(),
+            alignment: GGUF_DEFAULT_ALIGNMENT,
+            data_offset: 0,
+        };
+        let mut target = valid_muse_target_config();
+        target["dflash_config"] =
+            muse_dflash_config_value(&incompatible).expect("complete DFlash metadata");
+        let error = crate::models::muse_glimmer::config::MuseGlimmerConfig::from_json_str(
+            &serde_json::to_string(&target).expect("serialize incompatible target"),
+        )
+        .expect_err("DFlash hidden size must match the target");
+        assert!(error.reason.contains("does not match target hidden_size"));
     }
 
     #[test]
@@ -5275,23 +5363,22 @@ mod tests {
         fs::create_dir_all(&root).expect("create config directory");
         let config_path = root.join("config.json");
         let target = serde_json::json!({"bits": 6, "group_size": 16, "mode": "q6k"});
+        let mut primary = valid_muse_target_config();
+        primary["quantization"] = serde_json::json!({
+            "bits": 6,
+            "group_size": 16,
+            "mode": "q6k",
+            "language_model.model.layers.0.self_attn.q_proj": target.clone(),
+        });
+        primary["quantization_config"] = serde_json::json!({
+            "bits": 6,
+            "group_size": 16,
+            "mode": "q6k",
+            "language_model.model.layers.0.self_attn.q_proj": target,
+        });
         fs::write(
             &config_path,
-            serde_json::to_vec(&serde_json::json!({
-                "quantization": {
-                    "bits": 6,
-                    "group_size": 16,
-                    "mode": "q6k",
-                    "language_model.model.layers.0.self_attn.q_proj": target.clone(),
-                },
-                "quantization_config": {
-                    "bits": 6,
-                    "group_size": 16,
-                    "mode": "q6k",
-                    "language_model.model.layers.0.self_attn.q_proj": target,
-                }
-            }))
-            .expect("serialize primary config"),
+            serde_json::to_vec(&primary).expect("serialize primary config"),
         )
         .expect("write primary config");
 

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -215,9 +215,9 @@ impl GgufMetaValue {
     pub fn as_u32(&self) -> Option<u32> {
         match self {
             Self::Uint32(v) => Some(*v),
-            Self::Int32(v) => Some(*v as u32),
-            Self::Uint64(v) => Some(*v as u32),
-            Self::Int64(v) => Some(*v as u32),
+            Self::Int32(v) => u32::try_from(*v).ok(),
+            Self::Uint64(v) => u32::try_from(*v).ok(),
+            Self::Int64(v) => u32::try_from(*v).ok(),
             _ => None,
         }
     }
@@ -2605,10 +2605,15 @@ fn muse_dflash_config_value(gguf: &GgufFile) -> Result<serde_json::Value> {
         )));
     }
     let read_u32 = |key: &str| -> Result<u32> {
-        gguf.metadata
+        let value = gguf
+            .metadata
             .get(key)
-            .and_then(GgufMetaValue::as_u32)
-            .ok_or_else(|| Error::from_reason(format!("DFlash GGUF is missing '{key}'")))
+            .ok_or_else(|| Error::from_reason(format!("DFlash GGUF is missing '{key}'")))?;
+        value.as_u32().ok_or_else(|| {
+            Error::from_reason(format!(
+                "DFlash GGUF metadata '{key}' must be a nonnegative integer that fits u32"
+            ))
+        })
     };
     let target_layers = match gguf.metadata.get("dflash.target_layers") {
         Some(GgufMetaValue::ArrayU32(values)) => values.clone(),
@@ -5156,6 +5161,62 @@ mod tests {
             GgufMetaValue::Float32(10_000.0),
         );
         metadata
+    }
+
+    #[test]
+    fn gguf_u32_metadata_conversion_is_checked() {
+        assert_eq!(GgufMetaValue::Uint32(u32::MAX).as_u32(), Some(u32::MAX));
+        assert_eq!(GgufMetaValue::Int32(i32::MAX).as_u32(), Some(2_147_483_647));
+        assert_eq!(GgufMetaValue::Int32(-1).as_u32(), None);
+        assert_eq!(
+            GgufMetaValue::Uint64(u64::from(u32::MAX)).as_u32(),
+            Some(u32::MAX)
+        );
+        assert_eq!(
+            GgufMetaValue::Uint64(u64::from(u32::MAX) + 1).as_u32(),
+            None
+        );
+        assert_eq!(
+            GgufMetaValue::Int64(i64::from(u32::MAX)).as_u32(),
+            Some(u32::MAX)
+        );
+        assert_eq!(GgufMetaValue::Int64(-1).as_u32(), None);
+        assert_eq!(GgufMetaValue::Int64(i64::from(u32::MAX) + 1).as_u32(), None);
+    }
+
+    #[test]
+    fn dflash_config_rejects_negative_and_overflowing_integer_metadata() {
+        for (label, value) in [
+            ("negative i32", GgufMetaValue::Int32(-1)),
+            ("negative i64", GgufMetaValue::Int64(-1)),
+            (
+                "overflowing u64",
+                GgufMetaValue::Uint64(u64::from(u32::MAX) + 1),
+            ),
+            (
+                "overflowing i64",
+                GgufMetaValue::Int64(i64::from(u32::MAX) + 1),
+            ),
+        ] {
+            let mut metadata = complete_muse_glimmer_dflash_metadata();
+            metadata.insert("dflash.block_count".to_string(), value);
+            let gguf = GgufFile {
+                version: GGUF_VERSION_3,
+                tensor_count: 0,
+                metadata,
+                tensors: Vec::new(),
+                alignment: GGUF_DEFAULT_ALIGNMENT,
+                data_offset: 0,
+            };
+
+            let error = muse_dflash_config_value(&gguf)
+                .expect_err("out-of-range DFlash metadata must fail");
+            assert!(
+                error.reason.contains("dflash.block_count") && error.reason.contains("fits u32"),
+                "unexpected error for {label}: {}",
+                error.reason
+            );
+        }
     }
 
     fn valid_muse_target_config() -> serde_json::Value {

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -2685,13 +2685,22 @@ fn prepare_muse_secondary_config(
     })?;
 
     if !profiles.is_empty() {
+        let companion_quantization = preserved_source_quantization(gguf, import_k_quants)?
+            .ok_or_else(|| {
+                Error::from_reason(
+                    "Muse-Glimmer companion has quantized profiles but no quantization metadata",
+                )
+            })?;
         for key in ["quantization", "quantization_config"] {
+            if config.get(key).is_none() {
+                config[key] = companion_quantization.clone();
+            }
             let quant = config
                 .get_mut(key)
                 .and_then(serde_json::Value::as_object_mut)
                 .ok_or_else(|| {
                     Error::from_reason(format!(
-                        "Muse-Glimmer companion GGUF is K-quantized but {} has no object-valued '{key}' from the primary GGUF conversion",
+                        "Muse-Glimmer companion GGUF is K-quantized but {} has a non-object '{key}'",
                         config_path.display()
                     ))
                 })?;
@@ -5395,6 +5404,56 @@ mod tests {
         )
         .expect_err("DFlash hidden size must match the target");
         assert!(error.reason.contains("does not match target hidden_size"));
+    }
+
+    #[test]
+    fn kquant_dflash_initializes_quantization_for_a_dense_target() {
+        let gguf = GgufFile {
+            version: GGUF_VERSION_3,
+            tensor_count: 1,
+            metadata: complete_muse_glimmer_dflash_metadata(),
+            tensors: vec![GgufTensorInfo {
+                name: "blk.0.attn_q.weight".to_string(),
+                n_dims: 2,
+                dims: vec![256, 1],
+                tensor_type: GgufTensorType::Q4K,
+                offset: 0,
+            }],
+            alignment: GGUF_DEFAULT_ALIGNMENT,
+            data_offset: 0,
+        };
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-muse-dense-target-quant-draft-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("create config directory");
+        let config_path = root.join("config.json");
+        fs::write(
+            &config_path,
+            serde_json::to_vec(&valid_muse_target_config()).expect("serialize dense target config"),
+        )
+        .expect("write dense target config");
+
+        let prepared = prepare_muse_secondary_config(&config_path, &gguf, true)
+            .expect("prepare K-quant DFlash with dense target")
+            .expect("companion config update");
+        let config: serde_json::Value =
+            serde_json::from_str(&prepared).expect("parse companion config");
+        for block in ["quantization", "quantization_config"] {
+            assert_eq!(config[block]["bits"], 4);
+            assert_eq!(config[block]["group_size"], 32);
+            assert_eq!(config[block]["mode"], "q4k");
+            assert_eq!(
+                config[block]["language_model.model.layers.0.self_attn.q_proj"]["mode"],
+                "q4k"
+            );
+        }
+        assert_eq!(config["dflash_config"]["block_size"], 16);
+        fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/crates/mlx-core/tests/concurrent_batched_parity.rs
+++ b/crates/mlx-core/tests/concurrent_batched_parity.rs
@@ -132,7 +132,7 @@ async fn drain_stream_outcome(
     mut receiver: tokio::sync::mpsc::Receiver<napi::Result<ChatStreamChunk>>,
 ) -> Result<ChatStreamChunk, String> {
     while let Some(chunk) = receiver.recv().await {
-        let chunk = chunk.map_err(|error| error.reason)?;
+        let chunk = chunk.map_err(|error| error.reason.clone())?;
         if chunk.done {
             return Ok(chunk);
         }

--- a/crates/mlx-core/tests/muse_glimmer_cold_tier_parity.rs
+++ b/crates/mlx-core/tests/muse_glimmer_cold_tier_parity.rs
@@ -1,0 +1,37 @@
+//! Real-weight restart parity for Muse-Glimmer's grouped full + sliding cache.
+//!
+//! The test is the admission gate for the native/TypeScript cold-tier
+//! allowlists: the restart instance must restore a non-zero prefix, install the
+//! sliding sidecar, report zero corruptions, and match a persistence-disabled
+//! fresh prefill byte for byte.
+
+mod cold_tier_parity_harness;
+
+use cold_tier_parity_harness as harness;
+use mlx_core::models::muse_glimmer::MuseGlimmerModel;
+
+const PROMPT: &str = "Explain why a hybrid transformer with full-attention and sliding-window \
+    layers cannot safely restore only one cache group from SSD. Describe how a content-addressed \
+    full-attention chain, a companion sliding-window sidecar, an exact shared token boundary, \
+    model fingerprints, cache salts, checksums, and atomic publication prevent stale or \
+    cross-request state from being installed. Keep the response short and deterministic.";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "needs MLX_TEST_MUSE_GLIMMER_MODEL_PATH pointing to a converted Muse-Glimmer checkpoint"]
+async fn muse_glimmer_cold_tier_restart_parity() {
+    let mut spec = harness::ColdTierParitySpec::new("muse-glimmer-grouped")
+        .with_pool_memory_mb(2048)
+        .with_prompt(PROMPT)
+        .with_max_new_tokens(8)
+        .expecting_sidecar_install();
+    spec.model_path_env = "MLX_TEST_MUSE_GLIMMER_MODEL_PATH";
+    harness::run_restart_parity(spec, |model_dir, messages, mut config| async move {
+        let owner = String::from("muse-glimmer-cold-tier-parity");
+        config.cache_owner_id = Some(owner.clone());
+        config.cache_root_owner_id = Some(owner);
+        config.enable_mtp = Some(false);
+        let model = MuseGlimmerModel::load(model_dir.to_string_lossy().into_owned()).await?;
+        model.chat_session_start(messages, Some(config)).await
+    })
+    .await;
+}

--- a/docs/models.md
+++ b/docs/models.md
@@ -10,6 +10,7 @@ All language wrappers share a uniform `ChatSession<M>` surface (`send` / `sendSt
 | **Qwen3.5 Dense** |     yes      |     yes     | GRPO + SFT | Compiled C++ forward (see [ffi-cpp.md](ffi-cpp.md)); VLM variant                 |
 | **Qwen3.5 MoE**   |     yes      |     yes     | GRPO + SFT | Compiled C++ forward with expert routing; VLM variant                            |
 | **Gemma4**        |     yes      |     yes     |     —      | Hybrid sliding/global attention + MoE/PLE; DSpark + assistant-MTP spec. decoding |
+| **Muse-Glimmer**  |     yes      |     yes     |     —      | Text decoder; Q4_K import; DFlash; hybrid paged AR                              |
 | **LFM2.5**        |     yes      |     yes     |     —      | Hybrid conv + attention                                                          |
 
 `Qwen3Model | Qwen35Model | Qwen35MoeModel` is the public `TrainableModel` union in `@mlx-node/lm` — Gemma4 and LFM2.5 are inference-only.
@@ -59,7 +60,9 @@ const result = await pipeline.analyze(imageBuffer);
 
 Every role-aware turn sends the full structured history to native code. The checkpoint-provided chat template renders that history, and native KV reuse is allowed only when the rendered token sequence exactly extends the committed cache. A template mismatch safely falls back to full prefill; Rust never manufactures user/tool wire-format strings.
 
-All generative wrappers (Qwen3, Qwen3.5 Dense, Qwen3.5 MoE, Gemma4, LFM2.5, and the VLM `QianfanOCRModel`) structurally satisfy `SessionCapableModel` — any of them can be passed to `new ChatSession(model)`.
+All generative wrappers (Qwen3, Qwen3.5 Dense, Qwen3.5 MoE, Gemma4,
+Muse-Glimmer, LFM2.5, and the VLM `QianfanOCRModel`) structurally satisfy
+`SessionCapableModel` — any of them can be passed to `new ChatSession(model)`.
 
 ## Streaming
 
@@ -73,6 +76,48 @@ for await (const event of session.sendStream("Hello!")) {
 ```
 
 The streaming bridge is implemented in `packages/lm/src/stream.ts`: native callback-based methods are captured at module load and re-exposed as `AsyncGenerator` via `_runChatStream`.
+
+## Muse-Glimmer Q4_K and DFlash
+
+Convert Meta's GGUF target, vision projector, and DFlash companion together.
+`--gguf-kquant` imports Q4_K, Q5_K, and Q6_K blocks without dequantizing or
+requantizing them:
+
+```bash
+yarn mlx convert \
+  -i ./Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf \
+  -o ./muse-glimmer-30b-q4k \
+  --config-dir ./Muse-Glimmer-30B \
+  --mmproj ./mmproj-kquant.gguf \
+  --draft ./dflash-kquant.gguf \
+  --gguf-kquant
+```
+
+The output contains `model.safetensors`, `vision.safetensors`, and
+`draft.safetensors`. The current inference path is text-only; the converter
+preserves the vision sidecar, but Muse image/video execution is not wired yet.
+
+When `draft.safetensors` is present, `hasMtpWeights()` and
+`autoEnablesMtp()` return true and `ChatSession` enables DFlash unless a call
+sets `enableMtp: false`. Muse DFlash uses the checkpoint's 16-token parallel
+infill block by default. An explicit `mtpDepth` clamps to `[1, 16]`; leaving
+both depth knobs unset enables the measured target-AR fallback guard.
+
+Ordinary AR requests use the hybrid full/sliding paged cache and continuous
+batching. The default 2 GiB cache admits up to eight sequences for the release
+geometry. DFlash uses owner-isolated flat target and draft caches and is a
+scheduler barrier, so simultaneous DFlash turns are serialized; set
+`enableMtp: false` for request pools where batched concurrency is preferred.
+
+Paged AR prefixes can also survive hot-cache eviction and process restart via
+the SSD cold tier. Enable it with `persist_paged_cache: true` in the model
+config or `MLX_PERSIST_PAGED_CACHE=1`; `mlx agent` enables persistence by
+default for supported families. Muse persists the 13 full-attention layers as
+the authoritative block chain and all 39 sliding layers as a companion sidecar
+at the same token boundary. A missing, corrupt, or mismatched sidecar discards
+the full-group hit and recomputes from the start. DFlash's flat caches are not
+persisted, and an unfinished in-flight AR turn uses recompute preemption rather
+than publishing partial state.
 
 ## Speculative decoding: Gemma4 drafts (DSpark + assistant MTP)
 

--- a/packages/agent/src/cold-tier.ts
+++ b/packages/agent/src/cold-tier.ts
@@ -41,6 +41,8 @@ import type { ModelType } from '@mlx-node/lm';
  *  - `gemma4` owns full and sliding attention in distinct paged groups. The
  *    full-attention chain is authoritative and one grouped sliding sidecar
  *    restores every sliding group at the same exact boundary, atomically.
+ *  - `muse_glimmer` uses the same hybrid contract for its 13 full-attention
+ *    and 39 sliding-attention layers.
  *  - `qwen3_5` (dense) sizes its pool over the full-attention layers only, but
  *    persists its out-of-pool GDN recurrent state (conv + recurrent) as a
  *    `ColdGroup::GdnState` sidecar, and its `ColdSidecarPolicy` reconciles the
@@ -75,6 +77,7 @@ export const COLD_TIER_RESTORE_FAMILIES: ReadonlySet<string> = new Set<ModelType
   'qwen3_5',
   'qwen3_5_moe',
   'gemma4',
+  'muse_glimmer',
   'lfm2',
   'lfm2_moe',
 ]);

--- a/packages/agent/src/provider/models.ts
+++ b/packages/agent/src/provider/models.ts
@@ -85,6 +85,10 @@ const FAMILY_TRAITS: Record<string, FamilyTraits> = {
     },
     fallbackContextWindow: 131072,
   },
+  muse_glimmer: {
+    reasoning: true,
+    fallbackContextWindow: 131072,
+  },
   lfm2: { reasoning: true, fallbackContextWindow: 128000 },
   lfm2_moe: { reasoning: true, fallbackContextWindow: 128000 },
 };

--- a/packages/agent/src/provider/models.ts
+++ b/packages/agent/src/provider/models.ts
@@ -9,10 +9,10 @@
  * `contextWindow` starts as the checkpoint's trained window, read from the model dir's
  * `config.json` `max_position_embeddings` (root first, then the
  * `text_config` nesting used by qwen3_5 / qwen3_5_moe / gemma4 unified
- * checkpoints). Once a Qwen model loads, the provider narrows this shared
- * model metadata to the physical paged-cache window so pi's later
- * auto-compaction thresholds match reality. When both config fields are
- * absent the documented per-family fallback below applies.
+ * checkpoints). Once a Qwen or Muse-Glimmer model loads, the provider narrows
+ * this shared model metadata to the physical paged-cache window so pi's later
+ * auto-compaction thresholds match reality. When both config fields are absent
+ * the documented per-family fallback below applies.
  */
 
 import type { Dirent } from 'node:fs';

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -20,6 +20,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 vi.mock('@mlx-node/core', () => ({
   convertModel: vi.fn(async () => ({ numTensors: 0, numParameters: 0, outputPath: '', tensorNames: [] })),
   convertForeignWeights: vi.fn(() => ({})),
+  preflightMuseDflashGguf: vi.fn(() => {}),
   convertGgufToSafetensors: vi.fn(async () => ({
     numTensors: 0,
     numParameters: 0,
@@ -29,7 +30,12 @@ vi.mock('@mlx-node/core', () => ({
   })),
 }));
 
-import { convertModel, convertForeignWeights, convertGgufToSafetensors } from '@mlx-node/core';
+import {
+  convertModel,
+  convertForeignWeights,
+  convertGgufToSafetensors,
+  preflightMuseDflashGguf,
+} from '@mlx-node/core';
 
 import { run as runConvert } from '../src/commands/convert.js';
 
@@ -158,6 +164,39 @@ describe('mlx convert GGUF validation', () => {
     await runConvert(['--input', ggufPath, '--output', outputDir, '--gguf-kquant']);
 
     expect(existsSync(staleDraft)).toBe(false);
+  });
+
+  it('preflights --draft before the primary conversion can mutate the output', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const configDir = join(tmp, 'hf-config');
+    const draftPath = join(tmp, 'not-dflash.gguf');
+    mkdirSync(configDir);
+    writeFileSync(join(configDir, 'config.json'), '{}');
+    writeFileSync(draftPath, '');
+    vi.mocked(preflightMuseDflashGguf).mockImplementationOnce(() => {
+      throw new Error('requires a DFlash GGUF');
+    });
+
+    await expect(
+      runConvert([
+        '--input',
+        ggufPath,
+        '--output',
+        join(tmp, 'out'),
+        '--config-dir',
+        configDir,
+        '--draft',
+        draftPath,
+      ]),
+    ).rejects.toThrow('process.exit(1)');
+
+    expect(preflightMuseDflashGguf).toHaveBeenCalledWith(draftPath, configDir);
+    expect(convertGgufToSafetensors).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it('rejects --config-dir when the path is not a directory', async () => {

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -11,7 +11,7 @@
  * conversion runs; `process.exit` is mocked to throw so the test proves
  * validation halts before reaching the (mocked) native call.
  */
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -30,12 +30,7 @@ vi.mock('@mlx-node/core', () => ({
   })),
 }));
 
-import {
-  convertModel,
-  convertForeignWeights,
-  convertGgufToSafetensors,
-  preflightMuseDflashGguf,
-} from '@mlx-node/core';
+import { convertModel, convertForeignWeights, convertGgufToSafetensors, preflightMuseDflashGguf } from '@mlx-node/core';
 
 import { run as runConvert } from '../src/commands/convert.js';
 
@@ -124,9 +119,9 @@ describe('mlx convert GGUF validation', () => {
     writeFileSync(join(stDir, 'config.json'), JSON.stringify({ model_type: 'muse_glimmer' }));
     writeFileSync(draftPath, '');
 
-    await expect(
-      runConvert(['--input', stDir, '--output', join(tmp, 'out'), '--draft', draftPath]),
-    ).rejects.toThrow('process.exit(1)');
+    await expect(runConvert(['--input', stDir, '--output', join(tmp, 'out'), '--draft', draftPath])).rejects.toThrow(
+      'process.exit(1)',
+    );
 
     const errors = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
     expect(errors).toContain('--draft is only supported when --input is a GGUF file');
@@ -172,14 +167,16 @@ describe('mlx convert GGUF validation', () => {
     const outputDir = join(tmp, 'out');
     mkdirSync(outputDir);
     const staleDraft = join(outputDir, 'draft.safetensors');
+    const preservedExtra = join(outputDir, 'keep.txt');
     writeFileSync(staleDraft, 'stale draft');
-    vi.mocked(convertGgufToSafetensors).mockImplementationOnce(async () => {
-      writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ model_type: 'muse_glimmer' }));
+    writeFileSync(preservedExtra, 'keep me');
+    vi.mocked(convertGgufToSafetensors).mockImplementationOnce(async (options) => {
+      writeFileSync(join(options.outputDir, 'config.json'), JSON.stringify({ model_type: 'muse_glimmer' }));
       return {
         numTensors: 1,
         numParameters: 1,
         sourceFormat: 'Q4_K',
-        outputPath: outputDir,
+        outputPath: options.outputDir,
         tensorNames: ['weight'],
       };
     });
@@ -187,6 +184,49 @@ describe('mlx convert GGUF validation', () => {
     await runConvert(['--input', ggufPath, '--output', outputDir, '--gguf-kquant']);
 
     expect(existsSync(staleDraft)).toBe(false);
+    expect(readFileSync(preservedExtra, 'utf-8')).toBe('keep me');
+  });
+
+  it('leaves an existing Muse output untouched when the staged draft payload is corrupt', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const outputDir = join(tmp, 'out');
+    const draftPath = join(tmp, 'draft.gguf');
+    mkdirSync(outputDir);
+    writeFileSync(draftPath, 'header followed by a truncated payload');
+    const sentinels = {
+      'model.safetensors': 'previous model',
+      'config.json': '{"model_type":"muse_glimmer","dflash_config":{"block_size":16}}',
+      'draft.safetensors': 'previous draft',
+    } as const;
+    for (const [name, value] of Object.entries(sentinels)) writeFileSync(join(outputDir, name), value);
+
+    vi.mocked(convertGgufToSafetensors)
+      .mockImplementationOnce(async (options) => {
+        writeFileSync(join(options.outputDir, 'model.safetensors'), 'new staged model');
+        writeFileSync(join(options.outputDir, 'config.json'), JSON.stringify({ model_type: 'muse_glimmer' }));
+        return {
+          numTensors: 1,
+          numParameters: 1,
+          sourceFormat: 'Q4_K',
+          outputPath: options.outputDir,
+          tensorNames: ['weight'],
+        };
+      })
+      .mockRejectedValueOnce(new Error('unexpected EOF in DFlash tensor payload'));
+
+    await expect(runConvert(['--input', ggufPath, '--output', outputDir, '--draft', draftPath])).rejects.toThrow(
+      'process.exit(1)',
+    );
+
+    for (const [name, value] of Object.entries(sentinels)) {
+      expect(readFileSync(join(outputDir, name), 'utf-8')).toBe(value);
+    }
+    expect(readdirSync(tmp).some((name) => name.startsWith('.mlx-convert-stage-'))).toBe(false);
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it('preflights --draft before the primary conversion can mutate the output', async () => {
@@ -205,16 +245,7 @@ describe('mlx convert GGUF validation', () => {
     });
 
     await expect(
-      runConvert([
-        '--input',
-        ggufPath,
-        '--output',
-        join(tmp, 'out'),
-        '--config-dir',
-        configDir,
-        '--draft',
-        draftPath,
-      ]),
+      runConvert(['--input', ggufPath, '--output', join(tmp, 'out'), '--config-dir', configDir, '--draft', draftPath]),
     ).rejects.toThrow('process.exit(1)');
 
     expect(preflightMuseDflashGguf).toHaveBeenCalledWith(draftPath, configDir);

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -11,7 +11,7 @@
  * conversion runs; `process.exit` is mocked to throw so the test proves
  * validation halts before reaching the (mocked) native call.
  */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -135,6 +135,29 @@ describe('mlx convert GGUF validation', () => {
     expect(convertGgufToSafetensors).toHaveBeenCalledWith(
       expect.objectContaining({ importKQuants: true, quantize: false }),
     );
+  });
+
+  it('removes a stale Muse DFlash sidecar after a successful target-only conversion', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const outputDir = join(tmp, 'out');
+    mkdirSync(outputDir);
+    const staleDraft = join(outputDir, 'draft.safetensors');
+    writeFileSync(staleDraft, 'stale draft');
+    vi.mocked(convertGgufToSafetensors).mockImplementationOnce(async () => {
+      writeFileSync(join(outputDir, 'config.json'), JSON.stringify({ model_type: 'muse_glimmer' }));
+      return {
+        numTensors: 1,
+        numParameters: 1,
+        sourceFormat: 'Q4_K',
+        outputPath: outputDir,
+        tensorNames: ['weight'],
+      };
+    });
+
+    await runConvert(['--input', ggufPath, '--output', outputDir, '--gguf-kquant']);
+
+    expect(existsSync(staleDraft)).toBe(false);
   });
 
   it('rejects --config-dir when the path is not a directory', async () => {

--- a/packages/cli/__test__/convert-cmd.test.ts
+++ b/packages/cli/__test__/convert-cmd.test.ts
@@ -112,6 +112,29 @@ describe('mlx convert GGUF validation', () => {
     expect(convertGgufToSafetensors).not.toHaveBeenCalled();
   });
 
+  it('rejects --draft for SafeTensors input instead of silently ignoring it', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const stDir = join(tmp, 'st-in');
+    const draftPath = join(tmp, 'draft.gguf');
+    mkdirSync(stDir, { recursive: true });
+    writeFileSync(join(stDir, 'config.json'), JSON.stringify({ model_type: 'muse_glimmer' }));
+    writeFileSync(draftPath, '');
+
+    await expect(
+      runConvert(['--input', stDir, '--output', join(tmp, 'out'), '--draft', draftPath]),
+    ).rejects.toThrow('process.exit(1)');
+
+    const errors = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(errors).toContain('--draft is only supported when --input is a GGUF file');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(convertModel).not.toHaveBeenCalled();
+    expect(convertGgufToSafetensors).not.toHaveBeenCalled();
+  });
+
   it('rejects --gguf-kquant combined with --imatrix-path for .gguf input upfront', async () => {
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -683,7 +683,15 @@ export async function run(argv: string[]) {
     return;
   }
 
-  // Below here the input is SafeTensors, where --gguf-kquant has no meaning.
+  // Below here the input is SafeTensors. Companion DFlash import is a GGUF
+  // conversion feature; accepting the flag here would silently produce no
+  // draft.safetensors and no matching dflash_config.
+  if (draftPath) {
+    console.error('Error: --draft is only supported when --input is a GGUF file');
+    process.exit(1);
+  }
+
+  // SafeTensors input also gives --gguf-kquant no meaning.
   if (args['gguf-kquant']) {
     console.error('Error: --gguf-kquant applies only to GGUF input; ' + `'${inputPath}' is not a .gguf file`);
     process.exit(1);

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readFileSync, existsSync, rmSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
 import { convertModel, convertForeignWeights, convertGgufToSafetensors } from '@mlx-node/core';
@@ -604,6 +604,29 @@ export async function run(argv: string[]) {
         console.log('\nConverted tensors:');
         for (const name of result.tensorNames) {
           console.log(`  - ${name}`);
+        }
+      }
+
+      // A successful target-only Muse conversion rewrites config.json without
+      // DFlash metadata. Remove an older companion only after that primary
+      // conversion commits; otherwise the loader sees draft.safetensors beside
+      // a config with no dflash_config and refuses the whole checkpoint.
+      if (!draftPath) {
+        let isMuseOutput = false;
+        try {
+          const outputConfig = JSON.parse(readFileSync(join(outputDir, 'config.json'), 'utf-8')) as {
+            model_type?: unknown;
+          };
+          isMuseOutput = outputConfig.model_type === 'muse_glimmer';
+        } catch {
+          // The native conversion owns config validation. If a third-party
+          // backend did not emit a readable Muse config, do not delete files
+          // based on an unproven family guess.
+        }
+        if (isMuseOutput) {
+          // Once the family is proven, a deletion failure must fail the command
+          // rather than report a checkpoint that the loader will reject.
+          rmSync(join(outputDir, 'draft.safetensors'), { force: true });
         }
       }
 

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -1,8 +1,13 @@
 import { readFileSync, existsSync, rmSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
-import { convertModel, convertForeignWeights, convertGgufToSafetensors } from '@mlx-node/core';
+import {
+  convertModel,
+  convertForeignWeights,
+  convertGgufToSafetensors,
+  preflightMuseDflashGguf,
+} from '@mlx-node/core';
 
 // Canonical per-mode defaults for quantization bits/group_size.
 // Mirrors crates/mlx-core/src/convert.rs and crates/mlx-core/src/utils/gguf.rs.
@@ -577,6 +582,11 @@ export async function run(argv: string[]) {
     console.log('');
 
     try {
+      if (draftPath) {
+        // Header and target-geometry validation must precede the primary
+        // conversion: that conversion owns and overwrites config.json.
+        preflightMuseDflashGguf(draftPath, configSourceDir ?? dirname(inputPath));
+      }
       const result = await convertGgufToSafetensors({
         inputPath,
         outputDir,

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -1,13 +1,8 @@
-import { readFileSync, existsSync, rmSync, statSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, renameSync, rmSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 
-import {
-  convertModel,
-  convertForeignWeights,
-  convertGgufToSafetensors,
-  preflightMuseDflashGguf,
-} from '@mlx-node/core';
+import { convertModel, convertForeignWeights, convertGgufToSafetensors, preflightMuseDflashGguf } from '@mlx-node/core';
 
 // Canonical per-mode defaults for quantization bits/group_size.
 // Mirrors crates/mlx-core/src/convert.rs and crates/mlx-core/src/utils/gguf.rs.
@@ -21,6 +16,74 @@ const QUANT_MODE_DEFAULTS: Record<string, [number, number]> = {
   // layers; sym8 layers themselves carry one f32 scale per output row).
   sym8: [8, 64],
 };
+
+/**
+ * Install a fully converted sibling directory without exposing partial GGUF
+ * output. Existing non-conflicting files are moved into the new directory so
+ * conversion retains the CLI's historical in-place behavior. If any rename
+ * fails, the previous directory is restored before the error escapes.
+ */
+function commitStagedOutput(stageDir: string, outputDir: string, omitPrevious: ReadonlySet<string>): void {
+  if (!existsSync(outputDir)) {
+    renameSync(stageDir, outputDir);
+    return;
+  }
+
+  const parentDir = dirname(outputDir);
+  const backupRoot = mkdtempSync(join(parentDir, '.mlx-convert-backup-'));
+  const previousDir = join(backupRoot, 'previous');
+  const preservedEntries: string[] = [];
+  let previousMoved = false;
+  let stageInstalled = false;
+
+  try {
+    renameSync(outputDir, previousDir);
+    previousMoved = true;
+    renameSync(stageDir, outputDir);
+    stageInstalled = true;
+
+    for (const entry of readdirSync(previousDir)) {
+      if (omitPrevious.has(entry) || existsSync(join(outputDir, entry))) continue;
+      renameSync(join(previousDir, entry), join(outputDir, entry));
+      preservedEntries.push(entry);
+    }
+  } catch (error) {
+    let rollbackError: unknown;
+    try {
+      if (stageInstalled) {
+        for (const entry of preservedEntries.reverse()) {
+          renameSync(join(outputDir, entry), join(previousDir, entry));
+        }
+        renameSync(outputDir, stageDir);
+        stageInstalled = false;
+      }
+      if (previousMoved) {
+        renameSync(previousDir, outputDir);
+        previousMoved = false;
+      }
+    } catch (rollbackFailure) {
+      rollbackError = rollbackFailure;
+    }
+    if (rollbackError) {
+      const commitMessage = error instanceof Error ? error.message : 'unknown commit error';
+      const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : 'unknown rollback error';
+      throw new Error(
+        `Failed to commit staged GGUF output and rollback also failed: ${commitMessage}; rollback: ${rollbackMessage}. Recovery files remain under ${backupRoot}`,
+      );
+    }
+    rmSync(backupRoot, { recursive: true, force: true });
+    throw error;
+  }
+
+  try {
+    rmSync(backupRoot, { recursive: true, force: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown cleanup error';
+    console.warn(
+      `Warning: converted output was committed, but its backup could not be removed (${backupRoot}): ${message}`,
+    );
+  }
+}
 
 function printHelp() {
   console.log(`
@@ -581,15 +644,21 @@ export async function run(argv: string[]) {
     }
     console.log('');
 
+    let stagedOutputDir: string | undefined;
     try {
+      const outputParent = dirname(outputDir);
+      mkdirSync(outputParent, { recursive: true });
+      stagedOutputDir = mkdtempSync(join(outputParent, '.mlx-convert-stage-'));
+
       if (draftPath) {
         // Header and target-geometry validation must precede the primary
-        // conversion: that conversion owns and overwrites config.json.
+        // conversion. Payload validation happens when the draft is converted
+        // into stagedOutputDir below, before anything is committed.
         preflightMuseDflashGguf(draftPath, configSourceDir ?? dirname(inputPath));
       }
       const result = await convertGgufToSafetensors({
         inputPath,
-        outputDir,
+        outputDir: stagedOutputDir,
         dtype,
         verbose,
         quantize: args.quantize,
@@ -607,7 +676,7 @@ export async function run(argv: string[]) {
       const duration = ((Date.now() - startTime) / 1000).toFixed(2);
       console.log(`\n✓ Converted ${result.numTensors} tensors (source: ${result.sourceFormat})`);
       console.log(`✓ Total parameters: ${result.numParameters.toLocaleString()}`);
-      console.log(`✓ Output directory: ${result.outputPath}`);
+      console.log(`✓ Output directory: ${outputDir}`);
       console.log(`✓ Duration: ${duration}s`);
 
       if (verbose) {
@@ -617,14 +686,15 @@ export async function run(argv: string[]) {
         }
       }
 
-      // A successful target-only Muse conversion rewrites config.json without
-      // DFlash metadata. Remove an older companion only after that primary
-      // conversion commits; otherwise the loader sees draft.safetensors beside
-      // a config with no dflash_config and refuses the whole checkpoint.
+      // A successful target-only Muse conversion writes config.json without
+      // DFlash metadata. Mark an older companion for omission from the final
+      // directory swap; the live output remains untouched until every staged
+      // conversion has succeeded.
+      let omitPreviousDraft = false;
       if (!draftPath) {
         let isMuseOutput = false;
         try {
-          const outputConfig = JSON.parse(readFileSync(join(outputDir, 'config.json'), 'utf-8')) as {
+          const outputConfig = JSON.parse(readFileSync(join(stagedOutputDir, 'config.json'), 'utf-8')) as {
             model_type?: unknown;
           };
           isMuseOutput = outputConfig.model_type === 'muse_glimmer';
@@ -634,9 +704,7 @@ export async function run(argv: string[]) {
           // based on an unproven family guess.
         }
         if (isMuseOutput) {
-          // Once the family is proven, a deletion failure must fail the command
-          // rather than report a checkpoint that the loader will reject.
-          rmSync(join(outputDir, 'draft.safetensors'), { force: true });
+          omitPreviousDraft = true;
         }
       }
 
@@ -645,7 +713,7 @@ export async function run(argv: string[]) {
         console.log('\nConverting mmproj (vision encoder)...');
         const visionResult = await convertGgufToSafetensors({
           inputPath: mmprojPath,
-          outputDir,
+          outputDir: stagedOutputDir,
           dtype: 'bfloat16',
           verbose,
           quantize: false,
@@ -663,7 +731,7 @@ export async function run(argv: string[]) {
         console.log('\nConverting DFlash speculative drafter...');
         const draftResult = await convertGgufToSafetensors({
           inputPath: draftPath,
-          outputDir,
+          outputDir: stagedOutputDir,
           dtype: 'bfloat16',
           verbose,
           quantize: false,
@@ -673,7 +741,18 @@ export async function run(argv: string[]) {
         });
         console.log(`✓ Converted ${draftResult.numTensors} DFlash tensors`);
       }
+
+      commitStagedOutput(stagedOutputDir, outputDir, omitPreviousDraft ? new Set(['draft.safetensors']) : new Set());
+      stagedOutputDir = undefined;
     } catch (error: any) {
+      if (stagedOutputDir) {
+        try {
+          rmSync(stagedOutputDir, { recursive: true, force: true });
+        } catch (cleanupError) {
+          const message = cleanupError instanceof Error ? cleanupError.message : 'unknown cleanup error';
+          console.warn(`Warning: failed to remove staged GGUF output (${stagedOutputDir}): ${message}`);
+        }
+      }
       console.error('\nGGUF conversion failed:', error.message);
       if (error.stack && verbose) {
         console.error('\nStack trace:', error.stack);

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -43,6 +43,8 @@ Optional Arguments:
 Vision Arguments:
   --mmproj <path>       Path to mmproj GGUF file (vision encoder weights)
                         Converts and merges vision weights into output directory
+  --draft <path>        Path to Muse-Glimmer DFlash GGUF file
+                        Converts it to draft.safetensors beside the target
 
 Quantization Arguments:
   --quantize, -q        Enable quantization of converted weights
@@ -213,6 +215,7 @@ export async function run(argv: string[]) {
       'imatrix-path': { type: 'string' },
       'config-dir': { type: 'string' },
       mmproj: { type: 'string' },
+      draft: { type: 'string' },
       'gguf-kquant': { type: 'boolean', default: false },
       help: { type: 'boolean', short: 'h', default: false },
     },
@@ -474,6 +477,18 @@ export async function run(argv: string[]) {
     }
   }
 
+  const draftPath = args.draft ? resolve(args.draft) : undefined;
+  if (draftPath !== undefined) {
+    if (!existsSync(draftPath)) {
+      console.error(`Error: draft file not found: ${draftPath}`);
+      process.exit(1);
+    }
+    if (!draftPath.endsWith('.gguf')) {
+      console.error('Error: --draft must point to a .gguf file');
+      process.exit(1);
+    }
+  }
+
   const imatrixPath = args['imatrix-path'] ? resolve(args['imatrix-path']) : undefined;
   if (imatrixPath !== undefined) {
     if (!existsSync(imatrixPath)) {
@@ -553,6 +568,9 @@ export async function run(argv: string[]) {
     if (mmprojPath) {
       console.log(`mmproj:     ${mmprojPath}`);
     }
+    if (draftPath) {
+      console.log(`DFlash:    ${draftPath}`);
+    }
     if (configSourceDir) {
       console.log(`Config dir: ${configSourceDir}`);
     }
@@ -606,6 +624,21 @@ export async function run(argv: string[]) {
           outputFilename: 'vision.safetensors',
         });
         console.log(`✓ Converted ${visionResult.numTensors} vision tensors`);
+      }
+
+      if (draftPath) {
+        console.log('\nConverting DFlash speculative drafter...');
+        const draftResult = await convertGgufToSafetensors({
+          inputPath: draftPath,
+          outputDir,
+          dtype: 'bfloat16',
+          verbose,
+          quantize: false,
+          importKQuants: args['gguf-kquant'],
+          configSourceDir,
+          outputFilename: 'draft.safetensors',
+        });
+        console.log(`✓ Converted ${draftResult.numTensors} DFlash tensors`);
       }
     } catch (error: any) {
       console.error('\nGGUF conversion failed:', error.message);

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -813,6 +813,7 @@ module.exports.OutputFormat = nativeBinding.OutputFormat;
 module.exports.parsePaddleResponse = nativeBinding.parsePaddleResponse;
 module.exports.parseToolCallsFromText = nativeBinding.parseToolCallsFromText;
 module.exports.parseVlmOutput = nativeBinding.parseVlmOutput;
+module.exports.preflightMuseDflashGguf = nativeBinding.preflightMuseDflashGguf;
 module.exports.quantizedQmvMicrobench = nativeBinding.quantizedQmvMicrobench;
 module.exports.qwen3AsrAudioDevices = nativeBinding.qwen3AsrAudioDevices;
 module.exports.Qwen3AsrCaptureSource = nativeBinding.Qwen3AsrCaptureSource;

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -758,6 +758,7 @@ module.exports.GrpoTrainingEngine = nativeBinding.GrpoTrainingEngine;
 module.exports.GRPOTrainingEngine = nativeBinding.GRPOTrainingEngine;
 module.exports.HarrierModel = nativeBinding.HarrierModel;
 module.exports.Lfm2Model = nativeBinding.Lfm2Model;
+module.exports.MuseGlimmerModel = nativeBinding.MuseGlimmerModel;
 module.exports.MxArray = nativeBinding.MxArray;
 module.exports.NativeRewardRegistry = nativeBinding.NativeRewardRegistry;
 module.exports.OutputStore = nativeBinding.OutputStore;

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -650,6 +650,91 @@ export declare class Lfm2Model {
   ): Promise<ChatStreamHandle>;
 }
 
+export declare class MuseGlimmerModel {
+  static load(modelPath: string): Promise<MuseGlimmerModel>;
+  hasMtpWeights(): boolean;
+  autoEnablesMtp(): boolean;
+  hasBlockPagedCache(): boolean;
+  maxConcurrentSequences(): number;
+  schedulerStats(): Promise<SchedulerStats>;
+  /**
+   * Reset all caches and clear cached token history. Async so a reset
+   * queued behind an in-flight turn parks a tokio future, never the
+   * Node event loop (H1: a dead prefill used to freeze all HTTP traffic).
+   */
+  resetCaches(): Promise<void>;
+  /**
+   * Release scheduler-owned KV/history state for one logical
+   * session owner without purging content-addressed prefix blocks.
+   */
+  releaseCacheOwner(ownerId: string): Promise<void>;
+  /**
+   * Start a new chat session.
+   *
+   * Renders the complete conversation through the loaded chat
+   * template, decodes until the family's session stop token, and
+   * preserves the resulting KV state for exact-prefix reuse.
+   */
+  chatSessionStart(messages: Array<ChatMessage>, config?: ChatConfig | undefined | null): Promise<ChatResult>;
+  /**
+   * Internal operation bridge for `chatSessionStart` (H2). Resolves
+   * IMMEDIATELY with a `ChatSessionCall` whose `cancel()`
+   * can cancel the queued/running turn; the reply arrives via
+   * `call.result()`. A cancelled turn rejects `result()` with
+   * the exact string `"chat session cancelled"`. The LM wrapper
+   * keeps this two-phase operation private and exposes cancellation
+   * through the ordinary method's `AbortSignal` argument.
+   */
+  beginChatSessionStart(messages: Array<ChatMessage>, config?: ChatConfig | undefined | null): Promise<ChatSessionCall>;
+  /**
+   * Continue an existing chat session from the complete
+   * structured conversation. The loaded model template is the
+   * sole authority for the rendered suffix; native cache reuse
+   * occurs only after the completed structured history is verified
+   * against the saved token history.
+   */
+  chatSessionContinue(messages: Array<ChatMessage>, config?: ChatConfig | undefined | null): Promise<ChatResult>;
+  /**
+   * Internal operation bridge for `chatSessionContinue` (H2). Same
+   * contract as `beginChatSessionStart`.
+   */
+  beginChatSessionContinue(
+    messages: Array<ChatMessage>,
+    config?: ChatConfig | undefined | null,
+  ): Promise<ChatSessionCall>;
+  /**
+   * Continue an existing chat session from a complete
+   * structured conversation ending in a tool-role message.
+   */
+  chatSessionContinueTool(messages: Array<ChatMessage>, config?: ChatConfig | undefined | null): Promise<ChatResult>;
+  /**
+   * Internal operation bridge for `chatSessionContinueTool` (H2). Same
+   * contract as `beginChatSessionStart`.
+   */
+  beginChatSessionContinueTool(
+    messages: Array<ChatMessage>,
+    config?: ChatConfig | undefined | null,
+  ): Promise<ChatSessionCall>;
+  /** Streaming variant of `chatSessionStart`. */
+  chatStreamSessionStart(
+    messages: ChatMessage[],
+    config: ChatConfig | null,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ): Promise<ChatStreamHandle>;
+  /** Streaming variant of `chatSessionContinue`. */
+  chatStreamSessionContinue(
+    messages: ChatMessage[],
+    config: ChatConfig | null,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ): Promise<ChatStreamHandle>;
+  /** Streaming variant of `chatSessionContinueTool`. */
+  chatStreamSessionContinueTool(
+    messages: ChatMessage[],
+    config: ChatConfig | null,
+    callback: (err: Error | null, chunk: ChatStreamChunk) => void,
+  ): Promise<ChatStreamHandle>;
+}
+
 export declare class MxArray {
   equal(other: MxArray): MxArray;
   notEqual(other: MxArray): MxArray;
@@ -2518,6 +2603,10 @@ export interface ChatConfig {
    * - Assistant (Google `gemma-4-*-it-assistant`): an unset `mtpDepth`
    *   drafts 3 tokens per cycle (`ASSISTANT_DEFAULT_DEPTH`), and an
    *   explicit `mtpDepth` clamps to `[1, 8]` (`ASSISTANT_MAX_DEPTH`).
+   * - Muse-Glimmer DFlash follows DSpark's external-draft rules: unset
+   *   uses the checkpoint block size (16 for Muse-Glimmer-30B), while an
+   *   explicit value clamps to `[1, block_size]` and pins that depth unless
+   *   `mtpAdaptiveDepth: true` explicitly enables the break-even guard.
    *
    * `mtpAdaptiveDepth` is ignored for the Gemma4 assistant variant.
    */
@@ -2532,9 +2621,9 @@ export interface ChatConfig {
    * `MLX_MTP_EV_ALLOW_DEEPEN=0` to pin the base depth.
    * When false, the loop pins `mtpDepth` for every cycle.
    *
-   * Default: false, except Gemma4 DSpark enables its measured break-even
-   * guard when both this field and `mtpDepth` are unset. An explicit value
-   * always wins over the family default.
+   * Default: false, except Gemma4 DSpark and Muse-Glimmer DFlash enable the
+   * measured break-even guard when both this field and `mtpDepth` are unset.
+   * An explicit value always wins over the family default.
    */
   mtpAdaptiveDepth?: boolean | undefined;
 }

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -4292,6 +4292,12 @@ export interface PhaseProfile {
 }
 
 /**
+ * Header-only DFlash validation for the CLI's transactional ordering. This
+ * runs before the primary conversion touches its output directory.
+ */
+export declare function preflightMuseDflashGguf(inputPath: string, targetConfigDir: string): void;
+
+/**
  * Per-call Viterbi calibration overrides.
  *
  * Any field set to `Some(_)` overrides the corresponding bias from the

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -656,6 +656,12 @@ export declare class MuseGlimmerModel {
   autoEnablesMtp(): boolean;
   hasBlockPagedCache(): boolean;
   maxConcurrentSequences(): number;
+  /**
+   * Conservative model-wide context snapshot used by higher layers for
+   * compaction. It includes the paged AR limit even when DFlash is present,
+   * because DFlash is opt-in per request and can be disabled by the caller.
+   */
+  contextLimits(): MuseGlimmerContextLimits;
   schedulerStats(): Promise<SchedulerStats>;
   /**
    * Reset all caches and clear cached token history. Async so a reset
@@ -4100,6 +4106,19 @@ export interface ModelConfig {
 export declare const enum MultimodalContentOrder {
   TextThenMedia = 'textThenMedia',
   ImagesThenText = 'imagesThenText',
+}
+
+/**
+ * Trained and physically available active-context limits for one loaded
+ * Muse-Glimmer model. The effective window is conservative across both
+ * execution modes: DFlash may use the flat cache, but callers can disable it
+ * per request and fall back to the paged AR scheduler.
+ */
+export interface MuseGlimmerContextLimits {
+  trainedWindowTokens: number;
+  effectiveWindowTokens: number;
+  pagedBlockCapacity: number;
+  pagedBlockSize: number;
 }
 
 /** Result from document orientation classification. */

--- a/packages/lm/__test__/stream-template-policy.test.ts
+++ b/packages/lm/__test__/stream-template-policy.test.ts
@@ -11,6 +11,7 @@ vi.mock('@mlx-node/core', () => {
   return {
     Gemma4Model: UnusedNativeModel,
     Lfm2Model: UnusedNativeModel,
+    MuseGlimmerModel: UnusedNativeModel,
     Qwen3Model: UnusedNativeModel,
     Qwen35Model: UnusedNativeModel,
     Qwen35MoeModel: UnusedNativeModel,

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -369,7 +369,8 @@ export interface SessionCapableModel {
   expandedPromptTokenCount?(promptTokens: Uint32Array, messages: ChatMessage[]): Promise<number> | number;
   /**
    * Optional synchronous load-time snapshot of the model's usable context.
-   * Qwen3.5 dense/MoE expose this when adaptive paged-cache sizing is active.
+   * Qwen3.5 dense/MoE and Muse-Glimmer expose this when paged-cache sizing is
+   * active.
    */
   contextLimits?(): SessionContextLimits;
   /**

--- a/packages/lm/src/index.ts
+++ b/packages/lm/src/index.ts
@@ -19,6 +19,9 @@ export { Qwen3Model } from './stream.js';
 // Gemma4 models
 export { Gemma4Model } from './stream.js';
 
+// Muse-Glimmer models
+export { MuseGlimmerModel } from './stream.js';
+
 // Embedding models
 export { HarrierModel } from '@mlx-node/core';
 export { Qwen35Model } from './stream.js';

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -11,6 +11,7 @@ import {
   Gemma4Model as NativeGemma4Model,
   HarrierModel,
   Lfm2Model as NativeLfm2Model,
+  MuseGlimmerModel as NativeMuseGlimmerModel,
   QianfanOCRModel,
   Qwen3Model as NativeQwen3Model,
   Qwen35Model as NativeQwen35Model,
@@ -18,7 +19,7 @@ import {
 } from '@mlx-node/core';
 
 import { ChatSession, type SessionCapableModel } from '../chat-session.js';
-import { Gemma4Model, Lfm2Model, Qwen3Model, Qwen35Model, Qwen35MoeModel } from '../stream.js';
+import { Gemma4Model, Lfm2Model, MuseGlimmerModel, Qwen3Model, Qwen35Model, Qwen35MoeModel } from '../stream.js';
 
 /** Optional settings for {@link loadModel} / {@link loadSession}. */
 export interface LoadModelOptions {
@@ -116,6 +117,16 @@ const MODEL_FAMILY_REGISTRY = [
       ),
     nativeModelClass: NativeGemma4Model,
     acceptsDraftModel: true,
+  },
+  {
+    modelType: 'muse_glimmer',
+    kind: 'loadable',
+    match: {
+      rawModelTypes: ['muse_glimmer', 'muse_glimmer_text'],
+      architectureProbe: ({ architectures }) => architectures.has('MuseGlimmerForConditionalGeneration'),
+    },
+    load: (modelPath: string) => MuseGlimmerModel.load(modelPath),
+    nativeModelClass: NativeMuseGlimmerModel,
   },
   {
     modelType: 'harrier',

--- a/packages/lm/src/models/paged-config-override.ts
+++ b/packages/lm/src/models/paged-config-override.ts
@@ -15,7 +15,15 @@ import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 /** Every chat-capable family currently discovered by `@mlx-node/agent`. */
-export const AGENT_PAGED_MODEL_TYPES = ['qwen3', 'qwen3_5', 'qwen3_5_moe', 'gemma4', 'lfm2', 'lfm2_moe'] as const;
+export const AGENT_PAGED_MODEL_TYPES = [
+  'qwen3',
+  'qwen3_5',
+  'qwen3_5_moe',
+  'gemma4',
+  'muse_glimmer',
+  'lfm2',
+  'lfm2_moe',
+] as const;
 
 /** Families historically forced paged by `mlx launch claude`. */
 export const QWEN35_PAGED_MODEL_TYPES = ['qwen3_5', 'qwen3_5_moe'] as const;

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import {
   Gemma4Model as Gemma4ModelNative,
   Lfm2Model as Lfm2ModelNative,
+  MuseGlimmerModel as MuseGlimmerModelNative,
   Qwen3Tokenizer,
   Qwen3Model as Qwen3ModelNative,
   Qwen35Model as Qwen35ModelNative,
@@ -848,6 +849,11 @@ export class Gemma4Model extends makeStreamingModel(Gemma4ModelNative, {
   recordModelPath: true,
 }) {}
 
+/** Muse-Glimmer text model with embedded DFlash speculative decoding. */
+export class MuseGlimmerModel extends makeStreamingModel(MuseGlimmerModelNative, {
+  recordModelPath: true,
+}) {}
+
 /**
  * Qwen3 (first-gen, text-only) model.
  *
@@ -874,11 +880,13 @@ function _assertSessionCapable(): void {
   const _moe: SessionCapableModel = null as unknown as Qwen35MoeModel;
   const _lfm2: SessionCapableModel = null as unknown as Lfm2Model;
   const _gemma4: SessionCapableModel = null as unknown as Gemma4Model;
+  const _museGlimmer: SessionCapableModel = null as unknown as MuseGlimmerModel;
   const _qwen3: SessionCapableModel = null as unknown as Qwen3Model;
   void _qwen35;
   void _moe;
   void _lfm2;
   void _gemma4;
+  void _museGlimmer;
   void _qwen3;
 }
 void _assertSessionCapable;
@@ -921,10 +929,13 @@ function _assertPreservedNativeSurfaces(): void {
     null as unknown as Lfm2Model;
   const _gemma4: PreservedNativeSurface<typeof Gemma4ModelNative> =
     null as unknown as Gemma4Model;
+  const _museGlimmer: PreservedNativeSurface<typeof MuseGlimmerModelNative> =
+    null as unknown as MuseGlimmerModel;
   void _qwen3;
   void _qwen35;
   void _moe;
   void _lfm2;
   void _gemma4;
+  void _museGlimmer;
 }
 void _assertPreservedNativeSurfaces;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -55,7 +55,13 @@ export { resolveServerTuningForUsage } from './timing.js';
 // import it from the deep path
 // `packages/server/src/session-registry.js` instead.
 
-export { QWEN_SAMPLING_DEFAULTS, GEMMA4_SAMPLING_DEFAULTS, LFM2_SAMPLING_DEFAULTS, LAUNCH_PRESETS } from './presets.js';
+export {
+  QWEN_SAMPLING_DEFAULTS,
+  GEMMA4_SAMPLING_DEFAULTS,
+  MUSE_GLIMMER_SAMPLING_DEFAULTS,
+  LFM2_SAMPLING_DEFAULTS,
+  LAUNCH_PRESETS,
+} from './presets.js';
 export type { LaunchPreset } from './presets.js';
 export type { PublicModelEntry } from './handler.js';
 

--- a/packages/server/src/presets.ts
+++ b/packages/server/src/presets.ts
@@ -79,6 +79,16 @@ export const GEMMA4_SAMPLING_DEFAULTS: ChatConfig = {
   repetitionPenalty: 1.0,
 };
 
+/** Sampling defaults from Meta's Muse-Glimmer release recipe. */
+export const MUSE_GLIMMER_SAMPLING_DEFAULTS: ChatConfig = {
+  temperature: 0.6,
+  topP: 0.95,
+  topK: 20,
+  minP: 0.0,
+  presencePenalty: 0.0,
+  repetitionPenalty: 1.0,
+};
+
 /** Sampling defaults for LFM2.5 Thinking. */
 export const LFM2_SAMPLING_DEFAULTS: ChatConfig = {
   temperature: 0.05,
@@ -115,6 +125,10 @@ export const LAUNCH_PRESETS: Record<string, LaunchPreset> = {
   },
   gemma4: {
     sampling: GEMMA4_SAMPLING_DEFAULTS,
+    maxOutputTokens: 16384,
+  },
+  muse_glimmer: {
+    sampling: MUSE_GLIMMER_SAMPLING_DEFAULTS,
     maxOutputTokens: 16384,
   },
   lfm2: {


### PR DESCRIPTION
## Summary

- add the native Muse-Glimmer text runtime for converted Q4_K GGUF weights
- implement the checkpoint's 16-token DFlash/MTP path with target-AR fallback
- add hybrid full/sliding paged KV caching and continuous batching for autoregressive requests
- persist finalized paged prefixes to the SSD cold tier across hot eviction and process restart
- wire model discovery, presets, streaming policy, conversion support, declarations, and documentation

## Runtime behavior

Muse-Glimmer has 13 full-attention layers and 39 sliding-window layers. The paged runtime keeps those groups coordinated at a common token boundary.

DFlash is enabled automatically when draft weights are present unless the request sets `enableMtp: false`. DFlash owns isolated flat target/draft caches and acts as a scheduler barrier, so DFlash turns are serialized. Autoregressive requests use the hybrid paged scheduler and support continuous batching.

For SSD persistence, the full-attention block chain is authoritative and all sliding-window groups are encoded in a companion sidecar at the same boundary. Missing, corrupt, fingerprint-mismatched, salt-mismatched, or incomplete sidecars fail closed and restart prefill from zero. DFlash caches are not persisted, and unfinished in-flight AR requests retain recompute preemption.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p mlx-core`
- `cargo clippy -p mlx-core --lib -- -D warnings`
- `cargo test -p mlx-core muse_glimmer --lib`: 216 passed, 29 ignored
- `cargo test -p mlx-core cold_restore_allowlist_covers_gated_families_only --lib`
- `cargo test -p mlx-core --test muse_glimmer_cold_tier_parity --no-run`
- real Q4_K release restart-parity gate:
  - restored 64 prompt tokens
  - 4 cold-tier hits and 884,028 bytes restored
  - sliding sidecar installed
  - 0 corruptions
  - output and generated token count matched a persistence-disabled baseline
- `yarn build:native`
- `yarn build:ts`
- targeted agent/model-host/paged-config tests: 32 passed
- `yarn lint` (passes with 8 pre-existing warnings)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new inference family touching decode loops, speculative decoding, KV/cold-tier restore, and weight conversion—errors affect generation correctness, cache persistence, and multi-request scheduling.
> 
> **Overview**
> Adds **Muse-Glimmer** as a first-class model family: loader detection (`MuseGlimmerForConditionalGeneration` / `muse_glimmer`), `MuseGlimmerModel` NAPI surface, and a native text stack (hybrid full + sliding attention, gated GQA, sandwich norms).
> 
> **Runtime paths:** autoregressive turns use coordinated **hybrid paged KV** (13 full / 39 sliding layers) with optional **SSD cold restore** via a Gemma-style sliding sidecar at the same block boundary; **16-token DFlash** reuses the DSpark turn loop when draft weights are present, with shared target embeddings/LM head and MTP depth defaults aligned to checkpoint block size.
> 
> **Engine plumbing:** introduces **`TurnTokenObserver`** and **`StreamEmitter::on_token_id`** so Muse **StreamGuard** turn boundaries stop decode (sync, streaming, DSpark, and hybrid scheduler) before the next forward; DSpark steppers gain **`finish()`** for draft context handoff.
> 
> **Conversion:** HF Muse SafeTensors conversion bakes **sandwich-norm `(1 + weight)`** once for raw `model.language_model.*` keys; config gains DFlash, paged-cache, and RoPE layout fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aad11fde4591d3adfeb3913e941972242581be7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->