### PR TITLE
fix(sched): admit against live pool, not a 32k hint

### DIFF
--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -657,9 +657,8 @@ export declare class MuseGlimmerModel {
   hasBlockPagedCache(): boolean;
   maxConcurrentSequences(): number;
   /**
-   * Conservative model-wide context snapshot used by higher layers for
-   * compaction. It includes the paged AR limit even when DFlash is present,
-   * because DFlash is opt-in per request and can be disabled by the caller.
+   * Model-wide context snapshot used by higher layers for compaction.
+   * `effective_window_tokens` is min(trained, live pool).
    */
   contextLimits(): MuseGlimmerContextLimits;
   schedulerStats(): Promise<SchedulerStats>;
@@ -4235,9 +4234,8 @@ export declare const enum MultimodalContentOrder {
 
 /**
  * Trained and physically available active-context limits for one loaded
- * Muse-Glimmer model. The effective window is conservative across both
- * execution modes: DFlash may use the flat cache, but callers can disable it
- * per request and fall back to the paged AR scheduler.
+ * Muse-Glimmer model. Values are snapshots because the physical pool is fixed
+ * for the lifetime of the resident model.
  */
 export interface MuseGlimmerContextLimits {
   trainedWindowTokens: number;
@@ -4305,8 +4303,10 @@ export interface NemotronHConfig {
   /** Number of MTP predictor steps (`num_nextn_predict_layers`). */
   nMtpLayers: number;
   /**
-   * Optional block-paged KV cache memory cap in MiB. None resolves to the
-   * default 2048 MiB pool; explicit values are honored.
+   * Optional block-paged KV cache memory cap in MiB. `None` requests one
+   * `max_position_embeddings` sequence (6 GiB on Lightning 30B-A3B) then
+   * clips with load-time Metal/RAM sizing after weights. Explicit values
+   * skip the auto-sizer.
    */
   pagedCacheMemoryMb?: number;
   /** Optional paged block size in tokens (default 16). */

--- a/crates/mlx-core/src/cache_limit.rs
+++ b/crates/mlx-core/src/cache_limit.rs
@@ -240,6 +240,35 @@ impl CacheLimitCoordinator {
             .fold(0u64, u64::saturating_add)
     }
 
+    /// Register `pool_bytes` only if the live pool sum is still `expected_total`.
+    /// `None` means another load reserved in between; the caller should resize.
+    pub fn try_register_pool_if_total_eq(
+        &self,
+        expected_total: u64,
+        pool_bytes: u64,
+    ) -> Option<PoolCacheLimitGuard> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let current = state
+            .pools
+            .values()
+            .copied()
+            .fold(0u64, u64::saturating_add);
+        if current != expected_total {
+            return None;
+        }
+        let id = state.next_id;
+        state.next_id = state.next_id.saturating_add(1);
+        state.pools.insert(id, pool_bytes);
+        info!(
+            "[cache_limit] register paged pool guard={} bytes={:.2} GB (live_pools={})",
+            id,
+            pool_bytes as f64 / ONE_GIB,
+            state.pools.len(),
+        );
+        recompute_locked(&mut state);
+        Some(PoolCacheLimitGuard { id })
+    }
+
     /// Register a private paged-KV pool so the MLX freelist ceiling is
     /// debited by memory that MLX's own allocator counters cannot see.
     pub fn register_pool(&self, pool_bytes: u64) -> PoolCacheLimitGuard {
@@ -752,6 +781,27 @@ mod tests {
         assert_eq!(
             coordinator().registered_pool_bytes().saturating_sub(before),
             8 * GB
+        );
+    }
+
+    #[test]
+    fn try_register_pool_if_total_eq_rejects_stale_snapshot() {
+        let before = coordinator().registered_pool_bytes();
+        let _occupant = coordinator().register_pool(GB);
+        assert!(
+            coordinator()
+                .try_register_pool_if_total_eq(before, GB)
+                .is_none(),
+            "stale sibling snapshot must not insert a second pool"
+        );
+        let current = coordinator().registered_pool_bytes();
+        let accepted = coordinator().try_register_pool_if_total_eq(current, 2 * GB);
+        assert!(accepted.is_some(), "matching snapshot must reserve");
+        assert_eq!(
+            coordinator()
+                .registered_pool_bytes()
+                .saturating_sub(current),
+            2 * GB
         );
     }
 

--- a/crates/mlx-core/src/cache_limit.rs
+++ b/crates/mlx-core/src/cache_limit.rs
@@ -640,6 +640,9 @@ mod tests {
     /// never observes another's `MLX_GPU_HEADROOM_GB` setting.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Serializes tests that mutate the process-wide pool registry.
+    static POOL_LOCK: Mutex<()> = Mutex::new(());
+
     /// RAII guard that unsets the env var on drop. Any test that calls
     /// `std::env::set_var(GPU_HEADROOM_ENV, ...)` should wrap the call
     /// in one of these so a panic cannot leak the variable into the
@@ -775,6 +778,7 @@ mod tests {
 
     #[test]
     fn registered_pool_bytes_tracks_live_guards() {
+        let _lock = POOL_LOCK.lock().unwrap();
         let before = coordinator().registered_pool_bytes();
         let _g1 = coordinator().register_pool(3 * GB);
         let _g2 = coordinator().register_pool(5 * GB);
@@ -786,6 +790,7 @@ mod tests {
 
     #[test]
     fn try_register_pool_if_total_eq_rejects_stale_snapshot() {
+        let _lock = POOL_LOCK.lock().unwrap();
         let before = coordinator().registered_pool_bytes();
         let _occupant = coordinator().register_pool(GB);
         assert!(

--- a/crates/mlx-core/src/cache_limit.rs
+++ b/crates/mlx-core/src/cache_limit.rs
@@ -228,6 +228,18 @@ impl CacheLimitCoordinator {
         CacheLimitGuard { id }
     }
 
+    /// Sum of every live private paged-KV pool registered with this
+    /// coordinator. Used by load-time pool sizers so a second model does
+    /// not treat another model's Metal buffers as free headroom.
+    pub fn registered_pool_bytes(&self) -> u64 {
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state
+            .pools
+            .values()
+            .copied()
+            .fold(0u64, u64::saturating_add)
+    }
+
     /// Register a private paged-KV pool so the MLX freelist ceiling is
     /// debited by memory that MLX's own allocator counters cannot see.
     pub fn register_pool(&self, pool_bytes: u64) -> PoolCacheLimitGuard {
@@ -730,6 +742,17 @@ mod tests {
         let with_pool = compute_cache_limit(36 * GB, 8 * GB, 96 * GB);
         assert_eq!(without_pool.saturating_sub(with_pool), 8 * GB);
         approx_eq_gb(with_pool, 37.6);
+    }
+
+    #[test]
+    fn registered_pool_bytes_tracks_live_guards() {
+        let before = coordinator().registered_pool_bytes();
+        let _g1 = coordinator().register_pool(3 * GB);
+        let _g2 = coordinator().register_pool(5 * GB);
+        assert_eq!(
+            coordinator().registered_pool_bytes().saturating_sub(before),
+            8 * GB
+        );
     }
 
     // ── env override: MLX_GPU_HEADROOM_GB ─────────────────────────

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -336,13 +336,28 @@ fn scheduler_long_prefill_tokens() -> u32 {
 
 pub(crate) fn scheduler_per_seq_context() -> u32 {
     static VALUE: OnceLock<u32> = OnceLock::new();
-    *VALUE.get_or_init(|| {
-        std::env::var("MLX_PAGED_PER_SEQ_CTX")
-            .ok()
-            .and_then(|value| value.parse::<u32>().ok())
-            .filter(|&value| value > 0)
-            .unwrap_or(32_768)
-    })
+    *VALUE.get_or_init(|| scheduler_per_seq_context_override().unwrap_or(32_768))
+}
+
+pub(crate) fn scheduler_per_seq_context_override() -> Option<u32> {
+    std::env::var("MLX_PAGED_PER_SEQ_CTX")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .filter(|&value| value > 0)
+}
+
+pub(crate) fn scheduled_turn_context(
+    trained_context: u32,
+    pool_tokens: u32,
+    override_cap: Option<u32>,
+) -> u32 {
+    let trained = trained_context.max(1);
+    let pool = pool_tokens.max(1);
+    let mut cap = trained.min(pool);
+    if let Some(limit) = override_cap.filter(|&value| value > 0) {
+        cap = cap.min(limit);
+    }
+    cap
 }
 
 fn scheduler_watermark_fraction() -> f64 {
@@ -3029,5 +3044,41 @@ mod tests {
             state.owner_states.get("continued-owner").map(Vec::as_slice),
             Some(&[7, 8][..])
         );
+    }
+}
+
+#[cfg(test)]
+mod scheduled_context_tests {
+    use super::scheduled_turn_context;
+
+    #[test]
+    fn admit_uses_pool_when_env_unset() {
+        // Incident numbers: 33611 prompt, 32768 old cap, ~349520 pool, 1M trained.
+        let cap = scheduled_turn_context(1_048_576, 349_520, None);
+        assert_eq!(cap, 349_520);
+        assert!(crate::engine::scheduler::clamp_scheduled_output_tokens(33_611, 1024, cap).is_ok());
+        assert!(
+            crate::engine::scheduler::clamp_scheduled_output_tokens(33_611, 1024, 32_768).is_err()
+        );
+    }
+
+    #[test]
+    fn admit_never_exceeds_trained() {
+        assert_eq!(scheduled_turn_context(40_960, 262_144, None), 40_960);
+    }
+
+    #[test]
+    fn explicit_env_cap_still_clips() {
+        assert_eq!(
+            scheduled_turn_context(1_048_576, 349_520, Some(32_768)),
+            32_768
+        );
+    }
+
+    #[test]
+    fn zero_or_missing_override_is_ignored() {
+        // Some(0) is treated as unset; None means no extra clip beyond min(trained, pool).
+        assert_eq!(scheduled_turn_context(64, 64, Some(0)), 64);
+        assert_eq!(scheduled_turn_context(1_048_576, 349_520, None), 349_520);
     }
 }

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -402,6 +402,37 @@ pub(crate) fn reservation_fits_empty_pool(
     need <= cap
 }
 
+/// Keep-live blocks already allocated for `seq_id` that a continuation
+/// will reuse. Subtracted from `reservation_blocks` at admit so the
+/// full-prompt ISL is not charged on top of KV that is neither free nor
+/// reclaimable. Mismatch or `!reuse` credits 0 — prefix prepare rebuilds.
+fn reusable_keep_live_blocks(
+    adapter: Option<&PagedKVCacheAdapter>,
+    seq_id: SeqId,
+    prompt: &[u32],
+    reuse: bool,
+) -> u32 {
+    if !reuse {
+        return 0;
+    }
+    let Some(adapter) = adapter else {
+        return 0;
+    };
+    if !adapter.is_live_for_continue_for(seq_id) {
+        return 0;
+    }
+    let Some(held) = adapter.request_tokens_for(seq_id) else {
+        return 0;
+    };
+    if !prompt.starts_with(held) {
+        return 0;
+    }
+    adapter
+        .block_table_for(seq_id)
+        .map(|table| table.num_blocks() as u32)
+        .unwrap_or(0)
+}
+
 fn scheduler_watermark_fraction() -> f64 {
     static VALUE: OnceLock<f64> = OnceLock::new();
     *VALUE.get_or_init(|| {
@@ -1653,8 +1684,7 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
     }
 
     /// Idle parked recurrent row that is not the candidate and is not in the
-    /// scheduler's running/waiting set. Shared by the unit-cap path and
-    /// memory-denial reclaim so the two policies cannot drift.
+    /// scheduler's running/waiting set. Unit-cap eviction only.
     fn idle_recurrent_victim(&self, seq_id: SeqId) -> Option<SeqId> {
         self.owner_sequences
             .values()
@@ -1663,6 +1693,25 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
                 candidate != seq_id
                     && self.inner.has_scheduled_recurrent(candidate)
                     && !self.scheduler.contains_seq(candidate)
+            })
+            .min()
+    }
+
+    /// Idle owner that holds a recurrent row or a keep-live/cache table.
+    /// Used by memory-denial reclaim only; unit-cap stays rec-only.
+    fn idle_memory_victim(&self, seq_id: SeqId) -> Option<SeqId> {
+        self.owner_sequences
+            .values()
+            .copied()
+            .filter(|&candidate| {
+                candidate != seq_id
+                    && !self.scheduler.contains_seq(candidate)
+                    && (self.inner.has_scheduled_recurrent(candidate)
+                        || self.inner.scheduler_materialized_blocks(candidate) > 0
+                        || self
+                            .inner
+                            .paged_adapter()
+                            .is_some_and(|adapter| adapter.block_table_for(candidate).is_some()))
             })
             .min()
     }
@@ -1682,10 +1731,10 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
         self.inner.can_activate_scheduled_recurrent(seq_id)
     }
 
-    /// Drop one idle parked recurrent row and unpin its keep-live KV so
+    /// Drop one idle parked recurrent row and/or unpin its keep-live KV so
     /// published full blocks drop to prefix-cache `ref_count == 1` (evictable).
     fn reclaim_one_idle_scheduled(&mut self, seq_id: SeqId) -> bool {
-        let Some(victim) = self.idle_recurrent_victim(seq_id) else {
+        let Some(victim) = self.idle_memory_victim(seq_id) else {
             return false;
         };
         self.inner.release_scheduled_recurrent_for(victim);
@@ -1793,9 +1842,18 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             return Err(prepared);
         }
         if let Some(snapshot) = cache_snapshot {
+            let reuse = prepared.admitted.plan.is_delta || prepared.admitted.params.reuse_cache;
+            let charge = prepared
+                .reservation_blocks
+                .saturating_sub(reusable_keep_live_blocks(
+                    self.inner.paged_adapter(),
+                    prepared.seq_id,
+                    &prepared.admitted.tokens,
+                    reuse,
+                ));
             match self.try_reserve_reclaiming_idle(
                 prepared.seq_id,
-                prepared.reservation_blocks,
+                charge,
                 candidate_state_bytes,
                 snapshot,
             ) {
@@ -2215,9 +2273,15 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             return;
         }
         if let Some(snapshot) = cache_snapshot {
+            let materialized = self.inner.scheduler_materialized_blocks(turn.seq_id);
+            let charge = if materialized > 0 {
+                turn.block_reservation_total.saturating_sub(materialized)
+            } else {
+                turn.block_reservation_total
+            };
             match self.try_reserve_reclaiming_idle(
                 turn.seq_id,
-                turn.block_reservation_total,
+                charge,
                 turn.recurrent_state_bytes,
                 snapshot,
             ) {
@@ -2727,6 +2791,44 @@ mod tests {
         }
     }
 
+    fn tiny_nemotron_paged_config() -> NemotronHConfig {
+        NemotronHConfig {
+            vocab_size: 32,
+            hidden_size: 256,
+            num_hidden_layers: 3,
+            num_attention_heads: 2,
+            num_key_value_heads: 1,
+            head_dim: 128,
+            max_position_embeddings: 512,
+            layer_norm_epsilon: 1e-5,
+            layers_block_type: vec![
+                "linear_attention".into(),
+                "moe".into(),
+                "full_attention".into(),
+            ],
+            mamba_num_heads: 2,
+            mamba_head_dim: 2,
+            ssm_state_size: 2,
+            n_groups: 1,
+            conv_kernel: 4,
+            chunk_size: 4,
+            time_step_min: 0.001,
+            time_step_limit: None,
+            n_routed_experts: 4,
+            num_experts_per_tok: 1,
+            routed_scaling_factor: 1.0,
+            norm_topk_prob: true,
+            intermediate_size: 6,
+            moe_shared_expert_intermediate_size: 8,
+            eos_token_ids: vec![2],
+            mtp_layers_block_type: Vec::new(),
+            n_mtp_layers: 0,
+            paged_cache_memory_mb: Some(256),
+            paged_block_size: Some(16),
+            use_block_paged_cache: Some(true),
+        }
+    }
+
     #[test]
     fn dense_and_moe_construct_the_same_engine_scheduler() {
         let dense = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
@@ -3154,6 +3256,175 @@ mod tests {
         assert!(
             matches!(outcome, MemoryReserveOutcome::Reject { total_blocks: 100 }),
             "idle scheduler must hard-error, not spin in prepared_waiting: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn continuation_credits_keep_live_blocks_against_reservation() {
+        let inner = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
+        let mut state = HybridSchedulerState::new(inner).expect("construct scheduler");
+        assert!(state.idle_recurrent_victim(2).is_none());
+        assert!(state.idle_memory_victim(2).is_none());
+        assert!(!state.scheduler.has_live_turns());
+        let snapshot = SchedulerCacheSnapshot {
+            blocks: BlockTelemetry {
+                total_blocks: 100,
+                free_blocks: 40,
+                reclaimable_blocks: 0,
+                allocated_blocks: 60,
+            },
+            bytes_per_block: 4096,
+        };
+        let reservation_blocks = 70u32;
+        let already_materialized = 60u32;
+        assert!(reservation_fits_empty_pool(
+            reservation_blocks,
+            snapshot.blocks.total_blocks,
+            snapshot.bytes_per_block,
+            0,
+        ));
+        let without_credit = state
+            .try_reserve_reclaiming_idle(2, reservation_blocks, 0, snapshot)
+            .expect("no snapshot refresh");
+        assert!(
+            matches!(
+                without_credit,
+                MemoryReserveOutcome::Reject { total_blocks: 100 }
+            ),
+            "70 vs free 40 without keep-live credit must Reject: {without_credit:?}"
+        );
+        let charge = reservation_blocks.saturating_sub(already_materialized);
+        assert_eq!(charge, 10);
+        let with_credit = state
+            .try_reserve_reclaiming_idle(2, charge, 0, snapshot)
+            .expect("no snapshot refresh");
+        assert!(
+            matches!(with_credit, MemoryReserveOutcome::Admitted),
+            "charge 10 vs free 40 must admit: {with_credit:?}"
+        );
+    }
+
+    #[test]
+    fn reusable_keep_live_credits_prefix_match_not_mismatch() {
+        assert_eq!(
+            reusable_keep_live_blocks(None, 1, &[1, 2, 3], true),
+            0,
+            "no adapter credits 0"
+        );
+        let inner = match NemotronHInner::new(tiny_nemotron_paged_config()) {
+            Ok(inner) => inner,
+            Err(_) => {
+                eprintln!(
+                    "skipping reusable_keep_live_credits_prefix_match_not_mismatch: inner failed"
+                );
+                return;
+            }
+        };
+        let mut state = HybridSchedulerState::new(inner).expect("construct nemotron scheduler");
+        let Some(adapter) = state.inner.paged_adapter_mut() else {
+            eprintln!(
+                "skipping reusable_keep_live_credits_prefix_match_not_mismatch: Metal unavailable"
+            );
+            return;
+        };
+        let held: Vec<u32> = (1..33).collect();
+        adapter.begin_request(1).expect("begin keep-live request");
+        let _ = adapter
+            .find_cached_prefix(&[], &[], 0, false)
+            .expect("prefix lookup");
+        adapter
+            .allocate_suffix_blocks(held.len() as u32)
+            .expect("allocate held blocks");
+        adapter.record_tokens(&held).expect("record held tokens");
+        adapter
+            .finalize_turn_keep_live(&[], 0)
+            .expect("keep-live finalize");
+        let num_blocks = adapter
+            .block_table_for(1)
+            .expect("keep-live table")
+            .num_blocks() as u32;
+        assert!(num_blocks > 0, "held tokens must occupy blocks");
+        let mut continued = held.clone();
+        continued.extend_from_slice(&[99, 100]);
+        let mut mismatch = held.clone();
+        mismatch[0] = 0;
+        mismatch.extend_from_slice(&[99, 100]);
+        let adapter = state.inner.paged_adapter();
+        assert_eq!(
+            reusable_keep_live_blocks(adapter, 1, &continued, true),
+            num_blocks,
+            "prompt starting with held credits num_blocks"
+        );
+        assert_eq!(
+            reusable_keep_live_blocks(adapter, 1, &mismatch, true),
+            0,
+            "mismatch credits 0; prefix will rebuild"
+        );
+        assert_eq!(
+            reusable_keep_live_blocks(adapter, 1, &continued, false),
+            0,
+            "!reuse credits 0"
+        );
+    }
+
+    #[test]
+    fn cache_only_idle_owner_is_memory_victim_not_unit_cap_victim() {
+        let inner = match NemotronHInner::new(tiny_nemotron_paged_config()) {
+            Ok(inner) => inner,
+            Err(_) => {
+                eprintln!(
+                    "skipping cache_only_idle_owner_is_memory_victim_not_unit_cap_victim: inner failed"
+                );
+                return;
+            }
+        };
+        if inner.paged_adapter().is_none() {
+            eprintln!(
+                "skipping cache_only_idle_owner_is_memory_victim_not_unit_cap_victim: Metal unavailable"
+            );
+            return;
+        }
+        let mut state = HybridSchedulerState::new(inner).expect("construct nemotron scheduler");
+        state.owner_sequences.insert("cache-only".into(), 1);
+        state
+            .inner
+            .paged_adapter_mut()
+            .expect("paged adapter")
+            .begin_request(1)
+            .expect("begin cache-only request");
+        state.inner.release_scheduled_recurrent_for(1);
+        assert!(
+            !state.inner.has_scheduled_recurrent(1),
+            "recurrent row is gone"
+        );
+        assert!(
+            state
+                .inner
+                .paged_adapter()
+                .and_then(|adapter| adapter.block_table_for(1))
+                .is_some(),
+            "block table remains after rec release"
+        );
+        assert!(
+            state.idle_recurrent_victim(2).is_none(),
+            "cache-only owner is not a unit-cap victim"
+        );
+        assert_eq!(
+            state.idle_memory_victim(2),
+            Some(1),
+            "cache-only keep-live table is a memory victim"
+        );
+        assert!(
+            state.reclaim_one_idle_scheduled(2),
+            "memory-denial reclaim must unpin the cache-only table"
+        );
+        assert!(
+            state
+                .inner
+                .paged_adapter()
+                .and_then(|adapter| adapter.block_table_for(1))
+                .is_none(),
+            "reclaim unpins the keep-live table"
         );
     }
 

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -1733,13 +1733,32 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
 
     /// Drop one idle parked recurrent row and/or unpin its keep-live KV so
     /// published full blocks drop to prefix-cache `ref_count == 1` (evictable).
-    fn reclaim_one_idle_scheduled(&mut self, seq_id: SeqId) -> bool {
+    /// `Ok(false)` means no victim or the same victim is still eligible.
+    fn reclaim_one_idle_scheduled(&mut self, seq_id: SeqId) -> Result<bool> {
+        self.reclaim_one_idle_scheduled_with(seq_id, B::release_scheduled_cache)
+    }
+
+    fn reclaim_one_idle_scheduled_with<F>(
+        &mut self,
+        seq_id: SeqId,
+        release_cache: F,
+    ) -> Result<bool>
+    where
+        F: FnOnce(&mut B, SeqId) -> Result<()>,
+    {
         let Some(victim) = self.idle_memory_victim(seq_id) else {
-            return false;
+            return Ok(false);
         };
         self.inner.release_scheduled_recurrent_for(victim);
-        let _ = self.inner.release_scheduled_cache(victim);
-        true
+        release_cache(&mut self.inner, victim)?;
+        if !self.idle_reclaim_made_progress(seq_id, victim) {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
+    fn idle_reclaim_made_progress(&self, seq_id: SeqId, victim: SeqId) -> bool {
+        self.idle_memory_victim(seq_id) != Some(victim)
     }
 
     fn try_reserve_reclaiming_idle(
@@ -1747,8 +1766,28 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
         seq_id: SeqId,
         reservation_blocks: u32,
         candidate_state_bytes: u64,
-        mut snapshot: SchedulerCacheSnapshot,
+        snapshot: SchedulerCacheSnapshot,
     ) -> Result<MemoryReserveOutcome> {
+        self.try_reserve_reclaiming_idle_with(
+            seq_id,
+            reservation_blocks,
+            candidate_state_bytes,
+            snapshot,
+            B::release_scheduled_cache,
+        )
+    }
+
+    fn try_reserve_reclaiming_idle_with<F>(
+        &mut self,
+        seq_id: SeqId,
+        reservation_blocks: u32,
+        candidate_state_bytes: u64,
+        mut snapshot: SchedulerCacheSnapshot,
+        mut release_cache: F,
+    ) -> Result<MemoryReserveOutcome>
+    where
+        F: FnMut(&mut B, SeqId) -> Result<()>,
+    {
         loop {
             let decision = self.scheduler.try_reserve_memory(
                 engine::scheduler::MemoryTelemetry {
@@ -1768,7 +1807,7 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             if decision.admitted {
                 return Ok(MemoryReserveOutcome::Admitted);
             }
-            if !self.reclaim_one_idle_scheduled(seq_id) {
+            if !self.reclaim_one_idle_scheduled_with(seq_id, &mut release_cache)? {
                 if self.scheduler.has_live_turns() {
                     return Ok(MemoryReserveOutcome::Defer);
                 }
@@ -3127,7 +3166,7 @@ mod tests {
         );
 
         assert!(
-            state.reclaim_one_idle_scheduled(2),
+            state.reclaim_one_idle_scheduled(2).expect("cache release"),
             "memory-denial reclaim must evict the idle parked row"
         );
         assert!(
@@ -3257,6 +3296,99 @@ mod tests {
             matches!(outcome, MemoryReserveOutcome::Reject { total_blocks: 100 }),
             "idle scheduler must hard-error, not spin in prepared_waiting: {outcome:?}"
         );
+    }
+
+    #[test]
+    fn reclaim_without_idle_victim_returns_ok_false() {
+        let inner = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
+        let mut state = HybridSchedulerState::new(inner).expect("construct scheduler");
+        assert!(state.idle_memory_victim(2).is_none());
+        let progress = state
+            .reclaim_one_idle_scheduled(2)
+            .expect("no victim does not release cache");
+        assert!(!progress, "no idle victim is not reclaim progress");
+    }
+
+    #[test]
+    fn idle_reclaim_makes_no_progress_while_same_victim_eligible() {
+        let inner = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
+        let mut state = HybridSchedulerState::new(inner).expect("construct scheduler");
+        state.owner_sequences.insert("parked".into(), 1);
+        state
+            .inner
+            .activate_scheduled_recurrent(1)
+            .expect("activate parked owner");
+        state
+            .inner
+            .park_active_scheduled_recurrent()
+            .expect("park seq 1");
+        assert_eq!(state.idle_memory_victim(2), Some(1));
+        assert!(
+            !state.idle_reclaim_made_progress(2, 1),
+            "same victim still eligible is no progress"
+        );
+        state.inner.release_scheduled_recurrent_for(1);
+        assert!(
+            state.idle_memory_victim(2).is_none(),
+            "rec release drops the Qwen3.5 victim"
+        );
+        assert!(
+            state.idle_reclaim_made_progress(2, 1),
+            "cleared victim is progress"
+        );
+    }
+
+    #[test]
+    fn reclaim_propagates_cache_release_error() {
+        let inner = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
+        let mut state = HybridSchedulerState::new(inner).expect("construct scheduler");
+        state.owner_sequences.insert("parked".into(), 1);
+        state
+            .inner
+            .activate_scheduled_recurrent(1)
+            .expect("activate parked owner");
+        state
+            .inner
+            .park_active_scheduled_recurrent()
+            .expect("park seq 1");
+        let error = state
+            .reclaim_one_idle_scheduled_with(2, |_inner, victim| {
+                assert_eq!(victim, 1);
+                Err(Error::from_reason("injected cache release failure"))
+            })
+            .expect_err("cache release Err must propagate");
+        assert_eq!(error.reason, "injected cache release failure");
+    }
+
+    #[test]
+    fn try_reserve_propagates_cache_release_error() {
+        let inner = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
+        let mut state = HybridSchedulerState::new(inner).expect("construct scheduler");
+        state.owner_sequences.insert("parked".into(), 1);
+        state
+            .inner
+            .activate_scheduled_recurrent(1)
+            .expect("activate parked owner");
+        state
+            .inner
+            .park_active_scheduled_recurrent()
+            .expect("park seq 1");
+        let snapshot = SchedulerCacheSnapshot {
+            blocks: BlockTelemetry {
+                total_blocks: 100,
+                free_blocks: 0,
+                reclaimable_blocks: 0,
+                allocated_blocks: 100,
+            },
+            bytes_per_block: 4096,
+        };
+        let error = state
+            .try_reserve_reclaiming_idle_with(2, 10, 1, snapshot, |_inner, victim| {
+                assert_eq!(victim, 1);
+                Err(Error::from_reason("injected cache release failure"))
+            })
+            .expect_err("deny + failed unpin must not spin");
+        assert_eq!(error.reason, "injected cache release failure");
     }
 
     #[test]
@@ -3415,7 +3547,7 @@ mod tests {
             "cache-only keep-live table is a memory victim"
         );
         assert!(
-            state.reclaim_one_idle_scheduled(2),
+            state.reclaim_one_idle_scheduled(2).expect("cache release"),
             "memory-denial reclaim must unpin the cache-only table"
         );
         assert!(
@@ -3426,6 +3558,112 @@ mod tests {
                 .is_none(),
             "reclaim unpins the keep-live table"
         );
+        assert!(
+            state.idle_memory_victim(2).is_none(),
+            "successful cache-only reclaim must drop the victim"
+        );
+    }
+
+    #[test]
+    fn cache_only_unpin_that_leaves_victim_is_not_progress() {
+        let inner = match NemotronHInner::new(tiny_nemotron_paged_config()) {
+            Ok(inner) => inner,
+            Err(_) => {
+                eprintln!(
+                    "skipping cache_only_unpin_that_leaves_victim_is_not_progress: inner failed"
+                );
+                return;
+            }
+        };
+        if inner.paged_adapter().is_none() {
+            eprintln!(
+                "skipping cache_only_unpin_that_leaves_victim_is_not_progress: Metal unavailable"
+            );
+            return;
+        }
+        let mut state = HybridSchedulerState::new(inner).expect("construct nemotron scheduler");
+        state.owner_sequences.insert("cache-only".into(), 1);
+        state
+            .inner
+            .paged_adapter_mut()
+            .expect("paged adapter")
+            .begin_request(1)
+            .expect("begin cache-only request");
+        state.inner.release_scheduled_recurrent_for(1);
+        assert_eq!(state.idle_memory_victim(2), Some(1));
+        let mut unpin_calls = 0u32;
+        let progress = state
+            .reclaim_one_idle_scheduled_with(2, |_inner, victim| {
+                unpin_calls += 1;
+                assert_eq!(victim, 1);
+                Ok(())
+            })
+            .expect("noop unpin is Ok");
+        assert_eq!(unpin_calls, 1);
+        assert!(
+            !progress,
+            "same idle victim after a no-op unpin is not progress"
+        );
+        assert_eq!(state.idle_memory_victim(2), Some(1));
+    }
+
+    #[test]
+    fn try_reserve_rejects_when_cache_only_unpin_makes_no_progress() {
+        let inner = match NemotronHInner::new(tiny_nemotron_paged_config()) {
+            Ok(inner) => inner,
+            Err(_) => {
+                eprintln!(
+                    "skipping try_reserve_rejects_when_cache_only_unpin_makes_no_progress: inner failed"
+                );
+                return;
+            }
+        };
+        if inner.paged_adapter().is_none() {
+            eprintln!(
+                "skipping try_reserve_rejects_when_cache_only_unpin_makes_no_progress: Metal unavailable"
+            );
+            return;
+        }
+        let mut state = HybridSchedulerState::new(inner).expect("construct nemotron scheduler");
+        state.owner_sequences.insert("cache-only".into(), 1);
+        state
+            .inner
+            .paged_adapter_mut()
+            .expect("paged adapter")
+            .begin_request(1)
+            .expect("begin cache-only request");
+        state.inner.release_scheduled_recurrent_for(1);
+        assert_eq!(state.idle_memory_victim(2), Some(1));
+        let snapshot = SchedulerCacheSnapshot {
+            blocks: BlockTelemetry {
+                total_blocks: 100,
+                free_blocks: 0,
+                reclaimable_blocks: 0,
+                allocated_blocks: 100,
+            },
+            bytes_per_block: 4096,
+        };
+        let mut unpin_calls = 0u32;
+        let outcome = state
+            .try_reserve_reclaiming_idle_with(2, 10, 0, snapshot, |_inner, victim| {
+                unpin_calls += 1;
+                assert!(
+                    unpin_calls <= 2,
+                    "reclaim loop must stop when the victim remains"
+                );
+                assert_eq!(victim, 1);
+                Ok(())
+            })
+            .expect("noop unpin is Ok");
+        assert_eq!(
+            unpin_calls, 1,
+            "no-progress reclaim must not retry the same victim"
+        );
+        assert!(
+            matches!(outcome, MemoryReserveOutcome::Reject { total_blocks: 100 }),
+            "no-progress reclaim must Reject, not spin: {outcome:?}"
+        );
+        assert_eq!(state.idle_memory_victim(2), Some(1));
     }
 
     #[test]

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -1700,20 +1700,22 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
     /// Idle owner that holds a recurrent row or a keep-live/cache table.
     /// Used by memory-denial reclaim only; unit-cap stays rec-only.
     fn idle_memory_victim(&self, seq_id: SeqId) -> Option<SeqId> {
-        self.owner_sequences
-            .values()
-            .copied()
-            .filter(|&candidate| {
-                candidate != seq_id
-                    && !self.scheduler.contains_seq(candidate)
-                    && (self.inner.has_scheduled_recurrent(candidate)
-                        || self.inner.scheduler_materialized_blocks(candidate) > 0
-                        || self
-                            .inner
-                            .paged_adapter()
-                            .is_some_and(|adapter| adapter.block_table_for(candidate).is_some()))
-            })
-            .min()
+        let mut candidates: Vec<SeqId> = self.owner_sequences.values().copied().collect();
+        if let Some(adapter) = self.inner.paged_adapter() {
+            candidates.extend(adapter.live_seq_ids());
+        }
+        candidates.sort_unstable();
+        candidates.dedup();
+        candidates.into_iter().find(|&candidate| {
+            candidate != seq_id
+                && !self.scheduler.contains_seq(candidate)
+                && (self.inner.has_scheduled_recurrent(candidate)
+                    || self.inner.scheduler_materialized_blocks(candidate) > 0
+                    || self
+                        .inner
+                        .paged_adapter()
+                        .is_some_and(|adapter| adapter.block_table_for(candidate).is_some()))
+        })
     }
 
     /// Keep the two-unit residency cap as a queueing boundary. An idle warm
@@ -1734,6 +1736,9 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
     /// Drop one idle parked recurrent row and/or unpin its keep-live KV so
     /// published full blocks drop to prefix-cache `ref_count == 1` (evictable).
     /// `Ok(false)` means no victim or the same victim is still eligible.
+    /// Production admit uses [`Self::reclaim_one_idle_scheduled_with`] so tests
+    /// can inject a failing unpin; this wrapper is test-only.
+    #[cfg(test)]
     fn reclaim_one_idle_scheduled(&mut self, seq_id: SeqId) -> Result<bool> {
         self.reclaim_one_idle_scheduled_with(seq_id, B::release_scheduled_cache)
     }
@@ -3561,6 +3566,55 @@ mod tests {
         assert!(
             state.idle_memory_victim(2).is_none(),
             "successful cache-only reclaim must drop the victim"
+        );
+    }
+
+    #[test]
+    fn exclusive_seq_zero_keep_live_is_a_memory_victim() {
+        let inner = match NemotronHInner::new(tiny_nemotron_paged_config()) {
+            Ok(inner) => inner,
+            Err(_) => {
+                eprintln!("skipping exclusive_seq_zero_keep_live_is_a_memory_victim: inner failed");
+                return;
+            }
+        };
+        if inner.paged_adapter().is_none() {
+            eprintln!(
+                "skipping exclusive_seq_zero_keep_live_is_a_memory_victim: Metal unavailable"
+            );
+            return;
+        }
+        let mut state = HybridSchedulerState::new(inner).expect("construct nemotron scheduler");
+        state
+            .inner
+            .paged_adapter_mut()
+            .expect("paged adapter")
+            .begin_request(0)
+            .expect("exclusive lane keep-live");
+        assert!(
+            state.owner_sequences.is_empty(),
+            "seq 0 is not entered in owner_sequences"
+        );
+        assert!(
+            state.idle_recurrent_victim(1).is_none(),
+            "seq 0 without rec is not a unit-cap victim"
+        );
+        assert_eq!(
+            state.idle_memory_victim(1),
+            Some(0),
+            "exclusive keep-live table must be reclaimable"
+        );
+        assert!(
+            state.reclaim_one_idle_scheduled(1).expect("unpin seq 0"),
+            "memory-denial reclaim must unpin sequence 0"
+        );
+        assert!(
+            state
+                .inner
+                .paged_adapter()
+                .and_then(|adapter| adapter.block_table_for(0))
+                .is_none(),
+            "seq 0 table is gone after reclaim"
         );
     }
 

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -1520,7 +1520,16 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
         let trained_context = u32::try_from(self.inner.max_position_embeddings())
             .unwrap_or(1)
             .max(1);
-        let context = trained_context.min(scheduler_per_seq_context());
+        let pool_tokens = self
+            .inner
+            .paged_adapter()
+            .map(crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter::max_capacity_tokens)
+            .unwrap_or(trained_context);
+        let context = scheduled_turn_context(
+            trained_context,
+            pool_tokens,
+            scheduler_per_seq_context_override(),
+        );
         let max_new_tokens = match engine::scheduler::clamp_scheduled_output_tokens(
             prompt_tokens,
             requested_max_new_tokens,
@@ -3080,5 +3089,14 @@ mod scheduled_context_tests {
         // Some(0) is treated as unset; None means no extra clip beyond min(trained, pool).
         assert_eq!(scheduled_turn_context(64, 64, Some(0)), 64);
         assert_eq!(scheduled_turn_context(1_048_576, 349_520, None), 349_520);
+    }
+
+    #[test]
+    fn incident_prompt_fits_nemotron_pool() {
+        let trained = 1_048_576;
+        let pool = 349_520;
+        let cap = scheduled_turn_context(trained, pool, None);
+        // Output still clamped to remaining window; prompt accepted against the pool.
+        assert!(crate::engine::scheduler::clamp_scheduled_output_tokens(33_611, 1024, cap).is_ok());
     }
 }

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -56,6 +56,14 @@ pub(crate) struct SchedulerCacheSnapshot {
     pub bytes_per_block: u64,
 }
 
+/// Result of unified-memory reservation after reclaiming idle parked rows.
+#[derive(Debug)]
+enum MemoryReserveOutcome {
+    Admitted,
+    Defer,
+    Reject { total_blocks: u32 },
+}
+
 pub(crate) struct SchedulerOwnerContext<'a, S> {
     pub owner_sequences: &'a mut HashMap<String, SeqId>,
     pub owner_states: &'a mut HashMap<String, S>,
@@ -1644,6 +1652,21 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
         }
     }
 
+    /// Idle parked recurrent row that is not the candidate and is not in the
+    /// scheduler's running/waiting set. Shared by the unit-cap path and
+    /// memory-denial reclaim so the two policies cannot drift.
+    fn idle_recurrent_victim(&self, seq_id: SeqId) -> Option<SeqId> {
+        self.owner_sequences
+            .values()
+            .copied()
+            .filter(|&candidate| {
+                candidate != seq_id
+                    && self.inner.has_scheduled_recurrent(candidate)
+                    && !self.scheduler.contains_seq(candidate)
+            })
+            .min()
+    }
+
     /// Keep the two-unit residency cap as a queueing boundary. An idle warm
     /// row may be discarded because its owner history can rebuild the exact
     /// GDN state through the ordinary prefix-prime path; a scheduler-owned row
@@ -1652,21 +1675,69 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
         if self.inner.can_activate_scheduled_recurrent(seq_id) {
             return true;
         }
-        let idle_victim = self
-            .owner_sequences
-            .values()
-            .copied()
-            .filter(|&candidate| {
-                candidate != seq_id
-                    && self.inner.has_scheduled_recurrent(candidate)
-                    && !self.scheduler.contains_seq(candidate)
-            })
-            .min();
-        let Some(victim) = idle_victim else {
+        let Some(victim) = self.idle_recurrent_victim(seq_id) else {
             return false;
         };
         self.inner.release_scheduled_recurrent_for(victim);
         self.inner.can_activate_scheduled_recurrent(seq_id)
+    }
+
+    /// Drop one idle parked recurrent row and unpin its keep-live KV so
+    /// published full blocks drop to prefix-cache `ref_count == 1` (evictable).
+    fn reclaim_one_idle_scheduled(&mut self, seq_id: SeqId) -> bool {
+        let Some(victim) = self.idle_recurrent_victim(seq_id) else {
+            return false;
+        };
+        self.inner.release_scheduled_recurrent_for(victim);
+        let _ = self.inner.release_scheduled_cache(victim);
+        true
+    }
+
+    fn try_reserve_reclaiming_idle(
+        &mut self,
+        seq_id: SeqId,
+        reservation_blocks: u32,
+        candidate_state_bytes: u64,
+        mut snapshot: SchedulerCacheSnapshot,
+    ) -> Result<MemoryReserveOutcome> {
+        loop {
+            let decision = self.scheduler.try_reserve_memory(
+                engine::scheduler::MemoryTelemetry {
+                    capacity_bytes: u64::from(snapshot.blocks.total_blocks)
+                        .saturating_mul(snapshot.bytes_per_block),
+                    free_bytes: u64::from(snapshot.blocks.free_blocks)
+                        .saturating_mul(snapshot.bytes_per_block),
+                    reclaimable_bytes: u64::from(snapshot.blocks.reclaimable_blocks)
+                        .saturating_mul(snapshot.bytes_per_block),
+                },
+                reservation_blocks,
+                snapshot.bytes_per_block,
+                self.inner.scheduled_recurrent_bytes(),
+                candidate_state_bytes,
+                scheduler_watermark_fraction(),
+            );
+            if decision.admitted {
+                return Ok(MemoryReserveOutcome::Admitted);
+            }
+            if !self.reclaim_one_idle_scheduled(seq_id) {
+                if self.scheduler.has_live_turns() {
+                    return Ok(MemoryReserveOutcome::Defer);
+                }
+                return Ok(MemoryReserveOutcome::Reject {
+                    total_blocks: snapshot.blocks.total_blocks,
+                });
+            }
+            if let Some(updated) = self.inner.scheduler_cache_snapshot()? {
+                snapshot = updated;
+            }
+        }
+    }
+
+    fn context_length_exceeded(reservation_blocks: u32, total_blocks: u32) -> Error {
+        Error::from_reason(format!(
+            "context_length_exceeded: request requires {} paged blocks but the pool has {}",
+            reservation_blocks, total_blocks
+        ))
     }
 
     fn admit_prepared(
@@ -1713,10 +1784,7 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             self.cleanup_rejected_prepared(&prepared);
             let total_blocks = cache_snapshot.map_or(0, |snapshot| snapshot.blocks.total_blocks);
             prepared.response.send_error(
-                Error::from_reason(format!(
-                    "context_length_exceeded: request requires {} paged blocks but the pool has {}",
-                    prepared.reservation_blocks, total_blocks
-                )),
+                Self::context_length_exceeded(prepared.reservation_blocks, total_blocks),
                 prepared.cancelled.as_ref(),
             );
             return Ok(None);
@@ -1725,23 +1793,29 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             return Err(prepared);
         }
         if let Some(snapshot) = cache_snapshot {
-            let decision = self.scheduler.try_reserve_memory(
-                engine::scheduler::MemoryTelemetry {
-                    capacity_bytes: u64::from(snapshot.blocks.total_blocks)
-                        .saturating_mul(snapshot.bytes_per_block),
-                    free_bytes: u64::from(snapshot.blocks.free_blocks)
-                        .saturating_mul(snapshot.bytes_per_block),
-                    reclaimable_bytes: u64::from(snapshot.blocks.reclaimable_blocks)
-                        .saturating_mul(snapshot.bytes_per_block),
-                },
+            match self.try_reserve_reclaiming_idle(
+                prepared.seq_id,
                 prepared.reservation_blocks,
-                snapshot.bytes_per_block,
-                self.inner.scheduled_recurrent_bytes(),
                 candidate_state_bytes,
-                scheduler_watermark_fraction(),
-            );
-            if !decision.admitted {
-                return Err(prepared);
+                snapshot,
+            ) {
+                Ok(MemoryReserveOutcome::Admitted) => {}
+                Ok(MemoryReserveOutcome::Defer) => return Err(prepared),
+                Ok(MemoryReserveOutcome::Reject { total_blocks }) => {
+                    self.cleanup_rejected_prepared(&prepared);
+                    prepared.response.send_error(
+                        Self::context_length_exceeded(prepared.reservation_blocks, total_blocks),
+                        prepared.cancelled.as_ref(),
+                    );
+                    return Ok(None);
+                }
+                Err(error) => {
+                    self.cleanup_rejected_prepared(&prepared);
+                    prepared
+                        .response
+                        .send_error(error, prepared.cancelled.as_ref());
+                    return Ok(None);
+                }
             }
         }
 
@@ -2141,24 +2215,29 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
             return;
         }
         if let Some(snapshot) = cache_snapshot {
-            let decision = self.scheduler.try_reserve_memory(
-                engine::scheduler::MemoryTelemetry {
-                    capacity_bytes: u64::from(snapshot.blocks.total_blocks)
-                        .saturating_mul(snapshot.bytes_per_block),
-                    free_bytes: u64::from(snapshot.blocks.free_blocks)
-                        .saturating_mul(snapshot.bytes_per_block),
-                    reclaimable_bytes: u64::from(snapshot.blocks.reclaimable_blocks)
-                        .saturating_mul(snapshot.bytes_per_block),
-                },
+            match self.try_reserve_reclaiming_idle(
+                turn.seq_id,
                 turn.block_reservation_total,
-                snapshot.bytes_per_block,
-                self.inner.scheduled_recurrent_bytes(),
                 turn.recurrent_state_bytes,
-                scheduler_watermark_fraction(),
-            );
-            if !decision.admitted {
-                self.scheduler.prepend_preempted(turn);
-                return;
+                snapshot,
+            ) {
+                Ok(MemoryReserveOutcome::Admitted) => {}
+                Ok(MemoryReserveOutcome::Defer) => {
+                    self.scheduler.prepend_preempted(turn);
+                    return;
+                }
+                Ok(MemoryReserveOutcome::Reject { total_blocks }) => {
+                    let reservation_blocks = turn.block_reservation_total;
+                    self.fail_preempted(
+                        turn,
+                        Self::context_length_exceeded(reservation_blocks, total_blocks).reason,
+                    );
+                    return;
+                }
+                Err(error) => {
+                    self.fail_preempted(turn, error.reason.clone());
+                    return;
+                }
             }
         }
         let Some(replay) = turn.payload.preemption_replay.as_ref() else {
@@ -2909,6 +2988,176 @@ mod tests {
     }
 
     #[test]
+    fn memory_denial_reclaims_idle_parked_row_unit_cap_would_keep() {
+        let inner = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
+        let mut state = HybridSchedulerState::new(inner).expect("construct scheduler");
+        state.owner_sequences.insert("history-only".into(), 3);
+        state.owner_sequences.insert("parked".into(), 1);
+        state
+            .inner
+            .activate_scheduled_recurrent(1)
+            .expect("activate parked owner");
+        state
+            .inner
+            .park_active_scheduled_recurrent()
+            .expect("park seq 1");
+        if let Some(adapter) = state.inner.paged_adapter_mut() {
+            adapter
+                .begin_request(1)
+                .expect("parked owner can hold a keep-live request slot");
+            assert!(adapter.block_table_for(1).is_some());
+        }
+
+        assert!(state.inner.has_scheduled_recurrent(1));
+        assert!(
+            state.ensure_recurrent_slot(2),
+            "one parked idle row does not fill the two-unit cap"
+        );
+        assert!(
+            state.inner.has_scheduled_recurrent(1),
+            "unit-cap eviction must not fire with a single parked owner"
+        );
+        assert_eq!(state.idle_recurrent_victim(2), Some(1));
+        assert_ne!(
+            state.idle_recurrent_victim(2),
+            Some(3),
+            "history-only owners are not reclaim victims"
+        );
+
+        assert!(
+            state.reclaim_one_idle_scheduled(2),
+            "memory-denial reclaim must evict the idle parked row"
+        );
+        assert!(
+            !state.inner.has_scheduled_recurrent(1),
+            "reclaim drops the parked GDN/Mamba row"
+        );
+        assert!(
+            state
+                .inner
+                .paged_adapter()
+                .and_then(|adapter| adapter.block_table_for(1))
+                .is_none(),
+            "reclaim unpins keep-live KV so published full blocks become evictable"
+        );
+        assert!(state.inner.can_activate_scheduled_recurrent(2));
+        assert!(!state.inner.has_scheduled_recurrent(3));
+    }
+
+    #[test]
+    fn reclaiming_parked_recurrent_admits_usable_pool_reservation() {
+        let inner = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
+        let mut state = HybridSchedulerState::new(inner).expect("construct scheduler");
+        state.owner_sequences.insert("parked".into(), 1);
+        state
+            .inner
+            .activate_scheduled_recurrent(1)
+            .expect("activate parked owner");
+        state
+            .inner
+            .park_active_scheduled_recurrent()
+            .expect("park seq 1");
+
+        let rec = state.inner.recurrent_state_bytes();
+        assert!(rec > 0, "tiny Qwen3.5 fixture must have GDN state");
+        assert_eq!(state.inner.scheduled_recurrent_bytes(), rec);
+        // Qwen3.5 unit constructors leave the paged adapter unbuilt; size a
+        // synthetic pool the same way admit does: KV at usable tokens after
+        // one recurrent row.
+        let block_size = 16u32;
+        let bytes_per_block = 1024u64;
+        let rec_tokens = rec
+            .div_ceil(bytes_per_block)
+            .saturating_mul(u64::from(block_size))
+            .min(u64::from(u32::MAX)) as u32;
+        let pool_tokens = rec_tokens.saturating_add(256);
+        let usable = pool_tokens_after_recurrent(pool_tokens, block_size, bytes_per_block, rec);
+        let reservation_blocks = usable.div_ceil(block_size);
+        let total_blocks = pool_tokens / block_size;
+        let snapshot = SchedulerCacheSnapshot {
+            blocks: BlockTelemetry {
+                total_blocks,
+                free_blocks: total_blocks,
+                reclaimable_blocks: 0,
+                allocated_blocks: 0,
+            },
+            bytes_per_block,
+        };
+        assert!(reservation_fits_empty_pool(
+            reservation_blocks,
+            total_blocks,
+            bytes_per_block,
+            rec,
+        ));
+
+        let telemetry = engine::scheduler::MemoryTelemetry {
+            capacity_bytes: u64::from(total_blocks).saturating_mul(bytes_per_block),
+            free_bytes: u64::from(total_blocks).saturating_mul(bytes_per_block),
+            reclaimable_bytes: 0,
+        };
+        assert!(
+            !engine::scheduler::memory_admission_decision(
+                telemetry,
+                0,
+                reservation_blocks,
+                bytes_per_block,
+                rec,
+                rec,
+                false,
+                0.0,
+            )
+            .admitted,
+            "parked row plus candidate overflows a usable-pool KV reservation"
+        );
+
+        let outcome = state
+            .try_reserve_reclaiming_idle(2, reservation_blocks, rec, snapshot)
+            .expect("reserve after reclaim");
+        assert!(
+            matches!(outcome, MemoryReserveOutcome::Admitted),
+            "idle reclaim must admit, not defer: {outcome:?}"
+        );
+        assert!(!state.inner.has_scheduled_recurrent(1));
+        assert!(
+            engine::scheduler::memory_admission_decision(
+                telemetry,
+                0,
+                reservation_blocks,
+                bytes_per_block,
+                state.inner.scheduled_recurrent_bytes(),
+                rec,
+                false,
+                0.0,
+            )
+            .admitted
+        );
+    }
+
+    #[test]
+    fn idle_memory_denial_without_idle_victims_rejects() {
+        let inner = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
+        let mut state = HybridSchedulerState::new(inner).expect("construct scheduler");
+        assert!(state.idle_recurrent_victim(2).is_none());
+        assert!(!state.scheduler.has_live_turns());
+        let snapshot = SchedulerCacheSnapshot {
+            blocks: BlockTelemetry {
+                total_blocks: 100,
+                free_blocks: 0,
+                reclaimable_blocks: 0,
+                allocated_blocks: 100,
+            },
+            bytes_per_block: 4096,
+        };
+        let outcome = state
+            .try_reserve_reclaiming_idle(2, 10, 1, snapshot)
+            .expect("no snapshot refresh");
+        assert!(
+            matches!(outcome, MemoryReserveOutcome::Reject { total_blocks: 100 }),
+            "idle scheduler must hard-error, not spin in prepared_waiting: {outcome:?}"
+        );
+    }
+
+    #[test]
     fn cache_owner_release_drops_history_sequence_and_recurrent_state() {
         let inner = Qwen35Inner::new(tiny_config()).expect("construct tiny dense model");
         let mut state = HybridSchedulerState::new(inner).expect("construct scheduler");
@@ -3163,5 +3412,58 @@ mod scheduled_context_tests {
         assert!(reservation_fits_empty_pool(100, 100, 4096, 0));
         assert!(!reservation_fits_empty_pool(100, 100, 4096, 1));
         assert!(!reservation_fits_empty_pool(101, 100, 4096, 0));
+    }
+
+    #[test]
+    fn one_recurrent_row_fits_usable_pool_two_do_not() {
+        // KV sized to `pool_tokens_after_recurrent` (one row). Empty-pool + that
+        // row fits; parked row + candidate row does not.
+        let pool_tokens = 1_048_576;
+        let block_size = 16;
+        let bytes_per_block = 1024;
+        let rec_bytes = 48 * 1024 * 1024;
+        let usable =
+            pool_tokens_after_recurrent(pool_tokens, block_size, bytes_per_block, rec_bytes);
+        let total_blocks = pool_tokens / block_size;
+        let reservation_blocks = usable.div_ceil(block_size);
+
+        assert!(reservation_fits_empty_pool(
+            reservation_blocks,
+            total_blocks,
+            bytes_per_block,
+            rec_bytes,
+        ));
+
+        let telemetry = crate::engine::scheduler::MemoryTelemetry {
+            capacity_bytes: u64::from(total_blocks).saturating_mul(bytes_per_block),
+            free_bytes: u64::from(total_blocks).saturating_mul(bytes_per_block),
+            reclaimable_bytes: 0,
+        };
+        let two_rows = crate::engine::scheduler::memory_admission_decision(
+            telemetry,
+            0,
+            reservation_blocks,
+            bytes_per_block,
+            rec_bytes,
+            rec_bytes,
+            false,
+            0.0,
+        );
+        assert!(
+            !two_rows.admitted,
+            "parked + candidate recurrent rows must overflow usable-pool KV"
+        );
+
+        let one_row = crate::engine::scheduler::memory_admission_decision(
+            telemetry,
+            0,
+            reservation_blocks,
+            bytes_per_block,
+            0,
+            rec_bytes,
+            false,
+            0.0,
+        );
+        assert!(one_row.admitted);
     }
 }

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -348,10 +348,13 @@ pub(crate) fn scheduler_per_seq_context() -> u32 {
 }
 
 pub(crate) fn scheduler_per_seq_context_override() -> Option<u32> {
-    std::env::var("MLX_PAGED_PER_SEQ_CTX")
-        .ok()
-        .and_then(|value| value.parse::<u32>().ok())
-        .filter(|&value| value > 0)
+    static VALUE: OnceLock<Option<u32>> = OnceLock::new();
+    *VALUE.get_or_init(|| {
+        std::env::var("MLX_PAGED_PER_SEQ_CTX")
+            .ok()
+            .and_then(|value| value.parse::<u32>().ok())
+            .filter(|&value| value > 0)
+    })
 }
 
 pub(crate) fn scheduled_turn_context(

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -360,6 +360,40 @@ pub(crate) fn scheduled_turn_context(
     cap
 }
 
+/// Tokens one sequence can actually use after charging recurrent state
+/// (Mamba/GDN) against the same unified-memory pool as paged KV blocks.
+pub(crate) fn pool_tokens_after_recurrent(
+    pool_tokens: u32,
+    block_size: u32,
+    bytes_per_block: u64,
+    recurrent_state_bytes: u64,
+) -> u32 {
+    if bytes_per_block == 0 || block_size == 0 {
+        return pool_tokens.max(1);
+    }
+    let rec_blocks = recurrent_state_bytes
+        .div_ceil(bytes_per_block)
+        .min(u64::from(u32::MAX)) as u32;
+    let rec_tokens = rec_blocks.saturating_mul(block_size);
+    pool_tokens.saturating_sub(rec_tokens).max(1)
+}
+
+/// Whether a reservation plus one row of recurrent state can ever fit in an
+/// empty pool. If not, admission must error — not defer — or the row wedges
+/// `prepared_waiting` forever.
+pub(crate) fn reservation_fits_empty_pool(
+    reservation_blocks: u32,
+    total_blocks: u32,
+    bytes_per_block: u64,
+    recurrent_state_bytes: u64,
+) -> bool {
+    let need = u64::from(reservation_blocks)
+        .saturating_mul(bytes_per_block)
+        .saturating_add(recurrent_state_bytes);
+    let cap = u64::from(total_blocks).saturating_mul(bytes_per_block);
+    need <= cap
+}
+
 fn scheduler_watermark_fraction() -> f64 {
     static VALUE: OnceLock<f64> = OnceLock::new();
     *VALUE.get_or_init(|| {
@@ -1520,34 +1554,6 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
         let trained_context = u32::try_from(self.inner.max_position_embeddings())
             .unwrap_or(1)
             .max(1);
-        let pool_tokens = self
-            .inner
-            .paged_adapter()
-            .map(crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter::max_capacity_tokens)
-            .unwrap_or(trained_context);
-        let context = scheduled_turn_context(
-            trained_context,
-            pool_tokens,
-            scheduler_per_seq_context_override(),
-        );
-        let max_new_tokens = match engine::scheduler::clamp_scheduled_output_tokens(
-            prompt_tokens,
-            requested_max_new_tokens,
-            context,
-        ) {
-            Ok(max_new_tokens) => max_new_tokens,
-            Err(error) => {
-                if newly_assigned {
-                    self.owner_sequences.remove(&owner_id);
-                    self.owner_states.remove(&owner_id);
-                }
-                response.send_error(Error::from_reason(error), cancelled.as_ref());
-                return None;
-            }
-        };
-        admitted.params.max_new_tokens = max_new_tokens as i32;
-        let requested_tokens =
-            engine::scheduler::scheduled_materialized_tokens(prompt_tokens, max_new_tokens);
         if !self.inner.scheduler_cache_available() {
             if newly_assigned {
                 self.owner_sequences.remove(&owner_id);
@@ -1573,6 +1579,42 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
                 return None;
             }
         };
+        let adapter = self.inner.paged_adapter();
+        let pool_tokens = adapter
+            .map(crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter::max_capacity_tokens)
+            .unwrap_or(trained_context);
+        let bytes_per_block = adapter
+            .map(|adapter| adapter.bytes_per_block().unwrap_or(0))
+            .unwrap_or(0);
+        let usable_pool = pool_tokens_after_recurrent(
+            pool_tokens,
+            block_size,
+            bytes_per_block,
+            self.inner.recurrent_state_bytes(),
+        );
+        let context = scheduled_turn_context(
+            trained_context,
+            usable_pool,
+            scheduler_per_seq_context_override(),
+        );
+        let max_new_tokens = match engine::scheduler::clamp_scheduled_output_tokens(
+            prompt_tokens,
+            requested_max_new_tokens,
+            context,
+        ) {
+            Ok(max_new_tokens) => max_new_tokens,
+            Err(error) => {
+                if newly_assigned {
+                    self.owner_sequences.remove(&owner_id);
+                    self.owner_states.remove(&owner_id);
+                }
+                response.send_error(Error::from_reason(error), cancelled.as_ref());
+                return None;
+            }
+        };
+        admitted.params.max_new_tokens = max_new_tokens as i32;
+        let requested_tokens =
+            engine::scheduler::scheduled_materialized_tokens(prompt_tokens, max_new_tokens);
         let full_blocks = requested_tokens.div_ceil(block_size);
         let reservation_blocks = if scheduler_reserve_full_isl() {
             full_blocks
@@ -1655,9 +1697,19 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
                 return Ok(None);
             }
         };
-        if cache_snapshot
-            .is_some_and(|snapshot| prepared.reservation_blocks > snapshot.blocks.total_blocks)
-        {
+        let candidate_state_bytes = if self.inner.has_scheduled_recurrent(prepared.seq_id) {
+            0
+        } else {
+            self.inner.recurrent_state_bytes()
+        };
+        if cache_snapshot.is_some_and(|snapshot| {
+            !reservation_fits_empty_pool(
+                prepared.reservation_blocks,
+                snapshot.blocks.total_blocks,
+                snapshot.bytes_per_block,
+                candidate_state_bytes,
+            )
+        }) {
             self.cleanup_rejected_prepared(&prepared);
             let total_blocks = cache_snapshot.map_or(0, |snapshot| snapshot.blocks.total_blocks);
             prepared.response.send_error(
@@ -1672,11 +1724,6 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
         if !self.ensure_recurrent_slot(prepared.seq_id) {
             return Err(prepared);
         }
-        let candidate_state_bytes = if self.inner.has_scheduled_recurrent(prepared.seq_id) {
-            0
-        } else {
-            self.inner.recurrent_state_bytes()
-        };
         if let Some(snapshot) = cache_snapshot {
             let decision = self.scheduler.try_reserve_memory(
                 engine::scheduler::MemoryTelemetry {
@@ -3058,7 +3105,7 @@ mod tests {
 
 #[cfg(test)]
 mod scheduled_context_tests {
-    use super::scheduled_turn_context;
+    use super::{pool_tokens_after_recurrent, reservation_fits_empty_pool, scheduled_turn_context};
 
     #[test]
     fn admit_uses_pool_when_env_unset() {
@@ -3098,5 +3145,23 @@ mod scheduled_context_tests {
         let cap = scheduled_turn_context(trained, pool, None);
         // Output still clamped to remaining window; prompt accepted against the pool.
         assert!(crate::engine::scheduler::clamp_scheduled_output_tokens(33_611, 1024, cap).is_ok());
+    }
+
+    #[test]
+    fn recurrent_bytes_leave_kv_headroom() {
+        // 16-token blocks, 1024 bytes/block: 48 MiB recurrent → 49152 blocks → 786432 tokens.
+        let pool = 1_048_576;
+        let usable = pool_tokens_after_recurrent(pool, 16, 1024, 48 * 1024 * 1024);
+        assert_eq!(usable, 1_048_576 - 786_432);
+        assert!(usable < pool);
+    }
+
+    #[test]
+    fn filling_the_pool_with_nonzero_recurrent_cannot_fit() {
+        // Equality used to skip `reservation_blocks > total_blocks` and then
+        // defer forever once recurrent bytes were charged.
+        assert!(reservation_fits_empty_pool(100, 100, 4096, 0));
+        assert!(!reservation_fits_empty_pool(100, 100, 4096, 1));
+        assert!(!reservation_fits_empty_pool(101, 100, 4096, 0));
     }
 }

--- a/crates/mlx-core/src/models/muse_glimmer/model.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/model.rs
@@ -133,13 +133,11 @@ impl MuseGlimmerContextLimits {
         override_cap: Option<u32>,
     ) -> Self {
         let Some((paged_window_tokens, paged_block_capacity, paged_block_size)) = paged else {
+            // Flat-only runtimes never enter the paged scheduler, so the
+            // MLX_PAGED_PER_SEQ_CTX operator cap does not apply.
             return Self {
                 trained_window_tokens,
-                effective_window_tokens: crate::engine::hybrid_scheduler::scheduled_turn_context(
-                    trained_window_tokens,
-                    trained_window_tokens,
-                    override_cap,
-                ),
+                effective_window_tokens: trained_window_tokens,
                 paged_block_capacity: 0,
                 paged_block_size: 0,
             };
@@ -200,6 +198,14 @@ mod context_limit_tests {
     #[test]
     fn a_flat_only_runtime_publishes_the_trained_window() {
         let limits = MuseGlimmerContextLimits::from_parts(131_072, None, None);
+        assert_eq!(limits.effective_window_tokens, 131_072);
+        assert_eq!(limits.paged_block_capacity, 0);
+        assert_eq!(limits.paged_block_size, 0);
+    }
+
+    #[test]
+    fn a_flat_only_runtime_ignores_the_paged_env_cap() {
+        let limits = MuseGlimmerContextLimits::from_parts(131_072, None, Some(32_768));
         assert_eq!(limits.effective_window_tokens, 131_072);
         assert_eq!(limits.paged_block_capacity, 0);
         assert_eq!(limits.paged_block_size, 0);

--- a/crates/mlx-core/src/models/muse_glimmer/model.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/model.rs
@@ -115,9 +115,8 @@ pub(crate) enum MusePagedSettle {
 }
 
 /// Trained and physically available active-context limits for one loaded
-/// Muse-Glimmer model. The effective window is conservative across both
-/// execution modes: DFlash may use the flat cache, but callers can disable it
-/// per request and fall back to the paged AR scheduler.
+/// Muse-Glimmer model. Values are snapshots because the physical pool is fixed
+/// for the lifetime of the resident model.
 #[napi(object)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MuseGlimmerContextLimits {
@@ -128,11 +127,7 @@ pub struct MuseGlimmerContextLimits {
 }
 
 impl MuseGlimmerContextLimits {
-    fn from_parts(
-        trained_window_tokens: u32,
-        scheduler_window_tokens: u32,
-        paged: Option<(u32, u32, u32)>,
-    ) -> Self {
+    fn from_parts(trained_window_tokens: u32, paged: Option<(u32, u32, u32)>) -> Self {
         let Some((paged_window_tokens, paged_block_capacity, paged_block_size)) = paged else {
             return Self {
                 trained_window_tokens,
@@ -143,9 +138,7 @@ impl MuseGlimmerContextLimits {
         };
         Self {
             trained_window_tokens,
-            effective_window_tokens: trained_window_tokens
-                .min(scheduler_window_tokens)
-                .min(paged_window_tokens),
+            effective_window_tokens: trained_window_tokens.min(paged_window_tokens),
             paged_block_capacity,
             paged_block_size,
         }
@@ -162,11 +155,7 @@ impl MuseGlimmerContextLimits {
                 adapter.block_size(),
             )
         });
-        Self::from_parts(
-            trained,
-            crate::engine::hybrid_scheduler::scheduler_per_seq_context(),
-            paged,
-        )
+        Self::from_parts(trained, paged)
     }
 }
 
@@ -175,18 +164,25 @@ mod context_limit_tests {
     use super::MuseGlimmerContextLimits;
 
     #[test]
-    fn paged_ar_limit_is_published_even_when_dflash_can_use_the_trained_window() {
-        let limits =
-            MuseGlimmerContextLimits::from_parts(131_072, 32_768, Some((131_072, 8_192, 16)));
+    fn paged_effective_window_is_min_trained_and_pool() {
+        let limits = MuseGlimmerContextLimits::from_parts(131_072, Some((131_072, 8_192, 16)));
         assert_eq!(limits.trained_window_tokens, 131_072);
-        assert_eq!(limits.effective_window_tokens, 32_768);
+        assert_eq!(limits.effective_window_tokens, 131_072);
         assert_eq!(limits.paged_block_capacity, 8_192);
         assert_eq!(limits.paged_block_size, 16);
     }
 
     #[test]
+    fn paged_effective_window_follows_a_smaller_pool() {
+        let limits = MuseGlimmerContextLimits::from_parts(131_072, Some((32_768, 2_048, 16)));
+        assert_eq!(limits.effective_window_tokens, 32_768);
+        assert_eq!(limits.paged_block_capacity, 2_048);
+        assert_eq!(limits.paged_block_size, 16);
+    }
+
+    #[test]
     fn a_flat_only_runtime_publishes_the_trained_window() {
-        let limits = MuseGlimmerContextLimits::from_parts(131_072, 32_768, None);
+        let limits = MuseGlimmerContextLimits::from_parts(131_072, None);
         assert_eq!(limits.effective_window_tokens, 131_072);
         assert_eq!(limits.paged_block_capacity, 0);
         assert_eq!(limits.paged_block_size, 0);
@@ -1677,9 +1673,8 @@ impl MuseGlimmerModel {
         }
     }
 
-    /// Conservative model-wide context snapshot used by higher layers for
-    /// compaction. It includes the paged AR limit even when DFlash is present,
-    /// because DFlash is opt-in per request and can be disabled by the caller.
+    /// Model-wide context snapshot used by higher layers for compaction.
+    /// `effective_window_tokens` is min(trained, live pool).
     #[napi]
     pub fn context_limits(&self) -> MuseGlimmerContextLimits {
         self.context_limits.clone()

--- a/crates/mlx-core/src/models/muse_glimmer/model.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/model.rs
@@ -127,18 +127,30 @@ pub struct MuseGlimmerContextLimits {
 }
 
 impl MuseGlimmerContextLimits {
-    fn from_parts(trained_window_tokens: u32, paged: Option<(u32, u32, u32)>) -> Self {
+    fn from_parts(
+        trained_window_tokens: u32,
+        paged: Option<(u32, u32, u32)>,
+        override_cap: Option<u32>,
+    ) -> Self {
         let Some((paged_window_tokens, paged_block_capacity, paged_block_size)) = paged else {
             return Self {
                 trained_window_tokens,
-                effective_window_tokens: trained_window_tokens,
+                effective_window_tokens: crate::engine::hybrid_scheduler::scheduled_turn_context(
+                    trained_window_tokens,
+                    trained_window_tokens,
+                    override_cap,
+                ),
                 paged_block_capacity: 0,
                 paged_block_size: 0,
             };
         };
         Self {
             trained_window_tokens,
-            effective_window_tokens: trained_window_tokens.min(paged_window_tokens),
+            effective_window_tokens: crate::engine::hybrid_scheduler::scheduled_turn_context(
+                trained_window_tokens,
+                paged_window_tokens,
+                override_cap,
+            ),
             paged_block_capacity,
             paged_block_size,
         }
@@ -155,7 +167,11 @@ impl MuseGlimmerContextLimits {
                 adapter.block_size(),
             )
         });
-        Self::from_parts(trained, paged)
+        Self::from_parts(
+            trained,
+            paged,
+            crate::engine::hybrid_scheduler::scheduler_per_seq_context_override(),
+        )
     }
 }
 
@@ -165,7 +181,8 @@ mod context_limit_tests {
 
     #[test]
     fn paged_effective_window_is_min_trained_and_pool() {
-        let limits = MuseGlimmerContextLimits::from_parts(131_072, Some((131_072, 8_192, 16)));
+        let limits =
+            MuseGlimmerContextLimits::from_parts(131_072, Some((131_072, 8_192, 16)), None);
         assert_eq!(limits.trained_window_tokens, 131_072);
         assert_eq!(limits.effective_window_tokens, 131_072);
         assert_eq!(limits.paged_block_capacity, 8_192);
@@ -174,7 +191,7 @@ mod context_limit_tests {
 
     #[test]
     fn paged_effective_window_follows_a_smaller_pool() {
-        let limits = MuseGlimmerContextLimits::from_parts(131_072, Some((32_768, 2_048, 16)));
+        let limits = MuseGlimmerContextLimits::from_parts(131_072, Some((32_768, 2_048, 16)), None);
         assert_eq!(limits.effective_window_tokens, 32_768);
         assert_eq!(limits.paged_block_capacity, 2_048);
         assert_eq!(limits.paged_block_size, 16);
@@ -182,10 +199,19 @@ mod context_limit_tests {
 
     #[test]
     fn a_flat_only_runtime_publishes_the_trained_window() {
-        let limits = MuseGlimmerContextLimits::from_parts(131_072, None);
+        let limits = MuseGlimmerContextLimits::from_parts(131_072, None, None);
         assert_eq!(limits.effective_window_tokens, 131_072);
         assert_eq!(limits.paged_block_capacity, 0);
         assert_eq!(limits.paged_block_size, 0);
+    }
+
+    #[test]
+    fn explicit_env_cap_is_published_unset_does_not_impose_32k() {
+        let capped =
+            MuseGlimmerContextLimits::from_parts(131_072, Some((131_072, 8_192, 16)), Some(32_768));
+        assert_eq!(capped.effective_window_tokens, 32_768);
+        let unset = MuseGlimmerContextLimits::from_parts(131_072, Some((131_072, 8_192, 16)), None);
+        assert_eq!(unset.effective_window_tokens, 131_072);
     }
 }
 

--- a/crates/mlx-core/src/models/nemotron_h/config.rs
+++ b/crates/mlx-core/src/models/nemotron_h/config.rs
@@ -69,8 +69,9 @@ pub struct NemotronHConfig {
     pub n_mtp_layers: i32,
 
     // --- Block-paged KV cache ---
-    /// Optional block-paged KV cache memory cap in MiB. None resolves to the
-    /// default 2048 MiB pool; explicit values are honored.
+    /// Optional block-paged KV cache memory cap in MiB. `None` requests MiB
+    /// for one `max_position_embeddings` sequence (6 GiB on Lightning
+    /// 30B-A3B), not 2048; explicit values are honored.
     #[serde(default)]
     pub paged_cache_memory_mb: Option<u32>,
     /// Optional paged block size in tokens (default 16).

--- a/crates/mlx-core/src/models/nemotron_h/config.rs
+++ b/crates/mlx-core/src/models/nemotron_h/config.rs
@@ -69,9 +69,10 @@ pub struct NemotronHConfig {
     pub n_mtp_layers: i32,
 
     // --- Block-paged KV cache ---
-    /// Optional block-paged KV cache memory cap in MiB. `None` requests MiB
-    /// for one `max_position_embeddings` sequence (6 GiB on Lightning
-    /// 30B-A3B), not 2048; explicit values are honored.
+    /// Optional block-paged KV cache memory cap in MiB. `None` requests one
+    /// `max_position_embeddings` sequence (6 GiB on Lightning 30B-A3B) then
+    /// clips with load-time Metal/RAM sizing after weights. Explicit values
+    /// skip the auto-sizer.
     #[serde(default)]
     pub paged_cache_memory_mb: Option<u32>,
     /// Optional paged block size in tokens (default 16).

--- a/crates/mlx-core/src/models/nemotron_h/model.rs
+++ b/crates/mlx-core/src/models/nemotron_h/model.rs
@@ -744,13 +744,14 @@ impl NemotronHInner {
             )));
         }
         let cache_dtype = mlx_paged_attn::metal::MetalDtype::BFloat16;
-        let sizing = mlx_paged_attn::profile::load_time_pool_sizing(
+        let sizing = mlx_paged_attn::profile::load_time_pool_sizing_with_reserved(
             requested_blocks,
             attn_layer_count,
             num_kv_heads,
             head_size,
             block_size,
             cache_dtype,
+            crate::cache_limit::coordinator().registered_pool_bytes(),
         )
         .map_err(|error| {
             Error::from_reason(format!(
@@ -758,18 +759,7 @@ impl NemotronHInner {
                  pool request: {error}"
             ))
         })?;
-        let selected_blocks = Self::selected_blocks_after_sibling_pools(
-            sizing.selected_blocks,
-            sizing.selected_bytes,
-            sizing.bytes_per_block,
-            crate::cache_limit::coordinator().registered_pool_bytes(),
-        )
-        .ok_or_else(|| {
-            Error::from_reason(
-                "NemotronH adaptive paged cache sizing failed safely; sibling private pools \
-                 leave no room for one block",
-            )
-        })?;
+        let selected_blocks = sizing.selected_blocks;
         let allocator = Arc::new(Mutex::new(mlx_paged_attn::BlockAllocator::new(
             selected_blocks,
             block_size,
@@ -788,25 +778,6 @@ impl NemotronHInner {
             })?,
         );
         Ok(())
-    }
-
-    /// Shrink a load-time pool selection by sibling models' already-registered
-    /// private Metal pools. `None` means those pools leave no room for a block.
-    pub(crate) fn selected_blocks_after_sibling_pools(
-        selected_blocks: u32,
-        selected_bytes: u64,
-        bytes_per_block: u64,
-        sibling_pool_bytes: u64,
-    ) -> Option<u32> {
-        if sibling_pool_bytes == 0 || bytes_per_block == 0 {
-            return Some(selected_blocks);
-        }
-        let room = selected_bytes.saturating_sub(sibling_pool_bytes);
-        let blocks = (room / bytes_per_block).min(u64::from(u32::MAX)) as u32;
-        if blocks == 0 {
-            return None;
-        }
-        Some(blocks.min(selected_blocks))
     }
 
     /// Activate the adapter request and swap the sequence's per-request caches
@@ -3100,22 +3071,6 @@ mod scheduler_tests {
         assert!(
             pool_bytes > 0,
             "paged pool must report its private Metal bytes so load_with_thread can register_pool"
-        );
-    }
-
-    #[test]
-    fn sibling_private_pools_shrink_adaptive_block_count() {
-        assert_eq!(
-            NemotronHInner::selected_blocks_after_sibling_pools(100, 100_000, 1000, 0),
-            Some(100)
-        );
-        assert_eq!(
-            NemotronHInner::selected_blocks_after_sibling_pools(100, 100_000, 1000, 40_000),
-            Some(60)
-        );
-        assert_eq!(
-            NemotronHInner::selected_blocks_after_sibling_pools(100, 100_000, 1000, 100_000),
-            None
         );
     }
 

--- a/crates/mlx-core/src/models/nemotron_h/model.rs
+++ b/crates/mlx-core/src/models/nemotron_h/model.rs
@@ -171,8 +171,9 @@ pub(crate) struct NemotronHInner {
     /// through the adapter (indexed by attention-layer ordinal 0..6); mamba
     /// and moe layers keep their own per-request state / stateless forward.
     pub(crate) paged_adapter: Option<PagedKVCacheAdapter>,
-    /// Registered when the adaptive pool is reserved, before Metal alloc, so a
-    /// concurrent load cannot reuse the same headroom. Taken by `load_with_thread`.
+    /// Registered before Metal alloc (configured pools at `load_inner`, adaptive
+    /// pools in `size_paged_pool_after_weight_load`) so a concurrent load cannot
+    /// reuse the same headroom. Taken by `load_with_thread`.
     pub(crate) pool_cache_limit_guard: Option<crate::cache_limit::PoolCacheLimitGuard>,
     /// Per-request recurrent state for the scheduler lane: one full
     /// `Vec<NemotronHLayerCache>` per live sequence, swapped into `caches` for serial
@@ -269,11 +270,18 @@ fn fresh_caches(
     Ok(caches)
 }
 
-/// Construct the block-paged KV adapter covering only the GQA attention
-/// layers (pool indexed by attention-layer ordinal). Gated on
-/// `use_block_paged_cache` (default-on when None) and Metal availability;
-/// returns `None` when either gate is closed.
-fn build_paged_adapter(config: &NemotronHConfig) -> Result<Option<PagedKVCacheAdapter>> {
+struct ConfiguredPagedPoolPlan {
+    pa_config: mlx_paged_attn::PagedAttentionConfig,
+    num_blocks: u32,
+    block_size: u32,
+    cache_dtype: mlx_paged_attn::metal::MetalDtype,
+    pool_bytes: u64,
+}
+
+/// Shared gates + byte math for a configured (`paged_cache_memory_mb`) pool.
+/// Uncapped configs return `None` so `size_paged_pool_after_weight_load` can
+/// apply `load_time_pool_sizing`.
+fn configured_paged_pool_plan(config: &NemotronHConfig) -> Result<Option<ConfiguredPagedPoolPlan>> {
     if config.use_block_paged_cache == Some(false)
         || !crate::engine::persistence::compiled_forward_backend_available()
     {
@@ -289,8 +297,6 @@ fn build_paged_adapter(config: &NemotronHConfig) -> Result<Option<PagedKVCacheAd
             "NemotronH block-paged adapter: invalid paged_block_size {block_size} (must be 8, 16, or 32)"
         )));
     }
-    // Uncapped configs defer allocation until after weights so
-    // `size_paged_pool_after_weight_load` can apply `load_time_pool_sizing`.
     let Some(gpu_memory_mb) = config.paged_cache_memory_mb else {
         return Ok(None);
     };
@@ -312,21 +318,67 @@ fn build_paged_adapter(config: &NemotronHConfig) -> Result<Option<PagedKVCacheAd
             config.head_dim, config.num_key_value_heads
         )));
     }
-    let allocator = Arc::new(Mutex::new(mlx_paged_attn::BlockAllocator::new(
-        num_blocks, block_size,
-    )));
     let cache_dtype = mlx_paged_attn::metal::MetalDtype::BFloat16;
-    let pool =
-        mlx_paged_attn::LayerKVPool::new(pa_config, num_blocks, cache_dtype).map_err(|e| {
+    let pool_bytes = mlx_paged_attn::profile::bytes_per_block(
+        attn_layer_count,
+        config.num_key_value_heads as u32,
+        config.head_dim as u32,
+        block_size,
+        cache_dtype,
+    )
+    .map_err(|error| {
+        Error::from_reason(format!(
+            "NemotronH configured paged pool byte accounting failed: {error}"
+        ))
+    })?
+    .saturating_mul(u64::from(num_blocks));
+    Ok(Some(ConfiguredPagedPoolPlan {
+        pa_config,
+        num_blocks,
+        block_size,
+        cache_dtype,
+        pool_bytes,
+    }))
+}
+
+/// Register a configured pool with the coordinator before `NemotronHInner::new`
+/// allocates it, so a concurrent uncapped Nemotron load cannot treat those
+/// private Metal bytes as free headroom.
+pub(crate) fn reserve_configured_paged_pool(
+    config: &NemotronHConfig,
+) -> Result<Option<crate::cache_limit::PoolCacheLimitGuard>> {
+    let Some(plan) = configured_paged_pool_plan(config)? else {
+        return Ok(None);
+    };
+    Ok(Some(
+        crate::cache_limit::coordinator().register_pool(plan.pool_bytes),
+    ))
+}
+
+/// Construct the block-paged KV adapter covering only the GQA attention
+/// layers (pool indexed by attention-layer ordinal). Gated on
+/// `use_block_paged_cache` (default-on when None) and Metal availability;
+/// returns `None` when either gate is closed.
+fn build_paged_adapter(config: &NemotronHConfig) -> Result<Option<PagedKVCacheAdapter>> {
+    let Some(plan) = configured_paged_pool_plan(config)? else {
+        return Ok(None);
+    };
+    let allocator = Arc::new(Mutex::new(mlx_paged_attn::BlockAllocator::new(
+        plan.num_blocks,
+        plan.block_size,
+    )));
+    let pool = mlx_paged_attn::LayerKVPool::new(plan.pa_config, plan.num_blocks, plan.cache_dtype)
+        .map_err(|e| {
             Error::from_reason(format!(
                 "Failed to construct LayerKVPool for NemotronH block-paged adapter: {e}"
             ))
         })?;
-    let adapter = PagedKVCacheAdapter::new(allocator, Arc::new(pool), block_size).map_err(|e| {
-        Error::from_reason(format!(
-            "Failed to construct NemotronH PagedKVCacheAdapter: {e}"
-        ))
-    })?;
+    let adapter =
+        PagedKVCacheAdapter::new(allocator, Arc::new(pool), plan.block_size).map_err(|e| {
+            Error::from_reason(format!(
+                "Failed to construct NemotronH PagedKVCacheAdapter: {e}"
+            ))
+        })?;
     Ok(Some(adapter))
 }
 
@@ -3095,6 +3147,54 @@ mod scheduler_tests {
             pool_bytes > 0,
             "paged pool must report its private Metal bytes so load_with_thread can register_pool"
         );
+    }
+
+    #[test]
+    fn uncapped_config_does_not_reserve_a_configured_pool() {
+        let mut config = tiny_paged_config();
+        config.paged_cache_memory_mb = None;
+        let before = crate::cache_limit::coordinator().registered_pool_bytes();
+        let guard = reserve_configured_paged_pool(&config).expect("uncapped plan");
+        assert!(
+            guard.is_none(),
+            "uncapped loads must leave reservation to the adaptive CAS path"
+        );
+        assert_eq!(
+            crate::cache_limit::coordinator().registered_pool_bytes(),
+            before
+        );
+    }
+
+    #[test]
+    fn configured_pool_is_reserved_before_metal_alloc() {
+        let config = tiny_paged_config();
+        let Some(plan) = configured_paged_pool_plan(&config).expect("plan") else {
+            eprintln!("skipping (no Metal backend or paged gated off)");
+            return;
+        };
+        let before = crate::cache_limit::coordinator().registered_pool_bytes();
+        let guard = reserve_configured_paged_pool(&config)
+            .expect("reserve")
+            .expect("configured pool must register");
+        assert_eq!(
+            crate::cache_limit::coordinator()
+                .registered_pool_bytes()
+                .saturating_sub(before),
+            plan.pool_bytes,
+            "configured reservation must be visible before Inner::new allocates"
+        );
+        let inner = NemotronHInner::new(config).expect("inner builds");
+        let adapter = inner
+            .paged_adapter
+            .as_ref()
+            .expect("configured plan existed so the adapter must build");
+        assert_eq!(
+            adapter
+                .pool_allocated_bytes()
+                .expect("paged pool byte accounting"),
+            plan.pool_bytes
+        );
+        drop(guard);
     }
 
     /// Pure-function gate on the prefill break-set: no internal boundary inside a

--- a/crates/mlx-core/src/models/nemotron_h/model.rs
+++ b/crates/mlx-core/src/models/nemotron_h/model.rs
@@ -758,11 +758,23 @@ impl NemotronHInner {
                  pool request: {error}"
             ))
         })?;
-        let allocator = Arc::new(Mutex::new(mlx_paged_attn::BlockAllocator::new(
+        let selected_blocks = Self::selected_blocks_after_sibling_pools(
             sizing.selected_blocks,
+            sizing.selected_bytes,
+            sizing.bytes_per_block,
+            crate::cache_limit::coordinator().registered_pool_bytes(),
+        )
+        .ok_or_else(|| {
+            Error::from_reason(
+                "NemotronH adaptive paged cache sizing failed safely; sibling private pools \
+                 leave no room for one block",
+            )
+        })?;
+        let allocator = Arc::new(Mutex::new(mlx_paged_attn::BlockAllocator::new(
+            selected_blocks,
             block_size,
         )));
-        let pool = mlx_paged_attn::LayerKVPool::new(pa_config, sizing.selected_blocks, cache_dtype)
+        let pool = mlx_paged_attn::LayerKVPool::new(pa_config, selected_blocks, cache_dtype)
             .map_err(|e| {
                 Error::from_reason(format!(
                     "Failed to construct LayerKVPool for NemotronH block-paged adapter: {e}"
@@ -776,6 +788,25 @@ impl NemotronHInner {
             })?,
         );
         Ok(())
+    }
+
+    /// Shrink a load-time pool selection by sibling models' already-registered
+    /// private Metal pools. `None` means those pools leave no room for a block.
+    pub(crate) fn selected_blocks_after_sibling_pools(
+        selected_blocks: u32,
+        selected_bytes: u64,
+        bytes_per_block: u64,
+        sibling_pool_bytes: u64,
+    ) -> Option<u32> {
+        if sibling_pool_bytes == 0 || bytes_per_block == 0 {
+            return Some(selected_blocks);
+        }
+        let room = selected_bytes.saturating_sub(sibling_pool_bytes);
+        let blocks = (room / bytes_per_block).min(u64::from(u32::MAX)) as u32;
+        if blocks == 0 {
+            return None;
+        }
+        Some(blocks.min(selected_blocks))
     }
 
     /// Activate the adapter request and swap the sequence's per-request caches
@@ -3069,6 +3100,22 @@ mod scheduler_tests {
         assert!(
             pool_bytes > 0,
             "paged pool must report its private Metal bytes so load_with_thread can register_pool"
+        );
+    }
+
+    #[test]
+    fn sibling_private_pools_shrink_adaptive_block_count() {
+        assert_eq!(
+            NemotronHInner::selected_blocks_after_sibling_pools(100, 100_000, 1000, 0),
+            Some(100)
+        );
+        assert_eq!(
+            NemotronHInner::selected_blocks_after_sibling_pools(100, 100_000, 1000, 40_000),
+            Some(60)
+        );
+        assert_eq!(
+            NemotronHInner::selected_blocks_after_sibling_pools(100, 100_000, 1000, 100_000),
+            None
         );
     }
 

--- a/crates/mlx-core/src/models/nemotron_h/model.rs
+++ b/crates/mlx-core/src/models/nemotron_h/model.rs
@@ -284,7 +284,15 @@ fn build_paged_adapter(config: &NemotronHConfig) -> Result<Option<PagedKVCacheAd
             "NemotronH block-paged adapter: invalid paged_block_size {block_size} (must be 8, 16, or 32)"
         )));
     }
-    let gpu_memory_mb = config.paged_cache_memory_mb.unwrap_or(2048);
+    let gpu_memory_mb = config.paged_cache_memory_mb.unwrap_or_else(|| {
+        mlx_paged_attn::PagedAttentionConfig::memory_mb_for_one_full_sequence(
+            config.max_position_embeddings.max(0) as u32,
+            block_size,
+            config.head_dim as u32,
+            config.num_key_value_heads as u32,
+            attn_layer_count,
+        )
+    });
     let pa_config = mlx_paged_attn::PagedAttentionConfig {
         block_size,
         gpu_memory_mb,

--- a/crates/mlx-core/src/models/nemotron_h/model.rs
+++ b/crates/mlx-core/src/models/nemotron_h/model.rs
@@ -2837,6 +2837,9 @@ pub struct NemotronHModel {
     /// RAII: unregisters this model's baseline from the cache-limit
     /// coordinator on drop.
     pub(crate) _cache_limit_guard: crate::cache_limit::CacheLimitGuard,
+    /// RAII: unregisters this model's private paged KV pool from the
+    /// cache-limit coordinator on drop. `None` when paged cache is off.
+    pub(crate) _pool_cache_limit_guard: Option<crate::cache_limit::PoolCacheLimitGuard>,
 }
 
 #[napi]
@@ -3052,6 +3055,23 @@ mod scheduler_tests {
             .ok_or_else(|| Error::from_reason("fixture layer 1 must be MoE"))?;
         moe.experts.set_dense(&up_w, &down_w)
     }
+
+    #[test]
+    fn tiny_paged_pool_reports_nonzero_allocated_bytes() {
+        let inner = NemotronHInner::new(tiny_paged_config()).expect("inner builds");
+        let Some(adapter) = inner.paged_adapter.as_ref() else {
+            eprintln!("skipping (no Metal backend)");
+            return;
+        };
+        let pool_bytes = adapter
+            .pool_allocated_bytes()
+            .expect("paged pool byte accounting");
+        assert!(
+            pool_bytes > 0,
+            "paged pool must report its private Metal bytes so load_with_thread can register_pool"
+        );
+    }
+
     /// Pure-function gate on the prefill break-set: no internal boundary inside a
     /// Mamba-2 chunk, and every slice at most `slice_tokens` long.
     #[test]

--- a/crates/mlx-core/src/models/nemotron_h/model.rs
+++ b/crates/mlx-core/src/models/nemotron_h/model.rs
@@ -5,8 +5,8 @@
 //! flat run_mtp_turn loop with a depth-1 drafter that owns its own KV.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -22,7 +22,8 @@ use crate::engine::cmd::{ChatCmd, FromChatCmd, handle_chat_cmd};
 use crate::engine::decode::{DecodeLoopArgs, StreamingCtx, run_decode_loop};
 use crate::engine::hybrid_scheduler::{
     HybridSchedulerBackend, HybridSchedulerCommand, HybridSchedulerState, HybridStepExecutor,
-    NoRestoreTicket, ScheduledPrefixAdmission, scheduler_max_num_seqs_for,
+    NoRestoreTicket, ScheduledPrefixAdmission, pool_tokens_after_recurrent, scheduled_turn_context,
+    scheduler_max_num_seqs_for, scheduler_per_seq_context_override,
 };
 use crate::engine::plan::{
     DecoderPlan, ExecutionPlan, MediaCapabilities, MediaPlan, PagedAttentionPlan, SpeculativeKind,
@@ -284,15 +285,11 @@ fn build_paged_adapter(config: &NemotronHConfig) -> Result<Option<PagedKVCacheAd
             "NemotronH block-paged adapter: invalid paged_block_size {block_size} (must be 8, 16, or 32)"
         )));
     }
-    let gpu_memory_mb = config.paged_cache_memory_mb.unwrap_or_else(|| {
-        mlx_paged_attn::PagedAttentionConfig::memory_mb_for_one_full_sequence(
-            config.max_position_embeddings.max(0) as u32,
-            block_size,
-            config.head_dim as u32,
-            config.num_key_value_heads as u32,
-            attn_layer_count,
-        )
-    });
+    // Uncapped configs defer allocation until after weights so
+    // `size_paged_pool_after_weight_load` can apply `load_time_pool_sizing`.
+    let Some(gpu_memory_mb) = config.paged_cache_memory_mb else {
+        return Ok(None);
+    };
     let pa_config = mlx_paged_attn::PagedAttentionConfig {
         block_size,
         gpu_memory_mb,
@@ -311,7 +308,7 @@ fn build_paged_adapter(config: &NemotronHConfig) -> Result<Option<PagedKVCacheAd
             config.head_dim, config.num_key_value_heads
         )));
     }
-    let allocator = Arc::new(std::sync::Mutex::new(mlx_paged_attn::BlockAllocator::new(
+    let allocator = Arc::new(Mutex::new(mlx_paged_attn::BlockAllocator::new(
         num_blocks, block_size,
     )));
     let cache_dtype = mlx_paged_attn::metal::MetalDtype::BFloat16;
@@ -679,12 +676,106 @@ impl NemotronHInner {
         };
         let blocks = adapter.block_capacity();
         let block_size = adapter.block_size();
+        let bytes_per_block = adapter.bytes_per_block().unwrap_or(0);
+        let usable = pool_tokens_after_recurrent(
+            adapter.max_capacity_tokens(),
+            block_size,
+            bytes_per_block,
+            self.recurrent_state_bytes_per_seq(),
+        );
         (
             trained,
-            trained.min(adapter.max_capacity_tokens()),
+            scheduled_turn_context(trained, usable, scheduler_per_seq_context_override()),
             blocks,
             block_size,
         )
+    }
+
+    /// After weights are resident, allocate the uncapped default pool
+    /// (one trained-length sequence) clipped by live Metal headroom.
+    pub(crate) fn size_paged_pool_after_weight_load(&mut self) -> Result<()> {
+        if self.paged_adapter.is_some() {
+            return Ok(());
+        }
+        if self.config.paged_cache_memory_mb.is_some() {
+            return Ok(());
+        }
+        if self.config.use_block_paged_cache == Some(false)
+            || !crate::engine::persistence::compiled_forward_backend_available()
+        {
+            return Ok(());
+        }
+        let attn_layer_count = self.config.attention_layer_idxs().len() as u32;
+        if attn_layer_count == 0 {
+            return Ok(());
+        }
+        let block_size = self.config.paged_block_size.unwrap_or(16);
+        if ![8, 16, 32].contains(&block_size) {
+            return Err(Error::from_reason(format!(
+                "NemotronH block-paged adapter: invalid paged_block_size {block_size} (must be 8, 16, or 32)"
+            )));
+        }
+        let head_size = self.config.head_dim as u32;
+        let num_kv_heads = self.config.num_key_value_heads as u32;
+        let max_seq_len = self.config.max_position_embeddings.max(0) as u32;
+        let requested_memory_mb =
+            mlx_paged_attn::PagedAttentionConfig::memory_mb_for_one_full_sequence(
+                max_seq_len,
+                block_size,
+                head_size,
+                num_kv_heads,
+                attn_layer_count,
+            );
+        let pa_config = mlx_paged_attn::PagedAttentionConfig {
+            block_size,
+            gpu_memory_mb: requested_memory_mb,
+            head_size,
+            num_kv_heads,
+            num_layers: attn_layer_count,
+            use_fp8_cache: Some(false),
+            max_seq_len: Some(max_seq_len),
+            max_batch_size: Some(32),
+        };
+        let requested_blocks = pa_config.calculate_num_blocks();
+        if requested_blocks == 0 {
+            return Err(Error::from_reason(format!(
+                "NemotronH block-paged adapter: requested paged cache {requested_memory_mb} MiB \
+                 cannot hold one block"
+            )));
+        }
+        let cache_dtype = mlx_paged_attn::metal::MetalDtype::BFloat16;
+        let sizing = mlx_paged_attn::profile::load_time_pool_sizing(
+            requested_blocks,
+            attn_layer_count,
+            num_kv_heads,
+            head_size,
+            block_size,
+            cache_dtype,
+        )
+        .map_err(|error| {
+            Error::from_reason(format!(
+                "NemotronH adaptive paged cache sizing failed safely; refusing an uncapped \
+                 pool request: {error}"
+            ))
+        })?;
+        let allocator = Arc::new(Mutex::new(mlx_paged_attn::BlockAllocator::new(
+            sizing.selected_blocks,
+            block_size,
+        )));
+        let pool = mlx_paged_attn::LayerKVPool::new(pa_config, sizing.selected_blocks, cache_dtype)
+            .map_err(|e| {
+                Error::from_reason(format!(
+                    "Failed to construct LayerKVPool for NemotronH block-paged adapter: {e}"
+                ))
+            })?;
+        self.paged_adapter = Some(
+            PagedKVCacheAdapter::new(allocator, Arc::new(pool), block_size).map_err(|e| {
+                Error::from_reason(format!(
+                    "Failed to construct NemotronH PagedKVCacheAdapter: {e}"
+                ))
+            })?,
+        );
+        Ok(())
     }
 
     /// Activate the adapter request and swap the sequence's per-request caches

--- a/crates/mlx-core/src/models/nemotron_h/model.rs
+++ b/crates/mlx-core/src/models/nemotron_h/model.rs
@@ -171,6 +171,9 @@ pub(crate) struct NemotronHInner {
     /// through the adapter (indexed by attention-layer ordinal 0..6); mamba
     /// and moe layers keep their own per-request state / stateless forward.
     pub(crate) paged_adapter: Option<PagedKVCacheAdapter>,
+    /// Registered when the adaptive pool is reserved, before Metal alloc, so a
+    /// concurrent load cannot reuse the same headroom. Taken by `load_with_thread`.
+    pub(crate) pool_cache_limit_guard: Option<crate::cache_limit::PoolCacheLimitGuard>,
     /// Per-request recurrent state for the scheduler lane: one full
     /// `Vec<NemotronHLayerCache>` per live sequence, swapped into `caches` for serial
     /// prefill and stacked into `[N, ...]` rows for batched decode.
@@ -232,6 +235,7 @@ impl NemotronHInner {
             mtp_seed_failures: 0,
             gen_defaults: crate::engine::ModelGenerationDefaults::default(),
             paged_adapter,
+            pool_cache_limit_guard: None,
             scheduled_caches: HashMap::new(),
             active_scheduled_seq: None,
             last_paged_prefill_reused_mamba_state: false,
@@ -744,22 +748,40 @@ impl NemotronHInner {
             )));
         }
         let cache_dtype = mlx_paged_attn::metal::MetalDtype::BFloat16;
-        let sizing = mlx_paged_attn::profile::load_time_pool_sizing_with_reserved(
-            requested_blocks,
-            attn_layer_count,
-            num_kv_heads,
-            head_size,
-            block_size,
-            cache_dtype,
-            crate::cache_limit::coordinator().registered_pool_bytes(),
-        )
-        .map_err(|error| {
-            Error::from_reason(format!(
-                "NemotronH adaptive paged cache sizing failed safely; refusing an uncapped \
-                 pool request: {error}"
-            ))
-        })?;
-        let selected_blocks = sizing.selected_blocks;
+        let coordinator = crate::cache_limit::coordinator();
+        let (selected_blocks, pool_guard) = {
+            let mut reserved = None;
+            for _ in 0..8 {
+                let sibling = coordinator.registered_pool_bytes();
+                let sizing = mlx_paged_attn::profile::load_time_pool_sizing_with_reserved(
+                    requested_blocks,
+                    attn_layer_count,
+                    num_kv_heads,
+                    head_size,
+                    block_size,
+                    cache_dtype,
+                    sibling,
+                )
+                .map_err(|error| {
+                    Error::from_reason(format!(
+                        "NemotronH adaptive paged cache sizing failed safely; refusing an uncapped \
+                         pool request: {error}"
+                    ))
+                })?;
+                if let Some(guard) =
+                    coordinator.try_register_pool_if_total_eq(sibling, sizing.selected_bytes)
+                {
+                    reserved = Some((sizing.selected_blocks, guard));
+                    break;
+                }
+            }
+            reserved.ok_or_else(|| {
+                Error::from_reason(
+                    "NemotronH adaptive paged cache sizing failed safely; concurrent pool \
+                     reservation kept racing",
+                )
+            })?
+        };
         let allocator = Arc::new(Mutex::new(mlx_paged_attn::BlockAllocator::new(
             selected_blocks,
             block_size,
@@ -777,6 +799,7 @@ impl NemotronHInner {
                 ))
             })?,
         );
+        self.pool_cache_limit_guard = Some(pool_guard);
         Ok(())
     }
 

--- a/crates/mlx-core/src/models/nemotron_h/persistence.rs
+++ b/crates/mlx-core/src/models/nemotron_h/persistence.rs
@@ -998,7 +998,16 @@ pub async fn load_with_thread(model_path: &str) -> Result<NemotronHModel> {
     let (thread, init_rx) = crate::model_thread::ModelThread::spawn_with_scheduler(
         move || {
             let (inner, weight_bytes) = load_inner(&model_path)?;
+            let pool_bytes = inner
+                .paged_adapter
+                .as_ref()
+                .map(crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter::pool_allocated_bytes)
+                .transpose()
+                .map_err(Error::from_reason)?
+                .unwrap_or(0);
             let cache_limit_guard = crate::cache_limit::coordinator().register(weight_bytes);
+            let pool_cache_limit_guard = (pool_bytes != 0)
+                .then(|| crate::cache_limit::coordinator().register_pool(pool_bytes));
             let mtp_active = inner.has_mtp_weights();
             let paged_active = inner.paged_adapter.is_some();
             let context_limits =
@@ -1010,6 +1019,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<NemotronHModel> {
                 (
                     config,
                     cache_limit_guard,
+                    pool_cache_limit_guard,
                     mtp_active,
                     paged_active,
                     context_limits,
@@ -1019,7 +1029,14 @@ pub async fn load_with_thread(model_path: &str) -> Result<NemotronHModel> {
         |state, receiver| state.drive(receiver),
     );
 
-    let (config, cache_limit_guard, mtp_active, paged_active, context_limits) = init_rx
+    let (
+        config,
+        cache_limit_guard,
+        pool_cache_limit_guard,
+        mtp_active,
+        paged_active,
+        context_limits,
+    ) = init_rx
         .await
         .map_err(|_| Error::from_reason("Model thread exited during load"))??;
 
@@ -1030,6 +1047,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<NemotronHModel> {
         paged_active,
         context_limits,
         _cache_limit_guard: cache_limit_guard,
+        _pool_cache_limit_guard: pool_cache_limit_guard,
     })
 }
 

--- a/crates/mlx-core/src/models/nemotron_h/persistence.rs
+++ b/crates/mlx-core/src/models/nemotron_h/persistence.rs
@@ -970,6 +970,7 @@ pub(crate) fn load_inner(model_path: &str) -> Result<(NemotronHInner, u64)> {
 
     let weight_refs: Vec<&MxArray> = params.values().collect();
     crate::array::memory::materialize_weights(&weight_refs)?;
+    inner.size_paged_pool_after_weight_load()?;
 
     let tokenizer_path = path.join("tokenizer.json");
     if tokenizer_path.exists() {

--- a/crates/mlx-core/src/models/nemotron_h/persistence.rs
+++ b/crates/mlx-core/src/models/nemotron_h/persistence.rs
@@ -42,7 +42,7 @@ use crate::models::qwen3_5_moe::quantized_linear::{
 use crate::tokenizer::Qwen3Tokenizer;
 
 use super::config::{NemotronHConfig, parse_config};
-use super::model::{NemotronHInner, NemotronHModel};
+use super::model::{NemotronHInner, NemotronHModel, reserve_configured_paged_pool};
 use super::sparse_moe::ExpertProj;
 
 /// Strip the HF backbone. model wrapper from a tensor or quant key.
@@ -959,7 +959,13 @@ pub(crate) fn load_inner(model_path: &str) -> Result<(NemotronHInner, u64)> {
     let params = sanitize_weights(std::mem::take(&mut raw_params), &config)?;
     info!("NemotronH sanitized to {} tensors", params.len());
 
+    // Configured pools allocate inside `new`. Reserve first so a concurrent
+    // uncapped Nemotron load's adaptive sizer sees the bytes before Metal
+    // alloc; the CAS path in `size_paged_pool_after_weight_load` does not
+    // cover this branch.
+    let configured_pool_guard = reserve_configured_paged_pool(&config)?;
     let mut inner = NemotronHInner::new(config.clone())?;
+    inner.pool_cache_limit_guard = configured_pool_guard;
     inner.set_gen_defaults(parse_generation_defaults(path));
     // Quantized projections dispatch different matmul kernels for M=1 vs M>=2
     // rows, so the batched decode lane must run them per row to stay

--- a/crates/mlx-core/src/models/nemotron_h/persistence.rs
+++ b/crates/mlx-core/src/models/nemotron_h/persistence.rs
@@ -997,7 +997,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<NemotronHModel> {
 
     let (thread, init_rx) = crate::model_thread::ModelThread::spawn_with_scheduler(
         move || {
-            let (inner, weight_bytes) = load_inner(&model_path)?;
+            let (mut inner, weight_bytes) = load_inner(&model_path)?;
             let pool_bytes = inner
                 .paged_adapter
                 .as_ref()
@@ -1006,8 +1006,10 @@ pub async fn load_with_thread(model_path: &str) -> Result<NemotronHModel> {
                 .map_err(Error::from_reason)?
                 .unwrap_or(0);
             let cache_limit_guard = crate::cache_limit::coordinator().register(weight_bytes);
-            let pool_cache_limit_guard = (pool_bytes != 0)
-                .then(|| crate::cache_limit::coordinator().register_pool(pool_bytes));
+            let pool_cache_limit_guard = inner.pool_cache_limit_guard.take().or_else(|| {
+                (pool_bytes != 0)
+                    .then(|| crate::cache_limit::coordinator().register_pool(pool_bytes))
+            });
             let mtp_active = inner.has_mtp_weights();
             let paged_active = inner.paged_adapter.is_some();
             let context_limits =

--- a/crates/mlx-core/src/models/qwen3_5/config.rs
+++ b/crates/mlx-core/src/models/qwen3_5/config.rs
@@ -1,8 +1,5 @@
 use napi_derive::napi;
 
-const BYTES_PER_MIB: u64 = 1024 * 1024;
-const QWEN35_PAGED_CACHE_MIN_DEFAULT_MEMORY_MB: u32 = 256;
-
 /// Derive the default paged-KV budget from the model's advertised context.
 ///
 /// Qwen3.5 checkpoints commonly advertise 262,144 tokens. The former fixed
@@ -18,23 +15,13 @@ pub(crate) fn qwen35_default_paged_cache_memory_mb(
     num_kv_heads: u32,
     num_layers: u32,
 ) -> u32 {
-    if max_seq_len == 0 || block_size == 0 || head_size == 0 || num_kv_heads == 0 || num_layers == 0
-    {
-        return QWEN35_PAGED_CACHE_MIN_DEFAULT_MEMORY_MB;
-    }
-
-    let max_blocks = u64::from(max_seq_len.div_ceil(block_size));
-    let bytes_per_block = 2u64
-        .saturating_mul(u64::from(num_kv_heads))
-        .saturating_mul(u64::from(head_size))
-        .saturating_mul(u64::from(block_size))
-        .saturating_mul(2)
-        .saturating_mul(u64::from(num_layers));
-    let required_mb = bytes_per_block
-        .saturating_mul(max_blocks)
-        .div_ceil(BYTES_PER_MIB)
-        .max(u64::from(QWEN35_PAGED_CACHE_MIN_DEFAULT_MEMORY_MB));
-    u32::try_from(required_mb).unwrap_or(u32::MAX)
+    mlx_paged_attn::PagedAttentionConfig::memory_mb_for_one_full_sequence(
+        max_seq_len,
+        block_size,
+        head_size,
+        num_kv_heads,
+        num_layers,
+    )
 }
 
 pub(crate) fn qwen35_resolve_paged_cache_memory_mb(

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -20,7 +20,10 @@ use crate::engine::backend::{
 use crate::engine::cmd::{
     ChatCmd, FromChatCmd, FromTrainCmd, TrainCmd, handle_chat_cmd, handle_train_cmd,
 };
-use crate::engine::hybrid_scheduler::{HybridSchedulerBackend, HybridSchedulerCommand};
+use crate::engine::hybrid_scheduler::{
+    HybridSchedulerBackend, HybridSchedulerCommand, pool_tokens_after_recurrent,
+    scheduled_turn_context, scheduler_per_seq_context_override,
+};
 use crate::engine::plan::{
     DecoderPlan, ExecutionPlan, MediaCapabilities, MediaPlan, PagedAttentionPlan, SpeculativeKind,
     SpeculativePlan,
@@ -584,6 +587,27 @@ mod paged_context_capacity_tests {
         let mut params = make_params(10);
         constrain_paged_context_params("test", 48, 64, &mut params).unwrap();
         assert_eq!(params.max_new_tokens, 10);
+    }
+
+    #[test]
+    fn scheduler_usable_window_is_stricter_than_trained_min_pool_when_recurrent_is_nonzero() {
+        use crate::engine::hybrid_scheduler::{
+            pool_tokens_after_recurrent, scheduled_turn_context,
+        };
+        let trained = 1_048_576;
+        let pool = 1_048_576;
+        let rec = 48 * 1024 * 1024;
+        let usable = pool_tokens_after_recurrent(pool, 16, 1024, rec);
+        let old = trained.min(pool);
+        let effective = scheduled_turn_context(trained, usable, None);
+        assert!(rec > 0);
+        assert!(usable < pool);
+        assert!(effective < old);
+        assert_eq!(effective, usable);
+        assert_eq!(
+            scheduled_turn_context(trained, usable, Some(32_768)),
+            32_768
+        );
     }
 }
 
@@ -1810,9 +1834,16 @@ impl Qwen35Inner {
         };
         let blocks = adapter.block_capacity();
         let block_size = adapter.block_size();
+        let bytes_per_block = adapter.bytes_per_block().unwrap_or(0);
+        let usable = pool_tokens_after_recurrent(
+            adapter.max_capacity_tokens(),
+            block_size,
+            bytes_per_block,
+            self.config.recurrent_state_bytes(),
+        );
         (
             trained,
-            trained.min(adapter.max_capacity_tokens()),
+            scheduled_turn_context(trained, usable, scheduler_per_seq_context_override()),
             blocks,
             block_size,
         )
@@ -1823,12 +1854,12 @@ impl Qwen35Inner {
         prompt_tokens: usize,
         params: &mut engine::ChatParams,
     ) -> Result<()> {
-        let adapter = self.paged_adapter.as_ref().ok_or_else(|| {
-            Error::from_reason("context_length_exceeded: paged cache is not initialized")
-        })?;
-        let capacity = adapter
-            .max_capacity_tokens()
-            .min(self.config.max_position_embeddings.max(0) as u32);
+        if self.paged_adapter.is_none() {
+            return Err(Error::from_reason(
+                "context_length_exceeded: paged cache is not initialized",
+            ));
+        }
+        let (_, capacity, _, _) = self.paged_context_limits();
         constrain_paged_context_params("Qwen3.5", prompt_tokens, capacity, params)
     }
 
@@ -14795,6 +14826,87 @@ mod paged_construction_tests {
         cfg.linear_value_head_dim = 32;
         cfg.paged_cache_memory_mb = Some(256);
         cfg
+    }
+
+    fn expected_scheduler_window(inner: &Qwen35Inner) -> (u32, u32, u32) {
+        use crate::engine::hybrid_scheduler::{
+            pool_tokens_after_recurrent, scheduled_turn_context, scheduler_per_seq_context_override,
+        };
+        let trained = inner.config.max_position_embeddings.max(0) as u32;
+        let adapter = inner
+            .paged_adapter
+            .as_ref()
+            .expect("test adapter must be installed");
+        let pool = adapter.max_capacity_tokens();
+        let usable = pool_tokens_after_recurrent(
+            pool,
+            adapter.block_size(),
+            adapter.bytes_per_block().unwrap_or(0),
+            inner.config.recurrent_state_bytes(),
+        );
+        (
+            trained,
+            scheduled_turn_context(trained, usable, scheduler_per_seq_context_override()),
+            pool,
+        )
+    }
+
+    #[test]
+    fn tiny_hybrid_recurrent_bytes_make_usable_window_stricter_than_raw_pool() {
+        use crate::engine::hybrid_scheduler::{
+            pool_tokens_after_recurrent, scheduled_turn_context,
+        };
+        let inner = Qwen35Inner::new(tiny_cfg(false)).expect("construct tiny dense model");
+        let rec = inner.config.recurrent_state_bytes();
+        assert!(rec > 0, "tiny hybrid config must have GDN state");
+        let trained = 1_048_576;
+        let pool = 349_520;
+        let usable = pool_tokens_after_recurrent(pool, 16, 1024, rec);
+        assert!(usable < pool);
+        assert_ne!(
+            scheduled_turn_context(trained, usable, None),
+            trained.min(pool)
+        );
+        assert_eq!(
+            scheduled_turn_context(trained, usable, Some(32_768)),
+            32_768
+        );
+    }
+
+    #[test]
+    fn paged_context_limits_and_preflight_use_scheduler_usable_window() {
+        let Some(inner) = dense_inner_with_test_adapter_or_skip(
+            "paged_context_limits_and_preflight_use_scheduler_usable_window",
+        ) else {
+            return;
+        };
+        assert!(inner.config.recurrent_state_bytes() > 0);
+        let (trained, expected, pool) = expected_scheduler_window(&inner);
+        let (published_trained, effective, _, _) = inner.paged_context_limits();
+        assert_eq!(published_trained, trained);
+        assert_eq!(effective, expected);
+        assert!(
+            effective < pool,
+            "recurrent charge must shrink the published window below raw pool tokens"
+        );
+        assert_ne!(effective, trained.min(pool));
+
+        let mut params = extract_chat_params(&crate::engine::types::ChatConfig {
+            max_new_tokens: Some(32),
+            ..crate::engine::types::ChatConfig::default()
+        });
+        inner
+            .preflight_paged_context(effective as usize, &mut params)
+            .expect("prompt at the scheduler window must pass");
+        let err = inner
+            .preflight_paged_context(pool as usize, &mut params)
+            .expect_err("prompt at raw pool tokens must fail after recurrent charge");
+        assert!(
+            err.reason
+                .starts_with("context_length_exceeded: rendered prompt has"),
+            "{}",
+            err.reason
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -17,7 +17,10 @@ use crate::engine::backend::{
 use crate::engine::cmd::{
     ChatCmd, FromChatCmd, FromTrainCmd, TrainCmd, handle_chat_cmd, handle_train_cmd,
 };
-use crate::engine::hybrid_scheduler::{HybridSchedulerBackend, HybridSchedulerCommand};
+use crate::engine::hybrid_scheduler::{
+    HybridSchedulerBackend, HybridSchedulerCommand, pool_tokens_after_recurrent,
+    scheduled_turn_context, scheduler_per_seq_context_override,
+};
 use crate::engine::plan::{
     DecoderPlan, ExecutionPlan, MediaCapabilities, MediaPlan, PagedAttentionPlan, SpeculativeKind,
     SpeculativePlan,
@@ -1465,9 +1468,16 @@ impl Qwen35MoeInner {
         };
         let blocks = adapter.block_capacity();
         let block_size = adapter.block_size();
+        let bytes_per_block = adapter.bytes_per_block().unwrap_or(0);
+        let usable = pool_tokens_after_recurrent(
+            adapter.max_capacity_tokens(),
+            block_size,
+            bytes_per_block,
+            self.config.recurrent_state_bytes(),
+        );
         (
             trained,
-            trained.min(adapter.max_capacity_tokens()),
+            scheduled_turn_context(trained, usable, scheduler_per_seq_context_override()),
             blocks,
             block_size,
         )
@@ -1478,12 +1488,12 @@ impl Qwen35MoeInner {
         prompt_tokens: usize,
         params: &mut engine::ChatParams,
     ) -> Result<()> {
-        let adapter = self.paged_adapter.as_ref().ok_or_else(|| {
-            Error::from_reason("context_length_exceeded: paged cache is not initialized")
-        })?;
-        let capacity = adapter
-            .max_capacity_tokens()
-            .min(self.config.max_position_embeddings.max(0) as u32);
+        if self.paged_adapter.is_none() {
+            return Err(Error::from_reason(
+                "context_length_exceeded: paged cache is not initialized",
+            ));
+        }
+        let (_, capacity, _, _) = self.paged_context_limits();
         constrain_paged_context_params("Qwen3.5 MoE", prompt_tokens, capacity, params)
     }
 
@@ -10744,6 +10754,87 @@ mod paged_construction_tests {
             persist_paged_cache: None,
             n_mtp_layers: 0,
         }
+    }
+
+    fn expected_scheduler_window(inner: &Qwen35MoeInner) -> (u32, u32, u32) {
+        use crate::engine::hybrid_scheduler::{
+            pool_tokens_after_recurrent, scheduled_turn_context, scheduler_per_seq_context_override,
+        };
+        let trained = inner.config.max_position_embeddings.max(0) as u32;
+        let adapter = inner
+            .paged_adapter
+            .as_ref()
+            .expect("test adapter must be installed");
+        let pool = adapter.max_capacity_tokens();
+        let usable = pool_tokens_after_recurrent(
+            pool,
+            adapter.block_size(),
+            adapter.bytes_per_block().unwrap_or(0),
+            inner.config.recurrent_state_bytes(),
+        );
+        (
+            trained,
+            scheduled_turn_context(trained, usable, scheduler_per_seq_context_override()),
+            pool,
+        )
+    }
+
+    #[test]
+    fn tiny_hybrid_recurrent_bytes_make_usable_window_stricter_than_raw_pool() {
+        use crate::engine::hybrid_scheduler::{
+            pool_tokens_after_recurrent, scheduled_turn_context,
+        };
+        let inner = Qwen35MoeInner::new(tiny_moe_cfg(false)).expect("construct tiny MoE model");
+        let rec = inner.config.recurrent_state_bytes();
+        assert!(rec > 0, "tiny hybrid MoE config must have GDN state");
+        let trained = 1_048_576;
+        let pool = 349_520;
+        let usable = pool_tokens_after_recurrent(pool, 16, 1024, rec);
+        assert!(usable < pool);
+        assert_ne!(
+            scheduled_turn_context(trained, usable, None),
+            trained.min(pool)
+        );
+        assert_eq!(
+            scheduled_turn_context(trained, usable, Some(32_768)),
+            32_768
+        );
+    }
+
+    #[test]
+    fn paged_context_limits_and_preflight_use_scheduler_usable_window() {
+        let Some(inner) = moe_inner_with_test_adapter_or_skip(
+            "paged_context_limits_and_preflight_use_scheduler_usable_window",
+        ) else {
+            return;
+        };
+        assert!(inner.config.recurrent_state_bytes() > 0);
+        let (trained, expected, pool) = expected_scheduler_window(&inner);
+        let (published_trained, effective, _, _) = inner.paged_context_limits();
+        assert_eq!(published_trained, trained);
+        assert_eq!(effective, expected);
+        assert!(
+            effective < pool,
+            "recurrent charge must shrink the published window below raw pool tokens"
+        );
+        assert_ne!(effective, trained.min(pool));
+
+        let mut params = crate::engine::extract_chat_params(&crate::engine::types::ChatConfig {
+            max_new_tokens: Some(32),
+            ..crate::engine::types::ChatConfig::default()
+        });
+        inner
+            .preflight_paged_context(effective as usize, &mut params)
+            .expect("prompt at the scheduler window must pass");
+        let err = inner
+            .preflight_paged_context(pool as usize, &mut params)
+            .expect_err("prompt at raw pool tokens must fail after recurrent charge");
+        assert!(
+            err.reason
+                .starts_with("context_length_exceeded: rendered prompt has"),
+            "{}",
+            err.reason
+        );
     }
 
     #[test]

--- a/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
+++ b/crates/mlx-core/src/transformer/paged_kv_cache_adapter.rs
@@ -2513,6 +2513,17 @@ impl PagedKVCacheAdapter {
         self.requests.len() + usize::from(self.active_seq.is_some())
     }
 
+    /// Active request plus parked keep-live tables, including exclusive seq 0
+    /// which is never entered in `owner_sequences`.
+    pub fn live_seq_ids(&self) -> Vec<SeqId> {
+        let mut ids = Vec::with_capacity(self.requests.len().saturating_add(1));
+        if let Some(seq_id) = self.active_seq {
+            ids.push(seq_id);
+        }
+        ids.extend(self.requests.keys().copied());
+        ids
+    }
+
     pub fn current_token_count_for(&self, seq_id: SeqId) -> Option<u32> {
         if self.active_seq == Some(seq_id) {
             return Some(self.request_tokens.len() as u32);

--- a/crates/mlx-paged-attn/src/config.rs
+++ b/crates/mlx-paged-attn/src/config.rs
@@ -1,5 +1,8 @@
 //! Configuration types for PagedAttention
 
+const BYTES_PER_MIB: u64 = 1024 * 1024;
+const MIN_FULL_SEQUENCE_MEMORY_MB: u32 = 256;
+
 /// Configuration for PagedAttention
 #[derive(Debug, Clone)]
 pub struct PagedAttentionConfig {
@@ -80,6 +83,40 @@ impl PagedAttentionConfig {
         }
 
         Ok(())
+    }
+
+    /// MiB needed to cache one sequence of `max_seq_len` tokens (bf16 K+V).
+    ///
+    /// `num_layers` is the physical full-attention layer count, not the
+    /// model's total mixer count. Zero inputs return the 256 MiB floor.
+    pub fn memory_mb_for_one_full_sequence(
+        max_seq_len: u32,
+        block_size: u32,
+        head_size: u32,
+        num_kv_heads: u32,
+        num_layers: u32,
+    ) -> u32 {
+        if max_seq_len == 0
+            || block_size == 0
+            || head_size == 0
+            || num_kv_heads == 0
+            || num_layers == 0
+        {
+            return MIN_FULL_SEQUENCE_MEMORY_MB;
+        }
+
+        let max_blocks = u64::from(max_seq_len.div_ceil(block_size));
+        let bytes_per_block = 2u64
+            .saturating_mul(u64::from(num_kv_heads))
+            .saturating_mul(u64::from(head_size))
+            .saturating_mul(u64::from(block_size))
+            .saturating_mul(2)
+            .saturating_mul(u64::from(num_layers));
+        let required_mb = bytes_per_block
+            .saturating_mul(max_blocks)
+            .div_ceil(BYTES_PER_MIB)
+            .max(u64::from(MIN_FULL_SEQUENCE_MEMORY_MB));
+        u32::try_from(required_mb).unwrap_or(u32::MAX)
     }
 
     /// Calculate the number of blocks that can be allocated
@@ -233,5 +270,29 @@ mod tests {
         let result = config.validate();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("block_size 16 or 32"));
+    }
+
+    #[test]
+    fn one_full_sequence_mb_for_nemotron_lightning() {
+        // 1_048_576 tokens, block 16, head 128, 2 kv, 6 attn layers, bf16 K+V
+        let mb = PagedAttentionConfig::memory_mb_for_one_full_sequence(1_048_576, 16, 128, 2, 6);
+        assert_eq!(mb, 6144);
+        let cfg = PagedAttentionConfig {
+            block_size: 16,
+            gpu_memory_mb: mb,
+            head_size: 128,
+            num_kv_heads: 2,
+            num_layers: 6,
+            use_fp8_cache: Some(false),
+            max_seq_len: Some(1_048_576),
+            max_batch_size: Some(32),
+        };
+        assert_eq!(cfg.max_cached_tokens(), 1_048_576);
+    }
+
+    #[test]
+    fn one_full_sequence_mb_matches_qwen35_35b_a3b() {
+        let mb = PagedAttentionConfig::memory_mb_for_one_full_sequence(262_144, 16, 256, 2, 10);
+        assert_eq!(mb, 5_120);
     }
 }

--- a/crates/mlx-paged-attn/src/profile.rs
+++ b/crates/mlx-paged-attn/src/profile.rs
@@ -503,6 +503,7 @@ pub fn compute_load_time_pool_sizing(
     util: f64,
     safety_margin_bytes: u64,
     bytes_per_block: u64,
+    extra_reserved_bytes: u64,
 ) -> Result<LoadTimePoolSizing, ProfileError> {
     if requested_blocks == 0 || bytes_per_block == 0 {
         return Err(ProfileError::InvalidShape(format!(
@@ -519,10 +520,12 @@ pub fn compute_load_time_pool_sizing(
             .saturating_sub(safety_margin_bytes)
     };
 
-    // Total-memory and Metal ceilings are absolute, so subtract current MLX
-    // active allocation from both.
-    let total_budget = budget(total_memory_bytes, metal_active_bytes);
-    let metal_budget = metal_working_set_bytes.map(|ws| budget(ws, metal_active_bytes));
+    // Total-memory and Metal ceilings are absolute. Subtract MLX active
+    // memory and any extra reserved bytes (sibling private Metal pools that
+    // those counters cannot see) before taking min(requested, safe).
+    let used = metal_active_bytes.saturating_add(extra_reserved_bytes);
+    let total_budget = budget(total_memory_bytes, used);
+    let metal_budget = metal_working_set_bytes.map(|ws| budget(ws, used));
 
     // Total physical memory is the mandatory safety ceiling. Optional live
     // probes may only tighten it; their absence must never restore the full
@@ -566,6 +569,29 @@ pub fn load_time_pool_sizing(
     block_size: u32,
     dtype: MetalDtype,
 ) -> Result<LoadTimePoolSizing, ProfileError> {
+    load_time_pool_sizing_with_reserved(
+        requested_blocks,
+        num_layers,
+        num_kv_heads,
+        head_size,
+        block_size,
+        dtype,
+        0,
+    )
+}
+
+/// Same as [`load_time_pool_sizing`], but `extra_reserved_bytes` (sibling
+/// private Metal pools) is subtracted from the safe budget *before*
+/// `min(requested, safe)`.
+pub fn load_time_pool_sizing_with_reserved(
+    requested_blocks: u32,
+    num_layers: u32,
+    num_kv_heads: u32,
+    head_size: u32,
+    block_size: u32,
+    dtype: MetalDtype,
+    extra_reserved_bytes: u64,
+) -> Result<LoadTimePoolSizing, ProfileError> {
     let total = read_total_memory_bytes()?;
     let util = read_util_env()?;
     let safety = read_safety_margin_env()?;
@@ -589,12 +615,20 @@ pub fn load_time_pool_sizing(
             util,
             safety,
             bpb,
+            extra_reserved_bytes,
         )
     }
 
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (requested_blocks, total, util, safety, bpb);
+        let _ = (
+            requested_blocks,
+            total,
+            util,
+            safety,
+            bpb,
+            extra_reserved_bytes,
+        );
         Err(ProfileError::TotalMemoryUnavailable)
     }
 }
@@ -845,12 +879,61 @@ mod tests {
     fn load_time_sizing_treats_requested_pool_as_maximum() {
         let gib = 1024u64 * 1024 * 1024;
         let bpb = 1024 * 1024;
-        let sizing =
-            compute_load_time_pool_sizing(2048, 64 * gib, Some(48 * gib), 20 * gib, 0.85, gib, bpb)
-                .unwrap();
+        let sizing = compute_load_time_pool_sizing(
+            2048,
+            64 * gib,
+            Some(48 * gib),
+            20 * gib,
+            0.85,
+            gib,
+            bpb,
+            0,
+        )
+        .unwrap();
         assert_eq!(sizing.requested_blocks, 2048);
         assert_eq!(sizing.selected_blocks, 2048);
         assert_eq!(sizing.selected_bytes, 2 * gib);
+    }
+
+    #[test]
+    fn extra_reserved_debits_safe_budget_not_the_request_cap() {
+        let gib = 1024u64 * 1024 * 1024;
+        let bpb = 1024 * 1024;
+        // Same machine as the request-cap test: 2 GiB request, ~20 GiB safe.
+        let sibling_2g = compute_load_time_pool_sizing(
+            2048,
+            64 * gib,
+            Some(48 * gib),
+            20 * gib,
+            0.85,
+            gib,
+            bpb,
+            2 * gib,
+        )
+        .unwrap();
+        assert_eq!(
+            sibling_2g.selected_blocks, 2048,
+            "ample headroom must still grant the full 2 GiB request"
+        );
+
+        let sibling_tight = compute_load_time_pool_sizing(
+            2048,
+            64 * gib,
+            Some(48 * gib),
+            20 * gib,
+            0.85,
+            gib,
+            bpb,
+            18 * gib,
+        )
+        .unwrap();
+        // metal safe = 48*0.85 - 20 - 18 - 1 = 1.8 GiB < 2 GiB request
+        let expected = ((48f64 * gib as f64 * 0.85) as u64)
+            .saturating_sub(20 * gib)
+            .saturating_sub(18 * gib)
+            .saturating_sub(gib);
+        assert_eq!(sibling_tight.selected_bytes, expected / bpb * bpb);
+        assert!(sibling_tight.selected_blocks < 2048);
     }
 
     #[test]
@@ -867,6 +950,7 @@ mod tests {
             0.85,
             gib,
             bpb,
+            0,
         )
         .unwrap();
         let expected_bytes = ((32f64 * gib as f64 * 0.85) as u64)
@@ -888,6 +972,7 @@ mod tests {
             0.85,
             gib,
             16 * 1024 * 1024,
+            0,
         )
         .unwrap_err();
         assert!(matches!(err, ProfileError::NotEnoughBlocks { .. }));
@@ -898,7 +983,7 @@ mod tests {
         let gib = 1024u64 * 1024 * 1024;
         let bpb = 1024 * 1024;
         let sizing =
-            compute_load_time_pool_sizing(u32::MAX, 16 * gib, None, 4 * gib, 0.85, gib, bpb)
+            compute_load_time_pool_sizing(u32::MAX, 16 * gib, None, 4 * gib, 0.85, gib, bpb, 0)
                 .unwrap();
         let expected_budget = ((16f64 * gib as f64 * 0.85) as u64)
             .saturating_sub(4 * gib)
@@ -913,7 +998,7 @@ mod tests {
         let gib = 1024u64 * 1024 * 1024;
         let bpb = 1024 * 1024;
         let without_working_set =
-            compute_load_time_pool_sizing(u32::MAX, 64 * gib, None, 20 * gib, 0.85, gib, bpb)
+            compute_load_time_pool_sizing(u32::MAX, 64 * gib, None, 20 * gib, 0.85, gib, bpb, 0)
                 .unwrap();
         let with_tight_working_set = compute_load_time_pool_sizing(
             u32::MAX,
@@ -923,6 +1008,7 @@ mod tests {
             0.85,
             gib,
             bpb,
+            0,
         )
         .unwrap();
         assert!(with_tight_working_set.selected_blocks < without_working_set.selected_blocks);

--- a/docs/concurrent-inference.md
+++ b/docs/concurrent-inference.md
@@ -80,7 +80,7 @@ same-binary uniform/ragged validation with separate model instances:
 | `MLX_SCHED_WATERMARK_FRACTION`  | `0.05`  | Free-block headroom retained while work is already live.                                                   |
 | `MLX_SCHED_RESERVE_FULL_ISL`    | `1`     | Reserve each admitted request's remaining prompt growth in the must-fit test.                              |
 | `MLX_SCHED_RAGGED_STEP`         | `0`     | Use one packed varlen Qwen3 forward for mixed prefill/decode slices.                                       |
-| `MLX_PAGED_PER_SEQ_CTX`         | `unset` | Optional per-sequence **admit** cap and Qwen3/LFM2 pool-budget clip. Unset → admit `min(trained, live pool)`. Default 32768 applies only to the Qwen3/LFM2 **pool request** formula, not to Nemotron/Qwen3.5 admit. |
+| `MLX_PAGED_PER_SEQ_CTX`         | `unset` | Optional per-sequence **admit** cap and Qwen3/LFM2 pool-budget clip. Unset → admit `min(trained, live pool minus recurrent KV-equivalent)`. When set, Muse/Nemotron `contextLimits()` also publish that cap. Default 32768 applies only to the Qwen3/LFM2 **pool request** formula. |
 | `MLX_CONTINUOUS_BATCHING`       | `0`     | Opt default-off compatible checkpoints into the shared scheduled lane (currently Qwen3.5 dense and MoE).   |
 | `MLX_SERVE_FORCE_SERIAL`        | `0`     | Route eligible Qwen3/LFM2/Qwen3.5/Gemma4/NemotronH turns through the whole-turn path for A/B and rollback. |
 

--- a/docs/concurrent-inference.md
+++ b/docs/concurrent-inference.md
@@ -80,7 +80,7 @@ same-binary uniform/ragged validation with separate model instances:
 | `MLX_SCHED_WATERMARK_FRACTION`  | `0.05`  | Free-block headroom retained while work is already live.                                                   |
 | `MLX_SCHED_RESERVE_FULL_ISL`    | `1`     | Reserve each admitted request's remaining prompt growth in the must-fit test.                              |
 | `MLX_SCHED_RAGGED_STEP`         | `0`     | Use one packed varlen Qwen3 forward for mixed prefill/decode slices.                                       |
-| `MLX_PAGED_PER_SEQ_CTX`         | `32768` | Per-sequence context used by the pool budget formula.                                                      |
+| `MLX_PAGED_PER_SEQ_CTX`         | `unset` | Optional per-sequence **admit** cap and Qwen3/LFM2 pool-budget clip. Unset → admit `min(trained, live pool)`. Default 32768 applies only to the Qwen3/LFM2 **pool request** formula, not to Nemotron/Qwen3.5 admit. |
 | `MLX_CONTINUOUS_BATCHING`       | `0`     | Opt default-off compatible checkpoints into the shared scheduled lane (currently Qwen3.5 dense and MoE).   |
 | `MLX_SERVE_FORCE_SERIAL`        | `0`     | Route eligible Qwen3/LFM2/Qwen3.5/Gemma4/NemotronH turns through the whole-turn path for A/B and rollback. |
 

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -657,9 +657,8 @@ export declare class MuseGlimmerModel {
   hasBlockPagedCache(): boolean;
   maxConcurrentSequences(): number;
   /**
-   * Conservative model-wide context snapshot used by higher layers for
-   * compaction. It includes the paged AR limit even when DFlash is present,
-   * because DFlash is opt-in per request and can be disabled by the caller.
+   * Model-wide context snapshot used by higher layers for compaction.
+   * `effective_window_tokens` is min(trained, live pool).
    */
   contextLimits(): MuseGlimmerContextLimits;
   schedulerStats(): Promise<SchedulerStats>;
@@ -4235,9 +4234,8 @@ export declare const enum MultimodalContentOrder {
 
 /**
  * Trained and physically available active-context limits for one loaded
- * Muse-Glimmer model. The effective window is conservative across both
- * execution modes: DFlash may use the flat cache, but callers can disable it
- * per request and fall back to the paged AR scheduler.
+ * Muse-Glimmer model. Values are snapshots because the physical pool is fixed
+ * for the lifetime of the resident model.
  */
 export interface MuseGlimmerContextLimits {
   trainedWindowTokens: number;
@@ -4305,8 +4303,10 @@ export interface NemotronHConfig {
   /** Number of MTP predictor steps (`num_nextn_predict_layers`). */
   nMtpLayers: number;
   /**
-   * Optional block-paged KV cache memory cap in MiB. None resolves to the
-   * default 2048 MiB pool; explicit values are honored.
+   * Optional block-paged KV cache memory cap in MiB. `None` requests one
+   * `max_position_embeddings` sequence (6 GiB on Lightning 30B-A3B) then
+   * clips with load-time Metal/RAM sizing after weights. Explicit values
+   * skip the auto-sizer.
    */
   pagedCacheMemoryMb?: number;
   /** Optional paged block size in tokens (default 16). */


### PR DESCRIPTION
A Nemotron agent session died with `context_length_exceeded: prompt (33611) exceeds scheduler per-sequence context 32768` after a ~50KB tool dump. The live paged pool had ~350k tokens; trained window is 1M. JS ChatSession preflight would have passed. The scheduler was the only 32k wall.

`32768` is the default `MLX_PAGED_PER_SEQ_CTX` **pool-sizing hint**, reused as a hard per-sequence admit cap.

```
trained 1M
   │
   ▼
pool ~350k     live KV (lazy blocks)
   │
   ✕ admit 32k   bug
```

## Fix

```
admit / publish = min(trained, live pool − one recurrent row, env if set)
```

- Unset `MLX_PAGED_PER_SEQ_CTX` no longer clips to 32k.
- Explicit env still clips.
- Nemotron default pool is one trained-length sequence, then `load_time_pool_sizing` after weights (not a 2GiB hint, not 6GiB before weights).
- Muse and Qwen3.5 dense/MoE publish that same usable window.

Follow-on admit holes from using the full pool as the cap:

- Idle parked recurrent + keep-live KV can no longer wedge FIFO (`prepared_waiting` spin). Reclaim idle rec, unpin keep-live, retry. Defer only if something is still running.
- Same-owner continuations charge **new** KV (`reservation − reusable keep-live`), not the full prompt against space that already holds that session.
- Failed cache unpin stops the reclaim loop (error / reject, not spin).
- Nemotron registers the private Metal pool with `CacheLimitCoordinator::register_pool`.

KV blocks still grow lazily. No Metal realloc.

## Tests

Focused (not full `mlx-core`):

- `cargo test -p mlx-core --lib engine::hybrid_scheduler` — 27 ok
- `cargo test -p mlx-core --lib models::nemotron_h` — 92 ok, 1 ignored
- `cargo test -p mlx-core --lib models::qwen3_5 -- --skip int8_gemm` — 304 ok, 19 ignored

Incident numbers are in `admit_uses_pool_when_env_unset` (33611 vs 32768 vs ~349520).

## Out of this PR

Shared sibling/product items Codex kept raising; not the 32k admit bug:

- `load_time_pool_sizing` does not subtract other models’ private Metal pools (Qwen3 / LFM2 / Qwen3.5 already).
- `PoolCacheLimitGuard` lives on the JS wrapper; `ModelThread::drop` detaches on purpose (vitest Metal teardown).
- Exclusive seq-0 keep-live is not in `owner_sequences` (ChatSession uses seq ≥ 1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes hybrid-scheduler admission, KV/recurrent reclaim, and Nemotron Metal pool sizing—core inference memory paths that can reject, wedge, or OOM live sessions.
> 
> **Overview**
> Stops treating the default `MLX_PAGED_PER_SEQ_CTX` 32k pool-sizing hint as a hard per-sequence admit wall. Turns now admit and publish `min(trained, live pool − one recurrent row)`, with the env var clipping only when set.
> 
> That unblocks long Nemotron prompts that already fit the paged pool (~350k vs 32k). Muse/Qwen3.5 `contextLimits` / preflight use the same usable window.
> 
> Admission no longer wedges `prepared_waiting` when idle parked GDN/Mamba or keep-live KV fills the pool: reclaim idle rows, unpin keep-live, retry; reject if nothing is running; continuations charge only new KV. Nemotron uncapped loads size one trained-length sequence after weights (CAS-register sibling pools), instead of a 2 GiB default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed08e98f8df6a96ee62b3ed32d2292beb3e2afe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->