### PR TITLE
Recommend the platform's own 4-bit build, and show when it goes stale

### DIFF
--- a/__test__/cli/agent-wizard.test.ts
+++ b/__test__/cli/agent-wizard.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 
-import { MODEL_CATALOG, visibleCatalog } from '@mlx-node/agent';
+import { catalogRepo, MODEL_CATALOG, visibleCatalog } from '@mlx-node/agent';
 import { describe, expect, it } from 'vite-plus/test';
 
 import { runFirstRunWizard, type WizardIO } from '../../packages/cli/src/commands/agent/wizard.js';
@@ -66,24 +66,24 @@ describe('runFirstRunWizard', () => {
     const choices = selectCalls[0]!.choices;
 
     const visible = visibleCatalog();
-    expect(choices.map((c) => c.value).sort()).toEqual(visible.map((e) => e.hfRepo).sort());
+    expect(choices.map((c) => c.value).sort()).toEqual(visible.map((e) => catalogRepo(e)).sort());
 
     // Default entry is preselected by coming first.
     const defaultEntry = visible.find((e) => e.isDefault)!;
     expect(defaultEntry).toBeDefined();
-    expect(choices[0]!.value).toBe(defaultEntry.hfRepo);
+    expect(choices[0]!.value).toBe(catalogRepo(defaultEntry));
 
     // Hidden entries are never offered (the catalog must actually carry one
     // for this assertion to mean anything).
     const hidden = MODEL_CATALOG.filter((e) => e.hidden);
     expect(hidden.length).toBeGreaterThan(0);
     for (const entry of hidden) {
-      expect(choices.map((c) => c.value)).not.toContain(entry.hfRepo);
+      expect(choices.map((c) => c.value)).not.toContain(catalogRepo(entry));
     }
 
     // Labels carry size and description.
     for (const entry of visible) {
-      const choice = choices.find((c) => c.value === entry.hfRepo)!;
+      const choice = choices.find((c) => c.value === catalogRepo(entry))!;
       expect(choice.name).toContain(entry.label);
       expect(choice.name).toContain(`(~${entry.sizeGb} GB)`);
       expect(choice.name).toContain(entry.description);
@@ -92,7 +92,7 @@ describe('runFirstRunWizard', () => {
 
   it('passes the chosen repo to download and returns it', async () => {
     const visible = visibleCatalog();
-    const chosen = visible[visible.length - 1]!.hfRepo;
+    const chosen = catalogRepo(visible[visible.length - 1]!);
     const { io } = makeIO({ chosen });
     const { download, calls } = makeDownload();
 
@@ -104,7 +104,7 @@ describe('runFirstRunWizard', () => {
   });
 
   it('pins the download output under modelsDir when provided', async () => {
-    const chosen = visibleCatalog()[0]!.hfRepo;
+    const chosen = catalogRepo(visibleCatalog()[0]!);
     const { io } = makeIO({ chosen });
     const { download, calls } = makeDownload();
 
@@ -127,7 +127,7 @@ describe('runFirstRunWizard', () => {
     } catch (error) {
       const message = (error as Error).message;
       for (const entry of visibleCatalog()) {
-        expect(message).toContain(entry.hfRepo);
+        expect(message).toContain(catalogRepo(entry));
       }
     }
 
@@ -145,8 +145,8 @@ describe('runFirstRunWizard', () => {
     } catch (error) {
       const message = (error as Error).message;
       for (const entry of visibleCatalog()) {
-        const slug = entry.hfRepo.split('/').pop()!.toLowerCase();
-        expect(message).toContain(`mlx download model -m ${entry.hfRepo} -o ${join('/custom/models', slug)}`);
+        const slug = catalogRepo(entry).split('/').pop()!.toLowerCase();
+        expect(message).toContain(`mlx download model -m ${catalogRepo(entry)} -o ${join('/custom/models', slug)}`);
       }
     }
     expect(calls).toHaveLength(0);
@@ -169,14 +169,14 @@ describe('runFirstRunWizard', () => {
     }
 
     for (const entry of visibleCatalog()) {
-      const slug = entry.hfRepo.split('/').pop()!.toLowerCase();
-      const line = message.split('\n').find((l) => l.includes(entry.hfRepo));
+      const slug = catalogRepo(entry).split('/').pop()!.toLowerCase();
+      const line = message.split('\n').find((l) => l.includes(catalogRepo(entry)));
       expect(line).toBeDefined();
       const renderedArgs = line!.trim().replace(/^mlx download model /, '');
       // Round-trip: a real POSIX shell parses the displayed command back
       // into EXACTLY the argv the interactive path would pass — one `-o`
       // word, `$HOME` unexpanded, `;`/`&` inert.
-      expect(shellSplit(renderedArgs)).toEqual(['-m', entry.hfRepo, '-o', join(modelsDir, slug)]);
+      expect(shellSplit(renderedArgs)).toEqual(['-m', catalogRepo(entry), '-o', join(modelsDir, slug)]);
       // Known-correct quoted form: safe words bare, unsafe -o value
       // single-quoted with the embedded quote escaped as '\''.
       expect(line).toContain(`-o '/tmp/My Models/it'\\''s;echo x&$HOME/${slug}'`);
@@ -194,13 +194,13 @@ describe('runFirstRunWizard', () => {
     } catch (error) {
       const message = (error as Error).message;
       const entry = visibleCatalog()[0]!;
-      const slug = entry.hfRepo.split('/').pop()!.toLowerCase();
+      const slug = catalogRepo(entry).split('/').pop()!.toLowerCase();
       // Unchanged readable form for the common case...
-      expect(message).toContain(`mlx download model -m ${entry.hfRepo} -o /custom/models/${slug}`);
+      expect(message).toContain(`mlx download model -m ${catalogRepo(entry)} -o /custom/models/${slug}`);
       // ...and it still parses back to the intended argv.
-      const line = message.split('\n').find((l) => l.includes(entry.hfRepo))!;
+      const line = message.split('\n').find((l) => l.includes(catalogRepo(entry)))!;
       const renderedArgs = line.trim().replace(/^mlx download model /, '');
-      expect(shellSplit(renderedArgs)).toEqual(['-m', entry.hfRepo, '-o', `/custom/models/${slug}`]);
+      expect(shellSplit(renderedArgs)).toEqual(['-m', catalogRepo(entry), '-o', `/custom/models/${slug}`]);
     }
   });
 });

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -644,9 +644,13 @@ When no local model exists, an interactive terminal shows a first-run wizard ove
 
 | Model                 | HuggingFace repo                                 | Size   | Notes                        |
 | --------------------- | ------------------------------------------------ | ------ | ---------------------------- |
-| Qwen3.6-27B (default) | `Brooooooklyn/Qwen3.6-27B-NVFP4-mlx`             | ~22 GB | Best tool use — recommended  |
-| Qwen-AgentWorld-35B   | `Brooooooklyn/Qwen-AgentWorld-35B-A3B-nvfp4-mlx` | ~23 GB | Agent-tuned MoE, fast decode |
-| Gemma-4-26B-A4B       | `Brooooooklyn/Gemma-4-26B-A4B-NVFP4-mlx`         | ~19 GB | MoE, fast decode             |
+| Qwen3.8-27B (default) | `Brooooooklyn/Qwen3.8-27B-MXFP4-mlx`                 | ~23 GB | Best tool use — recommended  |
+| Qwen-AgentWorld-35B   | `Brooooooklyn/Qwen-AgentWorld-35B-A3B-mxfp4-mlx`     | ~23 GB | Agent-tuned MoE, fast decode |
+| Gemma-4-26B-A4B       | `Brooooooklyn/Gemma-4-26B-A4B-Unsloth-MXFP4-mlx`     | ~16 GB | MoE, fast decode             |
+
+The slugs above are what the wizard offers on Apple Silicon. On Linux + NVIDIA
+CUDA it offers the `nvfp4` build of the same model instead — see `catalogRepo`
+in `packages/agent/src/catalog.ts` for why.
 
 A more compact Gemma-4-12B entry (mxfp4 MLP + mxfp8 attention, ~9 GB, for smaller machines) is coming and will appear in the wizard once it is published.
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -182,6 +182,7 @@ over a port.
 | `/api/models`               | GET          | Local models: name, path, family, quant, size, ctx window                  |
 | `/api/models/:name`         | DELETE       | Delete a model dir (path-checked)                                          |
 | `/api/catalog`              | GET          | Recommended catalog + installed/installable state                          |
+| `/api/catalog/updates`      | GET          | Upstream sha per catalog repo; which installed models are stale            |
 | `/api/downloads`            | GET / POST   | List active jobs / start a catalog download                                |
 | `/api/downloads/:id/events` | GET          | Not served over the port — use `runtime.subscribe(jobId, fn)`; answers 503 |
 | `/api/sessions`             | GET          | Indexed session list; search + filters                                     |

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -29,8 +29,10 @@ during a 1.5 s query used to wait 1449 ms. With the split, a download-progress c
 made during a heavy query returns in 0.2 ms instead of 296 ms.
 
 Route ownership is data on the route (`mainRoute` / `workerRoute`), so a new route
-cannot silently land on the wrong thread. Only the four download routes stay on the
-transport thread, because network I/O and progress events are what must never stall.
+cannot silently land on the wrong thread. Only the four download routes and the
+catalog update check stay on the transport thread, because network I/O and progress
+events are what must never stall — and for the same reason none of them touches the
+filesystem: the update check answers with upstream shas alone.
 
 ## Using it as a library
 
@@ -182,7 +184,7 @@ over a port.
 | `/api/models`               | GET          | Local models: name, path, family, quant, size, ctx window                  |
 | `/api/models/:name`         | DELETE       | Delete a model dir (path-checked)                                          |
 | `/api/catalog`              | GET          | Recommended catalog + installed/installable state                          |
-| `/api/catalog/updates`      | GET          | Upstream sha per catalog repo; which installed models are stale            |
+| `/api/catalog/updates`      | GET          | Upstream sha per catalog repo; the page joins it against `/api/catalog`    |
 | `/api/downloads`            | GET / POST   | List active jobs / start a catalog download                                |
 | `/api/downloads/:id/events` | GET          | Not served over the port — use `runtime.subscribe(jobId, fn)`; answers 503 |
 | `/api/sessions`             | GET          | Indexed session list; search + filters                                     |

--- a/packages/agent/__test__/catalog.test.ts
+++ b/packages/agent/__test__/catalog.test.ts
@@ -10,7 +10,7 @@ describe('MODEL_CATALOG', () => {
   it('has exactly one default entry', () => {
     const defaults = MODEL_CATALOG.filter((entry) => entry.isDefault);
     expect(defaults).toHaveLength(1);
-    expect(defaults[0]!.label).toBe('Qwen3.6-27B');
+    expect(defaults[0]!.label).toBe('Qwen3.8-27B');
   });
 
   it('every hfRepo is a Brooooooklyn HF slug', () => {

--- a/packages/agent/__test__/catalog.test.ts
+++ b/packages/agent/__test__/catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 
-import { MODEL_CATALOG, visibleCatalog } from '../src/catalog.js';
+import { catalogRepo, MODEL_CATALOG, visibleCatalog } from '../src/catalog.js';
 
 describe('MODEL_CATALOG', () => {
   it('is non-empty', () => {
@@ -11,6 +11,31 @@ describe('MODEL_CATALOG', () => {
     const defaults = MODEL_CATALOG.filter((entry) => entry.isDefault);
     expect(defaults).toHaveLength(1);
     expect(defaults[0]!.label).toBe('Qwen3.8-27B');
+  });
+
+  it('resolves the CUDA build on linux and the Metal build everywhere else', () => {
+    // The whole platform split rides on this. Getting it wrong is silent: the
+    // wrong-platform repo is a real, downloadable checkpoint, so nothing errors
+    // — the user simply installs the build this catalog exists to steer them
+    // away from. It also silently breaks every provenance test that writes a
+    // marker naming `hfRepo` instead of the resolved repo.
+    const withCuda = MODEL_CATALOG.find((entry) => entry.hfRepoCuda !== undefined);
+    expect(withCuda, 'at least one entry must carry a CUDA build').toBeDefined();
+    const original = process.platform;
+    try {
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      expect(catalogRepo(withCuda!)).toBe(withCuda!.hfRepoCuda);
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      expect(catalogRepo(withCuda!)).toBe(withCuda!.hfRepo);
+      // An entry with no CUDA build serves both platforms from `hfRepo`.
+      const noCuda = MODEL_CATALOG.find((entry) => entry.hfRepoCuda === undefined);
+      if (noCuda !== undefined) {
+        Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+        expect(catalogRepo(noCuda)).toBe(noCuda.hfRepo);
+      }
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original, configurable: true });
+    }
   });
 
   it('every hfRepo is a Brooooooklyn HF slug', () => {

--- a/packages/agent/__test__/catalog.test.ts
+++ b/packages/agent/__test__/catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 
-import { catalogRepo, MODEL_CATALOG, visibleCatalog } from '../src/catalog.js';
+import { catalogRepo, catalogRepoFor, MODEL_CATALOG, visibleCatalog } from '../src/catalog.js';
 
 describe('MODEL_CATALOG', () => {
   it('is non-empty', () => {
@@ -21,21 +21,18 @@ describe('MODEL_CATALOG', () => {
     // marker naming `hfRepo` instead of the resolved repo.
     const withCuda = MODEL_CATALOG.find((entry) => entry.hfRepoCuda !== undefined);
     expect(withCuda, 'at least one entry must carry a CUDA build').toBeDefined();
-    const original = process.platform;
-    try {
-      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-      expect(catalogRepo(withCuda!)).toBe(withCuda!.hfRepoCuda);
-      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
-      expect(catalogRepo(withCuda!)).toBe(withCuda!.hfRepo);
-      // An entry with no CUDA build serves both platforms from `hfRepo`.
-      const noCuda = MODEL_CATALOG.find((entry) => entry.hfRepoCuda === undefined);
-      if (noCuda !== undefined) {
-        Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-        expect(catalogRepo(noCuda)).toBe(noCuda.hfRepo);
-      }
-    } finally {
-      Object.defineProperty(process, 'platform', { value: original, configurable: true });
+    // Via the pure helper, never by mutating `process.platform`: that global is
+    // shared with every test file on this worker, and stubbing it here made a
+    // sibling suite's download allowlist reject its own module-level repo.
+    expect(catalogRepoFor(withCuda!, 'linux')).toBe(withCuda!.hfRepoCuda);
+    expect(catalogRepoFor(withCuda!, 'darwin')).toBe(withCuda!.hfRepo);
+    // An entry with no CUDA build serves both platforms from `hfRepo`.
+    const noCuda = MODEL_CATALOG.find((entry) => entry.hfRepoCuda === undefined);
+    if (noCuda !== undefined) {
+      expect(catalogRepoFor(noCuda, 'linux')).toBe(noCuda.hfRepo);
     }
+    // And the live resolver agrees with the helper on THIS platform.
+    expect(catalogRepo(withCuda!)).toBe(catalogRepoFor(withCuda!, process.platform));
   });
 
   it('every hfRepo is a Brooooooklyn HF slug', () => {

--- a/packages/agent/src/catalog.ts
+++ b/packages/agent/src/catalog.ts
@@ -126,13 +126,6 @@ export function catalogRepo(entry: CatalogEntry): string {
   return process.platform === 'linux' && entry.hfRepoCuda !== undefined ? entry.hfRepoCuda : entry.hfRepo;
 }
 
-/** Every repo `entry` may occupy on ANY platform, lowercased. */
-export function catalogRepoAliases(entry: CatalogEntry): string[] {
-  const repos = [entry.hfRepo];
-  if (entry.hfRepoCuda !== undefined) repos.push(entry.hfRepoCuda);
-  return repos.map((repo) => repo.toLowerCase());
-}
-
 /** Catalog entries the wizard offers (hidden entries filtered out). */
 export function visibleCatalog(): CatalogEntry[] {
   return MODEL_CATALOG.filter((entry) => !entry.hidden);

--- a/packages/agent/src/catalog.ts
+++ b/packages/agent/src/catalog.ts
@@ -2,15 +2,30 @@
  * Curated model catalog for `mlx agent`.
  *
  * The first-run download wizard offers `visibleCatalog()` and feeds the chosen
- * `hfRepo` to `mlx download model`. Slugs are verified against the Brooooooklyn
+ * entry's `catalogRepo()` to `mlx download model`. Slugs are verified against the Brooooooklyn
  * HF account — use them verbatim.
  */
 
 export interface CatalogEntry {
   /** Wizard display name. */
   label: string;
-  /** HF slug for `mlx download model`. */
+  /**
+   * HF slug for `mlx download model` on Apple Silicon — the MXFP4 build.
+   *
+   * Metal's block scaling is MXFP4-shaped: the scale plane must be
+   * `metal_fp8_ue8m0_format` at block 32 (MSL Spec 4.1 Table 2.28). NVFP4's
+   * E4M3 scales at block 16 cannot be declared there, so it decodes through a
+   * dequant path instead of the native one.
+   */
   hfRepo: string;
+  /**
+   * HF slug on Linux + NVIDIA CUDA — the NVFP4 build, which is what
+   * `CublasQQMM` consumes natively (`nvfp4` -> `CUDA_R_4F_E2M1`).
+   *
+   * Absent means the entry has no CUDA-specific build and {@link hfRepo}
+   * serves both. Resolve with {@link catalogRepo}, never by reading the field.
+   */
+  hfRepoCuda?: string;
   /** Approximate download size in GB, for display. */
   sizeGb: number;
   /** One line for the wizard. */
@@ -37,22 +52,25 @@ export interface CatalogEntry {
 
 export const MODEL_CATALOG: readonly CatalogEntry[] = [
   {
-    label: 'Qwen3.6-27B',
-    hfRepo: 'Brooooooklyn/Qwen3.6-27B-NVFP4-mlx',
-    sizeGb: 22.2,
+    label: 'Qwen3.8-27B',
+    hfRepo: 'Brooooooklyn/Qwen3.8-27B-MXFP4-mlx',
+    hfRepoCuda: 'Brooooooklyn/Qwen3.8-27B-NVFP4-mlx',
+    sizeGb: 23.3,
     description: 'Best tool use — recommended default',
     isDefault: true,
   },
   {
     label: 'Qwen-AgentWorld-35B',
-    hfRepo: 'Brooooooklyn/Qwen-AgentWorld-35B-A3B-nvfp4-mlx',
-    sizeGb: 22.7,
+    hfRepo: 'Brooooooklyn/Qwen-AgentWorld-35B-A3B-mxfp4-mlx',
+    hfRepoCuda: 'Brooooooklyn/Qwen-AgentWorld-35B-A3B-nvfp4-mlx',
+    sizeGb: 23.3,
     description: 'Agent-tuned MoE, fast decode',
   },
   {
     label: 'Gemma-4-26B-A4B',
-    hfRepo: 'Brooooooklyn/Gemma-4-26B-A4B-NVFP4-mlx',
-    sizeGb: 18.8,
+    hfRepo: 'Brooooooklyn/Gemma-4-26B-A4B-Unsloth-MXFP4-mlx',
+    hfRepoCuda: 'Brooooooklyn/Gemma-4-26B-A4B-Unsloth-NVFP4-mlx',
+    sizeGb: 16.2,
     description: 'MoE, fast decode',
   },
   {
@@ -91,6 +109,29 @@ export const MODEL_CATALOG: readonly CatalogEntry[] = [
     hidden: true,
   },
 ];
+
+/**
+ * The repo THIS platform installs for `entry`.
+ *
+ * The quantization format is not a preference, it is a backend fact: Metal
+ * expresses MXFP4 natively and cannot express NVFP4 at all, while CUDA's
+ * `CublasQQMM` takes NVFP4 directly. Linux is the CUDA preview target
+ * (README "Platform Support"); everything else is Apple Silicon.
+ *
+ * Every consumer that turns a catalog entry into a download, a slug, or an
+ * allowlist check must go through here. Reading `entry.hfRepo` directly
+ * installs the macOS build on a CUDA box.
+ */
+export function catalogRepo(entry: CatalogEntry): string {
+  return process.platform === 'linux' && entry.hfRepoCuda !== undefined ? entry.hfRepoCuda : entry.hfRepo;
+}
+
+/** Every repo `entry` may occupy on ANY platform, lowercased. */
+export function catalogRepoAliases(entry: CatalogEntry): string[] {
+  const repos = [entry.hfRepo];
+  if (entry.hfRepoCuda !== undefined) repos.push(entry.hfRepoCuda);
+  return repos.map((repo) => repo.toLowerCase());
+}
 
 /** Catalog entries the wizard offers (hidden entries filtered out). */
 export function visibleCatalog(): CatalogEntry[] {

--- a/packages/agent/src/catalog.ts
+++ b/packages/agent/src/catalog.ts
@@ -9,18 +9,10 @@
 export interface CatalogEntry {
   /** Wizard display name. */
   label: string;
-  /**
-   * HF slug for `mlx download model` on Apple Silicon — the MXFP4 build.
-   *
-   * Metal's block scaling is MXFP4-shaped: the scale plane must be
-   * `metal_fp8_ue8m0_format` at block 32 (MSL Spec 4.1 Table 2.28). NVFP4's
-   * E4M3 scales at block 16 cannot be declared there, so it decodes through a
-   * dequant path instead of the native one.
-   */
+  /** HF slug for `mlx download model` on Apple Silicon — the MXFP4 build. */
   hfRepo: string;
   /**
-   * HF slug on Linux + NVIDIA CUDA — the NVFP4 build, which is what
-   * `CublasQQMM` consumes natively (`nvfp4` -> `CUDA_R_4F_E2M1`).
+   * HF slug on Linux + NVIDIA CUDA — the NVFP4 build.
    *
    * Absent means the entry has no CUDA-specific build and {@link hfRepo}
    * serves both. Resolve with {@link catalogRepo}, never by reading the field.
@@ -111,12 +103,29 @@ export const MODEL_CATALOG: readonly CatalogEntry[] = [
 ];
 
 /**
- * The repo THIS platform installs for `entry`.
+ * The repo THIS platform installs for `entry`. Linux is the CUDA preview
+ * target (README "Platform Support"); everything else is Apple Silicon.
  *
- * The quantization format is not a preference, it is a backend fact: Metal
- * expresses MXFP4 natively and cannot express NVFP4 at all, while CUDA's
- * `CublasQQMM` takes NVFP4 directly. Linux is the CUDA preview target
- * (README "Platform Support"); everything else is Apple Silicon.
+ * NOT because Metal cannot run NVFP4 — it can. MLX ships the same 234
+ * quantized Metal kernels for `nvfp4` as for `mxfp4`, NAX variants included,
+ * and only `fp8_e4m3` reconstructs BF16 at load. The MSL 4.1 hardware
+ * block-scale format (`metal_fp8_ue8m0_format`) appears nowhere in MLX's Metal
+ * backend, so it constrains neither format here.
+ *
+ * The split is:
+ * - CUDA takes NVFP4 through `CublasQQMM` (`nvfp4` -> `CUDA_R_4F_E2M1`), a
+ *   native path with no MXFP4 equivalent.
+ * - Metal has no such native-path advantage either way, so prefer the format
+ *   that survives quantization better. NVFP4 stores a block scale as `amax/6`
+ *   in E4M3, and real FFN blocks land in its subnormal band;
+ *   `apply_nvfp4_pow2_lift` repairs that for dense SwiGLU FFNs but SKIPS MoE
+ *   experts by design (`NVFP4_LIFT_MOE_MARKERS`, `crates/mlx-core/src/
+ *   convert.rs`), because the norm there also drives the router and the
+ *   shared-expert gate, neither scale-invariant. Two of the three visible
+ *   entries are MoE. MXFP4's E8M0 block scales have no such failure.
+ *
+ * Unmeasured: whether nvfp4 or mxfp4 decodes faster on Metal. The choice above
+ * is made on quantization quality, not throughput.
  *
  * Every consumer that turns a catalog entry into a download, a slug, or an
  * allowlist check must go through here. Reading `entry.hfRepo` directly

--- a/packages/agent/src/catalog.ts
+++ b/packages/agent/src/catalog.ts
@@ -132,7 +132,19 @@ export const MODEL_CATALOG: readonly CatalogEntry[] = [
  * installs the macOS build on a CUDA box.
  */
 export function catalogRepo(entry: CatalogEntry): string {
-  return process.platform === 'linux' && entry.hfRepoCuda !== undefined ? entry.hfRepoCuda : entry.hfRepo;
+  return catalogRepoFor(entry, process.platform);
+}
+
+/**
+ * {@link catalogRepo} with the platform passed in — the pure half.
+ *
+ * Exists so both branches can be asserted without touching `process.platform`.
+ * Mutating that global leaks across test files sharing a worker: it made
+ * `catalogRepo` disagree with a sibling suite's module-level constant and fail
+ * a download allowlist check that has nothing to do with the catalog.
+ */
+export function catalogRepoFor(entry: CatalogEntry, platform: NodeJS.Platform): string {
+  return platform === 'linux' && entry.hfRepoCuda !== undefined ? entry.hfRepoCuda : entry.hfRepo;
 }
 
 /** Catalog entries the wizard offers (hidden entries filtered out). */

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,6 +1,6 @@
 export type { DiscoveredModelLike } from './types.js';
 
-export { type CatalogEntry, catalogRepo, MODEL_CATALOG, visibleCatalog } from './catalog.js';
+export { type CatalogEntry, catalogRepo, catalogRepoFor, MODEL_CATALOG, visibleCatalog } from './catalog.js';
 export { createPermissionGateExtension } from './extensions/permission-gate.js';
 export {
   createSubagentExtension,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,6 +1,6 @@
 export type { DiscoveredModelLike } from './types.js';
 
-export { type CatalogEntry, MODEL_CATALOG, visibleCatalog } from './catalog.js';
+export { type CatalogEntry, catalogRepo, catalogRepoAliases, MODEL_CATALOG, visibleCatalog } from './catalog.js';
 export { createPermissionGateExtension } from './extensions/permission-gate.js';
 export {
   createSubagentExtension,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,6 +1,6 @@
 export type { DiscoveredModelLike } from './types.js';
 
-export { type CatalogEntry, catalogRepo, catalogRepoAliases, MODEL_CATALOG, visibleCatalog } from './catalog.js';
+export { type CatalogEntry, catalogRepo, MODEL_CATALOG, visibleCatalog } from './catalog.js';
 export { createPermissionGateExtension } from './extensions/permission-gate.js';
 export {
   createSubagentExtension,

--- a/packages/cli/src/commands/agent/wizard.ts
+++ b/packages/cli/src/commands/agent/wizard.ts
@@ -10,7 +10,7 @@
 
 import { join } from 'node:path';
 
-import { visibleCatalog } from '@mlx-node/agent';
+import { catalogRepo, visibleCatalog } from '@mlx-node/agent';
 
 export interface WizardIO {
   select: (opts: { message: string; choices: Array<{ name: string; value: string }> }) => Promise<string>;
@@ -77,7 +77,8 @@ export async function runFirstRunWizard(deps: WizardDeps): Promise<string> {
   if (!deps.io.isTTY) {
     const commands = catalog
       .map(
-        (entry) => `  mlx download model ${downloadModelArgv(entry.hfRepo, deps.modelsDir).map(shellQuote).join(' ')}`,
+        (entry) =>
+          `  mlx download model ${downloadModelArgv(catalogRepo(entry), deps.modelsDir).map(shellQuote).join(' ')}`,
       )
       .join('\n');
     throw new Error(
@@ -91,7 +92,7 @@ export async function runFirstRunWizard(deps: WizardDeps): Promise<string> {
     message: 'Model to download',
     choices: ordered.map((entry) => ({
       name: `${entry.label} (~${entry.sizeGb} GB) — ${entry.description}`,
-      value: entry.hfRepo,
+      value: catalogRepo(entry),
     })),
   });
 

--- a/packages/dashboard/__test__/download.test.ts
+++ b/packages/dashboard/__test__/download.test.ts
@@ -371,6 +371,34 @@ describe('DownloadManager.checkCatalogUpdates — the read half of the staleness
     expect(hub.modelInfoRepos.length).toBeGreaterThan(afterFirst);
     expect((await m.checkCatalogUpdates(1000 + 61_000)).get(REPO)).toBe(hub.sha);
   });
+
+  it("folds a job's freshly resolved revision into the cache", async () => {
+    // Upstream can advance between a sweep and the user's click. `processJob`
+    // then installs the NEW sha while the cache still holds the old one, so the
+    // card re-offers an update for the revision just installed and every click
+    // completes as a no-op. The job's own resolve IS a fresh upstream read, so
+    // it is authoritative for that repo.
+    hub.sha = SHA_OLD;
+    const m = new DownloadManager({
+      modelsDir,
+      cacheDir,
+      fetchImpl: makeFetchImpl({ 'config.json': 12, 'model.safetensors': 300 }),
+    });
+    expect((await m.checkCatalogUpdates(1000)).get(REPO)).toBe(SHA_OLD);
+
+    hub.sha = SHA_NEW;
+    const events: DownloadEvent[] = [];
+    const id = m.start(REPO);
+    m.subscribe(id, (event) => events.push(event));
+    await waitFor(() => events.some((event) => event.type === 'done'));
+
+    // Well inside the 6h TTL, so this is the CACHE answering — and it must have
+    // been corrected by the job rather than still serving the pre-install sha.
+    const shas = await m.checkCatalogUpdates(1000 + 60_000);
+    expect(shas.get(REPO)).toBe(SHA_NEW);
+    // Untouched repos keep the cached sweep; the job speaks only for its own.
+    expect(shas.get(REPO_OTHER)).toBe(SHA_OLD);
+  });
 });
 
 describe('DownloadManager', () => {

--- a/packages/dashboard/__test__/download.test.ts
+++ b/packages/dashboard/__test__/download.test.ts
@@ -451,6 +451,106 @@ describe('DownloadManager.checkCatalogUpdates — the read half of the staleness
     expect(shas.get(REPO)).toBe(SHA_NEW);
   });
 
+  it('keeps a sweep read that was ISSUED after the job asked for the same repo', async () => {
+    // The overlay above assumes the job asked LAST. Reversed — the job's read
+    // goes out, this sweep starts and asks the same repo, and the job's slower
+    // answer still lands first — the sweep holds the NEWER sha, and letting the
+    // job's older one overwrite it would bury a genuine update for the whole
+    // success TTL, which the post-download refresh reads straight back.
+    let releaseJob: (() => void) | undefined;
+    const jobGate = new Promise<void>((resolve) => {
+      releaseJob = resolve;
+    });
+    let releaseSweep: (() => void) | undefined;
+    const sweepGate = new Promise<void>((resolve) => {
+      releaseSweep = resolve;
+    });
+    hub.modelInfoUsesFetch = true;
+    const inner = makeFetchImpl({ 'config.json': 12, 'model.safetensors': 300 });
+    let jobAsked = false;
+    let sweepAsked = 0;
+    const gated: typeof fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      // Only the sha reads are parked — the job's file fetches run unimpeded, so
+      // this is the real write-through path, not a stub.
+      if (url.includes('/api/models/')) {
+        if (!jobAsked) {
+          jobAsked = true;
+          await jobGate;
+        } else {
+          sweepAsked += 1;
+          await sweepGate;
+        }
+      }
+      return inner(input, init);
+    };
+    const m = new DownloadManager({ modelsDir, cacheDir, fetchImpl: gated });
+
+    // The job asks first, so its answer is the sha upstream held BEFORE it moved.
+    hub.sha = SHA_OLD;
+    const events: DownloadEvent[] = [];
+    const id = m.start(REPO);
+    m.subscribe(id, (event) => events.push(event));
+    await waitFor(() => jobAsked);
+
+    // Upstream advances, and only THEN does the sweep ask.
+    hub.sha = SHA_NEW;
+    const sweep = m.checkCatalogUpdates(1000);
+    await waitFor(() => sweepAsked === MODEL_CATALOG.filter((e) => !e.hidden).length);
+
+    // The job's older answer lands first and writes itself through.
+    releaseJob!();
+    await waitFor(() => events.some((event) => event.type === 'done'));
+
+    releaseSweep!();
+    const shas = await sweep;
+    // The job pinned the older revision, so the sweep's read is a real update.
+    expect(hub.revisions).toContain(SHA_OLD);
+    expect(shas.get(REPO)).toBe(SHA_NEW);
+  });
+
+  it('refuses a job write-through into a cache a LATER read already filled', async () => {
+    // The other half of the same inversion. Here the sweep commits FIRST, so the
+    // job's write-through lands on an already-published map rather than being
+    // folded in by the overlay — a path the overlay guard never sees. The job
+    // still asked first, so its answer is the older observation, and letting it
+    // overwrite the committed newer sha buries the update for the success TTL.
+    let releaseJob: (() => void) | undefined;
+    const jobGate = new Promise<void>((resolve) => {
+      releaseJob = resolve;
+    });
+    hub.modelInfoUsesFetch = true;
+    const inner = makeFetchImpl({ 'config.json': 12, 'model.safetensors': 300 });
+    let jobAsked = false;
+    const gated: typeof fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes('/api/models/') && !jobAsked) {
+        jobAsked = true;
+        await jobGate;
+      }
+      return inner(input, init);
+    };
+    const m = new DownloadManager({ modelsDir, cacheDir, fetchImpl: gated });
+
+    hub.sha = SHA_OLD;
+    const events: DownloadEvent[] = [];
+    const id = m.start(REPO);
+    m.subscribe(id, (event) => events.push(event));
+    await waitFor(() => jobAsked);
+
+    // Upstream advances, and a whole sweep asks, answers and COMMITS while the
+    // job's own read is still out.
+    hub.sha = SHA_NEW;
+    expect((await m.checkCatalogUpdates(1000)).get(REPO)).toBe(SHA_NEW);
+
+    releaseJob!();
+    await waitFor(() => events.some((event) => event.type === 'done'));
+
+    // Inside the success TTL, so this reads the committed map back — the same
+    // map the post-download refresh gets, and the one the card compares against.
+    expect((await m.checkCatalogUpdates(1000 + 60_000)).get(REPO)).toBe(SHA_NEW);
+  });
+
   it('serves one sweep to every check that overlaps it', async () => {
     // Nothing serialises these calls: the RPC host fires each frame off with
     // `void Promise.resolve().then(...)`, and `useJson`'s `reload()` starts a

--- a/packages/dashboard/__test__/download.test.ts
+++ b/packages/dashboard/__test__/download.test.ts
@@ -67,6 +67,14 @@ const hub = vi.hoisted(() => ({
   modelInfoError: null as string | null,
   /** Repos whose `modelInfo` throws, for a PARTIALLY failed sweep. */
   modelInfoFailRepos: [] as string[],
+  /**
+   * Make `modelInfo` actually CALL the fetch it is handed.
+   *
+   * Off by default so existing tests keep their cheap stub. The probe's
+   * deadline and its abort signal live in that fetch, so they are unreachable
+   * — and untestable — unless the mock exercises it.
+   */
+  modelInfoUsesFetch: false,
   /** Paths whose `downloadFileToCacheDir` should throw, to simulate a mid-job failure. */
   failOn: [] as string[],
   /** Overrides the thrown message, so a remote-sized error body can be simulated. */
@@ -133,14 +141,22 @@ vi.mock('node:fs/promises', async (importActual) => {
 });
 
 vi.mock('@huggingface/hub', () => ({
-  modelInfo: async (params: { name?: string; revision?: string }) => {
+  modelInfo: async (params: { name?: string; revision?: string; fetch?: typeof fetch }) => {
     if (params.name !== undefined) hub.modelInfoRepos.push(params.name);
     if (hub.modelInfoError !== null) throw new Error(hub.modelInfoError);
     if (params.name !== undefined && hub.modelInfoFailRepos.includes(params.name)) {
       throw new Error(`simulated modelInfo failure for ${params.name}`);
     }
+    // Snapshot BEFORE any await, the way a real server answers with the sha as
+    // of the request. Reading it afterwards would let a parked call return a
+    // value written while it waited — which silently made the sweep-race test
+    // tautological, passing with the fix removed.
+    const sha = hub.sha;
+    if (hub.modelInfoUsesFetch && params.fetch !== undefined) {
+      await params.fetch(`https://huggingface.co/api/models/${params.name ?? 'x'}`);
+    }
     if (params.revision !== undefined) hub.revisions.push(params.revision);
-    return { sha: hub.sha };
+    return { sha };
   },
   listFiles: async function* (params: { revision?: string }) {
     if (params.revision !== undefined) hub.revisions.push(params.revision);
@@ -320,6 +336,7 @@ beforeEach(() => {
   hub.modelInfoRepos = [];
   hub.modelInfoError = null;
   hub.modelInfoFailRepos = [];
+  hub.modelInfoUsesFetch = false;
   modelsDir = mkdtempSync(join(tmpdir(), 'dash-dl-models-'));
   cacheDir = mkdtempSync(join(tmpdir(), 'dash-dl-cache-'));
 });
@@ -376,6 +393,62 @@ describe('DownloadManager.checkCatalogUpdates — the read half of the staleness
     await m.checkCatalogUpdates(1000 + 61_000);
     expect(hub.modelInfoRepos.length).toBeGreaterThan(afterFirst);
     expect((await m.checkCatalogUpdates(1000 + 61_000)).get(REPO)).toBe(hub.sha);
+  });
+
+  it('degrades a STALLED probe to null instead of hanging the route', async () => {
+    // The failure mode this guards is not hypothetical: an HF socket was seen
+    // here sitting in CLOSE_WAIT for hours at zero CPU. Unbounded, the
+    // `Promise.all` never settles, the route never answers, and the RPC client
+    // declares the whole runtime unresponsive and restarts it — killing any
+    // download in flight.
+    hub.modelInfoUsesFetch = true;
+    const hang: typeof fetch = (_input, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    const m = new DownloadManager({ modelsDir, cacheDir, fetchImpl: hang, probeTimeoutMs: 50 });
+    const shas = await m.checkCatalogUpdates();
+    expect(shas.size).toBeGreaterThan(0);
+    expect([...shas.values()].every((sha) => sha === null)).toBe(true);
+  });
+
+  it('keeps a job-resolved revision that landed while a sweep was in flight', async () => {
+    // The sweep replaces the WHOLE cache map when it commits. A job that
+    // resolved and installed a newer sha mid-sweep would have its write-through
+    // clobbered by the older value the sweep captured, so the card would
+    // re-offer an update for the revision just installed.
+    let releaseSweep: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseSweep = resolve;
+    });
+    hub.modelInfoUsesFetch = true;
+    const inner = makeFetchImpl({ 'config.json': 12, 'model.safetensors': 300 });
+    let parked = false;
+    const slow: typeof fetch = async (input, init) => {
+      // Park the sweep's FIRST request only; everything the job does afterwards
+      // proceeds normally, so this is the real write-through path, not a stub.
+      if (!parked) {
+        parked = true;
+        await gate;
+      }
+      return inner(input, init);
+    };
+    const m = new DownloadManager({ modelsDir, cacheDir, fetchImpl: slow });
+    hub.sha = SHA_OLD;
+    const sweep = m.checkCatalogUpdates(1000);
+    await waitFor(() => parked);
+
+    // With that sweep parked mid-flight, a real job resolves and installs NEW.
+    hub.sha = SHA_NEW;
+    const events: DownloadEvent[] = [];
+    const id = m.start(REPO);
+    m.subscribe(id, (event) => events.push(event));
+    await waitFor(() => events.some((event) => event.type === 'done'));
+
+    releaseSweep!();
+    const shas = await sweep;
+    // The sweep captured SHA_OLD for this repo; the job's newer read must win.
+    expect(shas.get(REPO)).toBe(SHA_NEW);
   });
 
   it('takes the short TTL when ANY repo failed, not only when all did', async () => {

--- a/packages/dashboard/__test__/download.test.ts
+++ b/packages/dashboard/__test__/download.test.ts
@@ -65,6 +65,8 @@ const hub = vi.hoisted(() => ({
   modelInfoRepos: [] as string[],
   /** When set, every `modelInfo` call throws it — the offline case. */
   modelInfoError: null as string | null,
+  /** Repos whose `modelInfo` throws, for a PARTIALLY failed sweep. */
+  modelInfoFailRepos: [] as string[],
   /** Paths whose `downloadFileToCacheDir` should throw, to simulate a mid-job failure. */
   failOn: [] as string[],
   /** Overrides the thrown message, so a remote-sized error body can be simulated. */
@@ -134,6 +136,9 @@ vi.mock('@huggingface/hub', () => ({
   modelInfo: async (params: { name?: string; revision?: string }) => {
     if (params.name !== undefined) hub.modelInfoRepos.push(params.name);
     if (hub.modelInfoError !== null) throw new Error(hub.modelInfoError);
+    if (params.name !== undefined && hub.modelInfoFailRepos.includes(params.name)) {
+      throw new Error(`simulated modelInfo failure for ${params.name}`);
+    }
     if (params.revision !== undefined) hub.revisions.push(params.revision);
     return { sha: hub.sha };
   },
@@ -314,6 +319,7 @@ beforeEach(() => {
   stagingHook.onVerifyWindow = null;
   hub.modelInfoRepos = [];
   hub.modelInfoError = null;
+  hub.modelInfoFailRepos = [];
   modelsDir = mkdtempSync(join(tmpdir(), 'dash-dl-models-'));
   cacheDir = mkdtempSync(join(tmpdir(), 'dash-dl-cache-'));
 });
@@ -370,6 +376,24 @@ describe('DownloadManager.checkCatalogUpdates — the read half of the staleness
     await m.checkCatalogUpdates(1000 + 61_000);
     expect(hub.modelInfoRepos.length).toBeGreaterThan(afterFirst);
     expect((await m.checkCatalogUpdates(1000 + 61_000)).get(REPO)).toBe(hub.sha);
+  });
+
+  it('takes the short TTL when ANY repo failed, not only when all did', async () => {
+    // One cache entry covers the whole sweep, so a single transient failure
+    // beside successes would otherwise pin that repo's `null` for six hours —
+    // no mount or reconnect in that window could surface its update.
+    hub.modelInfoFailRepos = [REPO_OTHER];
+    const m = manager();
+    const first = await m.checkCatalogUpdates(1000);
+    expect(first.get(REPO)).toBe(hub.sha);
+    expect(first.get(REPO_OTHER)).toBeNull();
+    const afterFirst = hub.modelInfoRepos.length;
+
+    // Inside the SUCCESS TTL but past the negative one: must re-dial.
+    hub.modelInfoFailRepos = [];
+    const second = await m.checkCatalogUpdates(1000 + 61_000);
+    expect(hub.modelInfoRepos.length).toBeGreaterThan(afterFirst);
+    expect(second.get(REPO_OTHER)).toBe(hub.sha);
   });
 
   it("folds a job's freshly resolved revision into the cache", async () => {

--- a/packages/dashboard/__test__/download.test.ts
+++ b/packages/dashboard/__test__/download.test.ts
@@ -484,7 +484,10 @@ describe('DownloadManager', () => {
       fetchImpl: makeFetchImpl({ 'config.json': 12, 'model.safetensors': 300 }),
     });
 
-    expect(() => manager.start(hidden!.hfRepo)).toThrow(/not in the model catalog/);
+    // Through the resolver, mirroring the allowlist. Hidden entries carry no
+    // CUDA build today, so this is the same string — but a raw `hfRepo` here
+    // would silently start testing the wrong thing the day one does.
+    expect(() => manager.start(catalogRepo(hidden!))).toThrow(/not in the model catalog/);
     // Rejected BEFORE any job is allocated — otherwise the SPA renders a job
     // that marches to a 401 instead of an immediate, actionable error.
     expect(manager.jobs()).toEqual([]);

--- a/packages/dashboard/__test__/download.test.ts
+++ b/packages/dashboard/__test__/download.test.ts
@@ -13,7 +13,7 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-import { MODEL_CATALOG } from '@mlx-node/agent/catalog';
+import { catalogRepo, MODEL_CATALOG } from '@mlx-node/agent/catalog';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { catalogWithState } from '../src/catalog.js';
@@ -61,6 +61,10 @@ const hub = vi.hoisted(() => ({
   sha: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
   /** Every `revision` the runner threaded into a list/download call. */
   revisions: [] as string[],
+  /** Repos `modelInfo` was asked to resolve, for the catalog sha sweep. */
+  modelInfoRepos: [] as string[],
+  /** When set, every `modelInfo` call throws it — the offline case. */
+  modelInfoError: null as string | null,
   /** Paths whose `downloadFileToCacheDir` should throw, to simulate a mid-job failure. */
   failOn: [] as string[],
   /** Overrides the thrown message, so a remote-sized error body can be simulated. */
@@ -127,7 +131,9 @@ vi.mock('node:fs/promises', async (importActual) => {
 });
 
 vi.mock('@huggingface/hub', () => ({
-  modelInfo: async (params: { revision?: string }) => {
+  modelInfo: async (params: { name?: string; revision?: string }) => {
+    if (params.name !== undefined) hub.modelInfoRepos.push(params.name);
+    if (hub.modelInfoError !== null) throw new Error(hub.modelInfoError);
     if (params.revision !== undefined) hub.revisions.push(params.revision);
     return { sha: hub.sha };
   },
@@ -250,10 +256,13 @@ async function waitFor(cond: () => boolean, timeoutMs = 5000): Promise<void> {
   }
 }
 
-const REPO = MODEL_CATALOG[0]!.hfRepo;
+// Resolved through `catalogRepo`, matching the allowlist gate in `start` — the
+// catalog carries a different build per platform, so the raw `hfRepo` would be
+// refused on a CUDA host.
+const REPO = catalogRepo(MODEL_CATALOG[0]!);
 const SLUG = REPO.split('/').pop()!.toLowerCase();
 /** A SECOND catalog repo, for the cases that need two genuinely distinct jobs. */
-const REPO_OTHER = MODEL_CATALOG[1]!.hfRepo;
+const REPO_OTHER = catalogRepo(MODEL_CATALOG[1]!);
 
 let modelsDir: string;
 let cacheDir: string;
@@ -303,12 +312,65 @@ beforeEach(() => {
   renameFault.failFromPrefix = null;
   raceHook.onMarkerWrite = null;
   stagingHook.onVerifyWindow = null;
+  hub.modelInfoRepos = [];
+  hub.modelInfoError = null;
   modelsDir = mkdtempSync(join(tmpdir(), 'dash-dl-models-'));
   cacheDir = mkdtempSync(join(tmpdir(), 'dash-dl-cache-'));
 });
 
 afterEach(() => {
   for (const dir of [modelsDir, cacheDir]) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('DownloadManager.checkCatalogUpdates — the read half of the staleness check', () => {
+  function manager(): DownloadManager {
+    return new DownloadManager({ modelsDir, cacheDir });
+  }
+
+  it('resolves a sha for every VISIBLE catalog repo, and skips the hidden ones', async () => {
+    // `hidden` entries are unpublished repos: Hugging Face answers 401 for them,
+    // so dialling would spend a request to learn nothing.
+    const shas = await manager().checkCatalogUpdates();
+    const visible = MODEL_CATALOG.filter((e) => !e.hidden).map((e) => catalogRepo(e));
+    expect([...shas.keys()].sort()).toEqual([...visible].sort());
+    expect(shas.get(REPO)).toBe(hub.sha);
+    for (const entry of MODEL_CATALOG.filter((e) => e.hidden)) {
+      expect(hub.modelInfoRepos).not.toContain(catalogRepo(entry));
+    }
+  });
+
+  it('maps an unreachable repo to null rather than rejecting', async () => {
+    // Offline must never break the Models page. `null` reads as "no badge",
+    // never as "up to date".
+    hub.modelInfoError = 'getaddrinfo ENOTFOUND huggingface.co';
+    const shas = await manager().checkCatalogUpdates();
+    expect(shas.size).toBeGreaterThan(0);
+    expect([...shas.values()].every((sha) => sha === null)).toBe(true);
+  });
+
+  it('reuses a resolved sweep instead of re-dialling on every mount', async () => {
+    // `useJson` refetches on every mount and every reconnect, and nothing polls
+    // to smooth the rate, so the cache is what keeps this off the network.
+    const m = manager();
+    await m.checkCatalogUpdates(1000);
+    const afterFirst = hub.modelInfoRepos.length;
+    expect(afterFirst).toBeGreaterThan(0);
+    await m.checkCatalogUpdates(1000 + 60_000);
+    expect(hub.modelInfoRepos).toHaveLength(afterFirst);
+  });
+
+  it('retries an all-failed sweep far sooner than a good one', async () => {
+    // A machine that regains its network must not stay stuck reporting nothing
+    // for the full success TTL.
+    hub.modelInfoError = 'offline';
+    const m = manager();
+    await m.checkCatalogUpdates(1000);
+    const afterFirst = hub.modelInfoRepos.length;
+    hub.modelInfoError = null;
+    await m.checkCatalogUpdates(1000 + 61_000);
+    expect(hub.modelInfoRepos.length).toBeGreaterThan(afterFirst);
+    expect((await m.checkCatalogUpdates(1000 + 61_000)).get(REPO)).toBe(hub.sha);
+  });
 });
 
 describe('DownloadManager', () => {

--- a/packages/dashboard/__test__/download.test.ts
+++ b/packages/dashboard/__test__/download.test.ts
@@ -451,6 +451,52 @@ describe('DownloadManager.checkCatalogUpdates — the read half of the staleness
     expect(shas.get(REPO)).toBe(SHA_NEW);
   });
 
+  it('serves one sweep to every check that overlaps it', async () => {
+    // Nothing serialises these calls: the RPC host fires each frame off with
+    // `void Promise.resolve().then(...)`, and `useJson`'s `reload()` starts a
+    // second request without cancelling the first — which the Models page does
+    // on mount, on reconcile, and at every job settle. Two independent sweeps
+    // both commit unconditionally, so the slower one lands last and pins the
+    // OLDER sha it captured for the full six-hour TTL, with no job in the
+    // interleaving for `jobResolvedShas` to repair it from. Each overlap also
+    // pays a second full fan-out, the very cost the cache exists to avoid.
+    const visible = MODEL_CATALOG.filter((e) => !e.hidden).length;
+    let releaseSweep: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseSweep = resolve;
+    });
+    hub.modelInfoUsesFetch = true;
+    const inner = makeFetchImpl({});
+    let parked = 0;
+    const slow: typeof fetch = async (input, init) => {
+      // Park exactly the first sweep's probes. A second sweep, if one is ever
+      // started, runs unimpeded and commits FIRST — the losing interleaving.
+      if (parked < visible) {
+        parked += 1;
+        await gate;
+      }
+      return inner(input, init);
+    };
+    const m = new DownloadManager({ modelsDir, cacheDir, fetchImpl: slow });
+    hub.sha = SHA_OLD;
+    const first = m.checkCatalogUpdates(1000);
+    await waitFor(() => parked === visible);
+
+    // Upstream advances while that sweep is parked, then a second check arrives.
+    hub.sha = SHA_NEW;
+    const second = m.checkCatalogUpdates(1000);
+    releaseSweep!();
+    const [firstShas, secondShas] = await Promise.all([first, second]);
+
+    // ONE fan-out for both callers, not two.
+    expect(hub.modelInfoRepos).toHaveLength(visible);
+    expect(secondShas).toBe(firstShas);
+    expect(firstShas.get(REPO)).toBe(SHA_OLD);
+    // Well inside the 6h TTL: the cache still holds that same map, so no late
+    // commit rolled it back.
+    expect(await m.checkCatalogUpdates(1000 + 60_000)).toBe(firstShas);
+  });
+
   it('takes the short TTL when ANY repo failed, not only when all did', async () => {
     // One cache entry covers the whole sweep, so a single transient failure
     // beside successes would otherwise pin that repo's `null` for six hours —

--- a/packages/dashboard/__test__/download.test.ts
+++ b/packages/dashboard/__test__/download.test.ts
@@ -542,7 +542,7 @@ describe('DownloadManager', () => {
     expect(job.receivedBytes).toBe(312);
   });
 
-  it('refuses a hidden catalog entry up front instead of failing mid-download', () => {
+  it('refuses a hidden catalog entry up front instead of failing mid-download', async () => {
     // A `hidden` entry is an UNPUBLISHED repo: it stays in MODEL_CATALOG so a
     // locally converted checkpoint at the canonical slug is still recognized as
     // Installed, but Hugging Face answers 401 for it. Membership alone is
@@ -567,6 +567,12 @@ describe('DownloadManager', () => {
 
     // Non-hidden entries are unaffected.
     expect(() => manager.start(REPO)).not.toThrow();
+    // That last `start` allocated a REAL job whose `drain` runs detached. Without
+    // this the test returns while `processJob` is still writing under `modelsDir`,
+    // and the `afterEach` `rmSync` races it to an intermittent ENOTEMPTY.
+    await manager.shutdown();
+    // Deterministic proof the wait happened: an unawaited job reads `running`.
+    expect(manager.jobs().map((job) => job.state)).toEqual(['cancelled']);
   });
 
   it('pins one resolved commit sha and threads it into every list/download call', async () => {

--- a/packages/dashboard/__test__/loading-shape-lists.test.ts
+++ b/packages/dashboard/__test__/loading-shape-lists.test.ts
@@ -161,40 +161,43 @@ function modelsRoutes(): Record<string, unknown> {
   const catalog: CatalogResponse = {
     items: [
       {
-        label: 'Qwen3.6-27B',
-        hfRepo: 'Brooooooklyn/Qwen3.6-27B-NVFP4-mlx',
-        sizeGb: 22.2,
+        label: 'Qwen3.8-27B',
+        hfRepo: 'Brooooooklyn/Qwen3.8-27B-MXFP4-mlx',
+        sizeGb: 23.3,
         description: 'Best tool use — recommended default',
-        slug: 'qwen3.6-27b-nvfp4-mlx',
+        slug: 'qwen3.8-27b-mxfp4-mlx',
         isDefault: true,
         installed: false,
         present: false,
         blockedByForeignDir: false,
+        localRevision: null,
       },
       {
         label: 'Qwen-AgentWorld-35B',
-        hfRepo: 'Brooooooklyn/Qwen-AgentWorld-35B-A3B-nvfp4-mlx',
-        sizeGb: 22.7,
+        hfRepo: 'Brooooooklyn/Qwen-AgentWorld-35B-A3B-mxfp4-mlx',
+        sizeGb: 23.3,
         description: 'Agent-tuned MoE, fast decode',
-        slug: 'qwen-agentworld-35b-a3b-nvfp4-mlx',
+        slug: 'qwen-agentworld-35b-a3b-mxfp4-mlx',
         installed: false,
         present: false,
         blockedByForeignDir: false,
+        localRevision: null,
       },
       {
         label: 'Gemma-4-26B-A4B',
-        hfRepo: 'Brooooooklyn/Gemma-4-26B-A4B-NVFP4-mlx',
-        sizeGb: 18.8,
+        hfRepo: 'Brooooooklyn/Gemma-4-26B-A4B-Unsloth-MXFP4-mlx',
+        sizeGb: 16.2,
         description: 'MoE, fast decode',
-        slug: 'gemma-4-26b-a4b-nvfp4-mlx',
+        slug: 'gemma-4-26b-a4b-unsloth-mxfp4-mlx',
         installed: false,
         present: false,
         blockedByForeignDir: false,
+        localRevision: null,
       },
     ],
   };
   const downloads: DownloadsResponse = { jobs: [] };
-  return { '/models': models, '/catalog': catalog, '/downloads': downloads };
+  return { '/models': models, '/catalog': catalog, '/catalog/updates': { items: [] }, '/downloads': downloads };
 }
 
 function sessionRow(overrides: Partial<SessionRow>): SessionRow {

--- a/packages/dashboard/__test__/models.test.ts
+++ b/packages/dashboard/__test__/models.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { MODEL_CATALOG } from '@mlx-node/agent/catalog';
+import { catalogRepo, MODEL_CATALOG } from '@mlx-node/agent/catalog';
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 
 import { type CatalogItem, catalogSlug, catalogWithState } from '../src/catalog.js';
@@ -633,6 +633,26 @@ describe('catalogWithState — a recommended model is identified by download pro
     expect(item.present).toBe(true);
     expect(item.installed).toBe(false);
     expect(item.localRevision).toBeNull();
+  });
+
+  it("does NOT mark present for the OTHER platform's build of the same model", () => {
+    // Regression: the catalog recommended the nvfp4 builds to EVERY platform
+    // before it became platform-conditional, so an existing macOS install is
+    // exactly the CUDA alias. Counting it renders the card "Installed" with
+    // `installed` false — no Install button and no update affordance — which
+    // permanently strands the users this change exists to move onto the
+    // Metal-native build.
+    const mine = catalogRepo(RECOMMENDED);
+    const other = mine === RECOMMENDED.hfRepo ? RECOMMENDED.hfRepoCuda : RECOMMENDED.hfRepo;
+    expect(other, 'the default entry must carry both platform builds').toBeDefined();
+    expect(other).not.toBe(mine);
+    writeModel(modelsDir, 'other-platform-build', QWEN_27B_MXFP4, 2048);
+    writeCompletion('other-platform-build', other!);
+    const item = catalogItem(RECOMMENDED.label);
+    expect(item.present).toBe(false);
+    expect(item.installed).toBe(false);
+    // And the card therefore still offers the install rather than a dead button.
+    expect(item.blockedByForeignDir).toBe(false);
   });
 
   it('does NOT mark present when the marker survived but the checkpoint did not', () => {

--- a/packages/dashboard/__test__/models.test.ts
+++ b/packages/dashboard/__test__/models.test.ts
@@ -539,7 +539,7 @@ describe('defaultModelsDir', () => {
   });
 });
 
-/** The default recommendation (Qwen3.6-27B) and the folder a download lands in. */
+/** The default recommendation (Qwen3.8-27B) and the folder a download lands in. */
 const RECOMMENDED = MODEL_CATALOG[0]!;
 const RECOMMENDED_SLUG = catalogSlug(RECOMMENDED);
 
@@ -559,38 +559,38 @@ function writeCompletion(name: string, repo: string, files = ['config.json', 'mo
 }
 
 describe('catalogWithState — a recommended model is identified by download provenance', () => {
-  // The Qwen3.6-27B recommendation is an nvfp4 qwen3_5 checkpoint. `mlx convert`
-  // mandates bits=4 / group_size=16 for nvfp4, so that triple is a FORMAT CONSTANT
-  // shared by every nvfp4 checkpoint of the family — config shape cannot tell two
+  // The Qwen3.8-27B recommendation is an mxfp4 qwen3_5 checkpoint. MX block
+  // scaling fixes the block at 32, so bits=4 / group_size=32 is a FORMAT CONSTANT
+  // shared by every mxfp4 checkpoint of the family — config shape cannot tell two
   // different weight sets apart, only a recorded repo can.
-  const QWEN_27B_NVFP4 = JSON.stringify({
+  const QWEN_27B_MXFP4 = JSON.stringify({
     model_type: 'qwen3_5',
-    quantization: { bits: 4, mode: 'nvfp4', group_size: 16 },
+    quantization: { bits: 4, mode: 'mxfp4', group_size: 32 },
   });
 
   it('does NOT mark present for a look-alike fine-tune with no download provenance', () => {
     // A local fine-tune of the same base, same quant, under a name that starts with
     // the catalog label. Marking it present disables the ONLY Install affordance on
     // the Models page, hard-blocking the user from installing the real checkpoint.
-    writeModel(modelsDir, 'qwen3.6-27b-custom', QWEN_27B_NVFP4, 2048);
-    expect(catalogItem('Qwen3.6-27B').present).toBe(false);
-    expect(catalogItem('Qwen3.6-27B').installed).toBe(false);
+    writeModel(modelsDir, 'qwen3.8-27b-custom', QWEN_27B_MXFP4, 2048);
+    expect(catalogItem(RECOMMENDED.label).present).toBe(false);
+    expect(catalogItem(RECOMMENDED.label).installed).toBe(false);
   });
 
   it('marks present for a renamed folder carrying our completion marker for this repo', () => {
     // The capability the folder-prefix heuristic was reaching for, done exactly: a
     // dashboard install the user renamed is still recognized, because the marker
     // pins WHICH repo those bytes came from.
-    writeModel(modelsDir, 'renamed-by-hand', QWEN_27B_NVFP4, 2048);
+    writeModel(modelsDir, 'renamed-by-hand', QWEN_27B_MXFP4, 2048);
     writeCompletion('renamed-by-hand', RECOMMENDED.hfRepo);
-    expect(catalogItem('Qwen3.6-27B').present).toBe(true);
+    expect(catalogItem(RECOMMENDED.label).present).toBe(true);
   });
 
   it('marks present for a complete CLI install under the canonical slug', () => {
     // `mlx download` writes no marker, so provenance comes from the slug itself.
-    writeModel(modelsDir, RECOMMENDED_SLUG, QWEN_27B_NVFP4, 2048);
-    expect(catalogItem('Qwen3.6-27B').present).toBe(true);
-    expect(catalogItem('Qwen3.6-27B').installed).toBe(false);
+    writeModel(modelsDir, RECOMMENDED_SLUG, QWEN_27B_MXFP4, 2048);
+    expect(catalogItem(RECOMMENDED.label).present).toBe(true);
+    expect(catalogItem(RECOMMENDED.label).installed).toBe(false);
   });
 
   it('does NOT cross-match a marker that names a different repo', () => {
@@ -604,11 +604,42 @@ describe('catalogWithState — a recommended model is identified by download pro
     expect(catalogItem('Qwen-AgentWorld-35B').present).toBe(false);
   });
 
+  it('reports the marker revision as localRevision for an owned canonical install', () => {
+    // The read half of the update check: a re-upload lands new bytes at the SAME
+    // repo id, so only this recorded sha can tell the user their copy is stale.
+    writeModel(modelsDir, RECOMMENDED_SLUG, QWEN_27B_MXFP4, 2048);
+    writeCompletion(RECOMMENDED_SLUG, RECOMMENDED.hfRepo);
+    const item = catalogItem(RECOMMENDED.label);
+    expect(item.installed).toBe(true);
+    expect(item.localRevision).toBe('a'.repeat(40));
+  });
+
+  it('reports localRevision null for a markerless CLI install', () => {
+    // No marker means the sha is genuinely unknowable. Null must read as "no
+    // update badge", never as "up to date".
+    writeModel(modelsDir, RECOMMENDED_SLUG, QWEN_27B_MXFP4, 2048);
+    const item = catalogItem(RECOMMENDED.label);
+    expect(item.present).toBe(true);
+    expect(item.localRevision).toBeNull();
+  });
+
+  it('reports localRevision null for a renamed install matched only by provenance', () => {
+    // `present` comes from the marker under another folder name, but `installed`
+    // is false, and the runner would refuse to re-install over the unowned
+    // canonical slug — so an update affordance here could only ever fail.
+    writeModel(modelsDir, 'renamed-by-hand', QWEN_27B_MXFP4, 2048);
+    writeCompletion('renamed-by-hand', RECOMMENDED.hfRepo);
+    const item = catalogItem(RECOMMENDED.label);
+    expect(item.present).toBe(true);
+    expect(item.installed).toBe(false);
+    expect(item.localRevision).toBeNull();
+  });
+
   it('does NOT mark present when the marker survived but the checkpoint did not', () => {
     // The marker records what was published, not what is still there: a dir gutted
     // down to its marker is not a loadable checkpoint.
     writeCompletion('gutted', RECOMMENDED.hfRepo);
-    expect(catalogItem('Qwen3.6-27B').present).toBe(false);
+    expect(catalogItem(RECOMMENDED.label).present).toBe(false);
   });
 });
 
@@ -632,8 +663,8 @@ describe('catalogWithState — an occupied, unowned slug dir blocks Install', ()
     // hit the runner's ownership preflight and error every single time, so the card
     // must state the blockage instead of offering the button.
     writePartialShardedInstall(RECOMMENDED_SLUG);
-    expect(catalogItem('Qwen3.6-27B').present).toBe(false);
-    expect(catalogItem('Qwen3.6-27B').blockedByForeignDir).toBe(true);
+    expect(catalogItem(RECOMMENDED.label).present).toBe(false);
+    expect(catalogItem(RECOMMENDED.label).blockedByForeignDir).toBe(true);
   });
 
   it('flags an occupant with no config.json at all as blocked', () => {
@@ -641,14 +672,14 @@ describe('catalogWithState — an occupied, unowned slug dir blocks Install', ()
     // discovery folds it into the skipped-directories warning, so this state has no
     // Delete row to recover through — all the more reason not to offer Install.
     mkdirSync(join(modelsDir, RECOMMENDED_SLUG), { recursive: true });
-    expect(catalogItem('Qwen3.6-27B').blockedByForeignDir).toBe(true);
+    expect(catalogItem(RECOMMENDED.label).blockedByForeignDir).toBe(true);
   });
 
   it('flags a dangling symlink at the slug as blocked (no-follow occupancy)', () => {
     // `existsSync` FOLLOWS the link and reads it as absent; the runner's preflight
     // is `lstat`-based and refuses it, so catalog state must be `lstat`-based too.
     symlinkSync(join(modelsDir, 'no-such-target'), join(modelsDir, RECOMMENDED_SLUG));
-    expect(catalogItem('Qwen3.6-27B').blockedByForeignDir).toBe(true);
+    expect(catalogItem(RECOMMENDED.label).blockedByForeignDir).toBe(true);
   });
 
   it('flags a LIVE symlink to an external checkpoint as blocked, not installed', () => {
@@ -665,8 +696,8 @@ describe('catalogWithState — an occupied, unowned slug dir blocks Install', ()
       // The link is LIVE — without this the case would hold for the wrong reason.
       expect(existsSync(join(link, 'config.json'))).toBe(true);
       expect(isModelPresent(link)).toBe(false);
-      expect(catalogItem('Qwen3.6-27B').present).toBe(false);
-      expect(catalogItem('Qwen3.6-27B').blockedByForeignDir).toBe(true);
+      expect(catalogItem(RECOMMENDED.label).present).toBe(false);
+      expect(catalogItem(RECOMMENDED.label).blockedByForeignDir).toBe(true);
       // The same directory the catalog now calls blocked is absent from discovery.
       expect(discoverLocalModels(modelsDir).models.map((model) => model.name)).not.toContain(RECOMMENDED_SLUG);
     } finally {
@@ -689,8 +720,8 @@ describe('catalogWithState — an occupied, unowned slug dir blocks Install', ()
     writeFileSync(join(victim, 'PRECIOUS.txt'), 'hand-made, not ours');
     symlinkSync(foreign, join(victim, DOWNLOAD_COMPLETE_MARKER));
 
-    expect(catalogItem('Qwen3.6-27B').present).toBe(false);
-    expect(catalogItem('Qwen3.6-27B').blockedByForeignDir).toBe(true);
+    expect(catalogItem(RECOMMENDED.label).present).toBe(false);
+    expect(catalogItem(RECOMMENDED.label).blockedByForeignDir).toBe(true);
 
     rmSync(external, { recursive: true, force: true });
   });
@@ -700,14 +731,14 @@ describe('catalogWithState — an occupied, unowned slug dir blocks Install', ()
     // genuinely works — blocking it would remove the one recovery that functions.
     writeCompletion(RECOMMENDED_SLUG, RECOMMENDED.hfRepo);
     writeFileSync(join(modelsDir, RECOMMENDED_SLUG, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
-    expect(catalogItem('Qwen3.6-27B').present).toBe(false);
-    expect(catalogItem('Qwen3.6-27B').blockedByForeignDir).toBe(false);
+    expect(catalogItem(RECOMMENDED.label).present).toBe(false);
+    expect(catalogItem(RECOMMENDED.label).blockedByForeignDir).toBe(false);
   });
 
   it('is not blocked when the slug is free, nor when a complete install occupies it', () => {
-    expect(catalogItem('Qwen3.6-27B').blockedByForeignDir).toBe(false);
+    expect(catalogItem(RECOMMENDED.label).blockedByForeignDir).toBe(false);
     writeModel(modelsDir, RECOMMENDED_SLUG, JSON.stringify({ model_type: 'qwen3_5' }), 2048);
-    expect(catalogItem('Qwen3.6-27B').present).toBe(true);
-    expect(catalogItem('Qwen3.6-27B').blockedByForeignDir).toBe(false);
+    expect(catalogItem(RECOMMENDED.label).present).toBe(true);
+    expect(catalogItem(RECOMMENDED.label).blockedByForeignDir).toBe(false);
   });
 });

--- a/packages/dashboard/__test__/models.test.ts
+++ b/packages/dashboard/__test__/models.test.ts
@@ -542,6 +542,12 @@ describe('defaultModelsDir', () => {
 /** The default recommendation (Qwen3.8-27B) and the folder a download lands in. */
 const RECOMMENDED = MODEL_CATALOG[0]!;
 const RECOMMENDED_SLUG = catalogSlug(RECOMMENDED);
+/**
+ * The repo THIS platform installs. `catalogWithState` matches provenance
+ * against `catalogRepo(entry)`, so a marker written with the raw `hfRepo`
+ * names the macOS build and silently fails every one of these tests on Linux.
+ */
+const RECOMMENDED_REPO = catalogRepo(RECOMMENDED);
 
 /** The catalog row for `label`, from a fresh scan of the temp models dir. */
 function catalogItem(label: string): CatalogItem {
@@ -582,7 +588,7 @@ describe('catalogWithState — a recommended model is identified by download pro
     // dashboard install the user renamed is still recognized, because the marker
     // pins WHICH repo those bytes came from.
     writeModel(modelsDir, 'renamed-by-hand', QWEN_27B_MXFP4, 2048);
-    writeCompletion('renamed-by-hand', RECOMMENDED.hfRepo);
+    writeCompletion('renamed-by-hand', RECOMMENDED_REPO);
     expect(catalogItem(RECOMMENDED.label).present).toBe(true);
   });
 
@@ -608,7 +614,7 @@ describe('catalogWithState — a recommended model is identified by download pro
     // The read half of the update check: a re-upload lands new bytes at the SAME
     // repo id, so only this recorded sha can tell the user their copy is stale.
     writeModel(modelsDir, RECOMMENDED_SLUG, QWEN_27B_MXFP4, 2048);
-    writeCompletion(RECOMMENDED_SLUG, RECOMMENDED.hfRepo);
+    writeCompletion(RECOMMENDED_SLUG, RECOMMENDED_REPO);
     const item = catalogItem(RECOMMENDED.label);
     expect(item.installed).toBe(true);
     expect(item.localRevision).toBe('a'.repeat(40));
@@ -628,7 +634,7 @@ describe('catalogWithState — a recommended model is identified by download pro
     // is false, and the runner would refuse to re-install over the unowned
     // canonical slug — so an update affordance here could only ever fail.
     writeModel(modelsDir, 'renamed-by-hand', QWEN_27B_MXFP4, 2048);
-    writeCompletion('renamed-by-hand', RECOMMENDED.hfRepo);
+    writeCompletion('renamed-by-hand', RECOMMENDED_REPO);
     const item = catalogItem(RECOMMENDED.label);
     expect(item.present).toBe(true);
     expect(item.installed).toBe(false);
@@ -658,7 +664,7 @@ describe('catalogWithState — a recommended model is identified by download pro
   it('does NOT mark present when the marker survived but the checkpoint did not', () => {
     // The marker records what was published, not what is still there: a dir gutted
     // down to its marker is not a loadable checkpoint.
-    writeCompletion('gutted', RECOMMENDED.hfRepo);
+    writeCompletion('gutted', RECOMMENDED_REPO);
     expect(catalogItem(RECOMMENDED.label).present).toBe(false);
   });
 });
@@ -733,7 +739,7 @@ describe('catalogWithState — an occupied, unowned slug dir blocks Install', ()
     const foreign = join(external, DOWNLOAD_COMPLETE_MARKER);
     writeFileSync(
       foreign,
-      JSON.stringify({ repo: RECOMMENDED.hfRepo, revision: 'd'.repeat(40), files: ['config.json'], completedAt: 'x' }),
+      JSON.stringify({ repo: RECOMMENDED_REPO, revision: 'd'.repeat(40), files: ['config.json'], completedAt: 'x' }),
     );
     const victim = join(modelsDir, RECOMMENDED_SLUG);
     mkdirSync(victim, { recursive: true });
@@ -749,7 +755,7 @@ describe('catalogWithState — an occupied, unowned slug dir blocks Install', ()
   it('leaves an OWNED but incomplete dir installable', () => {
     // Our marker is there, so the preflight permits the owned swap and a reinstall
     // genuinely works — blocking it would remove the one recovery that functions.
-    writeCompletion(RECOMMENDED_SLUG, RECOMMENDED.hfRepo);
+    writeCompletion(RECOMMENDED_SLUG, RECOMMENDED_REPO);
     writeFileSync(join(modelsDir, RECOMMENDED_SLUG, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
     expect(catalogItem(RECOMMENDED.label).present).toBe(false);
     expect(catalogItem(RECOMMENDED.label).blockedByForeignDir).toBe(false);

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -25,6 +25,7 @@ import type {
   CacheScope,
   CatalogItem,
   CatalogResponse,
+  CatalogUpdatesResponse,
   ColdTierHealth,
   DownloadJob,
   DownloadsResponse,
@@ -33,9 +34,9 @@ import type {
   SessionDetailResponse,
   SessionMetricsResponse,
   SessionRow,
-  SessionsResponse,
   SessionTraceMetric,
   SessionTurnMetric,
+  SessionsResponse,
 } from '@/lib/types';
 import Cache from '@/pages/cache';
 import Metrics from '@/pages/metrics';
@@ -1083,27 +1084,35 @@ describe('Session detail page', () => {
 });
 
 describe('Models page — the Install affordance', () => {
-  const REPO = 'Brooooooklyn/Qwen3.6-27B-NVFP4-mlx';
+  const REPO = 'Brooooooklyn/Qwen3.8-27B-MXFP4-mlx';
+  /** Card heading the settle predicates wait on, and the slug it installs to. */
+  const LABEL = 'Qwen3.8-27B';
+  const SLUG = 'qwen3.8-27b-mxfp4-mlx';
 
-  function catalogRoutes(item: Partial<CatalogItem>, jobs: DownloadJob[] = []): Record<string, unknown> {
+  function catalogRoutes(
+    item: Partial<CatalogItem>,
+    jobs: DownloadJob[] = [],
+    updates: CatalogUpdatesResponse = { items: [] },
+  ): Record<string, unknown> {
     const models: ModelsResponse = { models: [], warnings: [], dir: '/models' };
     const catalog: CatalogResponse = {
       items: [
         {
-          label: 'Qwen3.6-27B',
+          label: LABEL,
           hfRepo: REPO,
-          sizeGb: 22.2,
+          sizeGb: 23.3,
           description: 'Best tool use',
-          slug: 'qwen3.6-27b-nvfp4-mlx',
+          slug: SLUG,
           installed: false,
           present: false,
           blockedByForeignDir: false,
+          localRevision: null,
           ...item,
         },
       ],
     };
     const downloads: DownloadsResponse = { jobs };
-    return { '/models': models, '/catalog': catalog, '/downloads': downloads };
+    return { '/models': models, '/catalog': catalog, '/catalog/updates': updates, '/downloads': downloads };
   }
 
   /** Trimmed label of every rendered button. */
@@ -1181,7 +1190,7 @@ describe('Models page — the Install affordance', () => {
   }
 
   async function mountModels(): Promise<void> {
-    mounted = await renderPage(createElement(Models), (text) => text.includes('Qwen3.6-27B'));
+    mounted = await renderPage(createElement(Models), (text) => text.includes(LABEL));
     // The hydration effect fires once `/downloads` lands, which is after the
     // catalog text the settle condition waits on; give it and its calls room.
     await settle();
@@ -1195,7 +1204,7 @@ describe('Models page — the Install affordance', () => {
   it('offers Install for a recommended model that is simply absent', async () => {
     // The over-correction guard: the card must keep its button when the slug is
     // free, or the blocked branch below could be "fixed" by never offering Install.
-    await mount(createElement(Models), catalogRoutes({}), 'Qwen3.6-27B');
+    await mount(createElement(Models), catalogRoutes({}), LABEL);
     expect(buttonLabels()).toContain('Install');
   });
 
@@ -1203,17 +1212,58 @@ describe('Models page — the Install affordance', () => {
     // `<slug>` is occupied by an unowned directory (an interrupted `mlx download`).
     // The download's ownership preflight refuses it every time, so the button would
     // do nothing but raise a red toast.
-    const text = await mount(createElement(Models), catalogRoutes({ blockedByForeignDir: true }), 'Qwen3.6-27B');
+    const text = await mount(createElement(Models), catalogRoutes({ blockedByForeignDir: true }), LABEL);
     expect(buttonLabels()).not.toContain('Install');
     // And it says WHICH directory is in the way and what to do about it.
-    expect(text).toContain('qwen3.6-27b-nvfp4-mlx');
+    expect(text).toContain(SLUG);
     expect(text).toMatch(/remove/i);
   });
 
   it('still shows an installed model as installed', async () => {
-    await mount(createElement(Models), catalogRoutes({ present: true, installed: true }), 'Qwen3.6-27B');
+    await mount(createElement(Models), catalogRoutes({ present: true, installed: true }), LABEL);
     expect(buttonLabels()).toContain('Installed');
     expect(buttonLabels()).not.toContain('Install');
+  });
+
+  it('offers Update available when upstream holds a different revision', async () => {
+    // The whole point of the check: a re-upload lands new bytes at the SAME repo
+    // id, so an installed model must still be offered the newer weights.
+    await mount(
+      createElement(Models),
+      catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
+        items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: true }],
+      }),
+      LABEL,
+    );
+    expect(buttonLabels()).toContain('Update available');
+    expect(buttonLabels()).not.toContain('Installed');
+  });
+
+  it('stays Installed when the revisions match', async () => {
+    await mount(
+      createElement(Models),
+      catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
+        items: [{ hfRepo: REPO, remoteRevision: 'a'.repeat(40), updateAvailable: false }],
+      }),
+      LABEL,
+    );
+    expect(buttonLabels()).toContain('Installed');
+    expect(buttonLabels()).not.toContain('Update available');
+  });
+
+  it('stays Installed when the update check could not reach Hugging Face', async () => {
+    // Offline must degrade to exactly the old behaviour — never a badge the user
+    // cannot act on, and never a blocked page. `/catalog` never touched the
+    // network, so install state is unaffected either way.
+    await mount(
+      createElement(Models),
+      catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
+        items: [{ hfRepo: REPO, remoteRevision: null, updateAvailable: false }],
+      }),
+      LABEL,
+    );
+    expect(buttonLabels()).toContain('Installed');
+    expect(buttonLabels()).not.toContain('Update available');
   });
 
   it('dismisses a job that settled while the page was unmounted, without a word', async () => {
@@ -1460,7 +1510,7 @@ describe('Models page — the Install affordance', () => {
       port2.close();
     };
 
-    mounted = await renderPage(createElement(Models), (text) => text.includes('Qwen3.6-27B'));
+    mounted = await renderPage(createElement(Models), (text) => text.includes(LABEL));
     const install = [...mounted.container.querySelectorAll('button')].find((button) =>
       button.textContent?.includes('Install'),
     );

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -55,12 +55,13 @@ import { bindEventTargetPort } from '../src/rpc/port.js';
 import type { ApiCall } from '../src/runtime.js';
 import { connectDashboardApi, disconnectDashboardApi } from '../ui/src/lib/api.js';
 import {
+  STUB_FAILURE,
+  TICK_CHAR_PX,
+  TICK_LINE_PX,
   renderPage,
   sequence,
   stubApi,
   stubChartMetrics,
-  TICK_CHAR_PX,
-  TICK_LINE_PX,
   type RenderedPage,
 } from './render.js';
 
@@ -1371,6 +1372,59 @@ describe('Models page — the Install affordance', () => {
     );
     expect(buttonLabels()).toContain('Cancel');
     expect(buttonLabels()).not.toContain('Installed');
+  });
+
+  it('drops a stale update verdict when the post-download refresh FAILS', async () => {
+    // `useJson` keeps its previous `data` when a reload fails and only sets
+    // `error`. Consuming that blindly re-offers "Update available" for the
+    // revision just installed, and admits repeated no-op jobs, until some later
+    // probe happens to succeed.
+    const before = catalogRoutes(
+      { present: true, installed: true, localRevision: 'a'.repeat(40) },
+      [downloadJob({ id: 'job-upd', state: 'done' })],
+      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: true }] },
+    );
+    recordRequests({
+      ...before,
+      // First read succeeds; the post-download reload fails.
+      '/catalog/updates': sequence(before['/catalog/updates'], STUB_FAILURE),
+      '/downloads/job-upd': { cancelled: true, id: 'job-upd' },
+    });
+    await mountModels();
+    expect(buttonLabels()).not.toContain('Update available');
+    expect(buttonLabels()).toContain('Installed');
+  });
+
+  it('reloads the update check when a job settles as ERROR too', async () => {
+    // `error` does not mean nothing was installed: `publish()` renames staging
+    // into place and only THEN fsyncs and removes the backup, inside the job's
+    // try. A failure there reports `error` for a model already on disk, so the
+    // previous verdict must not survive it.
+    const failed = vi.spyOn(toast, 'error');
+    try {
+      const stale = catalogRoutes(
+        { present: true, installed: true, localRevision: 'a'.repeat(40) },
+        [downloadJob({ id: 'job-run', state: 'running' })],
+        { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: true }] },
+      );
+      const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'b'.repeat(40) }, [], {
+        items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: false }],
+      });
+      const calls = recordRequests({
+        ...stale,
+        '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
+        '/downloads/job-run': { cancelled: true, id: 'job-run' },
+      });
+      await mountModels();
+      expect(buttonLabels()).toContain('Cancel');
+
+      emitDownload('error', { id: 'job-run', message: 'fsync failed after publish' });
+      await settle();
+      expect(gets(calls, '/api/catalog/updates')).toBe(2);
+      expect(buttonLabels()).not.toContain('Update available');
+    } finally {
+      failed.mockRestore();
+    }
   });
 
   it('reloads the update check when a job settles, so it stops re-offering Update', async () => {

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -58,6 +58,7 @@ import {
   STUB_FAILURE,
   TICK_CHAR_PX,
   TICK_LINE_PX,
+  deferred,
   renderPage,
   sequence,
   stubApi,
@@ -1121,6 +1122,13 @@ describe('Models page — the Install affordance', () => {
     return Array.from(mounted!.container.querySelectorAll('button')).map((b) => (b.textContent ?? '').trim());
   }
 
+  /** Labels of the buttons a user can actually press — a disabled one cannot act. */
+  function liveButtonLabels(): string[] {
+    return Array.from(mounted!.container.querySelectorAll('button'))
+      .filter((button) => !button.disabled)
+      .map((button) => (button.textContent ?? '').trim());
+  }
+
   function downloadJob(overrides: Partial<DownloadJob>): DownloadJob {
     return { id: 'job-1', repo: REPO, state: 'running', receivedBytes: 0, totalBytes: 1024, ...overrides };
   }
@@ -1449,6 +1457,107 @@ describe('Models page — the Install affordance', () => {
       expect(gets(calls, '/api/catalog')).toBe(2);
       expect(buttonLabels()).not.toContain('Update available');
       expect(buttonLabels()).toContain('Installed');
+    } finally {
+      failed.mockRestore();
+    }
+  });
+
+  it('cannot start a second job in the render between a settle and the refreshed catalog', async () => {
+    // `setActive` clears synchronously while `reload()` only marks the previous
+    // body refreshing, so one committed render still carries the pre-download
+    // state: no job, the old `localRevision`, and the old remote sha. Left live,
+    // that button allocates a job the server can only short-circuit to `done` —
+    // two Hugging Face round trips, a spurious card and a spurious toast.
+    const stale = catalogRoutes(
+      { present: true, installed: true, localRevision: 'a'.repeat(40) },
+      [downloadJob({ id: 'job-upd', state: 'running' })],
+      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }] },
+    );
+    // Upstream moved again while that job ran, so once the refreshed bodies land
+    // there is a GENUINE update to offer. That is what proves the window closes:
+    // a suppression that never lifts would leave this button dead forever.
+    const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'b'.repeat(40) }, [], {
+      items: [{ hfRepo: REPO, remoteRevision: 'c'.repeat(40) }],
+    });
+    // Held, so the assertions below land INSIDE the window rather than after it.
+    const held = deferred(fresh['/catalog']);
+    recordRequests({
+      ...stale,
+      '/catalog': sequence(stale['/catalog'], held.body),
+      '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
+      '/downloads/job-upd': { cancelled: true, id: 'job-upd' },
+    });
+    await mountModels();
+
+    emitDownload('done', { id: 'job-upd', outputDir: '/models/x' });
+    await settle();
+    // The refreshed catalog has not landed, so the card still reads the stale
+    // comparison — but it must not be pressable while it does.
+    expect(buttonLabels()).toContain('Update available');
+    expect(liveButtonLabels()).not.toContain('Update available');
+
+    held.release();
+    await settle();
+    expect(liveButtonLabels()).toContain('Update available');
+  });
+
+  it('closes that window on a FIRST install too, where the stale body still says absent', async () => {
+    // The same one render, reached from the other side: nothing was installed
+    // before, so the stale body says `present: false` and the branch falls
+    // through to a live Install for the model that just finished installing.
+    const stale = catalogRoutes({ present: false, installed: false, localRevision: null }, [
+      downloadJob({ id: 'job-new', state: 'running' }),
+    ]);
+    const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'b'.repeat(40) });
+    const held = deferred(fresh['/catalog']);
+    recordRequests({
+      ...stale,
+      '/catalog': sequence(stale['/catalog'], held.body),
+      '/downloads/job-new': { cancelled: true, id: 'job-new' },
+    });
+    await mountModels();
+
+    emitDownload('done', { id: 'job-new', outputDir: '/models/x' });
+    await settle();
+    expect(buttonLabels()).toContain('Install');
+    expect(liveButtonLabels()).not.toContain('Install');
+
+    held.release();
+    await settle();
+    expect(buttonLabels()).toContain('Installed');
+  });
+
+  it('closes that window when the job settles as ERROR, which can still have installed', async () => {
+    // `publish()` renames staging into place and only THEN removes the backup,
+    // inside the job's try, so an `error` can name a model already on disk. That
+    // path clears `active` synchronously too, so it opens the same window.
+    const failed = vi.spyOn(toast, 'error');
+    try {
+      const stale = catalogRoutes(
+        { present: true, installed: true, localRevision: 'a'.repeat(40) },
+        [downloadJob({ id: 'job-err', state: 'running' })],
+        { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }] },
+      );
+      const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'b'.repeat(40) }, [], {
+        items: [{ hfRepo: REPO, remoteRevision: 'c'.repeat(40) }],
+      });
+      const held = deferred(fresh['/catalog']);
+      recordRequests({
+        ...stale,
+        '/catalog': sequence(stale['/catalog'], held.body),
+        '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
+        '/downloads/job-err': { cancelled: true, id: 'job-err' },
+      });
+      await mountModels();
+
+      emitDownload('error', { id: 'job-err', message: 'fsync failed after publish' });
+      await settle();
+      expect(buttonLabels()).toContain('Update available');
+      expect(liveButtonLabels()).not.toContain('Update available');
+
+      held.release();
+      await settle();
+      expect(liveButtonLabels()).toContain('Update available');
     } finally {
       failed.mockRestore();
     }

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -1527,6 +1527,39 @@ describe('Models page — the Install affordance', () => {
     expect(buttonLabels()).toContain('Installed');
   });
 
+  it('closes that window for a job that settled while the page was away', async () => {
+    // Reached without any live event. A job that went terminal while this page
+    // was unmounted (or across a reconnect) is skipped by the hydration above,
+    // so `active` never holds it and no `DownloadProgress` ever fires — the
+    // reconcile effect is the only thing that notices, and it reloads the same
+    // snapshots. Its window is identical, and the guard has to be set there too.
+    const stale = catalogRoutes({ present: false, installed: false, localRevision: null }, [
+      downloadJob({ id: 'job-away', state: 'done' }),
+    ]);
+    // Upstream is ahead of what that job installed, so once the body lands there
+    // is a real update to offer — a suppression that never lifts kills it.
+    const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'b'.repeat(40) }, [], {
+      items: [{ hfRepo: REPO, remoteRevision: 'c'.repeat(40) }],
+    });
+    const held = deferred(fresh['/catalog']);
+    recordRequests({
+      ...stale,
+      '/catalog': sequence(stale['/catalog'], held.body),
+      '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
+      '/downloads/job-away': { cancelled: true, id: 'job-away' },
+    });
+    await mountModels();
+
+    // The mount itself spans the publish: `/downloads` already says `done` while
+    // `/catalog` still says absent.
+    expect(buttonLabels()).toContain('Install');
+    expect(liveButtonLabels()).not.toContain('Install');
+
+    held.release();
+    await settle();
+    expect(liveButtonLabels()).toContain('Update available');
+  });
+
   it('closes that window when the job settles as ERROR, which can still have installed', async () => {
     // `publish()` renames staging into place and only THEN removes the backup,
     // inside the job's try, so an `error` can name a model already on disk. That

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -1357,6 +1357,22 @@ describe('Models page — the Install affordance', () => {
     expect(dismissed(calls)).toEqual(['job-done']);
   });
 
+  it('shows a live update job even when the update probe has not resolved', async () => {
+    // Regression: `downloading` was qualified by catalog state, so a remount
+    // mid-update — with `/catalog/updates` still loading or unable to resolve
+    // this repo — rendered "Installed" over a live multi-gigabyte transfer,
+    // with no progress and no Cancel. A live job must speak for itself.
+    await mount(
+      createElement(Models),
+      catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [downloadJob({})], {
+        items: [],
+      }),
+      LABEL,
+    );
+    expect(buttonLabels()).toContain('Cancel');
+    expect(buttonLabels()).not.toContain('Installed');
+  });
+
   it('reloads the update check when a job settles, so it stops re-offering Update', async () => {
     // Regression: `/catalog/updates` is a SEPARATE request, so it held the
     // pre-download verdict. Once the job cleared, the card re-offered "Update

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -1232,7 +1232,7 @@ describe('Models page — the Install affordance', () => {
     await mount(
       createElement(Models),
       catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
-        items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: true }],
+        items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }],
       }),
       LABEL,
     );
@@ -1244,7 +1244,29 @@ describe('Models page — the Install affordance', () => {
     await mount(
       createElement(Models),
       catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
-        items: [{ hfRepo: REPO, remoteRevision: 'a'.repeat(40), updateAvailable: false }],
+        items: [{ hfRepo: REPO, remoteRevision: 'a'.repeat(40) }],
+      }),
+      LABEL,
+    );
+    expect(buttonLabels()).toContain('Installed');
+    expect(buttonLabels()).not.toContain('Update available');
+  });
+
+  it('never offers Update for a checkpoint the dashboard does not own', async () => {
+    // The join is the page's now, so the ownership gate is too: an Update is a
+    // re-install, and the runner's preflight refuses every final dir it does not
+    // own. `present` without `installed` is exactly that dir (an `mlx download`
+    // install, or a dashboard one the user renamed), so the button could only
+    // ever raise a red toast — however stale the bytes are.
+    //
+    // `/catalog` pairs a revision with ownership today, so this pins the gate on
+    // the WIRE shape rather than on that invariant: the two halves of the
+    // comparison arrive from two different requests, and only `installed` says
+    // the stale one can be replaced.
+    await mount(
+      createElement(Models),
+      catalogRoutes({ present: true, installed: false, localRevision: 'a'.repeat(40) }, [], {
+        items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }],
       }),
       LABEL,
     );
@@ -1259,7 +1281,7 @@ describe('Models page — the Install affordance', () => {
     await mount(
       createElement(Models),
       catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
-        items: [{ hfRepo: REPO, remoteRevision: null, updateAvailable: false }],
+        items: [{ hfRepo: REPO, remoteRevision: null }],
       }),
       LABEL,
     );
@@ -1382,7 +1404,7 @@ describe('Models page — the Install affordance', () => {
     const before = catalogRoutes(
       { present: true, installed: true, localRevision: 'a'.repeat(40) },
       [downloadJob({ id: 'job-upd', state: 'done' })],
-      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: true }] },
+      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }] },
     );
     recordRequests({
       ...before,
@@ -1399,19 +1421,22 @@ describe('Models page — the Install affordance', () => {
     // `error` does not mean nothing was installed: `publish()` renames staging
     // into place and only THEN fsyncs and removes the backup, inside the job's
     // try. A failure there reports `error` for a model already on disk, so the
-    // previous verdict must not survive it.
+    // previous verdict must not survive it. BOTH halves of that verdict have to
+    // move: the freshly installed `localRevision` lives on `/catalog`, and the
+    // sha it is compared against on `/catalog/updates`.
     const failed = vi.spyOn(toast, 'error');
     try {
       const stale = catalogRoutes(
         { present: true, installed: true, localRevision: 'a'.repeat(40) },
         [downloadJob({ id: 'job-run', state: 'running' })],
-        { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: true }] },
+        { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }] },
       );
       const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'b'.repeat(40) }, [], {
-        items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: false }],
+        items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }],
       });
       const calls = recordRequests({
         ...stale,
+        '/catalog': sequence(stale['/catalog'], fresh['/catalog']),
         '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
         '/downloads/job-run': { cancelled: true, id: 'job-run' },
       });
@@ -1421,7 +1446,9 @@ describe('Models page — the Install affordance', () => {
       emitDownload('error', { id: 'job-run', message: 'fsync failed after publish' });
       await settle();
       expect(gets(calls, '/api/catalog/updates')).toBe(2);
+      expect(gets(calls, '/api/catalog')).toBe(2);
       expect(buttonLabels()).not.toContain('Update available');
+      expect(buttonLabels()).toContain('Installed');
     } finally {
       failed.mockRestore();
     }
@@ -1435,12 +1462,12 @@ describe('Models page — the Install affordance', () => {
     const stale = catalogRoutes(
       { present: true, installed: true, localRevision: 'a'.repeat(40) },
       [downloadJob({ id: 'job-upd', state: 'done' })],
-      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: true }] },
+      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }] },
     );
     const fresh = catalogRoutes(
       { present: true, installed: true, localRevision: 'b'.repeat(40) },
       [downloadJob({ id: 'job-upd', state: 'done' })],
-      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: false }] },
+      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }] },
     );
     const calls = recordRequests({
       ...stale,

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -1357,6 +1357,37 @@ describe('Models page — the Install affordance', () => {
     expect(dismissed(calls)).toEqual(['job-done']);
   });
 
+  it('reloads the update check when a job settles, so it stops re-offering Update', async () => {
+    // Regression: `/catalog/updates` is a SEPARATE request, so it held the
+    // pre-download verdict. Once the job cleared, the card re-offered "Update
+    // available" for the revision just installed, and every click started
+    // another job. The reconcile effect must refresh it alongside the catalog.
+    const stale = catalogRoutes(
+      { present: true, installed: true, localRevision: 'a'.repeat(40) },
+      [downloadJob({ id: 'job-upd', state: 'done' })],
+      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: true }] },
+    );
+    const fresh = catalogRoutes(
+      { present: true, installed: true, localRevision: 'b'.repeat(40) },
+      [downloadJob({ id: 'job-upd', state: 'done' })],
+      { items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40), updateAvailable: false }] },
+    );
+    const calls = recordRequests({
+      ...stale,
+      '/catalog': sequence(stale['/catalog'], fresh['/catalog']),
+      '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
+      '/models': sequence(stale['/models'], fresh['/models']),
+      '/downloads/job-upd': { cancelled: true, id: 'job-upd' },
+    });
+    await mountModels();
+    // Settled on the newly installed revision: Installed, not a fresh Update.
+    expect(buttonLabels()).toContain('Installed');
+    expect(buttonLabels()).not.toContain('Update available');
+    // Refetched exactly once, in step with the catalog it is compared against.
+    expect(gets(calls, '/api/catalog/updates')).toBe(2);
+    expect(gets(calls, '/api/catalog')).toBe(2);
+  });
+
   it('reloads after a FAILED job too — a failure can still leave the model installed', async () => {
     // Why the reload is not gated on `done`. `publish()` renames staging into the
     // final dir and only THEN removes the backup, and that `rm` runs inside the

--- a/packages/dashboard/__test__/render.ts
+++ b/packages/dashboard/__test__/render.ts
@@ -48,6 +48,15 @@ export type ApiStub = Record<string, unknown>;
 
 /** Brand for a route whose body CHANGES between calls; see {@link sequence}. */
 const SEQUENCE = Symbol('api-stub-sequence');
+/**
+ * Sequence element that makes the stub answer a FAILURE for that call.
+ *
+ * `useJson` keeps its previous `data` when a reload fails and only sets
+ * `error`, so "first call succeeds, reload fails" is the ONLY way to reach the
+ * data-and-error state a page must branch on. Without this the stub could
+ * model an always-failing route but never a route that goes bad.
+ */
+export const STUB_FAILURE = Symbol('api-stub-failure');
 
 /**
  * A route body that differs per request: `bodies[n]` answers the n-th call and
@@ -120,7 +129,9 @@ export function stubApi(routes: ApiStub, options: ApiStubOptions = {}): () => vo
         options.onCall?.(call);
         const path = call.path.split('?')[0].replace(/^\/api/, '');
         if (!Object.hasOwn(routes, path)) return Promise.resolve(failure('E_NOT_FOUND', `no stub for ${path}`));
-        return Promise.resolve({ ok: true as const, status: 200, body: bodyFor(path) });
+        const body = bodyFor(path);
+        if (body === STUB_FAILURE) return Promise.resolve(failure('E_UNAVAILABLE', `stubbed failure for ${path}`));
+        return Promise.resolve({ ok: true as const, status: 200, body });
       },
       subscribe: options.subscribe ?? (() => () => {}),
     },

--- a/packages/dashboard/__test__/render.ts
+++ b/packages/dashboard/__test__/render.ts
@@ -48,6 +48,7 @@ export type ApiStub = Record<string, unknown>;
 
 /** Brand for a route whose body CHANGES between calls; see {@link sequence}. */
 const SEQUENCE = Symbol('api-stub-sequence');
+const DEFERRED = Symbol('api-stub-deferred');
 /**
  * Sequence element that makes the stub answer a FAILURE for that call.
  *
@@ -72,6 +73,23 @@ export const STUB_FAILURE = Symbol('api-stub-failure');
  */
 export function sequence(...bodies: unknown[]): unknown {
   return { [SEQUENCE]: bodies };
+}
+
+/**
+ * A route body whose REPLY is withheld until the returned `release` is called.
+ *
+ * The only way to assert on a render that happens WHILE a reload is in flight.
+ * `sequence` controls what a refetch answers but never when, so a page bug that
+ * lives in the gap between "reload issued" and "body arrived" — where the hook
+ * still serves the previous body — is invisible to any assertion taken after
+ * the port has drained. Composes with `sequence`: hold only the second call.
+ */
+export function deferred(body: unknown): { body: unknown; release: () => void } {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { body: { [DEFERRED]: { body, gate } }, release };
 }
 
 /**
@@ -131,6 +149,10 @@ export function stubApi(routes: ApiStub, options: ApiStubOptions = {}): () => vo
         if (!Object.hasOwn(routes, path)) return Promise.resolve(failure('E_NOT_FOUND', `no stub for ${path}`));
         const body = bodyFor(path);
         if (body === STUB_FAILURE) return Promise.resolve(failure('E_UNAVAILABLE', `stubbed failure for ${path}`));
+        if (typeof body === 'object' && body !== null && DEFERRED in body) {
+          const held = (body as Record<symbol, unknown>)[DEFERRED] as { body: unknown; gate: Promise<void> };
+          return held.gate.then(() => ({ ok: true as const, status: 200, body: held.body }));
+        }
         return Promise.resolve({ ok: true as const, status: 200, body });
       },
       subscribe: options.subscribe ?? (() => () => {}),

--- a/packages/dashboard/__test__/runtime.test.ts
+++ b/packages/dashboard/__test__/runtime.test.ts
@@ -208,9 +208,14 @@ describe('dashboard runtime — thread split', () => {
 // later lands on the thread its table entry names — this locks WHICH entries name
 // the transport thread, since everything else is the worker by construction.
 describe('dashboard runtime — route ownership', () => {
-  it('keeps exactly the download routes on the transport thread', () => {
+  it('keeps exactly the network-owning routes on the transport thread', () => {
     const main = ROUTES.filter((r) => r.thread === 'main').map((r) => `${r.method} /${r.segments.join('/')}`);
+    // The main thread owns the routes that reach the network. That is the four
+    // download routes plus the catalog update check, which dials Hugging Face
+    // through the same `DownloadManager` fetch seam. `/api/catalog` itself stays
+    // on the worker: it is synchronous, filesystem-only and offline-safe.
     expect(main).toEqual([
+      'GET /api/catalog/updates',
       'GET /api/downloads',
       'POST /api/downloads',
       'DELETE /api/downloads/:id',

--- a/packages/dashboard/src/api/handlers/models.ts
+++ b/packages/dashboard/src/api/handlers/models.ts
@@ -27,7 +27,9 @@ export function handleCatalog(ctx: ApiPaths): unknown {
 }
 
 /**
- * Which installed catalog models have newer bytes upstream.
+ * Upstream commit sha for every visible catalog repo — the remote half of the
+ * staleness check. The comparison against the local marker is the caller's:
+ * `/api/catalog` already carries `installed` and `localRevision`.
  *
  * Split from `/api/catalog` on purpose. That route is synchronous,
  * filesystem-only and offline-safe, and the Models page cannot render without
@@ -36,26 +38,11 @@ export function handleCatalog(ctx: ApiPaths): unknown {
  *
  * Lives on the main thread because that is where the network is (the worker is
  * SQLite plus synchronous FS walks) and because `DownloadManager` already owns
- * the sha resolver and its fetch seam.
+ * the sha resolver and its fetch seam. Touches no filesystem for the same
+ * reason: this thread emits download progress and receives cancels, and a
+ * `catalogWithState` walk of the models directory blocks both.
  */
 export async function handleCatalogUpdates(ctx: MainApiContext): Promise<unknown> {
   const remote = await ctx.downloads.checkCatalogUpdates();
-  const items = catalogWithState(ctx.modelsDir)
-    .filter((item) => !item.hidden)
-    .map((item) => {
-      const remoteRevision = remote.get(item.hfRepo) ?? null;
-      return {
-        hfRepo: item.hfRepo,
-        remoteRevision,
-        // Gated on `installed`, never `present`: only a dashboard-owned install
-        // at the canonical slug carries a revision to compare AND can actually
-        // be re-installed. See `localRevision` on CatalogItem.
-        updateAvailable:
-          item.installed &&
-          item.localRevision !== null &&
-          remoteRevision !== null &&
-          remoteRevision !== item.localRevision,
-      };
-    });
-  return { items };
+  return { items: [...remote].map(([hfRepo, remoteRevision]) => ({ hfRepo, remoteRevision })) };
 }

--- a/packages/dashboard/src/api/handlers/models.ts
+++ b/packages/dashboard/src/api/handlers/models.ts
@@ -1,6 +1,6 @@
 import { catalogWithState } from '../../catalog.js';
 import { discoverLocalModels, deleteLocalModel } from '../../models.js';
-import type { ApiPaths, ApiRequest } from '../context.js';
+import type { ApiPaths, ApiRequest, MainApiContext } from '../context.js';
 import { ApiError } from '../errors.js';
 
 export function handleModels(ctx: ApiPaths): unknown {
@@ -24,4 +24,38 @@ export function handleDeleteModel(ctx: ApiPaths, req: ApiRequest): unknown {
 
 export function handleCatalog(ctx: ApiPaths): unknown {
   return { items: catalogWithState(ctx.modelsDir) };
+}
+
+/**
+ * Which installed catalog models have newer bytes upstream.
+ *
+ * Split from `/api/catalog` on purpose. That route is synchronous,
+ * filesystem-only and offline-safe, and the Models page cannot render without
+ * it; this one dials Hugging Face and is allowed to fail. Keeping them apart
+ * means a flaky network can never delay or break the install state.
+ *
+ * Lives on the main thread because that is where the network is (the worker is
+ * SQLite plus synchronous FS walks) and because `DownloadManager` already owns
+ * the sha resolver and its fetch seam.
+ */
+export async function handleCatalogUpdates(ctx: MainApiContext): Promise<unknown> {
+  const remote = await ctx.downloads.checkCatalogUpdates();
+  const items = catalogWithState(ctx.modelsDir)
+    .filter((item) => !item.hidden)
+    .map((item) => {
+      const remoteRevision = remote.get(item.hfRepo) ?? null;
+      return {
+        hfRepo: item.hfRepo,
+        remoteRevision,
+        // Gated on `installed`, never `present`: only a dashboard-owned install
+        // at the canonical slug carries a revision to compare AND can actually
+        // be re-installed. See `localRevision` on CatalogItem.
+        updateAvailable:
+          item.installed &&
+          item.localRevision !== null &&
+          remoteRevision !== null &&
+          remoteRevision !== item.localRevision,
+      };
+    });
+  return { items };
 }

--- a/packages/dashboard/src/api/routes.ts
+++ b/packages/dashboard/src/api/routes.ts
@@ -24,7 +24,7 @@ import {
 import { handleHealth } from './handlers/health.js';
 import { handleIngest } from './handlers/ingest.js';
 import { handleMetricsOverview, handleSessionMetrics } from './handlers/metrics.js';
-import { handleCatalog, handleDeleteModel, handleModels } from './handlers/models.js';
+import { handleCatalog, handleCatalogUpdates, handleDeleteModel, handleModels } from './handlers/models.js';
 import {
   handleSessionDelete,
   handleSessionDetail,
@@ -97,6 +97,7 @@ export const ROUTES: Route[] = [
   workerRoute('GET', '/api/models', handleModels),
   workerRoute('DELETE', '/api/models/:name', handleDeleteModel),
   workerRoute('GET', '/api/catalog', handleCatalog),
+  mainRoute('GET', '/api/catalog/updates', handleCatalogUpdates),
   // The download routes stay on the transport thread: network I/O and progress
   // events must never queue behind a synchronous query, and a cancel click has to
   // be RECEIVED while one is running.

--- a/packages/dashboard/src/catalog.ts
+++ b/packages/dashboard/src/catalog.ts
@@ -136,7 +136,7 @@ export function catalogWithState(modelsDir: string): CatalogItem[] {
     // e.g. `Qwen-AgentWorld-35B-A3B-nvfp4-mlx` is exactly the CUDA alias. Counting
     // it would render the card "Installed" with `installed` false — no Install
     // button, and no update affordance either — permanently stranding the very
-    // users this change exists to move onto the Metal-native mxfp4 build.
+    // users this change exists to move onto the mxfp4 build.
     const present = isModelPresent(dir) || downloaded.has(catalogRepo(entry).toLowerCase());
     // Exactly the state the download runner's ownership preflight refuses, computed
     // with the SAME no-follow predicates it uses so the two cannot disagree.

--- a/packages/dashboard/src/catalog.ts
+++ b/packages/dashboard/src/catalog.ts
@@ -9,11 +9,19 @@
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { type CatalogEntry, MODEL_CATALOG } from '@mlx-node/agent/catalog';
+import { type CatalogEntry, catalogRepo, catalogRepoAliases, MODEL_CATALOG } from '@mlx-node/agent/catalog';
 
 import { isDownloaderOwned, isModelInstalled, isModelPresent, isPathOccupied, readCompletion } from './models.js';
 
 export interface CatalogItem extends CatalogEntry {
+  /**
+   * The repo THIS platform installs, already resolved by
+   * {@link catalogRepo} — MXFP4 on Apple Silicon, NVFP4 on CUDA. It shadows
+   * `CatalogEntry.hfRepo` so every downstream consumer (the Models page, the
+   * download POST, the runner's allowlist) sees ONE repo and cannot
+   * accidentally install the other platform's build.
+   */
+  hfRepo: string;
   /** Local directory name a download lands in (`hfRepo` basename, lowercased). */
   slug: string;
   /**
@@ -40,11 +48,31 @@ export interface CatalogItem extends CatalogEntry {
    * legitimately re-installable through the owned swap.
    */
   blockedByForeignDir: boolean;
+  /**
+   * The commit sha the local bytes were pinned to, read off the completion
+   * marker at the canonical slug — or `null` when there is no marker to read.
+   *
+   * Only ever set when {@link installed} is true, i.e. for a dashboard-owned
+   * install at the canonical slug. Three cases deliberately report `null`:
+   * a hand-copied dir and a pre-marker CLI install (no marker exists, so
+   * staleness is genuinely unknowable), and a dashboard install the user
+   * RENAMED (matched into {@link present} by provenance, but the runner would
+   * refuse to re-install over the unowned canonical slug, so an update
+   * affordance there could only ever fail).
+   *
+   * A `null` here means "no update badge", never "up to date".
+   */
+  localRevision: string | null;
 }
 
-/** The slug a catalog entry installs to: the `hfRepo` basename, lowercased. */
+/**
+ * The slug a catalog entry installs to: the basename of THIS platform's repo,
+ * lowercased. Resolved through {@link catalogRepo}, so the macOS and CUDA
+ * builds of one model occupy different directories and never overwrite each
+ * other on a shared models dir.
+ */
 export function catalogSlug(entry: CatalogEntry): string {
-  return entry.hfRepo.split('/').pop()!.toLowerCase();
+  return catalogRepo(entry).split('/').pop()!.toLowerCase();
 }
 
 /**
@@ -70,8 +98,8 @@ export function catalogSlug(entry: CatalogEntry): string {
  * an on-disk check ({@link isModelPresent}) — a dir gutted down to its marker is
  * not a present checkpoint. Scanned once for the whole catalog.
  */
-function downloadedRepos(modelsDir: string): Set<string> {
-  const repos = new Set<string>();
+function downloadedRepos(modelsDir: string): Map<string, string> {
+  const repos = new Map<string, string>();
   let names: string[];
   try {
     names = readdirSync(modelsDir);
@@ -82,7 +110,7 @@ function downloadedRepos(modelsDir: string): Set<string> {
     const dir = join(modelsDir, name);
     const completion = readCompletion(dir);
     if (completion === undefined || !isModelPresent(dir)) continue;
-    repos.add(completion.repo.toLowerCase());
+    repos.set(completion.repo.toLowerCase(), completion.revision);
   }
   return repos;
 }
@@ -96,14 +124,29 @@ function downloadedRepos(modelsDir: string): Set<string> {
 export function catalogWithState(modelsDir: string): CatalogItem[] {
   const downloaded = downloadedRepos(modelsDir);
   return MODEL_CATALOG.map((entry) => {
+    const hfRepo = catalogRepo(entry);
     const slug = catalogSlug(entry);
     const dir = join(modelsDir, slug);
     // `present` is true for a loadable checkpoint at the canonical slug OR under any
-    // folder name whose completion marker names this entry's repo.
-    const present = isModelPresent(dir) || downloaded.has(entry.hfRepo.toLowerCase());
+    // folder name whose completion marker names this entry's repo. The marker may
+    // name EITHER platform's build: a models dir shared between an Apple Silicon and
+    // a CUDA machine holds both, and either one is this model being present.
+    const present = isModelPresent(dir) || catalogRepoAliases(entry).some((repo) => downloaded.has(repo));
     // Exactly the state the download runner's ownership preflight refuses, computed
     // with the SAME no-follow predicates it uses so the two cannot disagree.
     const blockedByForeignDir = !present && isPathOccupied(dir) && !isDownloaderOwned(dir);
-    return { ...entry, slug, installed: isModelInstalled(dir), present, blockedByForeignDir };
+    const installed = isModelInstalled(dir);
+    // Read from the canonical slug ONLY — see `localRevision` on CatalogItem for why
+    // a provenance-matched renamed dir deliberately reports null.
+    const completion = installed ? readCompletion(dir) : undefined;
+    return {
+      ...entry,
+      hfRepo,
+      slug,
+      installed,
+      present,
+      blockedByForeignDir,
+      localRevision: completion?.revision ?? null,
+    };
   });
 }

--- a/packages/dashboard/src/catalog.ts
+++ b/packages/dashboard/src/catalog.ts
@@ -9,7 +9,7 @@
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { type CatalogEntry, catalogRepo, catalogRepoAliases, MODEL_CATALOG } from '@mlx-node/agent/catalog';
+import { type CatalogEntry, catalogRepo, MODEL_CATALOG } from '@mlx-node/agent/catalog';
 
 import { isDownloaderOwned, isModelInstalled, isModelPresent, isPathOccupied, readCompletion } from './models.js';
 
@@ -128,10 +128,16 @@ export function catalogWithState(modelsDir: string): CatalogItem[] {
     const slug = catalogSlug(entry);
     const dir = join(modelsDir, slug);
     // `present` is true for a loadable checkpoint at the canonical slug OR under any
-    // folder name whose completion marker names this entry's repo. The marker may
-    // name EITHER platform's build: a models dir shared between an Apple Silicon and
-    // a CUDA machine holds both, and either one is this model being present.
-    const present = isModelPresent(dir) || catalogRepoAliases(entry).some((repo) => downloaded.has(repo));
+    // folder name whose completion marker names THIS PLATFORM's repo.
+    //
+    // Matching the other platform's build too would be actively harmful, and not
+    // hypothetically: the catalog recommended the nvfp4 builds to every platform
+    // before this became platform-conditional, so an existing macOS install of
+    // e.g. `Qwen-AgentWorld-35B-A3B-nvfp4-mlx` is exactly the CUDA alias. Counting
+    // it would render the card "Installed" with `installed` false — no Install
+    // button, and no update affordance either — permanently stranding the very
+    // users this change exists to move onto the Metal-native mxfp4 build.
+    const present = isModelPresent(dir) || downloaded.has(catalogRepo(entry).toLowerCase());
     // Exactly the state the download runner's ownership preflight refuses, computed
     // with the SAME no-follow predicates it uses so the two cannot disagree.
     const blockedByForeignDir = !present && isPathOccupied(dir) && !isDownloaderOwned(dir);

--- a/packages/dashboard/src/download.ts
+++ b/packages/dashboard/src/download.ts
@@ -47,8 +47,19 @@ import { catalogRepo, MODEL_CATALOG } from '@mlx-node/agent/catalog';
 
 /** How long a resolved set of catalog shas is reused before re-dialling HF. */
 const CATALOG_SHA_TTL_MS = 6 * 60 * 60 * 1000;
-/** Retry window after a sweep where every repo failed (the offline case). */
+/** Retry window after a sweep where any repo failed. */
 const CATALOG_SHA_NEGATIVE_TTL_MS = 60 * 1000;
+/**
+ * Deadline for one update probe.
+ *
+ * Load-bearing, not defensive. Hugging Face connections DO stall rather than
+ * reject — one was observed here holding a socket in CLOSE_WAIT for hours at
+ * zero CPU. Without a deadline the `Promise.all` below never settles, the route
+ * never answers, and the RPC client declares the whole runtime unresponsive
+ * and restarts it, killing any download in flight. A probe must degrade to
+ * `null`, never hang the process that serves it.
+ */
+const CATALOG_SHA_PROBE_TIMEOUT_MS = 15 * 1000;
 
 import {
   type DownloadCompletion,
@@ -347,6 +358,12 @@ export class DownloadManager {
   private readonly cacheDir: string;
   /** Memoized catalog shas; see {@link DownloadManager.checkCatalogUpdates}. */
   private catalogShaCache: { at: number; shas: Map<string, string | null>; ttlMs: number } | undefined;
+  /** Sweep counter, so a job can tell whether its write-through predates the sweep now committing. */
+  /** Deadline for one update probe; overridable so a test need not wait it out. */
+  private readonly probeTimeoutMs: number;
+  private catalogSweepSeq = 0;
+  /** Revisions a JOB resolved, tagged with the sweep in flight when it did. */
+  private jobResolvedShas = new Map<string, { revision: string; seq: number }>();
   private readonly fetchImpl: typeof fetch;
   private readonly wrappedFetch: typeof fetch;
 
@@ -372,10 +389,11 @@ export class DownloadManager {
   private currentJob: JobState | null = null;
   private currentFile: FileContext | null = null;
 
-  constructor(opts: { modelsDir: string; cacheDir?: string; fetchImpl?: typeof fetch }) {
+  constructor(opts: { modelsDir: string; cacheDir?: string; fetchImpl?: typeof fetch; probeTimeoutMs?: number }) {
     this.modelsDir = opts.modelsDir;
     this.cacheDir = opts.cacheDir ?? DEFAULT_CACHE_DIR;
     this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+    this.probeTimeoutMs = opts.probeTimeoutMs ?? CATALOG_SHA_PROBE_TIMEOUT_MS;
     this.wrappedFetch = this.makeCountingFetch();
     // Each job id can have many subscribers (SSE clients); lift the default cap.
     this.emitter.setMaxListeners(0);
@@ -687,6 +705,15 @@ export class DownloadManager {
   async checkCatalogUpdates(now: number = Date.now()): Promise<ReadonlyMap<string, string | null>> {
     const cached = this.catalogShaCache;
     if (cached !== undefined && now - cached.at < cached.ttlMs) return cached.shas;
+    const seq = ++this.catalogSweepSeq;
+    // Every probe carries its own deadline. `AbortSignal.any` keeps whatever
+    // signal the hub client supplies rather than replacing it.
+    const probeFetch: typeof fetch = (input, init) => {
+      const deadline = AbortSignal.timeout(this.probeTimeoutMs);
+      const existing = init?.signal ?? undefined;
+      const signal = existing !== undefined ? AbortSignal.any([existing, deadline]) : deadline;
+      return this.fetchImpl(input, { ...init, signal });
+    };
     const shas = new Map<string, string | null>();
     await Promise.all(
       MODEL_CATALOG.filter((entry) => !entry.hidden)
@@ -698,7 +725,7 @@ export class DownloadManager {
             // downloads would inflate that file's progress past its own total;
             // it also threads the active job's abort signal, which would make a
             // user's cancel kill an unrelated update check.
-            shas.set(repo, await this.resolveRevision(repo, this.fetchImpl));
+            shas.set(repo, await this.resolveRevision(repo, probeFetch));
           } catch {
             shas.set(repo, null);
           }
@@ -708,6 +735,12 @@ export class DownloadManager {
     // cache is one entry for the whole sweep, so a single transient failure
     // alongside successes would otherwise pin that repo's `null` for the full
     // six hours — no mount or reconnect in that window could surface its update.
+    // A job that installed a revision WHILE this sweep ran has the newer read:
+    // the sweep may have captured its repo early, then waited on another. Since
+    // the whole map is replaced below, that job's write-through would be lost.
+    for (const [repo, resolved] of this.jobResolvedShas) {
+      if (resolved.seq >= seq && shas.has(repo)) shas.set(repo, resolved.revision);
+    }
     const anyFailed = [...shas.values()].some((sha) => sha === null);
     this.catalogShaCache = { at: now, shas, ttlMs: anyFailed ? CATALOG_SHA_NEGATIVE_TTL_MS : CATALOG_SHA_TTL_MS };
     return shas;
@@ -794,6 +827,7 @@ export class DownloadManager {
       // Without it a sweep cached before upstream advanced keeps serving the
       // older sha for up to its full TTL, so the card re-offers an update for a
       // revision already installed and every click completes as a no-op.
+      this.jobResolvedShas.set(job.repo, { revision, seq: this.catalogSweepSeq });
       this.catalogShaCache?.shas.set(job.repo, revision);
 
       // Job-private staging: keyed by the IMMUTABLE revision (a different

--- a/packages/dashboard/src/download.ts
+++ b/packages/dashboard/src/download.ts
@@ -704,8 +704,12 @@ export class DownloadManager {
           }
         }),
     );
-    const allFailed = shas.size > 0 && [...shas.values()].every((sha) => sha === null);
-    this.catalogShaCache = { at: now, shas, ttlMs: allFailed ? CATALOG_SHA_NEGATIVE_TTL_MS : CATALOG_SHA_TTL_MS };
+    // ANY unresolved repo takes the short TTL, not only an all-failed sweep. The
+    // cache is one entry for the whole sweep, so a single transient failure
+    // alongside successes would otherwise pin that repo's `null` for the full
+    // six hours — no mount or reconnect in that window could surface its update.
+    const anyFailed = [...shas.values()].some((sha) => sha === null);
+    this.catalogShaCache = { at: now, shas, ttlMs: anyFailed ? CATALOG_SHA_NEGATIVE_TTL_MS : CATALOG_SHA_TTL_MS };
     return shas;
   }
 

--- a/packages/dashboard/src/download.ts
+++ b/packages/dashboard/src/download.ts
@@ -693,7 +693,12 @@ export class DownloadManager {
         .map((entry) => catalogRepo(entry))
         .map(async (repo) => {
           try {
-            shas.set(repo, await this.resolveRevision(repo));
+            // RAW fetch, never `wrappedFetch`. That wrapper attributes every
+            // response body to `currentFile`, so a probe running while a model
+            // downloads would inflate that file's progress past its own total;
+            // it also threads the active job's abort signal, which would make a
+            // user's cancel kill an unrelated update check.
+            shas.set(repo, await this.resolveRevision(repo, this.fetchImpl));
           } catch {
             shas.set(repo, null);
           }
@@ -704,8 +709,8 @@ export class DownloadManager {
     return shas;
   }
 
-  private async resolveRevision(repoName: string): Promise<string> {
-    const info = await modelInfo({ name: repoName, additionalFields: ['sha'], fetch: this.wrappedFetch });
+  private async resolveRevision(repoName: string, fetchImpl: typeof fetch = this.wrappedFetch): Promise<string> {
+    const info = await modelInfo({ name: repoName, additionalFields: ['sha'], fetch: fetchImpl });
     const sha: unknown = info.sha;
     if (!(typeof sha === 'string' && /^[0-9a-f]{40}$/i.test(sha))) {
       throw new Error(`Cannot resolve an immutable commit for "${repoName}"; refusing to pin to a mutable ref`);
@@ -781,6 +786,12 @@ export class DownloadManager {
       refuseIfUnownedFinal();
 
       const revision = await this.resolveRevision(job.repo);
+      // This IS a fresh upstream read, so fold it into the update-check cache.
+      // Without it a sweep cached before upstream advanced keeps serving the
+      // older sha for up to its full TTL, so the card re-offers an update for a
+      // revision already installed and every click completes as a no-op.
+      this.catalogShaCache?.shas.set(job.repo, revision);
+
       // Job-private staging: keyed by the IMMUTABLE revision (a different
       // revision never reuses another's staged bytes) and unique per invocation
       // (`.<pid>.<uuid>`) so no two processes ever write into the same tree.

--- a/packages/dashboard/src/download.ts
+++ b/packages/dashboard/src/download.ts
@@ -371,8 +371,23 @@ export class DownloadManager {
   private readonly probeTimeoutMs: number;
   /** Sweep counter, so a job can tell whether its write-through predates the sweep now committing. */
   private catalogSweepSeq = 0;
-  /** Revisions a JOB resolved, tagged with the sweep in flight when it did. */
-  private jobResolvedShas = new Map<string, { revision: string; seq: number }>();
+  /**
+   * Order in which sha reads were ISSUED — never completed. Upstream is observed
+   * as of the request, so a probe that stalls still answers with the sha it held
+   * when asked; ranking by completion would call that stale answer the newest read.
+   */
+  private resolveSeq = 0;
+  /**
+   * Revisions a JOB resolved, tagged with the sweep in flight when it did and
+   * with its place in {@link DownloadManager.resolveSeq}.
+   */
+  private jobResolvedShas = new Map<string, { revision: string; seq: number; at: number }>();
+  /**
+   * Issue stamp behind each repo's sha as currently cached. A job that asked
+   * BEFORE the sweep whose value is committed holds the older observation
+   * however late its answer lands, so its write-through must not overwrite it.
+   */
+  private catalogReadAt = new Map<string, number>();
   private readonly fetchImpl: typeof fetch;
   private readonly wrappedFetch: typeof fetch;
 
@@ -723,10 +738,12 @@ export class DownloadManager {
       return this.fetchImpl(input, { ...init, signal });
     };
     const shas = new Map<string, string | null>();
+    const reads = new Map<string, number>();
     await Promise.all(
       MODEL_CATALOG.filter((entry) => !entry.hidden)
         .map((entry) => catalogRepo(entry))
         .map(async (repo) => {
+          const at = ++this.resolveSeq;
           try {
             // RAW fetch, never `wrappedFetch`. That wrapper attributes every
             // response body to `currentFile`, so a probe running while a model
@@ -734,6 +751,9 @@ export class DownloadManager {
             // it also threads the active job's abort signal, which would make a
             // user's cancel kill an unrelated update check.
             shas.set(repo, await this.resolveRevision(repo, probeFetch));
+            // Only a SUCCESSFUL read claims the slot, so a job's real revision
+            // still beats this sweep's `null`.
+            reads.set(repo, at);
           } catch {
             shas.set(repo, null);
           }
@@ -743,12 +763,25 @@ export class DownloadManager {
     // cache is one entry for the whole sweep, so a single transient failure
     // alongside successes would otherwise pin that repo's `null` for the full
     // six hours — no mount or reconnect in that window could surface its update.
-    // A job that installed a revision WHILE this sweep ran has the newer read:
-    // the sweep may have captured its repo early, then waited on another. Since
-    // the whole map is replaced below, that job's write-through would be lost.
+    // A job that installed a revision WHILE this sweep ran has the newer read
+    // only if it asked LAST: the sweep may have captured its repo early, then
+    // waited on another, and since the whole map is replaced below that job's
+    // write-through would be lost. The opposite interleaving is just as real —
+    // the job asks, this sweep starts and asks the same repo, and the job's
+    // slower answer still lands first — and there the sweep holds the newer sha.
+    // Overlaying it would bury a genuine update for the whole success TTL, since
+    // the post-download refresh reads this very map back.
     for (const [repo, resolved] of this.jobResolvedShas) {
-      if (resolved.seq >= seq && shas.has(repo)) shas.set(repo, resolved.revision);
+      if (resolved.seq >= seq && shas.has(repo) && resolved.at > (reads.get(repo) ?? 0)) {
+        shas.set(repo, resolved.revision);
+        // Keeps `catalogReadAt` describing what was actually committed. No
+        // reachable write depends on it — one repo holds one nonterminal job,
+        // so the next stamp is always higher either way — but a reader who
+        // trusts the field's meaning should not have to derive that.
+        reads.set(repo, resolved.at);
+      }
     }
+    this.catalogReadAt = reads;
     const anyFailed = [...shas.values()].some((sha) => sha === null);
     this.catalogShaCache = { at: now, shas, ttlMs: anyFailed ? CATALOG_SHA_NEGATIVE_TTL_MS : CATALOG_SHA_TTL_MS };
     return shas;
@@ -840,13 +873,19 @@ export class DownloadManager {
       // could read the foreign marker and report a false `done` through the link.
       refuseIfUnownedFinal();
 
+      const at = ++this.resolveSeq;
       const revision = await this.resolveRevision(job.repo);
       // This IS a fresh upstream read, so fold it into the update-check cache.
       // Without it a sweep cached before upstream advanced keeps serving the
       // older sha for up to its full TTL, so the card re-offers an update for a
       // revision already installed and every click completes as a no-op.
-      this.jobResolvedShas.set(job.repo, { revision, seq: this.catalogSweepSeq });
-      this.catalogShaCache?.shas.set(job.repo, revision);
+      this.jobResolvedShas.set(job.repo, { revision, seq: this.catalogSweepSeq, at });
+      // The overlay guards a sweep that commits AFTER this. A sweep that already
+      // committed is past it, so the same ordering test has to run here too.
+      if (at > (this.catalogReadAt.get(job.repo) ?? 0)) {
+        this.catalogShaCache?.shas.set(job.repo, revision);
+        this.catalogReadAt.set(job.repo, at);
+      }
 
       // Job-private staging: keyed by the IMMUTABLE revision (a different
       // revision never reuses another's staged bytes) and unique per invocation

--- a/packages/dashboard/src/download.ts
+++ b/packages/dashboard/src/download.ts
@@ -358,9 +358,18 @@ export class DownloadManager {
   private readonly cacheDir: string;
   /** Memoized catalog shas; see {@link DownloadManager.checkCatalogUpdates}. */
   private catalogShaCache: { at: number; shas: Map<string, string | null>; ttlMs: number } | undefined;
-  /** Sweep counter, so a job can tell whether its write-through predates the sweep now committing. */
+  /**
+   * The sweep in flight, shared by every caller that arrives while it runs.
+   * Two concurrent sweeps each commit unconditionally, so a slow one landing
+   * after a fast one pins the older sha it captured for the whole success TTL —
+   * and with no job in the interleaving, `jobResolvedShas` holds nothing that
+   * could repair it. Cleared once the sweep settles, so a failed sweep's short
+   * TTL still buys a genuinely new attempt instead of replaying the failure.
+   */
+  private catalogSweep: Promise<ReadonlyMap<string, string | null>> | undefined;
   /** Deadline for one update probe; overridable so a test need not wait it out. */
   private readonly probeTimeoutMs: number;
+  /** Sweep counter, so a job can tell whether its write-through predates the sweep now committing. */
   private catalogSweepSeq = 0;
   /** Revisions a JOB resolved, tagged with the sweep in flight when it did. */
   private jobResolvedShas = new Map<string, { revision: string; seq: number }>();
@@ -673,16 +682,6 @@ export class DownloadManager {
   }
 
   /**
-   * Resolve the repo's current commit sha so the WHOLE job reads one immutable
-   * snapshot. Threading this same sha to `listFiles` and every
-   * `downloadFileToCacheDir` means a repo update mid-download can never assemble
-   * a mixed-revision checkpoint. The sha must be an immutable 40-hex commit: a
-   * missing sha or a mutable ref (a branch like `main`) is refused, never pinned —
-   * the completion marker's `revision` is trusted downstream as a stable identity,
-   * so a mutable value there would let a later same-shaped fine-tune restore stale
-   * state and would break this job's own mid-download atomicity.
-   */
-  /**
    * Remote commit sha for every VISIBLE catalog repo, for the "update
    * available" check on the Models page.
    *
@@ -705,6 +704,15 @@ export class DownloadManager {
   async checkCatalogUpdates(now: number = Date.now()): Promise<ReadonlyMap<string, string | null>> {
     const cached = this.catalogShaCache;
     if (cached !== undefined && now - cached.at < cached.ttlMs) return cached.shas;
+    if (this.catalogSweep === undefined) {
+      this.catalogSweep = this.sweepCatalogShas(now).finally(() => {
+        this.catalogSweep = undefined;
+      });
+    }
+    return this.catalogSweep;
+  }
+
+  private async sweepCatalogShas(now: number): Promise<ReadonlyMap<string, string | null>> {
     const seq = ++this.catalogSweepSeq;
     // Every probe carries its own deadline. `AbortSignal.any` keeps whatever
     // signal the hub client supplies rather than replacing it.
@@ -746,6 +754,16 @@ export class DownloadManager {
     return shas;
   }
 
+  /**
+   * Resolve the repo's current commit sha so the WHOLE job reads one immutable
+   * snapshot. Threading this same sha to `listFiles` and every
+   * `downloadFileToCacheDir` means a repo update mid-download can never assemble
+   * a mixed-revision checkpoint. The sha must be an immutable 40-hex commit: a
+   * missing sha or a mutable ref (a branch like `main`) is refused, never pinned —
+   * the completion marker's `revision` is trusted downstream as a stable identity,
+   * so a mutable value there would let a later same-shaped fine-tune restore stale
+   * state and would break this job's own mid-download atomicity.
+   */
   private async resolveRevision(repoName: string, fetchImpl: typeof fetch = this.wrappedFetch): Promise<string> {
     const info = await modelInfo({ name: repoName, additionalFields: ['sha'], fetch: fetchImpl });
     const sha: unknown = info.sha;

--- a/packages/dashboard/src/download.ts
+++ b/packages/dashboard/src/download.ts
@@ -43,7 +43,12 @@ import { homedir } from 'node:os';
 import { basename, dirname, join, resolve, sep } from 'node:path';
 
 import { downloadFileToCacheDir, listFiles, type ListFileEntry, modelInfo } from '@huggingface/hub';
-import { MODEL_CATALOG } from '@mlx-node/agent/catalog';
+import { catalogRepo, MODEL_CATALOG } from '@mlx-node/agent/catalog';
+
+/** How long a resolved set of catalog shas is reused before re-dialling HF. */
+const CATALOG_SHA_TTL_MS = 6 * 60 * 60 * 1000;
+/** Retry window after a sweep where every repo failed (the offline case). */
+const CATALOG_SHA_NEGATIVE_TTL_MS = 60 * 1000;
 
 import {
   type DownloadCompletion,
@@ -340,6 +345,8 @@ interface FileContext {
 export class DownloadManager {
   private readonly modelsDir: string;
   private readonly cacheDir: string;
+  /** Memoized catalog shas; see {@link DownloadManager.checkCatalogUpdates}. */
+  private catalogShaCache: { at: number; shas: Map<string, string | null>; ttlMs: number } | undefined;
   private readonly fetchImpl: typeof fetch;
   private readonly wrappedFetch: typeof fetch;
 
@@ -402,7 +409,7 @@ export class DownloadManager {
     // so admitting one here allocates a job that fails mid-download with a 401
     // instead of being refused up front. No UI reaches this for a hidden entry
     // (the Models page filters `!item.hidden`); a direct API POST does.
-    if (!MODEL_CATALOG.some((entry) => !entry.hidden && entry.hfRepo === repo)) {
+    if (!MODEL_CATALOG.some((entry) => !entry.hidden && catalogRepo(entry) === repo)) {
       throw new Error(`Repo "${repo}" is not in the model catalog`);
     }
     const active = this.activeJobFor(repo);
@@ -657,6 +664,46 @@ export class DownloadManager {
    * so a mutable value there would let a later same-shaped fine-tune restore stale
    * state and would break this job's own mid-download atomicity.
    */
+  /**
+   * Remote commit sha for every VISIBLE catalog repo, for the "update
+   * available" check on the Models page.
+   *
+   * A re-upload lands new bytes at the SAME repo id, so local presence alone
+   * can never tell a user their checkpoint is stale — only the sha can. This
+   * is the read half; the write half already works: `processJob` re-downloads
+   * whenever the installed marker's revision differs from the resolved one, so
+   * the UI's "Update" is literally the existing install.
+   *
+   * Never throws and never rejects. A repo that cannot be resolved — offline,
+   * 429, a deleted repo — maps to `null`, which the caller reads as "no badge",
+   * never as "up to date". `hidden` entries are skipped: they are unpublished
+   * repos that answer 401.
+   *
+   * Cached, because `useJson` refetches on every mount and every reconnect and
+   * there is no polling to smooth the rate. An all-`null` result (the offline
+   * case) is cached far more briefly so a machine that regains its network is
+   * not stuck reporting nothing for hours.
+   */
+  async checkCatalogUpdates(now: number = Date.now()): Promise<ReadonlyMap<string, string | null>> {
+    const cached = this.catalogShaCache;
+    if (cached !== undefined && now - cached.at < cached.ttlMs) return cached.shas;
+    const shas = new Map<string, string | null>();
+    await Promise.all(
+      MODEL_CATALOG.filter((entry) => !entry.hidden)
+        .map((entry) => catalogRepo(entry))
+        .map(async (repo) => {
+          try {
+            shas.set(repo, await this.resolveRevision(repo));
+          } catch {
+            shas.set(repo, null);
+          }
+        }),
+    );
+    const allFailed = shas.size > 0 && [...shas.values()].every((sha) => sha === null);
+    this.catalogShaCache = { at: now, shas, ttlMs: allFailed ? CATALOG_SHA_NEGATIVE_TTL_MS : CATALOG_SHA_TTL_MS };
+    return shas;
+  }
+
   private async resolveRevision(repoName: string): Promise<string> {
     const info = await modelInfo({ name: repoName, additionalFields: ['sha'], fetch: this.wrappedFetch });
     const sha: unknown = info.sha;
@@ -667,8 +714,10 @@ export class DownloadManager {
   }
 
   private async processJob(job: JobState): Promise<void> {
-    const entry = MODEL_CATALOG.find((candidate) => candidate.hfRepo === job.repo)!;
-    const slug = entry.hfRepo.split('/').pop()!.toLowerCase();
+    // Resolved per platform, matching the allowlist gate in `start` — a job can
+    // only exist for THIS platform's repo, so the lookup cannot miss.
+    const entry = MODEL_CATALOG.find((candidate) => catalogRepo(candidate) === job.repo)!;
+    const slug = catalogRepo(entry).split('/').pop()!.toLowerCase();
     const finalDir = join(this.modelsDir, slug);
     const repo = { type: 'model' as const, name: job.repo };
     this.currentJob = job;

--- a/packages/dashboard/ui/src/lib/types.ts
+++ b/packages/dashboard/ui/src/lib/types.ts
@@ -63,7 +63,6 @@ export interface CatalogUpdateItem {
   hfRepo: string;
   /** Upstream commit sha, or `null` when Hugging Face could not be reached. */
   remoteRevision: string | null;
-  updateAvailable: boolean;
 }
 
 export interface CatalogUpdatesResponse {

--- a/packages/dashboard/ui/src/lib/types.ts
+++ b/packages/dashboard/ui/src/lib/types.ts
@@ -46,10 +46,28 @@ export interface CatalogItem {
    * names the blockage rather than offering a button that always errors.
    */
   blockedByForeignDir: boolean;
+  /**
+   * Commit sha the local bytes were pinned to, or `null` when no completion
+   * marker exists to read (hand copy, pre-marker CLI install, renamed dir).
+   * `null` means staleness is unknowable, never "up to date".
+   */
+  localRevision: string | null;
 }
 
 export interface CatalogResponse {
   items: CatalogItem[];
+}
+
+/** One row of `/catalog/updates` — the upstream half of the staleness check. */
+export interface CatalogUpdateItem {
+  hfRepo: string;
+  /** Upstream commit sha, or `null` when Hugging Face could not be reached. */
+  remoteRevision: string | null;
+  updateAvailable: boolean;
+}
+
+export interface CatalogUpdatesResponse {
+  items: CatalogUpdateItem[];
 }
 
 export interface DownloadJob {

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -208,6 +208,13 @@ export default function Models() {
    * (a failed one renders the error card in place of the whole grid).
    */
   const [settledOn, setSettledOn] = useState<ReadonlyMap<string, unknown>>(() => new Map());
+  /**
+   * The same body, reachable from the reconcile effect below. That effect cannot
+   * depend on `catalog.data`: it calls `reloadCatalog()`, so listing the body it
+   * produces would re-run the effect on arrival and reload forever.
+   */
+  const catalogBody = useRef(catalog.data);
+  catalogBody.current = catalog.data;
 
   const [pendingDelete, setPendingDelete] = useState<LocalModel | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -304,6 +311,14 @@ export default function Models() {
     // reports a failed download for a model that is on disk. `recoverBackup`
     // likewise restores a crashed publish before the job can be cancelled.
     if (settled) {
+      // Same window as the live path: `active` never held these jobs (the
+      // hydration above skips terminal ones), so until the reload lands the
+      // stale body offers a live button for work that has already finished.
+      setSettledOn((prev) => {
+        const next = new Map(prev);
+        for (const job of jobs) if (isTerminalJob(job.state)) next.set(job.repo, catalogBody.current);
+        return next;
+      });
       reloadModels();
       reloadCatalog();
       // The update comparison predates the publish too, and it is the one

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -22,10 +22,11 @@ import type {
   CancelDownloadResponse,
   CatalogItem,
   CatalogResponse,
+  CatalogUpdatesResponse,
   DeleteModelResponse,
   DownloadJob,
-  DownloadsResponse,
   DownloadStartResponse,
+  DownloadsResponse,
   LocalModel,
   ModelsResponse,
 } from '@/lib/types';
@@ -167,6 +168,10 @@ function LocalModelsSkeletonRows() {
 export default function Models() {
   const models = useJson<ModelsResponse>('/models');
   const catalog = useJson<CatalogResponse>('/catalog');
+  // Deliberately a SEPARATE request from `/catalog`: this one dials Hugging Face
+  // and is allowed to fail. Its error is never rendered — a card that cannot
+  // reach the network simply shows no update badge.
+  const updates = useJson<CatalogUpdatesResponse>('/catalog/updates');
   const downloads = useJson<DownloadsResponse>('/downloads');
   const connection = useSyncExternalStore(subscribeConnection, getConnectionGeneration, getConnectionGeneration);
 
@@ -384,6 +389,11 @@ export default function Models() {
   const modelsDir = models.data?.dir ?? '';
   const totalBytes = localModels.reduce((sum, m) => sum + m.sizeBytes, 0);
   const catalogItems = (catalog.data?.items ?? []).filter((item) => !item.hidden);
+  // Empty whenever the update check failed or has not resolved yet, which is the
+  // correct default: no badge, cards render exactly as they did before.
+  const updatable = new Set(
+    (updates.data?.items ?? []).filter((item) => item.updateAvailable).map((item) => item.hfRepo),
+  );
 
   return (
     <div className="space-y-6">
@@ -551,6 +561,7 @@ export default function Models() {
             <CatalogCard
               key={item.hfRepo}
               item={item}
+              updateAvailable={updatable.has(item.hfRepo)}
               job={active[item.hfRepo]}
               onInstall={() => install(item.hfRepo)}
               onDone={() => onDownloadDone(item.hfRepo)}
@@ -635,6 +646,8 @@ function CatalogCardSkeleton() {
 
 interface CatalogCardProps {
   item: CatalogItem;
+  /** Upstream has different bytes at this repo than the local marker records. */
+  updateAvailable: boolean;
   job: ActiveJob | undefined;
   onInstall: () => void;
   onDone: () => void;
@@ -643,11 +656,22 @@ interface CatalogCardProps {
   onCancel: (id: string) => void;
 }
 
-function CatalogCard({ item, job, onInstall, onDone, onError, onCancelled, onCancel }: CatalogCardProps) {
+function CatalogCard({
+  item,
+  updateAvailable,
+  job,
+  onInstall,
+  onDone,
+  onError,
+  onCancelled,
+  onCancel,
+}: CatalogCardProps) {
   // Gate on `present` (loadable checkpoint on disk), not `installed` (dashboard
   // marker): a model installed via the `mlx download` CLI / wizard is present but
   // unowned, so offering Install would refuse to overwrite it and fail.
-  const downloading = job !== undefined && !item.present;
+  // `updateAvailable` is part of the gate: an update re-installs a model that is
+  // already `present`, so without it the job would run with no visible progress.
+  const downloading = job !== undefined && (!item.present || updateAvailable);
 
   return (
     <Card className="gap-4">
@@ -687,6 +711,14 @@ function CatalogCard({ item, job, onInstall, onDone, onError, onCancelled, onCan
               </Button>
             )}
           </div>
+        ) : item.present && updateAvailable ? (
+          // Same job pipeline as a first install: the runner already re-downloads
+          // whenever the installed marker's revision differs from upstream, and
+          // its owned-swap replaces the stale directory.
+          <Button className="w-full" onClick={onInstall}>
+            <Download className="size-4" />
+            Update available
+          </Button>
         ) : item.present ? (
           <Button variant="outline" className="w-full" disabled>
             <Check className="size-4" />

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -325,6 +325,12 @@ export default function Models() {
 
   const onDownloadError = (repo: string, message: string): void => {
     toast.error('Download failed', { description: message });
+    // `error` does not mean nothing was installed. `publish()` renames staging
+    // into the final dir and only THEN fsyncs and removes the backup, and those
+    // run inside the job's try — so a failure there reports `error` for a model
+    // whose new marker and weights are already on disk. Leaving the previous
+    // verdict in place would immediately re-offer "Update available" for it.
+    updates.reload();
     const id = active[repo]?.id;
     setActive((prev) => {
       const next = { ...prev };
@@ -404,8 +410,16 @@ export default function Models() {
   const catalogItems = (catalog.data?.items ?? []).filter((item) => !item.hidden);
   // Empty whenever the update check failed or has not resolved yet, which is the
   // correct default: no badge, cards render exactly as they did before.
+  //
+  // `updates.error` is part of that gate. `useJson` deliberately keeps the last
+  // `data` when a reload fails, so consuming it blindly would let a transient
+  // failure of the POST-DOWNLOAD refresh keep serving the pre-install verdict —
+  // re-offering "Update available" for the revision just installed, and
+  // admitting repeated no-op jobs until some later probe happens to succeed.
   const updatable = new Set(
-    (updates.data?.items ?? []).filter((item) => item.updateAvailable).map((item) => item.hfRepo),
+    updates.error !== undefined
+      ? []
+      : (updates.data?.items ?? []).filter((item) => item.updateAvailable).map((item) => item.hfRepo),
   );
 
   return (

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -193,6 +193,22 @@ export default function Models() {
   const downloads = useJson<DownloadsResponse>('/downloads');
   const connection = useSyncExternalStore(subscribeConnection, getConnectionGeneration, getConnectionGeneration);
 
+  /**
+   * For a repo whose job just settled, the catalog body that was current when it
+   * did. `setActive` clears synchronously while `reload()` only marks the old
+   * body refreshing, so one committed render still carries the pre-download
+   * state — a live Install (or Update available) for work that just finished.
+   * Clicking there is not idempotent: the settled job was already dismissed, so
+   * the server allocates a second one that can only short-circuit to `done`.
+   *
+   * Holding the body rather than a flag is what makes the window self-closing.
+   * `useJson` hands back a newly deserialized object per response, so the
+   * identity no longer matching IS the refreshed catalog arriving; nothing has
+   * to remember to clear it, and a reload that never returns cannot strand it
+   * (a failed one renders the error card in place of the whole grid).
+   */
+  const [settledOn, setSettledOn] = useState<ReadonlyMap<string, unknown>>(() => new Map());
+
   const [pendingDelete, setPendingDelete] = useState<LocalModel | null>(null);
   const [deleting, setDeleting] = useState(false);
   /** repo → active download job (seeded from the server, added on install). */
@@ -330,6 +346,7 @@ export default function Models() {
     if (id !== undefined) {
       void mutate<CancelDownloadResponse>('DELETE', `/downloads/${encodeURIComponent(id)}`).catch(() => {});
     }
+    setSettledOn((prev) => new Map(prev).set(repo, catalog.data));
     models.reload();
     catalog.reload();
     // The update comparison is a SEPARATE request, so it holds the pre-download
@@ -350,6 +367,7 @@ export default function Models() {
     // verdict in place would immediately re-offer "Update available" for it.
     // BOTH halves: the marker it must be compared against is `/catalog`'s
     // `localRevision`, so refreshing the remote shas alone repairs nothing.
+    setSettledOn((prev) => new Map(prev).set(repo, catalog.data));
     catalog.reload();
     updates.reload();
     const id = active[repo]?.id;
@@ -608,6 +626,7 @@ export default function Models() {
               key={item.hfRepo}
               item={item}
               updateAvailable={hasUpdate(item, remoteRevisions)}
+              settling={settledOn.has(item.hfRepo) && settledOn.get(item.hfRepo) === catalog.data}
               job={active[item.hfRepo]}
               onInstall={() => install(item.hfRepo)}
               onDone={() => onDownloadDone(item.hfRepo)}
@@ -694,6 +713,11 @@ interface CatalogCardProps {
   item: CatalogItem;
   /** Upstream has different bytes at this repo than the local marker records. */
   updateAvailable: boolean;
+  /**
+   * This repo's job has settled but the catalog body it invalidated has not
+   * arrived, so every field here still describes the state before the download.
+   */
+  settling: boolean;
   job: ActiveJob | undefined;
   onInstall: () => void;
   onDone: () => void;
@@ -705,6 +729,7 @@ interface CatalogCardProps {
 function CatalogCard({
   item,
   updateAvailable,
+  settling,
   job,
   onInstall,
   onDone,
@@ -769,7 +794,7 @@ function CatalogCard({
           // Same job pipeline as a first install: the runner already re-downloads
           // whenever the installed marker's revision differs from upstream, and
           // its owned-swap replaces the stale directory.
-          <Button className="w-full" onClick={onInstall}>
+          <Button className="w-full" onClick={onInstall} disabled={settling}>
             <Download className="size-4" />
             Update available
           </Button>
@@ -793,7 +818,7 @@ function CatalogCard({
             </p>
           </div>
         ) : (
-          <Button className="w-full" onClick={onInstall}>
+          <Button className="w-full" onClick={onInstall} disabled={settling}>
             <Download className="size-4" />
             Install
           </Button>

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -165,6 +165,24 @@ function LocalModelsSkeletonRows() {
   );
 }
 
+/**
+ * Upstream holds different bytes at this repo than the local install records.
+ *
+ * Joined here rather than served ready-made: `/api/catalog/updates` runs on the
+ * transport thread, which also emits download progress, so it reads the network
+ * only and never walks the models directory.
+ *
+ * Gated on `installed`, never `present`: only a dashboard-owned install at the
+ * canonical slug carries a revision to compare AND can actually be re-installed.
+ * A `null` on either side means staleness is unknowable, never "up to date".
+ */
+function hasUpdate(item: CatalogItem, remoteRevisions: ReadonlyMap<string, string | null>): boolean {
+  const remoteRevision = remoteRevisions.get(item.hfRepo) ?? null;
+  return (
+    item.installed && item.localRevision !== null && remoteRevision !== null && remoteRevision !== item.localRevision
+  );
+}
+
 export default function Models() {
   const models = useJson<ModelsResponse>('/models');
   const catalog = useJson<CatalogResponse>('/catalog');
@@ -315,11 +333,11 @@ export default function Models() {
     models.reload();
     catalog.reload();
     // The update comparison is a SEPARATE request, so it holds the pre-download
-    // verdict until told otherwise. Without this the card re-offers "Update
-    // available" the moment the job clears, and every click starts a fresh job
-    // for the revision just installed. The server re-reads the local marker per
-    // request (only the remote sha map is cached), so this reload is both
-    // correct and free of a new network call.
+    // verdict until told otherwise: the fresh local revision would be compared
+    // against the sha the map held BEFORE the job ran, re-offering "Update
+    // available" for the revision just installed and starting a fresh job on
+    // every click. The job writes its resolved sha straight into the server's
+    // cached map, so this reload costs no new network call.
     updates.reload();
   };
 
@@ -330,6 +348,9 @@ export default function Models() {
     // run inside the job's try — so a failure there reports `error` for a model
     // whose new marker and weights are already on disk. Leaving the previous
     // verdict in place would immediately re-offer "Update available" for it.
+    // BOTH halves: the marker it must be compared against is `/catalog`'s
+    // `localRevision`, so refreshing the remote shas alone repairs nothing.
+    catalog.reload();
     updates.reload();
     const id = active[repo]?.id;
     setActive((prev) => {
@@ -416,10 +437,8 @@ export default function Models() {
   // failure of the POST-DOWNLOAD refresh keep serving the pre-install verdict —
   // re-offering "Update available" for the revision just installed, and
   // admitting repeated no-op jobs until some later probe happens to succeed.
-  const updatable = new Set(
-    updates.error !== undefined
-      ? []
-      : (updates.data?.items ?? []).filter((item) => item.updateAvailable).map((item) => item.hfRepo),
+  const remoteRevisions = new Map<string, string | null>(
+    updates.error !== undefined ? [] : (updates.data?.items ?? []).map((item) => [item.hfRepo, item.remoteRevision]),
   );
 
   return (
@@ -588,7 +607,7 @@ export default function Models() {
             <CatalogCard
               key={item.hfRepo}
               item={item}
-              updateAvailable={updatable.has(item.hfRepo)}
+              updateAvailable={hasUpdate(item, remoteRevisions)}
               job={active[item.hfRepo]}
               onInstall={() => install(item.hfRepo)}
               onDone={() => onDownloadDone(item.hfRepo)}

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -682,9 +682,17 @@ function CatalogCard({
   // Gate on `present` (loadable checkpoint on disk), not `installed` (dashboard
   // marker): a model installed via the `mlx download` CLI / wizard is present but
   // unowned, so offering Install would refuse to overwrite it and fail.
-  // `updateAvailable` is part of the gate: an update re-installs a model that is
-  // already `present`, so without it the job would run with no visible progress.
-  const downloading = job !== undefined && (!item.present || updateAvailable);
+  // A live job is sufficient, and is the ONLY safe gate. `active` never holds a
+  // terminal job (the hydration effect skips them), so `job !== undefined` means
+  // a download is genuinely in flight right now.
+  //
+  // It must not be qualified by catalog state. Both earlier forms lost the card:
+  // `!item.present` hid an update, which by definition re-installs something
+  // already present; adding `|| updateAvailable` then hid it again whenever the
+  // update probe was still loading or could not resolve that repo — a remount
+  // mid-update would render "Installed" over a live multi-gigabyte transfer,
+  // with no progress and no Cancel.
+  const downloading = job !== undefined;
 
   return (
     <Card className="gap-4">

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -195,6 +195,7 @@ export default function Models() {
   // stable for the life of the hook and the deps array stays honest.
   const { reload: reloadModels } = models;
   const { reload: reloadCatalog } = catalog;
+  const { reload: reloadUpdates } = updates;
 
   useEffect(() => {
     const snapshot = downloads.data;
@@ -271,8 +272,12 @@ export default function Models() {
     if (settled) {
       reloadModels();
       reloadCatalog();
+      // The update comparison predates the publish too, and it is the one
+      // snapshot that would otherwise keep re-offering "Update available" for
+      // the revision this job just installed.
+      reloadUpdates();
     }
-  }, [downloads.data, connection, reloadModels, reloadCatalog]);
+  }, [downloads.data, connection, reloadModels, reloadCatalog, reloadUpdates]);
 
   const install = async (repo: string): Promise<void> => {
     const startedConnection = connection;
@@ -309,6 +314,13 @@ export default function Models() {
     }
     models.reload();
     catalog.reload();
+    // The update comparison is a SEPARATE request, so it holds the pre-download
+    // verdict until told otherwise. Without this the card re-offers "Update
+    // available" the moment the job clears, and every click starts a fresh job
+    // for the revision just installed. The server re-reads the local marker per
+    // request (only the remote sha map is cached), so this reload is both
+    // correct and free of a new network call.
+    updates.reload();
   };
 
   const onDownloadError = (repo: string, message: string): void => {
@@ -377,6 +389,7 @@ export default function Models() {
       setPendingDelete(null);
       models.reload();
       catalog.reload();
+      updates.reload();
     } catch (err) {
       toast.error('Failed to delete model', { description: errMessage(err) });
     } finally {


### PR DESCRIPTION
We re-uploaded the model collection to the **same** Hugging Face repo ids with
better weights. That broke two client assumptions at once: the catalog pointed
at the wrong build for the platform, and nothing could tell a user their local
copy was now stale.

## 1. The catalog recommends the platform's own 4-bit build

`CatalogEntry` gains `hfRepoCuda`; resolve with `catalogRepo(entry)`.

| | Apple Silicon | Linux + CUDA |
|---|---|---|
| format | MXFP4 | NVFP4 |
| why | Metal block scaling requires an E8M0 scale plane at block 32 — MXFP4 exactly. NVFP4's E4M3 scales at block 16 cannot be declared, so it decodes through a dequant path. | `CublasQQMM` takes NVFP4 directly (`nvfp4` → `CUDA_R_4F_E2M1`). |

`CatalogItem.hfRepo` now **shadows** the entry's field with the resolved repo, so
the Models page, the download POST and the runner's allowlist all see one repo
and cannot install the other platform's build. Reading `.hfRepo` raw is exactly
what would break that, so every consumer goes through `catalogRepo`.

Recommendations:

```
Qwen3.6-27B          ->  Qwen3.8-27B          MXFP4 / NVFP4   23.3 GB
Qwen-AgentWorld-35B  ->  (same model)         MXFP4 / NVFP4   23.3 GB
Gemma-4-26B-A4B      ->  the -Unsloth- line   MXFP4 / NVFP4   16.2 GB
```

**Bug found while doing this.** The Gemma entry pointed at
`Brooooooklyn/Gemma-4-26B-A4B-NVFP4-mlx` — a *separate* repo, last built
2026-07-05, that never received the #131 block-scale fix. Both repos exist, so
nothing ever failed loudly. Choosing MXFP4 forced the correction, because only
the `-Unsloth-` line has an MXFP4 build.

## 2. A stale install is now visible

A re-upload lands new bytes at an unchanged repo id, so presence can never imply
currency. Only the commit sha can tell, and the completion marker already
recorded it — `downloadedRepos()` was discarding it.

```
GET /api/catalog          worker, sync, FS-only, offline-safe   unchanged
GET /api/catalog/updates  main thread, dials HF, may fail       new
```

Two routes on purpose: a flaky network must never delay or break install state.
`DownloadManager.checkCatalogUpdates()` reuses the `modelInfo` sha resolver and
fetch seam the manager already owns. A repo that cannot be resolved maps to
`null`. Cached 6 h, or 60 s after a sweep where every repo failed — `useJson`
refetches on every mount and reconnect, and nothing polls.

**No download change was needed.** `processJob` already re-downloads whenever the
installed marker's revision differs from upstream (locked by the existing
`download.test.ts` "does NOT short-circuit when the installed marker is a
different revision"). "Update available" is literally the existing install button.

### Two judgment calls worth reviewing

- **The badge gates on `installed`, never `present`.** A markerless CLI install
  and a renamed directory are both `present` with no revision to compare, and the
  runner's ownership preflight would refuse the reinstall — a button that could
  only ever raise a red toast. A `null` revision means "no badge", never "up to
  date".
- **`downloading` also accepts an in-flight update.** It required `!item.present`,
  so updating an already-installed model would have run with no visible progress.

## Verification

```
typecheck   clean
lint        clean  (--type-aware --type-check)
tests       894 passed   packages/dashboard + packages/agent
```

New coverage: three `localRevision` cases (owned canonical install, markerless
CLI install, renamed dir), four `checkCatalogUpdates` cases (visible-only sweep,
offline → all null, cache reuse, short negative TTL), and three UI cases (update
offered, revisions match, check unreachable).

`packages/dashboard/__test__/runtime.test.ts` asserted "exactly the download
routes" on the transport thread. That invariant widened to "the network-owning
routes", and the test says so.

## Not covered by this PR

- `packages/cli/__test__/convert-detect.test.ts` fails with
  `convertibleModelTypes is not a function`. It reproduces with this branch
  stashed. The function is in the Rust source and in `index.d.cts`; the checkout
  has no built `.node`. Stale native build, unrelated.
- **The re-uploads are still running.** All three catalog repos held the old bytes
  at the time of writing, and AgentWorld mxfp4 is last in the queue. The code is
  correct either way, and this check is what tells existing users to pick the new
  weights up once they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQYimLSDEYyXgbqrea1QTF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model download paths, catalog provenance matching, and new Hugging Face probes on the transport thread; wrong `catalogRepo` usage would install the wrong platform build silently.
> 
> **Overview**
> **Platform-aware catalog.** Entries can carry optional `hfRepoCuda`; `catalogRepo()` picks MXFP4 (`hfRepo`) on Apple Silicon and NVFP4 on Linux. The wizard, download allowlist, and dashboard `CatalogItem.hfRepo` all resolve through that helper so CUDA hosts do not silently get the Metal build. Recommendations move to **Qwen3.8-27B** and refreshed mxfp4/nvfp4 slugs (including Gemma via the Unsloth line).
> 
> **Stale-weight visibility.** `GET /api/catalog/updates` on the main thread returns upstream commit shas (cached, probed with timeouts; failures → `null`). `/api/catalog` gains `localRevision` from completion markers. The Models page joins the two for dashboard-owned installs and shows **Update available** (same install pipeline as before); install/update buttons are disabled briefly after a job settles until catalog data refreshes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d435bed533276cfaab6c893beab29661af8c3d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->