### PR TITLE
feat: add Qwen3.8 DFlash2 speculative decoding

### DIFF
--- a/__test__/models/model-loader-registry.test.ts
+++ b/__test__/models/model-loader-registry.test.ts
@@ -8,6 +8,7 @@ import {
   loadModel,
   loadSession,
   MuseGlimmerModel,
+  Qwen35Model,
   type ModelType,
 } from '@mlx-node/lm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
@@ -173,10 +174,10 @@ describe.sequential('declarative model loader registry', () => {
     );
   });
 
-  it('preserves Gemma-only draft option validation', async () => {
+  it('rejects draftModelPath for families without external draft support', async () => {
     await writeConfig({ model_type: 'qwen3' });
     await expect(loadModel(tempDir, { draftModelPath: '/tmp/draft' })).rejects.toThrow(
-      `draftModelPath (speculative-decoding draft) is only supported by gemma4 models; ${tempDir} has model_type "qwen3"`,
+      `draftModelPath (speculative-decoding draft) is only supported by gemma4 and qwen3_5 models; ${tempDir} has model_type "qwen3"`,
     );
   });
 
@@ -188,6 +189,16 @@ describe.sequential('declarative model loader registry', () => {
     await expect(loadModel(tempDir, { draftModelPath: '/tmp/draft' })).resolves.toBe(loadedModel);
     expect(loadSpy).toHaveBeenCalledOnce();
     expect(loadSpy).toHaveBeenCalledWith(tempDir, { draftModelPath: '/tmp/draft' });
+  });
+
+  it('forwards draftModelPath through the dense Qwen3.5 family descriptor', async () => {
+    await writeConfig({ model_type: 'qwen3_5' });
+    const loadedModel = { model: 'qwen3_5' };
+    const loadSpy = vi.spyOn(Qwen35Model, 'load').mockResolvedValue(loadedModel as never);
+
+    await expect(loadModel(tempDir, { draftModelPath: '/tmp/dflash2' })).resolves.toBe(loadedModel);
+    expect(loadSpy).toHaveBeenCalledOnce();
+    expect(loadSpy).toHaveBeenCalledWith(tempDir, { draftModelPath: '/tmp/dflash2' });
   });
 
   it('loads Muse-Glimmer through its streaming wrapper', async () => {

--- a/crates/mlx-core/index.d.cts
+++ b/crates/mlx-core/index.d.cts
@@ -1444,11 +1444,9 @@ export declare class Qwen35Model {
   /** Snapshot scheduler occupancy plus unified block/recurrent admission. */
   schedulerStats(): Promise<SchedulerStats>;
   /**
-   * Whether this checkpoint shipped an MTP head (module loaded by
-   * `persistence::apply_weights_inner`). Snapshotted at load time from
-   * `Qwen35Inner::has_mtp_weights()` so the TS `ChatSession` can
-   * auto-default `enableMtp = true` for MTP-capable checkpoints without
-   * dispatching a command into the model thread.
+   * Whether this instance has an inline MTP head or external DFlash2
+   * companion. Snapshotted at load time so `ChatSession` can auto-default
+   * `enableMtp = true` without dispatching into the model thread.
    *
    * Note: this only reports weight availability. Whether the
    * speculative-decode path actually runs on a given call also requires the
@@ -1485,7 +1483,7 @@ export declare class Qwen35Model {
    * - model.safetensors (or model-*.safetensors)
    * - tokenizer.json + tokenizer_config.json
    */
-  static load(path: string): Promise<Qwen35Model>;
+  static load(path: string, options?: Qwen35LoadOptions | undefined | null): Promise<Qwen35Model>;
   /** Generate text from a prompt token sequence. */
   generate(promptTokens: MxArray, config: Qwen35GenerationConfig): Promise<Qwen35GenerationResult>;
   /**
@@ -2725,10 +2723,14 @@ export interface ChatConfig {
    * Adaptive depth is opt-in; set `mtpAdaptiveDepth: true` explicitly to
    * enable it.
    *
-   * Gemma4 external drafts (`draftModelPath`) resolve the field per draft
-   * variant instead (`gemma4/model.rs` `resolve_params`, always from the
-   * RAW config value — the engine's central `[1, 5]` clamp is an MTP-head
-   * contract that does not apply to external drafts):
+   * External drafts (`draftModelPath`) resolve the field against their
+   * checkpoint width instead (always from the RAW config value — the
+   * engine's central `[1, 5]` clamp is an MTP-head contract that does not
+   * apply to external drafts):
+   * - Qwen3.8 DFlash2: checkpoint `block_size = 8` contains one target
+   *   anchor plus seven proposals. Unset uses all seven; an explicit value
+   *   clamps to `[1, 7]` and pins that depth unless
+   *   `mtpAdaptiveDepth: true` explicitly enables the break-even guard.
    * - DSpark: with both knobs unset, full draft blocks (the checkpoint's
    *   block size — 7 tokens on `dspark_gemma4_12b_block7`) run behind a
    *   short target-AR/DSpark break-even calibration. A short generation
@@ -2759,7 +2761,8 @@ export interface ChatConfig {
    *
    * Default: false, except Gemma4 DSpark and Muse-Glimmer DFlash enable the
    * measured break-even guard when both this field and `mtpDepth` are unset.
-   * An explicit value always wins over the family default.
+   * Qwen3.8 DFlash2 remains fixed-width by default. An explicit value always
+   * wins over the family default.
    */
   mtpAdaptiveDepth?: boolean | undefined;
 }
@@ -4805,6 +4808,11 @@ export interface Qwen35GenerationResult {
   text: string;
   numTokens: number;
   finishReason: string;
+}
+
+export interface Qwen35LoadOptions {
+  /** External z-lab DFlash2 checkpoint directory. */
+  draftModelPath?: string;
 }
 
 /**

--- a/crates/mlx-core/src/calibration/napi.rs
+++ b/crates/mlx-core/src/calibration/napi.rs
@@ -260,7 +260,8 @@ pub async fn calibrate_activation_amax_raw(
         // Dense: Qwen35Inner is Send-but-!Sync, so raw-text prefill runs on its
         // dedicated model thread via a command.
         "qwen3_5" => {
-            let model = crate::models::qwen3_5::persistence::load_with_thread(&model_path).await?;
+            let model =
+                crate::models::qwen3_5::persistence::load_with_thread(&model_path, None).await?;
             prefill_and_persist(&model_path, || async {
                 crate::model_thread::send_and_await(&model.thread, |reply| {
                     Qwen35Cmd::CalibratePrefillRaw {

--- a/crates/mlx-core/src/engine/backend.rs
+++ b/crates/mlx-core/src/engine/backend.rs
@@ -1816,6 +1816,9 @@ pub(crate) struct DsparkProposal {
     /// (`sampling::is_greedy_temperature`) — greedy acceptance, with or
     /// without active penalties, is argmax-based and never reads `q`.
     pub draft_dists: Vec<MxArray>,
+    /// Sparse proposal rows for draft models with vocabulary-independent
+    /// support (DFlash2 uses a conditional top-16 selector).
+    pub draft_sparse_dists: Vec<crate::sampling::SparseDistribution>,
 }
 
 /// Output of [`DsparkStepper::verify`] — ONE batched target forward over

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -622,9 +622,13 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
             // Sampled path: per-position Leviathan accept + residual
             // resample against the stepper's proposal densities.
             (|| {
-                let has_dense = proposal.draft_dists.len() == draft_len;
-                let has_sparse = proposal.draft_sparse_dists.len() == draft_len;
-                if has_dense == has_sparse {
+                // A zero-draft cycle is the intentional AR-through-verify
+                // fallback: it owns no proposal rows and samples only the
+                // verifier boundary below. Enforce exclusive dense/sparse
+                // proposal ownership only when there is a drafted token.
+                let has_dense = draft_len > 0 && proposal.draft_dists.len() == draft_len;
+                let has_sparse = draft_len > 0 && proposal.draft_sparse_dists.len() == draft_len;
+                if draft_len > 0 && has_dense == has_sparse {
                     return Err(Error::from_reason(format!(
                         "DSpark sampled accept requires exactly one dense or sparse proposal \
                          distribution per drafted token (got {} dense, {} sparse for {} drafts)",
@@ -2535,6 +2539,32 @@ mod tests {
             !out.last_in_cache,
             "the degenerate cycle's emitted token is its boundary — no K/V"
         );
+    }
+
+    #[test]
+    fn dspark_turn_sampled_remaining_one_degenerate_ar_cycle() {
+        // Sampled decoding uses the same zero-draft AR-through-verify cycle.
+        // With no drafted token both proposal distribution vectors are empty;
+        // that is valid and must sample row 0 rather than failing the
+        // dense-vs-sparse exclusivity check.
+        let mut backend =
+            MockDsparkBackend::sampled(16, vec![CycleScript::greedy(Vec::new(), vec![8])]);
+        let mut p = dense_params();
+        p.max_new_tokens = 2;
+        let out = drive_turn(&mut backend, p, 3, 15, 2);
+
+        assert_eq!(out.generated, vec![3, 8]);
+        assert_eq!(out.finish_reason, "length");
+        assert_eq!(
+            out.ledger,
+            vec![
+                Call::Verify { ids: vec![3] },
+                Call::Commit { keep: 1, total: 1 },
+                Call::EvalBoundary { token: 8 },
+            ]
+        );
+        assert!(out.acceptance.is_none());
+        assert!(!out.last_in_cache);
     }
 
     #[test]

--- a/crates/mlx-core/src/engine/dspark_turn.rs
+++ b/crates/mlx-core/src/engine/dspark_turn.rs
@@ -513,6 +513,7 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
             DsparkProposal {
                 draft_ids: Vec::new(),
                 draft_dists: Vec::new(),
+                draft_sparse_dists: Vec::new(),
             }
         };
         // Contract enforcement at the proposal boundary: `propose` may
@@ -621,11 +622,14 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
             // Sampled path: per-position Leviathan accept + residual
             // resample against the stepper's proposal densities.
             (|| {
-                if proposal.draft_dists.len() != draft_len {
+                let has_dense = proposal.draft_dists.len() == draft_len;
+                let has_sparse = proposal.draft_sparse_dists.len() == draft_len;
+                if has_dense == has_sparse {
                     return Err(Error::from_reason(format!(
-                        "DSpark sampled accept requires one proposal distribution per \
-                         drafted token (got {} dists for {} drafts)",
+                        "DSpark sampled accept requires exactly one dense or sparse proposal \
+                         distribution per drafted token (got {} dense, {} sparse for {} drafts)",
                         proposal.draft_dists.len(),
+                        proposal.draft_sparse_dists.len(),
                         draft_len
                     )));
                 }
@@ -640,13 +644,22 @@ pub(crate) fn run_dspark_turn<B: DsparkBackend, R: rand::Rng>(
                     let p_target = sampling::sampling_distribution(&penalized, p.sampling_config)?
                         .astype(DType::Float32)?;
                     p_target.eval();
-                    let (accept, out_tok) = sampling::accept_with_residual(
-                        &p_target,
-                        &proposal.draft_dists[i],
-                        proposal.draft_ids[i],
-                        &sampling_cfg,
-                        rng,
-                    )?;
+                    let (accept, out_tok) = if has_sparse {
+                        sampling::accept_with_residual_dense_target_sparse_draft(
+                            &p_target,
+                            proposal.draft_sparse_dists[i].as_row(),
+                            proposal.draft_ids[i],
+                            rng,
+                        )?
+                    } else {
+                        sampling::accept_with_residual(
+                            &p_target,
+                            &proposal.draft_dists[i],
+                            proposal.draft_ids[i],
+                            &sampling_cfg,
+                            rng,
+                        )?
+                    };
                     if accept {
                         k += 1;
                         hist_extended.push(out_tok as u32);
@@ -1478,6 +1491,7 @@ mod tests {
             Ok(DsparkProposal {
                 draft_ids: script.draft_ids.clone(),
                 draft_dists,
+                draft_sparse_dists: Vec::new(),
             })
         }
 

--- a/crates/mlx-core/src/engine/types.rs
+++ b/crates/mlx-core/src/engine/types.rs
@@ -133,10 +133,14 @@ pub struct ChatConfig {
     /// Adaptive depth is opt-in; set `mtpAdaptiveDepth: true` explicitly to
     /// enable it.
     ///
-    /// Gemma4 external drafts (`draftModelPath`) resolve the field per draft
-    /// variant instead (`gemma4/model.rs` `resolve_params`, always from the
-    /// RAW config value — the engine's central `[1, 5]` clamp is an MTP-head
-    /// contract that does not apply to external drafts):
+    /// External drafts (`draftModelPath`) resolve the field against their
+    /// checkpoint width instead (always from the RAW config value — the
+    /// engine's central `[1, 5]` clamp is an MTP-head contract that does not
+    /// apply to external drafts):
+    /// - Qwen3.8 DFlash2: checkpoint `block_size = 8` contains one target
+    ///   anchor plus seven proposals. Unset uses all seven; an explicit value
+    ///   clamps to `[1, 7]` and pins that depth unless
+    ///   `mtpAdaptiveDepth: true` explicitly enables the break-even guard.
     /// - DSpark: with both knobs unset, full draft blocks (the checkpoint's
     ///   block size — 7 tokens on `dspark_gemma4_12b_block7`) run behind a
     ///   short target-AR/DSpark break-even calibration. A short generation
@@ -166,7 +170,8 @@ pub struct ChatConfig {
     ///
     /// Default: false, except Gemma4 DSpark and Muse-Glimmer DFlash enable the
     /// measured break-even guard when both this field and `mtpDepth` are unset.
-    /// An explicit value always wins over the family default.
+    /// Qwen3.8 DFlash2 remains fixed-width by default. An explicit value always
+    /// wins over the family default.
     #[napi(ts_type = "boolean | undefined")]
     pub mtp_adaptive_depth: Option<bool>,
 }

--- a/crates/mlx-core/src/models/gemma4/assistant_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/assistant_decode.rs
@@ -226,6 +226,7 @@ impl DsparkStepper for Gemma4AssistantStepper<'_> {
         Ok(DsparkProposal {
             draft_ids,
             draft_dists,
+            draft_sparse_dists: Vec::new(),
         })
     }
 

--- a/crates/mlx-core/src/models/gemma4/dspark_decode.rs
+++ b/crates/mlx-core/src/models/gemma4/dspark_decode.rs
@@ -399,6 +399,7 @@ impl DsparkStepper for Gemma4DsparkStepper<'_> {
         Ok(DsparkProposal {
             draft_ids,
             draft_dists,
+            draft_sparse_dists: Vec::new(),
         })
     }
 

--- a/crates/mlx-core/src/models/qwen3_5/dflash2.rs
+++ b/crates/mlx-core/src/models/qwen3_5/dflash2.rs
@@ -1,0 +1,1179 @@
+//! External DFlash2 drafter for dense Qwen3.8 targets.
+//!
+//! DFlash2 consumes five post-layer target residual streams, runs a five-layer
+//! parallel draft transformer, and chooses a Markov path through the top-16
+//! token candidates at each position. The drafter shares the target embedding
+//! and language-model head; its checkpoint therefore contains only the draft
+//! transformer, two-tap grouped dynamic convolutions, and selector codebooks.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use napi::bindgen_prelude::*;
+use rand::{Rng, RngExt};
+use serde::Deserialize;
+
+use crate::array::attention::scaled_dot_product_attention;
+use crate::array::{DType, MxArray};
+use crate::models::gemma4::layer_cache::Gemma4LayerCache;
+use crate::models::qwen3_5::quantized_linear::LinearProj;
+use crate::nn::{Activations, Embedding, Linear, RMSNorm, RoPE};
+use crate::sampling::{SparseDistribution, is_greedy_temperature};
+use crate::utils::safetensors::load_safetensors_lazy;
+
+#[derive(Clone, Debug, Deserialize)]
+struct RawDFlashConfig {
+    block_size: usize,
+    conv_group_size: usize,
+    conv_kernel_size: usize,
+    mask_token_id: usize,
+    selector_rank: usize,
+    selector_top_k: usize,
+    target_layer_ids: Vec<usize>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct RawConfig {
+    architectures: Vec<String>,
+    hidden_size: usize,
+    intermediate_size: usize,
+    num_hidden_layers: usize,
+    num_target_layers: usize,
+    num_attention_heads: usize,
+    num_key_value_heads: usize,
+    head_dim: usize,
+    vocab_size: usize,
+    rms_norm_eps: f64,
+    max_position_embeddings: usize,
+    sliding_window: usize,
+    layer_types: Vec<String>,
+    #[serde(default)]
+    is_causal: bool,
+    #[serde(default)]
+    rope_theta: Option<f64>,
+    #[serde(default)]
+    rope_parameters: Option<serde_json::Value>,
+    dflash_config: RawDFlashConfig,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DFlash2Config {
+    pub(crate) block_size: usize,
+    pub(crate) mask_token_id: usize,
+    pub(crate) target_layers: Vec<usize>,
+    target_num_layers: usize,
+    hidden_size: usize,
+    intermediate_size: usize,
+    num_hidden_layers: usize,
+    num_attention_heads: usize,
+    num_key_value_heads: usize,
+    head_dim: usize,
+    vocab_size: usize,
+    rms_norm_eps: f64,
+    max_position_embeddings: usize,
+    sliding_window: usize,
+    conv_group_size: usize,
+    conv_kernel_size: usize,
+    selector_rank: usize,
+    selector_top_k: usize,
+    rope_theta: f64,
+}
+
+impl DFlash2Config {
+    fn from_raw(raw: RawConfig) -> Result<Self> {
+        if !raw
+            .architectures
+            .iter()
+            .any(|name| name == "DFlash2DraftModel")
+        {
+            return Err(Error::from_reason(
+                "DFlash2 checkpoint architectures must contain DFlash2DraftModel",
+            ));
+        }
+        let draft = raw.dflash_config;
+        let rope_theta = raw
+            .rope_theta
+            .or_else(|| {
+                raw.rope_parameters
+                    .as_ref()
+                    .and_then(|value| value.get("rope_theta"))
+                    .and_then(serde_json::Value::as_f64)
+            })
+            .unwrap_or(10_000.0);
+        let valid = raw.hidden_size > 0
+            && raw.intermediate_size > 0
+            && raw.num_hidden_layers > 0
+            && raw.num_attention_heads > 0
+            && raw.num_key_value_heads > 0
+            && raw
+                .num_attention_heads
+                .is_multiple_of(raw.num_key_value_heads)
+            && raw.head_dim > 0
+            && raw.vocab_size > 0
+            && raw.sliding_window > 1
+            && raw.layer_types.len() == raw.num_hidden_layers
+            && raw
+                .layer_types
+                .iter()
+                .all(|kind| kind == "sliding_attention")
+            && !raw.is_causal
+            && draft.block_size > 1
+            && draft.conv_kernel_size == 2
+            && draft.conv_group_size > 0
+            && raw.hidden_size.is_multiple_of(draft.conv_group_size)
+            && draft.selector_rank > 0
+            && draft.selector_top_k > 0
+            && draft.selector_top_k <= raw.vocab_size
+            && !draft.target_layer_ids.is_empty()
+            && raw.num_target_layers > 0
+            && draft
+                .target_layer_ids
+                .iter()
+                .all(|&layer| layer < raw.num_target_layers)
+            && draft
+                .target_layer_ids
+                .windows(2)
+                .all(|pair| pair[0] < pair[1]);
+        if !valid {
+            return Err(Error::from_reason(
+                "unsupported DFlash2 configuration (requires non-causal sliding attention, two-tap grouped convolution, and a non-empty selector)",
+            ));
+        }
+        Ok(Self {
+            // z-lab names the total verify width (anchor + proposals)
+            // `block_size`. The engine's DSpark width counts proposals only.
+            block_size: draft.block_size - 1,
+            mask_token_id: draft.mask_token_id,
+            target_layers: draft.target_layer_ids,
+            target_num_layers: raw.num_target_layers,
+            hidden_size: raw.hidden_size,
+            intermediate_size: raw.intermediate_size,
+            num_hidden_layers: raw.num_hidden_layers,
+            num_attention_heads: raw.num_attention_heads,
+            num_key_value_heads: raw.num_key_value_heads,
+            head_dim: raw.head_dim,
+            vocab_size: raw.vocab_size,
+            rms_norm_eps: raw.rms_norm_eps,
+            max_position_embeddings: raw.max_position_embeddings,
+            sliding_window: raw.sliding_window,
+            conv_group_size: draft.conv_group_size,
+            conv_kernel_size: draft.conv_kernel_size,
+            selector_rank: draft.selector_rank,
+            selector_top_k: draft.selector_top_k,
+            rope_theta,
+        })
+    }
+}
+
+fn parallel_query_ids(anchor: u32, mask: usize, draft_len: usize) -> Vec<i32> {
+    let mut ids = Vec::with_capacity(draft_len.saturating_add(1));
+    ids.push(anchor as i32);
+    ids.resize(draft_len.saturating_add(1), mask as i32);
+    ids
+}
+
+fn non_causal_sliding_mask(
+    query_base: i32,
+    query_len: i64,
+    key_base: i32,
+    key_len: i64,
+    window: i64,
+) -> Result<Option<MxArray>> {
+    if key_len <= window {
+        return Ok(None);
+    }
+    let queries = MxArray::arange(
+        f64::from(query_base),
+        f64::from(query_base) + query_len as f64,
+        None,
+        None,
+    )?
+    .reshape(&[query_len, 1])?;
+    let keys = MxArray::arange(
+        f64::from(key_base),
+        f64::from(key_base) + key_len as f64,
+        None,
+        None,
+    )?
+    .reshape(&[1, key_len])?;
+    let window = MxArray::scalar_int(window as i32)?;
+    Ok(Some(
+        queries
+            .sub(&keys)?
+            .less(&window)?
+            .reshape(&[1, 1, query_len, key_len])?,
+    ))
+}
+
+struct DFlash2Attention {
+    q_proj: LinearProj,
+    k_proj: LinearProj,
+    v_proj: LinearProj,
+    o_proj: LinearProj,
+    q_norm: RMSNorm,
+    k_norm: RMSNorm,
+    rope: RoPE,
+    num_heads: i64,
+    num_kv_heads: i64,
+    head_dim: i64,
+    sliding_window: i64,
+}
+
+impl DFlash2Attention {
+    fn project_context(&self, x: &MxArray, base: i32) -> Result<(MxArray, MxArray)> {
+        let batch = x.shape_at(0)?;
+        let seq = x.shape_at(1)?;
+        let keys =
+            self.k_proj
+                .forward(x)?
+                .reshape(&[batch, seq, self.num_kv_heads, self.head_dim])?;
+        let keys = self.k_norm.forward(&keys)?.transpose(Some(&[0, 2, 1, 3]))?;
+        let keys = self.rope.forward(&keys, Some(base))?;
+        let values = self
+            .v_proj
+            .forward(x)?
+            .reshape(&[batch, seq, self.num_kv_heads, self.head_dim])?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        Ok((keys, values))
+    }
+
+    fn forward(
+        &self,
+        x: &MxArray,
+        context: Option<&(MxArray, MxArray)>,
+        context_base: i32,
+        query_base: i32,
+    ) -> Result<MxArray> {
+        let batch = x.shape_at(0)?;
+        let seq = x.shape_at(1)?;
+        let queries =
+            self.q_proj
+                .forward(x)?
+                .reshape(&[batch, seq, self.num_heads, self.head_dim])?;
+        let queries = self
+            .q_norm
+            .forward(&queries)?
+            .transpose(Some(&[0, 2, 1, 3]))?;
+        let queries = self.rope.forward(&queries, Some(query_base))?;
+        let (block_keys, block_values) = self.project_context(x, query_base)?;
+        let (keys, values, key_base) = match context {
+            Some((context_keys, context_values)) => (
+                MxArray::concatenate(context_keys, &block_keys, 2)?,
+                MxArray::concatenate(context_values, &block_values, 2)?,
+                context_base,
+            ),
+            None => (block_keys, block_values, query_base),
+        };
+        let key_len = keys.shape_at(2)?;
+        let mask =
+            non_causal_sliding_mask(query_base, seq, key_base, key_len, self.sliding_window)?;
+        let attended = scaled_dot_product_attention(
+            &queries,
+            &keys,
+            &values,
+            1.0 / (self.head_dim as f64).sqrt(),
+            mask.as_ref(),
+        )?
+        .transpose(Some(&[0, 2, 1, 3]))?
+        .reshape(&[batch, seq, self.num_heads * self.head_dim])?;
+        self.o_proj.forward(&attended)
+    }
+}
+
+struct DFlash2Mlp {
+    gate_proj: LinearProj,
+    up_proj: LinearProj,
+    down_proj: LinearProj,
+}
+
+impl DFlash2Mlp {
+    fn forward(&self, hidden: &MxArray) -> Result<MxArray> {
+        let gated = Activations::silu(&self.gate_proj.forward(hidden)?)?;
+        self.down_proj
+            .forward(&gated.mul(&self.up_proj.forward(hidden)?)?)
+    }
+}
+
+struct GroupedDynamicCausalConv {
+    base_kernel: MxArray,
+    kernel_projection: LinearProj,
+    kernel_size: usize,
+    group_size: usize,
+}
+
+impl GroupedDynamicCausalConv {
+    fn convolve(&self, hidden: &MxArray, dynamic: &MxArray, side: usize) -> Result<MxArray> {
+        let batch = hidden.shape_at(0)?;
+        let length = hidden.shape_at(1)?;
+        let hidden_size = hidden.shape_at(2)?;
+        let groups = hidden_size / self.group_size as i64;
+        let blocks = hidden.reshape(&[batch, length, groups, self.group_size as i64])?;
+        let mut output = MxArray::zeros(blocks.shape()?.as_ref(), Some(hidden.dtype()?))?;
+        for offset in 0..self.kernel_size {
+            let values = if offset == 0 {
+                blocks.clone()
+            } else {
+                blocks
+                    .pad(&[0, 0, offset as i32, 0, 0, 0, 0, 0], 0.0)?
+                    .slice_axis(1, 0, length)?
+            };
+            let base = self
+                .base_kernel
+                .slice(
+                    &[side as i64, offset as i64, 0],
+                    &[side as i64 + 1, offset as i64 + 1, hidden_size],
+                )?
+                .reshape(&[1, 1, groups, self.group_size as i64])?
+                .astype(hidden.dtype()?)?;
+            let correction = dynamic
+                .slice(
+                    &[0, 0, offset as i64, 0],
+                    &[batch, length, offset as i64 + 1, groups],
+                )?
+                .reshape(&[batch, length, groups, 1])?;
+            output = output.add(&base.add(&correction)?.mul(&values)?)?;
+        }
+        output.reshape(&[batch, length, hidden_size])
+    }
+
+    fn prepare(&self, hidden: &MxArray) -> Result<(MxArray, MxArray)> {
+        let batch = hidden.shape_at(0)?;
+        let length = hidden.shape_at(1)?;
+        let groups = hidden.shape_at(2)? / self.group_size as i64;
+        let dynamic = self.kernel_projection.forward(hidden)?.reshape(&[
+            batch,
+            length,
+            2,
+            self.kernel_size as i64,
+            groups,
+        ])?;
+        let before = dynamic.slice_axis(2, 0, 1)?.squeeze(Some(&[2]))?;
+        let after = dynamic.slice_axis(2, 1, 2)?.squeeze(Some(&[2]))?;
+        Ok((self.convolve(hidden, &before, 0)?, after))
+    }
+
+    fn finish(&self, hidden: &MxArray, dynamic: &MxArray) -> Result<MxArray> {
+        self.convolve(hidden, dynamic, 1)
+    }
+}
+
+struct DFlash2Layer {
+    attention: DFlash2Attention,
+    mlp: DFlash2Mlp,
+    input_norm: RMSNorm,
+    post_attention_norm: RMSNorm,
+    attention_conv: GroupedDynamicCausalConv,
+    mlp_conv: GroupedDynamicCausalConv,
+}
+
+impl DFlash2Layer {
+    fn forward(
+        &self,
+        hidden: &MxArray,
+        context: Option<&(MxArray, MxArray)>,
+        context_base: i32,
+        query_base: i32,
+    ) -> Result<MxArray> {
+        let residual = hidden;
+        let (prepared, dynamic) = self
+            .attention_conv
+            .prepare(&self.input_norm.forward(hidden)?)?;
+        let attention = self
+            .attention
+            .forward(&prepared, context, context_base, query_base)?;
+        let hidden = residual.add(&self.attention_conv.finish(&attention, &dynamic)?)?;
+        let (prepared, dynamic) = self
+            .mlp_conv
+            .prepare(&self.post_attention_norm.forward(&hidden)?)?;
+        hidden.add(
+            &self
+                .mlp_conv
+                .finish(&self.mlp.forward(&prepared)?, &dynamic)?,
+        )
+    }
+}
+
+struct CandidateSelector {
+    predecessor_codebook: Embedding,
+    successor_codebook: Embedding,
+    hidden_projection: LinearProj,
+    top_k: usize,
+    rank: usize,
+    vocab_size: usize,
+}
+
+fn normalized_selector_probs(scores: &[f32], temperature: f64) -> Result<Vec<f64>> {
+    let scale = temperature.max(f64::MIN_POSITIVE);
+    let max = scores
+        .iter()
+        .copied()
+        .filter(|value| value.is_finite())
+        .max_by(f32::total_cmp)
+        .ok_or_else(|| Error::from_reason("DFlash2 selector scores are all non-finite"))?;
+    let mut probs = scores
+        .iter()
+        .map(|&score| ((f64::from(score) - f64::from(max)) / scale).exp())
+        .collect::<Vec<_>>();
+    let total = probs.iter().sum::<f64>();
+    if !total.is_finite() || total <= 0.0 {
+        return Err(Error::from_reason(
+            "DFlash2 selector has no positive probability mass",
+        ));
+    }
+    for prob in &mut probs {
+        *prob /= total;
+    }
+    Ok(probs)
+}
+
+fn sample_selector_index<R: Rng + ?Sized>(probs: &[f64], rng: &mut R) -> usize {
+    let draw = rng.random::<f64>();
+    let mut cumulative = 0.0;
+    let mut last = 0usize;
+    for (index, &prob) in probs.iter().enumerate() {
+        if prob <= 0.0 {
+            continue;
+        }
+        cumulative += prob;
+        last = index;
+        if draw < cumulative {
+            return index;
+        }
+    }
+    last
+}
+
+impl CandidateSelector {
+    fn select<R: Rng + ?Sized>(
+        &self,
+        hidden: &MxArray,
+        logits: &MxArray,
+        anchor: u32,
+        temperature: f64,
+        rng: &mut R,
+    ) -> Result<(Vec<i32>, Vec<SparseDistribution>)> {
+        let length = hidden.shape_at(1)? as usize;
+        let candidates = logits
+            .argpartition(-(self.top_k as i32), Some(-1))?
+            .slice_axis(
+                2,
+                self.vocab_size as i64 - self.top_k as i64,
+                self.vocab_size as i64,
+            )?;
+        let unary = logits.take_along_axis(&candidates, -1)?;
+        let projected = self.hidden_projection.forward(hidden)?.reshape(&[
+            length as i64,
+            1,
+            self.rank as i64,
+        ])?;
+        let candidate_flat = candidates.reshape(&[(length * self.top_k) as i64])?;
+        let successors = self
+            .successor_codebook
+            .forward(&candidate_flat)?
+            .reshape(&[length as i64, self.top_k as i64, self.rank as i64])?;
+        let anchor_ids = MxArray::from_int32(&[anchor as i32], &[1])?;
+        let anchor_embedding = self
+            .predecessor_codebook
+            .forward(&anchor_ids)?
+            .reshape(&[1, 1, self.rank as i64])?
+            .broadcast_to(&[1, self.top_k as i64, self.rank as i64])?;
+        let predecessor_ids = if length > 1 {
+            candidates.slice_axis(1, 0, length as i64 - 1)?
+        } else {
+            MxArray::from_int32(&[], &[0, self.top_k as i64])?
+        };
+        let predecessors = if length > 1 {
+            let previous = self
+                .predecessor_codebook
+                .forward(&predecessor_ids.reshape(&[((length - 1) * self.top_k) as i64])?)?
+                .reshape(&[length as i64 - 1, self.top_k as i64, self.rank as i64])?;
+            MxArray::concatenate(&anchor_embedding, &previous, 0)?
+        } else {
+            anchor_embedding
+        };
+        let edges = predecessors
+            .mul(&projected)?
+            .matmul(&successors.transpose(Some(&[0, 2, 1]))?)?;
+        let scores = edges.add(&unary.reshape(&[length as i64, 1, self.top_k as i64])?)?;
+        let candidates = candidates.astype(DType::Int32)?;
+        let scores = scores.astype(DType::Float32)?;
+        MxArray::eval_arrays(&[&candidates, &scores])?;
+        let candidate_ids = candidates.to_int32()?;
+        let edge_scores = scores.to_float32()?;
+
+        let greedy = is_greedy_temperature(temperature);
+        let mut path = Vec::with_capacity(length);
+        let mut rows = Vec::with_capacity(if greedy { 0 } else { length });
+        let mut predecessor_index = 0usize;
+        for position in 0..length {
+            let start = (position * self.top_k + predecessor_index) * self.top_k;
+            let row = &edge_scores[start..start + self.top_k];
+            let selected = if greedy {
+                row.iter()
+                    .enumerate()
+                    .max_by(|(_, a), (_, b)| a.total_cmp(b))
+                    .map(|(index, _)| index)
+                    .unwrap_or(0)
+            } else {
+                let probs = normalized_selector_probs(row, temperature)?;
+                let support_start = position * self.top_k;
+                rows.push(SparseDistribution::from_parts(
+                    candidate_ids[support_start..support_start + self.top_k].to_vec(),
+                    probs.clone(),
+                    self.vocab_size,
+                )?);
+                sample_selector_index(&probs, rng)
+            };
+            let token = candidate_ids[position * self.top_k + selected];
+            path.push(token);
+            predecessor_index = selected;
+        }
+        Ok((path, rows))
+    }
+}
+
+pub(crate) struct DFlash2ContextCache {
+    layers: Vec<Gemma4LayerCache>,
+    logical_len: i32,
+    /// Exact token prefix represented by every layer cache above.
+    ///
+    /// A length alone is not cache provenance: an unrelated paged request can
+    /// end at the same position. Keep the ids beside the draft K/V so a warm
+    /// DFlash2 continuation is admitted only for the prefix that produced it.
+    token_history: Vec<u32>,
+}
+
+impl DFlash2ContextCache {
+    pub(crate) fn new(config: &DFlash2Config) -> Self {
+        Self {
+            layers: (0..config.num_hidden_layers)
+                .map(|_| Gemma4LayerCache::new_sliding(config.sliding_window as i32 - 1))
+                .collect(),
+            logical_len: 0,
+            token_history: Vec::new(),
+        }
+    }
+
+    pub(crate) fn append(
+        &mut self,
+        model: &DFlash2Model,
+        fused_context: &MxArray,
+        base: i32,
+        token_ids: &[u32],
+    ) -> Result<()> {
+        if base != self.logical_len {
+            return Err(Error::from_reason(format!(
+                "DFlash2 context append starts at {base}, expected {}",
+                self.logical_len
+            )));
+        }
+        if usize::try_from(self.logical_len).ok() != Some(self.token_history.len()) {
+            return Err(Error::from_reason(format!(
+                "DFlash2 context provenance length {} does not match logical length {}",
+                self.token_history.len(),
+                self.logical_len
+            )));
+        }
+        let rows = fused_context.shape_at(1)? as usize;
+        if rows != token_ids.len() {
+            return Err(Error::from_reason(format!(
+                "DFlash2 context append has {rows} hidden rows for {} token ids",
+                token_ids.len()
+            )));
+        }
+        for (layer, cache) in model.layers.iter().zip(self.layers.iter_mut()) {
+            let (keys, values) = layer.attention.project_context(fused_context, base)?;
+            let _ = cache.update_and_fetch(&keys, &values)?;
+        }
+        self.logical_len = self
+            .logical_len
+            .checked_add(i32::try_from(rows).map_err(|_| {
+                Error::from_reason(format!(
+                    "DFlash2 context append row count {rows} exceeds i32"
+                ))
+            })?)
+            .ok_or_else(|| Error::from_reason("DFlash2 context length overflow"))?;
+        self.token_history.extend_from_slice(token_ids);
+        Ok(())
+    }
+
+    pub(crate) fn logical_len(&self) -> i32 {
+        self.logical_len
+    }
+
+    pub(crate) fn token_history(&self) -> &[u32] {
+        &self.token_history
+    }
+
+    pub(crate) fn eval(&self) -> Result<()> {
+        let mut arrays = Vec::new();
+        for cache in &self.layers {
+            cache.collect_cache_arrays(&mut arrays);
+        }
+        if arrays.is_empty() {
+            Ok(())
+        } else {
+            MxArray::eval_arrays(&arrays)
+        }
+    }
+}
+
+pub(crate) struct DFlash2Model {
+    pub(crate) config: DFlash2Config,
+    pub(crate) weight_bytes: u64,
+    fc: LinearProj,
+    hidden_norm: RMSNorm,
+    layers: Vec<DFlash2Layer>,
+    norm: RMSNorm,
+    selector: CandidateSelector,
+}
+
+impl DFlash2Model {
+    pub(crate) fn validate_target(&self, target: &super::config::Qwen3_5Config) -> Result<()> {
+        let invalid_tap = self
+            .config
+            .target_layers
+            .iter()
+            .copied()
+            .find(|&layer| layer >= target.num_layers as usize);
+        if self.config.hidden_size != target.hidden_size as usize
+            || self.config.vocab_size != target.vocab_size as usize
+            || self.config.mask_token_id >= self.config.vocab_size
+            || self.config.target_num_layers != target.num_layers as usize
+            || invalid_tap.is_some()
+        {
+            return Err(Error::from_reason(format!(
+                "DFlash2/target mismatch: draft hidden={} vocab={} taps={:?}; target hidden={} vocab={} layers={}",
+                self.config.hidden_size,
+                self.config.vocab_size,
+                self.config.target_layers,
+                target.hidden_size,
+                target.vocab_size,
+                target.num_layers,
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn fuse_context(&self, taps: &[MxArray]) -> Result<MxArray> {
+        if taps.len() != self.config.target_layers.len() || taps.is_empty() {
+            return Err(Error::from_reason(format!(
+                "DFlash2 expects {} target taps, got {}",
+                self.config.target_layers.len(),
+                taps.len()
+            )));
+        }
+        let refs = taps.iter().collect::<Vec<_>>();
+        self.hidden_norm.forward(
+            &self
+                .fc
+                .forward(&MxArray::concatenate_many(refs, Some(2))?)?,
+        )
+    }
+
+    fn forward_hidden(
+        &self,
+        target_embedding: &Embedding,
+        block_ids: &MxArray,
+        query_base: i32,
+        context: &DFlash2ContextCache,
+    ) -> Result<MxArray> {
+        let mut hidden = target_embedding.forward(block_ids)?;
+        for (index, layer) in self.layers.iter().enumerate() {
+            let cached = context.layers[index].get_cached_kv();
+            let live_len = cached
+                .as_ref()
+                .map(|(keys, _)| keys.shape_at(2))
+                .transpose()?
+                .unwrap_or(0) as i32;
+            let context_base = context.logical_len.saturating_sub(live_len);
+            hidden = layer.forward(&hidden, cached.as_ref(), context_base, query_base)?;
+        }
+        self.norm.forward(&hidden)
+    }
+
+    pub(crate) fn propose<R: Rng + ?Sized>(
+        &self,
+        target_embedding: &Embedding,
+        target_lm_head: Option<&LinearProj>,
+        context: &DFlash2ContextCache,
+        anchor: u32,
+        max_len: usize,
+        temperature: f64,
+        rng: &mut R,
+    ) -> Result<(Vec<i32>, Vec<SparseDistribution>)> {
+        let query_end = context
+            .logical_len
+            .saturating_add(max_len.saturating_add(1) as i32);
+        if query_end as usize > self.config.max_position_embeddings {
+            return Err(Error::from_reason(format!(
+                "DFlash2 query end {query_end} exceeds trained context {}",
+                self.config.max_position_embeddings
+            )));
+        }
+        let ids = parallel_query_ids(anchor, self.config.mask_token_id, max_len);
+        let block = MxArray::from_int32(&ids, &[1, ids.len() as i64])?;
+        let hidden = self.forward_hidden(target_embedding, &block, context.logical_len, context)?;
+        let hidden = hidden.slice_axis(1, 1, max_len as i64 + 1)?;
+        let logits = match target_lm_head {
+            Some(head) => head.forward(&hidden)?,
+            None => target_embedding.as_linear(&hidden)?,
+        };
+        self.selector
+            .select(&hidden, &logits, anchor, temperature, rng)
+    }
+}
+
+fn required(params: &mut HashMap<String, MxArray>, key: &str, shape: &[i64]) -> Result<MxArray> {
+    let value = params
+        .remove(key)
+        .ok_or_else(|| Error::from_reason(format!("DFlash2 checkpoint is missing '{key}'")))?;
+    if value.shape()?.as_ref() != shape {
+        return Err(Error::from_reason(format!(
+            "DFlash2 tensor '{key}' has shape {:?}, expected {shape:?}",
+            value.shape()?.as_ref()
+        )));
+    }
+    if !matches!(
+        value.dtype()?,
+        DType::Float16 | DType::BFloat16 | DType::Float32
+    ) {
+        return Err(Error::from_reason(format!(
+            "DFlash2 tensor '{key}' must be floating point"
+        )));
+    }
+    Ok(value)
+}
+
+fn linear(
+    params: &mut HashMap<String, MxArray>,
+    prefix: &str,
+    input: usize,
+    output: usize,
+) -> Result<LinearProj> {
+    let weight = required(
+        params,
+        &format!("{prefix}.weight"),
+        &[output as i64, input as i64],
+    )?;
+    Ok(LinearProj::Standard(Linear::from_weights(&weight, None)?))
+}
+
+fn norm(
+    params: &mut HashMap<String, MxArray>,
+    key: &str,
+    size: usize,
+    eps: f64,
+) -> Result<RMSNorm> {
+    RMSNorm::from_weight(&required(params, key, &[size as i64])?, Some(eps))
+}
+
+fn codebook(
+    params: &mut HashMap<String, MxArray>,
+    key: &str,
+    vocab: usize,
+    rank: usize,
+) -> Result<Embedding> {
+    let weight = required(params, key, &[vocab as i64, rank as i64])?;
+    let mut embedding = Embedding::new_uninitialized(vocab as u32, rank as u32)?;
+    embedding.load_weight(&weight)?;
+    Ok(embedding)
+}
+
+fn grouped_conv(
+    params: &mut HashMap<String, MxArray>,
+    base: &str,
+    name: &str,
+    config: &DFlash2Config,
+) -> Result<GroupedDynamicCausalConv> {
+    let hidden = config.hidden_size;
+    let groups = hidden / config.conv_group_size;
+    Ok(GroupedDynamicCausalConv {
+        base_kernel: required(
+            params,
+            &format!("{base}.{name}.base_kernel"),
+            &[2, config.conv_kernel_size as i64, hidden as i64],
+        )?,
+        kernel_projection: linear(
+            params,
+            &format!("{base}.{name}.kernel_projection"),
+            hidden,
+            2 * config.conv_kernel_size * groups,
+        )?,
+        kernel_size: config.conv_kernel_size,
+        group_size: config.conv_group_size,
+    })
+}
+
+fn resolve_safetensors(path: &Path) -> Result<PathBuf> {
+    if path.join("model.safetensors").is_file() {
+        return Ok(path.join("model.safetensors"));
+    }
+    Err(Error::from_reason(format!(
+        "DFlash2 checkpoint {} is missing model.safetensors",
+        path.display()
+    )))
+}
+
+fn expected_tensor_shapes(config: &DFlash2Config) -> Vec<(String, Vec<i64>)> {
+    let hidden = config.hidden_size as i64;
+    let intermediate = config.intermediate_size as i64;
+    let groups = config.hidden_size / config.conv_group_size;
+    let mut expected = vec![
+        (
+            "fc.weight".to_string(),
+            vec![hidden, hidden * config.target_layers.len() as i64],
+        ),
+        ("hidden_norm.weight".to_string(), vec![hidden]),
+        ("norm.weight".to_string(), vec![hidden]),
+    ];
+    for index in 0..config.num_hidden_layers {
+        let base = format!("layers.{index}");
+        let attention = format!("{base}.self_attn");
+        expected.extend([
+            (
+                format!("{attention}.q_proj.weight"),
+                vec![
+                    (config.num_attention_heads * config.head_dim) as i64,
+                    hidden,
+                ],
+            ),
+            (
+                format!("{attention}.k_proj.weight"),
+                vec![
+                    (config.num_key_value_heads * config.head_dim) as i64,
+                    hidden,
+                ],
+            ),
+            (
+                format!("{attention}.v_proj.weight"),
+                vec![
+                    (config.num_key_value_heads * config.head_dim) as i64,
+                    hidden,
+                ],
+            ),
+            (
+                format!("{attention}.o_proj.weight"),
+                vec![
+                    hidden,
+                    (config.num_attention_heads * config.head_dim) as i64,
+                ],
+            ),
+            (
+                format!("{attention}.q_norm.weight"),
+                vec![config.head_dim as i64],
+            ),
+            (
+                format!("{attention}.k_norm.weight"),
+                vec![config.head_dim as i64],
+            ),
+            (
+                format!("{base}.mlp.gate_proj.weight"),
+                vec![intermediate, hidden],
+            ),
+            (
+                format!("{base}.mlp.up_proj.weight"),
+                vec![intermediate, hidden],
+            ),
+            (
+                format!("{base}.mlp.down_proj.weight"),
+                vec![hidden, intermediate],
+            ),
+            (format!("{base}.input_layernorm.weight"), vec![hidden]),
+            (
+                format!("{base}.post_attention_layernorm.weight"),
+                vec![hidden],
+            ),
+            (
+                format!("{base}.attention_conv.base_kernel"),
+                vec![2, config.conv_kernel_size as i64, hidden],
+            ),
+            (
+                format!("{base}.attention_conv.kernel_projection.weight"),
+                vec![(2 * config.conv_kernel_size * groups) as i64, hidden],
+            ),
+            (
+                format!("{base}.mlp_conv.base_kernel"),
+                vec![2, config.conv_kernel_size as i64, hidden],
+            ),
+            (
+                format!("{base}.mlp_conv.kernel_projection.weight"),
+                vec![(2 * config.conv_kernel_size * groups) as i64, hidden],
+            ),
+        ]);
+    }
+    expected.extend([
+        (
+            "candidate_selector.predecessor_codebook".to_string(),
+            vec![config.vocab_size as i64, config.selector_rank as i64],
+        ),
+        (
+            "candidate_selector.successor_codebook".to_string(),
+            vec![config.vocab_size as i64, config.selector_rank as i64],
+        ),
+        (
+            "candidate_selector.hidden_projection.weight".to_string(),
+            vec![config.selector_rank as i64, hidden],
+        ),
+    ]);
+    expected
+}
+
+fn validate_tensor_inventory(
+    params: &HashMap<String, MxArray>,
+    config: &DFlash2Config,
+) -> Result<()> {
+    let expected = expected_tensor_shapes(config);
+    let expected_names = expected
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    let mut missing = Vec::new();
+    for (name, shape) in &expected {
+        let Some(array) = params.get(name) else {
+            missing.push(name.clone());
+            continue;
+        };
+        if array.shape()?.as_ref() != shape.as_slice() {
+            return Err(Error::from_reason(format!(
+                "DFlash2 tensor '{name}' has shape {:?}, expected {shape:?}",
+                array.shape()?.as_ref()
+            )));
+        }
+        if !matches!(
+            array.dtype()?,
+            DType::Float16 | DType::BFloat16 | DType::Float32
+        ) {
+            return Err(Error::from_reason(format!(
+                "DFlash2 tensor '{name}' must be floating point"
+            )));
+        }
+    }
+    let mut unexpected = params
+        .keys()
+        .filter(|name| !expected_names.contains(name.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    unexpected.sort();
+    if !missing.is_empty() || !unexpected.is_empty() {
+        missing.sort();
+        return Err(Error::from_reason(format!(
+            "DFlash2 tensor inventory mismatch: missing={missing:?}, unexpected={unexpected:?}"
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn load_dflash2(path: &Path) -> Result<(DFlash2Model, u64)> {
+    if !path.is_dir() {
+        return Err(Error::from_reason(format!(
+            "DFlash2 path is not a directory: {}",
+            path.display()
+        )));
+    }
+    let config_data = fs::read_to_string(path.join("config.json")).map_err(|error| {
+        Error::from_reason(format!("Failed to read DFlash2 config.json: {error}"))
+    })?;
+    let raw: RawConfig = serde_json::from_str(&config_data).map_err(|error| {
+        Error::from_reason(format!("Failed to parse DFlash2 config.json: {error}"))
+    })?;
+    let config = DFlash2Config::from_raw(raw)?;
+    let tensor_path = resolve_safetensors(path)?;
+    crate::engine::persistence::prewarm_checkpoint_pages(path);
+    let mut params = load_safetensors_lazy(&tensor_path)?;
+    // Structural preflight precedes the first GPU evaluation. A descriptor-
+    // valid but incomplete companion must fail before any target or draft
+    // state can be mutated.
+    validate_tensor_inventory(&params, &config)?;
+    let weight_bytes = params.values().fold(0u64, |total, array| {
+        total.saturating_add(array.nbytes() as u64)
+    });
+    let arrays = params.values().collect::<Vec<_>>();
+    let _resident = crate::array::memory::materialize_weights(&arrays)?;
+
+    let hidden = config.hidden_size;
+    let fc = linear(
+        &mut params,
+        "fc",
+        hidden * config.target_layers.len(),
+        hidden,
+    )?;
+    let hidden_norm = norm(
+        &mut params,
+        "hidden_norm.weight",
+        hidden,
+        config.rms_norm_eps,
+    )?;
+    let final_norm = norm(&mut params, "norm.weight", hidden, config.rms_norm_eps)?;
+    let mut layers = Vec::with_capacity(config.num_hidden_layers);
+    for index in 0..config.num_hidden_layers {
+        let base = format!("layers.{index}");
+        let attention_base = format!("{base}.self_attn");
+        let attention = DFlash2Attention {
+            q_proj: linear(
+                &mut params,
+                &format!("{attention_base}.q_proj"),
+                hidden,
+                config.num_attention_heads * config.head_dim,
+            )?,
+            k_proj: linear(
+                &mut params,
+                &format!("{attention_base}.k_proj"),
+                hidden,
+                config.num_key_value_heads * config.head_dim,
+            )?,
+            v_proj: linear(
+                &mut params,
+                &format!("{attention_base}.v_proj"),
+                hidden,
+                config.num_key_value_heads * config.head_dim,
+            )?,
+            o_proj: linear(
+                &mut params,
+                &format!("{attention_base}.o_proj"),
+                config.num_attention_heads * config.head_dim,
+                hidden,
+            )?,
+            q_norm: norm(
+                &mut params,
+                &format!("{attention_base}.q_norm.weight"),
+                config.head_dim,
+                config.rms_norm_eps,
+            )?,
+            k_norm: norm(
+                &mut params,
+                &format!("{attention_base}.k_norm.weight"),
+                config.head_dim,
+                config.rms_norm_eps,
+            )?,
+            rope: RoPE::new(
+                config.head_dim as i32,
+                Some(false),
+                Some(config.rope_theta),
+                None,
+            ),
+            num_heads: config.num_attention_heads as i64,
+            num_kv_heads: config.num_key_value_heads as i64,
+            head_dim: config.head_dim as i64,
+            sliding_window: config.sliding_window as i64,
+        };
+        let mlp_base = format!("{base}.mlp");
+        let mlp = DFlash2Mlp {
+            gate_proj: linear(
+                &mut params,
+                &format!("{mlp_base}.gate_proj"),
+                hidden,
+                config.intermediate_size,
+            )?,
+            up_proj: linear(
+                &mut params,
+                &format!("{mlp_base}.up_proj"),
+                hidden,
+                config.intermediate_size,
+            )?,
+            down_proj: linear(
+                &mut params,
+                &format!("{mlp_base}.down_proj"),
+                config.intermediate_size,
+                hidden,
+            )?,
+        };
+        let input_norm = norm(
+            &mut params,
+            &format!("{base}.input_layernorm.weight"),
+            hidden,
+            config.rms_norm_eps,
+        )?;
+        let post_attention_norm = norm(
+            &mut params,
+            &format!("{base}.post_attention_layernorm.weight"),
+            hidden,
+            config.rms_norm_eps,
+        )?;
+        let attention_conv = grouped_conv(&mut params, &base, "attention_conv", &config)?;
+        let mlp_conv = grouped_conv(&mut params, &base, "mlp_conv", &config)?;
+        layers.push(DFlash2Layer {
+            attention,
+            mlp,
+            input_norm,
+            post_attention_norm,
+            attention_conv,
+            mlp_conv,
+        });
+    }
+    let selector = CandidateSelector {
+        predecessor_codebook: codebook(
+            &mut params,
+            "candidate_selector.predecessor_codebook",
+            config.vocab_size,
+            config.selector_rank,
+        )?,
+        successor_codebook: codebook(
+            &mut params,
+            "candidate_selector.successor_codebook",
+            config.vocab_size,
+            config.selector_rank,
+        )?,
+        hidden_projection: linear(
+            &mut params,
+            "candidate_selector.hidden_projection",
+            hidden,
+            config.selector_rank,
+        )?,
+        top_k: config.selector_top_k,
+        rank: config.selector_rank,
+        vocab_size: config.vocab_size,
+    };
+    if !params.is_empty() {
+        let mut unexpected = params.keys().cloned().collect::<Vec<_>>();
+        unexpected.sort();
+        return Err(Error::from_reason(format!(
+            "DFlash2 checkpoint contains unexpected tensors: {unexpected:?}"
+        )));
+    }
+    Ok((
+        DFlash2Model {
+            config,
+            weight_bytes,
+            fc,
+            hidden_norm,
+            layers,
+            norm: final_norm,
+            selector,
+        },
+        weight_bytes,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalized_selector_probs, parallel_query_ids};
+
+    #[test]
+    fn block_has_one_anchor_and_mask_rows() {
+        assert_eq!(
+            parallel_query_ids(7, 248_070, 3),
+            vec![7, 248_070, 248_070, 248_070]
+        );
+    }
+
+    #[test]
+    fn selector_softmax_is_normalized_and_temperature_scaled() {
+        let probs = normalized_selector_probs(&[0.0, 1.0, 2.0], 0.5).expect("selector probs");
+        assert!((probs.iter().sum::<f64>() - 1.0).abs() < 1e-12);
+        assert!(probs[2] > probs[1] && probs[1] > probs[0]);
+    }
+
+    #[test]
+    #[ignore = "requires the external 3.6 GB DFlash2 checkpoint"]
+    fn loads_real_qwen38_dflash2_checkpoint_strictly() {
+        let path = std::env::var("MLX_TEST_QWEN38_DFLASH2_PATH")
+            .expect("set MLX_TEST_QWEN38_DFLASH2_PATH");
+        let (model, bytes) = super::load_dflash2(std::path::Path::new(&path))
+            .expect("real DFlash2 checkpoint must load");
+        assert_eq!(model.config.block_size, 7);
+        assert_eq!(model.config.target_layers, vec![5, 19, 33, 47, 61]);
+        assert!(bytes > 3_000_000_000);
+    }
+}

--- a/crates/mlx-core/src/models/qwen3_5/dflash2.rs
+++ b/crates/mlx-core/src/models/qwen3_5/dflash2.rs
@@ -630,6 +630,10 @@ pub(crate) struct DFlash2Model {
 }
 
 impl DFlash2Model {
+    pub(crate) fn max_position_embeddings(&self) -> usize {
+        self.config.max_position_embeddings
+    }
+
     pub(crate) fn validate_target(&self, target: &super::config::Qwen3_5Config) -> Result<()> {
         let invalid_tap = self
             .config

--- a/crates/mlx-core/src/models/qwen3_5/dflash2_decode.rs
+++ b/crates/mlx-core/src/models/qwen3_5/dflash2_decode.rs
@@ -1,4 +1,4 @@
-//! DFlash speculative-turn integration for Muse-Glimmer.
+//! DFlash2 whole-turn integration for dense Qwen3.8.
 
 use std::time::Instant;
 
@@ -15,41 +15,44 @@ use crate::engine::dspark_turn::{DsparkTurnArgs, run_dspark_turn};
 use crate::engine::finalize::compute_performance_metrics;
 use crate::engine::params::generated_capacity_hint;
 use crate::engine::penalties::{ReasoningTracker, apply_all_penalties};
-use crate::models::gemma4::layer_cache::{
-    Gemma4VerifyRollback, active_cache_frontier, commit_after_verify, snapshot_before_verify,
-};
 use crate::stream::{DeviceType, Stream, StreamContext};
 
-use super::dflash::DFlashContextCache;
-use super::model::MuseGlimmerInner;
+use super::dflash2::DFlash2ContextCache;
+use super::layer_cache::{Qwen3_5LayerSnapshot, replay_mtp_snapshot_to, snapshot_all_mtp};
+use super::model::{PREFILL_STEP_SIZE, Qwen35Inner, async_eval_layer_caches};
 
-pub(crate) struct DFlashTurnState {
-    context: DFlashContextCache,
+pub(crate) struct DFlash2TurnState {
+    context: DFlash2ContextCache,
     next_position: i32,
 }
 
-pub(crate) struct MuseGlimmerDFlashStepper<'a> {
-    inner: &'a mut MuseGlimmerInner,
-    context: DFlashContextCache,
+pub(crate) struct Qwen35DFlash2Stepper<'a> {
+    inner: &'a mut Qwen35Inner,
+    context: DFlash2ContextCache,
     next_position: i32,
     tap_layers: Vec<usize>,
-    rollback: Option<Gemma4VerifyRollback>,
+    snapshot: Option<Vec<Qwen3_5LayerSnapshot>>,
+    tape: Option<Vec<Option<super::gated_delta_net::GdnLayerTape>>>,
     tapped: Option<Vec<MxArray>>,
+    verified_ids: Option<Vec<u32>>,
 }
 
-fn reusable_dflash_prefix(
+fn reusable_dflash2_prefix(
     is_delta: bool,
-    token_len: usize,
+    tokens: &[u32],
     prior_cached: usize,
     verified_hit: usize,
-    retained_context_len: Option<i32>,
+    retained_context_tokens: Option<&[u32]>,
+    flat_attention_frontier: Option<usize>,
+    flat_lane_authoritative: bool,
 ) -> usize {
     let candidate = if is_delta { prior_cached } else { verified_hit };
     if candidate > 0
-        && candidate < token_len
-        && i32::try_from(candidate)
-            .ok()
-            .is_some_and(|candidate| retained_context_len == Some(candidate))
+        && candidate < tokens.len()
+        && flat_lane_authoritative
+        && flat_attention_frontier == Some(candidate)
+        && retained_context_tokens
+            .is_some_and(|retained| retained.len() == candidate && retained == &tokens[..candidate])
     {
         candidate
     } else {
@@ -57,41 +60,73 @@ fn reusable_dflash_prefix(
     }
 }
 
-impl MuseGlimmerDFlashStepper<'_> {
+fn flat_attention_frontier(inner: &Qwen35Inner) -> Option<usize> {
+    let mut frontiers = inner.caches.as_ref()?.iter().filter_map(|cache| {
+        if matches!(
+            cache,
+            super::layer_cache::Qwen3_5LayerCache::FullAttention(_)
+        ) {
+            usize::try_from(cache.offset().max(0)).ok()
+        } else {
+            None
+        }
+    });
+    let first = frontiers.next()?;
+    frontiers.all(|frontier| frontier == first).then_some(first)
+}
+
+impl Qwen35DFlash2Stepper<'_> {
     fn ensure_clean(&self, operation: &str) -> Result<()> {
-        if self.rollback.is_some() || self.tapped.is_some() {
+        if self.snapshot.is_some()
+            || self.tape.is_some()
+            || self.tapped.is_some()
+            || self.verified_ids.is_some()
+        {
             return Err(Error::from_reason(format!(
-                "Muse-Glimmer DFlash {operation}: prior verify was not committed"
+                "Qwen3.8 DFlash2 {operation}: prior verify was not committed"
             )));
         }
         Ok(())
     }
 
-    fn target_forward(&mut self, ids: &[u32]) -> Result<(MxArray, Vec<MxArray>)> {
+    fn target_forward(
+        &mut self,
+        ids: &[u32],
+        record_tape: bool,
+    ) -> Result<(
+        MxArray,
+        Vec<MxArray>,
+        Vec<Option<super::gated_delta_net::GdnLayerTape>>,
+    )> {
         let ids = ids.iter().map(|&id| id as i32).collect::<Vec<_>>();
         let input = MxArray::from_int32(&ids, &[1, ids.len() as i64])?;
-        self.inner
-            .forward_with_taps_mode(&input, &self.tap_layers, false)
+        super::model::forward_dflash2_with_taps(self.inner, &input, &self.tap_layers, record_tape)
     }
 
-    fn append_tapped(&mut self, tapped: &[MxArray], keep: usize) -> Result<()> {
+    fn append_tapped(&mut self, tapped: &[MxArray], token_ids: &[u32]) -> Result<()> {
+        let keep = token_ids.len();
         let mut kept = Vec::with_capacity(tapped.len());
         for hidden in tapped {
             kept.push(hidden.slice_axis(1, 0, keep as i64)?);
         }
         let draft = self
             .inner
-            .dflash
+            .dflash2
             .as_ref()
-            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?;
+            .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 model disappeared"))?;
         let fused = draft.fuse_context(&kept)?;
-        self.context.append(draft, &fused, self.next_position)?;
+        self.context
+            .append(draft, &fused, self.next_position, token_ids)?;
         self.next_position = self.next_position.saturating_add(keep as i32);
         Ok(())
     }
+
+    fn attention_frontier(&self) -> Option<u64> {
+        flat_attention_frontier(self.inner).and_then(|frontier| u64::try_from(frontier).ok())
+    }
 }
 
-impl DsparkStepper for MuseGlimmerDFlashStepper<'_> {
+impl DsparkStepper for Qwen35DFlash2Stepper<'_> {
     fn supports_adaptive_ar_fallback(&self) -> bool {
         true
     }
@@ -106,16 +141,26 @@ impl DsparkStepper for MuseGlimmerDFlashStepper<'_> {
 
     fn verify_ar_probe(&mut self, anchor_id: u32) -> Result<DsparkVerifyOutput> {
         self.ensure_clean("AR probe")?;
-        let (logits, tapped) = self.target_forward(&[anchor_id])?;
+        let (logits, tapped, _) = self.target_forward(&[anchor_id], false)?;
         self.tapped = Some(tapped);
+        self.verified_ids = Some(vec![anchor_id]);
         Ok(DsparkVerifyOutput { logits })
     }
 
     fn commit_ar_probe(&mut self) -> Result<()> {
         let tapped = self.tapped.take().ok_or_else(|| {
-            Error::from_reason("Muse-Glimmer DFlash AR probe has no tapped target state")
+            Error::from_reason("Qwen3.8 DFlash2 AR probe has no tapped target state")
         })?;
-        self.append_tapped(&tapped, 1)
+        let verified_ids = self.verified_ids.take().ok_or_else(|| {
+            Error::from_reason("Qwen3.8 DFlash2 AR probe has no token provenance")
+        })?;
+        if verified_ids.len() != 1 {
+            return Err(Error::from_reason(format!(
+                "Qwen3.8 DFlash2 AR probe retained {} token ids, expected 1",
+                verified_ids.len()
+            )));
+        }
+        self.append_tapped(&tapped, &verified_ids)
     }
 
     fn propose(
@@ -127,150 +172,184 @@ impl DsparkStepper for MuseGlimmerDFlashStepper<'_> {
     ) -> Result<DsparkProposal> {
         let draft = self
             .inner
-            .dflash
+            .dflash2
             .as_ref()
-            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?;
-        let sampling = params.sampling_config.unwrap_or_default();
-        let (draft_ids, draft_dists) = draft.propose(
-            &self.inner.embed_tokens,
+            .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 model disappeared"))?;
+        let temperature = params
+            .sampling_config
+            .unwrap_or_default()
+            .temperature
+            .unwrap_or(1.0);
+        let (draft_ids, draft_sparse_dists) = draft.propose(
+            &self.inner.embedding,
             self.inner.lm_head.as_ref(),
-            &self.inner.config.text_config,
             &self.context,
             anchor_id,
             max_len,
-            &sampling,
+            temperature,
             rng,
         )?;
         Ok(DsparkProposal {
             draft_ids,
-            draft_dists,
-            draft_sparse_dists: Vec::new(),
+            draft_dists: Vec::new(),
+            draft_sparse_dists,
         })
     }
 
     fn verify(&mut self, verify_ids: &[u32]) -> Result<DsparkVerifyOutput> {
         if verify_ids.is_empty() {
             return Err(Error::from_reason(
-                "Muse-Glimmer DFlash verify block must not be empty",
+                "Qwen3.8 DFlash2 verify block must not be empty",
             ));
         }
         self.ensure_clean("verify")?;
-        let rollback = snapshot_before_verify(
-            &self.inner.caches,
-            verify_ids.len(),
-            &vec![false; self.inner.caches.len()],
+        let snapshot = snapshot_all_mtp(
+            self.inner
+                .caches
+                .as_ref()
+                .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 target caches are absent"))?,
+            false,
         )?;
-        let (logits, tapped) = self.target_forward(verify_ids)?;
-        self.rollback = Some(rollback);
+        let (logits, tapped, tape) = self.target_forward(verify_ids, true)?;
+        self.snapshot = Some(snapshot);
+        self.tape = Some(tape);
         self.tapped = Some(tapped);
+        self.verified_ids = Some(verify_ids.to_vec());
         Ok(DsparkVerifyOutput { logits })
     }
 
     fn commit(&mut self, keep: usize, total_written: usize) -> Result<()> {
         if keep == 0 || keep > total_written {
             return Err(Error::from_reason(format!(
-                "Muse-Glimmer DFlash invalid commit keep={keep}, total={total_written}"
+                "Qwen3.8 DFlash2 invalid commit keep={keep}, total={total_written}"
             )));
         }
-        let rollback = self.rollback.take().ok_or_else(|| {
-            Error::from_reason("Muse-Glimmer DFlash commit has no pending target rollback")
-        })?;
-        let tapped = self.tapped.take().ok_or_else(|| {
-            Error::from_reason("Muse-Glimmer DFlash commit has no pending target taps")
-        })?;
-        commit_after_verify(&mut self.inner.caches, &rollback, keep)?;
-        self.append_tapped(&tapped, keep)
+        let snapshot = self
+            .snapshot
+            .take()
+            .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 commit has no target snapshot"))?;
+        let tape = self
+            .tape
+            .take()
+            .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 commit has no GDN tape"))?;
+        let tapped = self
+            .tapped
+            .take()
+            .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 commit has no target taps"))?;
+        let verified_ids = self
+            .verified_ids
+            .take()
+            .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 commit has no token provenance"))?;
+        if verified_ids.len() != total_written {
+            return Err(Error::from_reason(format!(
+                "Qwen3.8 DFlash2 commit wrote {total_written} rows for {} token ids",
+                verified_ids.len()
+            )));
+        }
+        replay_mtp_snapshot_to(
+            self.inner
+                .caches
+                .as_mut()
+                .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 target caches are absent"))?,
+            &snapshot,
+            &tape,
+            keep,
+            false,
+            "Qwen3.8 DFlash2 commit",
+        )?;
+        self.append_tapped(&tapped, &verified_ids[..keep])
     }
 
     fn finish(self) -> Result<()> {
-        self.inner.dflash_context = Some(self.context);
+        self.ensure_clean("finish")?;
+        self.inner.dflash2_context = Some(self.context);
         Ok(())
     }
 
     fn eval_boundary(&self, token: &MxArray) {
+        async_eval_layer_caches(&self.inner.caches);
         MxArray::async_eval_arrays(&[token]);
     }
 
     fn frontier(&self) -> Option<SpecFrontier> {
-        // Pure-attention target with no KV-shared slots (the empty mask
-        // counts every cache as active); the DFlash context cache is
-        // drafter-private, not target state.
         Some(SpecFrontier {
-            attn_tokens: active_cache_frontier(&self.inner.caches, &[])?,
-            recurrent_tokens: None,
+            attn_tokens: self.attention_frontier()?,
+            recurrent_tokens: Some(self.next_position.max(0) as u64),
         })
     }
 }
 
-impl DsparkBackend for MuseGlimmerInner {
+impl DsparkBackend for Qwen35Inner {
     type DsparkDecode<'a>
-        = MuseGlimmerDFlashStepper<'a>
+        = Qwen35DFlash2Stepper<'a>
     where
         Self: 'a;
 
     fn begin_dspark_decode(&mut self, block_size: usize) -> Result<Self::DsparkDecode<'_>> {
         let expected = self
-            .dflash
+            .dflash2
             .as_ref()
-            .ok_or_else(|| Error::from_reason("Muse-Glimmer has no loaded DFlash companion"))?
+            .ok_or_else(|| Error::from_reason("Qwen3.8 has no loaded DFlash2 companion"))?
             .config
             .block_size;
         if block_size != expected {
             return Err(Error::from_reason(format!(
-                "Muse-Glimmer DFlash block size {block_size} does not match checkpoint {expected}"
+                "Qwen3.8 DFlash2 block size {block_size} does not match checkpoint {expected}"
             )));
         }
-        let state = self.dflash_turn_state.take().ok_or_else(|| {
-            Error::from_reason("Muse-Glimmer DFlash decode requires tapped prefill state")
+        let state = self.dflash2_turn_state.take().ok_or_else(|| {
+            Error::from_reason("Qwen3.8 DFlash2 decode requires tapped prefill state")
         })?;
         let tap_layers = self
-            .dflash
+            .dflash2
             .as_ref()
-            .expect("checked DFlash companion")
+            .expect("checked DFlash2 companion")
             .config
             .target_layers
             .clone();
-        Ok(MuseGlimmerDFlashStepper {
+        Ok(Qwen35DFlash2Stepper {
             inner: self,
             context: state.context,
             next_position: state.next_position,
             tap_layers,
-            rollback: None,
+            snapshot: None,
+            tape: None,
             tapped: None,
+            verified_ids: None,
         })
     }
 }
 
-impl MuseGlimmerInner {
-    fn dflash_prefill(
+impl Qwen35Inner {
+    fn dflash2_prefill(
         &mut self,
         tokens: &[u32],
         position_base: i32,
         stream: Stream,
-    ) -> Result<(MxArray, DFlashTurnState)> {
+    ) -> Result<(MxArray, DFlash2TurnState)> {
         if tokens.is_empty() {
             return Err(Error::from_reason(
-                "Muse-Glimmer DFlash requires at least one prefill token",
+                "Qwen3.8 DFlash2 requires at least one prefill token",
             ));
         }
         let draft = self
-            .dflash
+            .dflash2
             .as_ref()
-            .ok_or_else(|| Error::from_reason("Muse-Glimmer has no loaded DFlash companion"))?;
+            .ok_or_else(|| Error::from_reason("Qwen3.8 has no loaded DFlash2 companion"))?;
         let tap_layers = draft.config.target_layers.clone();
         let draft_config = draft.config.clone();
-        let mut context = match self.dflash_context.take() {
+        let mut context = match self.dflash2_context.take() {
             Some(context) if context.logical_len() == position_base => context,
             Some(context) => {
                 return Err(Error::from_reason(format!(
-                    "Muse-Glimmer DFlash context length {} does not match cached prefix {position_base}",
+                    "Qwen3.8 DFlash2 context length {} does not match cached prefix {position_base}",
                     context.logical_len()
                 )));
             }
-            None if position_base == 0 => DFlashContextCache::new_at(&draft_config, 0),
+            None if position_base == 0 => DFlash2ContextCache::new(&draft_config),
             None => {
                 return Err(Error::from_reason(format!(
-                    "Muse-Glimmer DFlash cached prefix {position_base} has no retained draft context"
+                    "Qwen3.8 DFlash2 cached prefix {position_base} has no retained draft context"
                 )));
             }
         };
@@ -285,77 +364,87 @@ impl MuseGlimmerInner {
             {
                 return Err(Error::from_reason("prefill cancelled"));
             }
-            let end = (offset + super::model::PREFILL_STEP_SIZE as usize).min(tokens.len());
+            let end = (offset + PREFILL_STEP_SIZE as usize).min(tokens.len());
             let chunk = tokens[offset..end]
                 .iter()
                 .map(|&id| id as i32)
                 .collect::<Vec<_>>();
             let input = MxArray::from_int32(&chunk, &[1, chunk.len() as i64])?;
-            let (logits, taps) = {
+            let (logits, taps, _) = {
                 let _stream = StreamContext::new(stream);
-                self.forward_with_taps(&input, &tap_layers)?
+                super::model::forward_dflash2_with_taps(self, &input, &tap_layers, false)?
             };
             let draft = self
-                .dflash
+                .dflash2
                 .as_ref()
-                .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?;
+                .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 model disappeared"))?;
             let fused = draft.fuse_context(&taps)?;
-            context.append(draft, &fused, position_base + offset as i32)?;
-            last_logits = Some(logits);
+            context.append(
+                draft,
+                &fused,
+                position_base + offset as i32,
+                &tokens[offset..end],
+            )?;
+            let vocab = logits.shape_at(2)?;
+            last_logits = Some(
+                logits
+                    .slice_axis(1, chunk.len() as i64 - 1, chunk.len() as i64)?
+                    .reshape(&[vocab])?,
+            );
             if end < tokens.len() {
-                self.eval_caches()?;
+                super::model::eval_layer_caches(&self.caches)?;
+                context.eval()?;
                 crate::array::clear_cache();
             }
             offset = end;
         }
         Ok((
-            last_logits
-                .expect("non-empty prefill")
-                .squeeze(Some(&[1]))?,
-            DFlashTurnState {
+            last_logits.expect("non-empty DFlash2 prefill"),
+            DFlash2TurnState {
                 context,
                 next_position: position_base.saturating_add(tokens.len() as i32),
             },
         ))
     }
 
-    fn dflash_fail_closed(&mut self, error: Error) -> Error {
-        let _ = ChatBackend::reset_caches(self, ResetScope::PrefixMiss);
-        self.dflash_turn_state = None;
+    fn dflash2_fail_closed(&mut self, error: Error) -> Error {
+        let _ = ChatBackend::reset_caches(self, ResetScope::Command);
+        self.dflash2_turn_state = None;
         error
     }
 
-    fn dflash_materialize_final(&mut self, token: u32, stream: Stream) -> Result<()> {
+    fn dflash2_materialize_final(&mut self, token: u32, stream: Stream) -> Result<()> {
         let tap_layers = self
-            .dflash
+            .dflash2
             .as_ref()
-            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?
+            .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 model disappeared"))?
             .config
             .target_layers
             .clone();
         let input = MxArray::from_int32(&[token as i32], &[1, 1])?;
         let _stream = StreamContext::new(stream);
-        let (_, taps) = self.forward_with_taps(&input, &tap_layers)?;
+        let (_, taps, _) =
+            super::model::forward_dflash2_with_taps(self, &input, &tap_layers, false)?;
         let fused = self
-            .dflash
+            .dflash2
             .as_ref()
-            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))?
+            .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 model disappeared"))?
             .fuse_context(&taps)?;
-        let mut context = self.dflash_context.take().ok_or_else(|| {
-            Error::from_reason("Muse-Glimmer DFlash final token has no retained draft context")
+        let mut context = self.dflash2_context.take().ok_or_else(|| {
+            Error::from_reason("Qwen3.8 DFlash2 final token has no retained draft context")
         })?;
         let base = context.logical_len();
         let append_result = self
-            .dflash
+            .dflash2
             .as_ref()
-            .ok_or_else(|| Error::from_reason("Muse-Glimmer DFlash model disappeared"))
-            .and_then(|draft| context.append(draft, &fused, base));
-        self.dflash_context = Some(context);
+            .ok_or_else(|| Error::from_reason("Qwen3.8 DFlash2 model disappeared"))
+            .and_then(|draft| context.append(draft, &fused, base, &[token]));
+        self.dflash2_context = Some(context);
         append_result?;
-        self.eval_caches()
+        super::model::eval_layer_caches(&self.caches)
     }
 
-    pub(crate) fn dflash_chat_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
+    pub(crate) fn dflash2_chat_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
         let tokenizer = args.tokenizer.clone();
         let tokens = args.tokens.to_vec();
         let is_delta = args.plan.is_delta;
@@ -367,26 +456,32 @@ impl MuseGlimmerInner {
         } else {
             0
         };
-        let retained_context_len = self
-            .dflash_context
-            .as_ref()
-            .map(DFlashContextCache::logical_len);
         let verified_hit = if is_delta {
             0
         } else {
             ChatBackend::verify_cache_prefix(self, &tokens, params.reuse_cache)
         };
-        let cached_prefix = reusable_dflash_prefix(
+        let flat_lane_authoritative =
+            !self.paged_full_attn_caches_dirty && !self.flat_mtp_caches_desynced;
+        let cached_prefix = reusable_dflash2_prefix(
             is_delta,
-            tokens.len(),
+            &tokens,
             prior_cached,
             verified_hit,
-            retained_context_len,
+            self.dflash2_context
+                .as_ref()
+                .map(DFlash2ContextCache::token_history),
+            flat_attention_frontier(self),
+            flat_lane_authoritative,
         );
         let prefill = if cached_prefix > 0 {
             tokens[cached_prefix..].to_vec()
         } else {
-            ChatBackend::reset_caches(self, ResetScope::PrefixMiss)?;
+            // A previous turn may have occupied the target's paged lane.
+            // Command reset also releases/purges that request before the
+            // DFlash2 flat-cache prefill rebuilds the complete prompt.
+            ChatBackend::reset_caches(self, ResetScope::Command)?;
+            self.init_caches_sync()?;
             tokens.clone()
         };
 
@@ -402,9 +497,9 @@ impl MuseGlimmerInner {
         profiler.snapshot_memory_before();
         profiler.begin_prefill();
         let (last_logits, state) =
-            match self.dflash_prefill(&prefill, cached_prefix as i32, generation_stream) {
+            match self.dflash2_prefill(&prefill, cached_prefix as i32, generation_stream) {
                 Ok(value) => value,
-                Err(error) => return Err(self.dflash_fail_closed(error)),
+                Err(error) => return Err(self.dflash2_fail_closed(error)),
             };
         profiler.end_prefill();
 
@@ -413,14 +508,16 @@ impl MuseGlimmerInner {
             .and_then(|logits| crate::sampling::sample(&logits, params.sampling_config))
         {
             Ok(token) => token,
-            Err(error) => return Err(self.dflash_fail_closed(error)),
+            Err(error) => return Err(self.dflash2_fail_closed(error)),
         };
         y.eval();
-        self.eval_caches()?;
+        if let Err(error) = super::model::eval_layer_caches(&self.caches) {
+            return Err(self.dflash2_fail_closed(error));
+        }
         if report_performance {
             first_token_instant = Some(Instant::now());
         }
-        self.dflash_turn_state = Some(state);
+        self.dflash2_turn_state = Some(state);
 
         let mut generated = Vec::with_capacity(generated_capacity_hint(params.max_new_tokens));
         let mut finish_reason = String::from("length");
@@ -433,9 +530,9 @@ impl MuseGlimmerInner {
             args.sink.map(|_| ChatBackend::stream_emitter(self));
         let turn_token_observer = ChatBackend::turn_token_observer(self);
         let block_size = self
-            .dflash
+            .dflash2
             .as_ref()
-            .expect("loaded DFlash companion")
+            .expect("loaded DFlash2 companion")
             .config
             .block_size;
         let mut rng = rand::rng();
@@ -477,13 +574,15 @@ impl MuseGlimmerInner {
         };
         let mut last_in_cache = match outcome {
             Ok(outcome) => outcome.last_in_cache,
-            Err(error) => return Err(self.dflash_fail_closed(error)),
+            Err(error) => return Err(self.dflash2_fail_closed(error)),
         };
         if finish_reason == "length"
             && !last_in_cache
             && let Some(&last) = generated.last()
         {
-            self.dflash_materialize_final(last, generation_stream)?;
+            if let Err(error) = self.dflash2_materialize_final(last, generation_stream) {
+                return Err(self.dflash2_fail_closed(error));
+            }
             last_in_cache = true;
         }
         let saved_generated = if !last_in_cache && !generated.is_empty() {
@@ -554,14 +653,43 @@ impl MuseGlimmerInner {
 
 #[cfg(test)]
 mod tests {
-    use super::reusable_dflash_prefix;
+    use super::reusable_dflash2_prefix;
 
     #[test]
-    fn continuation_reuses_only_a_matching_retained_dflash_context() {
-        assert_eq!(reusable_dflash_prefix(true, 14, 10, 0, Some(10)), 10);
-        assert_eq!(reusable_dflash_prefix(true, 14, 10, 0, None), 0);
-        assert_eq!(reusable_dflash_prefix(true, 14, 10, 0, Some(9)), 0);
-        assert_eq!(reusable_dflash_prefix(false, 14, 0, 10, Some(10)), 10);
-        assert_eq!(reusable_dflash_prefix(false, 14, 0, 10, Some(9)), 0);
+    fn continuation_requires_matching_prefix_and_flat_frontier() {
+        let tokens = (0..14).collect::<Vec<u32>>();
+        let retained = tokens[..10].to_vec();
+        assert_eq!(
+            reusable_dflash2_prefix(true, &tokens, 10, 0, Some(&retained), Some(10), true),
+            10
+        );
+        assert_eq!(
+            reusable_dflash2_prefix(true, &tokens, 10, 0, None, Some(10), true),
+            0
+        );
+        assert_eq!(
+            reusable_dflash2_prefix(false, &tokens, 0, 10, Some(&retained), Some(10), true),
+            10
+        );
+        assert_eq!(
+            reusable_dflash2_prefix(false, &tokens, 0, 10, Some(&retained), Some(9), true),
+            0
+        );
+    }
+
+    #[test]
+    fn same_length_different_prefix_and_paged_owner_are_cold_misses() {
+        let tokens = (0..14).collect::<Vec<u32>>();
+        let unrelated = (100..110).collect::<Vec<u32>>();
+        assert_eq!(
+            reusable_dflash2_prefix(true, &tokens, 10, 0, Some(&unrelated), Some(10), true,),
+            0,
+            "equal lengths do not establish cache provenance"
+        );
+        assert_eq!(
+            reusable_dflash2_prefix(true, &tokens, 10, 0, Some(&tokens[..10]), Some(10), false,),
+            0,
+            "a paged-owned target frontier cannot reuse flat DFlash2 state"
+        );
     }
 }

--- a/crates/mlx-core/src/models/qwen3_5/dflash2_decode.rs
+++ b/crates/mlx-core/src/models/qwen3_5/dflash2_decode.rs
@@ -75,6 +75,27 @@ fn flat_attention_frontier(inner: &Qwen35Inner) -> Option<usize> {
     frontiers.all(|frontier| frontier == first).then_some(first)
 }
 
+fn constrain_dflash2_context_params(
+    prompt_tokens: usize,
+    target_capacity: i32,
+    draft_capacity: usize,
+    params: &mut crate::engine::params::ChatParams,
+) -> Result<usize> {
+    let target_capacity = usize::try_from(target_capacity.max(0)).unwrap_or(usize::MAX);
+    let capacity = target_capacity.min(draft_capacity);
+    super::model::constrain_paged_context_params(
+        "Qwen3.8 DFlash2",
+        prompt_tokens,
+        u32::try_from(capacity).unwrap_or(u32::MAX),
+        params,
+    )?;
+    Ok(capacity)
+}
+
+fn dflash2_final_token_fits_context(logical_len: i32, capacity: usize) -> bool {
+    usize::try_from(logical_len).is_ok_and(|logical_len| logical_len < capacity)
+}
+
 impl Qwen35DFlash2Stepper<'_> {
     fn ensure_clean(&self, operation: &str) -> Result<()> {
         if self.snapshot.is_some()
@@ -451,6 +472,15 @@ impl Qwen35Inner {
         let is_streaming = args.sink.is_some();
         let mut params = ChatBackend::resolve_params(self, args.config);
         params.extra_eos_ids = ChatBackend::extra_eos_ids(self);
+        let dflash_context_capacity = constrain_dflash2_context_params(
+            tokens.len(),
+            self.config.max_position_embeddings,
+            self.dflash2
+                .as_ref()
+                .expect("loaded DFlash2 companion")
+                .max_position_embeddings(),
+            &mut params,
+        )?;
         let prior_cached = if is_delta {
             self.cached_token_history.len()
         } else {
@@ -576,8 +606,12 @@ impl Qwen35Inner {
             Ok(outcome) => outcome.last_in_cache,
             Err(error) => return Err(self.dflash2_fail_closed(error)),
         };
+        let final_token_fits_context = self.dflash2_context.as_ref().is_some_and(|context| {
+            dflash2_final_token_fits_context(context.logical_len(), dflash_context_capacity)
+        });
         if finish_reason == "length"
             && !last_in_cache
+            && final_token_fits_context
             && let Some(&last) = generated.last()
         {
             if let Err(error) = self.dflash2_materialize_final(last, generation_stream) {
@@ -653,7 +687,34 @@ impl Qwen35Inner {
 
 #[cfg(test)]
 mod tests {
-    use super::reusable_dflash2_prefix;
+    use super::{
+        constrain_dflash2_context_params, dflash2_final_token_fits_context, reusable_dflash2_prefix,
+    };
+    use crate::engine::extract_chat_params;
+    use crate::engine::types::ChatConfig;
+
+    #[test]
+    fn context_budget_uses_the_smaller_target_or_draft_window() {
+        let mut params = extract_chat_params(&ChatConfig {
+            max_new_tokens: Some(64),
+            ..ChatConfig::default()
+        });
+        let capacity = constrain_dflash2_context_params(10, 16, 12, &mut params)
+            .expect("valid prompt is clamped");
+        assert_eq!(capacity, 12);
+        assert_eq!(params.max_new_tokens, 3);
+
+        let mut too_long = extract_chat_params(&ChatConfig::default());
+        let error = constrain_dflash2_context_params(13, 16, 12, &mut too_long)
+            .expect_err("prompt beyond draft context must fail before prefill");
+        assert!(error.reason.contains("effective active context is 12"));
+
+        assert!(dflash2_final_token_fits_context(11, capacity));
+        assert!(
+            !dflash2_final_token_fits_context(12, capacity),
+            "the final sampled token may be returned at capacity but must not be forwarded"
+        );
+    }
 
     #[test]
     fn continuation_requires_matching_prefix_and_flat_frontier() {

--- a/crates/mlx-core/src/models/qwen3_5/mod.rs
+++ b/crates/mlx-core/src/models/qwen3_5/mod.rs
@@ -3,6 +3,8 @@ pub mod arrays_cache;
 pub mod attention;
 pub mod config;
 pub mod decoder_layer;
+pub(crate) mod dflash2;
+pub(crate) mod dflash2_decode;
 pub mod gated_delta;
 pub mod gated_delta_net;
 pub(crate) mod gdn_checkpoint_store;

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -11577,6 +11577,76 @@ impl Qwen35Inner {
     }
 }
 
+fn resolve_qwen35_chat_params(
+    config: &ChatConfig,
+    defaults: &crate::engine::ModelGenerationDefaults,
+    dflash_block_size: Option<usize>,
+) -> crate::engine::params::ChatParams {
+    // Mirror ChatBackend's default resolution before applying the
+    // algorithm-specific DFlash knobs. Overriding `resolve_params` must not
+    // discard generation_config.json defaults for ordinary Qwen turns.
+    let mut merged = config.clone();
+    crate::engine::apply_generation_defaults(&mut merged, defaults);
+    let mut params = crate::engine::extract_chat_params(&merged);
+    if let Some(block_size) = dflash_block_size {
+        params.mtp_depth = config
+            .mtp_depth
+            .map(|depth| (depth.max(1) as usize).min(block_size))
+            .unwrap_or(block_size);
+        params.mtp_adaptive_depth = config.mtp_adaptive_depth.unwrap_or(false);
+    }
+    params
+}
+
+#[cfg(test)]
+mod qwen35_param_resolution_tests {
+    use super::*;
+
+    #[test]
+    fn dflash_override_preserves_generation_defaults_and_request_precedence() {
+        let defaults = crate::engine::ModelGenerationDefaults {
+            temperature: Some(0.35),
+            top_k: Some(17),
+            top_p: Some(0.82),
+            min_p: Some(0.04),
+            repetition_penalty: Some(1.08),
+            ..crate::engine::ModelGenerationDefaults::default()
+        };
+        let ordinary = resolve_qwen35_chat_params(&ChatConfig::default(), &defaults, None);
+        let sampling = ordinary.sampling_config.expect("sampling config");
+        assert_eq!(sampling.temperature, Some(0.35));
+        assert_eq!(sampling.top_k, Some(17));
+        assert_eq!(ordinary.repetition_penalty, 1.08);
+        assert_eq!(ordinary.mtp_depth, 1);
+
+        let params = resolve_qwen35_chat_params(&ChatConfig::default(), &defaults, Some(8));
+        let sampling = params.sampling_config.expect("sampling config");
+        assert_eq!(sampling.temperature, Some(0.35));
+        assert_eq!(sampling.top_k, Some(17));
+        assert_eq!(sampling.top_p, Some(0.82));
+        assert_eq!(sampling.min_p, Some(0.04));
+        assert_eq!(params.repetition_penalty, 1.08);
+        assert_eq!(params.mtp_depth, 8);
+
+        let explicit = resolve_qwen35_chat_params(
+            &ChatConfig {
+                temperature: Some(0.0),
+                top_k: Some(3),
+                repetition_penalty: Some(1.0),
+                mtp_depth: Some(2),
+                ..ChatConfig::default()
+            },
+            &defaults,
+            Some(8),
+        );
+        let sampling = explicit.sampling_config.expect("sampling config");
+        assert_eq!(sampling.temperature, Some(0.0));
+        assert_eq!(sampling.top_k, Some(3));
+        assert_eq!(explicit.repetition_penalty, 1.0);
+        assert_eq!(explicit.mtp_depth, 2);
+    }
+}
+
 impl ChatBackend for Qwen35Inner {
     fn tokenizer(&self) -> Result<Arc<Qwen3Tokenizer>> {
         self.tokenizer
@@ -11614,15 +11684,11 @@ impl ChatBackend for Qwen35Inner {
     }
 
     fn resolve_params(&self, config: &ChatConfig) -> crate::engine::params::ChatParams {
-        let mut params = crate::engine::extract_chat_params(config);
-        if let Some(draft) = self.dflash2.as_ref() {
-            params.mtp_depth = config
-                .mtp_depth
-                .map(|depth| (depth.max(1) as usize).min(draft.config.block_size))
-                .unwrap_or(draft.config.block_size);
-            params.mtp_adaptive_depth = config.mtp_adaptive_depth.unwrap_or(false);
-        }
-        params
+        resolve_qwen35_chat_params(
+            config,
+            &self.gen_defaults,
+            self.dflash2.as_ref().map(|draft| draft.config.block_size),
+        )
     }
 
     fn extra_eos_ids(&self) -> Vec<u32> {

--- a/crates/mlx-core/src/models/qwen3_5/model.rs
+++ b/crates/mlx-core/src/models/qwen3_5/model.rs
@@ -828,6 +828,11 @@ pub(crate) struct Qwen35Inner {
     pub(crate) layers: Vec<DecoderLayer>,
     pub(crate) final_norm: RMSNorm,
     pub(crate) lm_head: Option<LinearProj>,
+    /// Optional external DFlash2 companion. When installed it takes
+    /// precedence over the target checkpoint's inline one-layer MTP head.
+    pub(crate) dflash2: Option<super::dflash2::DFlash2Model>,
+    pub(crate) dflash2_context: Option<super::dflash2::DFlash2ContextCache>,
+    pub(crate) dflash2_turn_state: Option<super::dflash2_decode::DFlash2TurnState>,
     pub(crate) caches: Option<Vec<Qwen3_5LayerCache>>,
     pub(crate) tokenizer: Option<Arc<Qwen3Tokenizer>>,
     pub(crate) vision_encoder: Option<Arc<Qwen3_5VisionEncoder>>,
@@ -1585,6 +1590,9 @@ impl Qwen35Inner {
             layers,
             final_norm,
             lm_head,
+            dflash2: None,
+            dflash2_context: None,
+            dflash2_turn_state: None,
             caches: None,
             tokenizer: None,
             vision_encoder: None,
@@ -1933,9 +1941,16 @@ impl Qwen35Inner {
             }
         }
         self.caches = None;
+        self.dflash2_context = None;
+        self.dflash2_turn_state = None;
         self.scheduled_recurrent = RecurrentStateTable::stage2();
         self.active_scheduled_seq = None;
         self.clear_reuse_state();
+        // No cache owner remains after a full reset. Clear both transition
+        // latches so the next flat prefill becomes authoritative instead of
+        // inheriting the preceding paged/partial-MTP lane's provenance.
+        self.paged_full_attn_caches_dirty = false;
+        self.flat_mtp_caches_desynced = false;
         // A full session reset must also clear the MTP acceptance gate
         // state: a new independent chat on this model starts fresh (probes)
         // instead of inheriting the previous chat's rejection.
@@ -9621,6 +9636,10 @@ impl Qwen35Inner {
     pub(crate) fn has_mtp_weights(&self) -> bool {
         self.mtp.is_some() && self.mtp_weights_loaded
     }
+
+    pub(crate) fn has_speculative_weights(&self) -> bool {
+        self.dflash2.is_some() || self.has_mtp_weights()
+    }
 }
 
 /// Adapter giving the engine's [`ChunkSink`] the `.call()` shape the
@@ -10359,6 +10378,11 @@ impl Qwen35Inner {
         self.preflight_paged_context(args.tokens.len(), &mut constrained_params)?;
         // Only dirty the flat-attention mirror after deterministic preflight
         // succeeds. A rejected request has not touched the paged adapter.
+        // The DFlash2 context belongs to that flat mirror, so discard it at
+        // the same ownership boundary. In particular, a future equal-length
+        // prompt must not mistake this stale draft K/V for the paged prefix.
+        self.dflash2_context = None;
+        self.dflash2_turn_state = None;
         self.paged_full_attn_caches_dirty = true;
         let mut constrained_args = WholeTurnArgs {
             tokens: args.tokens,
@@ -11589,6 +11613,18 @@ impl ChatBackend for Qwen35Inner {
         Some(&self.gen_defaults)
     }
 
+    fn resolve_params(&self, config: &ChatConfig) -> crate::engine::params::ChatParams {
+        let mut params = crate::engine::extract_chat_params(config);
+        if let Some(draft) = self.dflash2.as_ref() {
+            params.mtp_depth = config
+                .mtp_depth
+                .map(|depth| (depth.max(1) as usize).min(draft.config.block_size))
+                .unwrap_or(draft.config.block_size);
+            params.mtp_adaptive_depth = config.mtp_adaptive_depth.unwrap_or(false);
+        }
+        params
+    }
+
     fn extra_eos_ids(&self) -> Vec<u32> {
         self.gen_defaults.eos_token_ids.clone()
     }
@@ -11603,6 +11639,8 @@ impl ChatBackend for Qwen35Inner {
     }
 
     fn reset_caches(&mut self, scope: ResetScope) -> Result<()> {
+        self.dflash2_context = None;
+        self.dflash2_turn_state = None;
         match scope {
             // Prefix-miss reset: reset each live layer cache, then install a
             // fresh hybrid cache vec. PRESERVES `cached_token_history` /
@@ -11803,6 +11841,26 @@ impl ChatBackend for Qwen35Inner {
     }
 
     fn execution_plan(&self) -> ExecutionPlan {
+        let speculative = if self.dflash2.is_some() {
+            Some(SpeculativePlan {
+                kind: SpeculativeKind::DraftModel,
+                supported_input_media: MediaCapabilities::NONE,
+                supported_context_media: MediaCapabilities::NONE,
+                // DFlash2 verification currently uses the flat hybrid-cache
+                // snapshot/tape replay path. The target's paged adapter stays
+                // installed for ordinary AR turns but is not used here.
+                supports_paged_attention: false,
+                supports_streaming: true,
+            })
+        } else {
+            self.has_mtp_weights().then_some(SpeculativePlan {
+                kind: SpeculativeKind::NativeMtp,
+                supported_input_media: MediaCapabilities::NONE,
+                supported_context_media: MediaCapabilities::IMAGES,
+                supports_paged_attention: true,
+                supports_streaming: true,
+            })
+        };
         ExecutionPlan {
             media: qwen35_dense_media_plan(
                 self.vision_encoder.is_some(),
@@ -11812,25 +11870,17 @@ impl ChatBackend for Qwen35Inner {
             paged_attention: self.paged_adapter.as_ref().map(|_| PagedAttentionPlan {
                 supports_delta: true,
             }),
-            speculative: self.has_mtp_weights().then_some(SpeculativePlan {
-                kind: SpeculativeKind::NativeMtp,
-                supported_input_media: MediaCapabilities::NONE,
-                // A text delta can continue an image-derived live session
-                // with native MTP. The current turn carries no image bytes;
-                // the eager paged-MTP core verifies against the target's
-                // existing paged KV context. This is the same route the old
-                // session dispatcher selected: its paged probe ran before the
-                // MTP probe and dense `paged_turn` handled MTP directly.
-                supported_context_media: MediaCapabilities::IMAGES,
-                supports_paged_attention: true,
-                supports_streaming: true,
-            }),
+            speculative,
         }
     }
 
     fn wired_limit_bytes(&self) -> Option<usize> {
         // Per-turn wired-memory limit = the model's estimated footprint.
-        Some(self.config.estimate_memory_bytes() as usize)
+        let draft = self
+            .dflash2
+            .as_ref()
+            .map_or(0usize, |draft| draft.weight_bytes as usize);
+        Some((self.config.estimate_memory_bytes() as usize).saturating_add(draft))
     }
 
     fn profiler_label(&self, is_delta: bool, is_streaming: bool) -> &'static str {
@@ -11892,11 +11942,13 @@ impl ChatBackend for Qwen35Inner {
         // MTP weights, flat-cache admission, and text-only input. The dense
         // core retains the algorithm-specific MTP gate and AR fallback.
         debug_assert!(args.media.is_empty());
-        debug_assert!(matches!(
-            args.plan.decoder,
-            DecoderPlan::Speculative(SpeculativeKind::NativeMtp)
-        ));
-        self.dense_whole_turn(args)
+        match args.plan.decoder {
+            DecoderPlan::Speculative(SpeculativeKind::DraftModel) => self.dflash2_chat_turn(args),
+            DecoderPlan::Speculative(SpeculativeKind::NativeMtp) => self.dense_whole_turn(args),
+            _ => Err(Error::from_reason(
+                "Qwen3.5 speculative turn received a non-speculative decoder plan",
+            )),
+        }
     }
 
     fn run_multimodal_turn(&mut self, args: &mut WholeTurnArgs<'_>) -> Result<TurnOutput> {
@@ -11919,6 +11971,13 @@ pub struct Qwen3_5GenerationConfig {
     pub top_p: Option<f64>,
     #[napi(ts_type = "number | undefined")]
     pub min_p: Option<f64>,
+}
+
+#[napi(object)]
+#[derive(Debug, Clone, Default)]
+pub struct Qwen35LoadOptions {
+    /// External z-lab DFlash2 checkpoint directory.
+    pub draft_model_path: Option<String>,
 }
 
 /// Generation result
@@ -11977,11 +12036,11 @@ pub struct Qwen3_5Model {
     /// flat path. Dense image turns only run on the paged-vision core. Surfaced
     /// through the `hasBlockPagedCache()` NAPI method.
     pub(crate) paged_active: bool,
-    /// Snapshot of `Qwen35Inner::has_mtp_weights()` captured
+    /// Snapshot of `Qwen35Inner::has_speculative_weights()` captured
     /// at construction time, mirroring `paged_active`. Surfaced through
     /// the `hasMtpWeights()` NAPI method so the TS ChatSession can
-    /// auto-default `enableMtp = true` for checkpoints that ship an MTP
-    /// head without round-tripping through the model thread.
+    /// auto-default `enableMtp = true` for inline MTP or an attached DFlash2
+    /// companion without round-tripping through the model thread.
     pub(crate) mtp_active: bool,
     /// Snapshot of the fully loaded image execution stack. `true` only when
     /// the vision encoder and image processor were both installed and the
@@ -12062,11 +12121,9 @@ impl Qwen3_5Model {
         send_and_await(&self.thread, |reply| Qwen35Cmd::SchedulerStats { reply }).await
     }
 
-    /// Whether this checkpoint shipped an MTP head (module loaded by
-    /// `persistence::apply_weights_inner`). Snapshotted at load time from
-    /// `Qwen35Inner::has_mtp_weights()` so the TS `ChatSession` can
-    /// auto-default `enableMtp = true` for MTP-capable checkpoints without
-    /// dispatching a command into the model thread.
+    /// Whether this instance has an inline MTP head or external DFlash2
+    /// companion. Snapshotted at load time so `ChatSession` can auto-default
+    /// `enableMtp = true` without dispatching into the model thread.
     ///
     /// Note: this only reports weight availability. Whether the
     /// speculative-decode path actually runs on a given call also requires the
@@ -12121,7 +12178,8 @@ impl Qwen3_5Model {
     /// - model.safetensors (or model-*.safetensors)
     /// - tokenizer.json + tokenizer_config.json
     #[napi]
-    pub async fn load(path: String) -> Result<Qwen3_5Model> {
+    pub async fn load(path: String, options: Option<Qwen35LoadOptions>) -> Result<Qwen3_5Model> {
+        let draft_model_path = options.and_then(|options| options.draft_model_path);
         let source = std::path::Path::new(&path);
         if source.is_file()
             && source
@@ -12130,9 +12188,9 @@ impl Qwen3_5Model {
                 .is_some_and(|extension| extension.eq_ignore_ascii_case("gguf"))
         {
             let cache = crate::utils::gguf::prepare_qwen35_native_gguf(source).await?;
-            return persistence::load_with_thread(&cache.to_string_lossy()).await;
+            return persistence::load_with_thread(&cache.to_string_lossy(), draft_model_path).await;
         }
-        persistence::load_with_thread(&path).await
+        persistence::load_with_thread(&path, draft_model_path).await
     }
 
     /// Generate text from a prompt token sequence.
@@ -12433,7 +12491,7 @@ crate::models::chat_napi::chat_napi_surface! {
 /// At 1024-prompt single-chunk the value is irrelevant — the loop is
 /// guarded by `total_len - offset > PREFILL_STEP_SIZE` so any T < step
 /// goes through the single `remaining` branch unchanged.
-const PREFILL_STEP_SIZE: i64 = 2048;
+pub(crate) const PREFILL_STEP_SIZE: i64 = 2048;
 
 /// Evaluate all cache arrays across all layers to materialize them on GPU.
 /// Must be called between prefill chunks to break lazy dependency chains.
@@ -12812,6 +12870,71 @@ fn forward_pre_norm_inner_with_tape(
     }
 
     Ok(h)
+}
+
+/// Target forward used by the external DFlash2 stepper. Captures post-layer
+/// residuals in the companion checkpoint's declared order and optionally
+/// records the GDN recurrence tape needed to roll a speculative verify block
+/// back to its accepted prefix.
+pub(crate) fn forward_dflash2_with_taps(
+    inner: &mut Qwen35Inner,
+    input_ids: &MxArray,
+    tap_layers: &[usize],
+    record_tape: bool,
+) -> Result<(
+    MxArray,
+    Vec<MxArray>,
+    Vec<Option<super::gated_delta_net::GdnLayerTape>>,
+)> {
+    if tap_layers.is_empty() || tap_layers.iter().any(|&layer| layer >= inner.layers.len()) {
+        return Err(Error::from_reason(format!(
+            "DFlash2 target tap layers are invalid: {tap_layers:?} for {} layers",
+            inner.layers.len()
+        )));
+    }
+    let mut hidden = inner.embedding.forward(input_ids)?;
+    let mut taps: Vec<Option<MxArray>> = vec![None; tap_layers.len()];
+    let mut tape = std::iter::repeat_with(|| None)
+        .take(inner.layers.len())
+        .collect::<Vec<_>>();
+    for index in 0..inner.layers.len() {
+        let cache = inner.caches.as_mut().map(|caches| &mut caches[index]);
+        hidden = if record_tape {
+            let mut slot = None;
+            let hidden = inner.layers[index].forward_with_tape(
+                &hidden,
+                None,
+                cache,
+                None,
+                true,
+                Some(&mut slot),
+            )?;
+            tape[index] = slot;
+            hidden
+        } else {
+            inner.layers[index].forward(&hidden, None, cache, None, true)?
+        };
+        for (slot, &tap_layer) in tap_layers.iter().enumerate() {
+            if tap_layer == index {
+                taps[slot] = Some(hidden.clone());
+            }
+        }
+    }
+    let taps = taps
+        .into_iter()
+        .enumerate()
+        .map(|(slot, tap)| {
+            tap.ok_or_else(|| {
+                Error::from_reason(format!(
+                    "DFlash2 target tap {} at layer {} was not captured",
+                    slot, tap_layers[slot]
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let normalized = inner.final_norm.forward(&hidden)?;
+    let logits = project_logits_from_hidden(&normalized, &inner.lm_head, &inner.embedding)?;
+    Ok((logits, taps, tape))
 }
 
 fn project_logits_from_hidden(
@@ -18252,9 +18375,13 @@ mod paged_gdn_frontier_tests {
         let mut inner = Qwen35Inner::new(tiny_cfg()).expect("construct tiny dense model");
         inner.paged_gdn_state_dirty = true;
         inner.paged_gdn_force_mismatch_for_test = true;
+        inner.paged_full_attn_caches_dirty = true;
+        inner.flat_mtp_caches_desynced = true;
         inner.reset_caches_sync().expect("reset");
         assert!(!inner.paged_gdn_state_dirty);
         assert!(!inner.paged_gdn_force_mismatch_for_test);
+        assert!(!inner.paged_full_attn_caches_dirty);
+        assert!(!inner.flat_mtp_caches_desynced);
     }
 }
 

--- a/crates/mlx-core/src/models/qwen3_5/persistence.rs
+++ b/crates/mlx-core/src/models/qwen3_5/persistence.rs
@@ -1940,7 +1940,10 @@ fn validate_mandatory_weights(
 /// Spawns a `ModelThread<Qwen35Cmd>` whose resident state owns the dense
 /// hybrid scheduler after loading all weights inside the init function.
 /// Returns a `Qwen3_5Model` thin shell with the thread handle.
-pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
+pub async fn load_with_thread(
+    model_path: &str,
+    draft_model_path: Option<String>,
+) -> Result<Qwen3_5Model> {
     let model_assets_path = model_path.to_string();
     let model_path = model_assets_path.clone();
 
@@ -2194,6 +2197,16 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
                     crate::array::memory::materialize_weights(&arrays)?
                 };
 
+                let dflash2_weight_bytes = if let Some(draft_path) = draft_model_path.as_deref() {
+                    let (draft, bytes) = super::dflash2::load_dflash2(Path::new(draft_path))?;
+                    draft.validate_target(&config)?;
+                    inner.dflash2 = Some(draft);
+                    info!("Loaded external Qwen3.8 DFlash2 companion from {draft_path}");
+                    bytes
+                } else {
+                    0
+                };
+
                 // Set tokenizer
                 if let Some(tok) = tokenizer {
                     inner.set_tokenizer(Arc::new(tok));
@@ -2338,6 +2351,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
                 // The raw Uint8 weights + scales are already in `params`.
                 // Count only the retained BF16 correctness fallback arrays.
                 weight_bytes = weight_bytes.saturating_add(plain_fp8_residency.nbytes());
+                weight_bytes = weight_bytes.saturating_add(dflash2_weight_bytes);
 
                 Ok((inner, weight_bytes, pool_cache_limit_guard))
             })();
@@ -2363,7 +2377,7 @@ pub async fn load_with_thread(model_path: &str) -> Result<Qwen3_5Model> {
             let spatial_merge_size = inner.spatial_merge_size.unwrap_or(2);
             let tokenizer_out = inner.tokenizer.clone();
             let paged_active = inner.paged_adapter.is_some();
-            let mtp_active = inner.has_mtp_weights();
+            let mtp_active = inner.has_speculative_weights();
             let vision_active = super::model::qwen35_dense_vision_active(
                 inner.vision_encoder.is_some(),
                 inner.image_processor.is_some(),

--- a/crates/mlx-core/src/sampling.rs
+++ b/crates/mlx-core/src/sampling.rs
@@ -121,6 +121,56 @@ pub(crate) struct SparseDistributionRows {
 }
 
 impl SparseDistribution {
+    pub(crate) fn from_parts(
+        token_ids: Vec<i32>,
+        mut probs: Vec<f64>,
+        vocab_size: usize,
+    ) -> Result<Self> {
+        if token_ids.is_empty() || token_ids.len() != probs.len() || vocab_size == 0 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                format!(
+                    "invalid sparse distribution: ids={} probs={} vocab={vocab_size}",
+                    token_ids.len(),
+                    probs.len()
+                ),
+            ));
+        }
+        let mut seen = std::collections::HashSet::with_capacity(token_ids.len());
+        let mut total = 0.0f64;
+        for (&token_id, &prob) in token_ids.iter().zip(probs.iter()) {
+            if token_id < 0 || token_id as usize >= vocab_size || !seen.insert(token_id) {
+                return Err(Error::new(
+                    Status::InvalidArg,
+                    format!(
+                        "invalid sparse distribution token id {token_id} for vocab {vocab_size}"
+                    ),
+                ));
+            }
+            if !prob.is_finite() || prob < 0.0 {
+                return Err(Error::new(
+                    Status::InvalidArg,
+                    format!("invalid sparse distribution probability {prob}"),
+                ));
+            }
+            total += prob;
+        }
+        if !total.is_finite() || total <= 0.0 {
+            return Err(Error::new(
+                Status::InvalidArg,
+                "sparse distribution has no positive probability mass".to_string(),
+            ));
+        }
+        for prob in &mut probs {
+            *prob /= total;
+        }
+        Ok(Self {
+            token_ids,
+            probs,
+            vocab_size,
+        })
+    }
+
     pub(crate) fn as_row(&self) -> SparseDistributionRef<'_> {
         SparseDistributionRef {
             token_ids: &self.token_ids,
@@ -939,6 +989,72 @@ pub(crate) fn accept_with_residual_sparse<R: Rng + ?Sized>(
         false,
         sample_sparse_slices(&residual_ids, &residual_probs, rng)?,
     ))
+}
+
+/// Exact speculative acceptance for a dense target distribution and a sparse
+/// proposal. DFlash2's selector has only 16 candidates even when the target
+/// sampler has full-vocabulary support.
+pub(crate) fn accept_with_residual_dense_target_sparse_draft<R: Rng + ?Sized>(
+    target_p: &MxArray,
+    draft_q: SparseDistributionRef<'_>,
+    draft_id: i32,
+    rng: &mut R,
+) -> Result<(bool, i32)> {
+    if draft_id < 0 || target_p.ndim()? as usize != 1 {
+        return Err(Error::new(
+            Status::InvalidArg,
+            "dense-target/sparse-draft acceptance requires a non-negative draft id and 1D target"
+                .to_string(),
+        ));
+    }
+    let vocab = target_p.shape_at(0)? as usize;
+    if vocab != draft_q.vocab_size || draft_id as usize >= vocab {
+        return Err(Error::new(
+            Status::InvalidArg,
+            format!(
+                "dense-target/sparse-draft vocab mismatch: target={vocab} draft={} id={draft_id}",
+                draft_q.vocab_size
+            ),
+        ));
+    }
+
+    let target = target_p.astype(DType::Float32)?;
+    target.eval();
+    let p = f64::from(target.item_at_float32(draft_id as usize)?);
+    let q = draft_q.probability(draft_id);
+    let u: f64 = rng.random();
+    if u < acceptance_probability_from_probs(p, q) {
+        return Ok((true, draft_id));
+    }
+
+    // Rejection is the cold branch. Scatter only the selector's tiny support
+    // into a dense GPU row, then use the same MLX residual/categorical path as
+    // dense speculative acceptance. Accepted proposals never copy the full
+    // target distribution to CPU.
+    let ids = MxArray::from_int32(draft_q.token_ids, &[draft_q.token_ids.len() as i64])?;
+    let values = draft_q
+        .probs
+        .iter()
+        .map(|&prob| prob as f32)
+        .collect::<Vec<_>>();
+    let values = MxArray::from_float32(&values, &[values.len() as i64])?;
+    let sparse_dense =
+        MxArray::zeros(&[vocab as i64], Some(DType::Float32))?.put_along_axis(&ids, &values, 0)?;
+    let residual = target.sub(&sparse_dense)?.clip(Some(0.0), None)?;
+    let total_array = residual.sum(None, None)?;
+    total_array.eval();
+    let total = total_array.item_at_float32(0)?;
+    if !total.is_finite() || total <= 0.0 {
+        let best = target.argmax(0, None)?;
+        best.eval();
+        return Ok((false, best.item_at_int32(0)?));
+    }
+    let sampled = residual
+        .div_scalar(f64::from(total))?
+        .log()?
+        .categorical(Some(-1))?;
+    sampled.eval();
+    Ok((false, sampled.item_at_int32(0)?))
 }
 
 pub(crate) fn acceptance_probability_from_probs(p: f64, q: f64) -> f64 {
@@ -1986,6 +2102,26 @@ mod accept_with_residual_tests {
         let mut data = vec![0.0f32; vocab];
         data[token] = 1.0;
         MxArray::from_float32(&data, &[vocab as i64]).expect("from_float32")
+    }
+
+    #[test]
+    fn dense_target_sparse_draft_rejects_and_samples_full_vocab_residual() {
+        let target = MxArray::from_float32(&[0.1, 0.9, 0.0], &[3]).expect("target");
+        let draft =
+            SparseDistribution::from_parts(vec![0, 2], vec![0.8, 0.2], 3).expect("sparse draft");
+        let mut rng = ScriptedRng::new(&[u64::MAX]);
+        let (accepted, token) =
+            accept_with_residual_dense_target_sparse_draft(&target, draft.as_row(), 0, &mut rng)
+                .expect("dense/sparse correction");
+        assert!(!accepted);
+        assert_eq!(token, 1);
+    }
+
+    #[test]
+    fn sparse_distribution_constructor_rejects_duplicate_support() {
+        let error = SparseDistribution::from_parts(vec![1, 1], vec![0.5, 0.5], 3)
+            .expect_err("duplicate support must fail");
+        assert!(error.reason.contains("token id 1"));
     }
 
     /// SamplingConfig with `temperature = 1.0` — keeps the stochastic

--- a/crates/mlx-core/tests/p2_paged_thinking_honors_enable.rs
+++ b/crates/mlx-core/tests/p2_paged_thinking_honors_enable.rs
@@ -165,7 +165,7 @@ async fn qwen3_5_paged_honors_enable_thinking() {
         Err(e) => panic!("failed to clone model dir with paged forced on: {e}"),
     };
 
-    let model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string())
+    let model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load paged Qwen3.5 Dense model");
     assert!(

--- a/crates/mlx-core/tests/qwen3_5_cold_tier_parity.rs
+++ b/crates/mlx-core/tests/qwen3_5_cold_tier_parity.rs
@@ -138,7 +138,7 @@ async fn qwen3_5_cold_tier_restart_parity() {
         |model_dir, messages, config| async move {
             // Loaded fresh per instance and dropped when this future
             // completes, so instance 2 really starts from an empty hot cache.
-            let model = qwen3_5_load_with_thread(&model_dir.to_string_lossy()).await?;
+            let model = qwen3_5_load_with_thread(&model_dir.to_string_lossy(), None).await?;
             model.chat_session_start(messages, Some(config)).await
         },
     )

--- a/crates/mlx-core/tests/qwen3_5_concurrent_batched_parity.rs
+++ b/crates/mlx-core/tests/qwen3_5_concurrent_batched_parity.rs
@@ -74,7 +74,7 @@ async fn asymmetric_finish_and_cross_owner_warm_wave_match_serial() {
     // created. No sibling test runs in this binary.
     unsafe { std::env::set_var("MLX_CONTINUOUS_BATCHING", "1") };
     unsafe { std::env::set_var("MLX_SERVE_FORCE_SERIAL", "1") };
-    let model = load_with_thread(&path.to_string_lossy())
+    let model = load_with_thread(&path.to_string_lossy(), None)
         .await
         .expect("load qwen3.5");
     assert!(model.has_block_paged_cache(), "gate requires paged Qwen3.5");

--- a/crates/mlx-core/tests/qwen3_5_delta_chat.rs
+++ b/crates/mlx-core/tests/qwen3_5_delta_chat.rs
@@ -243,7 +243,7 @@ async fn session_path_keeps_ttft_flat_across_turns() {
     );
 
     // Load the model via the normal async path.
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Qwen3.5 model");
 
@@ -493,7 +493,7 @@ async fn stream_session_path_keeps_ttft_flat_across_turns() {
         model_path
     );
 
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Qwen3.5 model");
 
@@ -630,7 +630,7 @@ async fn stream_session_cancellation_preserves_cache_for_next_turn() {
         model_path
     );
 
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Qwen3.5 model");
 
@@ -750,7 +750,7 @@ async fn session_continue_rejects_images_with_restart_prefix() {
         model_path
     );
 
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Qwen3.5 model");
 
@@ -796,7 +796,7 @@ async fn session_continue_tool_round_trips() {
         model_path
     );
 
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Qwen3.5 model");
 
@@ -869,7 +869,7 @@ async fn session_start_accepts_images_for_vlm() {
     let image_uint8: napi::bindgen_prelude::Uint8Array =
         napi::bindgen_prelude::Uint8Array::new(image_bytes);
 
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Qwen3.5 VLM model");
 
@@ -960,7 +960,7 @@ async fn nonpositive_budget_emits_zero_tokens_mtp_matches_ar() {
     );
 
     let flat_dir = flat_clone_model_dir(model_dir, "nonpos").expect("flat clone failed");
-    let model = Qwen3_5Model::load(flat_dir.to_string_lossy().into_owned())
+    let model = Qwen3_5Model::load(flat_dir.to_string_lossy().into_owned(), None)
         .await
         .expect("failed to load Qwen3.5 model");
 
@@ -1176,7 +1176,7 @@ async fn cancel_midcycle_then_continue_mtp_keeps_session_usable() {
     );
 
     let flat_dir = flat_clone_model_dir(model_dir, "cancel").expect("flat clone failed");
-    let model = Qwen3_5Model::load(flat_dir.to_string_lossy().into_owned())
+    let model = Qwen3_5Model::load(flat_dir.to_string_lossy().into_owned(), None)
         .await
         .expect("failed to load Qwen3.5 model");
 
@@ -1365,7 +1365,7 @@ async fn desync_heal_reprefills_to_uncancelled() {
         "MLX_TEST_MODEL_PATH does not exist: {model_path}"
     );
     let flat_dir = flat_clone_model_dir(model_dir, "heal").expect("flat clone failed");
-    let model = Qwen3_5Model::load(flat_dir.to_string_lossy().into_owned())
+    let model = Qwen3_5Model::load(flat_dir.to_string_lossy().into_owned(), None)
         .await
         .expect("failed to load Qwen3.5 model");
     if !model.has_mtp_weights() {

--- a/crates/mlx-core/tests/qwen3_5_paged_mtp_midcycle.rs
+++ b/crates/mlx-core/tests/qwen3_5_paged_mtp_midcycle.rs
@@ -161,7 +161,7 @@ async fn load_paged_mtp_model_or_skip() -> Option<Qwen3_5Model> {
         model_dir.exists(),
         "MLX_TEST_MODEL_PATH does not exist: {model_path}"
     );
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Qwen3.5 model");
     if !model.has_mtp_weights() {

--- a/crates/mlx-core/tests/qwen3_5_paged_vs_flat_parity.rs
+++ b/crates/mlx-core/tests/qwen3_5_paged_vs_flat_parity.rs
@@ -186,7 +186,7 @@ async fn qwen3_5_paged_vs_flat_greedy_token_parity() {
     };
 
     let prompts = parity_prompts();
-    let flat_model = Qwen3_5Model::load(flat_dir.to_string_lossy().to_string())
+    let flat_model = Qwen3_5Model::load(flat_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load flat-path Qwen3.5 model");
     let mut flat_results = Vec::with_capacity(prompts.len());
@@ -210,7 +210,7 @@ async fn qwen3_5_paged_vs_flat_greedy_token_parity() {
         .expect("flat-path Qwen3.5 model thread panicked during teardown");
     mlx_core::array::synchronize_and_clear_cache();
 
-    let paged_model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string())
+    let paged_model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load paged-path Qwen3.5 model");
     assert!(

--- a/crates/mlx-core/tests/qwen3_5_paged_vs_flat_vlm_parity.rs
+++ b/crates/mlx-core/tests/qwen3_5_paged_vs_flat_vlm_parity.rs
@@ -285,7 +285,7 @@ async fn qwen3_5_paged_vlm_correctness() {
     let paged_dir =
         clone_model_dir(&src, "qwen35-vlm-paged", true).expect("clone paged model dir failed");
 
-    let paged_model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string())
+    let paged_model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load paged-path Qwen3.5-VL model");
 
@@ -385,7 +385,7 @@ async fn qwen3_5_paged_vlm_image_prefix_cache_lifecycle() {
 
     let paged_dir = clone_model_dir(&src, "qwen35-vlm-image-prefix-cache", true)
         .expect("clone paged model dir failed");
-    let model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string())
+    let model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load paged-path Qwen3.5-VL model");
 
@@ -581,7 +581,7 @@ async fn qwen3_5_paged_vlm_continue_preserves_image_context() {
 
     let paged_dir = clone_model_dir(&src, "qwen35-vlm-paged-continue", true)
         .expect("clone paged model dir failed");
-    let paged_model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string())
+    let paged_model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load paged-path Qwen3.5-VL model");
 
@@ -672,7 +672,7 @@ async fn qwen3_5_flat_vlm_image_turn_errors_without_paged_backend() {
     // the vision→paged load-force, so no paged adapter is built.
     let flat_dir =
         clone_model_dir(&src, "qwen35-vlm-flat-error", false).expect("clone flat model dir failed");
-    let flat_model = Qwen3_5Model::load(flat_dir.to_string_lossy().to_string())
+    let flat_model = Qwen3_5Model::load(flat_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load flat-path Qwen3.5-VL model");
 

--- a/crates/mlx-core/tests/qwen3_5_session.rs
+++ b/crates/mlx-core/tests/qwen3_5_session.rs
@@ -160,7 +160,7 @@ async fn qwen3_5_session_reset_purges_prefix_cache_cold_prefill() {
         Err(e) => panic!("failed to clone model dir with paged forced on: {e}"),
     };
 
-    let model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string())
+    let model = Qwen3_5Model::load(paged_dir.to_string_lossy().to_string(), None)
         .await
         .expect("failed to load paged Qwen3.5 Dense model");
     assert!(

--- a/crates/mlx-core/tests/qwen3_5_sym8_smoke.rs
+++ b/crates/mlx-core/tests/qwen3_5_sym8_smoke.rs
@@ -39,7 +39,7 @@ async fn sym8_checkpoint_loads_and_generates_coherent_text() {
         model_path
     );
 
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load sym8 Qwen3.5 model");
 

--- a/crates/mlx-core/tests/qwen3_5_vl_image_chat.rs
+++ b/crates/mlx-core/tests/qwen3_5_vl_image_chat.rs
@@ -218,7 +218,7 @@ async fn qwen3_5_vl_image_chat_t0_capture() {
     };
     let image = std::fs::read(&image_path).expect("failed to read test image");
 
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Qwen3.5-VL model");
 
@@ -328,7 +328,7 @@ async fn qwen3_5_vl_reads_document_text() {
     };
     let image = std::fs::read(&image_path).expect("failed to read test image");
 
-    let model = Qwen3_5Model::load(model_path.clone())
+    let model = Qwen3_5Model::load(model_path.clone(), None)
         .await
         .expect("failed to load Qwen3.5-VL model");
 

--- a/crates/mlx-core/tests/qwen3_8_dflash2.rs
+++ b/crates/mlx-core/tests/qwen3_8_dflash2.rs
@@ -1,0 +1,167 @@
+//! Real-checkpoint smoke for dense Qwen3.8 plus the external DFlash2 drafter.
+//!
+//! ```shell
+//! MLX_TEST_QWEN38_TARGET_PATH=/path/to/qwen3.8-27b-mlx \
+//! MLX_TEST_QWEN38_DFLASH2_PATH=/path/to/qwen3.8-27b-dflash2 \
+//! cargo test -p mlx-core --test qwen3_8_dflash2 -- --ignored --nocapture
+//! ```
+
+use mlx_core::engine::types::ChatConfig;
+use mlx_core::models::qwen3_5::model::{Qwen3_5Model, Qwen35LoadOptions};
+use mlx_core::tokenizer::ChatMessage;
+
+fn user_message(content: &str) -> ChatMessage {
+    ChatMessage {
+        role: "user".to_string(),
+        content: content.to_string(),
+        tool_calls: None,
+        tool_call_id: None,
+        is_error: None,
+        reasoning_content: None,
+        thinking_enabled: None,
+        images: None,
+        audio: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires real Qwen3.8 target and DFlash2 checkpoints"]
+async fn qwen38_dflash2_loads_and_runs_a_verified_cycle() {
+    let target =
+        std::env::var("MLX_TEST_QWEN38_TARGET_PATH").expect("set MLX_TEST_QWEN38_TARGET_PATH");
+    let draft =
+        std::env::var("MLX_TEST_QWEN38_DFLASH2_PATH").expect("set MLX_TEST_QWEN38_DFLASH2_PATH");
+    let model = Qwen3_5Model::load(
+        target,
+        Some(Qwen35LoadOptions {
+            draft_model_path: Some(draft),
+        }),
+    )
+    .await
+    .expect("load Qwen3.8 target with DFlash2 companion");
+    assert!(
+        model.has_mtp_weights(),
+        "external DFlash2 must advertise speculative capability"
+    );
+
+    let result = model
+        .chat_session_start(
+            vec![user_message(
+                "Reply with one short sentence about the Moon.",
+            )],
+            Some(ChatConfig {
+                max_new_tokens: Some(8),
+                temperature: Some(0.0),
+                report_performance: Some(true),
+                enable_mtp: Some(true),
+                mtp_depth: Some(2),
+                reasoning_effort: Some("none".to_string()),
+                ..ChatConfig::default()
+            }),
+        )
+        .await
+        .expect("DFlash2 chat turn");
+    assert!(result.num_tokens > 0 && result.num_tokens <= 8);
+    assert!(
+        result
+            .performance
+            .as_ref()
+            .and_then(|performance| performance.mtp_cycles)
+            .is_some_and(|cycles| cycles > 0),
+        "smoke must execute at least one DFlash2 propose/verify cycle"
+    );
+
+    // Exercise both cache owners without an explicit reset. Ordinary AR uses
+    // the target's default-on paged adapter; returning to DFlash2 must cross a
+    // cold flat-lane barrier and reproduce the original greedy result.
+    let paged = model
+        .chat_session_start(
+            vec![user_message("Reply with one short sentence about the Sun.")],
+            Some(ChatConfig {
+                max_new_tokens: Some(5),
+                temperature: Some(0.0),
+                report_performance: Some(true),
+                enable_mtp: Some(false),
+                reasoning_effort: Some("none".to_string()),
+                ..ChatConfig::default()
+            }),
+        )
+        .await
+        .expect("paged AR turn between DFlash2 turns");
+    assert!(paged.num_tokens > 0 && paged.num_tokens <= 5);
+    assert!(
+        paged
+            .performance
+            .as_ref()
+            .is_some_and(|performance| performance.mtp_cycles.is_none()),
+        "enable_mtp=false must stay on plain paged AR"
+    );
+
+    let replay = model
+        .chat_session_start(
+            vec![user_message(
+                "Reply with one short sentence about the Moon.",
+            )],
+            Some(ChatConfig {
+                max_new_tokens: Some(8),
+                temperature: Some(0.0),
+                report_performance: Some(true),
+                enable_mtp: Some(true),
+                mtp_depth: Some(2),
+                reasoning_effort: Some("none".to_string()),
+                ..ChatConfig::default()
+            }),
+        )
+        .await
+        .expect("DFlash2 turn after paged AR");
+    assert_eq!(
+        replay.raw_text, result.raw_text,
+        "paged-to-DFlash2 transition must match a cold greedy DFlash2 turn"
+    );
+    assert_eq!(
+        replay.cached_tokens, 0,
+        "paged target K/V must not be reported as reusable flat DFlash2 state"
+    );
+    assert!(
+        replay
+            .performance
+            .as_ref()
+            .and_then(|performance| performance.mtp_cycles)
+            .is_some_and(|cycles| cycles > 0),
+        "DFlash2 must resume after crossing the paged cache barrier"
+    );
+
+    model
+        .reset_caches()
+        .await
+        .expect("reset before sampled DFlash2 turn");
+    let sampled = model
+        .chat_session_start(
+            vec![user_message("Name one color.")],
+            Some(ChatConfig {
+                max_new_tokens: Some(5),
+                temperature: Some(0.7),
+                top_p: Some(0.9),
+                report_performance: Some(true),
+                enable_mtp: Some(true),
+                mtp_depth: Some(2),
+                reasoning_effort: Some("none".to_string()),
+                ..ChatConfig::default()
+            }),
+        )
+        .await
+        .expect("sampled sparse-selector DFlash2 turn");
+    assert!(sampled.num_tokens > 0 && sampled.num_tokens <= 5);
+    assert!(
+        sampled
+            .performance
+            .as_ref()
+            .and_then(|performance| performance.mtp_cycles)
+            .is_some_and(|cycles| cycles > 0),
+        "sampled smoke must execute sparse proposal correction"
+    );
+
+    model
+        .shutdown_for_test()
+        .expect("Qwen3.8 model thread must shut down cleanly");
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -410,6 +410,21 @@ Almost every flag belongs to pi and is forwarded verbatim; `mlx agent` only hand
 
 `mlx agent` discovers local models under the resolved models directory (`--models-dir <dir>`, else `MLX_MODELS_DIR`, else `modelsDir` in `~/.mlx-node/config.json`, else `~/.mlx-node/models`). A dash-leading path must use the `--models-dir=<dir>` form so it is not mistaken for another flag. Dense Qwen3.5/Qwen3.8 `Q<number>_K_XL.gguf` targets are also discovered when placed directly in that directory or one level inside a downloaded GGUF repository; each appears under its filename stem. Other GGUF variants and companion files such as imatrix, mmproj, draft, or DFlash2-only checkpoints are not advertised as agent models.
 
+To pair an XL GGUF target with DFlash2 automatically, use the mlx-node agent's embedded `draft/` convention:
+
+```text
+~/.mlx-node/models/qwen38-q4xl/
+├── config.json
+├── tokenizer.json
+├── tokenizer_config.json
+├── Qwen3.8-27B-UD-Q4_K_XL.gguf
+└── draft/
+    ├── config.json
+    └── model.safetensors
+```
+
+The root config and tokenizer files belong to the Qwen3.8 target. `draft/config.json` must declare `DFlash2DraftModel` in `architectures`; the draft weights stay in that directory exactly as published by z-lab. `draft/` may be a symlink to an existing local Hugging Face checkout. The agent advertises only `mlx/Qwen3.8-27B-UD-Q4_K_XL`, then passes `draft/` to the loader when that target becomes resident. mlx-vlm itself has no equivalent combined layout: it receives the same two paths explicitly through `--model` and `--draft-model`.
+
 On a fresh run (no explicit `--model`/`--provider`/session flag), it injects the first discovered local model — honoring a persisted `/model` pick when that model is still present — so ambient cloud credentials (e.g. a stray `GROQ_API_KEY`) never win over the local model this command promises.
 
 When no local model exists, an interactive terminal shows a first-run wizard over a curated catalog and downloads the choice via `mlx download model`. In a non-interactive shell it prints the equivalent `mlx download model` commands instead. The catalog:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -408,7 +408,7 @@ Almost every flag belongs to pi and is forwarded verbatim; `mlx agent` only hand
 
 ### Model selection and first-run wizard
 
-`mlx agent` discovers local models under the resolved models directory (`--models-dir <dir>`, else `MLX_MODELS_DIR`, else `modelsDir` in `~/.mlx-node/config.json`, else `~/.mlx-node/models`). A dash-leading path must use the `--models-dir=<dir>` form so it is not mistaken for another flag.
+`mlx agent` discovers local models under the resolved models directory (`--models-dir <dir>`, else `MLX_MODELS_DIR`, else `modelsDir` in `~/.mlx-node/config.json`, else `~/.mlx-node/models`). A dash-leading path must use the `--models-dir=<dir>` form so it is not mistaken for another flag. Dense Qwen3.5/Qwen3.8 `Q<number>_K_XL.gguf` targets are also discovered when placed directly in that directory or one level inside a downloaded GGUF repository; each appears under its filename stem. Other GGUF variants and companion files such as imatrix, mmproj, draft, or DFlash2-only checkpoints are not advertised as agent models.
 
 On a fresh run (no explicit `--model`/`--provider`/session flag), it injects the first discovered local model — honoring a persisted `/model` pick when that model is still present — so ambient cloud credentials (e.g. a stray `GROQ_API_KEY`) never win over the local model this command promises.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -7,7 +7,7 @@ All language wrappers share a uniform `ChatSession<M>` surface (`send` / `sendSt
 | Model                      | `generate()` | Session API |  Training  | Notes                                                                            |
 | -------------------------- | :----------: | :---------: | :--------: | -------------------------------------------------------------------------------- |
 | **Qwen3**                  |     yes      |     yes     | GRPO + SFT | Speculative decoding; paged attention                                            |
-| **Qwen3.5 Dense**          |     yes      |     yes     | GRPO + SFT | Compiled C++ forward (see [ffi-cpp.md](ffi-cpp.md)); VLM variant                 |
+| **Qwen3.5 Dense**          |     yes      |     yes     | GRPO + SFT | Hybrid GDN/attention; native MTP; Qwen3.8 DFlash2; VLM variant                   |
 | **Qwen3.5 MoE**            |     yes      |     yes     | GRPO + SFT | Compiled C++ forward with expert routing; VLM variant                            |
 | **Gemma4**                 |     yes      |     yes     |     —      | Hybrid sliding/global attention + MoE/PLE; DSpark + assistant-MTP spec. decoding |
 | **Muse-Glimmer**           |     yes      |     yes     |     —      | Text decoder; Q4_K import; DFlash; hybrid paged AR                               |
@@ -106,6 +106,54 @@ for await (const event of session.sendStream('Hello!')) {
 
 The streaming bridge is implemented in `packages/lm/src/stream.ts`: native callback-based methods are captured at module load and re-exposed as `AsyncGenerator` via `_runChatStream`.
 
+## Qwen3.8 DFlash2
+
+Dense Qwen3.8 targets can attach the external
+[`z-lab/Qwen3.8-27B-DFlash2`](https://huggingface.co/z-lab/Qwen3.8-27B-DFlash2)
+checkpoint at load time:
+
+```typescript
+import { loadSession } from '@mlx-node/lm';
+
+const session = await loadSession('./models/qwen3.8-27b-mxfp4-mlx', {
+  draftModelPath: './models/qwen3.8-27b-dflash2',
+});
+const result = await session.send('Explain speculative decoding briefly.', {
+  config: { temperature: 0 },
+});
+```
+
+The companion shares the target embedding and LM head. Its five post-layer
+target taps are fused into a sliding draft context; each draft layer applies
+two-tap grouped dynamic convolutions around attention and the MLP. A rank-256
+selector then walks a conditional path through 16 candidates per position.
+At sampled temperatures the runtime retains those sparse conditional
+probabilities for exact rejection correction against the target distribution.
+
+The checkpoint's block size 8 means one verified anchor plus seven proposals.
+Unset `mtpDepth` uses all seven; an explicit value clamps to `[1, 7]`.
+`mtpAdaptiveDepth` is off by default. The target verify path is flat because
+accepted-prefix rollback must restore both full-attention KV and Qwen3.8's GDN
+recurrent state; normal `enableMtp: false` requests may still use paged AR.
+An external DFlash2 companion takes precedence over an inline native MTP head.
+
+The two cache lanes are deliberately owner-isolated. vLLM gives the DFlash
+layers their own scheduler-managed KV groups and derives their physical slots
+from the target request's block tables. mlx-node's current DFlash verifier is
+flat, so it enforces the equivalent invariant with a lane barrier: entering
+paged AR invalidates retained DFlash context; returning to DFlash performs a
+cold full-prompt flat prefill and purges the live paged prefix. Warm DFlash
+continuation is allowed only when the exact retained token prefix, every flat
+full-attention frontier, and the draft-context frontier agree. Equal lengths
+alone are never a cache hit. This makes DFlash -> paged AR -> DFlash safe, but
+the second transition pays a reprefill; it is not a zero-copy cache conversion.
+
+Loading is fail-closed: the loader requires `DFlash2DraftModel`, validates the
+target hidden size, vocabulary, tap indices, every expected tensor shape, and
+rejects missing or extra tensors before the model becomes available. The
+implementation follows the [official DFlash repository](https://github.com/z-lab/dflash)
+and [DFlash2 architecture description](https://inco.ai/blog/dflash2/).
+
 ## Muse-Glimmer Q4_K and DFlash
 
 Convert Meta's GGUF target, vision projector, and DFlash companion together.
@@ -183,7 +231,7 @@ overlay by default and enables the embedded draft only when
 - **Stats** — `ChatResult.performance` reports `mtpCycles` (actual draft+verify cycles executed) and `mtpMeanAcceptedTokensTotal` (mean committed tokens per speculative cycle, including the always-verified token). DSpark's target-only calibration/fallback cycles remain part of the overall token/decode-speed metrics but are intentionally excluded from these MTP acceptance fields.
 - **Knobs** — DSpark: with both knobs unset, full draft blocks (7 tokens on the v1 draft) are guarded by a short, per-turn target-AR/DSpark throughput calibration; if speculation loses on the current host and context, the remainder of that turn uses exact target-only decoding. The guard activates only when the generation budget can contain the AR probe plus two full-depth speculative probes; shorter generations preserve the fixed-block schedule. An explicit `mtpDepth` caps and pins the block, disabling the guard unless `mtpAdaptiveDepth: true` opts it back in; `mtpAdaptiveDepth: false` always disables it. Assistant: unset `mtpDepth` defaults to 3 drafts per cycle, explicit values clamp to [1, 8], and `mtpAdaptiveDepth` remains ignored.
 - **Memory** — the draft loads alongside the target (~6.9 GB extra for the bf16 DSpark 12B draft; ~0.8 GB for an assistant). Both variants run on the flat KV-cache path; a target config that explicitly enables `use_block_paged_cache` is rejected at load.
-- `draftModelPath` is gemma4-only: `loadModel` / `loadSession` reject it for every other family.
+- `draftModelPath` is supported by gemma4 and dense qwen3_5; other families reject it.
 
 ## Server-side sessions
 

--- a/packages/agent/__test__/model-host.test.ts
+++ b/packages/agent/__test__/model-host.test.ts
@@ -55,6 +55,21 @@ describe('MlxModelHost', () => {
     expect(host.residentId).toBe('qwen-small');
   });
 
+  it('loads an auto-discovered DFlash2 companion with its Qwen target', async () => {
+    const loader = vi.fn(async () => ({ hasBlockPagedCache: () => true }) as unknown as LoadableModel);
+    const model: DiscoveredModelLike = {
+      name: 'qwen38-q4xl',
+      path: '/models/qwen38-q4xl/Qwen3.8-27B-UD-Q4_K_XL.gguf',
+      modelType: 'qwen3_5',
+      draftModelPath: '/models/qwen38-q4xl/draft',
+    };
+    const host = new MlxModelHost([model], { loadModelFn: loader, requirePagedCache: true });
+
+    await getSession(host, model.name);
+
+    expect(loader).toHaveBeenCalledWith(model.path, { draftModelPath: model.draftModelPath });
+  });
+
   it('forwards the loaded model image capability through ChatSession', async () => {
     const loader = vi.fn(async () => ({ supportsImages: () => true }) as unknown as LoadableModel);
     const host = new MlxModelHost(MODELS, { loadModelFn: loader });

--- a/packages/agent/__test__/models.test.ts
+++ b/packages/agent/__test__/models.test.ts
@@ -15,6 +15,35 @@ async function writeModelDir(name: string, config: unknown): Promise<void> {
   await writeFile(join(dir, 'config.json'), JSON.stringify(config));
 }
 
+function u32(value: number): Buffer {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value);
+  return buffer;
+}
+
+function u64(value: number): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64LE(BigInt(value));
+  return buffer;
+}
+
+function ggufString(value: string): Buffer {
+  const bytes = Buffer.from(value, 'utf8');
+  return Buffer.concat([u64(bytes.length), bytes]);
+}
+
+function minimalGguf(architecture: string): Buffer {
+  return Buffer.concat([
+    Buffer.from('GGUF'),
+    u32(3),
+    u64(0),
+    u64(1),
+    ggufString('general.architecture'),
+    u32(8),
+    ggufString(architecture),
+  ]);
+}
+
 beforeAll(async () => {
   modelsDir = await mkdtemp(join(tmpdir(), 'mlx-agent-models-'));
 
@@ -169,5 +198,101 @@ describe('discoverMlxModels', () => {
 
   it('returns an empty list for an unreadable models dir', async () => {
     expect(await discoverMlxModels(join(modelsDir, 'does-not-exist'))).toEqual([]);
+  });
+
+  it('discovers every nested Q<number>_K_XL target by its direct GGUF path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'mlx-agent-xl-gguf-'));
+    try {
+      const repo = join(root, 'qwen38-gguf');
+      await mkdir(repo, { recursive: true });
+      await writeFile(
+        join(repo, 'config.json'),
+        JSON.stringify({ model_type: 'qwen3_5', text_config: { max_position_embeddings: 65536 } }),
+      );
+      await Promise.all([
+        writeFile(join(repo, 'Qwen3.8-27B-UD-Q3_K_XL.gguf'), 'q3'),
+        writeFile(join(repo, 'Qwen3.8-27B-UD-Q4_K_XL.gguf'), 'q4'),
+        writeFile(join(repo, 'Qwen3.8-27B-Q4_K_M.gguf'), 'ordinary variant'),
+        writeFile(join(repo, 'imatrix_unsloth.gguf'), 'imatrix'),
+        writeFile(join(repo, 'mmproj-Q4_K_XL.gguf'), 'mmproj'),
+        writeFile(join(repo, 'dflash-Q4_K_XL.gguf'), 'draft'),
+      ]);
+
+      const discovered = await discoverMlxModels(root);
+      expect(discovered.map((model) => model.discovered)).toEqual([
+        {
+          name: 'Qwen3.8-27B-UD-Q3_K_XL',
+          path: join(repo, 'Qwen3.8-27B-UD-Q3_K_XL.gguf'),
+          modelType: 'qwen3_5',
+        },
+        {
+          name: 'Qwen3.8-27B-UD-Q4_K_XL',
+          path: join(repo, 'Qwen3.8-27B-UD-Q4_K_XL.gguf'),
+          modelType: 'qwen3_5',
+        },
+      ]);
+      expect(discovered.map((model) => model.piModel.contextWindow)).toEqual([65536, 65536]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('discovers a standalone top-level XL GGUF from its qwen35 header', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'mlx-agent-standalone-gguf-'));
+    try {
+      const gguf = join(root, 'Qwen3.8-27B-UD-Q6_K_XL.gguf');
+      await writeFile(gguf, minimalGguf('qwen35'));
+
+      const [discovered] = await discoverMlxModels(root);
+      expect(discovered?.discovered).toEqual({
+        name: 'Qwen3.8-27B-UD-Q6_K_XL',
+        path: gguf,
+        modelType: 'qwen3_5',
+      });
+      expect(discovered?.piModel.contextWindow).toBe(262144);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not advertise DFlash2 companions or XL files from unsupported direct-GGUF families', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'mlx-agent-nontarget-gguf-'));
+    try {
+      const draft = join(root, 'qwen38-dflash2');
+      await mkdir(draft, { recursive: true });
+      await writeFile(
+        join(draft, 'config.json'),
+        JSON.stringify({ model_type: 'qwen3', architectures: ['DFlash2DraftModel'] }),
+      );
+
+      const qwen3 = join(root, 'qwen3-gguf');
+      await mkdir(qwen3, { recursive: true });
+      await writeFile(join(qwen3, 'config.json'), JSON.stringify({ model_type: 'qwen3' }));
+      await writeFile(join(qwen3, 'Qwen3-8B-UD-Q5_K_XL.gguf'), 'unsupported direct qwen3');
+
+      const ordinary = join(root, 'qwen38-q4km-gguf');
+      await mkdir(ordinary, { recursive: true });
+      await writeFile(join(ordinary, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
+      await writeFile(join(ordinary, 'Qwen3.8-27B-Q4_K_M.gguf'), 'unsupported direct variant');
+
+      expect(await discoverMlxModels(root)).toEqual([]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps a converted SafeTensors model discoverable when it retains an imatrix GGUF', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'mlx-agent-converted-imatrix-'));
+    try {
+      const converted = join(root, 'qwen38-mlx');
+      await mkdir(converted, { recursive: true });
+      await writeFile(join(converted, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
+      await writeFile(join(converted, 'model.safetensors'), 'weights');
+      await writeFile(join(converted, 'imatrix_unsloth.gguf'), 'calibration');
+
+      expect((await discoverMlxModels(root)).map((model) => model.discovered.name)).toEqual(['qwen38-mlx']);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agent/__test__/models.test.ts
+++ b/packages/agent/__test__/models.test.ts
@@ -295,4 +295,34 @@ describe('discoverMlxModels', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('assigns colliding XL model IDs in sorted directory order', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'mlx-agent-colliding-xl-'));
+    try {
+      // Create zeta first so filesystem insertion order disagrees with the
+      // stable lexical order discovery must use for persisted model IDs.
+      const zeta = join(root, 'zeta-repo');
+      const alpha = join(root, 'alpha-repo');
+      for (const repo of [zeta, alpha]) {
+        await mkdir(repo, { recursive: true });
+        await writeFile(join(repo, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
+        await writeFile(join(repo, 'Shared-Qwen3.8-UD-Q4_K_XL.gguf'), 'target');
+      }
+
+      expect((await discoverMlxModels(root)).map((model) => model.discovered)).toEqual([
+        {
+          name: 'Shared-Qwen3.8-UD-Q4_K_XL',
+          path: join(alpha, 'Shared-Qwen3.8-UD-Q4_K_XL.gguf'),
+          modelType: 'qwen3_5',
+        },
+        {
+          name: 'zeta-repo-Shared-Qwen3.8-UD-Q4_K_XL',
+          path: join(zeta, 'Shared-Qwen3.8-UD-Q4_K_XL.gguf'),
+          modelType: 'qwen3_5',
+        },
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/agent/__test__/models.test.ts
+++ b/packages/agent/__test__/models.test.ts
@@ -209,6 +209,17 @@ describe('discoverMlxModels', () => {
         join(repo, 'config.json'),
         JSON.stringify({ model_type: 'qwen3_5', text_config: { max_position_embeddings: 65536 } }),
       );
+      const draft = join(repo, 'draft');
+      await mkdir(draft, { recursive: true });
+      await writeFile(
+        join(draft, 'config.json'),
+        JSON.stringify({
+          model_type: 'qwen3',
+          architectures: ['DFlash2DraftModel'],
+          dflash_config: { block_size: 8 },
+        }),
+      );
+      await writeFile(join(draft, 'model.safetensors'), 'draft weights');
       await Promise.all([
         writeFile(join(repo, 'Qwen3.8-27B-UD-Q3_K_XL.gguf'), 'q3'),
         writeFile(join(repo, 'Qwen3.8-27B-UD-Q4_K_XL.gguf'), 'q4'),
@@ -224,11 +235,13 @@ describe('discoverMlxModels', () => {
           name: 'Qwen3.8-27B-UD-Q3_K_XL',
           path: join(repo, 'Qwen3.8-27B-UD-Q3_K_XL.gguf'),
           modelType: 'qwen3_5',
+          draftModelPath: draft,
         },
         {
           name: 'Qwen3.8-27B-UD-Q4_K_XL',
           path: join(repo, 'Qwen3.8-27B-UD-Q4_K_XL.gguf'),
           modelType: 'qwen3_5',
+          draftModelPath: draft,
         },
       ]);
       expect(discovered.map((model) => model.piModel.contextWindow)).toEqual([65536, 65536]);

--- a/packages/agent/src/provider/model-host.ts
+++ b/packages/agent/src/provider/model-host.ts
@@ -168,7 +168,14 @@ export class MlxModelHost {
         const resolvedPath = COLD_TIER_RESTORE_FAMILIES.has(entry.modelType)
           ? await this.resolveModelPathFn(entry, { persistPagedCache: this.persistPagedCache })
           : await this.resolveModelPathFn(entry);
-        const model = await this.loadModelFn(resolvedPath);
+        // Preserve the ordinary one-argument call for unpaired checkpoints.
+        // A discovered DFlash2 companion is an explicit load option rather
+        // than a second advertised model: target and draft become one
+        // resident session and the native loader validates their compatibility.
+        const model =
+          entry.draftModelPath === undefined
+            ? await this.loadModelFn(resolvedPath)
+            : await this.loadModelFn(resolvedPath, { draftModelPath: entry.draftModelPath });
         const sessionModel = model as unknown as SessionCapableModel;
         const gemmaDraftActive = entry.modelType === 'gemma4' && sessionModel.hasMtpWeights?.() === true;
         if (this.requirePagedCache && sessionModel.hasBlockPagedCache?.() !== true && !gemmaDraftActive) {

--- a/packages/agent/src/provider/models.ts
+++ b/packages/agent/src/provider/models.ts
@@ -219,6 +219,10 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
   } catch {
     return [];
   }
+  // Collision resolution below gives the first occurrence the bare filename
+  // stem. Directory enumeration order is unspecified, so sort before assigning
+  // IDs to keep persisted `mlx/<id>` selections stable across filesystems.
+  entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 
   const out: MlxModelInfo[] = [];
   const usedNames = new Set<string>();

--- a/packages/agent/src/provider/models.ts
+++ b/packages/agent/src/provider/models.ts
@@ -69,6 +69,44 @@ interface FamilyTraits {
 interface DiscoveryMetadata {
   contextWindow: number;
   supportsImages: boolean;
+  draftOnly: boolean;
+}
+
+/**
+ * Native direct-GGUF loading currently exists for dense Qwen3.5/Qwen3.8.
+ * Match the Unsloth Dynamic XL target names users download, while excluding
+ * ordinary Q4_K_M files and companion artifacts such as imatrix/mmproj/draft.
+ */
+const QWEN35_XL_GGUF = /(?:^|[-_.])Q\d+_K_XL\.gguf$/i;
+const GGUF_COMPANION_NAME = /(?:^|[-_.])(?:imatrix|mmproj|dflash|draft)(?:[-_.]|$)/i;
+
+function isQwen35XlGguf(name: string): boolean {
+  return QWEN35_XL_GGUF.test(name) && !GGUF_COMPANION_NAME.test(name);
+}
+
+function ggufModelName(name: string): string {
+  return name.slice(0, -'.gguf'.length);
+}
+
+interface ModelFileInventory {
+  xlGgufs: string[];
+  hasGguf: boolean;
+  hasSafetensors: boolean;
+}
+
+async function modelFileInventory(modelDir: string): Promise<ModelFileInventory> {
+  try {
+    const files = (await readdir(modelDir, { withFileTypes: true }))
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name);
+    return {
+      xlGgufs: files.filter(isQwen35XlGguf).sort(),
+      hasGguf: files.some((name) => name.toLowerCase().endsWith('.gguf')),
+      hasSafetensors: files.some((name) => name.toLowerCase().endsWith('.safetensors')),
+    };
+  } catch {
+    return { xlGgufs: [], hasGguf: false, hasSafetensors: false };
+  }
 }
 
 /**
@@ -148,24 +186,29 @@ async function readDiscoveryMetadata(
       modelType === 'gemma4'
         ? hasVisionConfig || nonEmptyRecord(config.unified_vision_config)
         : (modelType === 'qwen3_5' || modelType === 'qwen3_5_moe') && hasVisionConfig;
+    const draftOnly = Array.isArray(config.architectures) && config.architectures.includes('DFlash2DraftModel');
 
     return {
       contextWindow: root ?? nested ?? fallbackContextWindow,
       supportsImages,
+      draftOnly,
     };
   } catch {
-    return { contextWindow: fallbackContextWindow, supportsImages: false };
+    return { contextWindow: fallbackContextWindow, supportsImages: false, draftOnly: false };
   }
 }
 
 /**
- * Scan `modelsDir` for chat-capable model subdirectories and build their
- * pi provider entries. Same tolerance as the cli discover walk: an
- * unreadable dir yields `[]`; entries with an undetectable config, a
- * non-generative type, or no launch preset are skipped silently
- * (warnings only when `MLX_DEBUG` is set). Cheap by contract — no
- * weights are loaded here. Results are sorted by directory name, which
- * becomes both the pi model `id` and display `name`.
+ * Scan `modelsDir` for chat-capable model subdirectories and native dense
+ * Qwen3.5/Qwen3.8 `Q<number>_K_XL.gguf` files, then build their pi provider
+ * entries. XL files may live directly under `modelsDir` or one level inside a
+ * downloaded GGUF repository. Each is registered by filename stem so multiple
+ * quant variants in one repository remain independently selectable.
+ *
+ * Same tolerance as the cli discover walk: an unreadable dir yields `[]`;
+ * entries with an undetectable config, a non-generative type, or no launch
+ * preset are skipped silently (warnings only when `MLX_DEBUG` is set). Cheap
+ * by contract — no weights are loaded here. Results are sorted by model name.
  */
 export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo[]> {
   const debug = Boolean(process.env.MLX_DEBUG);
@@ -178,7 +221,71 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
   }
 
   const out: MlxModelInfo[] = [];
+  const usedNames = new Set<string>();
+
+  const append = async (
+    preferredName: string,
+    path: string,
+    metadataRoot: string,
+    modelType: ModelType,
+    scopeName: string,
+  ): Promise<void> => {
+    if (NON_GENERATIVE.has(modelType)) return;
+
+    const preset = launchPresetFor(modelType);
+    if (!preset) {
+      if (debug) console.warn(`[mlx] skip ${path}: no launch preset for ${modelType}`);
+      return;
+    }
+    const traits = FAMILY_TRAITS[modelType];
+    if (!traits) {
+      if (debug) console.warn(`[mlx] skip ${path}: no FAMILY_TRAITS entry for ${modelType}`);
+      return;
+    }
+
+    const metadata = await readDiscoveryMetadata(metadataRoot, modelType, traits.fallbackContextWindow);
+    if (metadata.draftOnly) {
+      if (debug) console.warn(`[mlx] skip ${path}: companion draft checkpoint is not a chat model`);
+      return;
+    }
+
+    let name = preferredName;
+    if (usedNames.has(name)) {
+      name = `${scopeName}-${preferredName}`;
+      let suffix = 2;
+      while (usedNames.has(name)) name = `${scopeName}-${preferredName}-${suffix++}`;
+    }
+    usedNames.add(name);
+    out.push({
+      discovered: { name, path, modelType },
+      piModel: {
+        id: name,
+        name,
+        reasoning: traits.reasoning,
+        thinkingLevelMap: traits.thinkingLevelMap,
+        input: metadata.supportsImages ? ['text', 'image'] : ['text'],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: metadata.contextWindow,
+        maxTokens: preset.maxOutputTokens,
+      },
+    });
+  };
+
   for (const entry of entries) {
+    if (entry.isFile() && isQwen35XlGguf(entry.name)) {
+      const full = join(modelsDir, entry.name);
+      try {
+        const modelType = await detectModelType(full);
+        if (modelType === 'qwen3_5') {
+          await append(ggufModelName(entry.name), full, modelsDir, modelType, basename(modelsDir));
+        } else if (debug) {
+          console.warn(`[mlx] skip ${full}: direct XL GGUF loading is not supported for ${modelType}`);
+        }
+      } catch (err) {
+        if (debug) console.warn(`[mlx] skip ${full}: ${(err as Error).message}`);
+      }
+      continue;
+    }
     if (!entry.isDirectory()) continue;
     const full = join(modelsDir, entry.name);
 
@@ -190,38 +297,31 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
       continue;
     }
 
-    if (NON_GENERATIVE.has(modelType)) continue;
-
-    const preset = launchPresetFor(modelType);
-    if (!preset) {
-      if (debug) console.warn(`[mlx] skip ${full}: no launch preset for ${modelType}`);
+    const inventory = await modelFileInventory(full);
+    const { xlGgufs } = inventory;
+    if (xlGgufs.length > 0) {
+      if (modelType !== 'qwen3_5') {
+        if (debug) {
+          console.warn(`[mlx] skip ${full}: direct XL GGUF loading is not supported for ${modelType}`);
+        }
+        continue;
+      }
+      for (const gguf of xlGgufs) {
+        await append(ggufModelName(gguf), join(full, gguf), full, modelType, entry.name);
+      }
       continue;
     }
-    const traits = FAMILY_TRAITS[modelType];
-    if (!traits) {
-      if (debug) console.warn(`[mlx] skip ${full}: no FAMILY_TRAITS entry for ${modelType}`);
+
+    // A raw GGUF repository is not itself a loadable model path. Only the
+    // selected native Qwen3.5 XL files above may be handed directly to the
+    // loader. Keep converted model directories discoverable when they retain
+    // an imatrix/source GGUF beside their actual SafeTensors weights.
+    if (inventory.hasGguf && !inventory.hasSafetensors) {
+      if (debug) console.warn(`[mlx] skip ${full}: no supported direct GGUF target`);
       continue;
     }
 
-    const name = basename(full);
-    const { contextWindow, supportsImages } = await readDiscoveryMetadata(
-      full,
-      modelType,
-      traits.fallbackContextWindow,
-    );
-    out.push({
-      discovered: { name, path: full, modelType },
-      piModel: {
-        id: name,
-        name,
-        reasoning: traits.reasoning,
-        thinkingLevelMap: traits.thinkingLevelMap,
-        input: supportsImages ? ['text', 'image'] : ['text'],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow,
-        maxTokens: preset.maxOutputTokens,
-      },
-    });
+    await append(basename(full), full, full, modelType, entry.name);
   }
 
   out.sort((a, b) => (a.discovered.name < b.discovered.name ? -1 : a.discovered.name > b.discovered.name ? 1 : 0));

--- a/packages/agent/src/provider/models.ts
+++ b/packages/agent/src/provider/models.ts
@@ -88,6 +88,25 @@ function ggufModelName(name: string): string {
   return name.slice(0, -'.gguf'.length);
 }
 
+/**
+ * Agent-local convention for pairing a dense Qwen3.5/Qwen3.8 target with an
+ * external DFlash2 checkpoint. mlx-vlm accepts an explicit `--draft-model`
+ * path and does not define a combined directory layout; the agent needs a
+ * deterministic relationship it can discover without another CLI flag.
+ */
+async function embeddedDFlash2Path(modelDir: string): Promise<string | undefined> {
+  const draftPath = join(modelDir, 'draft');
+  try {
+    const raw = await readFile(join(draftPath, 'config.json'), 'utf-8');
+    const config = JSON.parse(raw) as Record<string, unknown>;
+    return Array.isArray(config.architectures) && config.architectures.includes('DFlash2DraftModel')
+      ? draftPath
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 interface ModelFileInventory {
   xlGgufs: string[];
   hasGguf: boolean;
@@ -233,6 +252,7 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
     metadataRoot: string,
     modelType: ModelType,
     scopeName: string,
+    draftModelPath?: string,
   ): Promise<void> => {
     if (NON_GENERATIVE.has(modelType)) return;
 
@@ -260,8 +280,14 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
       while (usedNames.has(name)) name = `${scopeName}-${preferredName}-${suffix++}`;
     }
     usedNames.add(name);
+    const discovered: DiscoveredModelLike = {
+      name,
+      path,
+      modelType,
+      ...(draftModelPath === undefined ? {} : { draftModelPath }),
+    };
     out.push({
-      discovered: { name, path, modelType },
+      discovered,
       piModel: {
         id: name,
         name,
@@ -310,8 +336,9 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
         }
         continue;
       }
+      const draftModelPath = await embeddedDFlash2Path(full);
       for (const gguf of xlGgufs) {
-        await append(ggufModelName(gguf), join(full, gguf), full, modelType, entry.name);
+        await append(ggufModelName(gguf), join(full, gguf), full, modelType, entry.name, draftModelPath);
       }
       continue;
     }
@@ -325,7 +352,8 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
       continue;
     }
 
-    await append(basename(full), full, full, modelType, entry.name);
+    const draftModelPath = modelType === 'qwen3_5' ? await embeddedDFlash2Path(full) : undefined;
+    await append(basename(full), full, full, modelType, entry.name, draftModelPath);
   }
 
   out.sort((a, b) => (a.discovered.name < b.discovered.name ? -1 : a.discovered.name > b.discovered.name ? 1 : 0));

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -5,4 +5,6 @@ export interface DiscoveredModelLike {
   name: string;
   path: string;
   modelType: ModelType;
+  /** Optional external speculative drafter paired with this target checkpoint. */
+  draftModelPath?: string;
 }

--- a/packages/core/index.d.cts
+++ b/packages/core/index.d.cts
@@ -1444,11 +1444,9 @@ export declare class Qwen35Model {
   /** Snapshot scheduler occupancy plus unified block/recurrent admission. */
   schedulerStats(): Promise<SchedulerStats>;
   /**
-   * Whether this checkpoint shipped an MTP head (module loaded by
-   * `persistence::apply_weights_inner`). Snapshotted at load time from
-   * `Qwen35Inner::has_mtp_weights()` so the TS `ChatSession` can
-   * auto-default `enableMtp = true` for MTP-capable checkpoints without
-   * dispatching a command into the model thread.
+   * Whether this instance has an inline MTP head or external DFlash2
+   * companion. Snapshotted at load time so `ChatSession` can auto-default
+   * `enableMtp = true` without dispatching into the model thread.
    *
    * Note: this only reports weight availability. Whether the
    * speculative-decode path actually runs on a given call also requires the
@@ -1485,7 +1483,7 @@ export declare class Qwen35Model {
    * - model.safetensors (or model-*.safetensors)
    * - tokenizer.json + tokenizer_config.json
    */
-  static load(path: string): Promise<Qwen35Model>;
+  static load(path: string, options?: Qwen35LoadOptions | undefined | null): Promise<Qwen35Model>;
   /** Generate text from a prompt token sequence. */
   generate(promptTokens: MxArray, config: Qwen35GenerationConfig): Promise<Qwen35GenerationResult>;
   /**
@@ -2725,10 +2723,14 @@ export interface ChatConfig {
    * Adaptive depth is opt-in; set `mtpAdaptiveDepth: true` explicitly to
    * enable it.
    *
-   * Gemma4 external drafts (`draftModelPath`) resolve the field per draft
-   * variant instead (`gemma4/model.rs` `resolve_params`, always from the
-   * RAW config value — the engine's central `[1, 5]` clamp is an MTP-head
-   * contract that does not apply to external drafts):
+   * External drafts (`draftModelPath`) resolve the field against their
+   * checkpoint width instead (always from the RAW config value — the
+   * engine's central `[1, 5]` clamp is an MTP-head contract that does not
+   * apply to external drafts):
+   * - Qwen3.8 DFlash2: checkpoint `block_size = 8` contains one target
+   *   anchor plus seven proposals. Unset uses all seven; an explicit value
+   *   clamps to `[1, 7]` and pins that depth unless
+   *   `mtpAdaptiveDepth: true` explicitly enables the break-even guard.
    * - DSpark: with both knobs unset, full draft blocks (the checkpoint's
    *   block size — 7 tokens on `dspark_gemma4_12b_block7`) run behind a
    *   short target-AR/DSpark break-even calibration. A short generation
@@ -2759,7 +2761,8 @@ export interface ChatConfig {
    *
    * Default: false, except Gemma4 DSpark and Muse-Glimmer DFlash enable the
    * measured break-even guard when both this field and `mtpDepth` are unset.
-   * An explicit value always wins over the family default.
+   * Qwen3.8 DFlash2 remains fixed-width by default. An explicit value always
+   * wins over the family default.
    */
   mtpAdaptiveDepth?: boolean | undefined;
 }
@@ -4805,6 +4808,11 @@ export interface Qwen35GenerationResult {
   text: string;
   numTokens: number;
   finishReason: string;
+}
+
+export interface Qwen35LoadOptions {
+  /** External z-lab DFlash2 checkpoint directory. */
+  draftModelPath?: string;
 }
 
 /**

--- a/packages/lm/src/chat-session.ts
+++ b/packages/lm/src/chat-session.ts
@@ -506,7 +506,8 @@ export interface SessionCapableModel {
   /**
    * MTP: whether the underlying native model can run speculative
    * decoding. Surfaced by `Qwen3_5Model` / `Qwen3_5MoeModel` (an MTP
-   * head shipped in the checkpoint and loaded by persistence) and by
+   * head shipped in the checkpoint, or an external DFlash2 companion on
+   * dense Qwen3.5) and by
    * `Gemma4Model` (an external draft model — DSpark or Google gemma-4
    * assistant, auto-detected from the draft's config.json — attached
    * via `loadModel` / `loadSession` `draftModelPath`; NOT in-checkpoint
@@ -544,9 +545,8 @@ export interface SessionCapableModel {
    *   verify FFI contract, and when unset native code currently pins
    *   depth 1. Setting `mtpDepth` explicitly pins that value unless
    *   the caller also passes `mtpAdaptiveDepth: true` to opt into
-   *   adaptive depth with the supplied maximum/seed. Gemma4 external
-   *   drafts resolve the field per draft variant instead — see the
-   *   Gemma4 section below.
+   *   adaptive depth with the supplied maximum/seed. External draft models
+   *   resolve the field against their checkpoint width instead — see below.
    * - **`mtpAdaptiveDepth`** — toggles the adaptive depth policy.
    *   Defaults to OFF for native MTP and assistants (Gemma4 DSpark has the
    *   family override documented below). When ON, the native-MTP default
@@ -569,6 +569,16 @@ export interface SessionCapableModel {
    * flag inventory), so omitting them from `defaultConfig` /
    * `SendOptions.config` is the recommended path for callers that
    * just want speculative decoding "on with sensible defaults".
+   *
+   * ## Qwen3.8 DFlash2 (`draftModelPath`)
+   *
+   * A dense Qwen3.8 target can attach `z-lab/Qwen3.8-27B-DFlash2`. Its
+   * checkpoint block size is 8 total target rows: one anchor plus seven
+   * proposals. With `mtpDepth` unset all seven proposals are used; an
+   * explicit value clamps to `[1, 7]`. `mtpAdaptiveDepth` is off by default
+   * and may be enabled explicitly for the engine's measured AR fallback.
+   * DFlash2 uses flat target caches so hybrid GDN state can be rewound by
+   * snapshot plus tape replay after verification.
    *
    * ## Gemma4 external drafts (`draftModelPath`)
    *

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -34,18 +34,22 @@ import {
 /** Optional settings for {@link loadModel} / {@link loadSession}. */
 export interface LoadModelOptions {
   /**
-   * Gemma4 only: directory of an external draft checkpoint (config.json +
-   * model.safetensors) loaded alongside the target model for speculative
-   * decoding (forwarded as `Gemma4LoadOptions.draftModelPath`). Accepts
-   * either a DSpark draft or a Google gemma-4 assistant draft
+   * Directory of an external draft checkpoint (config.json +
+   * model.safetensors) loaded alongside the target for speculative decoding.
+   * Gemma4 accepts either a DSpark draft or a Google gemma-4 assistant draft
    * (`google/gemma-4-*-it-assistant`); the variant is auto-detected from
    * the draft's config.json (`model_type` `gemma4_assistant` /
    * `gemma4_unified_assistant` → assistant, `architectures` containing
    * `Gemma4DSparkModel` → DSpark). When omitted, Gemma4 automatically loads
    * an embedded draft from `<modelPath>/draft/` when present. Draft decoding
    * runs on the flat KV-cache path, so the target checkpoint must not
-   * explicitly enable `use_block_paged_cache`. Setting this for any other
-   * model family is a hard error — no other loader accepts a draft model.
+   * explicitly enable `use_block_paged_cache`.
+   *
+   * Dense `qwen3_5` accepts a z-lab `DFlash2DraftModel` companion such as
+   * `z-lab/Qwen3.8-27B-DFlash2`. It shares the Qwen3.8 target embedding and
+   * LM head, validates all companion tensors at load time, and takes
+   * precedence over an inline target MTP head. Other model families reject
+   * this option.
    */
   draftModelPath?: string;
 }
@@ -161,8 +165,13 @@ const MODEL_FAMILY_REGISTRY = [
     modelType: 'qwen3_5',
     kind: 'trainable',
     match: { rawModelTypes: ['qwen3_5'] },
-    load: (modelPath: string) => Qwen35Model.load(modelPath),
+    load: (modelPath: string, options?: LoadModelOptions) =>
+      Qwen35Model.load(
+        modelPath,
+        options?.draftModelPath === undefined ? null : { draftModelPath: options.draftModelPath },
+      ),
     nativeModelClass: NativeQwen35Model,
+    acceptsDraftModel: true,
   },
   {
     modelType: 'qwen3_5_moe',
@@ -350,10 +359,9 @@ class UnsupportedModelTypeError extends Error {
 }
 
 /**
- * Dispatch a load through the registry, validating gemma4-only options.
- * `draftModelPath` reaches ONLY the gemma4 row; every other family rejects
- * it loudly instead of silently ignoring a caller's speculative-decode
- * intent.
+ * Dispatch a load through the registry, validating draft-capable families.
+ * `draftModelPath` reaches only gemma4 and dense qwen3_5; every other family
+ * rejects it loudly instead of silently ignoring speculative-decode intent.
  */
 function dispatchLoad(
   modelType: ModelType,
@@ -363,7 +371,7 @@ function dispatchLoad(
   const family = findFamily(modelType);
   if (options?.draftModelPath !== undefined && family.acceptsDraftModel !== true) {
     throw new Error(
-      `draftModelPath (speculative-decoding draft) is only supported by gemma4 models; ` +
+      `draftModelPath (speculative-decoding draft) is only supported by gemma4 and qwen3_5 models; ` +
         `${modelPath} has model_type "${modelType}"`,
     );
   }

--- a/packages/lm/src/stream.ts
+++ b/packages/lm/src/stream.ts
@@ -620,9 +620,8 @@ export function makeStreamingModel<
   // constructor — e.g. `new Gemma4Model(config)` / `new QianfanOCRModel(config)`
   // — visible on the generated wrapper for TypeScript consumers. Likewise,
   // `Parameters<C['load']>` keeps each family's native load signature —
-  // `[modelPath]` for most, `[modelPath, options?]` for Gemma4
-  // (`Gemma4LoadOptions.draftModelPath` — external DSpark or Google
-  // assistant draft).
+  // `[modelPath]` for most, `[modelPath, options?]` for Gemma4 and dense
+  // Qwen3.5 external draft models.
   new (...args: ConstructorParameters<C>): StreamingInstance<C, O>;
   load(...args: Parameters<C["load"]>): Promise<StreamingInstance<C, O>>;
 } {
@@ -661,7 +660,7 @@ export function makeStreamingModel<
       ...rest: unknown[]
     ): Promise<StreamingModel> {
       // Forward any trailing family-specific load options verbatim (e.g.
-      // Gemma4's `Gemma4LoadOptions` with `draftModelPath`); families whose
+      // Gemma4/Qwen3.5 `draftModelPath`); families whose
       // native `load` takes only the path receive no extras. The public
       // signature is re-narrowed per family via `Parameters<C['load']>` in
       // the factory return type below.


### PR DESCRIPTION
## Summary

- load `z-lab/Qwen3.8-27B-DFlash2` as an external companion for dense Qwen3.8 targets through `draftModelPath`, with strict architecture, shape, dtype, and tensor-inventory validation
- implement the five-tap DFlash2 draft transformer, grouped dynamic convolution, rank-256 conditional selector, verified target decoding, sampled sparse rejection correction, and Qwen3.8 GDN rollback
- keep DFlash2's flat verifier and ordinary paged AR cache ownership isolated with exact token provenance and explicit cold rebuilds across lane transitions
- let `mlx agent` discover supported `Q<number>_K_XL.gguf` Qwen3.5/Qwen3.8 targets and automatically pair a config-validated embedded `draft/` DFlash2 checkpoint

## Cache architecture

The local vLLM reference gives draft attention its own KV cache groups, maps them through the target request's block tables, masks rejected suffix slots, and aligns recurrent state to accepted tokens. mlx-node's DFlash2 verifier currently uses flat target KV plus GDN snapshot/tape replay, so this PR preserves the same ownership invariant without pretending the flat and paged pools are interchangeable:

- warm reuse requires exact retained token IDs, a matching draft frontier, and agreement across every flat full-attention frontier
- entering paged AR invalidates retained DFlash2 context
- returning from paged AR to DFlash2 purges the paged request and performs a cold full-prompt flat prefill
- accepted verified token IDs advance the draft context alongside target KV/GDN state
- full cache reset clears both lane-dirty latches

This makes DFlash2 -> paged AR -> DFlash2 safe. The paged-to-DFlash transition is deliberately a reprefill, not a zero-copy cache conversion.

## Agent GGUF and draft discovery

`mlx agent` scans both the models directory and one level of downloaded repository directories for dense Qwen3.5/Qwen3.8 `Q<number>_K_XL.gguf` targets. Each matching file is registered by filename stem and passed directly to the native GGUF loader, so multiple XL variants remain independently selectable.

When an eligible target repository contains `draft/config.json` whose `architectures` includes `DFlash2DraftModel`, discovery attaches that directory as the target's `draftModelPath`. The model picker still advertises only the target; the host loads target and draft together when it becomes resident. `draft/` may be a symlink to an existing Hugging Face checkout.

Discovery rejects standalone DFlash2 directories, imatrix/mmproj/draft artifacts, unsupported direct-GGUF families, and raw repositories that contain no supported XL target. Converted SafeTensors directories remain discoverable when they retain an imatrix or source GGUF.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p mlx-core --lib --tests -- -D warnings`
- `cargo test -p mlx-core --lib --quiet -- --skip models::qwen3_5::int8_gemm::tests::s1_int8_gemm_bit_exact` (3342 passed, 109 ignored; the excluded existing bit-exact kernel test was still consuming a core after five minutes)
- `yarn typecheck`
- `yarn lint` (no errors; existing repository warnings only)
- `yarn test __test__/models/model-loader-registry.test.ts` (27 passed)
- focused agent discovery + model-host tests (41 passed)
- deterministic agent suite excluding its gated live-model smoke (345 passed)
- `yarn build:native`
- live discovery over the development model cache selected `Qwen3.8-27B-UD-Q4_K_XL.gguf` as `qwen3_5` and excluded its standalone DFlash2 companion and imatrix
- real safetensors target + DFlash2 integration smoke
- real `Qwen3.8-27B-UD-Q4_K_XL.gguf` target + DFlash2 release-mode smoke, including DFlash2 -> paged AR -> DFlash2 replay and sampled sparse correction

## Exploratory GGUF performance

On an Apple M5 Max with the UD-Q4_K_XL target and bf16 DFlash2 companion, three 256-token runs per mode measured median decode throughput of 25.07 tok/s for AR and 30.23 tok/s for DFlash2 (+20.6%). Median TTFT was 329 ms vs 212 ms. This is prompt-dependent rather than a universal speedup.

Longer greedy outputs are not asserted byte-identical between token-by-token AR and batched DFlash2 verification for this mixed K-quant GGUF target. Flat AR and flat DFlash2 also diverged, so the evidence does not point to paged-KV ownership drift; differing small-M K-quant reduction geometry is the leading hypothesis, not a confirmed cause. The transition regression in this PR asserts cold DFlash2 replay stability, not GGUF AR/DFlash byte parity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new decode path touching Qwen3.5 cache ownership, GDN rollback, and speculative sampling; incorrect lane or prefix reuse could corrupt generation, though fail-closed loading and explicit barriers mitigate this.
> 
> **Overview**
> Adds **external DFlash2** speculative decoding for dense **Qwen3.5/Qwen3.8** targets via optional `draftModelPath` on `Qwen3_5Model.load` / `loadSession`, alongside existing Gemma4 draft support. The companion is loaded with strict checkpoint validation, takes precedence over inline native MTP, and surfaces through `hasMtpWeights()` as generic speculative capability.
> 
> The runtime implements the DFlash2 drafter (multi-layer taps, grouped dynamic conv, top-16 selector) and a **flat** DSpark-style verify loop with **sparse proposal distributions** and dense-target acceptance in sampled decoding. DFlash2 turns use dedicated prefill, GDN snapshot/tape rollback, and cache **lane barriers** so paged AR and flat DFlash2 state are not mixed; warm continuation requires matching token provenance and attention frontiers.
> 
> **`mlx agent`** discovers `Q<number>_K_XL.gguf` targets (top-level or one repo level), auto-pairs an embedded `draft/` directory when `architectures` includes `DFlash2DraftModel`, and loads target + draft as one resident session. Docs and `mtpDepth` semantics are extended for DFlash2’s seven-proposal block width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0930ec9dc922048ec219fc9179c22bdb5332d5bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->