### PR TITLE
fix(gemma4): load community 4-bit PLE checkpoints

### DIFF
--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -2341,7 +2341,9 @@ impl<B: HybridSchedulerBackend> HybridSchedulerState<B> {
                     let reservation_blocks = turn.block_reservation_total;
                     self.fail_preempted(
                         turn,
-                        Self::context_length_exceeded(reservation_blocks, total_blocks).reason,
+                        Self::context_length_exceeded(reservation_blocks, total_blocks)
+                            .reason
+                            .clone(),
                     );
                     return;
                 }

--- a/crates/mlx-core/src/models/gemma4/decoder_layer.rs
+++ b/crates/mlx-core/src/models/gemma4/decoder_layer.rs
@@ -10,7 +10,9 @@ use super::diagnostic;
 use super::layer_cache::Gemma4LayerCache;
 use super::mlp::GemmaMLP;
 use super::moe::{Gemma4MoE, Gemma4Router};
-use super::quantized_linear::{Gemma4MLPVariant, QuantizedLinear, QuantizedSwitchLinear};
+use super::quantized_linear::{
+    Gemma4MLPVariant, LinearProj, QuantizedLinear, QuantizedSwitchLinear,
+};
 
 /// Per-layer routing kind for Gemma4's paged dispatch.
 ///
