### PR TITLE
feat(quant): run Qwen3.8 UD GGUF natively

### DIFF
--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -3741,6 +3741,13 @@ export declare function getMemorySnapshot(): GpuMemorySnapshot;
 /** Retrieve all collected profiling data as a `ProfilingSession`. */
 export declare function getProfilingData(): ProfilingSession;
 
+/**
+ * Read the architecture declared by a GGUF header without loading any tensor
+ * payloads. This is the model-family detection seam for standalone GGUF files
+ * that intentionally do not ship a sibling `config.json`.
+ */
+export declare function ggufArchitecture(inputPath: string): string;
+
 export interface GgufConversionOptions {
   /** Path to the GGUF file */
   inputPath: string;

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -1415,6 +1415,12 @@ export declare class QianfanOCRModel {
  */
 export declare class Qwen35Model {
   /**
+   * Resolved directory containing this model's tokenizer/config assets.
+   * Streaming wrappers use it after a direct GGUF load so chat templating
+   * reads the reconstructed sidecars from the native-packed cache.
+   */
+  modelAssetsPath(): string;
+  /**
    * Whether the block-paged KV cache adapter is active on this model
    * instance.
    *
@@ -3792,13 +3798,19 @@ export interface GgufConversionOptions {
    */
   quantMxfp?: boolean;
   /**
-   * Import ggml Q4_K / Q5_K / Q6_K tensors as MLX K-quant arrays instead of
+   * Import supported ggml K/IQ tensors as native MLX packed arrays instead of
    * rejecting them (default: false). The blocks are repacked, never
    * dequantized, so the output keeps the source file's weights and byte size.
    * With this off, Q6_K remains the Gemma4 token-embedding BF16 fallback and
    * Q4_K / Q5_K are an error.
    */
   importKQuants?: boolean;
+  /**
+   * Preserve Qwen3.5/3.8 GGUF GDN tensors in llama.cpp's tiled value-head
+   * order. The runtime consumes this layout directly and avoids any packed
+   * weight permutation. Intended for native GGUF execution.
+   */
+  nativeQwen35Layout?: boolean;
 }
 
 export interface GgufConversionResult {
@@ -4739,6 +4751,12 @@ export interface Qwen35Config {
    * unavailable.
    */
   nMtpLayers: number;
+  /**
+   * Internal layout marker written by native Qwen3.5/3.8 GGUF conversion.
+   * `Some("tiled")` keeps llama.cpp's value-head order and lets GDN map
+   * value head h to key head h % Hk without permuting packed weights.
+   */
+  qwen35GgufGdnLayout?: string | undefined;
 }
 
 /**

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -4881,6 +4881,13 @@ export interface Qwen35MoeConfig {
    * unavailable.
    */
   nMtpLayers: number;
+  /**
+   * Internal layout marker written by native Qwen3.5/3.8 GGUF conversion.
+   * `Some("tiled")` keeps llama.cpp's value-head order and lets the shared
+   * GDN runtime map value head h to key head h % Hk without permuting
+   * packed weights.
+   */
+  qwen35GgufGdnLayout?: string | undefined;
 }
 
 /** Generation configuration for Qwen3.5 MoE */

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -3800,7 +3800,8 @@ export interface GgufConversionOptions {
   /**
    * Import supported ggml K/IQ tensors as native MLX packed arrays instead of
    * rejecting them (default: false). The blocks are repacked, never
-   * dequantized, so the output keeps the source file's weights and byte size.
+   * dequantized, so the output preserves the source quantized values. IQ3_S
+   * expands only its integer grid/sign encoding to signed 8-bit codes.
    * With this off, Q6_K remains the Gemma4 token-embedding BF16 fallback and
    * Q4_K / Q5_K are an error.
    */

--- a/crates/mlx-core/src/convert.rs
+++ b/crates/mlx-core/src/convert.rs
@@ -380,7 +380,11 @@ pub(crate) mod recipe {
             | PerLayerMode::Sym8
             | PerLayerMode::Q6K
             | PerLayerMode::Q4K
-            | PerLayerMode::Q5K => {
+            | PerLayerMode::Q5K
+            | PerLayerMode::Q3K
+            | PerLayerMode::IQ4NL
+            | PerLayerMode::IQ4XS
+            | PerLayerMode::IQ3S => {
                 return Err(Error::from_reason(format!(
                     "Qwen vision source mode {mode:?} is not a uniform packed mode supported by the dense vision sanitizer; dequantize the vision tower before conversion"
                 )));
@@ -7331,11 +7335,15 @@ fn validate_existing_quantized_entry(
         // including the interleave factor of 2 the q4k/q5k `(sc, m)` / `(d, dmin)`
         // pairs carry, so the generic affine shape check below cannot describe
         // them — this arm validates in full and returns.
-        "q4k" | "q5k" | "q6k" => {
+        "q3k" | "q4k" | "q5k" | "q6k" | "iq4nl" | "iq4xs" | "iq3s" => {
             let format = match entry.mode.as_str() {
+                "q3k" => KQuantFormat::Q3K,
                 "q4k" => KQuantFormat::Q4K,
                 "q5k" => KQuantFormat::Q5K,
-                _ => KQuantFormat::Q6K,
+                "q6k" => KQuantFormat::Q6K,
+                "iq4nl" => KQuantFormat::IQ4NL,
+                "iq4xs" => KQuantFormat::IQ4XS,
+                _ => KQuantFormat::IQ3S,
             };
             validate_existing_kquant_entry(weight, scales, weights, prefix, entry, format)?;
             return Ok(());
@@ -7484,10 +7492,11 @@ fn validate_existing_kquant_entry(
         )));
     }
     let k = weight_cols * 32 / bits;
-    if k % QK_K as i64 != 0 {
+    if k % format.block_size() as i64 != 0 {
         return Err(Error::from_reason(format!(
             "already-quantized {mode} group '{prefix}' decodes to K={k}, not a multiple of the \
-             {QK_K}-value ggml super-block"
+             {}-value ggml block",
+            format.block_size(),
         )));
     }
     let k = k as usize;
@@ -7530,11 +7539,13 @@ fn quant_entry_emits(array: &MxArray, mode: &str, group_size: i32) -> Result<boo
         ndim == 2 || ndim == 3
     } else if mode == "sym8" {
         last_dim % 16 == 0
-    } else if matches!(mode, "q4k" | "q5k" | "q6k") {
+    } else if matches!(mode, "q3k" | "q4k" | "q5k" | "q6k" | "iq4xs" | "iq3s") {
         // K-quants are packed in 256-value ggml super-blocks; the sub-scale
         // group_size (16 or 32) is a within-block subdivision, so the emission
         // gate is the super-block, not the group.
         last_dim % (QK_K as i32) == 0
+    } else if mode == "iq4nl" {
+        last_dim % 32 == 0
     } else {
         last_dim % group_size == 0
     })
@@ -12790,7 +12801,7 @@ mod tests {
     }
 
     /// The same guard covers a `--gguf-kquant` import directory, whose config
-    /// carries `mode: q4k/q5k/q6k` plus a per-tensor entry for every K-quant
+    /// carries the native packed `mode` plus a per-tensor entry for every K/IQ
     /// group. Bare `-q` would replace all of it with affine/4/64 while leaving
     /// ggml's packed blocks on disk untouched.
     ///

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -2771,6 +2771,7 @@ mod tests {
 
     fn tiny_config() -> Qwen3_5Config {
         Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 1024,
             hidden_size: 64,
             num_layers: 8,

--- a/crates/mlx-core/src/engine/hybrid_scheduler.rs
+++ b/crates/mlx-core/src/engine/hybrid_scheduler.rs
@@ -2838,6 +2838,7 @@ mod tests {
             use_block_paged_cache: None,
             persist_paged_cache: None,
             n_mtp_layers: 0,
+            qwen35_gguf_gdn_layout: None,
         }
     }
 

--- a/crates/mlx-core/src/models/gemma4/persistence.rs
+++ b/crates/mlx-core/src/models/gemma4/persistence.rs
@@ -1330,7 +1330,13 @@ fn resolve_packed_embed_params<'a>(
                 biases,
             })
         }
-        PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
+        PerLayerMode::Q6K
+        | PerLayerMode::Q4K
+        | PerLayerMode::Q5K
+        | PerLayerMode::Q3K
+        | PerLayerMode::IQ4NL
+        | PerLayerMode::IQ4XS
+        | PerLayerMode::IQ3S => {
             // Real gemma4 UD GGUFs ship `token_embd` as a K-quant (e.g. Q6_K).
             // A K-quant group is a uint32 `.weight`, integer sub-block `.scales`
             // (int8 for Q6_K, uint8 for Q4_K/Q5_K), and a MANDATORY float16
@@ -1412,7 +1418,13 @@ fn build_gemma_ql(
             try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
         }
         PerLayerMode::Sym8 => try_build_sym8_quantized_linear(params, prefix)?,
-        PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
+        PerLayerMode::Q6K
+        | PerLayerMode::Q4K
+        | PerLayerMode::Q5K
+        | PerLayerMode::Q3K
+        | PerLayerMode::IQ4NL
+        | PerLayerMode::IQ4XS
+        | PerLayerMode::IQ3S => {
             try_build_kquant_quantized_linear(params, prefix, plq.mode, "gemma4")?
         }
     })
@@ -1441,7 +1453,13 @@ fn build_gemma_qsl(
         PerLayerMode::Affine => {
             try_build_quantized_switch_linear(params, prefix, plq.group_size, plq.bits)
         }
-        PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
+        PerLayerMode::Q6K
+        | PerLayerMode::Q4K
+        | PerLayerMode::Q5K
+        | PerLayerMode::Q3K
+        | PerLayerMode::IQ4NL
+        | PerLayerMode::IQ4XS
+        | PerLayerMode::IQ3S => {
             try_build_kquant_quantized_switch_linear(params, prefix, plq.mode, "gemma4")?
         }
         PerLayerMode::Sym8 => {

--- a/crates/mlx-core/src/models/lfm2/persistence.rs
+++ b/crates/mlx-core/src/models/lfm2/persistence.rs
@@ -70,7 +70,13 @@ fn build_lfm2_qsl(
         PerLayerMode::Affine => {
             try_build_quantized_switch_linear(params, prefix, plq.group_size, plq.bits)
         }
-        PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
+        PerLayerMode::Q6K
+        | PerLayerMode::Q4K
+        | PerLayerMode::Q5K
+        | PerLayerMode::Q3K
+        | PerLayerMode::IQ4NL
+        | PerLayerMode::IQ4XS
+        | PerLayerMode::IQ3S => {
             try_build_kquant_quantized_switch_linear(params, prefix, plq.mode, "lfm2_moe")?
         }
         // FAIL-LOUD: the 3-D stacked experts have no sym8 dispatch
@@ -123,7 +129,13 @@ fn build_lfm2_gate_ql(
         PerLayerMode::Affine => {
             try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
         }
-        PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
+        PerLayerMode::Q6K
+        | PerLayerMode::Q4K
+        | PerLayerMode::Q5K
+        | PerLayerMode::Q3K
+        | PerLayerMode::IQ4NL
+        | PerLayerMode::IQ4XS
+        | PerLayerMode::IQ3S => {
             try_build_kquant_quantized_linear(params, prefix, plq.mode, "lfm2_moe")?
         }
         // FAIL-LOUD: the router gate is deliberately kept affine-8 by convert
@@ -182,9 +194,13 @@ fn build_lfm2_non_moe_ql(
         }
         PerLayerMode::Affine => try_build_quantized_linear(params, base, plq.group_size, plq.bits),
         PerLayerMode::Sym8 => try_build_sym8_quantized_linear(params, base)?,
-        PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
-            try_build_kquant_quantized_linear(params, base, plq.mode, "lfm2")?
-        }
+        PerLayerMode::Q6K
+        | PerLayerMode::Q4K
+        | PerLayerMode::Q5K
+        | PerLayerMode::Q3K
+        | PerLayerMode::IQ4NL
+        | PerLayerMode::IQ4XS
+        | PerLayerMode::IQ3S => try_build_kquant_quantized_linear(params, base, plq.mode, "lfm2")?,
     })
 }
 
@@ -357,7 +373,13 @@ fn plq_to_packed_params(plq: PerLayerQuant, ctx: &str) -> Result<(i32, i32, &'st
                  default), so this checkpoint is malformed; refusing to load"
             )));
         }
-        PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
+        PerLayerMode::Q6K
+        | PerLayerMode::Q4K
+        | PerLayerMode::Q5K
+        | PerLayerMode::Q3K
+        | PerLayerMode::IQ4NL
+        | PerLayerMode::IQ4XS
+        | PerLayerMode::IQ3S => {
             return Err(Error::from_reason(format!(
                 "lfm2: '{ctx}' resolved to K-quant ({:?}), but the packed embedding / \
                  quant-info path does not support ggml K-quants — a K-quant GGUF import keeps \

--- a/crates/mlx-core/src/models/muse_glimmer/persistence.rs
+++ b/crates/mlx-core/src/models/muse_glimmer/persistence.rs
@@ -82,7 +82,13 @@ pub(super) fn build_projection(
                 try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
             }
             PerLayerMode::Sym8 => try_build_sym8_quantized_linear(params, prefix)?,
-            PerLayerMode::Q4K | PerLayerMode::Q5K | PerLayerMode::Q6K => {
+            PerLayerMode::Q4K
+            | PerLayerMode::Q5K
+            | PerLayerMode::Q6K
+            | PerLayerMode::Q3K
+            | PerLayerMode::IQ4NL
+            | PerLayerMode::IQ4XS
+            | PerLayerMode::IQ3S => {
                 try_build_kquant_quantized_linear(params, prefix, plq.mode, "muse_glimmer")?
             }
         }

--- a/crates/mlx-core/src/models/quant_dispatch.rs
+++ b/crates/mlx-core/src/models/quant_dispatch.rs
@@ -143,6 +143,18 @@ pub enum PerLayerMode {
     /// ggml Q5_K: identical layout to `Q4K` with a 5-bit weight plane. Mode
     /// string `"q5k"`.
     Q5K,
+    /// ggml Q3_K: 3-bit symmetric 256-value super-block with signed int8
+    /// sub-scales. Codes stay packed at three bits and are decoded in-kernel.
+    Q3K,
+    /// ggml IQ4_NL: 4-bit indices into ggml's non-linear 16-value grid, with
+    /// one float16 scale per 32-value block.
+    IQ4NL,
+    /// ggml IQ4_XS: IQ4_NL codes with signed sub-scales under a 256-value
+    /// float16 super-scale.
+    IQ4XS,
+    /// ggml IQ3_S: grid/sign codes losslessly expanded to signed integer
+    /// magnitudes and packed at eight bits; no floating weight is materialized.
+    IQ3S,
 }
 
 /// Per-layer quantization metadata parsed from `config.json`.
@@ -187,6 +199,10 @@ pub fn parse_mode_str(s: Option<&str>) -> Option<PerLayerMode> {
         Some("q6k") => Some(PerLayerMode::Q6K),
         Some("q4k") => Some(PerLayerMode::Q4K),
         Some("q5k") => Some(PerLayerMode::Q5K),
+        Some("q3k") => Some(PerLayerMode::Q3K),
+        Some("iq4nl") => Some(PerLayerMode::IQ4NL),
+        Some("iq4xs") => Some(PerLayerMode::IQ4XS),
+        Some("iq3s") => Some(PerLayerMode::IQ3S),
         _ => None,
     }
 }
@@ -217,14 +233,24 @@ pub(crate) fn mode_to_str(mode: PerLayerMode) -> &'static str {
         PerLayerMode::Q6K => "q6k",
         PerLayerMode::Q4K => "q4k",
         PerLayerMode::Q5K => "q5k",
+        PerLayerMode::Q3K => "q3k",
+        PerLayerMode::IQ4NL => "iq4nl",
+        PerLayerMode::IQ4XS => "iq4xs",
+        PerLayerMode::IQ3S => "iq3s",
     }
 }
 
-/// True when `mode` is one of the ggml K-quant families (Q6_K / Q4_K / Q5_K).
+/// True when `mode` is one of the supported ggml K/IQ packed families.
 pub fn is_kquant_mode(mode: PerLayerMode) -> bool {
     matches!(
         mode,
-        PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K
+        PerLayerMode::Q6K
+            | PerLayerMode::Q4K
+            | PerLayerMode::Q5K
+            | PerLayerMode::Q3K
+            | PerLayerMode::IQ4NL
+            | PerLayerMode::IQ4XS
+            | PerLayerMode::IQ3S
     )
 }
 
@@ -250,15 +276,8 @@ pub fn has_sym8_mode(
         || per_layer.values().any(|p| p.mode == PerLayerMode::Sym8)
 }
 
-/// True when the resolved quantization settings reference a ggml K-quant mode
-/// (Q6_K / Q4_K / Q5_K) anywhere — top-level default OR any per-layer override.
-///
-/// Used by the LM loaders to scope-gate a K-quant checkpoint the same way
-/// `has_sym8_mode` scopes sym8: the speculative MTP head is disabled (the MTP
-/// builders map every K-quant mode to `None`, and an imported GGUF never ships
-/// an MTP head), so the loader fail-softs to plain AR decode. K-quants pack
-/// their weights as uint32 like affine, so — unlike sym8 — the paged KV cache
-/// and vision encoders stay supported.
+/// True when the resolved quantization settings reference a supported ggml
+/// K/IQ packed mode anywhere — top-level default or a per-layer override.
 pub fn has_kquant_mode(
     top_level_mode: Option<PerLayerMode>,
     per_layer: &HashMap<String, PerLayerQuant>,
@@ -455,6 +474,10 @@ pub(crate) fn kquant_mode_params(mode: PerLayerMode) -> Option<(&'static str, i3
         PerLayerMode::Q6K => Some(("q6k", 6, 16, DType::Int8)),
         PerLayerMode::Q4K => Some(("q4k", 4, 32, DType::Uint8)),
         PerLayerMode::Q5K => Some(("q5k", 5, 32, DType::Uint8)),
+        PerLayerMode::Q3K => Some(("q3k", 3, 16, DType::Int8)),
+        PerLayerMode::IQ4NL => Some(("iq4nl", 4, 32, DType::Int8)),
+        PerLayerMode::IQ4XS => Some(("iq4xs", 4, 32, DType::Int8)),
+        PerLayerMode::IQ3S => Some(("iq3s", 8, 32, DType::Int8)),
         _ => None,
     }
 }
@@ -597,7 +620,8 @@ fn parse_explicit_mode(value: Option<&Value>, context: &str) -> Result<Option<Pe
     parse_mode_str(Some(mode)).map(Some).ok_or_else(|| {
         Error::from_reason(format!(
             "Unknown quantization mode '{mode}' at {context}; supported modes are affine, \
-             mxfp4, mxfp8, nvfp4, fp8_e4m3, sym8, q6k, q4k, and q5k"
+             mxfp4, mxfp8, nvfp4, fp8_e4m3, sym8, q3k, q4k, q5k, q6k, \
+             iq4nl, iq4xs, and iq3s"
         ))
     })
 }
@@ -654,12 +678,16 @@ fn parse_i32(value: &Value, context: &str) -> Result<i32> {
 fn parse_bits(value: &Value, mode: Option<PerLayerMode>, context: &str) -> Result<i32> {
     let bits = parse_i32(value, context)?;
     let valid = match mode {
-        Some(PerLayerMode::Mxfp4) | Some(PerLayerMode::Nvfp4) | Some(PerLayerMode::Q4K) => {
-            bits == 4
-        }
-        Some(PerLayerMode::Mxfp8) | Some(PerLayerMode::Fp8E4m3) | Some(PerLayerMode::Sym8) => {
-            bits == 8
-        }
+        Some(PerLayerMode::Mxfp4)
+        | Some(PerLayerMode::Nvfp4)
+        | Some(PerLayerMode::Q4K)
+        | Some(PerLayerMode::IQ4NL)
+        | Some(PerLayerMode::IQ4XS) => bits == 4,
+        Some(PerLayerMode::Mxfp8)
+        | Some(PerLayerMode::Fp8E4m3)
+        | Some(PerLayerMode::Sym8)
+        | Some(PerLayerMode::IQ3S) => bits == 8,
+        Some(PerLayerMode::Q3K) => bits == 3,
         Some(PerLayerMode::Q6K) => bits == 6,
         Some(PerLayerMode::Q5K) => bits == 5,
         Some(PerLayerMode::Affine) | None => matches!(bits, 2 | 3 | 4 | 5 | 6 | 8),
@@ -688,8 +716,12 @@ fn parse_group_size(value: &Value, mode: Option<PerLayerMode>, context: &str) ->
     let valid = match mode {
         Some(PerLayerMode::Mxfp4) | Some(PerLayerMode::Mxfp8) => group_size == 32,
         Some(PerLayerMode::Nvfp4) => group_size == 16,
-        Some(PerLayerMode::Q6K) => group_size == 16,
-        Some(PerLayerMode::Q4K) | Some(PerLayerMode::Q5K) => group_size == 32,
+        Some(PerLayerMode::Q6K) | Some(PerLayerMode::Q3K) => group_size == 16,
+        Some(PerLayerMode::Q4K)
+        | Some(PerLayerMode::Q5K)
+        | Some(PerLayerMode::IQ4NL)
+        | Some(PerLayerMode::IQ4XS)
+        | Some(PerLayerMode::IQ3S) => group_size == 32,
         Some(PerLayerMode::Fp8E4m3) | Some(PerLayerMode::Sym8) => false,
         Some(PerLayerMode::Affine) | None => matches!(group_size, 32 | 64 | 128),
     };
@@ -911,8 +943,18 @@ fn parse_per_layer_entries(
             Some(value) => parse_group_size(value, Some(mode), &format!("{context}.group_size"))?,
             None if matches!(mode, PerLayerMode::Mxfp4 | PerLayerMode::Mxfp8) => 32,
             None if mode == PerLayerMode::Nvfp4 => 16,
-            None if mode == PerLayerMode::Q6K => 16,
-            None if matches!(mode, PerLayerMode::Q4K | PerLayerMode::Q5K) => 32,
+            None if matches!(mode, PerLayerMode::Q6K | PerLayerMode::Q3K) => 16,
+            None if matches!(
+                mode,
+                PerLayerMode::Q4K
+                    | PerLayerMode::Q5K
+                    | PerLayerMode::IQ4NL
+                    | PerLayerMode::IQ4XS
+                    | PerLayerMode::IQ3S
+            ) =>
+            {
+                32
+            }
             None if mode == PerLayerMode::Fp8E4m3 => crate::quant::fp8_weight::FP8_E4M3_GROUP_SIZE,
             None if mode == PerLayerMode::Sym8 => SYM8_GROUP_SIZE_SENTINEL,
             None => {
@@ -1152,6 +1194,10 @@ pub fn merge_per_layer(
             PerLayerMode::Q6K => 8,
             PerLayerMode::Q5K => 7,
             PerLayerMode::Q4K => 6,
+            PerLayerMode::IQ3S => 9,
+            PerLayerMode::IQ4XS => 8,
+            PerLayerMode::IQ4NL => 7,
+            PerLayerMode::Q3K => 6,
             PerLayerMode::Affine => 5,
             PerLayerMode::Fp8E4m3 => 4,
             PerLayerMode::Sym8 => 3,

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -2165,6 +2165,7 @@ mod tests {
 
     fn tiny_cfg() -> Qwen3_5Config {
         Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 32,
             hidden_size: 32,
             num_layers: 1,

--- a/crates/mlx-core/src/models/qwen3_5/attention.rs
+++ b/crates/mlx-core/src/models/qwen3_5/attention.rs
@@ -61,9 +61,9 @@ pub struct Qwen3_5Attention {
     /// fails MLX's `prepare_reshape` free-view check and dispatches a real
     /// strided `copy_gpu_inplace` (`CopyType::General`) Metal kernel on
     /// every call — this cache makes that copy a one-time load-time cost
-    /// instead of a per-forward one. Affine quantized q_proj stores the same
-    /// block order directly in its packed operands instead of using this
-    /// duplicate dense cache; other quantization modes retain the fallback.
+    /// instead of a per-forward one. Affine and native GGUF K/IQ q_proj store
+    /// the same block order directly in their packed operands instead of using
+    /// this duplicate dense cache; other quantization modes retain the fallback.
     q_gate_block_t: Option<MxArray>,
     /// Reordered `[2*num_heads*head_dim]` q_proj bias matching
     /// `q_gate_block_t`'s column order. `None` when q_proj has no bias.
@@ -519,7 +519,7 @@ impl Qwen3_5Attention {
     /// [B,T,H*D])`.
     ///
     /// Fast path (`finalize_q_gate_block()` installed either the dense cache or
-    /// an affine quantized block layout): one projection followed by two flat
+    /// a packed quantized block layout): one projection followed by two flat
     /// `slice_axis` calls. Both halves are already row-contiguous, so queries'
     /// `[B,T,H,D]` reshape is a free view and gate needs no reshape at all.
     /// `MLX_DISABLE_QGATE_BLOCK_SPLIT=1` is sampled by the finalizer at load
@@ -1643,9 +1643,10 @@ impl Qwen3_5Attention {
     /// comment for why the checkpoint's native per-head-interleaved column
     /// order forces a strided copy on every call.
     ///
-    /// Safe to call repeatedly (idempotent). Affine quantized q_proj consumes
-    /// its native-order packed operands and replaces them with materialized
-    /// block-order arrays. Other quantization modes remain on the fallback.
+    /// Safe to call repeatedly (idempotent). Affine and native GGUF K/IQ
+    /// q_proj consume their native-order packed operands and replace them with
+    /// materialized block-order arrays. Other quantization modes remain on the
+    /// fallback.
     pub fn finalize_q_gate_block(&mut self) -> Result<()> {
         self.finalize_q_gate_block_enabled(std::env::var("MLX_DISABLE_QGATE_BLOCK_SPLIT").is_err())
     }
@@ -1658,7 +1659,7 @@ impl Qwen3_5Attention {
         let d = self.head_dim as i64;
 
         if let LinearProj::Quantized(q_lin) = &mut self.q_proj {
-            q_lin.finalize_affine_q_gate_block(self.num_heads, self.head_dim)?;
+            q_lin.finalize_packed_q_gate_block(self.num_heads, self.head_dim)?;
             return Ok(());
         }
 
@@ -2553,6 +2554,103 @@ mod tests {
             block_gate.to_uint16_native()?,
             native_gate.to_uint16_native()?,
             "block-order affine gates must be bit-identical to native per-head splitting"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn q4k_quantized_q_gate_block_matches_native_h4_with_bias() -> Result<()> {
+        use crate::utils::gguf_kquant::{KQuantFormat, KQuantScales, repack_kquant};
+
+        let mut cfg = tiny_cfg();
+        cfg.hidden_size = 256;
+        cfg.head_dim = 32;
+        cfg.num_heads = 4;
+        cfg.num_kv_heads = 2;
+        cfg.intermediate_size = 512;
+        let h = cfg.num_heads as i64;
+        let d = cfg.head_dim as i64;
+        let hidden = cfg.hidden_size as i64;
+        let rows = 2 * h * d;
+        let format = KQuantFormat::Q4K;
+
+        // One deterministic ggml Q4_K block per output row. Repack through the
+        // same importer as a UD GGUF; keep d/dmin small and finite so the M=2
+        // qmv_wide comparison is numerically well-conditioned.
+        let mut state = 0x5147_4b21u64;
+        let mut blocks = (0..rows as usize * format.block_bytes())
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                (state >> 33) as u8
+            })
+            .collect::<Vec<_>>();
+        for row in 0..rows as usize {
+            let base = row * format.block_bytes();
+            blocks[base] = 0x00;
+            blocks[base + 1] = 0x24; // d = f16 0.015625
+            blocks[base + 2] = 0x00;
+            blocks[base + 3] = 0x20; // dmin = f16 0.0078125
+        }
+        let packed = repack_kquant(format, &blocks, rows as usize, hidden as usize)?;
+        let weight = MxArray::from_uint32(
+            &packed.weight,
+            &[rows, format.weight_cols(hidden as usize) as i64],
+        )?;
+        let scales = match &packed.scales {
+            KQuantScales::Unsigned(values) => {
+                MxArray::from_uint8(values, &[rows, format.scales_cols(hidden as usize) as i64])?
+            }
+            KQuantScales::Signed(_) => panic!("Q4_K scales must be unsigned"),
+        };
+        let quant_biases = MxArray::from_float16(
+            &packed.biases,
+            &[rows, format.biases_cols(hidden as usize) as i64],
+        )?;
+        let additive_values = (0..rows)
+            .map(|i| ((i as f32) * 0.031 - 0.2).cos() * 0.1)
+            .collect::<Vec<_>>();
+        let additive_bias =
+            MxArray::from_float32(&additive_values, &[rows])?.astype(DType::BFloat16)?;
+
+        let make_q_proj = || {
+            QuantizedLinear::new(
+                weight.clone(),
+                scales.clone(),
+                Some(quant_biases.clone()),
+                Some(additive_bias.clone()),
+                32,
+                4,
+                "q4k".to_string(),
+            )
+        };
+        let mut block = Qwen3_5Attention::new(&cfg)?;
+        let mut native = Qwen3_5Attention::new(&cfg)?;
+        block.set_quantized_q_proj(make_q_proj());
+        native.set_quantized_q_proj(make_q_proj());
+        block.finalize_q_gate_block_enabled(true)?;
+        native.finalize_q_gate_block_enabled(false)?;
+        assert!(block.q_proj.has_q_gate_block_layout());
+        assert!(!native.q_proj.has_q_gate_block_layout());
+        assert!(block.q_gate_block_t.is_none());
+
+        let x_values = (0..2 * hidden)
+            .map(|i| ((i as f32) * 0.023 + 0.7).sin())
+            .collect::<Vec<_>>();
+        let x = MxArray::from_float32(&x_values, &[1, 2, hidden])?.astype(DType::BFloat16)?;
+        let (block_q, block_gate) = block.project_q_gate(&x, 1, 2)?;
+        let (native_q, native_gate) = native.project_q_gate(&x, 1, 2)?;
+        MxArray::eval_arrays(&[&block_q, &block_gate, &native_q, &native_gate])?;
+        assert_eq!(
+            block_q.to_uint16_native()?,
+            native_q.to_uint16_native()?,
+            "block-order Q4_K queries must be bit-identical to native per-head splitting"
+        );
+        assert_eq!(
+            block_gate.to_uint16_native()?,
+            native_gate.to_uint16_native()?,
+            "block-order Q4_K gates must be bit-identical to native per-head splitting"
         );
         Ok(())
     }

--- a/crates/mlx-core/src/models/qwen3_5/config.rs
+++ b/crates/mlx-core/src/models/qwen3_5/config.rs
@@ -157,6 +157,13 @@ pub struct Qwen3_5Config {
     /// unavailable.
     #[serde(default)]
     pub n_mtp_layers: i32,
+
+    /// Internal layout marker written by native Qwen3.5/3.8 GGUF conversion.
+    /// `Some("tiled")` keeps llama.cpp's value-head order and lets GDN map
+    /// value head h to key head h % Hk without permuting packed weights.
+    #[serde(default)]
+    #[napi(ts_type = "string | undefined")]
+    pub qwen35_gguf_gdn_layout: Option<String>,
 }
 
 fn default_linear_num_value_heads() -> i32 {
@@ -293,6 +300,7 @@ mod tests {
     #[test]
     fn gdn_state_bytes_follow_the_real_conv_and_recurrent_shapes() {
         let config = Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 32,
             hidden_size: 16,
             num_layers: 4,

--- a/crates/mlx-core/src/models/qwen3_5/decoder_layer.rs
+++ b/crates/mlx-core/src/models/qwen3_5/decoder_layer.rs
@@ -32,6 +32,11 @@ pub(crate) enum Qwen3_5LayerKind {
 }
 
 /// Attention type for a decoder layer.
+///
+/// GDN carries native split packed-projection state and is the common hot path
+/// in this hybrid model. Keep it inline rather than adding a pointer chase to
+/// every linear-attention forward merely to equalize enum variant sizes.
+#[allow(clippy::large_enum_variant)]
 pub enum AttentionType {
     Linear(GatedDeltaNet),
     Full(Qwen3_5Attention),

--- a/crates/mlx-core/src/models/qwen3_5/gated_delta.rs
+++ b/crates/mlx-core/src/models/qwen3_5/gated_delta.rs
@@ -207,8 +207,8 @@ fn gated_delta_chunked(
 /// kernel launches. ~10x faster than the ops-based sequential loop.
 ///
 /// Shapes:
-///   q: [B, T, Hk, Dk]  (already GQA-expanded to Hv heads by caller)
-///   k: [B, T, Hk, Dk]  (already GQA-expanded)
+///   q: [B, T, Hk, Dk]  (`Hk == Hv`, or compact tiled-GGUF heads)
+///   k: [B, T, Hk, Dk]  (`Hk == Hv`, or compact tiled-GGUF heads)
 ///   v: [B, T, Hv, Dv]
 ///   g: [B, T, Hv]       - decay gate
 ///   beta: [B, T, Hv]    - beta (sigmoid already applied)
@@ -261,9 +261,10 @@ fn gated_delta_kernel(
 /// Per-step GDN recurrence record for the eager MTP tape replay.
 ///
 /// Captures the EXACT inputs passed to [`gated_delta_kernel`] for the whole
-/// `[B, T, ...]` verify window — `q`/`k` are already GQA-expanded and
-/// RMS-norm-scaled, `g` is the post-`exp` decay (`g_log.exp()`), and `beta`
-/// is post-sigmoid. All handles are lazy `MxArray` clones (no eval, no copy).
+/// `[B, T, ...]` verify window — `q`/`k` are RMS-norm-scaled and either
+/// GQA-expanded or compact tiled-GGUF heads, `g` is the post-`exp` decay
+/// (`g_log.exp()`), and `beta` is post-sigmoid. All handles are lazy `MxArray`
+/// clones (no eval, no copy).
 ///
 /// On accept the replay slices each window tensor to step `t` as `[B, 1, ...]`
 /// and re-runs [`gated_delta_kernel`] AT T=1 per accepted step, threading the
@@ -273,9 +274,9 @@ fn gated_delta_kernel(
 /// whole window, which is the divergence the replay corrects.
 #[derive(Clone)]
 pub(crate) struct GdnKernelTape {
-    /// Queries `[B, T, Hv, Dk]` (GQA-expanded, RMS-norm-scaled).
+    /// Queries `[B, T, Hk, Dk]` (expanded or compact tiled, RMS-norm-scaled).
     pub q: MxArray,
-    /// Keys `[B, T, Hv, Dk]` (GQA-expanded, RMS-norm-scaled).
+    /// Keys `[B, T, Hk, Dk]` (expanded or compact tiled, RMS-norm-scaled).
     pub k: MxArray,
     /// Values `[B, T, Hv, Dv]`.
     pub v: MxArray,
@@ -306,7 +307,7 @@ impl GdnKernelTape {
     ) -> Result<MxArray> {
         let mut state = start_state.clone();
         for t in 0..accepted_steps as i64 {
-            let q_t = self.q.slice_axis(1, t, t + 1)?; // [B, 1, Hv, Dk]
+            let q_t = self.q.slice_axis(1, t, t + 1)?; // [B, 1, Hk, Dk]
             let k_t = self.k.slice_axis(1, t, t + 1)?;
             let v_t = self.v.slice_axis(1, t, t + 1)?;
             let g_t = self.g.slice_axis(1, t, t + 1)?; // [B, 1, Hv]
@@ -665,7 +666,9 @@ pub fn gated_delta_update(
     mask: Option<&MxArray>,
     use_kernel: bool,
 ) -> Result<(MxArray, MxArray)> {
-    gated_delta_update_with_tape(q, k, v, a, b, a_log, dt_bias, state, mask, use_kernel, None)
+    gated_delta_update_with_tape(
+        q, k, v, a, b, a_log, dt_bias, state, mask, use_kernel, false, None,
+    )
 }
 
 /// Tape-recording variant of [`gated_delta_update`].
@@ -673,10 +676,10 @@ pub fn gated_delta_update(
 /// Identical to [`gated_delta_update`] except that, when the per-step Metal
 /// kernel runs (`use_kernel`, `k_dim % 32 == 0`, not chunked), it records the
 /// exact `(q, k, v, g, beta)` window tensors into `tape_sink` for the eager
-/// MTP replay. The captured `q`/`k` are GQA-expanded + RMS-norm-scaled and `g`
-/// is `g_log.exp()` — i.e. EXACTLY the tensors handed to the kernel, by lazy
-/// `.clone()` (no eval). When `tape_sink` is `None` the behavior is
-/// byte-identical to [`gated_delta_update`].
+/// MTP replay. The captured `q`/`k` are RMS-norm-scaled and may retain compact
+/// tiled-GGUF heads; `g` is `g_log.exp()` — i.e. EXACTLY the tensors handed to
+/// the kernel, by lazy `.clone()` (no eval). When `tape_sink` is `None` the
+/// behavior is byte-identical to [`gated_delta_update`].
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn gated_delta_update_with_tape(
     q: &MxArray,
@@ -689,6 +692,7 @@ pub(crate) fn gated_delta_update_with_tape(
     state: Option<&MxArray>,
     mask: Option<&MxArray>,
     use_kernel: bool,
+    tiled_gqa: bool,
     mut tape_sink: Option<&mut Option<GdnKernelTape>>,
 ) -> Result<(MxArray, MxArray)> {
     let batch = q.shape_at(0)?;
@@ -726,8 +730,17 @@ pub(crate) fn gated_delta_update_with_tape(
                 )));
             }
             let repeat_factor = num_v_heads / num_k_heads;
-            let q_expanded = q.repeat(repeat_factor as i32, 2)?;
-            let k_expanded = k.repeat(repeat_factor as i32, 2)?;
+            let (q_expanded, k_expanded) = if tiled_gqa {
+                (
+                    MxArray::tile(q, &[1, 1, repeat_factor as i32, 1])?,
+                    MxArray::tile(k, &[1, 1, repeat_factor as i32, 1])?,
+                )
+            } else {
+                (
+                    q.repeat(repeat_factor as i32, 2)?,
+                    k.repeat(repeat_factor as i32, 2)?,
+                )
+            };
             (q_expanded, k_expanded)
         } else {
             (q.clone(), k.clone())
@@ -784,8 +797,11 @@ pub(crate) fn gated_delta_update_with_tape(
         }
     };
 
-    // GQA head expansion: repeat q,k from Hk to Hv heads
-    let (q, k) = if num_v_heads != num_k_heads {
+    // Standard checkpoints group each key head contiguously and need
+    // repeat-interleave. GGUF Qwen3.5 keeps the value-major tiled order; the
+    // per-step Metal kernel consumes those compact heads directly and maps
+    // value head `hv` to key head `hv % Hk`, avoiding an activation copy.
+    let (q, k) = if num_v_heads != num_k_heads && !tiled_gqa {
         if num_k_heads == 0 {
             return Err(Error::from_reason(
                 "GatedDelta: num_k_heads is 0, cannot compute GQA repeat factor",
@@ -828,7 +844,16 @@ pub(crate) fn gated_delta_update_with_tape(
         if seq_len >= CHUNK_THRESHOLD && mask.is_none() {
             let choice = gdn_kernel_override();
             if should_use_chunked(seq_len, mask.is_none(), gpu_architecture_gen(), choice) {
-                match gated_delta_chunked(&q, &k, v, &g_log, &beta, &initial_state) {
+                let (chunk_q, chunk_k) = if tiled_gqa && num_v_heads != num_k_heads {
+                    let repeat_factor = num_v_heads / num_k_heads;
+                    (
+                        MxArray::tile(&q, &[1, 1, repeat_factor as i32, 1])?,
+                        MxArray::tile(&k, &[1, 1, repeat_factor as i32, 1])?,
+                    )
+                } else {
+                    (q.clone(), k.clone())
+                };
+                match gated_delta_chunked(&chunk_q, &chunk_k, v, &g_log, &beta, &initial_state) {
                     Ok(result) => return Ok(result),
                     Err(e) => {
                         // An explicit `MLX_GDN_KERNEL=chunked` force must be observable when it
@@ -867,7 +892,16 @@ pub(crate) fn gated_delta_update_with_tape(
 
     // Ops-based sequential loop fallback (also needs exp(g_log))
     let g = g_log.exp()?;
-    gated_delta_ops(&q, &k, v, &g, &beta, &initial_state, mask)
+    let (ops_q, ops_k) = if tiled_gqa && num_v_heads != num_k_heads {
+        let repeat_factor = num_v_heads / num_k_heads;
+        (
+            MxArray::tile(&q, &[1, 1, repeat_factor as i32, 1])?,
+            MxArray::tile(&k, &[1, 1, repeat_factor as i32, 1])?,
+        )
+    } else {
+        (q, k)
+    };
+    gated_delta_ops(&ops_q, &ops_k, v, &g, &beta, &initial_state, mask)
 }
 
 #[cfg(test)]

--- a/crates/mlx-core/src/models/qwen3_5/gated_delta_net.rs
+++ b/crates/mlx-core/src/models/qwen3_5/gated_delta_net.rs
@@ -106,9 +106,14 @@ pub struct GatedDeltaNet {
     // Projections
     in_proj_qkvz: LinearProj, // hidden → key_dim*2 + value_dim*2 (q,k,v,z combined)
     in_proj_ba: LinearProj,   // hidden → num_v_heads * 2 (b and a combined)
-    conv1d: Conv1d,           // depthwise conv, groups = conv_dim
-    norm: RMSNormGated,       // per-head norm: weight dim = value_head_dim
-    out_proj: LinearProj,     // value_dim → hidden
+    // Dynamic GGUFs can assign different packed modes to each half. In that
+    // case the source projections stay split and each uses its own native
+    // quantized matmul; no dense weight materialization is needed.
+    split_in_proj_qkv_z: Option<(LinearProj, LinearProj)>,
+    split_in_proj_b_a: Option<(LinearProj, LinearProj)>,
+    conv1d: Conv1d,       // depthwise conv, groups = conv_dim
+    norm: RMSNormGated,   // per-head norm: weight dim = value_head_dim
+    out_proj: LinearProj, // value_dim → hidden
 
     // Learnable parameters
     dt_bias: MxArray, // [num_v_heads]
@@ -123,6 +128,7 @@ pub struct GatedDeltaNet {
     value_dim: i32,
     conv_dim: i32,
     conv_kernel_dim: i32,
+    tiled_gguf_layout: bool,
     /// Pre-stacked `[w_qkvz; w_ba]` transposed to `[hidden, qkvz_dim + ba_dim]`.
     /// Populated by `finalize_in_proj()` after weights are loaded. When present
     /// (and non-quantized), `forward()` does ONE matmul + two slices instead of
@@ -178,6 +184,8 @@ impl GatedDeltaNet {
         Ok(Self {
             in_proj_qkvz: LinearProj::Standard(in_proj_qkvz),
             in_proj_ba: LinearProj::Standard(in_proj_ba),
+            split_in_proj_qkv_z: None,
+            split_in_proj_b_a: None,
             conv1d,
             norm,
             out_proj: LinearProj::Standard(out_proj),
@@ -191,6 +199,7 @@ impl GatedDeltaNet {
             value_dim,
             conv_dim,
             conv_kernel_dim,
+            tiled_gguf_layout: config.qwen35_gguf_gdn_layout.as_deref() == Some("tiled"),
             in_proj_qkvz_ba_t: None,
         })
     }
@@ -204,6 +213,10 @@ impl GatedDeltaNet {
     /// Standard linears. Quantized models stay on the unfused 2-matmul
     /// path (no-op here).
     pub fn finalize_in_proj(&mut self) -> Result<()> {
+        if self.split_in_proj_qkv_z.is_some() || self.split_in_proj_b_a.is_some() {
+            self.in_proj_qkvz_ba_t = None;
+            return Ok(());
+        }
         match (&self.in_proj_qkvz, &self.in_proj_ba) {
             (LinearProj::Standard(_), LinearProj::Standard(_)) => {}
             _ => return Ok(()),
@@ -258,33 +271,48 @@ impl GatedDeltaNet {
         // MLX_DISABLE_E51_STACKED_GDN_IN_PROJ=1 reverts to the two-matmul path.
         let qkvz_dim = (self.key_dim * 2 + self.value_dim * 2) as i64;
         let ba_dim = (self.num_v_heads * 2) as i64;
-        let (qkvz, ba) = if let Some(wqb_t) = &self.in_proj_qkvz_ba_t
+        let stacked = if let Some(wqb_t) = &self.in_proj_qkvz_ba_t
             && std::env::var("MLX_DISABLE_E51_STACKED_GDN_IN_PROJ").is_err()
         {
             let combined = x.matmul(wqb_t)?; // [B, T, qkvz_dim + ba_dim]
             let qkvz = combined.slice_axis(2, 0, qkvz_dim)?;
             let ba = combined.slice_axis(2, qkvz_dim, qkvz_dim + ba_dim)?;
-            (qkvz, ba)
+            Some((qkvz, ba))
         } else {
-            // Unfused path: two separate matmuls.
-            let qkvz = self.in_proj_qkvz.forward(x)?;
-            let ba = self.in_proj_ba.forward(x)?;
-            (qkvz, ba)
+            None
         };
 
-        // Split ba into b and a: each [B, T, num_v_heads]
-        let b = ba.slice_axis(2, 0, self.num_v_heads as i64)?;
-        let a = ba.slice_axis(2, self.num_v_heads as i64, (self.num_v_heads * 2) as i64)?;
+        let (qkv, z) = if let Some((qkv_proj, z_proj)) = &self.split_in_proj_qkv_z {
+            (qkv_proj.forward(x)?, z_proj.forward(x)?)
+        } else {
+            let qkvz = if let Some((qkvz, _)) = &stacked {
+                qkvz.clone()
+            } else {
+                self.in_proj_qkvz.forward(x)?
+            };
+            (
+                qkvz.slice_axis(2, 0, self.conv_dim as i64)?,
+                qkvz.slice_axis(
+                    2,
+                    self.conv_dim as i64,
+                    (self.key_dim * 2 + self.value_dim * 2) as i64,
+                )?,
+            )
+        };
 
-        // Split qkvz: qkv goes through conv, z bypasses
-        // qkv: [B, T, key_dim*2 + value_dim] = [B, T, conv_dim]
-        // z: [B, T, value_dim]
-        let qkv = qkvz.slice_axis(2, 0, self.conv_dim as i64)?;
-        let z = qkvz.slice_axis(
-            2,
-            self.conv_dim as i64,
-            (self.key_dim * 2 + self.value_dim * 2) as i64,
-        )?;
+        let (b, a) = if let Some((b_proj, a_proj)) = &self.split_in_proj_b_a {
+            (b_proj.forward(x)?, a_proj.forward(x)?)
+        } else {
+            let ba = if let Some((_, ba)) = &stacked {
+                ba.clone()
+            } else {
+                self.in_proj_ba.forward(x)?
+            };
+            (
+                ba.slice_axis(2, 0, self.num_v_heads as i64)?,
+                ba.slice_axis(2, self.num_v_heads as i64, (self.num_v_heads * 2) as i64)?,
+            )
+        };
 
         // Apply mask before conv to prevent masked values leaking through convolution
         let qkv = if let Some(m) = mask {
@@ -384,6 +412,14 @@ impl GatedDeltaNet {
         let k_normed = rms_norm_no_weight(&k, 1e-6)?;
         let q = q_normed.mul_scalar(inv_scale * inv_scale)?;
         let k = k_normed.mul_scalar(inv_scale)?;
+        if self.tiled_gguf_layout
+            && (self.num_k_heads <= 0 || self.num_v_heads % self.num_k_heads != 0)
+        {
+            return Err(Error::from_reason(format!(
+                "Qwen3.5 tiled GGUF GDN layout requires Hv ({}) to be divisible by Hk ({})",
+                self.num_v_heads, self.num_k_heads
+            )));
+        }
 
         // Run gated delta recurrence
         let recurrent_state = cache.as_deref().and_then(|c| c.get(1));
@@ -402,6 +438,7 @@ impl GatedDeltaNet {
                 recurrent_state,
                 mask,
                 use_kernel,
+                self.tiled_gguf_layout,
                 Some(&mut kernel_sink),
             )?;
             if let (Some(sink), Some(kernel), Some(qkv)) = (tape_sink.take(), kernel_sink, tape_qkv)
@@ -414,18 +451,35 @@ impl GatedDeltaNet {
             }
             result
         } else {
-            gated_delta_update(
-                &q,
-                &k,
-                &v,
-                &a,
-                &b,
-                &self.a_log,
-                &self.dt_bias,
-                recurrent_state,
-                mask,
-                use_kernel,
-            )?
+            if self.tiled_gguf_layout {
+                gated_delta_update_with_tape(
+                    &q,
+                    &k,
+                    &v,
+                    &a,
+                    &b,
+                    &self.a_log,
+                    &self.dt_bias,
+                    recurrent_state,
+                    mask,
+                    use_kernel,
+                    true,
+                    None,
+                )?
+            } else {
+                gated_delta_update(
+                    &q,
+                    &k,
+                    &v,
+                    &a,
+                    &b,
+                    &self.a_log,
+                    &self.dt_bias,
+                    recurrent_state,
+                    mask,
+                    use_kernel,
+                )?
+            }
         };
 
         // Update recurrent state in cache
@@ -456,10 +510,12 @@ impl GatedDeltaNet {
 
     pub fn set_in_proj_qkvz_weight(&mut self, w: &MxArray) -> Result<()> {
         self.in_proj_qkvz_ba_t = None; // invalidate stacked cache
+        self.split_in_proj_qkv_z = None;
         self.in_proj_qkvz.set_weight(w, "in_proj_qkvz")
     }
     pub fn set_in_proj_ba_weight(&mut self, w: &MxArray) -> Result<()> {
         self.in_proj_qkvz_ba_t = None;
+        self.split_in_proj_b_a = None;
         self.in_proj_ba.set_weight(w, "in_proj_ba")
     }
     pub fn set_conv1d_weight(&mut self, w: &MxArray) -> Result<()> {
@@ -494,11 +550,21 @@ impl GatedDeltaNet {
 
     pub fn set_quantized_in_proj_qkvz(&mut self, ql: QuantizedLinear) {
         self.in_proj_qkvz_ba_t = None;
+        self.split_in_proj_qkv_z = None;
         self.in_proj_qkvz.set_quantized(ql);
     }
     pub fn set_quantized_in_proj_ba(&mut self, ql: QuantizedLinear) {
         self.in_proj_qkvz_ba_t = None;
+        self.split_in_proj_b_a = None;
         self.in_proj_ba.set_quantized(ql);
+    }
+    pub fn set_quantized_in_proj_qkv_z(&mut self, qkv: QuantizedLinear, z: QuantizedLinear) {
+        self.in_proj_qkvz_ba_t = None;
+        self.split_in_proj_qkv_z = Some((LinearProj::Quantized(qkv), LinearProj::Quantized(z)));
+    }
+    pub fn set_quantized_in_proj_b_a(&mut self, b: QuantizedLinear, a: QuantizedLinear) {
+        self.in_proj_qkvz_ba_t = None;
+        self.split_in_proj_b_a = Some((LinearProj::Quantized(b), LinearProj::Quantized(a)));
     }
     pub fn set_quantized_out_proj(&mut self, ql: QuantizedLinear) {
         self.out_proj.set_quantized(ql);
@@ -509,6 +575,8 @@ impl GatedDeltaNet {
     pub fn is_quantized(&self) -> bool {
         self.in_proj_qkvz.is_quantized()
             || self.in_proj_ba.is_quantized()
+            || self.split_in_proj_qkv_z.is_some()
+            || self.split_in_proj_b_a.is_some()
             || self.out_proj.is_quantized()
     }
 

--- a/crates/mlx-core/src/models/qwen3_5/gated_delta_net.rs
+++ b/crates/mlx-core/src/models/qwen3_5/gated_delta_net.rs
@@ -558,13 +558,13 @@ impl GatedDeltaNet {
         self.split_in_proj_b_a = None;
         self.in_proj_ba.set_quantized(ql);
     }
-    pub fn set_quantized_in_proj_qkv_z(&mut self, qkv: QuantizedLinear, z: QuantizedLinear) {
+    pub fn set_split_in_proj_qkv_z(&mut self, qkv: LinearProj, z: LinearProj) {
         self.in_proj_qkvz_ba_t = None;
-        self.split_in_proj_qkv_z = Some((LinearProj::Quantized(qkv), LinearProj::Quantized(z)));
+        self.split_in_proj_qkv_z = Some((qkv, z));
     }
-    pub fn set_quantized_in_proj_b_a(&mut self, b: QuantizedLinear, a: QuantizedLinear) {
+    pub fn set_split_in_proj_b_a(&mut self, b: LinearProj, a: LinearProj) {
         self.in_proj_qkvz_ba_t = None;
-        self.split_in_proj_b_a = Some((LinearProj::Quantized(b), LinearProj::Quantized(a)));
+        self.split_in_proj_b_a = Some((b, a));
     }
     pub fn set_quantized_out_proj(&mut self, ql: QuantizedLinear) {
         self.out_proj.set_quantized(ql);
@@ -578,6 +578,21 @@ impl GatedDeltaNet {
             || self.split_in_proj_qkv_z.is_some()
             || self.split_in_proj_b_a.is_some()
             || self.out_proj.is_quantized()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn split_in_proj_quantized_sides(
+        &self,
+    ) -> (Option<(bool, bool)>, Option<(bool, bool)>) {
+        let qkv_z = self
+            .split_in_proj_qkv_z
+            .as_ref()
+            .map(|(qkv, z)| (qkv.is_quantized(), z.is_quantized()));
+        let b_a = self
+            .split_in_proj_b_a
+            .as_ref()
+            .map(|(b, a)| (b.is_quantized(), a.is_quantized()));
+        (qkv_z, b_a)
     }
 
     // ========== Weight getters (for training parameter extraction) ==========

--- a/crates/mlx-core/src/models/qwen3_5/gdn_checkpoint_store/tests/retention_sim.rs
+++ b/crates/mlx-core/src/models/qwen3_5/gdn_checkpoint_store/tests/retention_sim.rs
@@ -749,6 +749,7 @@ fn dense_0_8b() -> Qwen3_5Config {
 /// Fields `gdn_sidecar::geometry` never reads, filled with anything valid.
 fn small_config_shell() -> Qwen3_5Config {
     Qwen3_5Config {
+        qwen35_gguf_gdn_layout: None,
         vocab_size: 32,
         hidden_size: 16,
         num_layers: 8,

--- a/crates/mlx-core/src/models/qwen3_5/gdn_sidecar.rs
+++ b/crates/mlx-core/src/models/qwen3_5/gdn_sidecar.rs
@@ -510,6 +510,7 @@ mod tests {
     /// attention at 3,7. Small GDN dims so a mis-ordered round trip is visible.
     fn config() -> Qwen3_5Config {
         Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 32,
             hidden_size: 16,
             num_layers: 8,

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -11949,6 +11949,10 @@ pub struct Qwen3_5Model {
     /// `image_processor` for exact preflight geometry.
     pub(crate) spatial_merge_size: i32,
     pub(crate) context_limits: Qwen3_5ContextLimits,
+    /// Directory containing tokenizer/config assets for this loaded model.
+    /// For direct GGUF loads this is the lossless native-packed cache rather
+    /// than the source file path.
+    pub(crate) model_assets_path: String,
     /// RAII: unregisters this model's baseline from the cache-limit
     /// coordinator on drop, so the global cap can shrink once JS GCs
     /// the wrapper.
@@ -11959,6 +11963,14 @@ pub struct Qwen3_5Model {
 
 #[napi]
 impl Qwen3_5Model {
+    /// Resolved directory containing this model's tokenizer/config assets.
+    /// Streaming wrappers use it after a direct GGUF load so chat templating
+    /// reads the reconstructed sidecars from the native-packed cache.
+    #[napi]
+    pub fn model_assets_path(&self) -> String {
+        self.model_assets_path.clone()
+    }
+
     /// Whether the block-paged KV cache adapter is active on this model
     /// instance.
     ///
@@ -12057,6 +12069,16 @@ impl Qwen3_5Model {
     /// - tokenizer.json + tokenizer_config.json
     #[napi]
     pub async fn load(path: String) -> Result<Qwen3_5Model> {
+        let source = std::path::Path::new(&path);
+        if source.is_file()
+            && source
+                .extension()
+                .and_then(|value| value.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("gguf"))
+        {
+            let cache = crate::utils::gguf::prepare_qwen35_native_gguf(source).await?;
+            return persistence::load_with_thread(&cache.to_string_lossy()).await;
+        }
         persistence::load_with_thread(&path).await
     }
 
@@ -14784,6 +14806,7 @@ mod paged_construction_tests {
 
     fn tiny_cfg(use_block_paged: bool) -> Qwen3_5Config {
         Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 1024,
             hidden_size: 64,
             num_layers: 8,
@@ -17886,6 +17909,7 @@ mod layer_kinds_cache_tests {
 
     fn tiny_cfg() -> Qwen3_5Config {
         Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 1024,
             hidden_size: 64,
             num_layers: 8,
@@ -17939,6 +17963,7 @@ mod paged_gdn_frontier_tests {
 
     fn tiny_cfg() -> Qwen3_5Config {
         Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 1024,
             hidden_size: 64,
             num_layers: 2,
@@ -18071,6 +18096,7 @@ mod mtp_gate_state_tests {
 
     fn tiny_cfg() -> Qwen3_5Config {
         Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 1024,
             hidden_size: 64,
             num_layers: 2,

--- a/crates/mlx-core/src/models/qwen3_5/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5/mtp.rs
@@ -440,9 +440,9 @@ impl Qwen3_5MTPModule {
             if let Some(w) = params.get(&format!("{}.self_attn.o_proj.bias", prefix)) {
                 attn.set_o_proj_bias(Some(w))?;
             }
-            // Precompute the block-ordered q_proj weight so forward()/
-            // forward_paged() split queries/gate without a strided
-            // reshape-copy. No-op for quantized q_proj.
+            // Finalize the block-ordered q/gate split once: dense projections
+            // cache a transpose, while affine and native K/IQ projections
+            // reorder their packed row-coupled operands without dequantizing.
             attn.finalize_q_gate_block()?;
 
             // MLP — dense or per-mode quantized via the same swap as

--- a/crates/mlx-core/src/models/qwen3_5/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5/mtp.rs
@@ -46,9 +46,9 @@ use super::config::Qwen3_5Config;
 use super::decoder_layer::{AttentionType, DecoderLayer};
 use super::layer_cache::Qwen3_5LayerCache;
 use super::quantized_linear::{
-    LinearProj, MLPVariant, PerLayerMode, PerLayerQuant, is_quantized_checkpoint,
-    try_build_mxfp4_quantized_linear, try_build_mxfp8_quantized_linear,
-    try_build_nvfp4_quantized_linear, try_build_quantized_linear,
+    LinearProj, MLPVariant, PerLayerMode, PerLayerQuant, QuantizedLinear, is_quantized_checkpoint,
+    try_build_kquant_quantized_linear, try_build_mxfp4_quantized_linear,
+    try_build_mxfp8_quantized_linear, try_build_nvfp4_quantized_linear, try_build_quantized_linear,
 };
 
 /// Reject unsupported plain-E4M3 state before any MTP dense setter can see raw
@@ -308,30 +308,38 @@ impl Qwen3_5MTPModule {
         // Fresh per-prefix quant resolver, duplicating the closure in
         // `apply_weights_inner`. Surgical duplication is preferred over a
         // wide refactor of the dense persistence loader.
-        let try_build_ql = |params: &HashMap<String, MxArray>, prefix: &str| {
-            let plq = per_layer_quant.get(prefix).copied().unwrap_or(default_plq);
-            match plq.mode {
-                PerLayerMode::Mxfp4 => try_build_mxfp4_quantized_linear(params, prefix),
-                PerLayerMode::Mxfp8 => try_build_mxfp8_quantized_linear(params, prefix),
-                PerLayerMode::Nvfp4 => try_build_nvfp4_quantized_linear(params, prefix),
-                // The upfront state guard rejects explicit metadata / Uint8
-                // storage. A body-level FP8 default with BF16 MTP weights may
-                // still resolve here and correctly takes the dense fallback.
-                PerLayerMode::Fp8E4m3 => None,
-                PerLayerMode::Affine => {
-                    try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
-                }
-                // Unreachable in practice: `apply_weights_inner` skips the MTP
-                // load entirely for sym8 checkpoints (the dense loader
-                // disables speculative MTP under sym8). `None` here keeps the
-                // exhaustive match honest without silently mis-packing.
-                PerLayerMode::Sym8 => None,
-                // Unreachable: the dense loader disables MTP for K-quant
-                // checkpoints (`has_kquant_mode` gate), and an imported GGUF
-                // never ships an MTP head. `None` fails soft into AR decode.
-                PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => None,
-            }
-        };
+        let try_build_ql =
+            |params: &HashMap<String, MxArray>, prefix: &str| -> Result<Option<QuantizedLinear>> {
+                let plq = per_layer_quant.get(prefix).copied().unwrap_or(default_plq);
+                Ok(match plq.mode {
+                    PerLayerMode::Mxfp4 => try_build_mxfp4_quantized_linear(params, prefix),
+                    PerLayerMode::Mxfp8 => try_build_mxfp8_quantized_linear(params, prefix),
+                    PerLayerMode::Nvfp4 => try_build_nvfp4_quantized_linear(params, prefix),
+                    // The upfront state guard rejects explicit metadata / Uint8
+                    // storage. A body-level FP8 default with BF16 MTP weights may
+                    // still resolve here and correctly takes the dense fallback.
+                    PerLayerMode::Fp8E4m3 => None,
+                    PerLayerMode::Affine => {
+                        try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
+                    }
+                    // Unreachable in practice: `apply_weights_inner` skips the MTP
+                    // load entirely for sym8 checkpoints (the dense loader
+                    // disables speculative MTP under sym8). `None` here keeps the
+                    // exhaustive match honest without silently mis-packing.
+                    PerLayerMode::Sym8 => None,
+                    // Direct Qwen3.8 GGUFs may carry a packed inline MTP head;
+                    // build each projection with its exact source mode.
+                    PerLayerMode::Q6K
+                    | PerLayerMode::Q4K
+                    | PerLayerMode::Q5K
+                    | PerLayerMode::Q3K
+                    | PerLayerMode::IQ4NL
+                    | PerLayerMode::IQ4XS
+                    | PerLayerMode::IQ3S => {
+                        try_build_kquant_quantized_linear(params, prefix, plq.mode, "qwen3_5_mtp")?
+                    }
+                })
+            };
 
         // Top-level normalizations.
         if let Some(w) = params.get("mtp.pre_fc_norm_hidden.weight") {
@@ -346,11 +354,10 @@ impl Qwen3_5MTPModule {
 
         // fc projection. Installs through the same mode-aware `try_build_ql`
         // dispatch as the attention/MLP projections below, so a quantized fc
-        // honors its per-layer mode (affine / mxfp8 / mxfp4 / nvfp4) instead
-        // of being forced through affine-only dequant. A bf16 fc (no
-        // `.scales`) stays a `LinearProj::Standard` — the identical dense
-        // matmul as before; our checkpoints keep the MTP fc bf16.
-        if let Some(ql) = try_build_ql(params, "mtp.fc") {
+        // honors its per-layer mode (including native K/IQ modes) instead of
+        // being forced through affine-only dequant. A bf16 fc (no `.scales`)
+        // stays a `LinearProj::Standard` and uses the dense matmul as before.
+        if let Some(ql) = try_build_ql(params, "mtp.fc")? {
             self.fc.set_quantized(ql);
         } else if let Some(w) = params.get("mtp.fc.weight") {
             self.fc.set_weight(w, "mtp.fc")?;
@@ -381,22 +388,22 @@ impl Qwen3_5MTPModule {
             };
 
             if is_quantized {
-                if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.q_proj", prefix)) {
+                if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.q_proj", prefix))? {
                     attn.set_quantized_q_proj(ql);
                 } else if let Some(w) = params.get(&format!("{}.self_attn.q_proj.weight", prefix)) {
                     attn.set_q_proj_weight(w)?;
                 }
-                if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.k_proj", prefix)) {
+                if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.k_proj", prefix))? {
                     attn.set_quantized_k_proj(ql);
                 } else if let Some(w) = params.get(&format!("{}.self_attn.k_proj.weight", prefix)) {
                     attn.set_k_proj_weight(w)?;
                 }
-                if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.v_proj", prefix)) {
+                if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.v_proj", prefix))? {
                     attn.set_quantized_v_proj(ql);
                 } else if let Some(w) = params.get(&format!("{}.self_attn.v_proj.weight", prefix)) {
                     attn.set_v_proj_weight(w)?;
                 }
-                if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.o_proj", prefix)) {
+                if let Some(ql) = try_build_ql(params, &format!("{}.self_attn.o_proj", prefix))? {
                     attn.set_quantized_o_proj(ql);
                 } else if let Some(w) = params.get(&format!("{}.self_attn.o_proj.weight", prefix)) {
                     attn.set_o_proj_weight(w)?;
@@ -448,9 +455,9 @@ impl Qwen3_5MTPModule {
                         let gate_key = format!("{}.mlp.gate_proj", prefix);
                         let up_key = format!("{}.mlp.up_proj", prefix);
                         let down_key = format!("{}.mlp.down_proj", prefix);
-                        let q_gate = try_build_ql(params, &gate_key);
-                        let q_up = try_build_ql(params, &up_key);
-                        let q_down = try_build_ql(params, &down_key);
+                        let q_gate = try_build_ql(params, &gate_key)?;
+                        let q_up = try_build_ql(params, &up_key)?;
+                        let q_down = try_build_ql(params, &down_key)?;
                         if let (Some(qg), Some(qu), Some(qd)) = (q_gate, q_up, q_down) {
                             layer.set_quantized_dense_mlp(qg, qu, qd);
                         } else {
@@ -649,6 +656,7 @@ mod tests {
         // (head_dim divisible by 2 for RoPE). full_attention_interval=4
         // makes layer 3 a full-attention layer; n_mtp_layers=1.
         Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 1024,
             hidden_size: 64,
             num_layers: 4,

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -15,8 +15,8 @@ use crate::models::quant_dispatch::{
     PlainFp8Residency, default_per_layer_quant, defer_plain_fp8_materialization, effective_plq_for,
     ensure_affine_biases_present, ensure_dense_weight_floating, ensure_int8_storage_resolves_sym8,
     ensure_kquant_storage_resolves_kquant, ensure_plain_fp8_storage_resolves_fp8_e4m3,
-    has_sym8_mode, merge_per_layer, mode_to_str, normalize_per_layer_key, parse_mode_str,
-    parse_quant_settings, resolve_default_mode, select_quantization_block,
+    has_sym8_mode, is_kquant_mode, merge_per_layer, mode_to_str, normalize_per_layer_key,
+    parse_mode_str, parse_quant_settings, resolve_default_mode, select_quantization_block,
 };
 use crate::nn::LayerNorm;
 use crate::tokenizer::Qwen3Tokenizer;
@@ -53,8 +53,7 @@ fn should_load_packed_qwen_embedding(
     bits: i32,
     disable_value: Option<&str>,
 ) -> bool {
-    mode == PerLayerMode::Affine
-        && bits < 8
+    (is_kquant_mode(mode) || (mode == PerLayerMode::Affine && bits < 8))
         && packed_qwen_embedding_enabled_from_env(disable_value)
 }
 
@@ -64,10 +63,13 @@ fn should_load_packed_qwen_embedding(
 pub(crate) fn packed_qwen_embedding_enabled(mode: PerLayerMode, bits: i32) -> bool {
     let value = std::env::var(DISABLE_PACKED_QWEN_EMBEDDING_ENV).ok();
     // The tied-head projection is decode-critical. Exact same-binary E2E runs
-    // show that keeping sub-byte embeddings packed wins decisively, while the
-    // 8-bit affine head is faster after the one-time dense materialization.
-    // Keep the optimization on the measured shape class and leave every 8-bit
-    // mode on the legacy dense path until its packed head is proven faster.
+    // show that keeping sub-byte affine embeddings packed wins decisively,
+    // while the 8-bit affine head is faster after the one-time dense
+    // materialization. K/IQ embeddings must remain packed as well: their
+    // gather-then-dequant lookup is native, and eagerly decoding a large GGUF
+    // token table defeats native K/IQ residency. Leave other unmeasured 8-bit
+    // and floating-point modes on the legacy path until their packed head is
+    // proven faster.
     should_load_packed_qwen_embedding(mode, bits, value.as_deref())
 }
 use super::vision::{Qwen3_5VisionConfig, Qwen3_5VisionEncoder};
@@ -1331,10 +1333,10 @@ fn apply_weights_inner_with_residency(
         // Every inference consumer now carries `Embedding` itself: flat and
         // paged lookup call `forward`, tied logits call `as_linear`, MTP draft /
         // verify gather through `forward`, and VLM text merge does the same.
-        // Keep measured sub-byte affine embeddings packed regardless of cache
-        // backend, declared MTP depth, or vision presence. MTP execution is
-        // gated later by `has_mtp_weights()` (the actually loaded weight set),
-        // never merely by `config.n_mtp_layers`.
+        // Keep measured sub-byte affine and native GGUF K/IQ embeddings packed
+        // regardless of cache backend, declared MTP depth, or vision presence.
+        // MTP execution is gated later by `has_mtp_weights()` (the actually
+        // loaded weight set), never merely by `config.n_mtp_layers`.
         let prefer_packed = packed_qwen_embedding_enabled(plq.mode, plq.bits);
         // Resolve the packing mode from the checkpoint rather than assuming
         // affine: a GGUF `token_embd` repacked to q6k/q4k/q5k must decode as
@@ -1353,7 +1355,7 @@ fn apply_weights_inner_with_residency(
                 embed_mode,
             )?;
             info!(
-                "Loaded packed-quantized embedding ({}-bit {embed_mode}, quantized_matmul on forward + tied lm_head)",
+                "Loaded packed-quantized embedding ({}-bit {embed_mode}, gather-dequant lookup; packed matmul for tied lm_head)",
                 plq.bits
             );
         } else {
@@ -1366,7 +1368,7 @@ fn apply_weights_inner_with_residency(
                 embed_mode,
             )?;
             info!(
-                "Loaded quantized embedding ({}-bit {embed_mode}, quantized_matmul on forward)",
+                "Loaded dense embedding decoded from {}-bit {embed_mode} (full-table dequant; dense lookup/matmul)",
                 plq.bits
             );
         }
@@ -1658,9 +1660,10 @@ fn apply_weights_inner_with_residency(
                 if let Some(w) = params.get(&format!("{}.self_attn.o_proj.bias", prefix)) {
                     attn.set_o_proj_bias(Some(w))?;
                 }
-                // Precompute the block-ordered q_proj weight so forward()/
-                // forward_paged() split queries/gate without a strided
-                // reshape-copy. No-op for quantized q_proj.
+                // Finalize the block-ordered q/gate split once: dense
+                // projections cache a transpose, while affine and native
+                // K/IQ projections reorder packed operands without
+                // dequantizing.
                 attn.finalize_q_gate_block()?;
             }
         }
@@ -2712,7 +2715,7 @@ mod tests {
     }
 
     #[test]
-    fn packed_qwen_embedding_is_limited_to_sub_byte_weights() {
+    fn packed_qwen_embedding_covers_sub_byte_affine_and_native_k_iq() {
         for bits in [2, 3, 4, 5, 6] {
             assert!(
                 should_load_packed_qwen_embedding(PerLayerMode::Affine, bits, None),
@@ -2725,11 +2728,33 @@ mod tests {
         );
         assert!(
             !should_load_packed_qwen_embedding(PerLayerMode::Mxfp4, 4, None),
-            "unmeasured packing modes should stay on the dense path"
+            "unmeasured non-K/IQ packing modes should stay on the dense path"
+        );
+        for (mode, bits) in [
+            (PerLayerMode::Q3K, 3),
+            (PerLayerMode::Q4K, 4),
+            (PerLayerMode::Q5K, 5),
+            (PerLayerMode::Q6K, 6),
+            (PerLayerMode::IQ4NL, 4),
+            (PerLayerMode::IQ4XS, 4),
+            (PerLayerMode::IQ3S, 8),
+        ] {
+            assert!(
+                should_load_packed_qwen_embedding(mode, bits, None),
+                "native {mode:?} embeddings must stay packed"
+            );
+        }
+        assert!(
+            !should_load_packed_qwen_embedding(PerLayerMode::Sym8, 8, None),
+            "sym8 has a separate non-MLX packing contract"
         );
         assert!(
-            !should_load_packed_qwen_embedding(PerLayerMode::Affine, 6, Some("1")),
-            "the fallback must disable an otherwise eligible embedding"
+            !should_load_packed_qwen_embedding(PerLayerMode::Fp8E4m3, 8, None),
+            "plain E4M3 reconstructs through a separate backend"
+        );
+        assert!(
+            !should_load_packed_qwen_embedding(PerLayerMode::Q4K, 4, Some("1")),
+            "the fallback must disable the exact Q4_K embedding route"
         );
     }
 

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -18,7 +18,7 @@ use crate::models::quant_dispatch::{
     has_sym8_mode, is_kquant_mode, merge_per_layer, mode_to_str, normalize_per_layer_key,
     parse_mode_str, parse_quant_settings, resolve_default_mode, select_quantization_block,
 };
-use crate::nn::LayerNorm;
+use crate::nn::{LayerNorm, Linear};
 use crate::tokenizer::Qwen3Tokenizer;
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
 use crate::utils::safetensors::load_safetensors_lazy;
@@ -35,11 +35,11 @@ use super::decoder_layer::AttentionType;
 use super::model::{Qwen3_5Model, Qwen35Inner, Qwen35SchedulerState, handle_qwen35_cmd};
 use super::processing::Qwen35VLImageProcessor;
 use super::quantized_linear::{
-    DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, MLPVariant, PerLayerMode, PerLayerQuant,
-    is_mxfp8_checkpoint, is_quantized_checkpoint, try_build_fp8_e4m3_quantized_linear,
-    try_build_kquant_quantized_linear, try_build_mxfp4_quantized_linear,
-    try_build_mxfp8_quantized_linear, try_build_nvfp4_quantized_linear, try_build_quantized_linear,
-    try_build_sym8_quantized_linear,
+    DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, LinearProj, MLPVariant, PerLayerMode,
+    PerLayerQuant, is_mxfp8_checkpoint, is_quantized_checkpoint,
+    try_build_fp8_e4m3_quantized_linear, try_build_kquant_quantized_linear,
+    try_build_mxfp4_quantized_linear, try_build_mxfp8_quantized_linear,
+    try_build_nvfp4_quantized_linear, try_build_quantized_linear, try_build_sym8_quantized_linear,
 };
 
 const DISABLE_PACKED_QWEN_EMBEDDING_ENV: &str = "MLX_DISABLE_PACKED_QWEN_EMBEDDING";
@@ -1314,6 +1314,25 @@ fn apply_weights_inner_with_residency(
         Ok(built)
     };
 
+    // Split GDN halves are deliberately retained when a Dynamic GGUF assigns
+    // them different storage formats. Resolve each half independently so a
+    // packed+dense pair remains native on the packed side and dense only for
+    // the source tensor that was actually floating-point.
+    let try_build_linear_proj =
+        |params: &HashMap<String, MxArray>, prefix: &str| -> Result<Option<LinearProj>> {
+            if let Some(ql) = try_build_ql(params, prefix)? {
+                return Ok(Some(LinearProj::Quantized(ql)));
+            }
+            let weight_key = format!("{prefix}.weight");
+            let Some(weight) = params.get(&weight_key) else {
+                return Ok(None);
+            };
+            ensure_dense_weight_floating(&weight_key, weight)?;
+            Ok(Some(LinearProj::Standard(Linear::from_weights(
+                weight, None,
+            )?)))
+        };
+
     // Embedding
     if let Some(scales) = params.get("embedding.scales") {
         let weight = params.get("embedding.weight").ok_or_else(|| {
@@ -1421,11 +1440,6 @@ fn apply_weights_inner_with_residency(
                     };
                     if let Some(ql) = merged_qkvz_ql {
                         gdn.set_quantized_in_proj_qkvz(ql);
-                    } else if let (Some(qkv), Some(z)) = (
-                        try_build_ql(params, &format!("{}.linear_attn.in_proj_qkv", prefix))?,
-                        try_build_ql(params, &format!("{}.linear_attn.in_proj_z", prefix))?,
-                    ) {
-                        gdn.set_quantized_in_proj_qkv_z(qkv, z);
                     } else if let Some(w) =
                         params.get(&format!("{}.linear_attn.in_proj_qkvz.weight", prefix))
                     {
@@ -1434,6 +1448,26 @@ fn apply_weights_inner_with_residency(
                             w,
                         )?;
                         gdn.set_in_proj_qkvz_weight(w)?;
+                    } else {
+                        let qkv_prefix = format!("{}.linear_attn.in_proj_qkv", prefix);
+                        let z_prefix = format!("{}.linear_attn.in_proj_z", prefix);
+                        match (
+                            try_build_linear_proj(params, &qkv_prefix)?,
+                            try_build_linear_proj(params, &z_prefix)?,
+                        ) {
+                            (Some(qkv), Some(z)) => gdn.set_split_in_proj_qkv_z(qkv, z),
+                            (None, None) => {}
+                            (Some(_), None) => {
+                                return Err(Error::from_reason(format!(
+                                    "Layer {i}: {qkv_prefix}.weight found but {z_prefix}.weight missing"
+                                )));
+                            }
+                            (None, Some(_)) => {
+                                return Err(Error::from_reason(format!(
+                                    "Layer {i}: {z_prefix}.weight found but {qkv_prefix}.weight missing"
+                                )));
+                            }
+                        }
                     }
                     let merged_ba = format!("{}.linear_attn.in_proj_ba", prefix);
                     let merged_ba_ql = if params.contains_key(&format!("{merged_ba}.weight")) {
@@ -1443,11 +1477,6 @@ fn apply_weights_inner_with_residency(
                     };
                     if let Some(ql) = merged_ba_ql {
                         gdn.set_quantized_in_proj_ba(ql);
-                    } else if let (Some(b), Some(a)) = (
-                        try_build_ql(params, &format!("{}.linear_attn.in_proj_b", prefix))?,
-                        try_build_ql(params, &format!("{}.linear_attn.in_proj_a", prefix))?,
-                    ) {
-                        gdn.set_quantized_in_proj_b_a(b, a);
                     } else if let Some(w) =
                         params.get(&format!("{}.linear_attn.in_proj_ba.weight", prefix))
                     {
@@ -1456,6 +1485,26 @@ fn apply_weights_inner_with_residency(
                             w,
                         )?;
                         gdn.set_in_proj_ba_weight(w)?;
+                    } else {
+                        let b_prefix = format!("{}.linear_attn.in_proj_b", prefix);
+                        let a_prefix = format!("{}.linear_attn.in_proj_a", prefix);
+                        match (
+                            try_build_linear_proj(params, &b_prefix)?,
+                            try_build_linear_proj(params, &a_prefix)?,
+                        ) {
+                            (Some(b), Some(a)) => gdn.set_split_in_proj_b_a(b, a),
+                            (None, None) => {}
+                            (Some(_), None) => {
+                                return Err(Error::from_reason(format!(
+                                    "Layer {i}: {b_prefix}.weight found but {a_prefix}.weight missing"
+                                )));
+                            }
+                            (None, Some(_)) => {
+                                return Err(Error::from_reason(format!(
+                                    "Layer {i}: {a_prefix}.weight found but {b_prefix}.weight missing"
+                                )));
+                            }
+                        }
                     }
                     if let Some(ql) =
                         try_build_ql(params, &format!("{}.linear_attn.out_proj", prefix))?
@@ -2682,6 +2731,99 @@ mod tests {
         assert_eq!(merged.shape().unwrap().as_ref(), &[8, 4]);
         assert!(!params.contains_key(&format!("{prefix}.in_proj_qkv.weight")));
         assert!(!params.contains_key(&format!("{prefix}.in_proj_z.weight")));
+    }
+
+    #[test]
+    fn mixed_q4k_dense_split_gdn_projections_install_without_dense_dequant() {
+        let label = "mixed_q4k_dense_split_gdn_projections_install_without_dense_dequant";
+        let cfg = no_mtp_layer_cfg();
+        let mut inner = match Qwen35Inner::new(cfg.clone()) {
+            Ok(inner) => inner,
+            Err(error) => {
+                let message = error.reason.to_string();
+                if message.contains("Metal")
+                    || message.contains("device")
+                    || message.contains("LayerKVPool")
+                {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {message}");
+                    return;
+                }
+                panic!("unexpected Qwen35Inner::new failure in {label}: {message}");
+            }
+        };
+
+        let dense_bf16 = |rows: i64, cols: i64| {
+            MxArray::from_float32(&vec![0.01; (rows * cols) as usize], &[rows, cols])
+                .unwrap()
+                .astype(DType::BFloat16)
+                .unwrap()
+        };
+        let insert_q4k = |params: &mut HashMap<String, MxArray>, prefix: &str, rows: i64| {
+            params.insert(
+                format!("{prefix}.weight"),
+                MxArray::from_uint32(&vec![0; (rows * 4) as usize], &[rows, 4]).unwrap(),
+            );
+            params.insert(
+                format!("{prefix}.scales"),
+                MxArray::from_float32(&vec![1.0; (rows * 2) as usize], &[rows, 2])
+                    .unwrap()
+                    .astype(DType::Uint8)
+                    .unwrap(),
+            );
+            params.insert(
+                format!("{prefix}.biases"),
+                MxArray::from_float16(
+                    &vec![half::f16::from_f32(0.5).to_bits(); rows as usize],
+                    &[rows, 1],
+                )
+                .unwrap(),
+            );
+        };
+
+        let prefix = "layers.0.linear_attn";
+        let qkv_prefix = format!("{prefix}.in_proj_qkv");
+        let z_prefix = format!("{prefix}.in_proj_z");
+        let b_prefix = format!("{prefix}.in_proj_b");
+        let a_prefix = format!("{prefix}.in_proj_a");
+        let mut params = HashMap::new();
+        insert_q4k(&mut params, &qkv_prefix, 128);
+        params.insert(format!("{z_prefix}.weight"), dense_bf16(64, 64));
+        insert_q4k(&mut params, &b_prefix, 4);
+        params.insert(format!("{a_prefix}.weight"), dense_bf16(4, 64));
+
+        let q4k = PerLayerQuant {
+            bits: 4,
+            group_size: 32,
+            mode: PerLayerMode::Q4K,
+            input_amax: None,
+        };
+        let per_layer_quant = HashMap::from([(qkv_prefix, q4k), (b_prefix, q4k)]);
+
+        let error = apply_weights_inner(
+            &mut inner,
+            &params,
+            &cfg,
+            DEFAULT_QUANT_BITS,
+            DEFAULT_QUANT_GROUP_SIZE,
+            None,
+            &per_layer_quant,
+            false,
+        )
+        .expect_err("the intentionally partial checkpoint must fail completeness validation");
+        assert!(
+            error.reason.contains("missing mandatory weights"),
+            "mixed split installation must reach the final completeness gate: {}",
+            error.reason
+        );
+
+        match &inner.layers[0].attn {
+            AttentionType::Linear(gdn) => assert_eq!(
+                gdn.split_in_proj_quantized_sides(),
+                (Some((true, false)), Some((true, false))),
+                "each Q4_K half must stay packed while its BF16 peer stays dense"
+            ),
+            AttentionType::Full(_) => panic!("layer 0 must be a GDN layer"),
+        }
     }
 
     #[test]

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -86,7 +86,10 @@ use super::vision::{Qwen3_5VisionConfig, Qwen3_5VisionEncoder};
 /// mlx-vlm/mlx-lm store separate in_proj_qkv, in_proj_z, in_proj_a, in_proj_b,
 /// but our model expects merged in_proj_qkvz and in_proj_ba.
 /// Concatenates .weight, .scales, and .biases along axis 0.
-pub(crate) fn merge_split_projections(result: &mut HashMap<String, MxArray>) -> Result<()> {
+pub(crate) fn merge_split_projections(
+    result: &mut HashMap<String, MxArray>,
+    per_layer_quant: &HashMap<String, PerLayerQuant>,
+) -> Result<()> {
     fn companion_layouts_match(
         params: &HashMap<String, MxArray>,
         left: &str,
@@ -113,6 +116,31 @@ pub(crate) fn merge_split_projections(result: &mut HashMap<String, MxArray>) -> 
         Ok(true)
     }
 
+    fn declared_profiles_allow_merge(
+        per_layer_quant: &HashMap<String, PerLayerQuant>,
+        merged: &str,
+        left: &str,
+        right: &str,
+    ) -> bool {
+        let direct = per_layer_quant.get(merged);
+        let left = per_layer_quant.get(left);
+        let right = per_layer_quant.get(right);
+        if let Some(direct) = direct {
+            return left.is_none_or(|profile| profile == direct)
+                && right.is_none_or(|profile| profile == direct);
+        }
+        match (left, right) {
+            // Both sides inherit the same file-wide default, or explicitly
+            // name the same packing profile: one fused projection is valid.
+            (None, None) => true,
+            (Some(left), Some(right)) => left == right,
+            // A lone split override means its peer inherits the default. Even
+            // if the packed array shapes happen to match, one runtime mode
+            // cannot describe both halves, so retain the split representation.
+            _ => false,
+        }
+    }
+
     // Merge in_proj_qkv + in_proj_z → in_proj_qkvz
     let split_qkv_keys: Vec<String> = result
         .keys()
@@ -132,6 +160,10 @@ pub(crate) fn merge_split_projections(result: &mut HashMap<String, MxArray>) -> 
         // z. Packed buffers with different bit widths/sidecar geometry cannot
         // be concatenated. Leave those projections split for the GDN runtime.
         if !companion_layouts_match(result, &qkv_prefix, &z_prefix)? {
+            continue;
+        }
+        let merged_prefix = format!("{}.in_proj_qkvz", prefix);
+        if !declared_profiles_allow_merge(per_layer_quant, &merged_prefix, &qkv_prefix, &z_prefix) {
             continue;
         }
 
@@ -168,6 +200,10 @@ pub(crate) fn merge_split_projections(result: &mut HashMap<String, MxArray>) -> 
         if !companion_layouts_match(result, &b_prefix, &a_prefix)? {
             continue;
         }
+        let merged_prefix = format!("{}.in_proj_ba", prefix);
+        if !declared_profiles_allow_merge(per_layer_quant, &merged_prefix, &b_prefix, &a_prefix) {
+            continue;
+        }
 
         let b_w = result.remove(b_key).unwrap();
         let a_w = result.remove(&a_weight_key).unwrap();
@@ -194,6 +230,7 @@ pub(crate) fn merge_split_projections(result: &mut HashMap<String, MxArray>) -> 
 fn sanitize_weights(
     mut params: HashMap<String, MxArray>,
     config: &Qwen3_5Config,
+    per_layer_quant: &HashMap<String, PerLayerQuant>,
 ) -> Result<HashMap<String, MxArray>> {
     let mut result: HashMap<String, MxArray> = HashMap::new();
 
@@ -449,7 +486,7 @@ fn sanitize_weights(
         result.insert(name, array);
     }
 
-    merge_split_projections(&mut result)?;
+    merge_split_projections(&mut result, per_layer_quant)?;
 
     // For FP8 source checkpoints, keep dequantized bf16 weights as-is.
     // Re-quantizing (FP8→bf16→4bit or →MXFP8) compounds quantization error
@@ -2053,8 +2090,16 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
                     (raw_params, None)
                 };
 
+                // Parse quantization metadata before sanitizing: the sanitize
+                // pass may fuse matching GDN split buffers, and it must retain
+                // them as two projections when their declared packing profiles
+                // differ even if their physical array shapes happen to match.
+                let quant_cfg = select_quantization_block(&raw)?;
+                let (quant_bits, quant_group_size, top_level_mode, mut per_layer_quant) =
+                    parse_quant_settings(quant_cfg, DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE)?;
+
                 // Sanitize weights
-                let mut params = sanitize_weights(text_raw_params, &config)?;
+                let mut params = sanitize_weights(text_raw_params, &config, &per_layer_quant)?;
                 let quantized = is_quantized_checkpoint(&params);
                 info!(
                     "Sanitized to {} parameters (quantized={})",
@@ -2062,10 +2107,6 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
                     quantized
                 );
 
-                // Parse quantization config
-                let quant_cfg = select_quantization_block(&raw)?;
-                let (quant_bits, quant_group_size, top_level_mode, mut per_layer_quant) =
-                    parse_quant_settings(quant_cfg, DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE)?;
                 augment_mtplx_mtp_quantization(&raw, config.n_mtp_layers, &mut per_layer_quant)?;
 
                 // sym8 v1 scope: sym8 is only validated on the dense FLAT
@@ -2703,7 +2744,7 @@ mod tests {
         params.insert(format!("{prefix}.in_proj_z.scales"), z_s);
         params.insert(format!("{prefix}.in_proj_z.biases"), z_b);
 
-        merge_split_projections(&mut params).unwrap();
+        merge_split_projections(&mut params, &HashMap::new()).unwrap();
 
         assert!(params.contains_key(&format!("{prefix}.in_proj_qkv.weight")));
         assert!(params.contains_key(&format!("{prefix}.in_proj_z.weight")));
@@ -2723,7 +2764,7 @@ mod tests {
         params.insert(format!("{prefix}.in_proj_z.scales"), z_s);
         params.insert(format!("{prefix}.in_proj_z.biases"), z_b);
 
-        merge_split_projections(&mut params).unwrap();
+        merge_split_projections(&mut params, &HashMap::new()).unwrap();
 
         let merged = params
             .get(&format!("{prefix}.in_proj_qkvz.weight"))
@@ -2731,6 +2772,41 @@ mod tests {
         assert_eq!(merged.shape().unwrap().as_ref(), &[8, 4]);
         assert!(!params.contains_key(&format!("{prefix}.in_proj_qkv.weight")));
         assert!(!params.contains_key(&format!("{prefix}.in_proj_z.weight")));
+    }
+
+    #[test]
+    fn matching_split_buffers_with_different_declared_profiles_stay_split() {
+        let prefix = "layers.0.linear_attn";
+        let qkv_prefix = format!("{prefix}.in_proj_qkv");
+        let z_prefix = format!("{prefix}.in_proj_z");
+        let mut params = HashMap::new();
+        let (qkv_w, qkv_s, qkv_b) = packed_projection(6, 4);
+        let (z_w, z_s, z_b) = packed_projection(2, 4);
+        params.insert(format!("{qkv_prefix}.weight"), qkv_w);
+        params.insert(format!("{qkv_prefix}.scales"), qkv_s);
+        params.insert(format!("{qkv_prefix}.biases"), qkv_b);
+        params.insert(format!("{z_prefix}.weight"), z_w);
+        params.insert(format!("{z_prefix}.scales"), z_s);
+        params.insert(format!("{z_prefix}.biases"), z_b);
+
+        let q4k = PerLayerQuant {
+            bits: 4,
+            group_size: 32,
+            mode: PerLayerMode::Q4K,
+            input_amax: None,
+        };
+        let q5k = PerLayerQuant {
+            bits: 5,
+            mode: PerLayerMode::Q5K,
+            ..q4k
+        };
+        let profiles = HashMap::from([(qkv_prefix.clone(), q4k), (z_prefix.clone(), q5k)]);
+
+        merge_split_projections(&mut params, &profiles).unwrap();
+
+        assert!(params.contains_key(&format!("{qkv_prefix}.weight")));
+        assert!(params.contains_key(&format!("{z_prefix}.weight")));
+        assert!(!params.contains_key(&format!("{prefix}.in_proj_qkvz.weight")));
     }
 
     #[test]

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -15,8 +15,8 @@ use crate::models::quant_dispatch::{
     PlainFp8Residency, default_per_layer_quant, defer_plain_fp8_materialization, effective_plq_for,
     ensure_affine_biases_present, ensure_dense_weight_floating, ensure_int8_storage_resolves_sym8,
     ensure_kquant_storage_resolves_kquant, ensure_plain_fp8_storage_resolves_fp8_e4m3,
-    has_kquant_mode, has_sym8_mode, merge_per_layer, mode_to_str, normalize_per_layer_key,
-    parse_mode_str, parse_quant_settings, resolve_default_mode, select_quantization_block,
+    has_sym8_mode, merge_per_layer, mode_to_str, normalize_per_layer_key, parse_mode_str,
+    parse_quant_settings, resolve_default_mode, select_quantization_block,
 };
 use crate::nn::LayerNorm;
 use crate::tokenizer::Qwen3Tokenizer;
@@ -85,6 +85,32 @@ use super::vision::{Qwen3_5VisionConfig, Qwen3_5VisionEncoder};
 /// but our model expects merged in_proj_qkvz and in_proj_ba.
 /// Concatenates .weight, .scales, and .biases along axis 0.
 pub(crate) fn merge_split_projections(result: &mut HashMap<String, MxArray>) -> Result<()> {
+    fn companion_layouts_match(
+        params: &HashMap<String, MxArray>,
+        left: &str,
+        right: &str,
+    ) -> Result<bool> {
+        for suffix in ["weight", "scales", "biases"] {
+            let a = params.get(&format!("{left}.{suffix}"));
+            let b = params.get(&format!("{right}.{suffix}"));
+            match (a, b) {
+                (Some(a), Some(b)) => {
+                    let a_shape = a.shape()?;
+                    let b_shape = b.shape()?;
+                    if a.dtype()? != b.dtype()?
+                        || a_shape.len() != b_shape.len()
+                        || a_shape.get(1..) != b_shape.get(1..)
+                    {
+                        return Ok(false);
+                    }
+                }
+                (None, None) => {}
+                _ => return Ok(false),
+            }
+        }
+        Ok(true)
+    }
+
     // Merge in_proj_qkv + in_proj_z → in_proj_qkvz
     let split_qkv_keys: Vec<String> = result
         .keys()
@@ -94,8 +120,16 @@ pub(crate) fn merge_split_projections(result: &mut HashMap<String, MxArray>) -> 
 
     for qkv_key in &split_qkv_keys {
         let prefix = qkv_key.strip_suffix(".in_proj_qkv.weight").unwrap();
+        let qkv_prefix = format!("{}.in_proj_qkv", prefix);
+        let z_prefix = format!("{}.in_proj_z", prefix);
         let z_weight_key = format!("{}.in_proj_z.weight", prefix);
         if !result.contains_key(&z_weight_key) {
+            continue;
+        }
+        // Dynamic GGUFs may intentionally assign different qtypes to qkv and
+        // z. Packed buffers with different bit widths/sidecar geometry cannot
+        // be concatenated. Leave those projections split for the GDN runtime.
+        if !companion_layouts_match(result, &qkv_prefix, &z_prefix)? {
             continue;
         }
 
@@ -123,8 +157,13 @@ pub(crate) fn merge_split_projections(result: &mut HashMap<String, MxArray>) -> 
 
     for b_key in &split_b_keys {
         let prefix = b_key.strip_suffix(".in_proj_b.weight").unwrap();
+        let b_prefix = format!("{}.in_proj_b", prefix);
+        let a_prefix = format!("{}.in_proj_a", prefix);
         let a_weight_key = format!("{}.in_proj_a.weight", prefix);
         if !result.contains_key(&a_weight_key) {
+            continue;
+        }
+        if !companion_layouts_match(result, &b_prefix, &a_prefix)? {
             continue;
         }
 
@@ -528,12 +567,6 @@ fn parse_mtp_mode(
              supported by the dense or MoE MTP heads; official recipes keep all mtp.* tensors BF16"
         )));
     }
-    if crate::models::quant_dispatch::is_kquant_mode(mode) {
-        return Err(Error::from_reason(format!(
-            "Unsupported MTP quantization mode '{mode:?}' at {context}: ggml K-quants are only \
-             imported from GGUFs, which never ship an MTP head; MTP tensors are affine/mxfp/bf16"
-        )));
-    }
     Ok(mode)
 }
 
@@ -553,11 +586,16 @@ fn parse_mtp_i32(value: &Value, context: &str) -> Result<i32> {
 fn validate_mtp_bits(bits: i32, mode: PerLayerMode, context: &str) -> Result<()> {
     let valid = match mode {
         PerLayerMode::Affine => matches!(bits, 2 | 3 | 4 | 5 | 6 | 8),
-        PerLayerMode::Mxfp4 | PerLayerMode::Nvfp4 => bits == 4,
-        PerLayerMode::Mxfp8 | PerLayerMode::Sym8 => bits == 8,
-        // K-quants and fp8_e4m3 are never MTP modes (rejected in
-        // `parse_mtp_mode`); reject defensively so the match stays exhaustive.
-        PerLayerMode::Fp8E4m3 | PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => false,
+        PerLayerMode::Mxfp4
+        | PerLayerMode::Nvfp4
+        | PerLayerMode::Q4K
+        | PerLayerMode::IQ4NL
+        | PerLayerMode::IQ4XS => bits == 4,
+        PerLayerMode::Mxfp8 | PerLayerMode::Sym8 | PerLayerMode::IQ3S => bits == 8,
+        PerLayerMode::Q6K => bits == 6,
+        PerLayerMode::Q5K => bits == 5,
+        PerLayerMode::Q3K => bits == 3,
+        PerLayerMode::Fp8E4m3 => false,
     };
     if !valid {
         return Err(Error::from_reason(format!(
@@ -576,7 +614,11 @@ fn parse_mtp_bits(
     let Some(value) = value else {
         return Ok(match mode {
             PerLayerMode::Mxfp4 | PerLayerMode::Nvfp4 => 4,
-            PerLayerMode::Mxfp8 | PerLayerMode::Sym8 => 8,
+            PerLayerMode::Mxfp8 | PerLayerMode::Sym8 | PerLayerMode::IQ3S => 8,
+            PerLayerMode::Q4K | PerLayerMode::IQ4NL | PerLayerMode::IQ4XS => 4,
+            PerLayerMode::Q6K => 6,
+            PerLayerMode::Q5K => 5,
+            PerLayerMode::Q3K => 3,
             _ => absent_default,
         });
     };
@@ -594,7 +636,12 @@ fn parse_mtp_group_size(
     let Some(value) = value else {
         return Ok(match mode {
             PerLayerMode::Mxfp4 | PerLayerMode::Mxfp8 => 32,
-            PerLayerMode::Nvfp4 => 16,
+            PerLayerMode::Nvfp4 | PerLayerMode::Q6K | PerLayerMode::Q3K => 16,
+            PerLayerMode::Q4K
+            | PerLayerMode::Q5K
+            | PerLayerMode::IQ4NL
+            | PerLayerMode::IQ4XS
+            | PerLayerMode::IQ3S => 32,
             PerLayerMode::Sym8 => -1,
             _ => absent_default,
         });
@@ -613,13 +660,13 @@ fn parse_mtp_group_size(
         PerLayerMode::Affine => matches!(group_size, 32 | 64 | 128),
         PerLayerMode::Mxfp4 | PerLayerMode::Mxfp8 => group_size == 32,
         PerLayerMode::Nvfp4 => group_size == 16,
-        // K-quants and sym8/fp8_e4m3 are never MTP modes (rejected in
-        // `parse_mtp_mode`); reject defensively to keep the match exhaustive.
-        PerLayerMode::Sym8
-        | PerLayerMode::Fp8E4m3
-        | PerLayerMode::Q6K
-        | PerLayerMode::Q4K
-        | PerLayerMode::Q5K => false,
+        PerLayerMode::Q6K | PerLayerMode::Q3K => group_size == 16,
+        PerLayerMode::Q4K
+        | PerLayerMode::Q5K
+        | PerLayerMode::IQ4NL
+        | PerLayerMode::IQ4XS
+        | PerLayerMode::IQ3S => group_size == 32,
+        PerLayerMode::Sym8 | PerLayerMode::Fp8E4m3 => false,
     };
     if !valid {
         return Err(Error::from_reason(format!(
@@ -1223,7 +1270,13 @@ fn apply_weights_inner_with_residency(
                 try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
             }
             PerLayerMode::Sym8 => try_build_sym8_quantized_linear(params, prefix)?,
-            PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
+            PerLayerMode::Q6K
+            | PerLayerMode::Q4K
+            | PerLayerMode::Q5K
+            | PerLayerMode::Q3K
+            | PerLayerMode::IQ4NL
+            | PerLayerMode::IQ4XS
+            | PerLayerMode::IQ3S => {
                 try_build_kquant_quantized_linear(params, prefix, plq.mode, "qwen3_5")?
             }
         };
@@ -1358,10 +1411,19 @@ fn apply_weights_inner_with_residency(
                     // sym8 group (int8 `.weight` whose `.scales` was
                     // stripped) makes `try_build_ql` return `Ok(None)`, and
                     // the int8 bytes must NEVER reach the dense bf16 route.
-                    if let Some(ql) =
-                        try_build_ql(params, &format!("{}.linear_attn.in_proj_qkvz", prefix))?
-                    {
+                    let merged_qkvz = format!("{}.linear_attn.in_proj_qkvz", prefix);
+                    let merged_qkvz_ql = if params.contains_key(&format!("{merged_qkvz}.weight")) {
+                        try_build_ql(params, &merged_qkvz)?
+                    } else {
+                        None
+                    };
+                    if let Some(ql) = merged_qkvz_ql {
                         gdn.set_quantized_in_proj_qkvz(ql);
+                    } else if let (Some(qkv), Some(z)) = (
+                        try_build_ql(params, &format!("{}.linear_attn.in_proj_qkv", prefix))?,
+                        try_build_ql(params, &format!("{}.linear_attn.in_proj_z", prefix))?,
+                    ) {
+                        gdn.set_quantized_in_proj_qkv_z(qkv, z);
                     } else if let Some(w) =
                         params.get(&format!("{}.linear_attn.in_proj_qkvz.weight", prefix))
                     {
@@ -1371,10 +1433,19 @@ fn apply_weights_inner_with_residency(
                         )?;
                         gdn.set_in_proj_qkvz_weight(w)?;
                     }
-                    if let Some(ql) =
-                        try_build_ql(params, &format!("{}.linear_attn.in_proj_ba", prefix))?
-                    {
+                    let merged_ba = format!("{}.linear_attn.in_proj_ba", prefix);
+                    let merged_ba_ql = if params.contains_key(&format!("{merged_ba}.weight")) {
+                        try_build_ql(params, &merged_ba)?
+                    } else {
+                        None
+                    };
+                    if let Some(ql) = merged_ba_ql {
                         gdn.set_quantized_in_proj_ba(ql);
+                    } else if let (Some(b), Some(a)) = (
+                        try_build_ql(params, &format!("{}.linear_attn.in_proj_b", prefix))?,
+                        try_build_ql(params, &format!("{}.linear_attn.in_proj_a", prefix))?,
+                    ) {
+                        gdn.set_quantized_in_proj_b_a(b, a);
                     } else if let Some(w) =
                         params.get(&format!("{}.linear_attn.in_proj_ba.weight", prefix))
                     {
@@ -1671,17 +1742,11 @@ fn apply_weights_inner_with_residency(
     // `mtp.forward`; the module sits next to the main model and reads from
     // the same params HashMap.
     if let Some(mtp) = inner.mtp.as_mut() {
-        // sym8/K-quant v1 scope: MTP is OUT. The MTP quant builders map both
-        // `PerLayerMode::Sym8` and every K-quant mode to `None`, and an
-        // imported GGUF never ships an MTP head — skip the load and fail soft
-        // into plain AR decode, mirroring the missing-weights branch.
-        if has_sym8_mode(top_level_mode, per_layer_quant)
-            || has_kquant_mode(top_level_mode, per_layer_quant)
-        {
+        if has_sym8_mode(top_level_mode, per_layer_quant) {
             inner.mtp_weights_loaded = false;
             warn!(
-                "Qwen3.5: sym8/K-quant checkpoint with config.n_mtp_layers={} — MTP is not \
-                 supported on the imported-quant path; disabling speculative MTP.",
+                "Qwen3.5: sym8 checkpoint with config.n_mtp_layers={} — MTP is not \
+                 supported on the sym8 path; disabling speculative MTP.",
                 config.n_mtp_layers
             );
         } else {
@@ -1787,7 +1852,8 @@ fn validate_mandatory_weights(
 /// hybrid scheduler after loading all weights inside the init function.
 /// Returns a `Qwen3_5Model` thin shell with the thread handle.
 pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
-    let model_path = model_path.to_string();
+    let model_assets_path = model_path.to_string();
+    let model_path = model_assets_path.clone();
 
     let (thread, init_rx) = crate::model_thread::ModelThread::spawn_with_scheduler(
         move || {
@@ -2227,6 +2293,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
         image_processor,
         spatial_merge_size,
         context_limits,
+        model_assets_path,
         _cache_limit_guard: cache_limit_guard,
         _pool_cache_limit_guard: pool_cache_limit_guard,
     })
@@ -2370,6 +2437,10 @@ fn parse_config(raw: &Value) -> Result<Qwen3_5Config> {
         // (`resolve_persist_cold`), so this stays a strict tri-state read.
         persist_paged_cache: raw.get("persist_paged_cache").and_then(|v| v.as_bool()),
         n_mtp_layers: gi(&["mtp_num_hidden_layers", "num_nextn_predict_layers"], 0),
+        qwen35_gguf_gdn_layout: raw
+            .get("qwen35_gguf_gdn_layout")
+            .and_then(Value::as_str)
+            .map(str::to_string),
     })
 }
 
@@ -2558,6 +2629,57 @@ pub fn create_random_qwen35_checkpoint<'env>(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn packed_projection(rows: i64, weight_cols: i64) -> (MxArray, MxArray, MxArray) {
+        (
+            MxArray::zeros(&[rows, weight_cols], Some(DType::Uint32)).unwrap(),
+            MxArray::zeros(&[rows, 2], Some(DType::Int8)).unwrap(),
+            MxArray::zeros(&[rows, 1], Some(DType::Float16)).unwrap(),
+        )
+    }
+
+    #[test]
+    fn split_gdn_projections_with_different_packed_layouts_stay_split() {
+        let prefix = "layers.0.linear_attn";
+        let mut params = HashMap::new();
+        let (qkv_w, qkv_s, qkv_b) = packed_projection(6, 4);
+        let (z_w, z_s, z_b) = packed_projection(2, 5);
+        params.insert(format!("{prefix}.in_proj_qkv.weight"), qkv_w);
+        params.insert(format!("{prefix}.in_proj_qkv.scales"), qkv_s);
+        params.insert(format!("{prefix}.in_proj_qkv.biases"), qkv_b);
+        params.insert(format!("{prefix}.in_proj_z.weight"), z_w);
+        params.insert(format!("{prefix}.in_proj_z.scales"), z_s);
+        params.insert(format!("{prefix}.in_proj_z.biases"), z_b);
+
+        merge_split_projections(&mut params).unwrap();
+
+        assert!(params.contains_key(&format!("{prefix}.in_proj_qkv.weight")));
+        assert!(params.contains_key(&format!("{prefix}.in_proj_z.weight")));
+        assert!(!params.contains_key(&format!("{prefix}.in_proj_qkvz.weight")));
+    }
+
+    #[test]
+    fn split_gdn_projections_with_matching_packed_layouts_are_merged() {
+        let prefix = "layers.0.linear_attn";
+        let mut params = HashMap::new();
+        let (qkv_w, qkv_s, qkv_b) = packed_projection(6, 4);
+        let (z_w, z_s, z_b) = packed_projection(2, 4);
+        params.insert(format!("{prefix}.in_proj_qkv.weight"), qkv_w);
+        params.insert(format!("{prefix}.in_proj_qkv.scales"), qkv_s);
+        params.insert(format!("{prefix}.in_proj_qkv.biases"), qkv_b);
+        params.insert(format!("{prefix}.in_proj_z.weight"), z_w);
+        params.insert(format!("{prefix}.in_proj_z.scales"), z_s);
+        params.insert(format!("{prefix}.in_proj_z.biases"), z_b);
+
+        merge_split_projections(&mut params).unwrap();
+
+        let merged = params
+            .get(&format!("{prefix}.in_proj_qkvz.weight"))
+            .expect("compatible packed projections must merge");
+        assert_eq!(merged.shape().unwrap().as_ref(), &[8, 4]);
+        assert!(!params.contains_key(&format!("{prefix}.in_proj_qkv.weight")));
+        assert!(!params.contains_key(&format!("{prefix}.in_proj_z.weight")));
+    }
 
     #[test]
     fn packed_qwen_embedding_fallback_is_explicit_truthy_and_default_on() {
@@ -3069,6 +3191,7 @@ mod tests {
     /// per-layer linear loop is empty), keeping the fixture tiny.
     fn no_mtp_layer_cfg() -> Qwen3_5Config {
         Qwen3_5Config {
+            qwen35_gguf_gdn_layout: None,
             vocab_size: 1024,
             hidden_size: 64,
             num_layers: 4,

--- a/crates/mlx-core/src/models/qwen3_5/quantized_linear.rs
+++ b/crates/mlx-core/src/models/qwen3_5/quantized_linear.rs
@@ -479,10 +479,10 @@ pub fn try_build_kquant_quantized_linear(
 
 /// Linear layer backed by a serialized quantized weight format.
 ///
-/// Affine/MX/NVFP modes use packed Uint32 weights and MLX quantized_matmul;
-/// sym8 uses dedicated int8 kernels. Plain `fp8_e4m3` is the intentionally
-/// non-native exception: it retains raw Uint8 checkpoint storage, reconstructs
-/// BF16 once at load, and uses ordinary A16 matmul.
+/// Affine, MX/NVFP, and native GGUF K/IQ modes use packed weights and MLX
+/// quantized_matmul; sym8 uses dedicated int8 kernels. Plain `fp8_e4m3` is the
+/// intentionally non-native exception: it retains raw Uint8 checkpoint
+/// storage, reconstructs BF16 once at load, and uses ordinary A16 matmul.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 enum QuantizedOutputLayout {
     #[default]
@@ -527,11 +527,11 @@ fn q_gate_block_permutation(num_heads: i32, head_dim: i32, output_rows: i64) -> 
 pub struct QuantizedLinear {
     weight: MxArray,         // Packed uint32 quantized weights [out, in_packed]
     scales: MxArray,         // Quantization scales
-    biases: Option<MxArray>, // Quantization biases (for affine mode)
+    biases: Option<MxArray>, // Affine biases or native K/IQ floating sidecars
     bias: Option<MxArray>,   // Linear bias (additive)
     group_size: i32,
     bits: i32,
-    mode: String, // "affine", "mxfp8", "mxfp4", "nvfp4", "fp8_e4m3", or "sym8"
+    mode: String, // affine, MX/NVFP, native GGUF K/IQ, fp8_e4m3, or sym8
     // Reconstructed BF16 `[N,K]` weight for the plain E4M3 correctness
     // fallback. `Some` iff mode == fp8_e4m3; activations remain A16.
     fp8_dequant_weight: Option<MxArray>,
@@ -680,15 +680,18 @@ impl QuantizedLinear {
         }
     }
 
-    /// Reorder an affine q/gate projection's output rows from checkpoint order
+    /// Reorder a packed q/gate projection's output rows from checkpoint order
     /// `[Q_h0,G_h0,Q_h1,G_h1,...]` to `[Q_all_heads,G_all_heads]`.
     ///
     /// All row-coupled operands are materialized together before replacing the
-    /// stored arrays. Once this returns `true`, the original-order arrays are
-    /// no longer retained by the projection. Non-affine or incompatible direct
-    /// constructor inputs stay untouched and return `false` so attention keeps
-    /// using its native per-head split.
-    pub(crate) fn finalize_affine_q_gate_block(
+    /// stored arrays. Affine and every native GGUF K/IQ mode are row-coupled:
+    /// permuting axis 0 of weight/scales/quantization-bias sidecars preserves
+    /// the packed code stream and never dequantizes it. Once this returns
+    /// `true`, the original-order arrays are no longer retained by the
+    /// projection. Other modes or incompatible direct-constructor inputs stay
+    /// untouched and return `false` so attention keeps its native per-head
+    /// split.
+    pub(crate) fn finalize_packed_q_gate_block(
         &mut self,
         num_heads: i32,
         head_dim: i32,
@@ -696,7 +699,10 @@ impl QuantizedLinear {
         if self.output_layout == QuantizedOutputLayout::QGateBlock {
             return Ok(true);
         }
-        if self.mode != DEFAULT_QUANT_MODE {
+        let mode = crate::models::quant_dispatch::parse_mode_str(Some(&self.mode));
+        let row_permutable = self.mode == DEFAULT_QUANT_MODE
+            || mode.is_some_and(crate::models::quant_dispatch::is_kquant_mode);
+        if !row_permutable {
             return Ok(false);
         }
 
@@ -719,7 +725,7 @@ impl QuantizedLinear {
             || quant_biases_shape.len() != 2
             || weight_shape[0] != expected_rows
             || scales_shape[0] != expected_rows
-            || quant_biases_shape != scales_shape
+            || quant_biases_shape[0] != expected_rows
             || !additive_bias_compatible
         {
             return Ok(false);
@@ -977,8 +983,8 @@ impl QuantizedLinear {
         self.biases.as_ref()
     }
 
-    /// Quantization mode discriminator string ("affine", "mxfp8", "mxfp4",
-    /// "nvfp4", "fp8_e4m3", or "sym8").
+    /// Quantization mode discriminator string (affine, MX/NVFP, native GGUF
+    /// K/IQ, `fp8_e4m3`, or `sym8`).
     pub fn mode(&self) -> &str {
         &self.mode
     }
@@ -1183,7 +1189,7 @@ mod q_gate_block_tests {
             DEFAULT_QUANT_MODE.to_string(),
         );
 
-        assert!(linear.finalize_affine_q_gate_block(h, d).unwrap());
+        assert!(linear.finalize_packed_q_gate_block(h, d).unwrap());
         assert!(linear.has_q_gate_block_layout());
         assert_ne!(linear.weight.as_raw_ptr(), original_ptrs[0]);
         assert_ne!(linear.scales.as_raw_ptr(), original_ptrs[1]);
@@ -1230,8 +1236,83 @@ mod q_gate_block_tests {
         );
 
         assert!(
-            linear.finalize_affine_q_gate_block(h, d).unwrap(),
+            linear.finalize_packed_q_gate_block(h, d).unwrap(),
             "the finalized layout must be idempotent"
+        );
+    }
+
+    #[test]
+    fn q4k_q_gate_block_reorders_different_companion_widths_without_dequantizing() {
+        let h = 3;
+        let d = 2;
+        let rows = 12i64;
+        let permutation = q_gate_block_permutation(h, d, rows).unwrap();
+        let weight_values = (0..rows)
+            .flat_map(|row| [row as u32 * 100, row as u32 * 100 + 1])
+            .collect::<Vec<_>>();
+        let scales_values = (0..rows)
+            .flat_map(|row| {
+                [
+                    row as u8 * 4,
+                    row as u8 * 4 + 1,
+                    row as u8 * 4 + 2,
+                    row as u8 * 4 + 3,
+                ]
+            })
+            .collect::<Vec<_>>();
+        let quant_bias_values = (0..rows)
+            .flat_map(|row| [0x3000u16 + row as u16, 0x3400u16 + row as u16])
+            .collect::<Vec<_>>();
+
+        let mut linear = QuantizedLinear::new(
+            MxArray::from_uint32(&weight_values, &[rows, 2]).unwrap(),
+            MxArray::from_uint8(&scales_values, &[rows, 4]).unwrap(),
+            Some(MxArray::from_float16(&quant_bias_values, &[rows, 2]).unwrap()),
+            None,
+            32,
+            4,
+            "q4k".to_string(),
+        );
+
+        assert!(linear.finalize_packed_q_gate_block(h, d).unwrap());
+        assert!(linear.has_q_gate_block_layout());
+        assert_eq!(linear.weight.dtype().unwrap(), crate::array::DType::Uint32);
+        assert_eq!(linear.scales.dtype().unwrap(), crate::array::DType::Uint8);
+        assert_eq!(
+            linear.biases.as_ref().unwrap().dtype().unwrap(),
+            crate::array::DType::Float16
+        );
+
+        let expected_weight = permutation
+            .iter()
+            .flat_map(|&row| [row as u32 * 100, row as u32 * 100 + 1])
+            .collect::<Vec<_>>();
+        let expected_scales = permutation
+            .iter()
+            .flat_map(|&row| {
+                [
+                    row as u8 * 4,
+                    row as u8 * 4 + 1,
+                    row as u8 * 4 + 2,
+                    row as u8 * 4 + 3,
+                ]
+            })
+            .collect::<Vec<_>>();
+        let expected_biases = permutation
+            .iter()
+            .flat_map(|&row| [0x3000u16 + row as u16, 0x3400u16 + row as u16])
+            .collect::<Vec<_>>();
+        assert_eq!(linear.weight.to_uint32().unwrap().to_vec(), expected_weight);
+        assert_eq!(linear.scales.to_uint8().unwrap().to_vec(), expected_scales);
+        assert_eq!(
+            linear
+                .biases
+                .as_ref()
+                .unwrap()
+                .to_uint16_native()
+                .unwrap()
+                .to_vec(),
+            expected_biases
         );
     }
 
@@ -1251,7 +1332,7 @@ mod q_gate_block_tests {
             MXFP4_MODE.to_string(),
         );
         let original = non_affine.weight.as_raw_ptr();
-        assert!(!non_affine.finalize_affine_q_gate_block(3, 2).unwrap());
+        assert!(!non_affine.finalize_packed_q_gate_block(3, 2).unwrap());
         assert!(!non_affine.has_q_gate_block_layout());
         assert_eq!(non_affine.weight.as_raw_ptr(), original);
 
@@ -1265,7 +1346,7 @@ mod q_gate_block_tests {
             DEFAULT_QUANT_MODE.to_string(),
         );
         let original = incompatible.weight.as_raw_ptr();
-        assert!(!incompatible.finalize_affine_q_gate_block(3, 2).unwrap());
+        assert!(!incompatible.finalize_packed_q_gate_block(3, 2).unwrap());
         assert!(!incompatible.has_q_gate_block_layout());
         assert_eq!(incompatible.weight.as_raw_ptr(), original);
     }

--- a/crates/mlx-core/src/models/qwen3_5_moe/config.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/config.rs
@@ -187,6 +187,7 @@ impl Qwen3_5MoeConfig {
             // dense config it maps to never attaches a cold tier of its own.
             persist_paged_cache: None,
             n_mtp_layers: self.n_mtp_layers,
+            qwen35_gguf_gdn_layout: None,
         }
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/config.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/config.rs
@@ -113,6 +113,14 @@ pub struct Qwen3_5MoeConfig {
     /// unavailable.
     #[serde(default)]
     pub n_mtp_layers: i32,
+
+    /// Internal layout marker written by native Qwen3.5/3.8 GGUF conversion.
+    /// `Some("tiled")` keeps llama.cpp's value-head order and lets the shared
+    /// GDN runtime map value head h to key head h % Hk without permuting
+    /// packed weights.
+    #[serde(default)]
+    #[napi(ts_type = "string | undefined")]
+    pub qwen35_gguf_gdn_layout: Option<String>,
 }
 
 fn default_linear_num_value_heads() -> i32 {
@@ -187,7 +195,7 @@ impl Qwen3_5MoeConfig {
             // dense config it maps to never attaches a cold tier of its own.
             persist_paged_cache: None,
             n_mtp_layers: self.n_mtp_layers,
-            qwen35_gguf_gdn_layout: None,
+            qwen35_gguf_gdn_layout: self.qwen35_gguf_gdn_layout.clone(),
         }
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/decoder_layer.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/decoder_layer.rs
@@ -16,6 +16,11 @@ use super::sparse_moe::SparseMoeBlock;
 pub(crate) use crate::models::qwen3_5::decoder_layer::Qwen3_5LayerKind;
 
 /// Attention type for a decoder layer.
+///
+/// GDN carries native split packed-projection state and is the common hot path
+/// in this hybrid model. Keep it inline rather than adding a pointer chase to
+/// every linear-attention forward merely to equalize enum variant sizes.
+#[allow(clippy::large_enum_variant)]
 pub enum AttentionType {
     Linear(GatedDeltaNet),
     Full(Qwen3_5Attention),

--- a/crates/mlx-core/src/models/qwen3_5_moe/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/model.rs
@@ -10753,6 +10753,7 @@ mod paged_construction_tests {
             use_block_paged_cache: if use_block_paged { Some(true) } else { None },
             persist_paged_cache: None,
             n_mtp_layers: 0,
+            qwen35_gguf_gdn_layout: None,
         }
     }
 
@@ -12315,6 +12316,7 @@ mod mask_free_full_attention_parity_tests {
             use_block_paged_cache: None,
             persist_paged_cache: None,
             n_mtp_layers: 0,
+            qwen35_gguf_gdn_layout: None,
         }
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
@@ -362,7 +362,13 @@ impl Qwen3_5MoeMTPModule {
                 // Unreachable: the MoE loader disables MTP for K-quant
                 // checkpoints (`checkpoint_has_kquant` gate); an imported GGUF
                 // never ships an MTP head. `None` fails soft into AR decode.
-                PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => None,
+                PerLayerMode::Q6K
+                | PerLayerMode::Q4K
+                | PerLayerMode::Q5K
+                | PerLayerMode::Q3K
+                | PerLayerMode::IQ4NL
+                | PerLayerMode::IQ4XS
+                | PerLayerMode::IQ3S => None,
             }
         };
         let try_build_qsl = |params: &HashMap<String, MxArray>, prefix: &str| {
@@ -381,7 +387,13 @@ impl Qwen3_5MoeMTPModule {
                 // Unreachable: see try_build_ql above.
                 PerLayerMode::Sym8 => None,
                 // Unreachable: see try_build_ql above (K-quant MTP is gated off).
-                PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => None,
+                PerLayerMode::Q6K
+                | PerLayerMode::Q4K
+                | PerLayerMode::Q5K
+                | PerLayerMode::Q3K
+                | PerLayerMode::IQ4NL
+                | PerLayerMode::IQ4XS
+                | PerLayerMode::IQ3S => None,
             }
         };
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/mtp.rs
@@ -870,6 +870,7 @@ mod tests {
             use_block_paged_cache: None,
             persist_paged_cache: None,
             n_mtp_layers: 1,
+            qwen35_gguf_gdn_layout: None,
         }
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/paged_forward.rs
@@ -1223,6 +1223,7 @@ mod tests {
             use_block_paged_cache: Some(true),
             persist_paged_cache: None,
             n_mtp_layers: 0,
+            qwen35_gguf_gdn_layout: None,
         }
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -28,6 +28,7 @@ use crate::models::qwen3_5::persistence::{
 };
 use crate::models::qwen3_5::processing::Qwen35VLImageProcessor;
 use crate::models::qwen3_5::vision::Qwen3_5VisionEncoder;
+use crate::nn::Linear;
 use crate::tokenizer::Qwen3Tokenizer;
 use crate::transformer::paged_kv_cache_adapter::PagedKVCacheAdapter;
 
@@ -36,7 +37,7 @@ use super::decoder_layer::{AttentionType, MLPType};
 use super::model::{Qwen3_5MoeModel, Qwen35MoeInner, Qwen35MoeSchedulerState};
 use super::quantized_linear::{
     DEFAULT_QUANT_BITS, DEFAULT_QUANT_GROUP_SIZE, GATE_QUANT_BITS, GATE_QUANT_GROUP_SIZE,
-    MLPVariant, PerLayerMode, PerLayerQuant, QuantizedLinear, QuantizedSwitchLinear,
+    LinearProj, MLPVariant, PerLayerMode, PerLayerQuant, QuantizedLinear, QuantizedSwitchLinear,
     is_mxfp8_checkpoint, is_quantized_checkpoint, try_build_fp8_e4m3_quantized_linear,
     try_build_fp8_e4m3_quantized_switch_linear, try_build_kquant_quantized_linear,
     try_build_kquant_quantized_switch_linear, try_build_mxfp4_quantized_linear,
@@ -615,6 +616,24 @@ fn apply_weights_moe_inner_with_residency(
         Ok(built)
     };
 
+    // `merge_split_projections` preserves Dynamic GGUF halves whose storage
+    // modes differ. Resolve each retained half independently so mixed
+    // packed+dense GDN projections do not fall through to constructor weights.
+    let try_build_linear_proj =
+        |params: &HashMap<String, MxArray>, prefix: &str| -> Result<Option<LinearProj>> {
+            if let Some(ql) = try_build_ql(params, prefix)? {
+                return Ok(Some(LinearProj::Quantized(ql)));
+            }
+            let weight_key = format!("{prefix}.weight");
+            let Some(weight) = params.get(&weight_key) else {
+                return Ok(None);
+            };
+            ensure_dense_weight_floating(&weight_key, weight)?;
+            Ok(Some(LinearProj::Standard(Linear::from_weights(
+                weight, None,
+            )?)))
+        };
+
     let try_build_qsl = |params: &HashMap<String, MxArray>,
                          prefix: &str|
      -> Result<Option<QuantizedSwitchLinear>> {
@@ -789,6 +808,26 @@ fn apply_weights_moe_inner_with_residency(
                             w,
                         )?;
                         gdn.set_in_proj_qkvz_weight(w)?;
+                    } else {
+                        let qkv_prefix = format!("{}.linear_attn.in_proj_qkv", prefix);
+                        let z_prefix = format!("{}.linear_attn.in_proj_z", prefix);
+                        match (
+                            try_build_linear_proj(params, &qkv_prefix)?,
+                            try_build_linear_proj(params, &z_prefix)?,
+                        ) {
+                            (Some(qkv), Some(z)) => gdn.set_split_in_proj_qkv_z(qkv, z),
+                            (None, None) => {}
+                            (Some(_), None) => {
+                                return Err(Error::from_reason(format!(
+                                    "Layer {i}: {qkv_prefix}.weight found but {z_prefix}.weight missing"
+                                )));
+                            }
+                            (None, Some(_)) => {
+                                return Err(Error::from_reason(format!(
+                                    "Layer {i}: {z_prefix}.weight found but {qkv_prefix}.weight missing"
+                                )));
+                            }
+                        }
                     }
 
                     if let Some(ql) =
@@ -803,6 +842,26 @@ fn apply_weights_moe_inner_with_residency(
                             w,
                         )?;
                         gdn.set_in_proj_ba_weight(w)?;
+                    } else {
+                        let b_prefix = format!("{}.linear_attn.in_proj_b", prefix);
+                        let a_prefix = format!("{}.linear_attn.in_proj_a", prefix);
+                        match (
+                            try_build_linear_proj(params, &b_prefix)?,
+                            try_build_linear_proj(params, &a_prefix)?,
+                        ) {
+                            (Some(b), Some(a)) => gdn.set_split_in_proj_b_a(b, a),
+                            (None, None) => {}
+                            (Some(_), None) => {
+                                return Err(Error::from_reason(format!(
+                                    "Layer {i}: {b_prefix}.weight found but {a_prefix}.weight missing"
+                                )));
+                            }
+                            (None, Some(_)) => {
+                                return Err(Error::from_reason(format!(
+                                    "Layer {i}: {a_prefix}.weight found but {b_prefix}.weight missing"
+                                )));
+                            }
+                        }
                     }
 
                     if let Some(ql) =
@@ -2163,6 +2222,101 @@ mod tests {
             use_block_paged_cache: Some(true),
             persist_paged_cache: None,
             n_mtp_layers: 0,
+        }
+    }
+
+    #[test]
+    fn mixed_q4k_dense_split_gdn_projections_install_through_moe_loader() {
+        let label = "mixed_q4k_dense_split_gdn_projections_install_through_moe_loader";
+        let mut config = moe_paged_tiny_cfg();
+        config.use_block_paged_cache = Some(false);
+        config.paged_cache_memory_mb = None;
+        let mut inner = match Qwen35MoeInner::new(config.clone()) {
+            Ok(inner) => inner,
+            Err(error) => {
+                let message = error.reason.to_string();
+                if message.contains("Metal")
+                    || message.contains("device")
+                    || message.contains("LayerKVPool")
+                {
+                    eprintln!("skipping {label} (MLX/Metal unavailable): {message}");
+                    return;
+                }
+                panic!("unexpected Qwen35MoeInner::new failure in {label}: {message}");
+            }
+        };
+
+        let dense_bf16 = |rows: i64, cols: i64| {
+            MxArray::from_float32(&vec![0.01; (rows * cols) as usize], &[rows, cols])
+                .unwrap()
+                .astype(DType::BFloat16)
+                .unwrap()
+        };
+        let insert_q4k = |params: &mut HashMap<String, MxArray>, prefix: &str, rows: i64| {
+            params.insert(
+                format!("{prefix}.weight"),
+                MxArray::from_uint32(&vec![0; (rows * 4) as usize], &[rows, 4]).unwrap(),
+            );
+            params.insert(
+                format!("{prefix}.scales"),
+                MxArray::from_float32(&vec![1.0; (rows * 2) as usize], &[rows, 2])
+                    .unwrap()
+                    .astype(DType::Uint8)
+                    .unwrap(),
+            );
+            params.insert(
+                format!("{prefix}.biases"),
+                MxArray::from_float16(
+                    &vec![half::f16::from_f32(0.5).to_bits(); rows as usize],
+                    &[rows, 1],
+                )
+                .unwrap(),
+            );
+        };
+
+        let prefix = "layers.0.linear_attn";
+        let qkv_prefix = format!("{prefix}.in_proj_qkv");
+        let z_prefix = format!("{prefix}.in_proj_z");
+        let b_prefix = format!("{prefix}.in_proj_b");
+        let a_prefix = format!("{prefix}.in_proj_a");
+        let mut params = HashMap::new();
+        insert_q4k(&mut params, &qkv_prefix, 256);
+        params.insert(format!("{z_prefix}.weight"), dense_bf16(128, 128));
+        insert_q4k(&mut params, &b_prefix, 4);
+        params.insert(format!("{a_prefix}.weight"), dense_bf16(4, 128));
+
+        let q4k = PerLayerQuant {
+            bits: 4,
+            group_size: 32,
+            mode: PerLayerMode::Q4K,
+            input_amax: None,
+        };
+        let per_layer_quant = HashMap::from([(qkv_prefix, q4k), (b_prefix, q4k)]);
+
+        let error = apply_weights_moe_inner(
+            &mut inner,
+            &params,
+            &config,
+            DEFAULT_QUANT_BITS,
+            DEFAULT_QUANT_GROUP_SIZE,
+            None,
+            &per_layer_quant,
+            false,
+        )
+        .expect_err("the intentionally partial checkpoint must fail completeness validation");
+        assert!(
+            error.reason.contains("missing mandatory weights"),
+            "mixed split installation must reach the final completeness gate: {}",
+            error.reason
+        );
+
+        match &inner.layers[0].attn {
+            AttentionType::Linear(gdn) => assert_eq!(
+                gdn.split_in_proj_quantized_sides(),
+                (Some((true, false)), Some((true, false))),
+                "each Q4_K half must stay packed while its BF16 peer stays dense"
+            ),
+            AttentionType::Full(_) => panic!("layer 0 must be a GDN layer"),
         }
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -2101,6 +2101,10 @@ fn parse_config(raw: &Value) -> Result<Qwen3_5MoeConfig> {
         // (`resolve_persist_cold`), so this stays a strict tri-state read.
         persist_paged_cache: raw.get("persist_paged_cache").and_then(|v| v.as_bool()),
         n_mtp_layers: gi(&["mtp_num_hidden_layers", "num_nextn_predict_layers"], 0),
+        qwen35_gguf_gdn_layout: raw
+            .get("qwen35_gguf_gdn_layout")
+            .and_then(Value::as_str)
+            .map(str::to_string),
     })
 }
 
@@ -2186,6 +2190,28 @@ mod tests {
     };
     use std::collections::HashMap;
 
+    #[test]
+    fn native_tiled_gdn_layout_survives_moe_parse_and_dense_projection() {
+        let config = super::parse_config(&serde_json::json!({
+            "vocab_size": 128,
+            "hidden_size": 128,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 128,
+            "num_experts": 4,
+            "num_experts_per_tok": 2,
+            "qwen35_gguf_gdn_layout": "tiled"
+        }))
+        .unwrap();
+
+        assert_eq!(config.qwen35_gguf_gdn_layout.as_deref(), Some("tiled"));
+        assert_eq!(
+            config.to_dense_config().qwen35_gguf_gdn_layout.as_deref(),
+            Some("tiled")
+        );
+    }
+
     /// Paged, tied, non-MTP, non-VLM `Qwen3_5MoeConfig` fixture. `head_dim = 32`
     /// (smallest valid block-paged pool head size); `hidden_size = num_heads *
     /// head_dim = 128`. Mirrors `paged_forward::tests::moe_paged_tiny_config`.
@@ -2225,6 +2251,7 @@ mod tests {
             use_block_paged_cache: Some(true),
             persist_paged_cache: None,
             n_mtp_layers: 0,
+            qwen35_gguf_gdn_layout: None,
         }
     }
 
@@ -2495,6 +2522,7 @@ mod tests {
             use_block_paged_cache: None,
             persist_paged_cache: None,
             n_mtp_layers: 0,
+            qwen35_gguf_gdn_layout: None,
         }
     }
 

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -571,7 +571,13 @@ fn apply_weights_moe_inner_with_residency(
                 try_build_quantized_linear(params, prefix, plq.group_size, plq.bits)
             }
             PerLayerMode::Sym8 => try_build_sym8_quantized_linear(params, prefix)?,
-            PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
+            PerLayerMode::Q6K
+            | PerLayerMode::Q4K
+            | PerLayerMode::Q5K
+            | PerLayerMode::Q3K
+            | PerLayerMode::IQ4NL
+            | PerLayerMode::IQ4XS
+            | PerLayerMode::IQ3S => {
                 try_build_kquant_quantized_linear(params, prefix, plq.mode, "qwen3_5_moe")?
             }
         };
@@ -625,7 +631,13 @@ fn apply_weights_moe_inner_with_residency(
             PerLayerMode::Affine => {
                 try_build_quantized_switch_linear(params, prefix, plq.group_size, plq.bits)
             }
-            PerLayerMode::Q6K | PerLayerMode::Q4K | PerLayerMode::Q5K => {
+            PerLayerMode::Q6K
+            | PerLayerMode::Q4K
+            | PerLayerMode::Q5K
+            | PerLayerMode::Q3K
+            | PerLayerMode::IQ4NL
+            | PerLayerMode::IQ4XS
+            | PerLayerMode::IQ3S => {
                 try_build_kquant_quantized_switch_linear(params, prefix, plq.mode, "qwen3_5_moe")?
             }
             // Per-expert 3-D stacked projections route through gather_qmm,

--- a/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5_moe/persistence.rs
@@ -52,6 +52,7 @@ use super::switch_glu::SwitchGLU;
 fn sanitize_weights(
     mut params: HashMap<String, MxArray>,
     config: &Qwen3_5MoeConfig,
+    per_layer_quant: &HashMap<String, PerLayerQuant>,
 ) -> Result<HashMap<String, MxArray>> {
     let mut result: HashMap<String, MxArray> = HashMap::new();
 
@@ -403,7 +404,7 @@ fn sanitize_weights(
         }
     }
 
-    crate::models::qwen3_5::persistence::merge_split_projections(&mut result)?;
+    crate::models::qwen3_5::persistence::merge_split_projections(&mut result, per_layer_quant)?;
 
     // For FP8 source checkpoints, keep dequantized bf16 weights as-is.
     // Re-quantizing (FP8→bf16→4bit or →MXFP8) compounds quantization error
@@ -1683,16 +1684,9 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5MoeModel> {
                         (raw_params, None)
                     };
 
-                    // Sanitize weights
-                    let params = sanitize_weights(text_raw_params, &config)?;
-                    let quantized = is_quantized_checkpoint(&params);
-                    info!(
-                        "Sanitized to {} parameters (quantized={})",
-                        params.len(),
-                        quantized
-                    );
-
-                    // Parse quantization config
+                    // Parse quantization metadata before sanitizing so the
+                    // shared GDN fusion gate can compare the two split
+                    // projections' declared packing profiles.
                     let quant_cfg = select_quantization_block(&raw)?;
                     let (quant_bits, quant_group_size, top_level_mode, mut per_layer_quant) =
                         parse_quant_settings(
@@ -1700,6 +1694,15 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5MoeModel> {
                             DEFAULT_QUANT_BITS,
                             DEFAULT_QUANT_GROUP_SIZE,
                         )?;
+
+                    // Sanitize weights
+                    let params = sanitize_weights(text_raw_params, &config, &per_layer_quant)?;
+                    let quantized = is_quantized_checkpoint(&params);
+                    info!(
+                        "Sanitized to {} parameters (quantized={})",
+                        params.len(),
+                        quantized
+                    );
 
                     // Augment the per-layer-quant table with the MTP head's
                     // quantization metadata derived from the
@@ -2622,7 +2625,8 @@ mod tests {
             }
         }
 
-        let out = sanitize_weights(params, &config).expect("K-quant expert stacking must succeed");
+        let out = sanitize_weights(params, &config, &HashMap::new())
+            .expect("K-quant expert stacking must succeed");
 
         for proj in ["gate_proj", "up_proj", "down_proj"] {
             let w = out

--- a/crates/mlx-core/src/nn/embedding.rs
+++ b/crates/mlx-core/src/nn/embedding.rs
@@ -19,14 +19,15 @@ use std::sync::{
 /// packed-resident (real memory savings of `vocab × hidden × 2` bytes for a
 /// large vocab). `forward` does a per-row gather-then-dequant (only the looked-
 /// up rows are dequantized) and `as_linear` runs `mlx_quantized_matmul` for the
-/// tied lm_head. `mode` is the quantization mode string ("affine" / "mxfp4" /
-/// "mxfp8" / "nvfp4") threaded into both ops.
+/// tied lm_head. `mode` is the quantization mode string (affine, MX/NVFP, or
+/// native GGUF K/IQ) threaded into both ops.
 struct QuantizedEmbeddingBackend {
     /// Packed quantized weight `[num_embeddings, packed_dim]`.
     weight: MxArray,
     /// Quantization scales.
     scales: MxArray,
-    /// Quantization biases (affine mode only; `None` for mxfp4/mxfp8/nvfp4).
+    /// Affine biases or native K/IQ floating super-block sidecars; `None` for
+    /// MXFP4/MXFP8/NVFP4.
     biases: Option<MxArray>,
     group_size: i32,
     bits: i32,
@@ -290,11 +291,11 @@ impl Embedding {
     /// Pre-dequantizes the full table into `self.weight` — the packed
     /// weight/scales/biases are NOT retained. Kept as an exact compatibility
     /// fallback for callers that still require a dense table. `mode` is the quantization mode string
-    /// ("affine" / "mxfp4" / "mxfp8" / "nvfp4" / "q6k" / "q4k" / "q5k") the
-    /// dequant is decoded with — the caller passes the mode resolved from the
-    /// checkpoint, so a K-quant table decodes as K-quant instead of being
-    /// misread as affine. Do not route new callers here; use
-    /// `load_quantized_packed` for memory savings.
+    /// (affine, MXFP/NVFP, or native GGUF K/IQ) the dequant is decoded with —
+    /// the caller passes the mode resolved from the checkpoint, so a K/IQ
+    /// table decodes with its actual format instead of being misread as
+    /// affine. Do not route new callers here; use `load_quantized_packed` for
+    /// memory savings.
     pub fn load_quantized(
         &mut self,
         weight: &MxArray,
@@ -329,8 +330,9 @@ impl Embedding {
     /// Retains the packed `weight`/`scales`/(`biases`) AS-IS — does NOT
     /// dequantize the table. `forward` gather-then-dequantizes only the looked-
     /// up rows; `as_linear` runs `mlx_quantized_matmul`. The dense table is
-    /// never materialized, so the embedding stays packed-resident. Supports ALL
-    /// modes (affine + mxfp4/mxfp8/nvfp4); mxfp/nvfp pass `biases = None`.
+    /// never materialized, so the embedding stays packed-resident. Supports all
+    /// modes accepted by MLX quantized matmul/dequantize, including native GGUF
+    /// K/IQ; MXFP/NVFP pass `biases = None`.
     ///
     /// `self.weight` is left as a small placeholder (never read on the
     /// packed forward/logits paths).
@@ -381,9 +383,9 @@ impl Embedding {
     ///   only a tiny placeholder, so this DEQUANTIZES the full table on demand
     ///   from the packed backend and returns CORRECT `[vocab, hidden]` data — it
     ///   never returns the placeholder. The dense table is materialized only if a
-    ///   caller actually evals the result; the production lfm2 logits path uses
+    ///   caller actually evals the result; production logits paths use
     ///   `as_linear` (a `mlx_quantized_matmul` on the packed tensors) and never
-    ///   hits this, so no full dense table is resident under normal inference.
+    ///   hit this, so no full dense table is resident under normal inference.
     pub fn get_weight(&self) -> MxArray {
         if let Some(ref q) = self.quantized_packed {
             #[cfg(test)]
@@ -433,8 +435,9 @@ impl Embedding {
     }
 
     /// Whether this embedding holds a PACKED-quantized backend
-    /// (`load_quantized_packed`). When true, the tied-head logits path MUST use
-    /// `as_linear` (the dense `get_weight()` is only a placeholder).
+    /// (`load_quantized_packed`). When true, the tied-head logits path must use
+    /// `as_linear`; `get_weight()` is an explicit compatibility/export accessor
+    /// that constructs a full-table dequantization graph on demand.
     pub fn is_packed_quantized(&self) -> bool {
         self.quantized_packed.is_some()
     }
@@ -829,123 +832,138 @@ mod tests {
         );
     }
 
-    /// PACKED q6k embedding (the GGUF K-quant import path): a repacked
-    /// `token_embd` group loaded via `load_quantized_packed(..., "q6k")` must
+    /// PACKED q4k/q6k embeddings (the GGUF K-quant import path): a repacked
+    /// `token_embd` group loaded via `load_quantized_packed` must
     /// gather-then-dequant in `forward` and quantized-matmul in `as_linear`,
     /// both returning finite values that match a reference `mlx_dequantize` in
-    /// "q6k" mode. Regression guard for the fix on this branch: the embedding
+    /// the corresponding K-quant mode. Regression guard for this branch: the embedding
     /// consumers used to hardcode "affine", which cannot decode a K-quant group
-    /// (its int8 `.scales` fail affine's floating-scale check), so a K-quant
-    /// tied embedding could not load end-to-end. Builds the group through the
-    /// production repacker (`utils::gguf_kquant`) from synthetic ggml Q6_K
-    /// super-block bytes, so the whole import→decode chain is exercised.
+    /// (its integer `.scales` fail affine's floating-scale check), so a K-quant
+    /// embedding could not load end-to-end. Q4_K is the exact UD-Q4_K_XL input
+    /// embedding format; Q6_K covers the tied-head-capable symmetric layout.
+    /// Both groups are built through the production repacker from synthetic
+    /// ggml super-block bytes, so the whole import→decode chain is exercised.
     #[test]
-    fn packed_q6k_forward_and_as_linear_match_reference_dequant() {
+    fn packed_q4k_and_q6k_forward_and_as_linear_match_reference_dequant() {
         use crate::utils::gguf_kquant::{KQuantFormat, KQuantScales, QK_K, repack_kquant};
 
         let vocab = 6i64;
-        let hidden = 256i64; // one q6k super-block (256 values) per row
+        let hidden = 256i64; // one K-quant super-block per row
         let k = hidden as usize;
         let rows = vocab as usize;
-        let fmt = KQuantFormat::Q6K;
+        for (fmt, group_size, bits) in [(KQuantFormat::Q4K, 32, 4), (KQuantFormat::Q6K, 16, 6)] {
+            let mode = fmt.mlx_mode();
+            let block_bytes = fmt.block_bytes();
+            let sb_per_row = k / QK_K;
 
-        // Synthesize deterministic ggml Q6_K super-blocks: a fixed-seed LCG fills
-        // the ql/qh code planes and the int8 sub-scales, and each super-block's
-        // `d` (the f16 super-block scale at byte offset 208) is forced to a
-        // finite value (0.25 = f16 0x3400) so the decode is guaranteed finite.
-        let block_bytes = fmt.block_bytes();
-        let sb_per_row = k / QK_K;
-        let mut blocks: Vec<u8> = {
-            let mut state = 0xC0FFEEu64;
-            (0..rows * sb_per_row * block_bytes)
-                .map(|_| {
-                    state = state
-                        .wrapping_mul(6364136223846793005)
-                        .wrapping_add(1442695040888963407);
-                    (state >> 33) as u8
-                })
-                .collect()
-        };
-        for sb in 0..(rows * sb_per_row) {
-            let d_off = sb * block_bytes + 208; // Q6_K `d` offset
-            blocks[d_off] = 0x00;
-            blocks[d_off + 1] = 0x34; // f16 0.25, little-endian
-        }
-        let arrays = repack_kquant(fmt, &blocks, rows, k).expect("repack q6k");
+            // A fixed-seed LCG fills the code planes and sub-scales. Force
+            // each floating super-block scale to a small finite value: Q4_K
+            // stores `(d,dmin)` at bytes 0..4, while Q6_K stores `d` at 208.
+            let mut blocks: Vec<u8> = {
+                let mut state = 0xC0FFEEu64 ^ fmt.gguf_type() as u64;
+                (0..rows * sb_per_row * block_bytes)
+                    .map(|_| {
+                        state = state
+                            .wrapping_mul(6364136223846793005)
+                            .wrapping_add(1442695040888963407);
+                        (state >> 33) as u8
+                    })
+                    .collect()
+            };
+            for sb in 0..(rows * sb_per_row) {
+                let base = sb * block_bytes;
+                match fmt {
+                    KQuantFormat::Q4K => {
+                        blocks[base] = 0x00;
+                        blocks[base + 1] = 0x34; // d = f16 0.25
+                        blocks[base + 2] = 0x00;
+                        blocks[base + 3] = 0x30; // dmin = f16 0.125
+                    }
+                    KQuantFormat::Q6K => {
+                        blocks[base + 208] = 0x00;
+                        blocks[base + 209] = 0x34; // d = f16 0.25
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            let arrays = repack_kquant(fmt, &blocks, rows, k)
+                .unwrap_or_else(|err| panic!("repack {mode}: {err}"));
+            let weight = MxArray::from_uint32(&arrays.weight, &[vocab, fmt.weight_cols(k) as i64])
+                .expect("weight");
+            let scales = match &arrays.scales {
+                KQuantScales::Signed(v) => {
+                    MxArray::from_int8(v, &[vocab, fmt.scales_cols(k) as i64])
+                }
+                KQuantScales::Unsigned(v) => {
+                    MxArray::from_uint8(v, &[vocab, fmt.scales_cols(k) as i64])
+                }
+            }
+            .expect("scales");
+            let biases = MxArray::from_float16(&arrays.biases, &[vocab, fmt.biases_cols(k) as i64])
+                .expect("biases");
 
-        let weight = MxArray::from_uint32(&arrays.weight, &[vocab, fmt.weight_cols(k) as i64])
-            .expect("weight");
-        let scales_i8 = match &arrays.scales {
-            KQuantScales::Signed(v) => v,
-            KQuantScales::Unsigned(_) => panic!("q6k scales must be signed int8"),
-        };
-        let scales =
-            MxArray::from_int8(scales_i8, &[vocab, fmt.scales_cols(k) as i64]).expect("scales");
-        let biases = MxArray::from_float16(&arrays.biases, &[vocab, fmt.biases_cols(k) as i64])
-            .expect("biases");
+            let mut emb = Embedding::new(vocab as u32, hidden as u32).expect("new");
+            emb.load_quantized_packed(&weight, &scales, Some(&biases), group_size, bits, mode)
+                .unwrap_or_else(|err| panic!("load packed {mode}: {err}"));
+            assert!(emb.is_packed_quantized());
 
-        let mut emb = Embedding::new(vocab as u32, hidden as u32).expect("new");
-        emb.load_quantized_packed(&weight, &scales, Some(&biases), 16, 6, "q6k")
-            .expect("load packed q6k");
-        assert!(emb.is_packed_quantized());
+            // Reference: dequantize the full table once in the same mode.
+            let full = dequantize(&weight, &scales, Some(&biases), group_size, bits, mode)
+                .unwrap_or_else(|err| panic!("dequant full {mode}: {err}"));
 
-        // Reference: dequantize the full table once, in q6k mode.
-        let full = dequantize(&weight, &scales, Some(&biases), 16, 6, "q6k").expect("dequant full");
-
-        // forward: gather-then-dequant must equal dequant-then-gather EXACTLY —
-        // K-quant dequant is per-row independent (no cross-row reduction), so
-        // the order of gather and dequant does not change the bits.
-        let idx = MxArray::from_int32(&[0, 3, 5, 1], &[4]).expect("idx");
-        let got = emb.forward(&idx).expect("forward");
-        let got_v = to_f32_vec(&got);
-        assert!(
-            got_v.iter().all(|v| v.is_finite()),
-            "q6k forward produced non-finite values"
-        );
-        let ref_rows = full.take(&idx, 0).expect("gather ref");
-        let max_err = max_abs_err(&got_v, &to_f32_vec(&ref_rows));
-        assert_eq!(
-            max_err, 0.0,
-            "packed q6k forward (gather-then-dequant) must equal dequant-then-gather: max_err={max_err}"
-        );
-
-        // as_linear: the tied-head quantized_matmul must run and stay finite.
-        let xdata: Vec<f32> = (0..(2 * hidden))
-            .map(|i| ((i % 7) as f32 - 3.0) * 0.05)
-            .collect();
-        let x = MxArray::from_float32(&xdata, &[2, hidden])
-            .expect("x")
-            .astype(DType::BFloat16)
-            .expect("x bf16");
-        let logits = emb.as_linear(&x).expect("as_linear q6k");
-        let logits_v = to_f32_vec(&logits);
-        assert_eq!(logits_v.len(), (2 * vocab) as usize, "logits shape");
-        assert!(
-            logits_v.iter().all(|v| v.is_finite()),
-            "q6k as_linear produced non-finite values"
-        );
-
-        // Match `x @ dequant(table)^T` where the host's half-precision GEMM is
-        // trustworthy (the reference side is a bf16 GEMM; skip on hosts whose
-        // NAX half-GEMM fails the canary, exactly as the affine as_linear parity
-        // does — the quantized_matmul under test is CORRECT there, only its bf16
-        // dense-matmul oracle is broken). The tolerance is RELATIVE to the logit
-        // magnitude: the reference rounds the whole table to bf16 before the
-        // K=256 matmul, so at these synthetic magnitudes (~O(100)) its ~0.4%
-        // per-element rounding dominates — a fixed absolute bound would flag
-        // pure bf16 noise, while a wrong mode/transpose still errors or lands
-        // orders of magnitude off.
-        if !crate::test_support::half_gemm_untrustworthy() {
-            let full_t = full.transpose(Some(&[1, 0])).expect("transpose");
-            let ref_logits = x.matmul(&full_t).expect("ref matmul");
-            let ref_v = to_f32_vec(&ref_logits);
-            let scale = ref_v.iter().fold(0f32, |m, v| m.max(v.abs())).max(1.0);
-            let lmax = max_abs_err(&logits_v, &ref_v);
+            // K-quant dequant is row-independent, so gather-then-dequant must
+            // equal dequant-then-gather bit-for-bit.
+            let idx = MxArray::from_int32(&[0, 3, 5, 1], &[4]).expect("idx");
+            let got = emb
+                .forward(&idx)
+                .unwrap_or_else(|err| panic!("forward {mode}: {err}"));
+            let got_v = to_f32_vec(&got);
             assert!(
-                lmax <= 5e-2 * scale,
-                "packed q6k as_linear must match x @ dequant(table)^T within bf16 \
-                 GEMM tolerance: max_err={lmax}, ref_scale={scale}"
+                got_v.iter().all(|v| v.is_finite()),
+                "{mode} forward produced non-finite values"
             );
+            let ref_rows = full.take(&idx, 0).expect("gather ref");
+            let max_err = max_abs_err(&got_v, &to_f32_vec(&ref_rows));
+            assert_eq!(
+                max_err, 0.0,
+                "packed {mode} gather-dequant must equal dequant-then-gather: max_err={max_err}"
+            );
+
+            // Also exercise the tied-head path. The exact target is untied,
+            // but this proves that keeping Q4_K packed does not strand a tied
+            // checkpoint on an unsupported backend.
+            let xdata: Vec<f32> = (0..(2 * hidden))
+                .map(|i| ((i % 7) as f32 - 3.0) * 0.05)
+                .collect();
+            let x = MxArray::from_float32(&xdata, &[2, hidden])
+                .expect("x")
+                .astype(DType::BFloat16)
+                .expect("x bf16");
+            let logits = emb
+                .as_linear(&x)
+                .unwrap_or_else(|err| panic!("as_linear {mode}: {err}"));
+            let logits_v = to_f32_vec(&logits);
+            assert_eq!(logits_v.len(), (2 * vocab) as usize, "logits shape");
+            assert!(
+                logits_v.iter().all(|v| v.is_finite()),
+                "{mode} as_linear produced non-finite values"
+            );
+
+            // The reference side is a bf16 GEMM, so skip only on hosts whose
+            // half-GEMM canary is broken. Use a relative tolerance because the
+            // dense table is rounded to bf16 before the K=256 matmul.
+            if !crate::test_support::half_gemm_untrustworthy() {
+                let full_t = full.transpose(Some(&[1, 0])).expect("transpose");
+                let ref_logits = x.matmul(&full_t).expect("ref matmul");
+                let ref_v = to_f32_vec(&ref_logits);
+                let scale = ref_v.iter().fold(0f32, |m, v| m.max(v.abs())).max(1.0);
+                let lmax = max_abs_err(&logits_v, &ref_v);
+                assert!(
+                    lmax <= 5e-2 * scale,
+                    "packed {mode} as_linear must match x @ dequant(table)^T within bf16 \
+                     GEMM tolerance: max_err={lmax}, ref_scale={scale}"
+                );
+            }
         }
     }
 

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -583,6 +583,26 @@ pub fn parse_gguf<P: AsRef<Path>>(path: P) -> Result<GgufFile> {
     })
 }
 
+/// Read the architecture declared by a GGUF header without loading any tensor
+/// payloads. This is the model-family detection seam for standalone GGUF files
+/// that intentionally do not ship a sibling `config.json`.
+#[napi]
+pub fn gguf_architecture(input_path: String) -> Result<String> {
+    let gguf = parse_gguf(&input_path)?;
+    let architecture = gguf
+        .metadata
+        .get("general.architecture")
+        .and_then(GgufMetaValue::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            Error::from_reason(format!(
+                "GGUF file '{}' does not declare a non-empty general.architecture",
+                input_path
+            ))
+        })?;
+    Ok(architecture.to_string())
+}
+
 fn align_offset(offset: u64, alignment: u64) -> u64 {
     let remainder = offset % alignment;
     if remainder == 0 {
@@ -2064,9 +2084,18 @@ pub fn extract_config(metadata: &HashMap<String, GgufMetaValue>) -> serde_json::
             serde_json::Value::String(name.to_string()),
         );
     }
+    // llama.cpp architecture identifiers are not always the Hugging Face
+    // model_type values consumed by mlx-node's public loader. Keep the GGUF
+    // architecture for metadata lookups below, but write the canonical config
+    // family so a synthesized cache is independently loadable as a directory.
+    let model_type = match arch.as_str() {
+        "qwen35" => "qwen3_5",
+        "qwen35moe" => "qwen3_5_moe",
+        _ => arch.as_str(),
+    };
     config.insert(
         "model_type".to_string(),
-        serde_json::Value::String(arch.clone()),
+        serde_json::Value::String(model_type.to_string()),
     );
 
     // Map GGUF keys to HF config keys
@@ -4197,10 +4226,18 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
         return Ok(output_dir);
     }
 
+    // `Some(dir)` means an explicitly authoritative config source to the
+    // converter. A standalone GGUF has no config by design, so pass `None` in
+    // that case: the converter still uses the GGUF parent for optional assets,
+    // while allowing config/tokenizer reconstruction from header metadata.
+    let config_source_dir = parent
+        .join("config.json")
+        .is_file()
+        .then(|| parent.to_string_lossy().into_owned());
     convert_gguf_to_safetensors(GgufConversionOptions {
         input_path: input_path.to_string_lossy().into_owned(),
         output_dir: output_dir.to_string_lossy().into_owned(),
-        config_source_dir: Some(parent.to_string_lossy().into_owned()),
+        config_source_dir,
         dtype: Some("bfloat16".to_string()),
         verbose: Some(true),
         quantize: Some(false),
@@ -4376,6 +4413,76 @@ mod tests {
         }
 
         fs::remove_file(&tmp).ok();
+    }
+
+    #[test]
+    fn gguf_architecture_reads_header_without_tensor_payloads() {
+        let data = build_minimal_gguf(
+            &[(
+                "general.architecture",
+                GgufMetaValue::String("qwen35".to_string()),
+            )],
+            &[],
+        );
+        let tmp = std::env::temp_dir().join(format!(
+            "mlx-node-gguf-architecture-{}-{}.gguf",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::write(&tmp, data).unwrap();
+
+        assert_eq!(
+            gguf_architecture(tmp.to_string_lossy().into_owned()).unwrap(),
+            "qwen35"
+        );
+
+        fs::remove_file(tmp).ok();
+    }
+
+    #[tokio::test]
+    async fn native_qwen35_prepare_synthesizes_config_for_standalone_gguf() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-standalone-qwen35-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let data = build_minimal_gguf(
+            &[
+                (
+                    "general.architecture",
+                    GgufMetaValue::String("qwen35".to_string()),
+                ),
+                ("qwen35.embedding_length", GgufMetaValue::Uint32(1)),
+            ],
+            &[("output_norm.weight", &[1], GgufTensorType::BF16, &[0, 0])],
+        );
+        let input = root.join("standalone.gguf");
+        fs::write(&input, data).unwrap();
+
+        let output = prepare_qwen35_native_gguf(&input)
+            .await
+            .unwrap_or_else(|error| {
+                panic!(
+                    "standalone GGUF preparation must synthesize config.json: {}",
+                    error.reason
+                )
+            });
+        let config: serde_json::Value = serde_json::from_slice(
+            &fs::read(output.join("config.json")).expect("synthesized config.json"),
+        )
+        .unwrap();
+        assert_eq!(config["model_type"], serde_json::json!("qwen3_5"));
+        assert!(output.join("model.safetensors").is_file());
+        assert!(output.join(".complete").is_file());
+
+        fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -1461,24 +1461,102 @@ fn gguf_name_to_hf_for_metadata(
     }
 }
 
-/// Qwen3.5 GGUFs with inline MTP encode the draft layer as the final block and
-/// attach the four nextn projections/norms to that same block. HF/MLX stores
-/// those tensors under the mtp prefix, outside the main decoder layer list.
-fn qwen35_name_to_hf(name: &str, metadata: &HashMap<String, GgufMetaValue>) -> String {
-    let arch = metadata
+const QWEN35_INLINE_MTP_NEXTN_SUFFIXES: [&str; 4] = [
+    "nextn.eh_proj.weight",
+    "nextn.enorm.weight",
+    "nextn.hnorm.weight",
+    "nextn.shared_head_norm.weight",
+];
+const QWEN35_INLINE_MTP_INDEX_METADATA: &str = "mlx_node.internal.qwen35_inline_mtp_index";
+
+/// Return the final GGUF block index when a Qwen3.5 file carries llama.cpp's
+/// inline one-layer MTP layout.
+///
+/// The architecture metadata alone cannot distinguish a plain final decoder
+/// block from an inline draft block. The four `nextn.*` descriptors are the
+/// structural witness: when any one is present, require the complete group on
+/// `blk.(block_count - 1)` so config synthesis and tensor remapping cannot
+/// disagree about whether that block belongs to the main decoder or MTP.
+fn qwen35_inline_mtp_index(gguf: &GgufFile) -> Result<Option<u64>> {
+    let arch = gguf
+        .metadata
         .get("general.architecture")
         .and_then(GgufMetaValue::as_str)
         .unwrap_or("");
     if !matches!(arch, "qwen35" | "qwen35moe") {
-        return gguf_name_to_hf(name);
+        return Ok(None);
     }
-    let Some(block_count) = metadata
+
+    let nextn_names = gguf
+        .tensors
+        .iter()
+        .map(|tensor| tensor.name.as_str())
+        .filter(|name| name.contains(".nextn."))
+        .collect::<Vec<_>>();
+    if nextn_names.is_empty() {
+        return Ok(None);
+    }
+
+    let block_count = gguf
+        .metadata
         .get(&format!("{arch}.block_count"))
         .and_then(GgufMetaValue::as_u64)
-    else {
-        return gguf_name_to_hf(name);
+        .ok_or_else(|| {
+            Error::from_reason(format!(
+                "Qwen3.5 GGUF carries inline nextn tensors but is missing a positive \
+                 '{arch}.block_count'"
+            ))
+        })?;
+    let mtp_index = block_count.checked_sub(1).ok_or_else(|| {
+        Error::from_reason(format!(
+            "Qwen3.5 GGUF carries inline nextn tensors but '{arch}.block_count' is zero"
+        ))
+    })?;
+    let prefix = format!("blk.{mtp_index}.");
+    if let Some(unexpected) = nextn_names.iter().find(|name| !name.starts_with(&prefix)) {
+        return Err(Error::from_reason(format!(
+            "Qwen3.5 inline MTP tensor '{unexpected}' is outside the final GGUF block \
+             '{prefix}*'"
+        )));
+    }
+
+    for suffix in QWEN35_INLINE_MTP_NEXTN_SUFFIXES {
+        let required = format!("{prefix}{suffix}");
+        if !gguf.tensors.iter().any(|tensor| tensor.name == required) {
+            return Err(Error::from_reason(format!(
+                "Qwen3.5 inline MTP block {mtp_index} is incomplete: missing tensor '{required}'"
+            )));
+        }
+    }
+    Ok(Some(mtp_index))
+}
+
+fn apply_qwen35_inline_mtp_config(config: &mut serde_json::Value, mtp_index: Option<u64>) {
+    let Some(mtp_index) = mtp_index else {
+        return;
     };
-    let Some(mtp_index) = block_count.checked_sub(1) else {
+    // `block_count` includes the inline MTP block, while the runtime's main
+    // decoder length does not. Qwen3.5 checkpoints in the HF ecosystem spell
+    // the draft depth as `mtp_num_hidden_layers`; emit the accepted legacy
+    // alias too so synthesized standalone configs are portable to readers that
+    // use `num_nextn_predict_layers`.
+    config["num_hidden_layers"] = serde_json::json!(mtp_index);
+    config["mtp_num_hidden_layers"] = serde_json::json!(1);
+    config["num_nextn_predict_layers"] = serde_json::json!(1);
+}
+
+/// Qwen3.5 GGUFs with inline MTP encode the draft layer as the final block and
+/// attach the four nextn projections/norms to that same block. HF/MLX stores
+/// those tensors under the mtp prefix, outside the main decoder layer list.
+fn qwen35_name_to_hf(name: &str, metadata: &HashMap<String, GgufMetaValue>) -> String {
+    // Conversion annotates the in-memory metadata only after validating all
+    // four `nextn.*` descriptors. A bare qwen35 block_count is insufficient:
+    // files without inline MTP use their final block as an ordinary decoder
+    // layer and must retain `model.layers.(N-1)` names.
+    let Some(mtp_index) = metadata
+        .get(QWEN35_INLINE_MTP_INDEX_METADATA)
+        .and_then(GgufMetaValue::as_u64)
+    else {
         return gguf_name_to_hf(name);
     };
     let prefix = format!("blk.{mtp_index}.");
@@ -3387,7 +3465,7 @@ pub async fn convert_gguf_to_safetensors(
 
     // Parse GGUF header and metadata
     info!("Parsing GGUF file: {}", input_path.display());
-    let gguf = parse_gguf(&input_path)?;
+    let mut gguf = parse_gguf(&input_path)?;
 
     info!(
         "GGUF v{}: {} tensors, {} metadata keys",
@@ -3416,6 +3494,20 @@ pub async fn convert_gguf_to_safetensors(
 
     let import_k_quants = options.import_k_quants.unwrap_or(false);
     let native_qwen35_layout = options.native_qwen35_layout.unwrap_or(false);
+    // Validate the descriptor-level inline-MTP witness before any destination
+    // file can be created or truncated. The resulting index is also the exact
+    // main-decoder length to write when config.json must be synthesized.
+    let qwen35_inline_mtp_index = qwen35_inline_mtp_index(&gguf)?;
+    if let Some(index) = qwen35_inline_mtp_index {
+        // Keep tensor-name mapping and config synthesis on one validated
+        // witness without threading a second context argument through every
+        // descriptor-only mapping consumer. This key exists only in memory;
+        // extract_config copies a fixed GGUF field set, so it is never emitted.
+        gguf.metadata.insert(
+            QWEN35_INLINE_MTP_INDEX_METADATA.to_string(),
+            GgufMetaValue::Uint64(index),
+        );
+    }
 
     // Plain Qwen3 has no quantized inference runtime. Preserving Q4_0/Q4_1/
     // Q8_0 or K-quant source groups would successfully write an artifact whose
@@ -4019,7 +4111,9 @@ pub async fn convert_gguf_to_safetensors(
             serde_json::from_str(&data)
                 .map_err(|e| Error::from_reason(format!("Failed to parse config.json: {e}")))?
         } else {
-            extract_config(&gguf.metadata)
+            let mut synthesized = extract_config(&gguf.metadata);
+            apply_qwen35_inline_mtp_config(&mut synthesized, qwen35_inline_mtp_index);
+            synthesized
         };
 
         // Measured off the tensor list and cross-checked against the header, so
@@ -4217,8 +4311,15 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
         .join(".mlx-node-native")
         .join(format!("{stem}-{}-{modified}", metadata.len()));
     let marker = output_dir.join(".complete");
-    let marker_is_current = fs::read_to_string(&marker)
-        .is_ok_and(|contents| contents.contains("format=2\n") && contents.contains("dtype=bf16\n"));
+    let has_sibling_config = parent.join("config.json").is_file();
+    let marker_is_current = fs::read_to_string(&marker).is_ok_and(|contents| {
+        let config_semantics_are_current = contents.contains("format=3\n")
+            // v2 caches built from an authoritative sibling config already
+            // carry the correct decoder/MTP depths. Only standalone v2 caches
+            // used the now-fixed metadata-only layer count and must rebuild.
+            || (has_sibling_config && contents.contains("format=2\n"));
+        config_semantics_are_current && contents.contains("dtype=bf16\n")
+    });
     if marker_is_current
         && output_dir.join("model.safetensors").is_file()
         && output_dir.join("config.json").is_file()
@@ -4230,10 +4331,7 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
     // converter. A standalone GGUF has no config by design, so pass `None` in
     // that case: the converter still uses the GGUF parent for optional assets,
     // while allowing config/tokenizer reconstruction from header metadata.
-    let config_source_dir = parent
-        .join("config.json")
-        .is_file()
-        .then(|| parent.to_string_lossy().into_owned());
+    let config_source_dir = has_sibling_config.then(|| parent.to_string_lossy().into_owned());
     convert_gguf_to_safetensors(GgufConversionOptions {
         input_path: input_path.to_string_lossy().into_owned(),
         output_dir: output_dir.to_string_lossy().into_owned(),
@@ -4256,7 +4354,7 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
     fs::write(
         &marker,
         format!(
-            "format=2\nsource={}\nsize={}\nmodified_ns={}\nlayout=tiled\ndtype=bf16\n",
+            "format=3\nsource={}\nsize={}\nmodified_ns={}\nlayout=tiled\ndtype=bf16\n",
             input_path.display(),
             metadata.len(),
             modified
@@ -4460,8 +4558,35 @@ mod tests {
                     GgufMetaValue::String("qwen35".to_string()),
                 ),
                 ("qwen35.embedding_length", GgufMetaValue::Uint32(1)),
+                ("qwen35.block_count", GgufMetaValue::Uint32(2)),
             ],
-            &[("output_norm.weight", &[1], GgufTensorType::BF16, &[0, 0])],
+            &[
+                ("output_norm.weight", &[1], GgufTensorType::BF16, &[0, 0]),
+                (
+                    "blk.1.nextn.eh_proj.weight",
+                    &[1],
+                    GgufTensorType::BF16,
+                    &[0, 0],
+                ),
+                (
+                    "blk.1.nextn.enorm.weight",
+                    &[1],
+                    GgufTensorType::BF16,
+                    &[0, 0],
+                ),
+                (
+                    "blk.1.nextn.hnorm.weight",
+                    &[1],
+                    GgufTensorType::BF16,
+                    &[0, 0],
+                ),
+                (
+                    "blk.1.nextn.shared_head_norm.weight",
+                    &[1],
+                    GgufTensorType::BF16,
+                    &[0, 0],
+                ),
+            ],
         );
         let input = root.join("standalone.gguf");
         fs::write(&input, data).unwrap();
@@ -4479,10 +4604,83 @@ mod tests {
         )
         .unwrap();
         assert_eq!(config["model_type"], serde_json::json!("qwen3_5"));
+        assert_eq!(config["num_hidden_layers"], serde_json::json!(1));
+        assert_eq!(config["mtp_num_hidden_layers"], serde_json::json!(1));
+        assert_eq!(config["num_nextn_predict_layers"], serde_json::json!(1));
         assert!(output.join("model.safetensors").is_file());
         assert!(output.join(".complete").is_file());
 
         fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn qwen35_without_nextn_keeps_full_synthesized_decoder_count() {
+        let mut gguf = source_quant_fixture(&[("blk.1.attn_norm.weight", GgufTensorType::BF16)]);
+        gguf.metadata.insert(
+            "general.architecture".into(),
+            GgufMetaValue::String("qwen35".into()),
+        );
+        gguf.metadata
+            .insert("qwen35.block_count".into(), GgufMetaValue::Uint32(2));
+
+        let mtp_index = qwen35_inline_mtp_index(&gguf).unwrap();
+        assert_eq!(mtp_index, None);
+        let mut config = extract_config(&gguf.metadata);
+        apply_qwen35_inline_mtp_config(&mut config, mtp_index);
+        assert_eq!(config["num_hidden_layers"], serde_json::json!(2));
+        assert!(config.get("mtp_num_hidden_layers").is_none());
+        assert_eq!(
+            gguf_name_to_hf_for_metadata("blk.1.attn_norm.weight", &gguf.metadata).as_deref(),
+            Some("model.layers.1.input_layernorm.weight"),
+            "the final non-MTP block must remain in the main decoder namespace"
+        );
+    }
+
+    #[test]
+    fn incomplete_qwen35_inline_mtp_group_fails_before_conversion() {
+        let mut gguf =
+            source_quant_fixture(&[("blk.1.nextn.eh_proj.weight", GgufTensorType::BF16)]);
+        gguf.metadata.insert(
+            "general.architecture".into(),
+            GgufMetaValue::String("qwen35".into()),
+        );
+        gguf.metadata
+            .insert("qwen35.block_count".into(), GgufMetaValue::Uint32(2));
+
+        let error = qwen35_inline_mtp_index(&gguf).unwrap_err();
+        assert!(error.reason.contains("inline MTP block 1 is incomplete"));
+        assert!(error.reason.contains("nextn.enorm.weight"));
+    }
+
+    #[test]
+    fn validated_qwen35_inline_mtp_witness_controls_final_block_remap() {
+        let mut gguf = source_quant_fixture(&[
+            ("blk.1.nextn.eh_proj.weight", GgufTensorType::BF16),
+            ("blk.1.nextn.enorm.weight", GgufTensorType::BF16),
+            ("blk.1.nextn.hnorm.weight", GgufTensorType::BF16),
+            ("blk.1.nextn.shared_head_norm.weight", GgufTensorType::BF16),
+            ("blk.1.attn_norm.weight", GgufTensorType::BF16),
+        ]);
+        gguf.metadata.insert(
+            "general.architecture".into(),
+            GgufMetaValue::String("qwen35".into()),
+        );
+        gguf.metadata
+            .insert("qwen35.block_count".into(), GgufMetaValue::Uint32(2));
+
+        let mtp_index = qwen35_inline_mtp_index(&gguf).unwrap().unwrap();
+        gguf.metadata.insert(
+            QWEN35_INLINE_MTP_INDEX_METADATA.into(),
+            GgufMetaValue::Uint64(mtp_index),
+        );
+        assert_eq!(
+            gguf_name_to_hf_for_metadata("blk.1.nextn.eh_proj.weight", &gguf.metadata).as_deref(),
+            Some("mtp.fc.weight")
+        );
+        assert_eq!(
+            gguf_name_to_hf_for_metadata("blk.1.attn_norm.weight", &gguf.metadata).as_deref(),
+            Some("mtp.layers.0.input_layernorm.weight")
+        );
     }
 
     #[test]
@@ -7712,6 +7910,46 @@ mod tests {
                 SYMMETRIC_ZERO_POINT_KEY: 8,
             })
         );
+    }
+
+    #[test]
+    fn merged_gdn_resolves_matching_split_q4k_overrides_not_file_default() {
+        // Make Q6_K the modal file-wide profile while both halves of the
+        // mergeable GDN projection use Q4_K. `preserved_source_quantization`
+        // intentionally records the source names; the runtime's merged-prefix
+        // resolver must consume those two split entries rather than Q6_K.
+        let gguf = source_quant_fixture(&[
+            ("blk.0.attn_q.weight", GgufTensorType::Q6K),
+            ("blk.0.attn_k.weight", GgufTensorType::Q6K),
+            ("blk.0.ffn_down.weight", GgufTensorType::Q6K),
+            ("blk.0.attn_qkv.weight", GgufTensorType::Q4K),
+            ("blk.0.attn_gate.weight", GgufTensorType::Q4K),
+        ]);
+        let quant = preserved_source_quantization(&gguf, true).unwrap().unwrap();
+        let (bits, group_size, top_level_mode, per_layer) =
+            crate::models::quant_dispatch::parse_quant_settings(Some(&quant), 4, 64).unwrap();
+        let default = crate::models::quant_dispatch::default_per_layer_quant(
+            bits,
+            group_size,
+            crate::models::quant_dispatch::resolve_default_mode(top_level_mode, false),
+        );
+        let merged = crate::models::quant_dispatch::effective_plq_for(
+            "layers.0.linear_attn.in_proj_qkvz",
+            &per_layer,
+            default,
+            None,
+        );
+
+        assert_eq!(
+            default.mode,
+            crate::models::quant_dispatch::PerLayerMode::Q6K
+        );
+        assert_eq!(
+            merged.mode,
+            crate::models::quant_dispatch::PerLayerMode::Q4K
+        );
+        assert_eq!(merged.bits, 4);
+        assert_eq!(merged.group_size, 32);
     }
 
     #[test]

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -5184,7 +5184,7 @@ mod tests {
         );
         assert!(output.join("model.safetensors").is_file());
         let marker = fs::read_to_string(output.join(".complete")).unwrap();
-        assert!(marker.contains("format=4\n"));
+        assert!(marker.contains(&format!("format={QWEN35_NATIVE_CACHE_FORMAT}\n")));
         assert!(marker.contains("assets_sha256="));
 
         fs::remove_dir_all(root).ok();

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -16,12 +16,15 @@
 ///
 /// Reference: https://github.com/ggml-org/ggml/blob/master/docs/gguf.md
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::{BufReader, Read, Seek, SeekFrom};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
 use crate::array::{DType, MxArray};
@@ -34,6 +37,21 @@ use crate::utils::safetensors::save_safetensors;
 const GGUF_MAGIC: u32 = 0x46554747; // "GGUF" in little-endian
 const GGUF_VERSION_3: u32 = 3;
 const GGUF_DEFAULT_ALIGNMENT: u64 = 32;
+
+const GGUF_RUNTIME_ASSET_FILES: &[&str] = &[
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "vocab.json",
+    "merges.txt",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "chat_template.jinja",
+    "generation_config.json",
+    "preprocessor_config.json",
+    "video_preprocessor_config.json",
+    "processor_config.json",
+    "viterbi_calibration.json",
+];
 
 // ── GGUF Tensor Types ───────────────────────────────────────────────────────
 
@@ -1543,6 +1561,134 @@ fn apply_qwen35_inline_mtp_config(config: &mut serde_json::Value, mtp_index: Opt
     config["num_hidden_layers"] = serde_json::json!(mtp_index);
     config["mtp_num_hidden_layers"] = serde_json::json!(1);
     config["num_nextn_predict_layers"] = serde_json::json!(1);
+    apply_qwen35_layer_types(config);
+}
+
+fn apply_qwen35_layer_types(config: &mut serde_json::Value) {
+    let Some(num_layers) = config
+        .get("num_hidden_layers")
+        .and_then(|value| value.as_u64())
+    else {
+        return;
+    };
+    let Some(interval) = config
+        .get("full_attention_interval")
+        .and_then(|value| value.as_u64())
+    else {
+        return;
+    };
+    let layer_types = (0..num_layers)
+        .map(|index| {
+            let full_attention = interval > 0 && (index + 1).is_multiple_of(interval);
+            serde_json::Value::String(
+                if full_attention {
+                    "full_attention"
+                } else {
+                    "linear_attention"
+                }
+                .to_string(),
+            )
+        })
+        .collect();
+    config["layer_types"] = serde_json::Value::Array(layer_types);
+}
+
+fn apply_qwen35_gdn_config(
+    config: &mut serde_json::Value,
+    metadata: &HashMap<String, GgufMetaValue>,
+) {
+    let Some(arch) = metadata
+        .get("general.architecture")
+        .and_then(GgufMetaValue::as_str)
+        .filter(|arch| matches!(*arch, "qwen35" | "qwen35moe"))
+    else {
+        return;
+    };
+    let get = |suffix: &str| {
+        metadata
+            .get(&format!("{arch}.{suffix}"))
+            .and_then(GgufMetaValue::as_u64)
+    };
+    let mut insert = |key: &str, value: Option<u64>| {
+        if let Some(value) = value {
+            config[key] = serde_json::json!(value);
+        }
+    };
+
+    // llama.cpp's Qwen3.5 schema spells the GatedDeltaNet geometry in SSM
+    // terms. `time_step_rank` is the value-head count, `group_count` is the
+    // key-head count, and `state_size` is the per-head key/value width. The
+    // independent `inner_size` is validated before standalone conversion and
+    // provides a fallback for older writers that omit `time_step_rank`.
+    let state_size = get("ssm.state_size");
+    let value_heads = get("ssm.time_step_rank").or_else(|| {
+        let inner_size = get("ssm.inner_size")?;
+        let state_size = state_size.filter(|value| *value > 0)?;
+        inner_size
+            .is_multiple_of(state_size)
+            .then_some(inner_size / state_size)
+    });
+    insert("linear_num_value_heads", value_heads);
+    insert("linear_num_key_heads", get("ssm.group_count"));
+    insert("linear_key_head_dim", state_size);
+    insert("linear_value_head_dim", state_size);
+    insert("linear_conv_kernel_dim", get("ssm.conv_kernel"));
+    insert("full_attention_interval", get("full_attention_interval"));
+
+    if let (Some(rotary), Some(head_dim)) =
+        (get("rope.dimension_count"), get("attention.key_length"))
+        && rotary > 0
+        && head_dim > 0
+        && rotary <= head_dim
+        && let Some(value) = serde_json::Number::from_f64(rotary as f64 / head_dim as f64)
+    {
+        config["partial_rotary_factor"] = serde_json::Value::Number(value);
+    }
+    apply_qwen35_layer_types(config);
+}
+
+fn validate_qwen35_standalone_geometry(metadata: &HashMap<String, GgufMetaValue>) -> Result<()> {
+    let Some(arch) = metadata
+        .get("general.architecture")
+        .and_then(GgufMetaValue::as_str)
+        .filter(|arch| matches!(*arch, "qwen35" | "qwen35moe"))
+    else {
+        return Ok(());
+    };
+    let required = |suffix: &str| -> Result<u64> {
+        let key = format!("{arch}.{suffix}");
+        metadata
+            .get(&key)
+            .and_then(GgufMetaValue::as_u64)
+            .ok_or_else(|| {
+                Error::from_reason(format!(
+                    "Standalone Qwen3.5 GGUF is missing required GDN geometry metadata '{key}'"
+                ))
+            })
+    };
+    let state_size = required("ssm.state_size")?;
+    let inner_size = required("ssm.inner_size")?;
+    let value_heads = required("ssm.time_step_rank")?;
+    let key_heads = required("ssm.group_count")?;
+    let conv_kernel = required("ssm.conv_kernel")?;
+    let _full_attention_interval = required("full_attention_interval")?;
+    if state_size == 0 || value_heads == 0 || key_heads == 0 || conv_kernel == 0 {
+        return Err(Error::from_reason(format!(
+            "Standalone Qwen3.5 GGUF has non-positive GDN geometry: state_size={state_size}, \
+             time_step_rank={value_heads}, group_count={key_heads}, conv_kernel={conv_kernel}"
+        )));
+    }
+    let expected_inner = state_size.checked_mul(value_heads).ok_or_else(|| {
+        Error::from_reason("Standalone Qwen3.5 GGUF GDN geometry overflows u64".to_string())
+    })?;
+    if inner_size != expected_inner {
+        return Err(Error::from_reason(format!(
+            "Standalone Qwen3.5 GGUF has inconsistent GDN geometry: ssm.inner_size={inner_size}, \
+             but ssm.state_size ({state_size}) * ssm.time_step_rank ({value_heads}) = \
+             {expected_inner}"
+        )));
+    }
+    Ok(())
 }
 
 /// Qwen3.5 GGUFs with inline MTP encode the draft layer as the final block and
@@ -2271,7 +2417,20 @@ pub fn extract_config(metadata: &HashMap<String, GgufMetaValue>) -> serde_json::
         );
     }
 
-    serde_json::Value::Object(config)
+    for (gguf_key, config_key) in [
+        ("tokenizer.ggml.bos_token_id", "bos_token_id"),
+        ("tokenizer.ggml.eos_token_id", "eos_token_id"),
+        ("tokenizer.ggml.padding_token_id", "pad_token_id"),
+    ] {
+        if let Some(value) = metadata.get(gguf_key).and_then(GgufMetaValue::as_u64) {
+            config.insert(config_key.to_string(), serde_json::json!(value));
+        }
+    }
+
+    let mut config = serde_json::Value::Object(config);
+    apply_qwen35_gdn_config(&mut config, metadata);
+
+    config
 }
 
 /// What a `quantization` config entry says about one tensor: the
@@ -3694,6 +3853,16 @@ pub async fn convert_gguf_to_safetensors(
         ));
     }
 
+    // Direct native Qwen loads are allowed to synthesize a standalone config,
+    // so every GDN dimension the runtime consumes must be present and
+    // self-consistent in the GGUF header. Falling through to the loader's
+    // model-size-specific defaults can build random projections with plausible
+    // but wrong shapes. An authoritative sibling config remains the stronger
+    // source and intentionally bypasses this metadata completeness gate.
+    if is_primary_model && native_qwen35_layout && synthesized_config {
+        validate_qwen35_standalone_geometry(&gguf.metadata)?;
+    }
+
     // Validate and serialize every companion-driven config mutation before
     // loading tensor payloads or opening the destination SafeTensors file.
     // `save_safetensors` truncates an existing sidecar immediately; a missing
@@ -4195,21 +4364,7 @@ pub async fn convert_gguf_to_safetensors(
         // Copy the same runtime assets as the SafeTensors converter. In
         // particular unified Gemma4 requires its external chat template and
         // processor config in addition to tokenizer.json.
-        let asset_files = [
-            "tokenizer.json",
-            "tokenizer_config.json",
-            "vocab.json",
-            "merges.txt",
-            "special_tokens_map.json",
-            "added_tokens.json",
-            "chat_template.jinja",
-            "generation_config.json",
-            "preprocessor_config.json",
-            "video_preprocessor_config.json",
-            "processor_config.json",
-            "viterbi_calibration.json",
-        ];
-        for filename in &asset_files {
+        for filename in GGUF_RUNTIME_ASSET_FILES {
             let src = asset_dir.join(filename);
             if src.exists() {
                 let dst = output_dir.join(filename);
@@ -4274,6 +4429,105 @@ pub async fn convert_gguf_to_safetensors(
 /// they are never expanded into a dense floating-point weight tensor. Native
 /// F32 norms/biases are narrowed to BF16 so they do not promote inference
 /// activations away from the model's BF16 execution/cache dtype.
+const QWEN35_NATIVE_CACHE_FORMAT: u32 = 4;
+
+fn qwen35_native_asset_digest(parent: &Path) -> Result<String> {
+    let mut hasher = Sha256::new();
+    for filename in std::iter::once("config.json").chain(GGUF_RUNTIME_ASSET_FILES.iter().copied()) {
+        hasher.update((filename.len() as u64).to_le_bytes());
+        hasher.update(filename.as_bytes());
+        let path = parent.join(filename);
+        match fs::File::open(&path) {
+            Ok(mut file) => {
+                hasher.update([1]);
+                let mut buffer = [0_u8; 64 * 1024];
+                loop {
+                    let read = file.read(&mut buffer).map_err(|error| {
+                        Error::from_reason(format!(
+                            "Failed to hash native GGUF source asset '{}': {error}",
+                            path.display()
+                        ))
+                    })?;
+                    if read == 0 {
+                        break;
+                    }
+                    hasher.update(&buffer[..read]);
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => hasher.update([0]),
+            Err(error) => {
+                return Err(Error::from_reason(format!(
+                    "Failed to open native GGUF source asset '{}': {error}",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect())
+}
+
+fn qwen35_native_prepare_mutex() -> &'static tokio::sync::Mutex<()> {
+    static MUTEX: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    MUTEX.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+struct Qwen35NativeCacheLock {
+    _file: fs::File,
+}
+
+impl Qwen35NativeCacheLock {
+    #[cfg(unix)]
+    fn acquire(path: &Path) -> std::io::Result<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(path)?;
+        // SAFETY: `file` owns this live descriptor for at least the lifetime of
+        // the returned guard. `flock` changes only the kernel lock state for
+        // that descriptor, and Drop releases it before the file is closed.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(Self { _file: file })
+    }
+
+    #[cfg(not(unix))]
+    fn acquire(_path: &Path) -> std::io::Result<Self> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "native Qwen GGUF cache locking requires Unix flock",
+        ))
+    }
+}
+
+#[cfg(unix)]
+impl Drop for Qwen35NativeCacheLock {
+    fn drop(&mut self) {
+        // SAFETY: `_file` still owns a live descriptor here. Unlock failure is
+        // not actionable during Drop; closing the file releases the lock too.
+        unsafe {
+            libc::flock(self._file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+fn qwen35_native_cache_is_current(output_dir: &Path, asset_digest: &str) -> bool {
+    let marker = output_dir.join(".complete");
+    fs::read_to_string(marker).is_ok_and(|contents| {
+        contents.contains(&format!("format={QWEN35_NATIVE_CACHE_FORMAT}\n"))
+            && contents.contains(&format!("assets_sha256={asset_digest}\n"))
+            && contents.contains("dtype=bf16\n")
+            && output_dir.join("model.safetensors").is_file()
+            && output_dir.join("config.json").is_file()
+    })
+}
+
 pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
     let input_path = input_path.canonicalize().map_err(|error| {
         Error::from_reason(format!(
@@ -4307,23 +4561,53 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
         })
         .collect::<String>();
     let parent = input_path.parent().unwrap_or(Path::new("."));
-    let output_dir = parent
-        .join(".mlx-node-native")
-        .join(format!("{stem}-{}-{modified}", metadata.len()));
-    let marker = output_dir.join(".complete");
-    let has_sibling_config = parent.join("config.json").is_file();
-    let marker_is_current = fs::read_to_string(&marker).is_ok_and(|contents| {
-        let config_semantics_are_current = contents.contains("format=3\n")
-            // v2 caches built from an authoritative sibling config already
-            // carry the correct decoder/MTP depths. Only standalone v2 caches
-            // used the now-fixed metadata-only layer count and must rebuild.
-            || (has_sibling_config && contents.contains("format=2\n"));
-        config_semantics_are_current && contents.contains("dtype=bf16\n")
-    });
-    if marker_is_current
-        && output_dir.join("model.safetensors").is_file()
-        && output_dir.join("config.json").is_file()
-    {
+    let asset_digest = qwen35_native_asset_digest(parent)?;
+    let cache_root = parent.join(".mlx-node-native");
+    fs::create_dir_all(&cache_root).map_err(|error| {
+        Error::from_reason(format!(
+            "Failed to create native GGUF cache root '{}': {error}",
+            cache_root.display()
+        ))
+    })?;
+    let cache_key = format!(
+        "{stem}-{}-{modified}-v{QWEN35_NATIVE_CACHE_FORMAT}-{}",
+        metadata.len(),
+        asset_digest
+    );
+    let output_dir = cache_root.join(&cache_key);
+
+    // The process lock closes the same-process flock ambiguity on BSD/macOS;
+    // the persistent per-key flock extends serialization across processes.
+    // Both are acquired before the marker check, so a queued caller observes
+    // the cache the first caller just published instead of converting twice.
+    let _process_lock = qwen35_native_prepare_mutex().lock().await;
+    let lock_path = cache_root.join(format!(".{cache_key}.lock"));
+    let lock_path_for_thread = lock_path.clone();
+    let _file_lock =
+        tokio::task::spawn_blocking(move || Qwen35NativeCacheLock::acquire(&lock_path_for_thread))
+            .await
+            .map_err(|error| {
+                Error::from_reason(format!(
+                    "Native GGUF cache lock task failed for '{}': {error}",
+                    lock_path.display()
+                ))
+            })?
+            .map_err(|error| {
+                Error::from_reason(format!(
+                    "Failed to lock native GGUF cache '{}': {error}",
+                    lock_path.display()
+                ))
+            })?;
+
+    let locked_asset_digest = qwen35_native_asset_digest(parent)?;
+    if locked_asset_digest != asset_digest {
+        return Err(Error::from_reason(
+            "Qwen3.5 sibling config/tokenizer assets changed while acquiring the native GGUF \
+             cache lock; retry the load"
+                .to_string(),
+        ));
+    }
+    if qwen35_native_cache_is_current(&output_dir, &asset_digest) {
         return Ok(output_dir);
     }
 
@@ -4331,10 +4615,16 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
     // converter. A standalone GGUF has no config by design, so pass `None` in
     // that case: the converter still uses the GGUF parent for optional assets,
     // while allowing config/tokenizer reconstruction from header metadata.
+    let has_sibling_config = parent.join("config.json").is_file();
     let config_source_dir = has_sibling_config.then(|| parent.to_string_lossy().into_owned());
-    convert_gguf_to_safetensors(GgufConversionOptions {
+    let staging_dir = cache_root.join(format!(
+        ".{cache_key}.staging-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4().simple()
+    ));
+    let conversion = convert_gguf_to_safetensors(GgufConversionOptions {
         input_path: input_path.to_string_lossy().into_owned(),
-        output_dir: output_dir.to_string_lossy().into_owned(),
+        output_dir: staging_dir.to_string_lossy().into_owned(),
         config_source_dir,
         dtype: Some("bfloat16".to_string()),
         verbose: Some(true),
@@ -4350,19 +4640,62 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
         import_k_quants: Some(true),
         native_qwen35_layout: Some(true),
     })
-    .await?;
-    fs::write(
-        &marker,
+    .await;
+    if let Err(error) = conversion {
+        fs::remove_dir_all(&staging_dir).ok();
+        return Err(error);
+    }
+
+    let final_asset_digest = match qwen35_native_asset_digest(parent) {
+        Ok(digest) => digest,
+        Err(error) => {
+            fs::remove_dir_all(&staging_dir).ok();
+            return Err(error);
+        }
+    };
+    if final_asset_digest != asset_digest {
+        fs::remove_dir_all(&staging_dir).ok();
+        return Err(Error::from_reason(
+            "Qwen3.5 sibling config/tokenizer assets changed during native GGUF preparation; \
+             discarded the staged cache, retry the load"
+                .to_string(),
+        ));
+    }
+    let marker = staging_dir.join(".complete");
+    if let Err(error) = fs::write(
+        marker,
         format!(
-            "format=3\nsource={}\nsize={}\nmodified_ns={}\nlayout=tiled\ndtype=bf16\n",
+            "format={QWEN35_NATIVE_CACHE_FORMAT}\nsource={}\nsize={}\nmodified_ns={}\nassets_sha256={}\nlayout=tiled\ndtype=bf16\n",
             input_path.display(),
             metadata.len(),
-            modified
+            modified,
+            asset_digest
         ),
-    )
-    .map_err(|error| {
-        Error::from_reason(format!(
+    ) {
+        fs::remove_dir_all(&staging_dir).ok();
+        return Err(Error::from_reason(format!(
             "Failed to finalize native GGUF cache '{}': {error}",
+            output_dir.display()
+        )));
+    }
+
+    // The format and asset digest are part of the directory key, so a current
+    // cache is never replaced. Only a prior interrupted/corrupt build can
+    // occupy this exact path; remove it while both locks are held, then publish
+    // the complete staging directory with one atomic rename.
+    if output_dir.exists() {
+        fs::remove_dir_all(&output_dir).map_err(|error| {
+            fs::remove_dir_all(&staging_dir).ok();
+            Error::from_reason(format!(
+                "Failed to remove incomplete native GGUF cache '{}': {error}",
+                output_dir.display()
+            ))
+        })?;
+    }
+    fs::rename(&staging_dir, &output_dir).map_err(|error| {
+        fs::remove_dir_all(&staging_dir).ok();
+        Error::from_reason(format!(
+            "Failed to publish native GGUF cache '{}' atomically: {error}",
             output_dir.display()
         ))
     })?;
@@ -4559,6 +4892,12 @@ mod tests {
                 ),
                 ("qwen35.embedding_length", GgufMetaValue::Uint32(1)),
                 ("qwen35.block_count", GgufMetaValue::Uint32(2)),
+                ("qwen35.ssm.state_size", GgufMetaValue::Uint32(2)),
+                ("qwen35.ssm.inner_size", GgufMetaValue::Uint32(6)),
+                ("qwen35.ssm.time_step_rank", GgufMetaValue::Uint32(3)),
+                ("qwen35.ssm.group_count", GgufMetaValue::Uint32(1)),
+                ("qwen35.ssm.conv_kernel", GgufMetaValue::Uint32(4)),
+                ("qwen35.full_attention_interval", GgufMetaValue::Uint32(2)),
             ],
             &[
                 ("output_norm.weight", &[1], GgufTensorType::BF16, &[0, 0]),
@@ -4607,10 +4946,318 @@ mod tests {
         assert_eq!(config["num_hidden_layers"], serde_json::json!(1));
         assert_eq!(config["mtp_num_hidden_layers"], serde_json::json!(1));
         assert_eq!(config["num_nextn_predict_layers"], serde_json::json!(1));
+        assert_eq!(config["linear_num_value_heads"], serde_json::json!(3));
+        assert_eq!(config["linear_num_key_heads"], serde_json::json!(1));
+        assert_eq!(config["linear_key_head_dim"], serde_json::json!(2));
+        assert_eq!(config["linear_value_head_dim"], serde_json::json!(2));
+        assert_eq!(config["linear_conv_kernel_dim"], serde_json::json!(4));
+        assert_eq!(config["full_attention_interval"], serde_json::json!(2));
+        assert_eq!(
+            config["layer_types"],
+            serde_json::json!(["linear_attention"])
+        );
         assert!(output.join("model.safetensors").is_file());
-        assert!(output.join(".complete").is_file());
+        let marker = fs::read_to_string(output.join(".complete")).unwrap();
+        assert!(marker.contains("format=4\n"));
+        assert!(marker.contains("assets_sha256="));
 
         fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn qwen35_exact_header_geometry_synthesizes_runtime_fields_and_layer_pattern() {
+        let metadata = HashMap::from([
+            (
+                "general.architecture".to_string(),
+                GgufMetaValue::String("qwen35".to_string()),
+            ),
+            ("qwen35.block_count".to_string(), GgufMetaValue::Uint32(65)),
+            (
+                "qwen35.attention.key_length".to_string(),
+                GgufMetaValue::Uint32(256),
+            ),
+            (
+                "qwen35.rope.dimension_count".to_string(),
+                GgufMetaValue::Uint32(64),
+            ),
+            (
+                "qwen35.ssm.state_size".to_string(),
+                GgufMetaValue::Uint32(128),
+            ),
+            (
+                "qwen35.ssm.inner_size".to_string(),
+                GgufMetaValue::Uint32(6144),
+            ),
+            (
+                "qwen35.ssm.time_step_rank".to_string(),
+                GgufMetaValue::Uint32(48),
+            ),
+            (
+                "qwen35.ssm.group_count".to_string(),
+                GgufMetaValue::Uint32(16),
+            ),
+            (
+                "qwen35.ssm.conv_kernel".to_string(),
+                GgufMetaValue::Uint32(4),
+            ),
+            (
+                "qwen35.full_attention_interval".to_string(),
+                GgufMetaValue::Uint32(4),
+            ),
+            (
+                "tokenizer.ggml.bos_token_id".to_string(),
+                GgufMetaValue::Uint32(151643),
+            ),
+            (
+                "tokenizer.ggml.eos_token_id".to_string(),
+                GgufMetaValue::Uint32(151645),
+            ),
+        ]);
+
+        validate_qwen35_standalone_geometry(&metadata).unwrap();
+        let mut config = extract_config(&metadata);
+        apply_qwen35_inline_mtp_config(&mut config, Some(64));
+        assert_eq!(config["num_hidden_layers"], serde_json::json!(64));
+        assert_eq!(config["linear_num_value_heads"], serde_json::json!(48));
+        assert_eq!(config["linear_num_key_heads"], serde_json::json!(16));
+        assert_eq!(config["linear_key_head_dim"], serde_json::json!(128));
+        assert_eq!(config["linear_value_head_dim"], serde_json::json!(128));
+        assert_eq!(config["linear_conv_kernel_dim"], serde_json::json!(4));
+        assert_eq!(config["full_attention_interval"], serde_json::json!(4));
+        assert_eq!(config["partial_rotary_factor"], serde_json::json!(0.25));
+        assert_eq!(config["bos_token_id"], serde_json::json!(151643));
+        assert_eq!(config["eos_token_id"], serde_json::json!(151645));
+        let layer_types = config["layer_types"].as_array().unwrap();
+        assert_eq!(layer_types.len(), 64);
+        assert_eq!(layer_types[0], serde_json::json!("linear_attention"));
+        assert_eq!(layer_types[3], serde_json::json!("full_attention"));
+        assert_eq!(layer_types[63], serde_json::json!("full_attention"));
+    }
+
+    #[test]
+    fn qwen35_standalone_geometry_fails_closed_when_missing_or_inconsistent() {
+        let mut metadata = HashMap::from([
+            (
+                "general.architecture".to_string(),
+                GgufMetaValue::String("qwen35".to_string()),
+            ),
+            (
+                "qwen35.ssm.state_size".to_string(),
+                GgufMetaValue::Uint32(128),
+            ),
+        ]);
+        let missing = validate_qwen35_standalone_geometry(&metadata).unwrap_err();
+        assert!(missing.reason.contains("qwen35.ssm.inner_size"));
+
+        metadata.extend([
+            (
+                "qwen35.ssm.inner_size".to_string(),
+                GgufMetaValue::Uint32(6145),
+            ),
+            (
+                "qwen35.ssm.time_step_rank".to_string(),
+                GgufMetaValue::Uint32(48),
+            ),
+            (
+                "qwen35.ssm.group_count".to_string(),
+                GgufMetaValue::Uint32(16),
+            ),
+            (
+                "qwen35.ssm.conv_kernel".to_string(),
+                GgufMetaValue::Uint32(4),
+            ),
+            (
+                "qwen35.full_attention_interval".to_string(),
+                GgufMetaValue::Uint32(4),
+            ),
+        ]);
+        let inconsistent = validate_qwen35_standalone_geometry(&metadata).unwrap_err();
+        assert!(inconsistent.reason.contains("ssm.inner_size=6145"));
+        assert!(
+            inconsistent
+                .reason
+                .contains("128) * ssm.time_step_rank (48) = 6144")
+        );
+    }
+
+    #[tokio::test]
+    async fn qwen35_native_cache_tracks_source_asset_presence_and_contents() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-qwen35-assets-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let input = root.join("model.gguf");
+        fs::write(
+            &input,
+            build_minimal_gguf(
+                &[
+                    (
+                        "general.architecture",
+                        GgufMetaValue::String("qwen35".to_string()),
+                    ),
+                    ("qwen35.block_count", GgufMetaValue::Uint32(1)),
+                    ("qwen35.ssm.state_size", GgufMetaValue::Uint32(2)),
+                    ("qwen35.ssm.inner_size", GgufMetaValue::Uint32(4)),
+                    ("qwen35.ssm.time_step_rank", GgufMetaValue::Uint32(2)),
+                    ("qwen35.ssm.group_count", GgufMetaValue::Uint32(1)),
+                    ("qwen35.ssm.conv_kernel", GgufMetaValue::Uint32(4)),
+                    ("qwen35.full_attention_interval", GgufMetaValue::Uint32(1)),
+                ],
+                &[("output_norm.weight", &[1], GgufTensorType::BF16, &[0, 0])],
+            ),
+        )
+        .unwrap();
+
+        let standalone = prepare_qwen35_native_gguf(&input).await.unwrap();
+        fs::write(
+            root.join("config.json"),
+            r#"{"model_type":"qwen3_5","asset_sentinel":1}"#,
+        )
+        .unwrap();
+        let added = prepare_qwen35_native_gguf(&input).await.unwrap();
+        fs::write(
+            root.join("config.json"),
+            r#"{"model_type":"qwen3_5","asset_sentinel":2}"#,
+        )
+        .unwrap();
+        let edited_same_size = prepare_qwen35_native_gguf(&input).await.unwrap();
+
+        assert_ne!(
+            standalone, added,
+            "adding config.json must change the cache key"
+        );
+        assert_ne!(
+            added, edited_same_size,
+            "same-size asset edits must change the key"
+        );
+        let config: serde_json::Value =
+            serde_json::from_slice(&fs::read(edited_same_size.join("config.json")).unwrap())
+                .unwrap();
+        assert_eq!(config["asset_sentinel"], serde_json::json!(2));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn concurrent_qwen35_native_prepares_publish_one_complete_cache() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-qwen35-concurrent-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("config.json"), r#"{"model_type":"qwen3_5"}"#).unwrap();
+        let input = root.join("model.gguf");
+        fs::write(
+            &input,
+            build_minimal_gguf(
+                &[
+                    (
+                        "general.architecture",
+                        GgufMetaValue::String("qwen35".to_string()),
+                    ),
+                    ("qwen35.block_count", GgufMetaValue::Uint32(1)),
+                ],
+                &[("output_norm.weight", &[1], GgufTensorType::BF16, &[0, 0])],
+            ),
+        )
+        .unwrap();
+
+        let (left, right) = tokio::join!(
+            prepare_qwen35_native_gguf(&input),
+            prepare_qwen35_native_gguf(&input)
+        );
+        let left = left.unwrap();
+        let right = right.unwrap();
+        assert_eq!(left, right);
+        assert!(left.join("model.safetensors").is_file());
+        assert!(left.join("config.json").is_file());
+        assert!(left.join(".complete").is_file());
+        let staged = fs::read_dir(root.join(".mlx-node-native"))
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".staging-"))
+            .count();
+        assert_eq!(staged, 0, "no staging directory may survive publication");
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn qwen35_native_cache_lock_serializes_separate_processes() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-qwen35-process-lock-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let lock_path = root.join("cache.lock");
+        let started_path = root.join("child.started");
+        let acquired_path = root.join("child.acquired");
+        let parent_lock = Qwen35NativeCacheLock::acquire(&lock_path).unwrap();
+
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("utils::gguf::tests::qwen35_native_cache_lock_child")
+            .arg("--ignored")
+            .env("MLX_NODE_QWEN35_LOCK_TEST_PATH", &lock_path)
+            .env("MLX_NODE_QWEN35_LOCK_TEST_STARTED", &started_path)
+            .env("MLX_NODE_QWEN35_LOCK_TEST_ACQUIRED", &acquired_path)
+            .spawn()
+            .unwrap();
+
+        for _ in 0..500 {
+            if started_path.is_file() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(started_path.is_file(), "child never reached the flock call");
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert!(
+            acquired_path.try_exists().is_ok_and(|exists| !exists),
+            "child acquired the same cache-key lock while the parent still held it"
+        );
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "child exited instead of blocking on the parent lock"
+        );
+
+        drop(parent_lock);
+        let status = child.wait().unwrap();
+        assert!(status.success(), "lock-test child failed: {status}");
+        assert!(acquired_path.is_file());
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "helper process for qwen35_native_cache_lock_serializes_separate_processes"]
+    fn qwen35_native_cache_lock_child() {
+        let lock_path = PathBuf::from(
+            std::env::var_os("MLX_NODE_QWEN35_LOCK_TEST_PATH").expect("lock-test child path"),
+        );
+        let started_path = PathBuf::from(
+            std::env::var_os("MLX_NODE_QWEN35_LOCK_TEST_STARTED")
+                .expect("lock-test child started path"),
+        );
+        let acquired_path = PathBuf::from(
+            std::env::var_os("MLX_NODE_QWEN35_LOCK_TEST_ACQUIRED")
+                .expect("lock-test child acquired path"),
+        );
+        fs::write(started_path, b"started").unwrap();
+        let _lock = Qwen35NativeCacheLock::acquire(&lock_path).unwrap();
+        fs::write(acquired_path, b"acquired").unwrap();
     }
 
     #[test]

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -20,6 +20,8 @@ use std::fs::{self, OpenOptions};
 use std::io::{BufReader, Read, Seek, SeekFrom};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use napi::bindgen_prelude::*;
@@ -1668,16 +1670,41 @@ fn validate_qwen35_standalone_geometry(metadata: &HashMap<String, GgufMetaValue>
     };
     let state_size = required("ssm.state_size")?;
     let inner_size = required("ssm.inner_size")?;
-    let value_heads = required("ssm.time_step_rank")?;
     let key_heads = required("ssm.group_count")?;
     let conv_kernel = required("ssm.conv_kernel")?;
-    let _full_attention_interval = required("full_attention_interval")?;
-    if state_size == 0 || value_heads == 0 || key_heads == 0 || conv_kernel == 0 {
+    let full_attention_interval = required("full_attention_interval")?;
+    if state_size == 0
+        || inner_size == 0
+        || key_heads == 0
+        || conv_kernel == 0
+        || full_attention_interval == 0
+    {
         return Err(Error::from_reason(format!(
             "Standalone Qwen3.5 GGUF has non-positive GDN geometry: state_size={state_size}, \
-             time_step_rank={value_heads}, group_count={key_heads}, conv_kernel={conv_kernel}"
+             inner_size={inner_size}, group_count={key_heads}, conv_kernel={conv_kernel}, \
+             full_attention_interval={full_attention_interval}"
         )));
     }
+    let declared_value_heads = metadata
+        .get(&format!("{arch}.ssm.time_step_rank"))
+        .and_then(GgufMetaValue::as_u64);
+    let value_heads = match declared_value_heads {
+        Some(value_heads) if value_heads > 0 => value_heads,
+        Some(_) => {
+            return Err(Error::from_reason(
+                "Standalone Qwen3.5 GGUF has non-positive GDN geometry: time_step_rank=0"
+                    .to_string(),
+            ));
+        }
+        None if inner_size.is_multiple_of(state_size) => inner_size / state_size,
+        None => {
+            return Err(Error::from_reason(format!(
+                "Standalone Qwen3.5 GGUF cannot derive the value-head count without \
+                 ssm.time_step_rank: ssm.inner_size ({inner_size}) is not divisible by \
+                 ssm.state_size ({state_size})"
+            )));
+        }
+    };
     let expected_inner = state_size.checked_mul(value_heads).ok_or_else(|| {
         Error::from_reason("Standalone Qwen3.5 GGUF GDN geometry overflows u64".to_string())
     })?;
@@ -4536,8 +4563,37 @@ fn qwen35_native_asset_digest(parent: &Path) -> Result<String> {
         .collect())
 }
 
-fn qwen35_native_source_digest(input_path: &Path) -> String {
-    Sha256::digest(input_path.as_os_str().as_encoded_bytes())
+fn qwen35_native_source_identity_digest(input_path: &Path, metadata: &fs::Metadata) -> String {
+    let mut hasher = Sha256::new();
+    let path = input_path.as_os_str().as_encoded_bytes();
+    hasher.update((path.len() as u64).to_le_bytes());
+    hasher.update(path);
+    hasher.update(metadata.len().to_le_bytes());
+
+    // Hashing a multi-gigabyte GGUF on every cached load would dominate load
+    // time. Unix ctime cannot be restored by cp -p or ordinary users, while a
+    // replacement-by-rename changes the inode, so these fields detect both
+    // in-place rewrites and same-size/same-mtime artifact replacements.
+    #[cfg(unix)]
+    {
+        hasher.update(metadata.dev().to_le_bytes());
+        hasher.update(metadata.ino().to_le_bytes());
+        hasher.update(metadata.ctime().to_le_bytes());
+        hasher.update(metadata.ctime_nsec().to_le_bytes());
+    }
+    #[cfg(not(unix))]
+    {
+        for timestamp in [metadata.created().ok(), metadata.modified().ok()] {
+            let nanos = timestamp
+                .and_then(|value| value.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|value| value.as_nanos())
+                .unwrap_or(0);
+            hasher.update(nanos.to_le_bytes());
+        }
+    }
+
+    hasher
+        .finalize()
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect()
@@ -4592,13 +4648,15 @@ impl Drop for Qwen35NativeCacheLock {
 
 fn qwen35_native_cache_is_current(
     output_dir: &Path,
-    source_digest: &str,
+    source_identity_digest: &str,
     asset_digest: &str,
 ) -> bool {
     let marker = output_dir.join(".complete");
     fs::read_to_string(marker).is_ok_and(|contents| {
         contents.contains(&format!("format={QWEN35_NATIVE_CACHE_FORMAT}\n"))
-            && contents.contains(&format!("source_sha256={source_digest}\n"))
+            && contents.contains(&format!(
+                "source_identity_sha256={source_identity_digest}\n"
+            ))
             && contents.contains(&format!("assets_sha256={asset_digest}\n"))
             && contents.contains("dtype=bf16\n")
             && output_dir.join("model.safetensors").is_file()
@@ -4656,10 +4714,10 @@ async fn prepare_qwen35_native_gguf_inner(input_path: &Path, cache_root: &Path) 
         .take(32)
         .collect::<String>();
     let parent = input_path.parent().unwrap_or(Path::new("."));
-    let source_digest = qwen35_native_source_digest(&input_path);
+    let source_identity_digest = qwen35_native_source_identity_digest(&input_path, &metadata);
     let asset_digest = qwen35_native_asset_digest(parent)?;
     let cache_key = format!(
-        "{stem}-{}-{modified}-v{QWEN35_NATIVE_CACHE_FORMAT}-{source_digest}-{asset_digest}",
+        "{stem}-{}-{modified}-v{QWEN35_NATIVE_CACHE_FORMAT}-{source_identity_digest}-{asset_digest}",
         metadata.len(),
     );
     let output_dir = cache_root.join(&cache_key);
@@ -4695,7 +4753,20 @@ async fn prepare_qwen35_native_gguf_inner(input_path: &Path, cache_root: &Path) 
                 .to_string(),
         ));
     }
-    if qwen35_native_cache_is_current(&output_dir, &source_digest, &asset_digest) {
+    let locked_metadata = fs::metadata(&input_path).map_err(|error| {
+        Error::from_reason(format!(
+            "Failed to restat GGUF path '{}' after acquiring the native cache lock: {error}",
+            input_path.display()
+        ))
+    })?;
+    if qwen35_native_source_identity_digest(&input_path, &locked_metadata) != source_identity_digest
+    {
+        return Err(Error::from_reason(
+            "Qwen3.5 GGUF source changed while acquiring the native cache lock; retry the load"
+                .to_string(),
+        ));
+    }
+    if qwen35_native_cache_is_current(&output_dir, &source_identity_digest, &asset_digest) {
         return Ok(output_dir);
     }
 
@@ -4749,13 +4820,32 @@ async fn prepare_qwen35_native_gguf_inner(input_path: &Path, cache_root: &Path) 
                 .to_string(),
         ));
     }
+    let final_metadata = match fs::metadata(&input_path) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            fs::remove_dir_all(&staging_dir).ok();
+            return Err(Error::from_reason(format!(
+                "Failed to restat GGUF path '{}' after native preparation: {error}",
+                input_path.display()
+            )));
+        }
+    };
+    if qwen35_native_source_identity_digest(&input_path, &final_metadata) != source_identity_digest
+    {
+        fs::remove_dir_all(&staging_dir).ok();
+        return Err(Error::from_reason(
+            "Qwen3.5 GGUF source changed during native preparation; discarded the staged cache, \
+             retry the load"
+                .to_string(),
+        ));
+    }
     let marker = staging_dir.join(".complete");
     if let Err(error) = fs::write(
         marker,
         format!(
-            "format={QWEN35_NATIVE_CACHE_FORMAT}\nsource={}\nsource_sha256={}\nsize={}\nmodified_ns={}\nassets_sha256={}\nlayout=tiled\ndtype=bf16\n",
+            "format={QWEN35_NATIVE_CACHE_FORMAT}\nsource={}\nsource_identity_sha256={}\nsize={}\nmodified_ns={}\nassets_sha256={}\nlayout=tiled\ndtype=bf16\n",
             input_path.display(),
-            source_digest,
+            source_identity_digest,
             metadata.len(),
             modified,
             asset_digest
@@ -5168,6 +5258,27 @@ mod tests {
                 .reason
                 .contains("128) * ssm.time_step_rank (48) = 6144")
         );
+
+        metadata.insert(
+            "qwen35.ssm.inner_size".to_string(),
+            GgufMetaValue::Uint32(6144),
+        );
+        metadata.remove("qwen35.ssm.time_step_rank");
+        validate_qwen35_standalone_geometry(&metadata).unwrap();
+        let config = extract_config(&metadata);
+        assert_eq!(config["linear_num_value_heads"], serde_json::json!(48));
+
+        metadata.insert(
+            "qwen35.ssm.inner_size".to_string(),
+            GgufMetaValue::Uint32(6145),
+        );
+        let not_divisible = validate_qwen35_standalone_geometry(&metadata).unwrap_err();
+        assert!(
+            not_divisible
+                .reason
+                .contains("cannot derive the value-head count")
+        );
+        assert!(not_divisible.reason.contains("is not divisible"));
     }
 
     #[test]
@@ -5385,11 +5496,90 @@ mod tests {
         let source_line = |marker: &str| {
             marker
                 .lines()
-                .find(|line| line.starts_with("source_sha256="))
+                .find(|line| line.starts_with("source_identity_sha256="))
                 .unwrap()
                 .to_string()
         };
         assert_ne!(source_line(&left_marker), source_line(&right_marker));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn qwen35_native_cache_detects_same_size_same_mtime_source_replacement() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-qwen35-source-replacement-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("config.json"), r#"{"model_type":"qwen3_5"}"#).unwrap();
+        let metadata = [
+            (
+                "general.architecture",
+                GgufMetaValue::String("qwen35".to_string()),
+            ),
+            ("qwen35.block_count", GgufMetaValue::Uint32(1)),
+        ];
+        let input = root.join("model.gguf");
+        let replacement = root.join("replacement.gguf");
+        fs::write(
+            &input,
+            build_minimal_gguf(
+                &metadata,
+                &[("output_norm.weight", &[1], GgufTensorType::BF16, &[0, 0])],
+            ),
+        )
+        .unwrap();
+        fs::write(
+            &replacement,
+            build_minimal_gguf(
+                &metadata,
+                &[("output_norm.weight", &[1], GgufTensorType::BF16, &[1, 0])],
+            ),
+        )
+        .unwrap();
+        let original_metadata = fs::metadata(&input).unwrap();
+        let original_modified = original_metadata.modified().unwrap();
+        let cache_root = root.join("native-cache");
+        let original = prepare_qwen35_native_gguf_in(&input, &cache_root)
+            .await
+            .unwrap();
+
+        OpenOptions::new()
+            .write(true)
+            .open(&replacement)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+        fs::rename(&replacement, &input).unwrap();
+        let replacement_metadata = fs::metadata(&input).unwrap();
+        assert_eq!(replacement_metadata.len(), original_metadata.len());
+        assert_eq!(replacement_metadata.modified().unwrap(), original_modified);
+
+        let replaced = prepare_qwen35_native_gguf_in(&input, &cache_root)
+            .await
+            .unwrap();
+        assert_ne!(
+            original, replaced,
+            "same-size/same-mtime replacement must not reuse the prior cache"
+        );
+        let original_marker = fs::read_to_string(original.join(".complete")).unwrap();
+        let replaced_marker = fs::read_to_string(replaced.join(".complete")).unwrap();
+        let source_identity = |marker: &str| {
+            marker
+                .lines()
+                .find(|line| line.starts_with("source_identity_sha256="))
+                .unwrap()
+                .to_string()
+        };
+        assert_ne!(
+            source_identity(&original_marker),
+            source_identity(&replaced_marker)
+        );
         fs::remove_dir_all(root).ok();
     }
 

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -4470,6 +4470,13 @@ fn qwen35_native_asset_digest(parent: &Path) -> Result<String> {
         .collect())
 }
 
+fn qwen35_native_source_digest(input_path: &Path) -> String {
+    Sha256::digest(input_path.as_os_str().as_encoded_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
 fn qwen35_native_prepare_mutex() -> &'static tokio::sync::Mutex<()> {
     static MUTEX: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
     MUTEX.get_or_init(|| tokio::sync::Mutex::new(()))
@@ -4517,10 +4524,15 @@ impl Drop for Qwen35NativeCacheLock {
     }
 }
 
-fn qwen35_native_cache_is_current(output_dir: &Path, asset_digest: &str) -> bool {
+fn qwen35_native_cache_is_current(
+    output_dir: &Path,
+    source_digest: &str,
+    asset_digest: &str,
+) -> bool {
     let marker = output_dir.join(".complete");
     fs::read_to_string(marker).is_ok_and(|contents| {
         contents.contains(&format!("format={QWEN35_NATIVE_CACHE_FORMAT}\n"))
+            && contents.contains(&format!("source_sha256={source_digest}\n"))
             && contents.contains(&format!("assets_sha256={asset_digest}\n"))
             && contents.contains("dtype=bf16\n")
             && output_dir.join("model.safetensors").is_file()
@@ -4559,8 +4571,10 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
                 '_'
             }
         })
+        .take(32)
         .collect::<String>();
     let parent = input_path.parent().unwrap_or(Path::new("."));
+    let source_digest = qwen35_native_source_digest(&input_path);
     let asset_digest = qwen35_native_asset_digest(parent)?;
     let cache_root = parent.join(".mlx-node-native");
     fs::create_dir_all(&cache_root).map_err(|error| {
@@ -4570,9 +4584,8 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
         ))
     })?;
     let cache_key = format!(
-        "{stem}-{}-{modified}-v{QWEN35_NATIVE_CACHE_FORMAT}-{}",
+        "{stem}-{}-{modified}-v{QWEN35_NATIVE_CACHE_FORMAT}-{source_digest}-{asset_digest}",
         metadata.len(),
-        asset_digest
     );
     let output_dir = cache_root.join(&cache_key);
 
@@ -4607,7 +4620,7 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
                 .to_string(),
         ));
     }
-    if qwen35_native_cache_is_current(&output_dir, &asset_digest) {
+    if qwen35_native_cache_is_current(&output_dir, &source_digest, &asset_digest) {
         return Ok(output_dir);
     }
 
@@ -4665,8 +4678,9 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
     if let Err(error) = fs::write(
         marker,
         format!(
-            "format={QWEN35_NATIVE_CACHE_FORMAT}\nsource={}\nsize={}\nmodified_ns={}\nassets_sha256={}\nlayout=tiled\ndtype=bf16\n",
+            "format={QWEN35_NATIVE_CACHE_FORMAT}\nsource={}\nsource_sha256={}\nsize={}\nmodified_ns={}\nassets_sha256={}\nlayout=tiled\ndtype=bf16\n",
             input_path.display(),
+            source_digest,
             metadata.len(),
             modified,
             asset_digest
@@ -5139,6 +5153,78 @@ mod tests {
             serde_json::from_slice(&fs::read(edited_same_size.join("config.json")).unwrap())
                 .unwrap();
         assert_eq!(config["asset_sentinel"], serde_json::json!(2));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn qwen35_native_cache_key_separates_sanitized_source_name_collisions() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-qwen35-source-key-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("config.json"), r#"{"model_type":"qwen3_5"}"#).unwrap();
+        let metadata = [
+            (
+                "general.architecture",
+                GgufMetaValue::String("qwen35".to_string()),
+            ),
+            ("qwen35.block_count", GgufMetaValue::Uint32(1)),
+        ];
+        let left_input = root.join("model!.gguf");
+        let right_input = root.join("model?.gguf");
+        fs::write(
+            &left_input,
+            build_minimal_gguf(
+                &metadata,
+                &[("output_norm.weight", &[1], GgufTensorType::BF16, &[0, 0])],
+            ),
+        )
+        .unwrap();
+        fs::write(
+            &right_input,
+            build_minimal_gguf(
+                &metadata,
+                &[("output_norm.weight", &[1], GgufTensorType::BF16, &[1, 0])],
+            ),
+        )
+        .unwrap();
+        let shared_modified = fs::metadata(&left_input).unwrap().modified().unwrap();
+        OpenOptions::new()
+            .write(true)
+            .open(&right_input)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(shared_modified))
+            .unwrap();
+        assert_eq!(
+            fs::metadata(&left_input).unwrap().len(),
+            fs::metadata(&right_input).unwrap().len()
+        );
+        assert_eq!(
+            fs::metadata(&left_input).unwrap().modified().unwrap(),
+            fs::metadata(&right_input).unwrap().modified().unwrap()
+        );
+
+        let left = prepare_qwen35_native_gguf(&left_input).await.unwrap();
+        let right = prepare_qwen35_native_gguf(&right_input).await.unwrap();
+        assert_ne!(
+            left, right,
+            "canonical source identity must participate in the key"
+        );
+        let left_marker = fs::read_to_string(left.join(".complete")).unwrap();
+        let right_marker = fs::read_to_string(right.join(".complete")).unwrap();
+        let source_line = |marker: &str| {
+            marker
+                .lines()
+                .find(|line| line.starts_with("source_sha256="))
+                .unwrap()
+                .to_string()
+        };
+        assert_ne!(source_line(&left_marker), source_line(&right_marker));
         fs::remove_dir_all(root).ok();
     }
 

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -4430,6 +4430,72 @@ pub async fn convert_gguf_to_safetensors(
 /// F32 norms/biases are narrowed to BF16 so they do not promote inference
 /// activations away from the model's BF16 execution/cache dtype.
 const QWEN35_NATIVE_CACHE_FORMAT: u32 = 4;
+const QWEN35_NATIVE_CACHE_DIR_ENV: &str = "MLX_NATIVE_GGUF_CACHE_DIR";
+
+fn qwen35_native_cache_candidates_from(
+    override_root: Option<PathBuf>,
+    xdg_cache_home: Option<PathBuf>,
+    home: Option<PathBuf>,
+    temp: PathBuf,
+) -> Vec<PathBuf> {
+    if let Some(root) = override_root.filter(|path| !path.as_os_str().is_empty()) {
+        return vec![root];
+    }
+    let mut candidates = Vec::new();
+    if let Some(root) = xdg_cache_home.filter(|path| !path.as_os_str().is_empty()) {
+        candidates.push(root.join("mlx-node/native-gguf"));
+    }
+    if let Some(home) = home.filter(|path| !path.as_os_str().is_empty()) {
+        #[cfg(target_os = "macos")]
+        candidates.push(home.join("Library/Caches/mlx-node/native-gguf"));
+        #[cfg(not(target_os = "macos"))]
+        candidates.push(home.join(".cache/mlx-node/native-gguf"));
+    }
+    candidates.push(temp.join("mlx-node/native-gguf"));
+    candidates.dedup();
+    candidates
+}
+
+fn initialize_qwen35_native_cache_root(root: &Path) -> std::io::Result<PathBuf> {
+    fs::create_dir_all(root)?;
+    let probe = root.join(format!(
+        ".write-probe-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4().simple()
+    ));
+    OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&probe)?;
+    fs::remove_file(&probe)?;
+    root.canonicalize()
+}
+
+fn qwen35_native_cache_root() -> Result<PathBuf> {
+    let override_root = std::env::var_os(QWEN35_NATIVE_CACHE_DIR_ENV).map(PathBuf::from);
+    let candidates = qwen35_native_cache_candidates_from(
+        override_root.clone(),
+        std::env::var_os("XDG_CACHE_HOME").map(PathBuf::from),
+        std::env::var_os("HOME").map(PathBuf::from),
+        std::env::temp_dir(),
+    );
+    let mut failures = Vec::new();
+    for candidate in candidates {
+        match initialize_qwen35_native_cache_root(&candidate) {
+            Ok(root) => return Ok(root),
+            Err(error) => failures.push(format!("{}: {error}", candidate.display())),
+        }
+    }
+    let authority = if override_root.is_some() {
+        format!(" from {QWEN35_NATIVE_CACHE_DIR_ENV}")
+    } else {
+        String::new()
+    };
+    Err(Error::from_reason(format!(
+        "No writable native GGUF cache directory{authority}: {}",
+        failures.join("; ")
+    )))
+}
 
 fn qwen35_native_asset_digest(parent: &Path) -> Result<String> {
     let mut hasher = Sha256::new();
@@ -4541,6 +4607,22 @@ fn qwen35_native_cache_is_current(
 }
 
 pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
+    let cache_root = qwen35_native_cache_root()?;
+    prepare_qwen35_native_gguf_inner(input_path, &cache_root).await
+}
+
+#[cfg(test)]
+async fn prepare_qwen35_native_gguf_in(input_path: &Path, cache_root: &Path) -> Result<PathBuf> {
+    let cache_root = initialize_qwen35_native_cache_root(cache_root).map_err(|error| {
+        Error::from_reason(format!(
+            "Failed to create native GGUF cache root '{}': {error}",
+            cache_root.display()
+        ))
+    })?;
+    prepare_qwen35_native_gguf_inner(input_path, &cache_root).await
+}
+
+async fn prepare_qwen35_native_gguf_inner(input_path: &Path, cache_root: &Path) -> Result<PathBuf> {
     let input_path = input_path.canonicalize().map_err(|error| {
         Error::from_reason(format!(
             "Failed to canonicalize GGUF path '{}': {error}",
@@ -4576,13 +4658,6 @@ pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
     let parent = input_path.parent().unwrap_or(Path::new("."));
     let source_digest = qwen35_native_source_digest(&input_path);
     let asset_digest = qwen35_native_asset_digest(parent)?;
-    let cache_root = parent.join(".mlx-node-native");
-    fs::create_dir_all(&cache_root).map_err(|error| {
-        Error::from_reason(format!(
-            "Failed to create native GGUF cache root '{}': {error}",
-            cache_root.display()
-        ))
-    })?;
     let cache_key = format!(
         "{stem}-{}-{modified}-v{QWEN35_NATIVE_CACHE_FORMAT}-{source_digest}-{asset_digest}",
         metadata.len(),
@@ -4943,8 +5018,9 @@ mod tests {
         );
         let input = root.join("standalone.gguf");
         fs::write(&input, data).unwrap();
+        let cache_root = root.join("native-cache");
 
-        let output = prepare_qwen35_native_gguf(&input)
+        let output = prepare_qwen35_native_gguf_in(&input, &cache_root)
             .await
             .unwrap_or_else(|error| {
                 panic!(
@@ -5094,6 +5170,83 @@ mod tests {
         );
     }
 
+    #[test]
+    fn qwen35_native_cache_root_prefers_override_then_application_cache() {
+        let override_root = PathBuf::from("/override");
+        let xdg = PathBuf::from("/xdg");
+        let home = PathBuf::from("/home/tester");
+        let temp = PathBuf::from("/tmp/tester");
+        assert_eq!(
+            qwen35_native_cache_candidates_from(
+                Some(override_root.clone()),
+                Some(xdg.clone()),
+                Some(home.clone()),
+                temp.clone(),
+            ),
+            vec![override_root]
+        );
+        assert_eq!(
+            qwen35_native_cache_candidates_from(None, Some(xdg), Some(home.clone()), temp.clone())
+                [0],
+            PathBuf::from("/xdg/mlx-node/native-gguf")
+        );
+        let without_xdg = qwen35_native_cache_candidates_from(None, None, Some(home), temp.clone());
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            without_xdg[0],
+            PathBuf::from("/home/tester/Library/Caches/mlx-node/native-gguf")
+        );
+        #[cfg(not(target_os = "macos"))]
+        assert_eq!(
+            without_xdg[0],
+            PathBuf::from("/home/tester/.cache/mlx-node/native-gguf")
+        );
+        assert_eq!(without_xdg.last(), Some(&temp.join("mlx-node/native-gguf")));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn qwen35_native_prepare_never_writes_beside_read_only_source() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-qwen35-read-only-source-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let source = root.join("source");
+        let cache_root = root.join("cache");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("config.json"), r#"{"model_type":"qwen3_5"}"#).unwrap();
+        let input = source.join("model.gguf");
+        fs::write(
+            &input,
+            build_minimal_gguf(
+                &[
+                    (
+                        "general.architecture",
+                        GgufMetaValue::String("qwen35".to_string()),
+                    ),
+                    ("qwen35.block_count", GgufMetaValue::Uint32(1)),
+                ],
+                &[("output_norm.weight", &[1], GgufTensorType::BF16, &[0, 0])],
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o555)).unwrap();
+        let prepared = prepare_qwen35_native_gguf_in(&input, &cache_root).await;
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o755)).unwrap();
+        let output = prepared.unwrap();
+
+        assert!(output.starts_with(cache_root.canonicalize().unwrap()));
+        assert!(!source.join(".mlx-node-native").exists());
+        assert!(output.join("model.safetensors").is_file());
+        fs::remove_dir_all(root).ok();
+    }
+
     #[tokio::test]
     async fn qwen35_native_cache_tracks_source_asset_presence_and_contents() {
         let root = std::env::temp_dir().join(format!(
@@ -5126,20 +5279,27 @@ mod tests {
             ),
         )
         .unwrap();
+        let cache_root = root.join("native-cache");
 
-        let standalone = prepare_qwen35_native_gguf(&input).await.unwrap();
+        let standalone = prepare_qwen35_native_gguf_in(&input, &cache_root)
+            .await
+            .unwrap();
         fs::write(
             root.join("config.json"),
             r#"{"model_type":"qwen3_5","asset_sentinel":1}"#,
         )
         .unwrap();
-        let added = prepare_qwen35_native_gguf(&input).await.unwrap();
+        let added = prepare_qwen35_native_gguf_in(&input, &cache_root)
+            .await
+            .unwrap();
         fs::write(
             root.join("config.json"),
             r#"{"model_type":"qwen3_5","asset_sentinel":2}"#,
         )
         .unwrap();
-        let edited_same_size = prepare_qwen35_native_gguf(&input).await.unwrap();
+        let edited_same_size = prepare_qwen35_native_gguf_in(&input, &cache_root)
+            .await
+            .unwrap();
 
         assert_ne!(
             standalone, added,
@@ -5208,9 +5368,14 @@ mod tests {
             fs::metadata(&left_input).unwrap().modified().unwrap(),
             fs::metadata(&right_input).unwrap().modified().unwrap()
         );
+        let cache_root = root.join("native-cache");
 
-        let left = prepare_qwen35_native_gguf(&left_input).await.unwrap();
-        let right = prepare_qwen35_native_gguf(&right_input).await.unwrap();
+        let left = prepare_qwen35_native_gguf_in(&left_input, &cache_root)
+            .await
+            .unwrap();
+        let right = prepare_qwen35_native_gguf_in(&right_input, &cache_root)
+            .await
+            .unwrap();
         assert_ne!(
             left, right,
             "canonical source identity must participate in the key"
@@ -5255,10 +5420,11 @@ mod tests {
             ),
         )
         .unwrap();
+        let cache_root = root.join("native-cache");
 
         let (left, right) = tokio::join!(
-            prepare_qwen35_native_gguf(&input),
-            prepare_qwen35_native_gguf(&input)
+            prepare_qwen35_native_gguf_in(&input, &cache_root),
+            prepare_qwen35_native_gguf_in(&input, &cache_root)
         );
         let left = left.unwrap();
         let right = right.unwrap();
@@ -5266,7 +5432,7 @@ mod tests {
         assert!(left.join("model.safetensors").is_file());
         assert!(left.join("config.json").is_file());
         assert!(left.join(".complete").is_file());
-        let staged = fs::read_dir(root.join(".mlx-node-native"))
+        let staged = fs::read_dir(&cache_root)
             .unwrap()
             .filter_map(|entry| entry.ok())
             .filter(|entry| entry.file_name().to_string_lossy().contains(".staging-"))

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -26,7 +26,7 @@ use tracing::{info, warn};
 
 use crate::array::{DType, MxArray};
 use crate::models::quant_dispatch::SYMMETRIC_ZERO_POINT_KEY;
-use crate::utils::gguf_kquant::{KQuantArrays, KQuantFormat, KQuantRepacker, KQuantScales, QK_K};
+use crate::utils::gguf_kquant::{KQuantArrays, KQuantFormat, KQuantRepacker, KQuantScales};
 use crate::utils::safetensors::save_safetensors;
 
 // ── GGUF Constants ──────────────────────────────────────────────────────────
@@ -45,9 +45,13 @@ pub enum GgufTensorType {
     Q4_0 = 2,
     Q4_1 = 3,
     Q8_0 = 8,
+    Q3K = 11,
     Q4K = 12,
     Q5K = 13,
     Q6K = 14,
+    IQ4NL = 20,
+    IQ3S = 21,
+    IQ4XS = 23,
     BF16 = 30,
 }
 
@@ -59,9 +63,13 @@ impl GgufTensorType {
             2 => Some(Self::Q4_0),
             3 => Some(Self::Q4_1),
             8 => Some(Self::Q8_0),
+            11 => Some(Self::Q3K),
             12 => Some(Self::Q4K),
             13 => Some(Self::Q5K),
             14 => Some(Self::Q6K),
+            20 => Some(Self::IQ4NL),
+            21 => Some(Self::IQ3S),
+            23 => Some(Self::IQ4XS),
             30 => Some(Self::BF16),
             _ => None,
         }
@@ -78,6 +86,7 @@ impl GgufTensorType {
             Self::Q4_0 => 18, // block size: 2 byte scale + 16 bytes (32 x 4-bit)
             Self::Q4_1 => 20, // 2 byte scale + 2 byte bias + 16 bytes
             Self::Q8_0 => 34, // 2 byte scale + 32 bytes
+            Self::Q3K | Self::IQ3S => 110,
             // f16 d + f16 dmin + 12 packed 6-bit (sub-scale, min) pairs +
             // 128 nibble bytes for 256 values.
             Self::Q4K => 144,
@@ -86,6 +95,8 @@ impl GgufTensorType {
             // 128 low-nibble bytes + 64 high-two-bit bytes + 16 signed
             // sub-scales + one f16 super-scale for 256 values.
             Self::Q6K => 210,
+            Self::IQ4NL => 18,
+            Self::IQ4XS => 136,
         }
     }
 
@@ -100,7 +111,8 @@ impl GgufTensorType {
         match self {
             Self::F32 | Self::F16 | Self::BF16 => 1,
             Self::Q4_0 | Self::Q4_1 | Self::Q8_0 => 32,
-            Self::Q4K | Self::Q5K | Self::Q6K => 256,
+            Self::IQ4NL => 32,
+            Self::Q3K | Self::Q4K | Self::Q5K | Self::Q6K | Self::IQ3S | Self::IQ4XS => 256,
         }
     }
 
@@ -129,6 +141,10 @@ impl GgufTensorType {
             Self::Q4K => Some(KQuantFormat::Q4K),
             Self::Q5K => Some(KQuantFormat::Q5K),
             Self::Q6K => Some(KQuantFormat::Q6K),
+            Self::Q3K => Some(KQuantFormat::Q3K),
+            Self::IQ4NL => Some(KQuantFormat::IQ4NL),
+            Self::IQ3S => Some(KQuantFormat::IQ3S),
+            Self::IQ4XS => Some(KQuantFormat::IQ4XS),
             Self::F32 | Self::F16 | Self::BF16 | Self::Q4_0 | Self::Q4_1 | Self::Q8_0 => None,
         }
     }
@@ -140,9 +156,13 @@ impl GgufTensorType {
             Self::Q4_0 => "Q4_0",
             Self::Q4_1 => "Q4_1",
             Self::Q8_0 => "Q8_0",
+            Self::Q3K => "Q3_K",
             Self::Q4K => "Q4_K",
             Self::Q5K => "Q5_K",
             Self::Q6K => "Q6_K",
+            Self::IQ4NL => "IQ4_NL",
+            Self::IQ3S => "IQ3_S",
+            Self::IQ4XS => "IQ4_XS",
             Self::BF16 => "BF16",
         }
     }
@@ -742,7 +762,11 @@ pub fn symmetric_zero_point(ty: GgufTensorType) -> Option<i32> {
         | GgufTensorType::BF16
         | GgufTensorType::Q4K
         | GgufTensorType::Q5K
-        | GgufTensorType::Q6K => None,
+        | GgufTensorType::Q6K
+        | GgufTensorType::Q3K
+        | GgufTensorType::IQ4NL
+        | GgufTensorType::IQ4XS
+        | GgufTensorType::IQ3S => None,
     }
 }
 
@@ -981,11 +1005,12 @@ fn load_kquant_repack(
 ) -> Result<Vec<(String, MxArray)>> {
     let shape = tensor.mlx_shape();
     let last_dim = shape.last().copied().unwrap_or(0);
-    if last_dim <= 0 || !(last_dim as usize).is_multiple_of(QK_K) {
+    if last_dim <= 0 || !(last_dim as usize).is_multiple_of(format.block_size()) {
         return Err(Error::from_reason(format!(
-            "{} tensor '{}' has last dimension {last_dim}; expected a positive multiple of {QK_K}",
+            "{} tensor '{}' has last dimension {last_dim}; expected a positive multiple of {}",
             tensor.tensor_type.name(),
-            tensor.name
+            tensor.name,
+            format.block_size(),
         )));
     }
     let k = last_dim as usize;
@@ -1052,7 +1077,7 @@ fn load_kquant_repack(
 pub struct GgufLoadOptions {
     /// Log progress every 50 tensors.
     pub verbose: bool,
-    /// Repack ggml Q4_K / Q5_K / Q6_K blocks into MLX K-quant arrays.
+    /// Repack supported ggml K/IQ blocks into native MLX packed arrays.
     ///
     /// Off by default, which is the pre-K-quant behaviour: Q6_K is accepted
     /// only as the Gemma4 token embedding and dequantized to BF16, and Q4_K /
@@ -1177,7 +1202,7 @@ fn is_muse_glimmer_dflash_gguf(metadata: &HashMap<String, GgufMetaValue>) -> boo
 
 /// The three names a quantized tensor group ships under. Both GGUF quant
 /// importers emit the same trio: `load_quantized_tensor` (affine Q4_0/Q4_1/Q8_0)
-/// and `load_kquant_repack` (Q4_K/Q5_K/Q6_K) each write `{base}.weight` plus a
+/// and `load_kquant_repack` (supported K/IQ formats) each write `{base}.weight` plus a
 /// `{base}.scales` / `{base}.biases` sidecar pair. Loaders probe the sidecar by
 /// name to decide a tensor is quantized (e.g. `embed_tokens.scales`), so a
 /// rename that moves only `.weight` strands the sidecars under their old names
@@ -1412,8 +1437,48 @@ fn gguf_name_to_hf_for_metadata(
     } else if is_muse_glimmer_dflash_gguf(metadata) {
         muse_glimmer_dflash_name_to_hf(name)
     } else {
-        Some(gguf_name_to_hf(name))
+        Some(qwen35_name_to_hf(name, metadata))
     }
+}
+
+/// Qwen3.5 GGUFs with inline MTP encode the draft layer as the final block and
+/// attach the four nextn projections/norms to that same block. HF/MLX stores
+/// those tensors under the mtp prefix, outside the main decoder layer list.
+fn qwen35_name_to_hf(name: &str, metadata: &HashMap<String, GgufMetaValue>) -> String {
+    let arch = metadata
+        .get("general.architecture")
+        .and_then(GgufMetaValue::as_str)
+        .unwrap_or("");
+    if !matches!(arch, "qwen35" | "qwen35moe") {
+        return gguf_name_to_hf(name);
+    }
+    let Some(block_count) = metadata
+        .get(&format!("{arch}.block_count"))
+        .and_then(GgufMetaValue::as_u64)
+    else {
+        return gguf_name_to_hf(name);
+    };
+    let Some(mtp_index) = block_count.checked_sub(1) else {
+        return gguf_name_to_hf(name);
+    };
+    let prefix = format!("blk.{mtp_index}.");
+    let Some(suffix) = name.strip_prefix(&prefix) else {
+        return gguf_name_to_hf(name);
+    };
+
+    for (gguf, mlx) in [
+        ("nextn.eh_proj", "mtp.fc"),
+        ("nextn.enorm", "mtp.pre_fc_norm_embedding"),
+        ("nextn.hnorm", "mtp.pre_fc_norm_hidden"),
+        ("nextn.shared_head_norm", "mtp.norm"),
+    ] {
+        if let Some(mapped) = rename_global_quant_group(suffix, gguf, mlx) {
+            return mapped;
+        }
+    }
+
+    let mapped = gguf_name_to_hf(name);
+    mapped.replacen(&format!("model.layers.{mtp_index}."), "mtp.layers.0.", 1)
 }
 
 /// Remap GGUF tensor name to HuggingFace-style name (standard LLM mapping)
@@ -1719,10 +1784,28 @@ fn reinterleave_cols(arr: &MxArray, n_heads: i64, head_dim: i64) -> Result<MxArr
 fn fixup_qwen35_linear_attn(
     weights: &mut HashMap<String, MxArray>,
     metadata: &HashMap<String, GgufMetaValue>,
+    preserve_tiled_layout: bool,
 ) -> Result<()> {
     // Detect Qwen3.5 by checking for linear attention weights
     let has_linear_attn = weights.keys().any(|k| k.contains("linear_attn."));
     if !has_linear_attn {
+        return Ok(());
+    }
+
+    if preserve_tiled_layout {
+        // The fused GDN runtime consumes llama.cpp's tiled value-head order
+        // directly. Only ssm_a's numeric representation differs: GGUF stores
+        // -exp(A_log), while the model keeps A_log and applies -exp at runtime.
+        let keys = weights
+            .keys()
+            .filter(|key| key.ends_with("linear_attn.A_log"))
+            .cloned()
+            .collect::<Vec<_>>();
+        for key in keys {
+            if let Some(arr) = weights.remove(&key) {
+                weights.insert(key, arr.negative()?.log()?);
+            }
+        }
         return Ok(());
     }
 
@@ -2127,9 +2210,13 @@ impl SourceQuantProfile {
             // `load_kquant_repack` keeps ggml's geometry verbatim, so the
             // triple is read off the repacker format rather than restated
             // here; `k_quant_format` stays the only type -> format mapping.
-            GgufTensorType::Q4K | GgufTensorType::Q5K | GgufTensorType::Q6K => {
-                ty.k_quant_format().map(Self::k_quant)
-            }
+            GgufTensorType::Q3K
+            | GgufTensorType::Q4K
+            | GgufTensorType::Q5K
+            | GgufTensorType::Q6K
+            | GgufTensorType::IQ4NL
+            | GgufTensorType::IQ4XS
+            | GgufTensorType::IQ3S => ty.k_quant_format().map(Self::k_quant),
         }
     }
 
@@ -2198,7 +2285,7 @@ impl SourceQuantProfile {
 /// Describe tensors that were already quantized in the GGUF source.
 ///
 /// Q4_0/Q4_1/Q8_0 go through `load_quantized_tensor` and — when the K-quant
-/// import is on — Q4_K/Q5_K/Q6_K go through `load_kquant_repack`. Neither path
+/// import is on — supported K/IQ tensors go through `load_kquant_repack`. Neither path
 /// changes the source block geometry, so that geometry has to reach the output
 /// config even when the caller never asked for a `--quantize` pass; otherwise
 /// Gemma4 falls back to the runtime's generic group-size default (64) and
@@ -3022,12 +3109,18 @@ pub struct GgufConversionOptions {
     /// Forces `group_size = 32` for upgraded layers.
     pub quant_mxfp: Option<bool>,
 
-    /// Import ggml Q4_K / Q5_K / Q6_K tensors as MLX K-quant arrays instead of
+    /// Import supported ggml K/IQ tensors as native MLX packed arrays instead of
     /// rejecting them (default: false). The blocks are repacked, never
-    /// dequantized, so the output keeps the source file's weights and byte size.
+    /// dequantized, so the output preserves the source quantized values. IQ3_S
+    /// expands only its integer grid/sign encoding to signed 8-bit codes.
     /// With this off, Q6_K remains the Gemma4 token-embedding BF16 fallback and
     /// Q4_K / Q5_K are an error.
     pub import_k_quants: Option<bool>,
+
+    /// Preserve Qwen3.5/3.8 GGUF GDN tensors in llama.cpp's tiled value-head
+    /// order. The runtime consumes this layout directly and avoids any packed
+    /// weight permutation. Intended for native GGUF execution.
+    pub native_qwen35_layout: Option<bool>,
 }
 
 #[napi(object)]
@@ -3037,6 +3130,145 @@ pub struct GgufConversionResult {
     pub output_path: String,
     pub tensor_names: Vec<String>,
     pub source_format: String,
+}
+
+fn write_embedded_gpt2_tokenizer(
+    metadata: &HashMap<String, GgufMetaValue>,
+    output_dir: &Path,
+) -> Result<bool> {
+    let Some(GgufMetaValue::String(model)) = metadata.get("tokenizer.ggml.model") else {
+        return Ok(false);
+    };
+    if model != "gpt2" {
+        return Ok(false);
+    }
+    let Some(GgufMetaValue::ArrayString(tokens)) = metadata.get("tokenizer.ggml.tokens") else {
+        return Ok(false);
+    };
+    let Some(GgufMetaValue::ArrayI32(types)) = metadata.get("tokenizer.ggml.token_type") else {
+        return Ok(false);
+    };
+    let Some(GgufMetaValue::ArrayString(merges)) = metadata.get("tokenizer.ggml.merges") else {
+        return Ok(false);
+    };
+    if tokens.len() != types.len() {
+        return Err(Error::from_reason(format!(
+            "GGUF tokenizer token/type length mismatch: {} tokens vs {} types",
+            tokens.len(),
+            types.len()
+        )));
+    }
+
+    let mut vocab = serde_json::Map::new();
+    let mut added = Vec::new();
+    for (id, (token, token_type)) in tokens.iter().zip(types).enumerate() {
+        match *token_type {
+            // GGML_TOKEN_TYPE_NORMAL
+            1 => {
+                vocab.insert(token.clone(), serde_json::json!(id));
+            }
+            // GGML_TOKEN_TYPE_CONTROL / USER_DEFINED. These are the exact
+            // special-token rows represented by added_tokens in HF's Qwen
+            // tokenizer; UNUSED rows deliberately remain ID holes.
+            3 | 4 => added.push(serde_json::json!({
+                "id": id,
+                "content": token,
+                "single_word": false,
+                "lstrip": false,
+                "rstrip": false,
+                "normalized": false,
+                "special": true
+            })),
+            _ => {}
+        }
+    }
+
+    let tokenizer = serde_json::json!({
+        "version": "1.0",
+        "truncation": null,
+        "padding": null,
+        "added_tokens": added,
+        "normalizer": {"type": "NFC"},
+        "pre_tokenizer": {
+            "type": "Sequence",
+            "pretokenizers": [
+                {
+                    "type": "Split",
+                    "pattern": {"Regex": "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?[\\p{L}\\p{M}]+|\\p{N}| ?[^\\s\\p{L}\\p{M}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+"},
+                    "behavior": "Isolated",
+                    "invert": false
+                },
+                {
+                    "type": "ByteLevel",
+                    "add_prefix_space": false,
+                    "trim_offsets": false,
+                    "use_regex": false
+                }
+            ]
+        },
+        "post_processor": {
+            "type": "ByteLevel",
+            "add_prefix_space": false,
+            "trim_offsets": false,
+            "use_regex": false
+        },
+        "decoder": {
+            "type": "ByteLevel",
+            "add_prefix_space": false,
+            "trim_offsets": false,
+            "use_regex": false
+        },
+        "model": {
+            "type": "BPE",
+            "dropout": null,
+            "unk_token": null,
+            "continuing_subword_prefix": "",
+            "end_of_word_suffix": "",
+            "fuse_unk": false,
+            "byte_fallback": false,
+            "ignore_merges": false,
+            "vocab": vocab,
+            "merges": merges
+        }
+    });
+    let bytes = serde_json::to_vec(&tokenizer).map_err(|error| {
+        Error::from_reason(format!("Failed to serialize GGUF tokenizer: {error}"))
+    })?;
+    fs::write(output_dir.join("tokenizer.json"), bytes)
+        .map_err(|error| Error::from_reason(format!("Failed to write tokenizer.json: {error}")))?;
+
+    // A standalone GGUF has no Hugging Face sidecars. Preserve the embedded
+    // template and special-token spellings so the regular chat-session loader
+    // behaves exactly as it does for a downloaded tokenizer snapshot.
+    let mut tokenizer_config = serde_json::Map::new();
+    if let Some(GgufMetaValue::String(template)) = metadata.get("tokenizer.chat_template") {
+        tokenizer_config.insert("chat_template".into(), serde_json::json!(template));
+        fs::write(output_dir.join("chat_template.jinja"), template).map_err(|error| {
+            Error::from_reason(format!("Failed to write chat_template.jinja: {error}"))
+        })?;
+    }
+    for (metadata_key, config_key) in [
+        ("tokenizer.ggml.bos_token_id", "bos_token"),
+        ("tokenizer.ggml.eos_token_id", "eos_token"),
+        ("tokenizer.ggml.padding_token_id", "pad_token"),
+    ] {
+        if let Some(token) = metadata
+            .get(metadata_key)
+            .and_then(GgufMetaValue::as_u32)
+            .and_then(|id| tokens.get(id as usize))
+        {
+            tokenizer_config.insert(config_key.into(), serde_json::json!(token));
+        }
+    }
+    let config_bytes = serde_json::to_vec(&tokenizer_config).map_err(|error| {
+        Error::from_reason(format!(
+            "Failed to serialize GGUF tokenizer config: {error}"
+        ))
+    })?;
+    fs::write(output_dir.join("tokenizer_config.json"), config_bytes).map_err(|error| {
+        Error::from_reason(format!("Failed to write tokenizer_config.json: {error}"))
+    })?;
+    Ok(true)
 }
 
 fn apply_gguf_awq_prescaling(
@@ -3154,6 +3386,7 @@ pub async fn convert_gguf_to_safetensors(
     }
 
     let import_k_quants = options.import_k_quants.unwrap_or(false);
+    let native_qwen35_layout = options.native_qwen35_layout.unwrap_or(false);
 
     // Plain Qwen3 has no quantized inference runtime. Preserving Q4_0/Q4_1/
     // Q8_0 or K-quant source groups would successfully write an artifact whose
@@ -3175,7 +3408,10 @@ pub async fn convert_gguf_to_safetensors(
     // previously crossed the MLX FFI boundary with impossible packed geometry
     // and aborted the process with an uncaught foreign exception. Fail from the
     // header instead of loading or mutating any tensor payload.
-    if import_k_quants && let Some((tensor, mapped)) = qwen35_kquant_dense_fixup_target(&gguf) {
+    if import_k_quants
+        && !native_qwen35_layout
+        && let Some((tensor, mapped)) = qwen35_kquant_dense_fixup_target(&gguf)
+    {
         return Err(Error::from_reason(format!(
             "GGUF tensor '{}' ({}) maps to Qwen3.5 linear-attention tensor '{}', which requires a head-axis reinterleave during conversion. --gguf-kquant cannot safely apply that dense transform to packed codes without also reordering the group's .scales/.biases, so this source cannot currently be imported losslessly. Use a floating-point source or a preconverted checkpoint. Rejected from the GGUF header before tensor data was loaded.",
             tensor.name,
@@ -3184,7 +3420,7 @@ pub async fn convert_gguf_to_safetensors(
         )));
     }
 
-    // K-quant import repacks ggml's Q4_K/Q5_K/Q6_K blocks bit-for-bit and never
+    // K-quant import losslessly repacks supported ggml K/IQ blocks and never
     // dequantizes them, so any path that would re-quantize the model — an
     // explicit `--quantize`, a `--q-recipe`, the `--q-mxfp` upgrade, or
     // `--imatrix-path` AWQ pre-scaling — both contradicts the import and forces
@@ -3207,7 +3443,7 @@ pub async fn convert_gguf_to_safetensors(
             return Err(Error::from_reason(
                 "K-quant GGUF import cannot be combined with re-quantization \
                  (--quantize / --q-recipe / --q-mxfp / --imatrix-path): ggml \
-                 Q4_K/Q5_K/Q6_K blocks are imported bit-for-bit and never \
+                 supported K/IQ blocks are losslessly imported and never \
                  dequantized. Import them as-is, or drop --gguf-kquant to convert \
                  a dequantized copy.",
             ));
@@ -3432,7 +3668,7 @@ pub async fn convert_gguf_to_safetensors(
     fixup_shapes(&mut weights)?;
 
     // Fix Qwen3.5 linear attention head deinterleaving and A_log conversion
-    fixup_qwen35_linear_attn(&mut weights, &gguf.metadata)?;
+    fixup_qwen35_linear_attn(&mut weights, &gguf.metadata, native_qwen35_layout)?;
 
     // Optional dtype conversion (only for non-quantized weights)
     if let Some(dtype_str) = &options.dtype {
@@ -3794,6 +4030,10 @@ pub async fn convert_gguf_to_safetensors(
                 serde_json::Value::String("interleaved".to_string());
         }
 
+        if native_qwen35_layout {
+            config_json["qwen35_gguf_gdn_layout"] = serde_json::Value::String("tiled".to_string());
+        }
+
         if do_quantize {
             let quant_obj = crate::convert::build_quantization_object(
                 quant_bits,
@@ -3870,6 +4110,11 @@ pub async fn convert_gguf_to_safetensors(
                 );
             }
         }
+        if !output_dir.join("tokenizer.json").exists()
+            && write_embedded_gpt2_tokenizer(&gguf.metadata, &output_dir)?
+        {
+            info!("Reconstructed tokenizer.json from embedded GGUF GPT-2 metadata");
+        }
     } else {
         if let Some(config) = prepared_muse_secondary_config {
             fs::write(&muse_secondary_config_path, config).map_err(|error| {
@@ -3901,12 +4146,100 @@ pub async fn convert_gguf_to_safetensors(
     })
 }
 
+/// Prepare the lossless native-packed cache used when a Qwen3.5/3.8 model is
+/// loaded from a GGUF file path. Quantized source blocks are only repacked;
+/// they are never expanded into a dense floating-point weight tensor. Native
+/// F32 norms/biases are narrowed to BF16 so they do not promote inference
+/// activations away from the model's BF16 execution/cache dtype.
+pub async fn prepare_qwen35_native_gguf(input_path: &Path) -> Result<PathBuf> {
+    let input_path = input_path.canonicalize().map_err(|error| {
+        Error::from_reason(format!(
+            "Failed to canonicalize GGUF path '{}': {error}",
+            input_path.display()
+        ))
+    })?;
+    let metadata = fs::metadata(&input_path).map_err(|error| {
+        Error::from_reason(format!(
+            "Failed to stat GGUF path '{}': {error}",
+            input_path.display()
+        ))
+    })?;
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let stem = input_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("model")
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let parent = input_path.parent().unwrap_or(Path::new("."));
+    let output_dir = parent
+        .join(".mlx-node-native")
+        .join(format!("{stem}-{}-{modified}", metadata.len()));
+    let marker = output_dir.join(".complete");
+    let marker_is_current = fs::read_to_string(&marker)
+        .is_ok_and(|contents| contents.contains("format=2\n") && contents.contains("dtype=bf16\n"));
+    if marker_is_current
+        && output_dir.join("model.safetensors").is_file()
+        && output_dir.join("config.json").is_file()
+    {
+        return Ok(output_dir);
+    }
+
+    convert_gguf_to_safetensors(GgufConversionOptions {
+        input_path: input_path.to_string_lossy().into_owned(),
+        output_dir: output_dir.to_string_lossy().into_owned(),
+        config_source_dir: Some(parent.to_string_lossy().into_owned()),
+        dtype: Some("bfloat16".to_string()),
+        verbose: Some(true),
+        quantize: Some(false),
+        quant_bits: None,
+        quant_group_size: None,
+        quant_mode: None,
+        quant_recipe: None,
+        imatrix_path: None,
+        output_filename: None,
+        vlm_key_prefix: None,
+        quant_mxfp: None,
+        import_k_quants: Some(true),
+        native_qwen35_layout: Some(true),
+    })
+    .await?;
+    fs::write(
+        &marker,
+        format!(
+            "format=2\nsource={}\nsize={}\nmodified_ns={}\nlayout=tiled\ndtype=bf16\n",
+            input_path.display(),
+            metadata.len(),
+            modified
+        ),
+    )
+    .map_err(|error| {
+        Error::from_reason(format!(
+            "Failed to finalize native GGUF cache '{}': {error}",
+            output_dir.display()
+        ))
+    })?;
+    Ok(output_dir)
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::gguf_kquant::repack_kquant;
+    use crate::utils::gguf_kquant::{QK_K, repack_kquant};
 
     fn build_minimal_gguf(
         metadata: &[(&str, GgufMetaValue)],
@@ -4890,6 +5223,7 @@ mod tests {
             vlm_key_prefix: Some(false),
             quant_mxfp: Some(false),
             import_k_quants: Some(true),
+            native_qwen35_layout: None,
         })
         .await
         .unwrap();
@@ -4979,6 +5313,7 @@ mod tests {
             vlm_key_prefix: Some(false),
             quant_mxfp: Some(false),
             import_k_quants: Some(true),
+            native_qwen35_layout: None,
         })
         .await;
         let err = match result {
@@ -6026,6 +6361,7 @@ mod tests {
             vlm_key_prefix: Some(false),
             quant_mxfp: Some(false),
             import_k_quants: Some(false),
+            native_qwen35_layout: None,
         })
         .await
         .expect("primary Muse conversion");
@@ -6173,6 +6509,7 @@ mod tests {
             vlm_key_prefix: Some(false),
             quant_mxfp: Some(false),
             import_k_quants: Some(false),
+            native_qwen35_layout: None,
         })
         .await
         .expect("primary Muse conversion");
@@ -6635,6 +6972,7 @@ mod tests {
             vlm_key_prefix: Some(false),
             quant_mxfp: Some(false),
             import_k_quants: Some(true),
+            native_qwen35_layout: None,
         })
         .await;
         let error = match outcome {
@@ -6736,6 +7074,7 @@ mod tests {
             vlm_key_prefix: Some(false),
             quant_mxfp: Some(false),
             import_k_quants: Some(true),
+            native_qwen35_layout: None,
         })
         .await;
         let error = match outcome {
@@ -7403,6 +7742,7 @@ mod tests {
             vlm_key_prefix: Some(false),
             quant_mxfp: Some(false),
             import_k_quants: Some(false),
+            native_qwen35_layout: None,
         })
         .await
         .unwrap();
@@ -7583,6 +7923,7 @@ mod tests {
             vlm_key_prefix: Some(false),
             quant_mxfp: Some(false),
             import_k_quants: Some(false),
+            native_qwen35_layout: None,
         })
         .await;
         let Err(err) = converted else {
@@ -7668,6 +8009,7 @@ mod tests {
                     vlm_key_prefix: Some(false),
                     quant_mxfp: Some(false),
                     import_k_quants: Some(false),
+                    native_qwen35_layout: None,
                 };
 
             let Err(err) = convert_gguf_to_safetensors(options(&output, None)).await else {
@@ -7761,6 +8103,7 @@ mod tests {
                     vlm_key_prefix: Some(false),
                     quant_mxfp: Some(false),
                     import_k_quants: Some(false),
+                    native_qwen35_layout: None,
                 })
                 .await
                 .unwrap();
@@ -7890,6 +8233,7 @@ mod tests {
                 vlm_key_prefix: Some(false),
                 quant_mxfp: Some(false),
                 import_k_quants: Some(false),
+                native_qwen35_layout: None,
             })
             .await;
             fs::remove_dir_all(&root).ok();
@@ -8012,6 +8356,7 @@ mod tests {
                 vlm_key_prefix: Some(false),
                 quant_mxfp: Some(false),
                 import_k_quants: Some(import_k_quants),
+                native_qwen35_layout: None,
             };
             (root, options)
         }

--- a/crates/mlx-core/src/utils/gguf.rs
+++ b/crates/mlx-core/src/utils/gguf.rs
@@ -3481,7 +3481,10 @@ fn write_embedded_gpt2_tokenizer(
         "truncation": null,
         "padding": null,
         "added_tokens": added,
-        "normalizer": {"type": "NFC"},
+        // GGUF's embedded GPT-2 vocabulary and merges operate on the original
+        // byte sequence. No standard metadata here declares Unicode
+        // normalization, so synthesizing NFC would change decomposed prompts.
+        "normalizer": null,
         "pre_tokenizer": {
             "type": "Sequence",
             "pretokenizers": [
@@ -4456,7 +4459,7 @@ pub async fn convert_gguf_to_safetensors(
 /// they are never expanded into a dense floating-point weight tensor. Native
 /// F32 norms/biases are narrowed to BF16 so they do not promote inference
 /// activations away from the model's BF16 execution/cache dtype.
-const QWEN35_NATIVE_CACHE_FORMAT: u32 = 4;
+const QWEN35_NATIVE_CACHE_FORMAT: u32 = 5;
 const QWEN35_NATIVE_CACHE_DIR_ENV: &str = "MLX_NATIVE_GGUF_CACHE_DIR";
 
 fn qwen35_native_cache_candidates_from(
@@ -4987,6 +4990,49 @@ mod tests {
         }
 
         buf
+    }
+
+    #[test]
+    fn embedded_gpt2_tokenizer_preserves_decomposed_unicode_bytes() {
+        let root = std::env::temp_dir().join(format!(
+            "mlx-node-gguf-tokenizer-normalizer-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let metadata = HashMap::from([
+            (
+                "tokenizer.ggml.model".to_string(),
+                GgufMetaValue::String("gpt2".to_string()),
+            ),
+            (
+                "tokenizer.ggml.tokens".to_string(),
+                GgufMetaValue::ArrayString(vec!["e".into(), "Ì".into(), "ģ".into()]),
+            ),
+            (
+                "tokenizer.ggml.token_type".to_string(),
+                GgufMetaValue::ArrayI32(vec![1, 1, 1]),
+            ),
+            (
+                "tokenizer.ggml.merges".to_string(),
+                GgufMetaValue::ArrayString(Vec::new()),
+            ),
+        ]);
+
+        assert!(write_embedded_gpt2_tokenizer(&metadata, &root).unwrap());
+        let json: serde_json::Value =
+            serde_json::from_slice(&fs::read(root.join("tokenizer.json")).unwrap()).unwrap();
+        assert!(json["normalizer"].is_null());
+        let tokenizer = tokenizers::Tokenizer::from_file(root.join("tokenizer.json")).unwrap();
+        assert!(tokenizer.get_normalizer().is_none());
+        assert_eq!(
+            tokenizer.encode("e\u{301}", false).unwrap().get_ids(),
+            &[0, 1, 2]
+        );
+        fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/crates/mlx-core/src/utils/gguf_kquant.rs
+++ b/crates/mlx-core/src/utils/gguf_kquant.rs
@@ -1,15 +1,17 @@
-//! ggml K-quant block bytes -> the MLX K-quant array contract.
+//! ggml K/I-quant block bytes -> the MLX packed super-block array contract.
 //!
-//! GGUF stores Q4_K / Q5_K / Q6_K as fixed-size super-blocks of 256 values with
+//! GGUF stores Q3_K / Q4_K / Q5_K / Q6_K and the IQ formats used by Unsloth
+//! Dynamic GGUFs as fixed-size blocks with
 //! the codes interleaved across nibble and bit planes. MLX's K-quant decode
 //! wants three plain arrays per tensor instead:
 //!
 //! ```text
-//!   q6k  bits=6 group_size=16
-//!     .weight uint32[N, K*6/32]  LSB-first 6-bit stream, code in [0, 63]
+//!   q3k/q6k  bits=3/6 group_size=16
+//!     .weight uint32[N, K*bits/32] LSB-first stream, code in [0, 2^bits)
 //!     .scales int8  [N, K/16]    ggml sc, verbatim, SIGNED
 //!     .biases f16   [N, K/256]   ggml d, verbatim
-//!     decode  scale = .biases[g >> 4] * .scales[g];  bias = -32 * scale
+//!     decode  scale = .biases[g >> 4] * .scales[g]
+//!             bias = -(1 << (bits - 1)) * scale
 //!
 //!   q4k  bits=4 group_size=32   (q5k is the same with bits=5)
 //!     .weight uint32[N, K*4/32]  LSB-first 4-bit stream, code in [0, 15]
@@ -52,21 +54,33 @@ use napi::{Error, Result};
 /// Values per ggml super-block. `ggml-common.h:89`.
 pub const QK_K: usize = 256;
 
-/// ggml K-quant formats mlx-node can import.
+/// ggml packed formats mlx-node can import into the shared super-block runtime
+/// contract. The historic name is retained because it is serialized throughout
+/// the existing converter and runtime metadata.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum KQuantFormat {
+    Q3K,
     Q4K,
     Q5K,
     Q6K,
+    IQ4NL,
+    IQ4XS,
+    IQ3S,
 }
 
 impl KQuantFormat {
     /// Bit width of one code.
     pub fn bits(self) -> usize {
         match self {
+            Self::Q3K => 3,
             Self::Q4K => 4,
             Self::Q5K => 5,
             Self::Q6K => 6,
+            Self::IQ4NL | Self::IQ4XS => 4,
+            // IQ3_S is losslessly expanded from its grid indices/signs into one
+            // signed grid value per weight. It remains integer packed and is
+            // never reconstructed as a floating-point matrix.
+            Self::IQ3S => 8,
         }
     }
 
@@ -74,40 +88,60 @@ impl KQuantFormat {
     pub fn group_size(self) -> usize {
         match self {
             Self::Q4K | Self::Q5K => 32,
-            Self::Q6K => 16,
+            Self::Q3K | Self::Q6K => 16,
+            Self::IQ4NL | Self::IQ4XS | Self::IQ3S => 32,
+        }
+    }
+
+    /// Values covered by one source GGUF block.
+    pub fn block_size(self) -> usize {
+        match self {
+            Self::IQ4NL => 32,
+            Self::Q3K | Self::Q4K | Self::Q5K | Self::Q6K | Self::IQ4XS | Self::IQ3S => QK_K,
         }
     }
 
     /// Size of one ggml super-block in bytes. `ggml-common.h:326/344/361`.
     pub fn block_bytes(self) -> usize {
         match self {
+            Self::Q3K | Self::IQ3S => 110,
             Self::Q4K => 144,
             Self::Q5K => 176,
             Self::Q6K => 210,
+            Self::IQ4NL => 18,
+            Self::IQ4XS => 136,
         }
     }
 
     /// The `mode` string MLX's quantized ops dispatch on.
     pub fn mlx_mode(self) -> &'static str {
         match self {
+            Self::Q3K => "q3k",
             Self::Q4K => "q4k",
             Self::Q5K => "q5k",
             Self::Q6K => "q6k",
+            Self::IQ4NL => "iq4nl",
+            Self::IQ4XS => "iq4xs",
+            Self::IQ3S => "iq3s",
         }
     }
 
     /// GGUF tensor type id. `ggml.h` `GGML_TYPE_Q4_K` / `Q5_K` / `Q6_K`.
     pub fn gguf_type(self) -> u32 {
         match self {
+            Self::Q3K => 11,
             Self::Q4K => 12,
             Self::Q5K => 13,
             Self::Q6K => 14,
+            Self::IQ4NL => 20,
+            Self::IQ4XS => 23,
+            Self::IQ3S => 21,
         }
     }
 
-    /// Whether `.scales` is signed int8 (q6k) rather than uint8 (q4k/q5k).
+    /// Whether `.scales` is signed int8 rather than uint8 (q4k/q5k).
     pub fn scales_are_signed(self) -> bool {
-        matches!(self, Self::Q6K)
+        !matches!(self, Self::Q4K | Self::Q5K)
     }
 
     /// `.weight` columns for a row of `k` values.
@@ -119,8 +153,9 @@ impl KQuantFormat {
     /// 16 values; q4k/q5k store a (sc, m) pair per 32.
     pub fn scales_cols(self, k: usize) -> usize {
         match self {
-            Self::Q6K => k / 16,
+            Self::Q3K | Self::Q6K => k / 16,
             Self::Q4K | Self::Q5K => 2 * (k / 32),
+            Self::IQ4NL | Self::IQ4XS | Self::IQ3S => k / 32,
         }
     }
 
@@ -128,15 +163,18 @@ impl KQuantFormat {
     /// the `(d, dmin)` pair.
     pub fn biases_cols(self, k: usize) -> usize {
         match self {
-            Self::Q6K => k / QK_K,
+            Self::Q3K | Self::Q6K => k / QK_K,
             Self::Q4K | Self::Q5K => 2 * (k / QK_K),
+            Self::IQ4NL => k / 32,
+            Self::IQ4XS | Self::IQ3S => k / QK_K,
         }
     }
 
     /// Bytes one row of `k` values occupies in the GGUF payload. `k` is assumed
-    /// to be a multiple of `QK_K`, which `KQuantRepacker::new` enforces.
+    /// to be a multiple of the source format's block size, which
+    /// `KQuantRepacker::new` enforces.
     pub fn row_bytes(self, k: usize) -> usize {
-        (k / QK_K) * self.block_bytes()
+        (k / self.block_size()) * self.block_bytes()
     }
 }
 
@@ -236,6 +274,12 @@ const Q6K_QH_OFFSET: usize = 128;
 const Q6K_SCALES_OFFSET: usize = 192;
 const Q6K_D_OFFSET: usize = 208;
 
+// ggml-common.h:315 — block_q3_K field offsets.
+const Q3K_HMASK_OFFSET: usize = 0;
+const Q3K_QS_OFFSET: usize = 32;
+const Q3K_SCALES_OFFSET: usize = 96;
+const Q3K_D_OFFSET: usize = 108;
+
 // ggml-common.h:326 — block_q4_K field offsets.
 const Q4K_D_OFFSET: usize = 0;
 const Q4K_DMIN_OFFSET: usize = 2;
@@ -248,6 +292,153 @@ const Q5K_DMIN_OFFSET: usize = 2;
 const Q5K_SCALES_OFFSET: usize = 4;
 const Q5K_QH_OFFSET: usize = 16;
 const Q5K_QS_OFFSET: usize = 48;
+
+// ggml-common.h:456/463 — IQ4_NL / IQ4_XS field offsets.
+const IQ4NL_D_OFFSET: usize = 0;
+const IQ4NL_QS_OFFSET: usize = 2;
+const IQ4XS_D_OFFSET: usize = 0;
+const IQ4XS_SCALES_H_OFFSET: usize = 2;
+const IQ4XS_SCALES_L_OFFSET: usize = 4;
+const IQ4XS_QS_OFFSET: usize = 8;
+
+// ggml-common.h:415 — IQ3_S field offsets.
+const IQ3S_D_OFFSET: usize = 0;
+const IQ3S_QS_OFFSET: usize = 2;
+const IQ3S_QH_OFFSET: usize = 66;
+const IQ3S_SIGNS_OFFSET: usize = 74;
+const IQ3S_SCALES_OFFSET: usize = 106;
+
+// Canonical 512-entry iq3s_grid from ggml-common.h, encoded as the little-
+// endian table bytes. Keeping the compressed textual representation here
+// avoids a noisy 512-element literal while the OnceLock makes its decode a
+// one-time conversion cost, never an inference-time operation.
+const IQ3S_GRID_BASE64: &str = concat!(
+    "AQEBAQMBAQEFAQEBCwEBAQ8BAQEBAwEBAwMBAQUDAQEJAwEBDQMBAQEFAQEDBQEBCwUBAQcHAQEBCQEBBQkBAQsJAQEPCQEBAwsB",
+    "AQcLAQEBDQEBBQ0BAQMPAQEJDwEBDw8BAQEBAwEDAQMBBQEDAQkBAwEBAwMBAwMDAQsDAwEBBQMBBwUDAQ8FAwEDBwMBCwcDAQkJ",
+    "AwEDDQMBCw0DAQUPAwEBAQUBAwEFAQsBBQEPAQUBAQMFAQcDBQENAwUBAwUFAQsFBQEBBwUBCQcFAQUJBQELCQUBDwkFAQMLBQEH",
+    "CwUBAQ8FAQcPBQEHAQcBAwMHAQsDBwEBBQcBBQUHAQMHBwEHBwcBDQcHAQkJBwEBCwcBBQsHAQ8NBwEDDwcBCw8HAQEBCQEHAwkB",
+    "DwMJAQMFCQEJBQkBBQcJAQEJCQEHCQkBAwsJAQEPCQEFAQsBCQELAQEFCwEFBQsBDQULAQcHCwEDCQsBCwkLAQ8JCwENDQsBBw8L",
+    "AQ0BDQEDAw0BBwMNAQMHDQEFCw0BAw8NAQEBDwEFAQ8BCQEPAQEFDwEFBQ8BDQUPAQcHDwEBCw8BCQsPAQEBAQMDAQEDBQEBAwkB",
+    "AQMBAwEDAwMBAwcDAQMLAwEDDwMBAwEFAQMFBQEDAwcBAwkHAQMNBwEDCQsBAw0LAQMDDQEDBQ8BAwEBAwMDAQMDBwEDAw0BAwMB",
+    "AwMDCQMDAwMFAwMBBwMDBwcDAwMJAwMBCwMDBQsDAwEPAwMNDwMDAQEFAwUDBQMLAwUDDwMFAwEFBQMJBQUDBQcFAwEJBQMHCQUD",
+    "CwsFAwENBQMFDwUDAwEHAwkBBwMPAQcDAQMHAwcDBwMDBQcDDwUHAwEHBwMJBwcDAwkHAwUNBwMBDwcDBwEJAwsBCQMFAwkDCQMJ",
+    "AwMHCQMHBwkDBQkJAw0JCQMBCwkDCQsJAwMBCwMBAwsDBwMLAwMFCwMBBwsDBQcLAwMLCwMBBQ0DCQUNAw8FDQMJCQ0DDQkNAwMB",
+    "DwMHAQ8DAQMPAwUDDwMDBQ8DCwcPAwMJDwMFDQ8DAQ8PAwEBAQUDAQEFBwEBBQsBAQUPAQEFAQMBBQUDAQUJAwEFDQMBBQMFAQUH",
+    "BQEFDwUBBQEHAQUFBwEFAwkBBQcJAQULCQEFAQsBBQULAQUPDQEFAQ8BBQcPAQULDwEFAQEDBQUBAwUBAwMFBwMDBQ8DAwUFBQMF",
+    "CwUDBQMHAwUJBwMFBQkDBQMLAwUDAQUFCQEFBQ8BBQUDBQUFBwUFBQEHBQUPBwUFAwkFBQcLBQUPCwUFAw8FBQkPBQUBAQcFBQEH",
+    "BQsBBwUDAwcFBQUHBQkFBwUDBwcFBwcHBQUJBwUBCwcFDQ0HBQMBCQUPAQkFAQUJBQcFCQUFBwkFCwcJBQMJCQUFDwkFCw8JBQkB",
+    "CwUDAwsFBQULBQ8HCwUBCQsFBwsLBQEPCwUBAQ0FBQENBQ8BDQUDBQ0FCwsNBQMNDQULAQ8FAwMPBQ0FDwUBBw8FBwkPBQELDwUF",
+    "AQEHAwMBBwcDAQcLAwEHDwMBBwUFAQcDBwEHBwcBBwsHAQcFCQEHCQkBBw8JAQcDCwEHBw0BBwMPAQcDAQMHBwEDBwsBAwcJAwMH",
+    "AwUDBwcFAwcBCQMHAQ0DBwUPAwcNDwMHAQEFBwUDBQcBBQUHBQcFBwkHBQcBCwUHAwEHBwEDBwcJAwcHAwUHBwcFBwcPBQcHAQcH",
+    "BwMJBwcHCQcHDwkHBwsLBwcHDwcHBwEJBwMDCQcNAwkHBQUJBwMHCQcFCwkHAQ0JBwkNCQcDAQsHAQMLBwUDCwcLBQsHBQcLBwkJ",
+    "CwcNCwsHBw8LBw0DDQcDCQ0HAwEPBwcBDwcBBQ8HBQUPBwsHDwcBAQEJCQEBCQUDAQkBBQEJCQUBCQ8FAQkFBwEJAwkBCQELAQkB",
+    "DwEJBQEDCQ8BAwkDAwMJBwMDCQUFAwkBBwMJCwcDCQcJAwkDCwMJCwsDCQMBBQkHAQUJAQMFCQsDBQkDBQUJBwcFCQEJBQkPCwUJ",
+    "BQ0FCQEPBQkJAQcJAwMHCQcDBwkBBQcJBQUHCQMHBwkLBwcJAQEJCQUBCQkJBQkJDwcJCQEJCQkDDwkJCwELCQ8BCwkDBQsJBQ0L",
+    "CQcDDQkJBw0JAQ0NCQEDDwkLAw8JAQcPCQcJDwkDCw8JBQEBCwEDAQsJAwELBQUBCwEJAQsJCQELDwkBCwULAQsNDQELCQ8BCwMB",
+    "AwsHAQMLCwEDCwUDAwsDBQMLBQcDCwUPAwsBAQULAwMFCwcFBQsBBwULDQcFCwcLBQsFAQcLDwEHCwEDBwsPBQcLCQkHCwMLBwsL",
+    "DQcLBw8HCwMBCQsJAQkLAQUJCwUHCQsNCQkLBQMLCw0FCwsDCwsLBwsLCwUJDQsFAQ8LCQEPCwUFDwsDAwENBwMBDQsDAQ0DBwEN",
+    "BwcBDQENAQ0BAQMNAQUDDQ8FAw0JDQMNBQMFDQkHBQ0FCQUNCwsFDQUNBQ0BDwUNAQEHDQkDBw0DBQcNAQkHDQsFCQ0HCQkNBQ0J",
+    "DQEBCw0HAQsNCQcLDQENCw0LAQ0NAQkNDQMDDw0HAw8NAQEBDwkBAQ8PAQEPAQUBDwUFAQ8NBwEPAQkBDwkLAQ8FDQEPBQEDDwMD",
+    "Aw8JBQMPBwkDDwsJAw8DAQUPCQEFDwEDBQ8NAwUPAwUFDwEHBQ8DCwUPBQEHDwUHBw8LBwcPBwsHDwMBCQ8LAQkPBwMJDwEFCQ8B",
+    "CwkPBQULDwUJCw8FAQ0PAwcNDwEBDw8="
+);
+
+fn iq3s_grid() -> &'static [u8] {
+    use std::sync::OnceLock;
+    static GRID: OnceLock<Vec<u8>> = OnceLock::new();
+    GRID.get_or_init(|| {
+        fn sextet(b: u8) -> Option<u8> {
+            match b {
+                b'A'..=b'Z' => Some(b - b'A'),
+                b'a'..=b'z' => Some(b - b'a' + 26),
+                b'0'..=b'9' => Some(b - b'0' + 52),
+                b'+' => Some(62),
+                b'/' => Some(63),
+                _ => None,
+            }
+        }
+        let mut out = Vec::with_capacity(512 * 4);
+        let mut acc = 0u32;
+        let mut bits = 0u32;
+        for b in IQ3S_GRID_BASE64.bytes() {
+            let Some(v) = sextet(b) else { continue };
+            acc = (acc << 6) | u32::from(v);
+            bits += 6;
+            while bits >= 8 {
+                bits -= 8;
+                out.push((acc >> bits) as u8);
+                acc &= (1u32 << bits).wrapping_sub(1);
+            }
+        }
+        assert_eq!(out.len(), 512 * 4, "embedded iq3s_grid is corrupt");
+        out
+    })
+}
+
+fn iq3s_value(blk: &[u8], group: usize, position: usize) -> i8 {
+    let pair = group / 2;
+    let parity = group % 2;
+    let chunk = position / 8;
+    let in_chunk = position % 8;
+    let half = in_chunk / 4;
+    let lane = in_chunk % 4;
+    let q_index = IQ3S_QS_OFFSET + pair * 16 + parity * 8 + chunk * 2 + half;
+    let qh = blk[IQ3S_QH_OFFSET + pair * 2 + parity];
+    let grid_index = usize::from(blk[q_index]) | (usize::from((qh >> (2 * chunk + half)) & 1) << 8);
+    let grid = iq3s_grid();
+    let magnitude = grid[grid_index * 4 + lane] as i8;
+    let signs = blk[IQ3S_SIGNS_OFFSET + pair * 8 + parity * 4 + chunk];
+    if signs & (1 << in_chunk) != 0 {
+        -magnitude
+    } else {
+        magnitude
+    }
+}
+
+/// Expand ggml's packed 6-bit Q3_K scale table to sixteen signed sub-scales.
+/// This is the bytewise form of `dequantize_row_q3_K` in ggml-quants.c.
+fn q3k_scales(blk: &[u8]) -> [i8; 16] {
+    let q = &blk[Q3K_SCALES_OFFSET..Q3K_SCALES_OFFSET + 12];
+    let mut out = [0i8; 16];
+    for j in 0..16 {
+        let raw = if j < 8 {
+            (q[j] & 0x0f) | (((q[8 + j % 4] >> (2 * (j / 4))) & 0x03) << 4)
+        } else {
+            let k = j - 8;
+            (q[k] >> 4) | (((q[8 + k % 4] >> (4 + 2 * (k / 4))) & 0x03) << 4)
+        };
+        out[j] = raw as i8 - 32;
+    }
+    out
+}
+
+/// Q3_K code at logical index `v`, shifted from ggml's signed [-4, 3] grid to
+/// the shared unsigned 3-bit stream [0, 7].
+pub fn q3k_code(blk: &[u8], v: usize) -> u32 {
+    let half = v / 128;
+    let in_half = v % 128;
+    let group = in_half / 32;
+    let lane = in_half % 32;
+    let low_byte = blk[Q3K_QS_OFFSET + half * 32 + lane];
+    let low = (low_byte >> (2 * group)) & 0x03;
+    let mask = 1u8 << (half * 4 + group);
+    let high = u8::from(blk[Q3K_HMASK_OFFSET + lane] & mask != 0);
+    // ggml: low - (high ? 0 : 4). Adding four yields low + 4*high.
+    u32::from(low | (high << 2))
+}
+
+fn iq4nl_code(blk: &[u8], v: usize, qs_offset: usize) -> u32 {
+    let lane = v % 16;
+    let byte = blk[qs_offset + lane];
+    u32::from(if v < 16 { byte & 0x0f } else { byte >> 4 })
+}
+
+fn iq4xs_scale(blk: &[u8], group: usize) -> i8 {
+    let low = (blk[IQ4XS_SCALES_L_OFFSET + group / 2] >> (4 * (group % 2))) & 0x0f;
+    let scales_h = u16::from_le_bytes([blk[IQ4XS_SCALES_H_OFFSET], blk[IQ4XS_SCALES_H_OFFSET + 1]]);
+    let high = ((scales_h >> (2 * group)) & 0x03) as u8;
+    (low | (high << 4)) as i8 - 32
+}
 
 /// Q6_K code at logical index `v` of a super-block. Cross-checked against
 /// `dequantize_row_q6_K` (`ggml-quants.c:1939`): with `v = n + 32k + l` this
@@ -320,16 +511,18 @@ fn reserve_rows<T>(dst: &mut Vec<T>, rows: usize, cols: usize, what: &str) -> Re
 /// pins that.
 ///
 /// The destination still grows to the full repacked tensor — only the *source*
-/// is streamed. Nothing here dequantizes; the output is the same bits at ggml's
-/// byte size.
+/// is streamed. Nothing here reconstructs a floating-point weight matrix; the
+/// output remains integer-packed. IQ3_S deliberately expands its grid/sign
+/// representation to signed 8-bit codes so MLX can use its generic integer
+/// matmul kernels directly.
 pub struct KQuantRepacker {
     format: KQuantFormat,
     k: usize,
     rows: usize,
     weight: Vec<u32>,
-    /// q6k `.scales`; empty for q4k/q5k.
+    /// Signed sub-scales for q3k/q6k/iq formats; empty for q4k/q5k.
     scales_i8: Vec<i8>,
-    /// q4k/q5k `.scales`; empty for q6k.
+    /// q4k/q5k `.scales`; empty for every symmetric/non-linear format.
     scales_u8: Vec<u8>,
     biases: Vec<u16>,
 }
@@ -339,9 +532,10 @@ impl KQuantRepacker {
     /// number of rows regardless, but passing the tensor's true row count keeps
     /// the destination to a single allocation.
     pub fn new(format: KQuantFormat, k: usize, rows_hint: usize) -> Result<Self> {
-        if k == 0 || !k.is_multiple_of(QK_K) {
+        let block_size = format.block_size();
+        if k == 0 || !k.is_multiple_of(block_size) {
             return Err(Error::from_reason(format!(
-                "{} repack: K must be a positive multiple of {QK_K}, got {k}",
+                "{} repack: K must be a positive multiple of {block_size}, got {k}",
                 format.mlx_mode()
             )));
         }
@@ -380,7 +574,7 @@ impl KQuantRepacker {
     pub fn push_rows(&mut self, blocks: &[u8], rows: usize) -> Result<()> {
         let (format, k) = (self.format, self.k);
         let block_bytes = format.block_bytes();
-        let sb_per_row = k / QK_K;
+        let sb_per_row = k / format.block_size();
         let want_bytes = rows
             .checked_mul(sb_per_row)
             .and_then(|n| n.checked_mul(block_bytes))
@@ -402,6 +596,16 @@ impl KQuantRepacker {
                 let blk = &blocks[start..start + block_bytes];
 
                 match format {
+                    KQuantFormat::Q3K => {
+                        self.biases.push(u16::from_le_bytes([
+                            blk[Q3K_D_OFFSET],
+                            blk[Q3K_D_OFFSET + 1],
+                        ]));
+                        self.scales_i8.extend_from_slice(&q3k_scales(blk));
+                        for v in 0..QK_K {
+                            packer.push(q3k_code(blk, v), bits);
+                        }
+                    }
                     KQuantFormat::Q6K => {
                         // .biases[G] = ggml d, raw f16 bits — no float math, so
                         // exactness is free.
@@ -446,6 +650,49 @@ impl KQuantRepacker {
                             packer.push(code, bits);
                         }
                     }
+                    KQuantFormat::IQ4NL => {
+                        self.biases.push(u16::from_le_bytes([
+                            blk[IQ4NL_D_OFFSET],
+                            blk[IQ4NL_D_OFFSET + 1],
+                        ]));
+                        // One source block is one 32-value scale group.
+                        self.scales_i8.push(1);
+                        for v in 0..32 {
+                            packer.push(iq4nl_code(blk, v, IQ4NL_QS_OFFSET), bits);
+                        }
+                    }
+                    KQuantFormat::IQ4XS => {
+                        self.biases.push(u16::from_le_bytes([
+                            blk[IQ4XS_D_OFFSET],
+                            blk[IQ4XS_D_OFFSET + 1],
+                        ]));
+                        for group in 0..8 {
+                            self.scales_i8.push(iq4xs_scale(blk, group));
+                            let group_bytes = IQ4XS_QS_OFFSET + group * 16;
+                            for v in 0..32 {
+                                packer.push(iq4nl_code(blk, v, group_bytes), bits);
+                            }
+                        }
+                    }
+                    KQuantFormat::IQ3S => {
+                        self.biases.push(u16::from_le_bytes([
+                            blk[IQ3S_D_OFFSET],
+                            blk[IQ3S_D_OFFSET + 1],
+                        ]));
+                        for group in 0..8 {
+                            let packed_scale = blk[IQ3S_SCALES_OFFSET + group / 2];
+                            let nibble = if group % 2 == 0 {
+                                packed_scale & 0x0f
+                            } else {
+                                packed_scale >> 4
+                            };
+                            self.scales_i8.push((1 + 2 * nibble) as i8);
+                            for position in 0..32 {
+                                let signed = i16::from(iq3s_value(blk, group, position));
+                                packer.push((signed + 128) as u32, bits);
+                            }
+                        }
+                    }
                 }
             }
             packer.finish()?;
@@ -468,7 +715,8 @@ impl KQuantRepacker {
     }
 }
 
-/// Repack `rows * (k / 256)` contiguous ggml super-blocks into the MLX K-quant
+/// Repack contiguous ggml blocks for `rows` rows of `k` values into the MLX
+/// K-quant
 /// array contract. `blocks` is the tensor's GGUF payload, row-major.
 ///
 /// Whole-tensor convenience over [`KQuantRepacker`]; a loader that does not want
@@ -491,12 +739,16 @@ mod tests {
     #[test]
     fn repack_shapes_follow_the_array_contract() {
         for (format, k) in [
+            (KQuantFormat::Q3K, 256),
             (KQuantFormat::Q4K, 256),
             (KQuantFormat::Q5K, 512),
             (KQuantFormat::Q6K, 1024),
+            (KQuantFormat::IQ4NL, 64),
+            (KQuantFormat::IQ4XS, 512),
+            (KQuantFormat::IQ3S, 256),
         ] {
             let rows = 3;
-            let blocks = vec![0u8; rows * (k / QK_K) * format.block_bytes()];
+            let blocks = vec![0u8; rows * (k / format.block_size()) * format.block_bytes()];
             let out = repack_kquant(format, &blocks, rows, k).expect("repack");
             assert_eq!(out.weight.len(), rows * format.weight_cols(k));
             assert_eq!(out.biases.len(), rows * format.biases_cols(k));
@@ -538,9 +790,13 @@ mod tests {
     #[test]
     fn chunked_repack_equals_whole_tensor_repack() {
         for (format, k) in [
+            (KQuantFormat::Q3K, 512),
             (KQuantFormat::Q4K, 512),
             (KQuantFormat::Q5K, 256),
             (KQuantFormat::Q6K, 768),
+            (KQuantFormat::IQ4NL, 96),
+            (KQuantFormat::IQ4XS, 512),
+            (KQuantFormat::IQ3S, 768),
         ] {
             let rows = 5;
             let row_bytes = format.row_bytes(k);

--- a/crates/mlx-core/tests/common/mod.rs
+++ b/crates/mlx-core/tests/common/mod.rs
@@ -93,6 +93,7 @@ fn tiny_mtp_config() -> Qwen3_5MoeConfig {
         use_block_paged_cache: Some(false),
         persist_paged_cache: None,
         n_mtp_layers: 1,
+        qwen35_gguf_gdn_layout: None,
     }
 }
 

--- a/crates/mlx-core/tests/kquant_ggml_parity.rs
+++ b/crates/mlx-core/tests/kquant_ggml_parity.rs
@@ -87,6 +87,7 @@ fn ggml_decode_row(format: KQuantFormat, row_blocks: &[u8], k: usize) -> Vec<f32
             KQuantFormat::Q4K => dequantize_row_q4_K(x, y, k as i64),
             KQuantFormat::Q5K => dequantize_row_q5_K(x, y, k as i64),
             KQuantFormat::Q6K => dequantize_row_q6_K(x, y, k as i64),
+            _ => panic!("legacy ggml parity fixture does not implement {format:?}"),
         }
     }
     out
@@ -453,6 +454,7 @@ fn gen_block(format: KQuantFormat, blk: &mut [u8], p: Profile, rng: &mut Lcg, bl
                 assert_eq!((sc, m), (ls[j], lm[j]), "scale packer disagrees at j={j}");
             }
         }
+        _ => panic!("legacy ggml parity fixture does not implement {format:?}"),
     }
 }
 
@@ -903,6 +905,7 @@ fn run_format(format: KQuantFormat) -> FormatRun {
                             *cov.submins.entry(want_m).or_default() += 1;
                         }
                     }
+                    _ => panic!("legacy ggml parity fixture does not implement {format:?}"),
                 }
             }
             for v in 0..spec.k {
@@ -912,6 +915,7 @@ fn run_format(format: KQuantFormat) -> FormatRun {
                     KQuantFormat::Q6K => q6k_code(blk, v % QK_K),
                     KQuantFormat::Q4K => q4k_code(blk, v % QK_K),
                     KQuantFormat::Q5K => q5k_code(blk, v % QK_K),
+                    _ => panic!("legacy ggml parity fixture does not implement {format:?}"),
                 };
                 let got_code = extract_code(w, v, bits);
                 assert_eq!(
@@ -948,6 +952,7 @@ fn run_format(format: KQuantFormat) -> FormatRun {
                     KQuantFormat::Q6K => q6k_code(blk, v % QK_K),
                     KQuantFormat::Q4K => q4k_code(blk, v % QK_K),
                     KQuantFormat::Q5K => q5k_code(blk, v % QK_K),
+                    _ => panic!("legacy ggml parity fixture does not implement {format:?}"),
                 };
                 // Q6_K's folded bias turns ggml's -0.0 into +0.0 and nothing
                 // else. Both sides must be exactly zero to qualify, and only
@@ -1048,6 +1053,7 @@ fn assert_coverage(format: KQuantFormat, cov: &Coverage) {
                  its hard half was never exercised"
             );
         }
+        _ => panic!("legacy ggml parity fixture does not implement {format:?}"),
     }
     assert!(cov.d_subnormal > 0, "no binary16-subnormal super-scale");
     assert!(cov.d_zero > 0, "no zero super-scale");

--- a/crates/mlx-core/tests/kquant_mode_guards.rs
+++ b/crates/mlx-core/tests/kquant_mode_guards.rs
@@ -77,7 +77,16 @@ struct KQuant {
     biases_cols: i64,
 }
 
-const KQUANTS: [KQuant; 3] = [
+const KQUANTS: [KQuant; 7] = [
+    KQuant {
+        mode: "q3k",
+        bits: 3,
+        group_size: 16,
+        scales_signed: true,
+        weight_cols: 24,
+        scales_cols: 16,
+        biases_cols: 1,
+    },
     KQuant {
         mode: "q6k",
         bits: 6,
@@ -104,6 +113,33 @@ const KQUANTS: [KQuant; 3] = [
         weight_cols: 40,
         scales_cols: 16,
         biases_cols: 2,
+    },
+    KQuant {
+        mode: "iq4nl",
+        bits: 4,
+        group_size: 32,
+        scales_signed: true,
+        weight_cols: 32,
+        scales_cols: 8,
+        biases_cols: 8,
+    },
+    KQuant {
+        mode: "iq4xs",
+        bits: 4,
+        group_size: 32,
+        scales_signed: true,
+        weight_cols: 32,
+        scales_cols: 8,
+        biases_cols: 1,
+    },
+    KQuant {
+        mode: "iq3s",
+        bits: 8,
+        group_size: 32,
+        scales_signed: true,
+        weight_cols: 64,
+        scales_cols: 8,
+        biases_cols: 1,
     },
 ];
 
@@ -487,9 +523,9 @@ const HALF_SCALES: [u16; 6] = [0x3000, 0x2C00, 0x3400, 0x2E66, 0x3155, 0x2800];
 /// `(&[N], K)`; for a non-transposed one the packed axis is the output dim, so
 /// it is `(&[K], N)`. An expert stack prepends to `leading`.
 ///
-/// All three arrays hold a fixed number of entries per 256-value super-block,
-/// so the `KQUANTS` column counts — which are stated for one super-block —
-/// scale linearly.
+/// All three arrays hold a fixed number of entries per 256 decoded values, so
+/// the `KQUANTS` column counts scale linearly. IQ4_NL stores eight independent
+/// 32-value source blocks in that span, hence its eight bias entries.
 fn filled_kquant_weights(kq: &KQuant, leading: &[i64], packed: i64) -> Weights {
     assert_eq!(packed % K, 0, "packed dim must be whole super-blocks");
     let rows: i64 = leading.iter().product();
@@ -509,7 +545,7 @@ fn filled_kquant_weights(kq: &KQuant, leading: &[i64], packed: i64) -> Weights {
     let weight: Vec<u32> = (0..rows * weight_cols).map(|_| lcg(&mut st)).collect();
     let scales_len = (rows * scales_cols) as usize;
     let scales = if kq.scales_signed {
-        // q6k sub-scales are signed.
+        // Symmetric K-quants and IQ modes use signed sub-scales.
         let v: Vec<i8> = (0..scales_len)
             .map(|_| (lcg(&mut st) % 17) as i8 - 8)
             .collect();

--- a/crates/mlx-core/tests/kquant_small_m_bench.rs
+++ b/crates/mlx-core/tests/kquant_small_m_bench.rs
@@ -1,0 +1,218 @@
+//! Manual small-M benchmark for the native GGUF K/IQ matmul path.
+//!
+//! The default shape is Qwen3.8-27B's dominant MLP projection
+//! `[N=17408, K=5120]`; M=1 measures decode and M=2/M=4/M=6 cover the
+//! verification widths reachable by the current depth-1 through depth-5 MTP
+//! policy. Run only on an otherwise idle GPU:
+//!
+//! ```text
+//! MLX_KQUANT_SMALL_M_BENCH=1 cargo test -p mlx-core --release \
+//!   --test kquant_small_m_bench -- --ignored --nocapture
+//! ```
+
+use std::ffi::CString;
+use std::time::Instant;
+
+use mlx_core::array::MxArray;
+
+const N: i64 = 17_408;
+const K: i64 = 5_120;
+const WARMUP: usize = 4;
+const REPS: usize = 17;
+
+#[derive(Clone, Copy)]
+struct Format {
+    mode: &'static str,
+    bits: i32,
+    group_size: i32,
+    scales_cols: i64,
+    biases_cols: i64,
+    signed_scales: bool,
+}
+
+const FORMATS: [Format; 4] = [
+    Format {
+        mode: "q5k",
+        bits: 5,
+        group_size: 32,
+        scales_cols: 2 * K / 32,
+        biases_cols: 2 * K / 256,
+        signed_scales: false,
+    },
+    Format {
+        mode: "iq4xs",
+        bits: 4,
+        group_size: 32,
+        scales_cols: K / 32,
+        biases_cols: K / 256,
+        signed_scales: true,
+    },
+    Format {
+        mode: "q6k",
+        bits: 6,
+        group_size: 16,
+        scales_cols: K / 16,
+        biases_cols: K / 256,
+        signed_scales: true,
+    },
+    Format {
+        mode: "q4k",
+        bits: 4,
+        group_size: 32,
+        scales_cols: 2 * K / 32,
+        biases_cols: 2 * K / 256,
+        signed_scales: false,
+    },
+];
+
+fn select_gpu() -> bool {
+    unsafe {
+        mlx_sys::mlx_set_default_device(1);
+        if mlx_sys::mlx_default_device() != 1 {
+            return false;
+        }
+        let stream = mlx_sys::mlx_default_stream(1);
+        mlx_sys::mlx_set_default_stream(stream);
+    }
+    true
+}
+
+fn lcg(state: &mut u32) -> u32 {
+    *state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+    *state
+}
+
+fn activation(m: i64, seed: u32) -> MxArray {
+    let mut state = seed;
+    let values: Vec<u16> = (0..m * K)
+        .map(|_| {
+            // Small, finite BF16 values in roughly [-1, 1].
+            let value = ((lcg(&mut state) >> 16) as i32 - 32_768) as f32 / 32_768.0;
+            half::bf16::from_f32(value).to_bits()
+        })
+        .collect();
+    MxArray::from_bfloat16(&values, &[m, K]).expect("activation")
+}
+
+fn packed_arrays(format: Format, seed: u32) -> (MxArray, MxArray, MxArray, u64) {
+    let mut state = seed;
+    let weight_cols = K * i64::from(format.bits) / 32;
+    let weight: Vec<u32> = (0..N * weight_cols).map(|_| lcg(&mut state)).collect();
+    let scales_len = N * format.scales_cols;
+    let scales = if format.signed_scales {
+        let values: Vec<i8> = (0..scales_len)
+            .map(|_| (lcg(&mut state) % 31) as i8 - 15)
+            .collect();
+        MxArray::from_int8(&values, &[N, format.scales_cols]).expect("signed scales")
+    } else {
+        let values: Vec<u8> = (0..scales_len)
+            .map(|_| (lcg(&mut state) % 48 + 1) as u8)
+            .collect();
+        MxArray::from_uint8(&values, &[N, format.scales_cols]).expect("unsigned scales")
+    };
+    let half_scales = [0x2800u16, 0x2c00, 0x3000, 0x3200, 0x3400, 0x3600];
+    let biases: Vec<u16> = (0..N * format.biases_cols)
+        .map(|_| half_scales[(lcg(&mut state) as usize) % half_scales.len()])
+        .collect();
+    let resident_bytes = weight.len() as u64 * 4 + scales_len as u64 + biases.len() as u64 * 2;
+    (
+        MxArray::from_uint32(&weight, &[N, weight_cols]).expect("weight"),
+        scales,
+        MxArray::from_float16(&biases, &[N, format.biases_cols]).expect("biases"),
+        resident_bytes,
+    )
+}
+
+fn qmm(
+    x: &MxArray,
+    w: &MxArray,
+    scales: &MxArray,
+    biases: &MxArray,
+    format: Format,
+) -> *mut mlx_sys::mlx_array {
+    let mode = CString::new(format.mode).expect("mode");
+    let handle = unsafe {
+        mlx_sys::mlx_quantized_matmul(
+            x.as_raw_ptr(),
+            w.as_raw_ptr(),
+            scales.as_raw_ptr(),
+            biases.as_raw_ptr(),
+            true,
+            format.group_size,
+            format.bits,
+            mode.as_ptr(),
+        )
+    };
+    assert!(!handle.is_null(), "{} qmm construction failed", format.mode);
+    handle
+}
+
+fn eval(handle: *mut mlx_sys::mlx_array) {
+    let mut error = [0i8; 512];
+    let mut handle = handle;
+    let ok =
+        unsafe { mlx_sys::mlx_eval_with_error(&mut handle, 1, error.as_mut_ptr(), error.len()) };
+    assert!(ok, "qmm eval failed");
+}
+
+fn drop_array(handle: *mut mlx_sys::mlx_array) {
+    unsafe { mlx_sys::mlx_array_delete(handle) };
+}
+
+fn median_ms(samples: &mut [f64]) -> f64 {
+    samples.sort_by(|a, b| a.total_cmp(b));
+    samples[samples.len() / 2] * 1e3
+}
+
+fn measure(x: &MxArray, w: &MxArray, scales: &MxArray, biases: &MxArray, format: Format) -> f64 {
+    for _ in 0..WARMUP {
+        let handle = qmm(x, w, scales, biases, format);
+        eval(handle);
+        drop_array(handle);
+    }
+    let handles: Vec<_> = (0..REPS)
+        .map(|_| qmm(x, w, scales, biases, format))
+        .collect();
+    let mut samples = Vec::with_capacity(REPS);
+    for handle in handles {
+        let started = Instant::now();
+        eval(handle);
+        samples.push(started.elapsed().as_secs_f64());
+        drop_array(handle);
+    }
+    median_ms(&mut samples)
+}
+
+#[test]
+#[ignore = "manual exact-shape K/IQ small-M microbenchmark"]
+fn qwen38_dominant_small_m_qmm() {
+    if std::env::var("MLX_KQUANT_SMALL_M_BENCH").as_deref() != Ok("1") {
+        eprintln!("set MLX_KQUANT_SMALL_M_BENCH=1 to run this benchmark");
+        return;
+    }
+    if !select_gpu() {
+        eprintln!("skipping: no GPU device");
+        return;
+    }
+
+    println!("\n  BF16 input, N={N}, K={K}, warmup={WARMUP}, reps={REPS}");
+    println!(
+        "  {:<8} {:>10} {:>10} {:>10} {:>10} {:>12}",
+        "mode", "M1 ms", "M2 ms", "M4 ms", "M6 ms", "M2 GB/s"
+    );
+    for (index, format) in FORMATS.into_iter().enumerate() {
+        let (w, scales, biases, resident_bytes) = packed_arrays(format, 0x51a7_0000 + index as u32);
+        w.eval();
+        scales.eval();
+        biases.eval();
+        let m1 = measure(&activation(1, 0x1010), &w, &scales, &biases, format);
+        let m2 = measure(&activation(2, 0x2020), &w, &scales, &biases, format);
+        let m4 = measure(&activation(4, 0x4040), &w, &scales, &biases, format);
+        let m6 = measure(&activation(6, 0x6060), &w, &scales, &biases, format);
+        let gb_s = resident_bytes as f64 / (m2 / 1e3) / 1e9;
+        println!(
+            "  {:<8} {:>10.4} {:>10.4} {:>10.4} {:>10.4} {:>12.1}",
+            format.mode, m1, m2, m4, m6, gb_s
+        );
+    }
+}

--- a/crates/mlx-sys/build.rs
+++ b/crates/mlx-sys/build.rs
@@ -278,6 +278,20 @@ fn main() {
     // `CMAKE_OSX_ARCHITECTURES` is an Apple-only knob; setting it on Linux
     // confuses the GCC/CUDA toolchain. Only emit it on macOS.
     if is_macos {
+        // napi-rs invokes Cargo with an explicit Darwin target even when that
+        // target is the native Apple-silicon host. Some CMake launches then
+        // retain an x86_64 host processor while honoring the arm64 compiler
+        // flags, and upstream MLX rejects the configure before it can inspect
+        // CMAKE_OSX_ARCHITECTURES. Pin both views of the target architecture.
+        cfg.define("CMAKE_SYSTEM_NAME", "Darwin");
+        cfg.define(
+            "CMAKE_SYSTEM_PROCESSOR",
+            if target_arch == "aarch64" {
+                "arm64"
+            } else {
+                "x86_64"
+            },
+        );
         cfg.define(
             "CMAKE_OSX_ARCHITECTURES",
             if target_arch == "aarch64" {

--- a/crates/mlx-sys/src/metal/gated_delta_step.metal.inc
+++ b/crates/mlx-sys/src/metal/gated_delta_step.metal.inc
@@ -4,7 +4,7 @@ R"(
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
         auto hv_idx = n % Hv;
-        auto hk_idx = hv_idx / (Hv / Hk);
+        auto hk_idx = hv_idx % Hk;
         constexpr int n_per_t = Dk / 32;
 
         // q, k: [B, T, Hk, Dk]

--- a/crates/mlx-sys/src/metal/gated_delta_step_2vcol.metal.inc
+++ b/crates/mlx-sys/src/metal/gated_delta_step_2vcol.metal.inc
@@ -11,7 +11,7 @@ R"(
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
         auto hv_idx = n % Hv;
-        auto hk_idx = hv_idx / (Hv / Hk);
+        auto hk_idx = hv_idx % Hk;
         constexpr int n_per_t = Dk / 32;
 
         // q, k: [B, T, Hk, Dk]

--- a/crates/mlx-sys/src/metal/gated_delta_step_4vcol.metal.inc
+++ b/crates/mlx-sys/src/metal/gated_delta_step_4vcol.metal.inc
@@ -12,7 +12,7 @@ R"(
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
         auto hv_idx = n % Hv;
-        auto hk_idx = hv_idx / (Hv / Hk);
+        auto hk_idx = hv_idx % Hk;
         constexpr int n_per_t = Dk / 32;
 
         auto q_ = q + b_idx * T * Hk * Dk + hk_idx * Dk;

--- a/crates/mlx-sys/src/metal/gated_delta_step_mask.metal.inc
+++ b/crates/mlx-sys/src/metal/gated_delta_step_mask.metal.inc
@@ -4,7 +4,7 @@ R"(
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
         auto hv_idx = n % Hv;
-        auto hk_idx = hv_idx / (Hv / Hk);
+        auto hk_idx = hv_idx % Hk;
         constexpr int n_per_t = Dk / 32;
 
         // q, k: [B, T, Hk, Dk]

--- a/crates/mlx-sys/src/metal/gated_delta_step_tape.metal.inc
+++ b/crates/mlx-sys/src/metal/gated_delta_step_tape.metal.inc
@@ -12,7 +12,7 @@ R"(
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
         auto hv_idx = n % Hv;
-        auto hk_idx = hv_idx / (Hv / Hk);
+        auto hk_idx = hv_idx % Hk;
         constexpr int n_per_t = Dk / 32;
 
         // q, k: [B, T, Hk, Dk]

--- a/crates/mlx-sys/src/metal/gated_delta_step_vec.metal.inc
+++ b/crates/mlx-sys/src/metal/gated_delta_step_vec.metal.inc
@@ -4,7 +4,7 @@ R"(
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
         auto hv_idx = n % Hv;
-        auto hk_idx = hv_idx / (Hv / Hk);
+        auto hk_idx = hv_idx % Hk;
         constexpr int n_per_t = Dk / 32;
 
         // q, k: [B, T, Hk, Dk]

--- a/crates/mlx-sys/src/metal/gated_delta_step_vec_mask.metal.inc
+++ b/crates/mlx-sys/src/metal/gated_delta_step_vec_mask.metal.inc
@@ -4,7 +4,7 @@ R"(
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
         auto hv_idx = n % Hv;
-        auto hk_idx = hv_idx / (Hv / Hk);
+        auto hk_idx = hv_idx % Hk;
         constexpr int n_per_t = Dk / 32;
 
         // q, k: [B, T, Hk, Dk]

--- a/crates/mlx-sys/src/metal/tape_replay.metal.inc
+++ b/crates/mlx-sys/src/metal/tape_replay.metal.inc
@@ -13,7 +13,7 @@ R"(
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
         auto hv_idx = n % Hv;
-        auto hk_idx = hv_idx / (Hv / Hk);
+        auto hk_idx = hv_idx % Hk;
         constexpr int n_per_t = Dk / 32;
 
         // tape: [B, T, Hv, Dv]

--- a/crates/mlx-sys/src/mlx_gated_delta.cpp
+++ b/crates/mlx-sys/src/mlx_gated_delta.cpp
@@ -90,8 +90,8 @@ extern "C" {
 /// Run the gated delta recurrence using a custom Metal kernel.
 ///
 /// Inputs:
-///   q: [B, T, Hk, Dk]  - queries (GQA-expanded by caller)
-///   k: [B, T, Hk, Dk]  - keys (GQA-expanded by caller)
+///   q: [B, T, Hk, Dk]  - queries (expanded, or compact tiled-GGUF heads)
+///   k: [B, T, Hk, Dk]  - keys (expanded, or compact tiled-GGUF heads)
 ///   v: [B, T, Hv, Dv]  - values
 ///   g: [B, T, Hv]       - decay gate (non-vectorized for Qwen3.5)
 ///   beta: [B, T, Hv]    - beta (sigmoid already applied by caller)

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -217,7 +217,7 @@ Quantization Arguments:
                         Required for legacy affine "unsloth". Optional for its
                         fixed --q-mxfp / --q-mode nvfp4 maps, but preferred
                         when matching calibration data is available.
-  --gguf-kquant         Import ggml Q4_K / Q5_K / Q6_K tensors as MLX K-quant
+  --gguf-kquant         Import supported ggml K/IQ tensors as native MLX packed weights
                         arrays instead of rejecting them. Blocks are repacked
                         bit-for-bit, never dequantized, so the output keeps the
                         source weights and byte size. Cannot be combined with
@@ -617,7 +617,7 @@ export async function run(argv: string[]) {
       );
       process.exit(1);
     }
-    // K-quant import (--gguf-kquant) repacks ggml Q4_K/Q5_K/Q6_K bit-for-bit and
+    // K-quant import (--gguf-kquant) losslessly repacks supported ggml K/IQ blocks and
     // never dequantizes, so any re-quantization flag both contradicts it and
     // forces whole-model float residency. Reject upfront (mirrors the native
     // guard in crates/mlx-core/src/utils/gguf.rs::convert_gguf_to_safetensors).

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -118,18 +118,22 @@ async function removeMetallibsForCpuOnlyBuild() {
   console.log('Removed stale metallibs from MLX_DISABLE_METAL CPU-only build outputs.');
 }
 
-// Derive the napi addon file name + the matching `npm/<triple>/` directory
-// from the current platform/arch. napi-rs emits `mlx-core.<triple>.node`
-// where the triple is e.g. `darwin-arm64` or `linux-arm64-gnu`.
-function nativeAddonTriple(): string {
-  if (process.platform === 'darwin') {
-    return `darwin-${process.arch}`;
+// Derive the matching `npm/<triple>/` directory from napi-rs's actual output.
+// This must not use `process.arch`: an x64 Node under Rosetta can legitimately
+// drive the configured aarch64 Rust build.
+function nativeAddonTriple(actualName: string): string {
+  const match = /^mlx-core\.(.+)\.node$/.exec(actualName);
+  if (match == null) {
+    throw new Error(`[build.ts] unrecognized native addon output: ${actualName}`);
   }
-  if (process.platform === 'linux') {
-    // glibc only for this milestone (GB10 is glibc); musl is out of scope.
-    return `linux-${process.arch}-gnu`;
+  const triple = match[1];
+  if (process.platform === 'darwin' && !triple.startsWith('darwin-')) {
+    throw new Error(`[build.ts] expected a Darwin addon, got ${actualName}`);
   }
-  throw new Error(`[build.ts] unsupported platform for native addon: ${process.platform}`);
+  if (process.platform === 'linux' && !triple.startsWith('linux-')) {
+    throw new Error(`[build.ts] expected a Linux addon, got ${actualName}`);
+  }
+  return triple;
 }
 
 async function copyNativeAddon(outputs: Awaited<typeof task>) {
@@ -137,9 +141,9 @@ async function copyNativeAddon(outputs: Awaited<typeof task>) {
   if (!nodeOutput) {
     throw new Error('[build.ts smoke check] native addon output missing from napi build');
   }
-  const triple = nativeAddonTriple();
-  const expectedName = `mlx-core.${triple}.node`;
   const actualName = basename(nodeOutput.path);
+  const triple = nativeAddonTriple(actualName);
+  const expectedName = `mlx-core.${triple}.node`;
   if (actualName !== expectedName) {
     throw new Error(
       `[build.ts smoke check] expected native addon output ${expectedName}, got ${actualName} at ${nodeOutput.path}`,

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -807,6 +807,7 @@ module.exports.formatDocument = nativeBinding.formatDocument;
 module.exports.gdnPrefixCheckpointLimit = nativeBinding.gdnPrefixCheckpointLimit;
 module.exports.getMemorySnapshot = nativeBinding.getMemorySnapshot;
 module.exports.getProfilingData = nativeBinding.getProfilingData;
+module.exports.ggufArchitecture = nativeBinding.ggufArchitecture;
 module.exports.isProfilingEnabled = nativeBinding.isProfilingEnabled;
 module.exports.memoryStats = nativeBinding.memoryStats;
 module.exports.MultimodalContentOrder = nativeBinding.MultimodalContentOrder;

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -3741,6 +3741,13 @@ export declare function getMemorySnapshot(): GpuMemorySnapshot;
 /** Retrieve all collected profiling data as a `ProfilingSession`. */
 export declare function getProfilingData(): ProfilingSession;
 
+/**
+ * Read the architecture declared by a GGUF header without loading any tensor
+ * payloads. This is the model-family detection seam for standalone GGUF files
+ * that intentionally do not ship a sibling `config.json`.
+ */
+export declare function ggufArchitecture(inputPath: string): string;
+
 export interface GgufConversionOptions {
   /** Path to the GGUF file */
   inputPath: string;

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -1415,6 +1415,12 @@ export declare class QianfanOCRModel {
  */
 export declare class Qwen35Model {
   /**
+   * Resolved directory containing this model's tokenizer/config assets.
+   * Streaming wrappers use it after a direct GGUF load so chat templating
+   * reads the reconstructed sidecars from the native-packed cache.
+   */
+  modelAssetsPath(): string;
+  /**
    * Whether the block-paged KV cache adapter is active on this model
    * instance.
    *
@@ -3792,13 +3798,19 @@ export interface GgufConversionOptions {
    */
   quantMxfp?: boolean;
   /**
-   * Import ggml Q4_K / Q5_K / Q6_K tensors as MLX K-quant arrays instead of
+   * Import supported ggml K/IQ tensors as native MLX packed arrays instead of
    * rejecting them (default: false). The blocks are repacked, never
    * dequantized, so the output keeps the source file's weights and byte size.
    * With this off, Q6_K remains the Gemma4 token-embedding BF16 fallback and
    * Q4_K / Q5_K are an error.
    */
   importKQuants?: boolean;
+  /**
+   * Preserve Qwen3.5/3.8 GGUF GDN tensors in llama.cpp's tiled value-head
+   * order. The runtime consumes this layout directly and avoids any packed
+   * weight permutation. Intended for native GGUF execution.
+   */
+  nativeQwen35Layout?: boolean;
 }
 
 export interface GgufConversionResult {
@@ -4739,6 +4751,12 @@ export interface Qwen35Config {
    * unavailable.
    */
   nMtpLayers: number;
+  /**
+   * Internal layout marker written by native Qwen3.5/3.8 GGUF conversion.
+   * `Some("tiled")` keeps llama.cpp's value-head order and lets GDN map
+   * value head h to key head h % Hk without permuting packed weights.
+   */
+  qwen35GgufGdnLayout?: string | undefined;
 }
 
 /**

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -4881,6 +4881,13 @@ export interface Qwen35MoeConfig {
    * unavailable.
    */
   nMtpLayers: number;
+  /**
+   * Internal layout marker written by native Qwen3.5/3.8 GGUF conversion.
+   * `Some("tiled")` keeps llama.cpp's value-head order and lets the shared
+   * GDN runtime map value head h to key head h % Hk without permuting
+   * packed weights.
+   */
+  qwen35GgufGdnLayout?: string | undefined;
 }
 
 /** Generation configuration for Qwen3.5 MoE */

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -3800,7 +3800,8 @@ export interface GgufConversionOptions {
   /**
    * Import supported ggml K/IQ tensors as native MLX packed arrays instead of
    * rejecting them (default: false). The blocks are repacked, never
-   * dequantized, so the output keeps the source file's weights and byte size.
+   * dequantized, so the output preserves the source quantized values. IQ3_S
+   * expands only its integer grid/sign encoding to signed 8-bit codes.
    * With this off, Q6_K remains the Gemma4 token-embedding BF16 fallback and
    * Q4_K / Q5_K are an error.
    */

--- a/packages/lm/__test__/model-loader-gguf.test.ts
+++ b/packages/lm/__test__/model-loader-gguf.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { detectModelType } from '@mlx-node/lm';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) await cleanups.pop()!();
+});
+
+function u32(value: number): Buffer {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value);
+  return buffer;
+}
+
+function u64(value: number): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64LE(BigInt(value));
+  return buffer;
+}
+
+function ggufString(value: string): Buffer {
+  const bytes = Buffer.from(value, 'utf8');
+  return Buffer.concat([u64(bytes.length), bytes]);
+}
+
+function minimalGguf(architecture: string): Buffer {
+  return Buffer.concat([
+    Buffer.from('GGUF'),
+    u32(3), // GGUF version
+    u64(0), // tensor count
+    u64(1), // metadata count
+    ggufString('general.architecture'),
+    u32(8), // GGUF_TYPE_STRING
+    ggufString(architecture),
+  ]);
+}
+
+async function writeStandaloneGguf(architecture: string): Promise<{ root: string; modelPath: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'mlx-model-loader-gguf-'));
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  const modelPath = join(root, 'model.gguf');
+  await writeFile(modelPath, minimalGguf(architecture));
+  return { root, modelPath };
+}
+
+describe('standalone GGUF model detection', () => {
+  it('maps the qwen35 header to qwen3_5 without config.json', async () => {
+    const { modelPath } = await writeStandaloneGguf('qwen35');
+    await expect(detectModelType(modelPath)).resolves.toBe('qwen3_5');
+  });
+
+  it('keeps an existing sibling config.json authoritative', async () => {
+    const { root, modelPath } = await writeStandaloneGguf('qwen35');
+    await writeFile(join(root, 'config.json'), JSON.stringify({ model_type: 'qwen3' }), 'utf8');
+    await expect(detectModelType(modelPath)).resolves.toBe('qwen3');
+  });
+
+  it('rejects an unsupported standalone architecture instead of guessing a family', async () => {
+    const { modelPath } = await writeStandaloneGguf('llama');
+    await expect(detectModelType(modelPath)).rejects.toThrow('Unsupported GGUF architecture "llama"');
+  });
+});

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -5,7 +5,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, extname, join } from 'node:path';
 
 import {
   Gemma4Model as NativeGemma4Model,
@@ -422,7 +422,11 @@ export async function loadSession(
 
 export async function detectModelType(modelPath: string): Promise<ModelType> {
   try {
-    const raw = await readFile(join(modelPath, 'config.json'), 'utf-8');
+    const configPath =
+      extname(modelPath).toLowerCase() === '.gguf'
+        ? join(dirname(modelPath), 'config.json')
+        : join(modelPath, 'config.json');
+    const raw = await readFile(configPath, 'utf-8');
     const config = normalizeConfig(modelPath, JSON.parse(raw));
     const baseFamily = config.usesDefaultModelType
       ? MODEL_FAMILY_INDEX.defaultForNullishModelType

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -9,6 +9,7 @@ import { dirname, extname, join } from 'node:path';
 
 import {
   Gemma4Model as NativeGemma4Model,
+  ggufArchitecture,
   HarrierModel,
   Lfm2Model as NativeLfm2Model,
   MuseGlimmerModel as NativeMuseGlimmerModel,
@@ -20,7 +21,15 @@ import {
 } from '@mlx-node/core';
 
 import { ChatSession, type SessionCapableModel } from '../chat-session.js';
-import { Gemma4Model, Lfm2Model, MuseGlimmerModel, NemotronHModel, Qwen3Model, Qwen35Model, Qwen35MoeModel } from '../stream.js';
+import {
+  Gemma4Model,
+  Lfm2Model,
+  MuseGlimmerModel,
+  NemotronHModel,
+  Qwen3Model,
+  Qwen35Model,
+  Qwen35MoeModel,
+} from '../stream.js';
 
 /** Optional settings for {@link loadModel} / {@link loadSession}. */
 export interface LoadModelOptions {
@@ -273,6 +282,10 @@ function buildModelFamilyIndex<const Family extends ModelFamilyDescriptor>(
 
 const MODEL_FAMILY_INDEX = buildModelFamilyIndex(MODEL_FAMILY_REGISTRY);
 
+// Only families whose native `load(path)` accepts a GGUF file belong here.
+// Qwen3.5-MoE currently consumes converted directories, not direct files.
+const GGUF_ARCHITECTURE_MODEL_TYPES = new Map<string, ModelType>([['qwen35', 'qwen3_5']]);
+
 function findFamily(modelType: ModelType): ModelFamilyDescriptor {
   const family = MODEL_FAMILY_INDEX.byModelType.get(modelType);
   if (family === undefined) {
@@ -421,12 +434,24 @@ export async function loadSession(
 }
 
 export async function detectModelType(modelPath: string): Promise<ModelType> {
+  const isGguf = extname(modelPath).toLowerCase() === '.gguf';
+  const configPath = isGguf ? join(dirname(modelPath), 'config.json') : join(modelPath, 'config.json');
+  let raw: string;
   try {
-    const configPath =
-      extname(modelPath).toLowerCase() === '.gguf'
-        ? join(dirname(modelPath), 'config.json')
-        : join(modelPath, 'config.json');
-    const raw = await readFile(configPath, 'utf-8');
+    raw = await readFile(configPath, 'utf-8');
+  } catch (e) {
+    if (isGguf && typeof e === 'object' && e !== null && 'code' in e && e.code === 'ENOENT') {
+      const architecture = ggufArchitecture(modelPath);
+      const modelType = GGUF_ARCHITECTURE_MODEL_TYPES.get(architecture);
+      if (modelType === undefined) {
+        throw new Error(`Unsupported GGUF architecture "${architecture}" in ${modelPath}`);
+      }
+      return modelType;
+    }
+    throw new Error(`Cannot detect model type: config.json not found in ${modelPath}`);
+  }
+
+  try {
     const config = normalizeConfig(modelPath, JSON.parse(raw));
     const baseFamily = config.usesDefaultModelType
       ? MODEL_FAMILY_INDEX.defaultForNullishModelType

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -672,7 +672,12 @@ export function makeStreamingModel<
       // concrete subclass declared per family supplies the prototype and
       // `instanceof ConcreteSubclass` holds.
       Object.setPrototypeOf(instance, this.prototype);
-      if (recordPath) rememberModelPath(instance, modelPath);
+      if (recordPath) {
+        const resolvedAssetsPath = (
+          instance as { modelAssetsPath?: () => string }
+        ).modelAssetsPath?.();
+        rememberModelPath(instance, resolvedAssetsPath ?? modelPath);
+      }
       return instance as unknown as StreamingModel;
     }
 

--- a/scripts/benchmark-model.ts
+++ b/scripts/benchmark-model.ts
@@ -100,10 +100,11 @@ async function readPackageFile(
 }
 
 function usage(): string {
-  return `Usage: oxnode scripts/benchmark-model.ts <model-directory> [options]
+  return `Usage: oxnode scripts/benchmark-model.ts <model-path> [options]
 
-Benchmarks one model artifact in isolated child processes. Every sample includes
-a fresh model load followed by one deterministic ChatSession generation.
+Benchmarks one model artifact (a native model directory or directly loadable
+GGUF file) in isolated child processes. Every sample includes a fresh model load
+followed by one deterministic ChatSession generation.
 
 Options:
   --runs <count>             Measured runs (default: ${DEFAULT_RUNS})
@@ -509,7 +510,7 @@ async function writeJsonAtomically(
   }
 }
 
-async function assertModelDirectory(modelPath: string): Promise<void> {
+async function assertModelPath(modelPath: string): Promise<void> {
   let modelStat;
   try {
     modelStat = await stat(modelPath);
@@ -519,12 +520,13 @@ async function assertModelDirectory(modelPath: string): Promise<void> {
       { cause: error },
     );
   }
-  if (!modelStat.isDirectory())
-    throw new Error(`Model path is not a directory: ${modelPath}`);
+  if (!modelStat.isDirectory() && !modelStat.isFile()) {
+    throw new Error(`Model path is neither a directory nor a file: ${modelPath}`);
+  }
 }
 
 async function runParent(options: CliOptions): Promise<void> {
-  await assertModelDirectory(options.modelPath);
+  await assertModelPath(options.modelPath);
   const startedAt = new Date();
   const environment = await environmentMetadata();
   const warmups: RunReport[] = [];


### PR DESCRIPTION
## Summary

- load a Qwen3.8 Qwen3.5-family GGUF by passing the `.gguf` file directly to the existing model loader
- import Q3_K, IQ4_NL, IQ4_XS, and IQ3_S alongside Q4_K/Q5_K/Q6_K as native packed arrays, without requantizing or expanding projection weights to BF16
- reconstruct tokenizer/config/chat-template assets from GGUF metadata and preserve the inline one-layer MTP checkpoint
- preserve llama.cpp's tiled Qwen GDN layout and keep mixed-format GDN projections split when their packed modes differ
- keep K/IQ token embeddings packed and gather-dequantize only selected rows
- reorder affine/K/IQ attention q/gate operands while still packed, eliminating the per-forward strided gate reshape-copy
- let the benchmark harness accept either a native model directory or a directly loadable GGUF file

## Direct GGUF behavior

The tested entry point is the exact source artifact:

```text
/Users/brooklyn/workspace/github/mlx-node/.cache/models/qwen3.8-27b-gguf/Qwen3.8-27B-UD-Q4_K_XL.gguf
```

The public loader accepts that file path. On first use it builds a content-keyed native cache by losslessly repacking GGUF blocks into the MLX kernel ABI; subsequent loads mmap that cache. This is direct at the API boundary, but intentionally not zero-copy mmap of the original GGUF block layout.

Runtime logging confirms:

```text
Loaded packed-quantized embedding (4-bit q4k, gather-dequant lookup; packed matmul for tied lm_head)
Materialized 1668 weight arrays (16.7 GB) in 19 chunks
Qwen3.5 MTP gate (paged): enable_mtp=true has_mtp_weights=true -> eager_mtp_paged=true
```

## Residency audit

The generated native cache contains 1,768 tensors:

| dtype | tensors | bytes |
|---|---:|---:|
| U32 packed codes | 506 | 16,045,178,880 |
| U8 sidecars/codes | 260 | 1,060,536,320 |
| I8 sidecars | 136 | 436,961,280 |
| F16 quantization sidecars | 506 | 379,965,440 |
| BF16 source tensors | 360 | 5,343,232 |

There are zero floating-point embedding, LM-head, attention, MLP, or MTP projection weights. The only rank-2+ floating `.weight` tensors are 48 source-BF16 depthwise `conv1d.weight` tensors, totaling 3,932,160 bytes. They are BF16 in the GGUF source and are not dequantized linear layers.

## Performance

M5 Max, greedy temperature 0, one fresh child/model load, 106 prompt tokens and 256 generated tokens:

```text
load       1438 ms
TTFT        219 ms
prefill   484.6 tok/s
decode     33.75 tok/s
```

The prior clean observation was 1,482 ms load, 261 ms TTFT, 406 tok/s prefill, and 32.81 tok/s decode. Shared GPU use makes this directional rather than a controlled attribution.

A same-binary run with only packed q/gate ordering disabled measured 33.66 tok/s versus 33.75 tok/s enabled. That is within noise, but the retained path removes 17 known per-forward strided gate copies and has exact parity coverage.

## Kernel dispatch research

The local MLX submodule already routes large-M K/IQ matmul to its NAX tensor-op kernels. Decode and MTP verification use the simdgroup qmv/qmv-wide kernels.

Forcing NAX at M=1/2/4/6 was consistently slower for Q5_K, IQ4_XS, Q6_K, and Q4_K, commonly by 1.3-1.8x. A vector-qmv experiment and a lazy MTP argmax experiment likewise produced no stable end-to-end win, so all three experiments were reverted. The submodule diff retained by this PR contains only the native Q3_K/IQ kernels.

## Submodule

`crates/mlx-sys/mlx` moves from `fef8890f` to `6d45ab90`:

```text
Add native Q3_K and IQ quantized kernels
```

The commit is reachable from `mlx-node/mlx:feat/gguf-iq-qwen38-native`. It is based directly on the SHA currently pinned by `mlx-node/main`; both parent and submodule branches contain their current `origin/main` histories.

## Validation

- `cargo fmt --all`
- focused packed embedding and packed q/gate parity tests: 4 passed
- `cargo test -p mlx-core 'models::qwen3_5::' --lib -- --nocapture`: 266 passed, 24 ignored
- `cargo test -p mlx-core --test kquant_small_m_bench -- --list`
- `cargo clippy -p mlx-core --tests -- -A clippy::large-enum-variant -D warnings`
  - the suppression is for two pre-existing Qwen3.5/Qwen3.5-MoE enum-size warnings outside this diff
- `yarn typecheck`
- `yarn lint` (passes with pre-existing repository warnings)
- `yarn build:native`
- exact GGUF 256-token direct-load benchmark above
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches native quantization, GDN recurrence, embeddings, MTP, and the public model-load path. Incorrect packing or layout handling would silently corrupt inference.
> 
> **Overview**
> Qwen3.5/3.8 GGUF files can now be passed straight to `Qwen35Model.load`. The loader losslessly repacks ggml blocks into a content-keyed native cache, reconstructs tokenizer/config sidecars, and keeps inline MTP heads instead of dequantizing projections to BF16.
> 
> Packed support expands from Q4_K/Q5_K/Q6_K to **Q3_K, IQ4_NL, IQ4_XS, and IQ3_S**. Token embeddings stay packed and gather-dequantize selected rows. Affine and K/IQ `q_proj` rows are reordered while still packed so the q/gate split avoids a per-forward strided copy.
> 
> GDN now honors llama.cpp’s tiled value-head order (`qwen35_gguf_gdn_layout: "tiled"`) and maps value head `h` to key head `h % Hk` without permuting packed weights. Split `in_proj` halves stay split when Dynamic GGUFs assign different packed modes (or mixed packed/dense), so each half uses its native matmul.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3fa5f50ea210822e0b01210116aef3c5fd3435d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->