@@ -106,8 +108,8 @@ pub struct Gemma4DecoderLayer {
 
     // PLE (Per-Layer Embeddings) per-layer components.
     // Only present when config.per_layer_input_embeds is true.
-    per_layer_input_gate: Option<Linear>,
-    per_layer_projection: Option<Linear>,
+    per_layer_input_gate: Option<LinearProj>,
+    per_layer_projection: Option<LinearProj>,
     post_per_layer_input_norm: Option<RMSNorm>,
 
     // MoE components (None for dense-only models like E2B).
@@ -144,8 +146,16 @@ impl Gemma4DecoderLayer {
         let (per_layer_input_gate, per_layer_projection, post_per_layer_input_norm) =
             if config.per_layer_input_embeds && ple_dim > 0 {
                 (
-                    Some(Linear::new(h, ple_dim as u32, Some(false))?),
-                    Some(Linear::new(ple_dim as u32, h, Some(false))?),
+                    Some(LinearProj::Standard(Linear::new(
+                        h,
+                        ple_dim as u32,
+                        Some(false),
+                    )?)),
+                    Some(LinearProj::Standard(Linear::new(
+                        ple_dim as u32,
+                        h,
+                        Some(false),
+                    )?)),
                     Some(RMSNorm::new(h, eps)?),
                 )
             } else {
@@ -545,7 +555,7 @@ impl Gemma4DecoderLayer {
 
     pub fn set_per_layer_input_gate_weight(&mut self, w: &MxArray) -> Result<()> {
         if let Some(ref mut gate) = self.per_layer_input_gate {
-            gate.set_weight(w)
+            gate.set_weight(w, "per_layer_input_gate")
         } else {
             Err(Error::from_reason(
                 "per_layer_input_gate not initialized (PLE not enabled)",
@@ -555,7 +565,29 @@ impl Gemma4DecoderLayer {
 
     pub fn set_per_layer_projection_weight(&mut self, w: &MxArray) -> Result<()> {
         if let Some(ref mut proj) = self.per_layer_projection {
-            proj.set_weight(w)
+            proj.set_weight(w, "per_layer_projection")
+        } else {
+            Err(Error::from_reason(
+                "per_layer_projection not initialized (PLE not enabled)",
+            ))
+        }
+    }
+
+    pub fn set_per_layer_input_gate_quantized(&mut self, ql: QuantizedLinear) -> Result<()> {
+        if let Some(ref mut gate) = self.per_layer_input_gate {
+            gate.set_quantized(ql);
+            Ok(())
+        } else {
+            Err(Error::from_reason(
+                "per_layer_input_gate not initialized (PLE not enabled)",
+            ))
+        }
+    }
+
+    pub fn set_per_layer_projection_quantized(&mut self, ql: QuantizedLinear) -> Result<()> {
+        if let Some(ref mut proj) = self.per_layer_projection {
+            proj.set_quantized(ql);
+            Ok(())
         } else {
             Err(Error::from_reason(
                 "per_layer_projection not initialized (PLE not enabled)",
@@ -576,6 +608,14 @@ impl Gemma4DecoderLayer {
     /// Returns true if this layer has PLE components.
     pub fn has_ple(&self) -> bool {
         self.per_layer_input_gate.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn ple_projections_are_quantized(&self) -> (bool, bool) {
+        (
+            matches!(self.per_layer_input_gate, Some(LinearProj::Quantized(_))),
+            matches!(self.per_layer_projection, Some(LinearProj::Quantized(_))),
+        )
     }
 
     /// Returns true if this layer has MoE components.

--- a/crates/mlx-core/src/models/gemma4/model.rs
+++ b/crates/mlx-core/src/models/gemma4/model.rs
@@ -66,7 +66,7 @@ pub(crate) struct PleComponents {
     /// Embedding table: [vocab_size_per_layer_input, num_layers * ple_dim]
     pub embed_tokens_per_layer: Embedding,
     /// Projection: [hidden_size, num_layers * ple_dim]
-    pub per_layer_model_projection: Linear,
+    pub per_layer_model_projection: LinearProj,
     /// Norm applied per ple_dim slice: weight shape [ple_dim]
     pub per_layer_projection_norm: RMSNorm,
     /// Scale factor: 2.0^(-0.5) = 1/sqrt(2) for per_layer_input_scale
@@ -831,7 +831,7 @@ impl SpecPagedCache for Gemma4SpecPagedCache<'_> {
         })?;
         self.0
             .settle_grouped_kv_step_at(seq_id, committed)
-            .map_err(|error| error.reason)
+            .map_err(|error| error.reason.clone())
     }
 
     fn settle_captures_durable_state(&self) -> bool {
@@ -2268,11 +2268,11 @@ impl Gemma4Inner {
                 let total_ple_dim = (num_layers as i32) * ple_dim;
                 Some(PleComponents {
                     embed_tokens_per_layer: Embedding::new(vocab_ple as u32, total_ple_dim as u32)?,
-                    per_layer_model_projection: Linear::new(
+                    per_layer_model_projection: LinearProj::Standard(Linear::new(
                         hidden_size,
                         total_ple_dim as u32,
                         Some(false),
-                    )?,
+                    )?),
                     per_layer_projection_norm: RMSNorm::new(
                         ple_dim as u32,
                         Some(config.rms_norm_eps),

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -524,10 +524,11 @@ fn validate_required_weights(
         let attn = format!("{}.self_attn", prefix);
         let mlp = format!("{}.mlp", prefix);
 
-        // Attention projections always required
+        // Q/O projections are always required. KV-shared layers reuse both K
+        // and V from an earlier anchor and legitimately omit their own
+        // projections from the checkpoint.
         let attn_keys = [
             format!("{}.q_proj.weight", attn),
-            format!("{}.k_proj.weight", attn),
             format!("{}.o_proj.weight", attn),
         ];
         for key in &attn_keys {
@@ -539,9 +540,21 @@ fn validate_required_weights(
             }
         }
 
-        // v_proj required when this layer does not use k_eq_v
+        let is_kv_shared = config.is_kv_shared_layer(i);
+        if !is_kv_shared {
+            let key = format!("{}.k_proj.weight", attn);
+            if !has(&key) {
+                return Err(Error::from_reason(format!(
+                    "Missing required weight: {}",
+                    key
+                )));
+            }
+        }
+
+        // v_proj is required only when the layer owns its KV and does not use
+        // K=V sharing within the attention projection itself.
         let layer_k_eq_v = config.attention_k_eq_v && config.is_global_layer(i);
-        if !layer_k_eq_v {
+        if !is_kv_shared && !layer_k_eq_v {
             let key = format!("{}.v_proj.weight", attn);
             if !has(&key) {
                 return Err(Error::from_reason(format!(
@@ -4437,6 +4450,85 @@ mod tests {
             format!("{err}").contains("layers.0.mlp.gate_proj.weight"),
             "error must name the missing .weight, got: {err}"
         );
+    }
+
+    /// Gemma 4 E2B checkpoints store K/V projections only on the physical
+    /// (non-shared) prefix of the decoder. Trailing KV-shared layers retain
+    /// their own Q/O projections but reuse K/V from an earlier same-kind
+    /// anchor, so their absent k_proj/v_proj weights are valid.
+    #[test]
+    fn validate_required_weights_accepts_kv_shared_projection_omissions() {
+        let config: Gemma4Config = serde_json::from_value(serde_json::json!({
+            "vocab_size": 8,
+            "hidden_size": 16,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 16,
+            "intermediate_size": 16,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 64,
+            "layer_types": ["sliding_attention", "sliding_attention"],
+            "num_kv_shared_layers": 1,
+            "attention_k_eq_v": false
+        }))
+        .expect("minimal KV-shared Gemma4Config");
+        assert_eq!(config.first_kv_shared_layer(), 1);
+
+        let dummy = || MxArray::from_float32(&[0.0], &[1]).expect("dummy");
+        let full = || -> HashMap<String, MxArray> {
+            let mut params = HashMap::new();
+            for key in ["embed_tokens.weight", "norm.weight"] {
+                params.insert(key.to_string(), dummy());
+            }
+            for layer in 0..2 {
+                for suffix in [
+                    "self_attn.q_proj.weight",
+                    "self_attn.o_proj.weight",
+                    "self_attn.q_norm.weight",
+                    "layer_scalar",
+                    "mlp.gate_proj.weight",
+                    "mlp.up_proj.weight",
+                    "mlp.down_proj.weight",
+                    "input_layernorm.weight",
+                    "post_attention_layernorm.weight",
+                    "pre_feedforward_layernorm.weight",
+                    "post_feedforward_layernorm.weight",
+                ] {
+                    params.insert(format!("layers.{layer}.{suffix}"), dummy());
+                }
+            }
+            for suffix in [
+                "self_attn.k_proj.weight",
+                "self_attn.v_proj.weight",
+                "self_attn.k_norm.weight",
+            ] {
+                params.insert(format!("layers.0.{suffix}"), dummy());
+            }
+            params
+        };
+
+        let params = full();
+        assert!(!params.contains_key("layers.1.self_attn.k_proj.weight"));
+        assert!(!params.contains_key("layers.1.self_attn.v_proj.weight"));
+        validate_required_weights(&params, &config)
+            .expect("a KV-shared layer may omit its own K/V projections");
+
+        for missing in [
+            "layers.0.self_attn.k_proj.weight",
+            "layers.0.self_attn.v_proj.weight",
+            "layers.1.self_attn.q_proj.weight",
+        ] {
+            let mut params = full();
+            params.remove(missing);
+            let err = validate_required_weights(&params, &config)
+                .expect_err("owned K/V and every layer's Q projection remain mandatory");
+            assert!(
+                format!("{err}").contains(missing),
+                "error must name {missing}, got: {err}"
+            );
+        }
     }
 
     /// An untied Gemma4 checkpoint that carries `lm_head.scales` (and

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -491,7 +491,7 @@ fn parse_eos_token_ids(value: &Value) -> Vec<i32> {
 ///
 /// Exhaustively checks embed_tokens, final norm, and per-layer attention + MLP weights,
 /// including o_proj, up_proj, down_proj, all 4 norms, v_proj (when !k_eq_v),
-/// and MoE weights (when enabled).
+/// PLE components (when enabled), and MoE weights (when enabled).
 ///
 /// Quantized variants are NOT special-cased: every quant format this loader
 /// understands (affine, mxfp4/mxfp8, nvfp4, sym8) stores its payload under
@@ -516,6 +516,19 @@ fn validate_required_weights(
     }
     if !has("norm.weight") {
         return Err(Error::from_reason("Missing required weight: norm.weight"));
+    }
+    if config.per_layer_input_embeds {
+        for key in [
+            "embed_tokens_per_layer.weight",
+            "per_layer_model_projection.weight",
+            "per_layer_projection_norm.weight",
+        ] {
+            if !has(key) {
+                return Err(Error::from_reason(format!(
+                    "Missing required weight: {key}"
+                )));
+            }
+        }
     }
 
     // Per-layer required weights
@@ -618,6 +631,21 @@ fn validate_required_weights(
                     "Missing required weight: {}",
                     key
                 )));
+            }
+        }
+
+        if config.per_layer_input_embeds {
+            for suffix in [
+                "per_layer_input_gate.weight",
+                "per_layer_projection.weight",
+                "post_per_layer_input_norm.weight",
+            ] {
+                let key = format!("{prefix}.{suffix}");
+                if !has(&key) {
+                    return Err(Error::from_reason(format!(
+                        "Missing required weight: {key}"
+                    )));
+                }
             }
         }
 
@@ -1634,11 +1662,13 @@ fn apply_weights(
                 ple.embed_tokens_per_layer.load_weight(w)?;
                 info!("PLE embed_tokens_per_layer loaded");
             }
-            if let Some(w) = params.get("per_layer_model_projection.weight") {
-                // Quantizable linear (convert keeps it bf16 today) — cheap
-                // in-class dtype guard.
+            if let Some(ql) = try_build_ql("per_layer_model_projection")? {
+                ple.per_layer_model_projection.set_quantized(ql);
+                info!("PLE per_layer_model_projection loaded (quantized)");
+            } else if let Some(w) = params.get("per_layer_model_projection.weight") {
                 ensure_dense_weight_floating("per_layer_model_projection.weight", w)?;
-                ple.per_layer_model_projection.set_weight(w)?;
+                ple.per_layer_model_projection
+                    .set_weight(w, "per_layer_model_projection")?;
                 info!("PLE per_layer_model_projection loaded");
             }
             if let Some(w) = params.get("per_layer_projection_norm.weight") {
@@ -1809,22 +1839,21 @@ fn apply_weights(
             layer.set_layer_scalar(w)?;
         }
 
-        // PLE per-layer weights. The two PLE linears are quantizable
-        // projections (convert keeps them bf16 today) — cheap in-class
-        // dtype guards; the norm below is never quantized.
+        // PLE per-layer weights. The projections may be quantized independently;
+        // the norm below remains dense.
         if layer.has_ple() {
-            if let Some(w) = params.get(&format!("{}.per_layer_input_gate.weight", prefix)) {
-                ensure_dense_weight_floating(
-                    &format!("{}.per_layer_input_gate.weight", prefix),
-                    w,
-                )?;
+            let gate_prefix = format!("{}.per_layer_input_gate", prefix);
+            if let Some(ql) = try_build_ql(&gate_prefix)? {
+                layer.set_per_layer_input_gate_quantized(ql)?;
+            } else if let Some(w) = params.get(&format!("{}.weight", gate_prefix)) {
+                ensure_dense_weight_floating(&format!("{}.weight", gate_prefix), w)?;
                 layer.set_per_layer_input_gate_weight(w)?;
             }
-            if let Some(w) = params.get(&format!("{}.per_layer_projection.weight", prefix)) {
-                ensure_dense_weight_floating(
-                    &format!("{}.per_layer_projection.weight", prefix),
-                    w,
-                )?;
+            let projection_prefix = format!("{}.per_layer_projection", prefix);
+            if let Some(ql) = try_build_ql(&projection_prefix)? {
+                layer.set_per_layer_projection_quantized(ql)?;
+            } else if let Some(w) = params.get(&format!("{}.weight", projection_prefix)) {
+                ensure_dense_weight_floating(&format!("{}.weight", projection_prefix), w)?;
                 layer.set_per_layer_projection_weight(w)?;
             }
             if let Some(w) = params.get(&format!("{}.post_per_layer_input_norm.weight", prefix)) {
@@ -4531,6 +4560,85 @@ mod tests {
         }
     }
 
+    #[test]
+    fn validate_required_weights_fails_closed_for_ple() {
+        let make_config = |ple: bool| -> Gemma4Config {
+            serde_json::from_value(serde_json::json!({
+                "vocab_size": 8,
+                "hidden_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 1,
+                "num_key_value_heads": 1,
+                "head_dim": 16,
+                "intermediate_size": 16,
+                "rms_norm_eps": 1e-6,
+                "tie_word_embeddings": true,
+                "max_position_embeddings": 64,
+                "per_layer_input_embeds": ple,
+                "hidden_size_per_layer_input": if ple { Some(8) } else { None },
+                "vocab_size_per_layer_input": if ple { Some(8) } else { None }
+            }))
+            .expect("minimal Gemma4Config")
+        };
+        let dummy = || MxArray::from_float32(&[0.0], &[1]).expect("dummy");
+        let full = || -> HashMap<String, MxArray> {
+            let mut params = HashMap::new();
+            for key in [
+                "embed_tokens.weight",
+                "norm.weight",
+                "embed_tokens_per_layer.weight",
+                "per_layer_model_projection.weight",
+                "per_layer_projection_norm.weight",
+                "layers.0.self_attn.q_proj.weight",
+                "layers.0.self_attn.k_proj.weight",
+                "layers.0.self_attn.v_proj.weight",
+                "layers.0.self_attn.o_proj.weight",
+                "layers.0.self_attn.q_norm.weight",
+                "layers.0.self_attn.k_norm.weight",
+                "layers.0.layer_scalar",
+                "layers.0.mlp.gate_proj.weight",
+                "layers.0.mlp.up_proj.weight",
+                "layers.0.mlp.down_proj.weight",
+                "layers.0.input_layernorm.weight",
+                "layers.0.post_attention_layernorm.weight",
+                "layers.0.pre_feedforward_layernorm.weight",
+                "layers.0.post_feedforward_layernorm.weight",
+                "layers.0.per_layer_input_gate.weight",
+                "layers.0.per_layer_projection.weight",
+                "layers.0.post_per_layer_input_norm.weight",
+            ] {
+                params.insert(key.to_string(), dummy());
+            }
+            params
+        };
+
+        let ple_config = make_config(true);
+        validate_required_weights(&full(), &ple_config)
+            .expect("complete PLE checkpoint must validate");
+        for missing in [
+            "embed_tokens_per_layer.weight",
+            "per_layer_model_projection.weight",
+            "per_layer_projection_norm.weight",
+            "layers.0.per_layer_input_gate.weight",
+            "layers.0.per_layer_projection.weight",
+            "layers.0.post_per_layer_input_norm.weight",
+        ] {
+            let mut params = full();
+            params.remove(missing);
+            let err = validate_required_weights(&params, &ple_config)
+                .expect_err("every enabled PLE component must be required");
+            assert!(
+                format!("{err}").contains(missing),
+                "error must name {missing}, got: {err}"
+            );
+        }
+
+        let mut non_ple = full();
+        non_ple.retain(|key, _| !key.contains("per_layer"));
+        validate_required_weights(&non_ple, &make_config(false))
+            .expect("non-PLE checkpoints must not require PLE weights");
+    }
+
     /// An untied Gemma4 checkpoint that carries `lm_head.scales` (and
     /// `.biases`) but NO `lm_head.weight` must be rejected by both
     /// `validate_required_weights` and `apply_weights`; a tied checkpoint
@@ -4942,6 +5050,196 @@ mod tests {
                 inner.lm_head.is_none(),
                 "tied lm_head must remain None when tie_word_embeddings=true"
             );
+        }
+    }
+
+    #[test]
+    fn ple_projections_install_quantized_and_dense_weights() {
+        use super::super::quantized_linear::LinearProj;
+
+        let config: Gemma4Config = serde_json::from_value(serde_json::json!({
+            "vocab_size": 8,
+            "hidden_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 64,
+            "intermediate_size": 64,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 64,
+            "use_block_paged_cache": false,
+            "per_layer_input_embeds": true,
+            "hidden_size_per_layer_input": 32,
+            "vocab_size_per_layer_input": 8
+        }))
+        .expect("minimal PLE Gemma4Config");
+
+        let packed = |rows: i64, cols: i64| {
+            MxArray::from_float32(&vec![0.0f32; (rows * cols) as usize], &[rows, cols])
+                .expect("from_float32")
+                .astype(DType::Uint32)
+                .expect("uint32")
+        };
+        let bf16 = |rows: i64, cols: i64, value: f32| {
+            MxArray::from_float32(&vec![value; (rows * cols) as usize], &[rows, cols])
+                .expect("from_float32")
+                .astype(DType::BFloat16)
+                .expect("bf16")
+        };
+        let groups = [
+            ("per_layer_model_projection", 32, 8, 2),
+            ("layers.0.per_layer_input_gate", 32, 8, 2),
+            ("layers.0.per_layer_projection", 64, 4, 1),
+        ];
+
+        let mut quantized = HashMap::new();
+        for (prefix, rows, packed_cols, sidecar_cols) in groups {
+            quantized.insert(format!("{prefix}.weight"), packed(rows, packed_cols));
+            quantized.insert(format!("{prefix}.scales"), bf16(rows, sidecar_cols, 0.5));
+            quantized.insert(format!("{prefix}.biases"), bf16(rows, sidecar_cols, 0.0));
+        }
+
+        let mut inner = Gemma4Inner::new(config.clone()).expect("Gemma4Inner::new");
+        apply_weights(
+            &mut inner,
+            &quantized,
+            &config,
+            4,
+            32,
+            Some(PerLayerMode::Affine),
+            &HashMap::new(),
+        )
+        .expect("all quantized PLE projections must load");
+        assert!(matches!(
+            inner.ple.as_ref().expect("PLE").per_layer_model_projection,
+            LinearProj::Quantized(_)
+        ));
+        assert_eq!(
+            inner.layers[0].ple_projections_are_quantized(),
+            (true, true)
+        );
+        let input = bf16(1, 64, 1.0);
+        let output = inner
+            .ple
+            .as_ref()
+            .expect("PLE")
+            .per_layer_model_projection
+            .forward(&input)
+            .expect("quantized model-level PLE projection forward");
+        assert_eq!(output.shape().expect("shape").as_ref(), &[1, 32]);
+
+        let dense = HashMap::from([
+            (
+                "per_layer_model_projection.weight".to_string(),
+                bf16(32, 64, 0.01),
+            ),
+            (
+                "layers.0.per_layer_input_gate.weight".to_string(),
+                bf16(32, 64, 0.01),
+            ),
+            (
+                "layers.0.per_layer_projection.weight".to_string(),
+                bf16(64, 32, 0.01),
+            ),
+        ]);
+        let mut inner = Gemma4Inner::new(config.clone()).expect("Gemma4Inner::new");
+        apply_weights(
+            &mut inner,
+            &dense,
+            &config,
+            4,
+            32,
+            Some(PerLayerMode::Affine),
+            &HashMap::new(),
+        )
+        .expect("dense PLE projections must remain supported");
+        assert!(matches!(
+            inner.ple.as_ref().expect("PLE").per_layer_model_projection,
+            LinearProj::Standard(_)
+        ));
+        assert_eq!(
+            inner.layers[0].ple_projections_are_quantized(),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn ple_quantized_projection_sidecars_fail_closed() {
+        use crate::models::quant_dispatch::SYMMETRIC_ZERO_POINT_KEY;
+
+        let config: Gemma4Config = serde_json::from_value(serde_json::json!({
+            "vocab_size": 8,
+            "hidden_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 1,
+            "num_key_value_heads": 1,
+            "head_dim": 64,
+            "intermediate_size": 64,
+            "rms_norm_eps": 1e-6,
+            "tie_word_embeddings": true,
+            "max_position_embeddings": 64,
+            "use_block_paged_cache": false,
+            "per_layer_input_embeds": true,
+            "hidden_size_per_layer_input": 32,
+            "vocab_size_per_layer_input": 8
+        }))
+        .expect("minimal PLE Gemma4Config");
+        let packed = |rows: i64, cols: i64| {
+            MxArray::from_float32(&vec![0.0f32; (rows * cols) as usize], &[rows, cols])
+                .expect("from_float32")
+                .astype(DType::Uint32)
+                .expect("uint32")
+        };
+        let sidecar = |rows: i64, cols: i64| {
+            MxArray::from_float32(&vec![0.5f32; (rows * cols) as usize], &[rows, cols])
+                .expect("from_float32")
+                .astype(DType::BFloat16)
+                .expect("bf16")
+        };
+
+        for (prefix, rows, packed_cols, sidecar_cols) in [
+            ("per_layer_model_projection", 32, 8, 2),
+            ("layers.0.per_layer_input_gate", 32, 8, 2),
+            ("layers.0.per_layer_projection", 64, 4, 1),
+        ] {
+            let truncated = HashMap::from([
+                (format!("{prefix}.weight"), packed(rows, packed_cols)),
+                (format!("{prefix}.biases"), sidecar(rows, sidecar_cols)),
+            ]);
+            let mut inner = Gemma4Inner::new(config.clone()).expect("Gemma4Inner::new");
+            let err = apply_weights(
+                &mut inner,
+                &truncated,
+                &config,
+                4,
+                32,
+                Some(PerLayerMode::Affine),
+                &HashMap::new(),
+            )
+            .expect_err("packed PLE weight without scales must fail loud");
+            let message = format!("{err}");
+            assert!(message.contains(prefix), "got: {message}");
+            assert!(message.contains("non-float dtype"), "got: {message}");
+
+            let missing_bias = HashMap::from([
+                (format!("{prefix}.weight"), packed(rows, packed_cols)),
+                (format!("{prefix}.scales"), sidecar(rows, sidecar_cols)),
+            ]);
+            let mut inner = Gemma4Inner::new(config.clone()).expect("Gemma4Inner::new");
+            let err = apply_weights(
+                &mut inner,
+                &missing_bias,
+                &config,
+                4,
+                32,
+                Some(PerLayerMode::Affine),
+                &HashMap::new(),
+            )
+            .expect_err("affine PLE weight without biases must fail loud");
+            let message = format!("{err}");
+            assert!(message.contains(prefix), "got: {message}");
+            assert!(message.contains(SYMMETRIC_ZERO_POINT_KEY), "got: {message}");
         }
     }
 

--- a/crates/mlx-core/src/models/nemotron_h/model.rs
+++ b/crates/mlx-core/src/models/nemotron_h/model.rs
@@ -3862,7 +3862,11 @@ mod scheduler_tests {
         fn send(&self, chunk: Result<ChatStreamChunk>) {
             match chunk {
                 Ok(chunk) => self.chunks.lock().expect("chunks").push(chunk),
-                Err(error) => self.errors.lock().expect("errors").push(error.reason),
+                Err(error) => self
+                    .errors
+                    .lock()
+                    .expect("errors")
+                    .push(error.reason.clone()),
             }
         }
     }

--- a/crates/mlx-core/src/models/nemotron_h/persistence.rs
+++ b/crates/mlx-core/src/models/nemotron_h/persistence.rs
@@ -1324,7 +1324,8 @@ mod tests {
             let err = load_inner(dir.to_str().unwrap())
                 .err()
                 .unwrap_or_else(|| panic!("{tag}: load_inner must FAIL on this checkpoint"))
-                .reason;
+                .reason
+                .clone();
             let _ = fs::remove_dir_all(&dir);
             err
         };
@@ -1825,7 +1826,7 @@ mod tests {
             per_layer.insert(format!("layers.7.mixer.{proj}"), mxfp8);
             let err = reject_legacy_mxfp8_mamba(&per_layer)
                 .expect_err("an mxfp8 mamba projection must be rejected");
-            let msg = err.reason;
+            let msg = err.reason.clone();
             assert!(msg.contains(&format!("layers.7.mixer.{proj}")), "{msg}");
             assert!(msg.contains("mxfp8"), "{msg}");
             assert!(msg.contains("mlx convert -m nemotron_h"), "{msg}");
@@ -1875,7 +1876,8 @@ mod tests {
         );
         let msg = require_affine_sidecars(&legacy, prefix)
             .expect_err("Uint8 scales are the mxfp8 payload")
-            .reason;
+            .reason
+            .clone();
         assert!(msg.contains("Uint8"), "{msg}");
         assert!(msg.contains("mlx convert -m nemotron_h"), "{msg}");
 
@@ -1884,7 +1886,8 @@ mod tests {
         no_biases.insert(format!("{prefix}.scales"), f_scales.clone());
         let msg = require_affine_sidecars(&no_biases, prefix)
             .expect_err("a missing .biases sidecar must be rejected")
-            .reason;
+            .reason
+            .clone();
         assert!(msg.contains(".biases"), "{msg}");
         assert!(msg.contains("mlx convert -m nemotron_h"), "{msg}");
 
@@ -1900,7 +1903,8 @@ mod tests {
         );
         let msg = require_affine_sidecars(&skewed, prefix)
             .expect_err("a shape-skewed .biases must be rejected")
-            .reason;
+            .reason
+            .clone();
         assert!(msg.contains("must match"), "{msg}");
     }
 
@@ -1927,7 +1931,8 @@ mod tests {
         );
         let msg = apply_nvfp4(&params)
             .expect_err("a BF16 router bias must be rejected")
-            .reason;
+            .reason
+            .clone();
         assert!(msg.contains("e_score_correction_bias"), "{msg}");
         assert!(msg.contains("BF16"), "{msg}");
         assert!(msg.contains("mlx convert -m nemotron_h"), "{msg}");
@@ -1966,7 +1971,8 @@ mod tests {
         let quant_cfg = select_quantization_block(&raw).unwrap();
         let msg = parse_nemotron_quant_settings(quant_cfg)
             .expect_err("input_amax on nvfp4 must be rejected")
-            .reason;
+            .reason
+            .clone();
         assert!(msg.contains("input_amax"), "{msg}");
 
         assert!(admits_static_fp8_activation(PerLayerMode::Affine, 8, 32));


### PR DESCRIPTION
## Summary

- accept omitted K/V projections on decoder layers configured to share KV with an earlier anchor
- load the model-level and per-layer PLE projections through the existing dense-or-quantized linear path
- require every enabled PLE component and fail closed on incomplete affine sidecars
- keep dense Gemma 4 checkpoints supported
- retain NAPI error reasons by clone so fresh lockless builds compile with napi 3.9.4

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p mlx-core --all-targets -- -D warnings`
- `cargo test -p mlx-core`
- Gemma 4 persistence tests: 49 passed, 1 ignored
- `yarn build:native`
- current cached `mlx-community/gemma-4-e2b-it-4bit` revision: load plus two-turn generation passed
- issue snapshot `99d9a53ff828d365a8ecae538e45f80a08d612cd`: Rust load/generation passed
- issue snapshot through `@mlx-node/lm`: release N-API load plus 8-token `chatSessionStart` generation passed

Fixes #54