### PR TITLE
feat(desktop): add automatic macOS updates

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -29,23 +29,20 @@ name: Desktop Release
 # CSC_LINK, which nothing here can replace.
 
 on:
-  release:
-    types: [published]
+  # Published releases are already visible to updater clients. Build from the
+  # tag and keep the release in draft until every required asset is attached.
+  push:
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       dry_run:
         description: 'Build and sign, but skip notarization and publishing'
         type: boolean
         default: true
-      # Without this a dispatch run has no tag, falls back to the desktop
-      # manifest, and therefore rehearses whatever version that file happens to
-      # hold — which on a release day is the STALE one, since `tools bump` skips
-      # private workspaces. The rehearsal would pass and the real
-      # `release: published` run would then be the first thing to see the tag,
-      # and to fail, with the release already public. Pass the tag you are about
-      # to cut and the dry run checks the same thing the real run will.
+      # Dry runs can validate a planned tag before it exists. Publishing requires
+      # an existing tag and checks out that exact ref, regardless of the UI branch.
       release_tag:
-        description: 'Tag to validate against, e.g. v0.0.9 (default: the desktop manifest version)'
+        description: 'Release tag, e.g. v0.0.14 (required to publish; optional for a dry run)'
         type: string
         default: ''
       staging_percentage:
@@ -53,7 +50,12 @@ on:
         type: string
         default: '100'
 
+concurrency:
+  group: desktop-release-${{ inputs.release_tag || github.ref_name }}
+  cancel-in-progress: false
+
 env:
+  RELEASE_TAG: ${{ inputs.release_tag || (github.ref_type == 'tag' && github.ref_name) || '' }}
   # Must match ci.yml. Without it the deployment floor silently tracks the runner
   # image's macOS version and ratchets with runner updates.
   MACOSX_DEPLOYMENT_TARGET: '26.0'
@@ -72,6 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.dry_run && github.ref || (inputs.release_tag && format('refs/tags/{0}', inputs.release_tag)) || github.ref }}
           submodules: recursive
 
       - name: Setup Node.js
@@ -111,15 +114,20 @@ jobs:
       # the DMG 0.0.8 and bumps the cask to 0.0.8: consistently wrong, because all
       # three read that same stale manifest.
       #
-      # `github.event.release.tag_name` is empty on workflow_dispatch, where the
-      # `release_tag` input takes over; with neither, the script treats the
-      # manifest as the source. Passed through `env` rather than interpolated
-      # into the script body — a tag name is attacker-supplied text.
+      # RELEASE_TAG comes from the pushed tag or the dispatch input. With neither,
+      # only a dry run is allowed to use the manifest as its source. Tag values
+      # are passed through env rather than interpolated into shell code.
       - name: Resolve release version
         id: version
         env:
-          TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+          TAG: ${{ env.RELEASE_TAG }}
         run: yarn oxnode packages/desktop/scripts/check-release.ts resolve --tag "$TAG" --manifest packages/desktop/package.json
+
+      - name: Prepare draft release
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn oxnode packages/desktop/scripts/publish-release.ts prepare --tag "$RELEASE_TAG"
 
       # Deliberately a fresh build, not a `gh run download` of ci.yml's artifacts.
       # A release is rare and the ~16 min is worth it: artifact reuse is exactly how
@@ -265,7 +273,7 @@ jobs:
 
       - name: Verify archived update
         env:
-          TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+          TAG: ${{ env.RELEASE_TAG }}
           ZIP: ${{ steps.zip.outputs.path }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
@@ -316,7 +324,7 @@ jobs:
       # artifacts do. Runs before the DMG is notarized — the expensive step.
       - name: Validate artifact versions
         env:
-          TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+          TAG: ${{ env.RELEASE_TAG }}
         run: |
           yarn oxnode packages/desktop/scripts/check-release.ts verify \
             --tag "$TAG" --manifest packages/desktop/package.json \
@@ -354,19 +362,17 @@ jobs:
             ${{ steps.update.outputs.blockmap }}
             ${{ steps.update.outputs.manifest }}
 
-      - name: Attach desktop artifacts to the release
-        if: inputs.dry_run != true && github.event_name == 'release'
+      - name: Upload artifacts and publish the draft release
+        if: inputs.dry_run != true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DMG: ${{ steps.dmg.outputs.path }}
           ZIP: ${{ steps.zip.outputs.path }}
           BLOCKMAP: ${{ steps.update.outputs.blockmap }}
           MANIFEST: ${{ steps.update.outputs.manifest }}
-          TAG: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload "$TAG" "$DMG" "$ZIP" "$BLOCKMAP" --clobber
-          # Publish eligibility only after all download artifacts are available.
-          gh release upload "$TAG" "$MANIFEST" --clobber
+          yarn oxnode packages/desktop/scripts/publish-release.ts publish --tag "$RELEASE_TAG" \
+            --dmg "$DMG" --zip "$ZIP" --blockmap "$BLOCKMAP" --manifest "$MANIFEST"
 
       # The `secrets` context is NOT available in a step `if` — only github, needs,
       # strategy, matrix, job, runner, env, vars, steps and inputs are. Writing
@@ -374,7 +380,7 @@ jobs:
       # would silently stop being bumped. The token is hoisted to job-level `env`
       # (which IS in scope) and tested there instead.
       - name: Bump the Homebrew cask
-        if: inputs.dry_run != true && github.event_name == 'release' && env.HOMEBREW_TAP_TOKEN != ''
+        if: inputs.dry_run != true && !contains(steps.version.outputs.version, '-') && env.HOMEBREW_TAP_TOKEN != ''
         env:
           GH_TOKEN: ${{ env.HOMEBREW_TAP_TOKEN }}
           # From the tag, via the same validated value the DMG was named with —

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -68,6 +68,7 @@ jobs:
     runs-on: macos-26
     permissions:
       contents: write
+      actions: read
     env:
       # Hoisted so the cask step's `if` can test it — see the comment there.
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -364,6 +365,9 @@ jobs:
 
       - name: Upload artifacts and publish the draft release
         if: inputs.dry_run != true
+        # Includes up to three hours for CI on the exact tagged commit. A failed
+        # or missing CI run leaves the fully uploaded release in draft.
+        timeout-minutes: 190
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DMG: ${{ steps.dmg.outputs.path }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -10,7 +10,7 @@ name: Desktop Release
 # notarization secrets exist — which matters, because notarization is the step with
 # the slowest feedback loop and the least reproducible failures.
 #
-# Required secrets (none of these exist in the repo yet):
+# Required secrets:
 #   CSC_LINK                     base64 of the Developer ID Application .p12
 #   CSC_KEY_PASSWORD             its export password
 #   APPLE_TEAM_ID                10-char Team ID
@@ -48,6 +48,10 @@ on:
         description: 'Tag to validate against, e.g. v0.0.9 (default: the desktop manifest version)'
         type: string
         default: ''
+      staging_percentage:
+        description: 'Percentage of installed apps offered the update (0-100)'
+        type: string
+        default: '100'
 
 env:
   # Must match ci.yml. Without it the deployment floor silently tracks the runner
@@ -245,6 +249,47 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: yarn oxnode packages/desktop/scripts/verify-bundle.ts "${{ steps.package.outputs.app }}" --notarized
 
+      # Squirrel.Mac consumes a ZIP, not a DMG. Archive the stapled app so the
+      # updater gets the same signed payload as a fresh installation. The name
+      # includes the version and architecture for differential-update lookup.
+      - name: Build update ZIP
+        id: zip
+        env:
+          APP: ${{ steps.package.outputs.app }}
+          ZIP_NAME: ${{ steps.version.outputs.zip_name }}
+        run: |
+          set -euo pipefail
+          ZIP="packages/desktop/out/$ZIP_NAME"
+          ditto -c -k --sequesterRsrc --keepParent "$APP" "$ZIP"
+          echo "path=$ZIP" >> "$GITHUB_OUTPUT"
+
+      - name: Verify archived update
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+          ZIP: ${{ steps.zip.outputs.path }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          EXTRACTED="$RUNNER_TEMP/update-verification"
+          ditto -x -k "$ZIP" "$EXTRACTED"
+          APP="$EXTRACTED/mlx-node.app"
+          codesign --verify --deep --strict "$APP"
+          yarn oxnode packages/desktop/scripts/check-release.ts verify \
+            --tag "$TAG" --manifest packages/desktop/package.json --app "$APP" --zip "$ZIP"
+          if [ "$DRY_RUN" != "true" ]; then
+            xcrun stapler validate "$APP"
+          fi
+
+      - name: Generate update manifest and blockmap
+        id: update
+        env:
+          APP: ${{ steps.package.outputs.app }}
+          ZIP: ${{ steps.zip.outputs.path }}
+          STAGING_PERCENTAGE: ${{ inputs.staging_percentage || vars.DESKTOP_UPDATE_STAGING_PERCENTAGE || '100' }}
+        run: |
+          yarn oxnode packages/desktop/scripts/generate-update.ts --app "$APP" --zip "$ZIP" \
+            --staging-percentage "$STAGING_PERCENTAGE"
+
       # The filename is spelled once, by `scripts/release-version.ts`, and parsed
       # back out of it by the next step — so a DMG whose name disagrees with what
       # is inside it cannot reach a release.
@@ -275,7 +320,8 @@ jobs:
         run: |
           yarn oxnode packages/desktop/scripts/check-release.ts verify \
             --tag "$TAG" --manifest packages/desktop/package.json \
-            --app "${{ steps.package.outputs.app }}" --dmg "${{ steps.dmg.outputs.path }}"
+            --app "${{ steps.package.outputs.app }}" --dmg "${{ steps.dmg.outputs.path }}" \
+            --zip "${{ steps.zip.outputs.path }}"
 
       # The DMG is a separate distributable and Gatekeeper assesses it on its own,
       # so it needs its own signature, notarization and ticket. Skipping this is the
@@ -300,12 +346,27 @@ jobs:
           name: mlx-node-desktop-dmg
           path: ${{ steps.dmg.outputs.path }}
 
-      - name: Attach DMG to the release
+      - uses: actions/upload-artifact@v7
+        with:
+          name: mlx-node-desktop-update
+          path: |
+            ${{ steps.zip.outputs.path }}
+            ${{ steps.update.outputs.blockmap }}
+            ${{ steps.update.outputs.manifest }}
+
+      - name: Attach desktop artifacts to the release
         if: inputs.dry_run != true && github.event_name == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DMG: ${{ steps.dmg.outputs.path }}
-        run: gh release upload "${{ github.event.release.tag_name }}" "$DMG" --clobber
+          ZIP: ${{ steps.zip.outputs.path }}
+          BLOCKMAP: ${{ steps.update.outputs.blockmap }}
+          MANIFEST: ${{ steps.update.outputs.manifest }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release upload "$TAG" "$DMG" "$ZIP" "$BLOCKMAP" --clobber
+          # Publish eligibility only after all download artifacts are available.
+          gh release upload "$TAG" "$MANIFEST" --clobber
 
       # The `secrets` context is NOT available in a step `if` — only github, needs,
       # strategy, matrix, job, runner, env, vars, steps and inputs are. Writing

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -13,6 +13,10 @@ put an unauthenticated control panel API on a LAN.
 The dashboard still never links the native addon (no Metal init, instant start), and
 all data still comes from disk under `~/.mlx-node`.
 
+The [macOS desktop app](../packages/desktop/README.md) downloads app updates in the
+background. Use **Restart to Update…** from the tray when ready, or **Check for Updates…**
+to check manually.
+
 ## Where it runs
 
 ```

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -60,9 +60,11 @@ workflow verifies that the ZIP, blockmap, DMG, and manifest are fully uploaded
 before publishing the draft release.
 
 Push the version tag to start a release. The workflow creates or resumes a draft,
-builds from the tagged commit, and publishes only after signing, notarization, and
-all uploads succeed. Keep any release notes you prepare in a draft; do not publish
-through the GitHub release editor first. A failed build leaves the draft hidden
+builds from the tagged commit, and publishes only after signing, notarization,
+all uploads, and main-branch CI for that exact commit succeed. The publication
+step waits up to three hours for the latest `ci.yml` push run on `main`; failed,
+cancelled, or missing CI cannot publish an update. Keep release notes in a draft;
+do not publish through the GitHub release editor first. A failed build leaves the draft hidden
 from updater clients, and existing published releases are never overwritten.
 
 To retry a failed release, rerun its workflow or dispatch **Desktop Release** with

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -56,7 +56,19 @@ not enabled in the desktop UI.
 Packaging stamps update eligibility into the staged app manifest before signing;
 the source manifest does not enable updates. The release tag, desktop manifest,
 bundle version, DMG filename, ZIP filename, and update metadata must agree. The
-workflow publishes the manifest after the ZIP, blockmap, and DMG are uploaded.
+workflow verifies that the ZIP, blockmap, DMG, and manifest are fully uploaded
+before publishing the draft release.
+
+Push the version tag to start a release. The workflow creates or resumes a draft,
+builds from the tagged commit, and publishes only after signing, notarization, and
+all uploads succeed. Keep any release notes you prepare in a draft; do not publish
+through the GitHub release editor first. A failed build leaves the draft hidden
+from updater clients, and existing published releases are never overwritten.
+
+To retry a failed release, rerun its workflow or dispatch **Desktop Release** with
+`dry_run=false` and its existing `release_tag`. The dispatch checks out that tag.
+Dry runs default to `true`, build the selected ref, and make no release changes;
+an optional tag input validates the planned version without requiring the tag yet.
 
 Before the first production rollout, verify an upgrade between signed releases,
 including normal quit without relaunch, **Restart to Update…**, active inference,

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -1,0 +1,63 @@
+# mlx-node for macOS
+
+Install the signed DMG from [GitHub Releases](https://github.com/mlx-node/mlx-node/releases)
+by dragging mlx-node to Applications. The app requires Apple Silicon and macOS 26 or newer.
+
+## Updates
+
+Signed stable builds check for updates at launch and every six hours. Updates download
+in the background. Use **Restart to Update…** in the tray or application menu when
+you are ready to stop inference and restart. A downloaded update also applies the
+next time you launch the app after quitting normally.
+
+The same menu offers **Check for Updates…**, download progress, and a retry action if
+an update fails. Models, sessions, and settings stay in their existing data directories.
+Development, unsigned, and prerelease builds do not check the public update feed.
+
+Versions released before this updater was added need one manual installation of a
+release that includes it.
+
+## Release artifacts
+
+The [desktop release workflow](../../.github/workflows/desktop-release.yml) produces:
+
+- `mlx-node-<version>-arm64.dmg` for installation.
+- `mlx-node-<version>-darwin-arm64.zip` for automatic updates.
+- `mlx-node-<version>-darwin-arm64.zip.blockmap` for differential downloads.
+- `latest-mac.yml` with the update version, archive size/hash, minimum macOS, and rollout percentage.
+
+Both contain the same Developer ID signed, notarized, and stapled app. The ZIP is
+created after stapling, then extracted to verify its signature, ticket, and version
+before publication. Dry runs build and verify both archives but skip notarization
+and release uploads.
+
+The app uses [electron-updater](https://www.electron.build/v26/docs/features/auto-update/)
+with public GitHub Releases. macOS installation still uses Squirrel.Mac. Keep the
+archive naming, bundle ID `ai.mlxnode.desktop`, and Developer ID signing identity
+consistent across releases. No additional update server, client token, or signing
+secret is needed. Packaging includes `Contents/Resources/app-update.yml` before signing.
+
+The release workflow generates blockmaps from the final ZIP using electron-builder's
+build-time library; it does not replace our packager or ship that library in the app.
+The updater reuses a previously cached ZIP where possible and falls back to a full
+download when the cache or blockmaps are unavailable. The first update normally
+downloads the complete ZIP. Retain old ZIPs and blockmaps on their original releases.
+
+Updates default to a 100% rollout. Set the repository variable
+`DESKTOP_UPDATE_STAGING_PERCENTAGE` to an integer from 0 to 100 before a release
+to limit automatic offers; the manual workflow has a matching input. To expand or
+pause an existing rollout, edit only `stagingPercentage` in that release's
+`latest-mac.yml` and replace the manifest asset. Keep all archive hashes and URLs
+unchanged. Clients keep a persistent rollout ID, so increasing the percentage
+includes the earlier group. A rollout change does not undo installed updates;
+publish a higher fixed version to repair a bad release. Beta-channel selection is
+not enabled in the desktop UI.
+
+Packaging stamps update eligibility into the staged app manifest before signing;
+the source manifest does not enable updates. The release tag, desktop manifest,
+bundle version, DMG filename, ZIP filename, and update metadata must agree. The
+workflow publishes the manifest after the ZIP, blockmap, and DMG are uploaded.
+
+Before the first production rollout, verify an upgrade between signed releases,
+including normal quit without relaunch, **Restart to Update…**, active inference,
+and a failed differential download falling back to the full ZIP.

--- a/packages/desktop/__test__/mac-updater.test.ts
+++ b/packages/desktop/__test__/mac-updater.test.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from 'node:events';
+import { createRequire, Module } from 'node:module';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { createQuitHandler } from '../src/main/quit.js';
+import { createDesktopUpdater } from '../src/main/updates.js';
+
+const require = createRequire(import.meta.url);
+const { MacUpdater } =
+  require('electron-updater/out/MacUpdater.js') as typeof import('electron-updater/out/MacUpdater.js');
+
+function harness() {
+  const squirrel = Object.assign(new EventEmitter(), {
+    quitAndInstall: vi.fn(),
+    checkForUpdates: vi.fn(),
+  });
+  const app = {
+    version: '0.0.13',
+    name: 'mlx-node',
+    isPackaged: true,
+    appUpdateConfigPath: '',
+    userDataPath: '',
+    baseCachePath: '',
+    whenReady: async () => {},
+    relaunch: vi.fn(),
+    quit: vi.fn(),
+    onQuit: vi.fn(),
+  };
+
+  // MacUpdater loads Electron through CommonJS in its constructor. Replace
+  // only that native boundary, then immediately restore the module cache.
+  // Its staging wait and quit/relaunch methods remain the shipped library code.
+  const electronPath = require.resolve('electron');
+  const previous = require.cache[electronPath];
+  const electronModule = new Module(electronPath);
+  electronModule.exports = { autoUpdater: squirrel };
+  require.cache[electronPath] = electronModule;
+  let client: InstanceType<typeof MacUpdater>;
+  try {
+    client = new MacUpdater(undefined, app);
+  } finally {
+    if (previous) require.cache[electronPath] = previous;
+    else delete require.cache[electronPath];
+  }
+  client.logger = null;
+  vi.spyOn(client, 'checkForUpdates').mockResolvedValue(null);
+  const requestQuit = vi.fn();
+  const report = vi.fn();
+  const updater = createDesktopUpdater({
+    enabled: true,
+    systemVersion: '26.0',
+    native: client,
+    onChange: vi.fn(),
+    requestQuit,
+    report,
+  });
+  return { squirrel, app, client, updater, requestQuit, report };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe.each(['already staged', 'still staging'] as const)('MacUpdater with Squirrel %s', (staging) => {
+  it.each(['ordinary quit', 'Restart to Update', 'Finder relaunch'] as const)(
+    'honors the relaunch choice for %s after shutdown',
+    async (action) => {
+      const { squirrel, app, client, updater, requestQuit, report } = harness();
+      const drain = Promise.withResolvers<void>();
+      const quit = createQuitHandler({
+        beginShutdown: () => updater.stop(),
+        shutdown: () => drain.promise,
+        deadlineMs: 14_000,
+        installUpdate: (relaunchRequested) => updater.installOnQuit(relaunchRequested),
+        shouldRelaunch: () => action === 'Finder relaunch',
+        relaunch: app.relaunch,
+        quit: app.quit,
+        report,
+      });
+      const prevented = vi.fn();
+      requestQuit.mockImplementation(() => quit({ preventDefault: prevented }));
+
+      updater.start();
+      client.emit('update-downloaded', {
+        version: '0.0.14',
+        files: [],
+        path: 'update.zip',
+        sha512: '',
+        releaseDate: '2026-09-08T00:00:00Z',
+        downloadedFile: 'update.zip',
+      });
+      if (staging === 'already staged') squirrel.emit('update-downloaded');
+      if (action === 'Restart to Update') updater.restartAndInstall();
+      else quit({ preventDefault: prevented });
+      expect(prevented).toHaveBeenCalledTimes(1);
+      expect(app.quit).not.toHaveBeenCalled();
+      expect(squirrel.quitAndInstall).not.toHaveBeenCalled();
+
+      drain.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      if (staging === 'still staging') {
+        expect(app.quit).not.toHaveBeenCalled();
+        expect(squirrel.quitAndInstall).not.toHaveBeenCalled();
+        squirrel.emit('update-downloaded');
+      }
+
+      // Assert the actual native endpoint, not just autoRunAppAfterInstall:
+      // ordinary quit must stay closed; an explicit restart belongs to Squirrel.
+      expect(app.quit).toHaveBeenCalledTimes(action === 'ordinary quit' ? 1 : 0);
+      expect(squirrel.quitAndInstall).toHaveBeenCalledTimes(action === 'ordinary quit' ? 0 : 1);
+      expect(app.relaunch).not.toHaveBeenCalled();
+      expect(squirrel.checkForUpdates).not.toHaveBeenCalled();
+      expect(report).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+      quit({ preventDefault: prevented });
+      expect(prevented).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/packages/desktop/__test__/mac-updater.test.ts
+++ b/packages/desktop/__test__/mac-updater.test.ts
@@ -51,6 +51,7 @@ function harness() {
     enabled: true,
     systemVersion: '26.0',
     native: client,
+    squirrel,
     onChange: vi.fn(),
     requestQuit,
     report,
@@ -71,7 +72,7 @@ describe.each(['already staged', 'still staging'] as const)('MacUpdater with Squ
         beginShutdown: () => updater.stop(),
         shutdown: () => drain.promise,
         deadlineMs: 14_000,
-        installUpdate: (relaunchRequested) => updater.installOnQuit(relaunchRequested),
+        installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
         shouldRelaunch: () => action === 'Finder relaunch',
         relaunch: app.relaunch,
         quit: app.quit,
@@ -101,6 +102,9 @@ describe.each(['already staged', 'still staging'] as const)('MacUpdater with Squ
       if (staging === 'still staging') {
         expect(app.quit).not.toHaveBeenCalled();
         expect(squirrel.quitAndInstall).not.toHaveBeenCalled();
+        quit({ preventDefault: prevented });
+        quit({ preventDefault: prevented });
+        expect(prevented).toHaveBeenCalledTimes(3);
         squirrel.emit('update-downloaded');
       }
 
@@ -112,8 +116,83 @@ describe.each(['already staged', 'still staging'] as const)('MacUpdater with Squ
       expect(squirrel.checkForUpdates).not.toHaveBeenCalled();
       expect(report).not.toHaveBeenCalled();
       expect(vi.getTimerCount()).toBe(0);
+      const blockedQuits = prevented.mock.calls.length;
       quit({ preventDefault: prevented });
-      expect(prevented).toHaveBeenCalledTimes(1);
+      expect(prevented).toHaveBeenCalledTimes(blockedQuits);
     },
   );
+});
+
+it('releases a blocked quit on native staging failure and ignores late completion', async () => {
+  const { squirrel, app, client, updater, requestQuit, report } = harness();
+  const quit = createQuitHandler({
+    beginShutdown: () => updater.stop(),
+    shutdown: async () => {},
+    deadlineMs: 14_000,
+    installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
+    shouldRelaunch: () => false,
+    relaunch: app.relaunch,
+    quit: app.quit,
+    report,
+  });
+  const prevented = vi.fn();
+  requestQuit.mockImplementation(() => quit({ preventDefault: prevented }));
+  updater.start();
+  client.emit('update-downloaded', {
+    version: '0.0.14',
+    files: [],
+    path: 'update.zip',
+    sha512: '',
+    releaseDate: '2026-09-08T00:00:00Z',
+    downloadedFile: 'update.zip',
+  });
+  quit({ preventDefault: prevented });
+  await vi.advanceTimersByTimeAsync(0);
+  quit({ preventDefault: prevented });
+  expect(prevented).toHaveBeenCalledTimes(2);
+  const error = new Error('native staging failed');
+  squirrel.emit('error', error);
+  expect(report).toHaveBeenCalledWith(error);
+  expect(requestQuit).toHaveBeenCalledTimes(1);
+  expect(prevented).toHaveBeenCalledTimes(2);
+  squirrel.emit('update-downloaded');
+  expect(squirrel.quitAndInstall).not.toHaveBeenCalled();
+  expect(app.relaunch).not.toHaveBeenCalled();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it('finishes an explicit update quit when staging fails during the resource drain', async () => {
+  const { squirrel, app, client, updater, requestQuit, report } = harness();
+  const drain = Promise.withResolvers<void>();
+  const quit = createQuitHandler({
+    beginShutdown: () => updater.stop(),
+    shutdown: () => drain.promise,
+    deadlineMs: 14_000,
+    installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
+    shouldRelaunch: () => false,
+    relaunch: app.relaunch,
+    quit: app.quit,
+    report,
+  });
+  const prevented = vi.fn();
+  requestQuit.mockImplementation(() => quit({ preventDefault: prevented }));
+  updater.start();
+  client.emit('update-downloaded', {
+    version: '0.0.14',
+    files: [],
+    path: 'update.zip',
+    sha512: '',
+    releaseDate: '2026-09-08T00:00:00Z',
+    downloadedFile: 'update.zip',
+  });
+  updater.restartAndInstall();
+  squirrel.emit('error', new Error('staging failed during shutdown'));
+  expect(app.quit).not.toHaveBeenCalled();
+  drain.resolve();
+  await vi.advanceTimersByTimeAsync(0);
+  expect(app.quit).toHaveBeenCalledTimes(1);
+  expect(squirrel.quitAndInstall).not.toHaveBeenCalled();
+  quit({ preventDefault: prevented });
+  expect(prevented).toHaveBeenCalledTimes(1);
+  expect(report).toHaveBeenCalledTimes(1);
 });

--- a/packages/desktop/__test__/mac-updater.test.ts
+++ b/packages/desktop/__test__/mac-updater.test.ts
@@ -3,6 +3,7 @@ import { createRequire, Module } from 'node:module';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
+import { createLaunchVisibility } from '../src/main/launch-visibility.js';
 import { createQuitHandler } from '../src/main/quit.js';
 import { createDesktopUpdater } from '../src/main/updates.js';
 
@@ -72,7 +73,7 @@ describe.each(['already staged', 'still staging'] as const)('MacUpdater with Squ
         beginShutdown: () => updater.stop(),
         shutdown: () => drain.promise,
         deadlineMs: 14_000,
-        installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
+        installUpdate: (completeQuit) => updater.installOnQuit(completeQuit),
         shouldRelaunch: () => action === 'Finder relaunch',
         relaunch: app.relaunch,
         quit: app.quit,
@@ -129,7 +130,7 @@ it('releases a blocked quit on native staging failure and ignores late completio
     beginShutdown: () => updater.stop(),
     shutdown: async () => {},
     deadlineMs: 14_000,
-    installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
+    installUpdate: (completeQuit) => updater.installOnQuit(completeQuit),
     shouldRelaunch: () => false,
     relaunch: app.relaunch,
     quit: app.quit,
@@ -153,7 +154,8 @@ it('releases a blocked quit on native staging failure and ignores late completio
   const error = new Error('native staging failed');
   squirrel.emit('error', error);
   expect(report).toHaveBeenCalledWith(error);
-  expect(requestQuit).toHaveBeenCalledTimes(1);
+  expect(app.quit).toHaveBeenCalledTimes(1);
+  quit({ preventDefault: prevented });
   expect(prevented).toHaveBeenCalledTimes(2);
   squirrel.emit('update-downloaded');
   expect(squirrel.quitAndInstall).not.toHaveBeenCalled();
@@ -168,7 +170,7 @@ it('finishes an explicit update quit when staging fails during the resource drai
     beginShutdown: () => updater.stop(),
     shutdown: () => drain.promise,
     deadlineMs: 14_000,
-    installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
+    installUpdate: (completeQuit) => updater.installOnQuit(completeQuit),
     shouldRelaunch: () => false,
     relaunch: app.relaunch,
     quit: app.quit,
@@ -196,3 +198,59 @@ it('finishes an explicit update quit when staging fails during the resource drai
   expect(prevented).toHaveBeenCalledTimes(1);
   expect(report).toHaveBeenCalledTimes(1);
 });
+
+it.each(['success', 'staging error', 'install throws', 'install error'])(
+  'honors a Finder/Dock open during native staging through %s',
+  async (outcome) => {
+    const { squirrel, app, client, updater, report } = harness();
+    const visibility = createLaunchVisibility();
+    const shouldRelaunch = vi.fn(() => visibility.takeRelaunchRequest());
+    const quit = createQuitHandler({
+      beginShutdown: () => {
+        updater.stop();
+        visibility.beginShutdown();
+      },
+      shutdown: async () => {},
+      deadlineMs: 14_000,
+      installUpdate: (completeQuit) => updater.installOnQuit(completeQuit),
+      shouldRelaunch,
+      relaunch: app.relaunch,
+      quit: app.quit,
+      report,
+    });
+    const prevented = vi.fn();
+    updater.start();
+    client.emit('update-downloaded', {
+      version: '0.0.14',
+      files: [],
+      path: 'update.zip',
+      sha512: '',
+      releaseDate: '2026-09-08T00:00:00Z',
+      downloadedFile: 'update.zip',
+    });
+    quit({ preventDefault: prevented });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(shouldRelaunch).not.toHaveBeenCalled();
+    visibility.activate(); // Finder/Dock reopens after the resource drain.
+    quit({ preventDefault: prevented });
+    expect(prevented).toHaveBeenCalledTimes(2);
+    const error = new Error('native update failed');
+    if (outcome === 'staging error') {
+      squirrel.emit('error', error);
+    } else {
+      if (outcome === 'install throws')
+        squirrel.quitAndInstall.mockImplementationOnce(() => {
+          throw error;
+        });
+      squirrel.emit('update-downloaded');
+      if (outcome === 'install error') squirrel.emit('error', error);
+      expect(client.autoRunAppAfterInstall).toBe(true);
+    }
+    expect(squirrel.quitAndInstall).toHaveBeenCalledTimes(outcome === 'staging error' ? 0 : 1);
+    expect(app.relaunch).toHaveBeenCalledTimes(outcome === 'success' ? 0 : 1);
+    expect(app.quit).toHaveBeenCalledTimes(outcome === 'success' ? 0 : 1);
+    expect(report).toHaveBeenCalledTimes(outcome === 'success' ? 0 : 1);
+    quit({ preventDefault: prevented });
+    expect(prevented).toHaveBeenCalledTimes(2);
+  },
+);

--- a/packages/desktop/__test__/quit.test.ts
+++ b/packages/desktop/__test__/quit.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { createQuitHandler } from '../src/main/quit.js';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('desktop quit', () => {
+  it.each(['normal', 'failed', 'deadline'])(
+    'preserves normal exit and activation relaunch after %s cleanup',
+    async (mode) => {
+      const drain = Promise.withResolvers<void>();
+      const options = {
+        beginShutdown: vi.fn(),
+        shutdown: vi.fn(() => drain.promise),
+        deadlineMs: 14_000,
+        installUpdate: vi.fn(() => false),
+        shouldRelaunch: () => true,
+        relaunch: vi.fn(),
+        quit: vi.fn(),
+        report: vi.fn(),
+      };
+      const quit = createQuitHandler(options);
+      const preventDefault = vi.fn();
+      quit({ preventDefault });
+      quit({ preventDefault });
+      expect(options.beginShutdown).toHaveBeenCalledTimes(1);
+      expect(options.shutdown).toHaveBeenCalledTimes(1);
+      expect(options.quit).not.toHaveBeenCalled();
+      if (mode === 'normal') drain.resolve();
+      if (mode === 'failed') drain.reject(new Error('child exit failed'));
+      await vi.advanceTimersByTimeAsync(mode === 'deadline' ? 14_000 : 0);
+      expect(options.report).toHaveBeenCalledTimes(mode === 'normal' ? 0 : 1);
+      expect(options.relaunch).toHaveBeenCalledTimes(1);
+      expect(options.quit).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+      quit({ preventDefault });
+      expect(preventDefault).toHaveBeenCalledTimes(2);
+      drain.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(options.quit).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/packages/desktop/__test__/release-ci.test.ts
+++ b/packages/desktop/__test__/release-ci.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { CI_POLL_INTERVAL_MS, CI_WAIT_TIMEOUT_MS, waitForReleaseCI } from '../scripts/release-ci.js';
+
+const commit = 'a'.repeat(40);
+const successful = {
+  id: 10,
+  head_sha: commit,
+  head_branch: 'main',
+  event: 'push',
+  path: '.github/workflows/ci.yml',
+  status: 'completed',
+  conclusion: 'success',
+  html_url: 'https://github.com/mlx-node/mlx-node/actions/runs/10',
+};
+const response = (...runs: object[]): string => JSON.stringify({ workflow_runs: runs });
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('release CI gate', () => {
+  it('waits for the exact main-push workflow run to appear and finish', async () => {
+    const github = vi
+      .fn()
+      .mockReturnValueOnce(
+        response(
+          { ...successful, head_sha: 'b'.repeat(40) },
+          { ...successful, event: 'pull_request' },
+          { ...successful, head_branch: 'feature' },
+          { ...successful, path: '.github/workflows/desktop-release.yml' },
+        ),
+      )
+      .mockReturnValueOnce(response({ ...successful, status: 'in_progress', conclusion: null }))
+      .mockReturnValue(response(successful));
+    const done = vi.fn();
+    const waiting = waitForReleaseCI(commit, github).then(done);
+    expect(done).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(CI_POLL_INTERVAL_MS);
+    expect(done).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(CI_POLL_INTERVAL_MS);
+    await waiting;
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(github).toHaveBeenCalledWith([
+      'api',
+      `repos/{owner}/{repo}/actions/workflows/ci.yml/runs?head_sha=${commit}&branch=main&event=push&per_page=100`,
+    ]);
+  });
+
+  it.each(['failure', 'cancelled', 'timed_out', 'action_required', 'skipped', 'neutral', null])(
+    'rejects a completed run with conclusion %s',
+    async (conclusion) => {
+      const github = vi.fn(() => response({ ...successful, conclusion }));
+      await expect(waitForReleaseCI(commit, github)).rejects.toThrow('Release blocked');
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it('does not reuse an older success when the newest run failed', async () => {
+    const github = vi.fn(() => response(successful, { ...successful, id: 11, conclusion: 'failure' }));
+    await expect(waitForReleaseCI(commit, github)).rejects.toThrow('Release blocked');
+  });
+
+  it('waits for a rerun even if its previous attempt succeeded', async () => {
+    const github = vi
+      .fn()
+      .mockReturnValueOnce(response({ ...successful, status: 'queued' }))
+      .mockReturnValue(response(successful));
+    const done = vi.fn();
+    const waiting = waitForReleaseCI(commit, github).then(done);
+    expect(done).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(CI_POLL_INTERVAL_MS);
+    await waiting;
+    expect(done).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['missing', 'pending'])('times out when CI remains %s', async (state) => {
+    const github = vi.fn(() => (state === 'missing' ? response() : response({ ...successful, status: 'in_progress' })));
+    const rejection = expect(waitForReleaseCI(commit, github)).rejects.toThrow('release remains a draft');
+    await vi.advanceTimersByTimeAsync(CI_WAIT_TIMEOUT_MS);
+    await rejection;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('fails closed on API errors', async () => {
+    const github = vi.fn(() => {
+      throw new Error('API unavailable');
+    });
+    await expect(waitForReleaseCI(commit, github)).rejects.toThrow('API unavailable');
+  });
+
+  it('requires the full tagged commit SHA', async () => {
+    const github = vi.fn();
+    await expect(waitForReleaseCI('main', github)).rejects.toThrow('full commit SHA');
+    expect(github).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/__test__/release-publication.test.ts
+++ b/packages/desktop/__test__/release-publication.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { prepareDraftRelease, publishDesktopRelease } from '../scripts/release-publication.js';
 
 const tag = 'v0.0.14';
+const commit = 'a'.repeat(40);
 const names = [
   'mlx-node-0.0.14-arm64.dmg',
   'mlx-node-0.0.14-darwin-arm64.zip',
@@ -33,9 +34,20 @@ function harness() {
     isPrerelease: false,
     assets: [] as { name: string; state: string; size: number }[],
   };
+  const ci = {
+    id: 10,
+    head_sha: commit,
+    head_branch: 'main',
+    event: 'push',
+    path: '.github/workflows/ci.yml',
+    status: 'completed',
+    conclusion: 'success',
+    html_url: 'https://github.com/mlx-node/mlx-node/actions/runs/10',
+  };
   let exists = false;
   const onUpload = vi.fn();
   const github = vi.fn((args: string[]): string => {
+    if (args[0] === 'api') return JSON.stringify({ workflow_runs: [ci] });
     if (args[1] === 'view') {
       if (!exists) throw new Error('release not found');
       return JSON.stringify(release);
@@ -59,7 +71,7 @@ function harness() {
     }
     throw new Error(`Unexpected GitHub operation: ${args.join(' ')}`);
   });
-  return { github, release, onUpload };
+  return { github, release, onUpload, ci };
 }
 
 describe('desktop release publication', () => {
@@ -79,11 +91,11 @@ describe('desktop release publication', () => {
     ]);
   });
 
-  it('publishes only after all four assets are uploaded and verified', () => {
+  it('publishes only after all four assets are uploaded and CI succeeds', async () => {
     const { github, release, onUpload } = harness();
     prepareDraftRelease(tag, github);
     onUpload.mockImplementation(() => expect(release.isDraft).toBe(true));
-    publishDesktopRelease(tag, files, github);
+    await publishDesktopRelease(tag, commit, files, github);
     expect(release.assets.map((asset) => asset.name)).toEqual(names);
     expect(release.isDraft).toBe(false);
     expect(github.mock.calls.at(-1)?.[0]).toEqual(['release', 'edit', tag, '--draft=false', '--verify-tag']);
@@ -91,7 +103,7 @@ describe('desktop release publication', () => {
 
   it.each(['upload throws', 'missing manifest', 'wrong size', 'unfinished upload'])(
     'keeps the draft hidden when %s, then allows a successful retry',
-    (failure) => {
+    async (failure) => {
       const { github, release, onUpload } = harness();
       prepareDraftRelease(tag, github);
       onUpload.mockImplementationOnce(() => {
@@ -101,34 +113,50 @@ describe('desktop release publication', () => {
         if (failure === 'wrong size') manifest.size++;
         if (failure === 'unfinished upload') manifest.state = 'starter';
       });
-      expect(() => publishDesktopRelease(tag, files, github)).toThrow();
+      await expect(publishDesktopRelease(tag, commit, files, github)).rejects.toThrow();
       expect(release.isDraft).toBe(true);
       expect(github.mock.calls.some(([args]) => args[1] === 'edit')).toBe(false);
       const creates = github.mock.calls.filter(([args]) => args[1] === 'create').length;
       prepareDraftRelease(tag, github);
       expect(github.mock.calls.filter(([args]) => args[1] === 'create')).toHaveLength(creates);
-      publishDesktopRelease(tag, files, github);
+      await publishDesktopRelease(tag, commit, files, github);
       expect(release.isDraft).toBe(false);
     },
   );
 
-  it('refuses to overwrite a published release', () => {
+  it('refuses to overwrite a published release', async () => {
     const { github, release } = harness();
     prepareDraftRelease(tag, github);
     release.isDraft = false;
     github.mockClear();
     expect(() => prepareDraftRelease(tag, github)).toThrow('must remain a draft');
-    expect(() => publishDesktopRelease(tag, files, github)).toThrow('must remain a draft');
+    await expect(publishDesktopRelease(tag, commit, files, github)).rejects.toThrow('must remain a draft');
     expect(github.mock.calls.every(([args]) => args[1] === 'view')).toBe(true);
   });
 
-  it.each(['missing file', 'empty file', 'wrong version'])('rejects %s before any release mutation', (failure) => {
-    const { github } = harness();
-    if (failure === 'missing file') files.pop();
-    if (failure === 'empty file') writeFileSync(files[0], '');
-    if (failure === 'wrong version') files[0] = files[0].replace('0.0.14', '0.0.13');
-    expect(() => publishDesktopRelease(tag, files, github)).toThrow();
-    expect(github).not.toHaveBeenCalled();
+  it.each(['missing file', 'empty file', 'wrong version'])(
+    'rejects %s before any release mutation',
+    async (failure) => {
+      const { github } = harness();
+      if (failure === 'missing file') files.pop();
+      if (failure === 'empty file') writeFileSync(files[0], '');
+      if (failure === 'wrong version') files[0] = files[0].replace('0.0.14', '0.0.13');
+      await expect(publishDesktopRelease(tag, commit, files, github)).rejects.toThrow();
+      expect(github).not.toHaveBeenCalled();
+    },
+  );
+
+  it('keeps a fully uploaded release in draft when main CI fails', async () => {
+    const { github, release, ci } = harness();
+    prepareDraftRelease(tag, github);
+    ci.conclusion = 'failure';
+    await expect(publishDesktopRelease(tag, commit, files, github)).rejects.toThrow('Release blocked');
+    expect(release.assets.map((asset) => asset.name)).toEqual(names);
+    expect(release.isDraft).toBe(true);
+    expect(github.mock.calls.some(([args]) => args[1] === 'edit')).toBe(false);
+    ci.conclusion = 'success';
+    await publishDesktopRelease(tag, commit, files, github);
+    expect(release.isDraft).toBe(false);
   });
 
   it('requires prerelease tags to remain marked as prereleases', () => {

--- a/packages/desktop/__test__/release-publication.test.ts
+++ b/packages/desktop/__test__/release-publication.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { prepareDraftRelease, publishDesktopRelease } from '../scripts/release-publication.js';
+
+const tag = 'v0.0.14';
+const names = [
+  'mlx-node-0.0.14-arm64.dmg',
+  'mlx-node-0.0.14-darwin-arm64.zip',
+  'mlx-node-0.0.14-darwin-arm64.zip.blockmap',
+  'latest-mac.yml',
+];
+let root: string;
+let files: string[];
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'mlx-release-publication-'));
+  files = names.map((name) => {
+    const file = join(root, name);
+    writeFileSync(file, name);
+    return file;
+  });
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+function harness() {
+  const release = {
+    tagName: tag,
+    isDraft: true,
+    isPrerelease: false,
+    assets: [] as { name: string; state: string; size: number }[],
+  };
+  let exists = false;
+  const onUpload = vi.fn();
+  const github = vi.fn((args: string[]): string => {
+    if (args[1] === 'view') {
+      if (!exists) throw new Error('release not found');
+      return JSON.stringify(release);
+    }
+    if (args[1] === 'create') {
+      exists = true;
+      release.isDraft = args.includes('--draft');
+      return '';
+    }
+    if (args[1] === 'upload') {
+      for (const file of args.slice(3).filter((value) => value !== '--clobber')) {
+        release.assets = release.assets.filter((asset) => asset.name !== basename(file));
+        release.assets.push({ name: basename(file), state: 'uploaded', size: statSync(file).size });
+      }
+      onUpload();
+      return '';
+    }
+    if (args[1] === 'edit') {
+      release.isDraft = !args.includes('--draft=false');
+      return '';
+    }
+    throw new Error(`Unexpected GitHub operation: ${args.join(' ')}`);
+  });
+  return { github, release, onUpload };
+}
+
+describe('desktop release publication', () => {
+  it('leaves a newly prepared release hidden if the build never reaches publication', () => {
+    const { github, release } = harness();
+    prepareDraftRelease(tag, github);
+    expect(release.isDraft).toBe(true);
+    expect(release.assets).toEqual([]);
+    expect(github).toHaveBeenCalledWith([
+      'release',
+      'create',
+      tag,
+      '--draft',
+      '--verify-tag',
+      '--generate-notes',
+      '--prerelease=false',
+    ]);
+  });
+
+  it('publishes only after all four assets are uploaded and verified', () => {
+    const { github, release, onUpload } = harness();
+    prepareDraftRelease(tag, github);
+    onUpload.mockImplementation(() => expect(release.isDraft).toBe(true));
+    publishDesktopRelease(tag, files, github);
+    expect(release.assets.map((asset) => asset.name)).toEqual(names);
+    expect(release.isDraft).toBe(false);
+    expect(github.mock.calls.at(-1)?.[0]).toEqual(['release', 'edit', tag, '--draft=false', '--verify-tag']);
+  });
+
+  it.each(['upload throws', 'missing manifest', 'wrong size', 'unfinished upload'])(
+    'keeps the draft hidden when %s, then allows a successful retry',
+    (failure) => {
+      const { github, release, onUpload } = harness();
+      prepareDraftRelease(tag, github);
+      onUpload.mockImplementationOnce(() => {
+        const manifest = release.assets.find((asset) => asset.name === 'latest-mac.yml')!;
+        if (failure === 'upload throws') throw new Error('connection lost');
+        if (failure === 'missing manifest') release.assets.pop();
+        if (failure === 'wrong size') manifest.size++;
+        if (failure === 'unfinished upload') manifest.state = 'starter';
+      });
+      expect(() => publishDesktopRelease(tag, files, github)).toThrow();
+      expect(release.isDraft).toBe(true);
+      expect(github.mock.calls.some(([args]) => args[1] === 'edit')).toBe(false);
+      const creates = github.mock.calls.filter(([args]) => args[1] === 'create').length;
+      prepareDraftRelease(tag, github);
+      expect(github.mock.calls.filter(([args]) => args[1] === 'create')).toHaveLength(creates);
+      publishDesktopRelease(tag, files, github);
+      expect(release.isDraft).toBe(false);
+    },
+  );
+
+  it('refuses to overwrite a published release', () => {
+    const { github, release } = harness();
+    prepareDraftRelease(tag, github);
+    release.isDraft = false;
+    github.mockClear();
+    expect(() => prepareDraftRelease(tag, github)).toThrow('must remain a draft');
+    expect(() => publishDesktopRelease(tag, files, github)).toThrow('must remain a draft');
+    expect(github.mock.calls.every(([args]) => args[1] === 'view')).toBe(true);
+  });
+
+  it.each(['missing file', 'empty file', 'wrong version'])('rejects %s before any release mutation', (failure) => {
+    const { github } = harness();
+    if (failure === 'missing file') files.pop();
+    if (failure === 'empty file') writeFileSync(files[0], '');
+    if (failure === 'wrong version') files[0] = files[0].replace('0.0.14', '0.0.13');
+    expect(() => publishDesktopRelease(tag, files, github)).toThrow();
+    expect(github).not.toHaveBeenCalled();
+  });
+
+  it('requires prerelease tags to remain marked as prereleases', () => {
+    const { github, release } = harness();
+    prepareDraftRelease(tag, github);
+    release.isPrerelease = true;
+    expect(() => prepareDraftRelease(tag, github)).toThrow('incorrect prerelease setting');
+  });
+});

--- a/packages/desktop/__test__/release-version.test.ts
+++ b/packages/desktop/__test__/release-version.test.ts
@@ -20,6 +20,8 @@ import {
   type ReleaseVersions,
   versionFromDmgPath,
   versionFromTag,
+  updateZipFileName,
+  versionFromUpdateZipPath,
 } from '../scripts/release-version.js';
 
 /** Everything agreeing on 0.0.9 — the shape a good release has. */
@@ -29,6 +31,7 @@ const AGREED: ReleaseVersions = {
   bundleShort: '0.0.9',
   bundleVersion: '0.0.9',
   dmg: '0.0.9',
+  zip: '0.0.9',
 };
 
 describe('versionFromTag', () => {
@@ -141,8 +144,38 @@ describe('assertVersionsAgree, untagged path', () => {
     // trivially. The manifest's own semver check is the only thing standing
     // between a typo and a stamped, signed, published bundle -- and nothing
     // else in this module can cover it.
-    const junk = { tag: null, manifest: 'nightly', bundleShort: 'nightly', bundleVersion: 'nightly', dmg: 'nightly' };
+    const junk = {
+      tag: null,
+      manifest: 'nightly',
+      bundleShort: 'nightly',
+      bundleVersion: 'nightly',
+      dmg: 'nightly',
+      zip: 'nightly',
+    };
     expect(() => assertVersionsAgree(junk)).toThrow(/packages\/desktop\/package\.json version/);
+  });
+});
+
+describe('update ZIP release versions', () => {
+  it('names the archive for Apple Silicon discovery by update.electronjs.org', () => {
+    expect(updateZipFileName('0.0.14')).toBe('mlx-node-0.0.14-darwin-arm64.zip');
+    expect(versionFromUpdateZipPath('/out/mlx-node-0.0.14-darwin-arm64.zip')).toBe('0.0.14');
+  });
+
+  it('rejects archives for a different app, platform, architecture or version scheme', () => {
+    for (const path of [
+      'mlx-node-0.0.14-arm64.zip',
+      'mlx-node-0.0.14-darwin-x64.zip',
+      'other-0.0.14-darwin-arm64.zip',
+      'mlx-node-nightly-darwin-arm64.zip',
+    ]) {
+      expect(versionFromUpdateZipPath(path)).toBeNull();
+    }
+    expect(() => updateZipFileName('nightly')).toThrow();
+  });
+
+  it('blocks a ZIP that advertises a different version from its bundle', () => {
+    expect(() => assertVersionsAgree({ ...AGREED, zip: '0.0.8' })).toThrow(/ZIP filename/);
   });
 });
 

--- a/packages/desktop/__test__/release-version.test.ts
+++ b/packages/desktop/__test__/release-version.test.ts
@@ -182,11 +182,8 @@ describe('update ZIP release versions', () => {
 /**
  * The guard that runs BEFORE a tag exists.
  *
- * Everything above only fires inside `desktop-release.yml`, which on a
- * `release: published` run cannot start any earlier than the release itself. By
- * then the mismatch costs a release with no DMG attached, and re-running is
- * awkward: `workflow_dispatch` carries no tag, and the upload step is gated on
- * `github.event_name == 'release'`.
+ * The workflow checks versions before building from a pushed tag. Catch the
+ * underlying manifest drift earlier, in ordinary pull request CI.
  *
  * The drift is created by `tools bump`, in an ordinary commit, days earlier —
  * so that is where it should be caught. `tools bump` reads its current version

--- a/packages/desktop/__test__/stage-app.test.ts
+++ b/packages/desktop/__test__/stage-app.test.ts
@@ -37,7 +37,13 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vite-plus/test';
 
-import { isNonRuntimeFile, pruneExcludedNested, runtimeClosure, stageRuntimeBuildFiles } from '../scripts/stage-app.js';
+import {
+  isNonRuntimeFile,
+  pruneExcludedNested,
+  runtimeClosure,
+  stageApp,
+  stageRuntimeBuildFiles,
+} from '../scripts/stage-app.js';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
@@ -71,7 +77,32 @@ describe('runtime build assets', () => {
 
 // The same roots packaging uses: what the three entries import, not what
 // packages/desktop/package.json happens to declare.
-const ROOTS = ['@mlx-node/dashboard', '@mlx-node/server', '@mlx-node/lm'];
+const ROOTS = ['@mlx-node/dashboard', '@mlx-node/server', '@mlx-node/lm', 'electron-updater'];
+
+describe('packaged update eligibility', () => {
+  it.each([undefined, false, true])('enables updates only when the packager explicitly signs: %s', (autoUpdates) => {
+    const root = mkdtempSync(join(tmpdir(), 'mlx-update-stage-'));
+    const desktop = join(root, 'desktop');
+    const stage = join(root, 'stage');
+    try {
+      mkdirSync(join(desktop, 'dist'), { recursive: true });
+      mkdirSync(join(desktop, 'build'), { recursive: true });
+      writeFileSync(join(desktop, 'dist', 'index.js'), 'export {};');
+      for (const name of ['iconTemplate.png', 'iconTemplate@2x.png']) {
+        writeFileSync(join(desktop, 'build', name), name);
+      }
+      // The source manifest must not be able to opt an unsigned package in.
+      writeFileSync(join(desktop, 'package.json'), JSON.stringify({ version: '0.0.13', autoUpdates: true }));
+      mkdirSync(join(root, 'node_modules', 'fixture'), { recursive: true });
+      writeFileSync(join(root, 'node_modules', 'fixture', 'package.json'), JSON.stringify({ name: 'fixture' }));
+      stageApp({ repoRoot: root, desktopDir: desktop, stageDir: stage, roots: ['fixture'], autoUpdates });
+      const manifest = JSON.parse(readFileSync(join(stage, 'package.json'), 'utf-8')) as { autoUpdates: boolean };
+      expect(manifest.autoUpdates).toBe(autoUpdates === true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('runtimeClosure', () => {
   const closure = runtimeClosure(repoRoot, ROOTS);
@@ -80,6 +111,8 @@ describe('runtimeClosure', () => {
     expect(closure.workspace).toContain('@mlx-node/dashboard');
     expect(closure.workspace).toContain('@mlx-node/server');
     expect(closure.external.length).toBeGreaterThan(0);
+    expect(closure.external).toContain('electron-updater');
+    expect(closure.external).not.toContain('app-builder-lib');
   });
 
   it('excludes the clipboard prebuilts that leak a build path', () => {

--- a/packages/desktop/__test__/update-artifacts.test.ts
+++ b/packages/desktop/__test__/update-artifacts.test.ts
@@ -1,0 +1,126 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gunzipSync } from 'node:zlib';
+
+import { computeOperations, OperationKind } from 'electron-updater/out/differentialDownloader/downloadPlanBuilder.js';
+import { parseUpdateInfo } from 'electron-updater/out/providers/Provider.js';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { assertStagingPercentage, createUpdateArtifacts, writeUpdaterConfig } from '../scripts/update-artifacts.js';
+
+const roots: string[] = [];
+function temporary(): string {
+  const root = mkdtempSync(join(tmpdir(), 'mlx-update-artifacts-'));
+  roots.push(root);
+  return root;
+}
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('update release artifacts', () => {
+  it('produces metadata and blockmaps the installed updater can consume without changing the archive', async () => {
+    const root = temporary();
+    const archive = randomBytes(256 * 1024);
+    const zipPath = join(root, 'mlx-node-0.0.14-darwin-arm64.zip');
+    writeFileSync(zipPath, archive);
+    const { manifestPath, blockmapPath } = await createUpdateArtifacts({
+      zipPath,
+      version: '0.0.14',
+      minimumSystemVersion: '26.0',
+      stagingPercentage: 25,
+      releaseDate: new Date('2026-09-08T00:00:00Z'),
+    });
+    // Parse with electron-updater itself, not a matching parser of our own.
+    const info = parseUpdateInfo(
+      readFileSync(manifestPath, 'utf-8'),
+      'latest-mac.yml',
+      new URL('https://example.test/'),
+    );
+    expect(info).toMatchObject({
+      version: '0.0.14',
+      minimumSystemVersion: '26.0',
+      stagingPercentage: 25,
+      releaseDate: '2026-09-08T00:00:00.000Z',
+      files: [
+        {
+          url: 'mlx-node-0.0.14-darwin-arm64.zip',
+          size: archive.length,
+          sha512: createHash('sha512').update(archive).digest('base64'),
+        },
+      ],
+    });
+    expect(readFileSync(zipPath)).toEqual(archive);
+    const map = JSON.parse(gunzipSync(readFileSync(blockmapPath)).toString()) as Parameters<
+      typeof computeOperations
+    >[0];
+    expect(map.version).toBe('2');
+    expect(map.files[0].sizes.reduce((sum, size) => sum + size, 0)).toBe(archive.length);
+  });
+
+  it('reconstructs an updated archive using the real updater download planner and reusable old bytes', async () => {
+    const root = temporary();
+    const previous = randomBytes(512 * 1024);
+    // Insert bytes so fixed offsets cannot accidentally pass the compatibility check.
+    const updated = Buffer.concat([
+      previous.subarray(0, 100_000),
+      Buffer.from('new release'),
+      previous.subarray(100_000),
+    ]);
+    const maps: Parameters<typeof computeOperations>[0][] = [];
+    for (const [version, bytes] of [
+      ['0.0.13', previous],
+      ['0.0.14', updated],
+    ] as const) {
+      const zipPath = join(root, `mlx-node-${version}-darwin-arm64.zip`);
+      writeFileSync(zipPath, bytes);
+      const result = await createUpdateArtifacts({ zipPath, version, minimumSystemVersion: '26.0' });
+      maps.push(JSON.parse(gunzipSync(readFileSync(result.blockmapPath)).toString()));
+    }
+    const plan = computeOperations(maps[0], maps[1], { info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    const reconstructed = Buffer.concat(
+      plan.map((operation) =>
+        (operation.kind === OperationKind.COPY ? previous : updated).subarray(operation.start, operation.end),
+      ),
+    );
+    expect(reconstructed).toEqual(updated);
+    expect(plan.some((operation) => operation.kind === OperationKind.COPY)).toBe(true);
+    expect(plan.some((operation) => operation.kind === OperationKind.DOWNLOAD)).toBe(true);
+    const transferred = plan
+      .filter((operation) => operation.kind === OperationKind.DOWNLOAD)
+      .reduce((sum, operation) => sum + operation.end - operation.start, 0);
+    expect(transferred).toBeLessThan(updated.length / 2);
+  });
+
+  it('rejects mismatched versions and missing OS eligibility before generating release files', async () => {
+    const root = temporary();
+    const options = {
+      zipPath: join(root, 'mlx-node-0.0.14-darwin-arm64.zip'),
+      version: '0.0.13',
+      minimumSystemVersion: '26.0',
+    };
+    await expect(createUpdateArtifacts(options)).rejects.toThrow('filename must match');
+    await expect(createUpdateArtifacts({ ...options, version: '0.0.14', minimumSystemVersion: '' })).rejects.toThrow(
+      'minimum macOS',
+    );
+  });
+
+  it.each([-1, 101, 1.5, Number.NaN, Infinity])('rejects invalid rollout percentage %s', (value) => {
+    expect(() => assertStagingPercentage(value)).toThrow();
+  });
+
+  it('supports a paused rollout and full rollout', () => {
+    expect(assertStagingPercentage(0)).toBe(0);
+    expect(assertStagingPercentage(100)).toBe(100);
+  });
+
+  it('writes the production provider and a stable per-app cache identity outside the app directory', () => {
+    const root = temporary();
+    writeUpdaterConfig(root);
+    expect(readFileSync(join(root, 'app-update.yml'), 'utf-8')).toBe(
+      'provider: github\nowner: mlx-node\nrepo: mlx-node\nupdaterCacheDirName: ai.mlxnode.desktop-updater\n',
+    );
+  });
+});

--- a/packages/desktop/__test__/updates.test.ts
+++ b/packages/desktop/__test__/updates.test.ts
@@ -1,0 +1,340 @@
+import { EventEmitter } from 'node:events';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+import { createQuitHandler } from '../src/main/quit.js';
+import {
+  canAutoUpdate,
+  createDesktopUpdater,
+  isMacUpdateSupported,
+  presentUpdate,
+  UPDATE_INTERVAL_MS,
+} from '../src/main/updates.js';
+
+const release = { packaged: true, enabled: true, platform: 'darwin', arch: 'arm64', version: '0.0.13' };
+
+class NativeUpdater extends EventEmitter {
+  autoDownload = false;
+  autoInstallOnAppQuit = false;
+  autoRunAppAfterInstall = false;
+  allowPrerelease = true;
+  allowDowngrade = true;
+  isUpdateSupported = (_info: { version: string; minimumSystemVersion?: string }) => true;
+  checkForUpdates = vi.fn<() => Promise<{ downloadPromise?: Promise<unknown> } | null>>().mockResolvedValue(null);
+  quitAndInstall = vi.fn();
+}
+
+function harness(enabled = canAutoUpdate(release)) {
+  const native = new NativeUpdater();
+  const onChange = vi.fn();
+  const requestQuit = vi.fn();
+  const report = vi.fn();
+  const updater = createDesktopUpdater({ enabled, systemVersion: '26.0', native, onChange, requestQuit, report });
+  return { native, updater, onChange, requestQuit, report };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('release update feed', () => {
+  it('enables signed stable Apple Silicon releases', () => {
+    expect(canAutoUpdate(release)).toBe(true);
+  });
+
+  it.each([
+    { packaged: false },
+    { enabled: false },
+    { platform: 'linux' },
+    { arch: 'x64' },
+    { version: '0.0.14-rc.1' },
+    { version: '0.0.14+local' },
+    { version: 'nightly' },
+    { version: '0.01.0' },
+  ])('disables updates for an ineligible build: %j', (override) => {
+    expect(canAutoUpdate({ ...release, ...override })).toBe(false);
+  });
+});
+
+describe('desktop updates', () => {
+  it('enables background download and staging with stable-only version policy', () => {
+    const { native } = harness();
+    expect(native.autoDownload).toBe(true);
+    expect(native.autoInstallOnAppQuit).toBe(true);
+    expect(native.allowPrerelease).toBe(false);
+    expect(native.allowDowngrade).toBe(false);
+    expect(native.isUpdateSupported({ version: '0.0.14', minimumSystemVersion: '26.1' })).toBe(false);
+    expect(native.isUpdateSupported({ version: '0.0.14', minimumSystemVersion: '26.0' })).toBe(true);
+    expect(native.isUpdateSupported({ version: '0.0.14-rc.1', minimumSystemVersion: '26.0' })).toBe(false);
+  });
+
+  it('catches check and separate download promise failures once, then permits retry', async () => {
+    const { updater, native, report } = harness();
+    const error = new Error('check failed');
+    native.checkForUpdates.mockImplementationOnce(async () => {
+      native.emit('error', error);
+      throw error;
+    });
+    updater.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(updater.status()).toBe('error');
+    expect(report).toHaveBeenCalledTimes(1);
+
+    const download = Promise.withResolvers<void>();
+    native.checkForUpdates.mockImplementationOnce(async () => {
+      native.emit('update-available');
+      return { downloadPromise: download.promise };
+    });
+    updater.check();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(updater.status()).toBe('downloading');
+    const failure = new Error('download failed');
+    native.emit('error', failure);
+    updater.check(); // The failed download has not settled yet.
+    expect(native.checkForUpdates).toHaveBeenCalledTimes(2);
+    download.reject(failure);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(report).toHaveBeenCalledTimes(2);
+    expect(updater.status()).toBe('error');
+    updater.check();
+    expect(native.checkForUpdates).toHaveBeenCalledTimes(3);
+  });
+
+  it('shows bounded whole-number download progress without redundant menu rebuilds', () => {
+    const { updater, native, onChange } = harness();
+    updater.start();
+    native.emit('update-available');
+    onChange.mockClear();
+    for (const percent of [42.1, 42.9, Number.NaN, Infinity]) native.emit('download-progress', { percent });
+    expect(updater.progress()).toBe(42);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(presentUpdate(updater.status(), updater.progress()).label).toContain('42%');
+    native.emit('download-progress', { percent: 102 });
+    expect(updater.progress()).toBe(100);
+    updater.stop();
+    onChange.mockClear();
+    native.emit('download-progress', { percent: 50 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('finishes staging on an ordinary quit without requesting a relaunch', () => {
+    const { updater, native } = harness();
+    updater.start();
+    native.emit('update-downloaded');
+    updater.stop();
+    expect(updater.installOnQuit()).toBe(true);
+    expect(native.autoRunAppAfterInstall).toBe(false);
+    expect(native.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it('never configures native updates or starts timers for disabled builds', () => {
+    const { updater, native } = harness(false);
+    updater.start();
+    updater.check();
+    updater.restartAndInstall();
+    expect(updater.status()).toBe('disabled');
+    expect(native.checkForUpdates).not.toHaveBeenCalled();
+    expect(native.autoDownload).toBe(false);
+    expect(native.quitAndInstall).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('checks on startup and periodically, without overlapping checks or downloads', async () => {
+    const { updater, native } = harness();
+    updater.start();
+    updater.start();
+    expect(updater.status()).toBe('checking');
+    updater.check();
+    await vi.advanceTimersByTimeAsync(UPDATE_INTERVAL_MS);
+    expect(native.checkForUpdates).toHaveBeenCalledTimes(1);
+    native.emit('update-not-available');
+    expect(updater.status()).toBe('current');
+    await vi.advanceTimersByTimeAsync(UPDATE_INTERVAL_MS);
+    expect(native.checkForUpdates).toHaveBeenCalledTimes(2);
+    native.emit('update-available');
+    expect(updater.status()).toBe('downloading');
+    updater.check();
+    await vi.advanceTimersByTimeAsync(UPDATE_INTERVAL_MS * 2);
+    expect(native.checkForUpdates).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a downloaded update ready without interrupting inference or downloading again', async () => {
+    const { updater, native, requestQuit } = harness();
+    updater.start();
+    updater.restartAndInstall();
+    expect(requestQuit).not.toHaveBeenCalled();
+    native.emit('update-available');
+    native.emit('update-downloaded', {}, 'Notes', 'v0.0.14', new Date(), 'https://github.com/');
+    expect(updater.status()).toBe('ready');
+    expect(requestQuit).not.toHaveBeenCalled();
+    updater.check();
+    await vi.advanceTimersByTimeAsync(UPDATE_INTERVAL_MS);
+    expect(native.checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(native.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  it('recovers from a download error on the next scheduled or manual check', async () => {
+    const { updater, native, report } = harness();
+    updater.start();
+    native.emit('update-available');
+    const error = new Error('network disconnected');
+    native.emit('error', error);
+    expect(report).toHaveBeenCalledWith(error);
+    expect(updater.status()).toBe('error');
+    await vi.advanceTimersByTimeAsync(UPDATE_INTERVAL_MS);
+    expect(native.checkForUpdates).toHaveBeenCalledTimes(2);
+    native.emit('update-not-available');
+    await vi.advanceTimersByTimeAsync(0);
+    updater.check();
+    expect(native.checkForUpdates).toHaveBeenCalledTimes(3);
+  });
+
+  it('handles a synchronous check failure without throwing out of a menu action', async () => {
+    const { updater, native, report } = harness();
+    native.checkForUpdates.mockImplementationOnce(() => {
+      throw new Error('check failed');
+    });
+    expect(() => updater.start()).not.toThrow();
+    expect(updater.status()).toBe('error');
+    expect(report).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(0);
+    updater.check();
+    expect(updater.status()).toBe('checking');
+  });
+
+  it('stops timers and ignores late results while retaining an error handler', async () => {
+    const { updater, native, onChange, requestQuit, report } = harness();
+    updater.start();
+    updater.stop();
+    onChange.mockClear();
+    native.emit('update-available');
+    native.emit('update-downloaded');
+    native.emit('update-not-available');
+    native.emit('error', new Error('late failure'));
+    updater.check();
+    updater.start();
+    updater.restartAndInstall();
+    await vi.advanceTimersByTimeAsync(UPDATE_INTERVAL_MS * 2);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(native.checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(requestQuit).not.toHaveBeenCalled();
+    expect(report).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains once before installing and leaves relaunch to Squirrel even during activation', async () => {
+    const { updater, native, requestQuit } = harness();
+    const drain = Promise.withResolvers<void>();
+    const shutdown = vi.fn(() => drain.promise);
+    const relaunch = vi.fn();
+    const finalQuit = vi.fn();
+    const quit = createQuitHandler({
+      beginShutdown: () => updater.stop(),
+      shutdown,
+      deadlineMs: 14_000,
+      installUpdate: (relaunchRequested) => updater.installOnQuit(relaunchRequested),
+      shouldRelaunch: () => true,
+      relaunch,
+      quit: finalQuit,
+      report: vi.fn(),
+    });
+    const prevented = vi.fn();
+    requestQuit.mockImplementation(() => quit({ preventDefault: prevented }));
+    updater.start();
+    native.emit('update-available');
+    native.emit('update-downloaded');
+    updater.restartAndInstall();
+    updater.restartAndInstall();
+    quit({ preventDefault: prevented }); // Cmd+Q during the drain must also wait.
+    expect(requestQuit).toHaveBeenCalledTimes(1);
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(prevented).toHaveBeenCalledTimes(2);
+    expect(native.quitAndInstall).not.toHaveBeenCalled();
+    drain.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(native.quitAndInstall).toHaveBeenCalledTimes(1);
+    expect(native.autoRunAppAfterInstall).toBe(true);
+    expect(relaunch).not.toHaveBeenCalled();
+    expect(finalQuit).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+    updater.installOnQuit();
+    expect(native.quitAndInstall).toHaveBeenCalledTimes(1);
+    quit({ preventDefault: prevented }); // Squirrel's final app.quit().
+    expect(prevented).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(['throw', 'event'])('finishes quitting if installation fails through %s', (failure) => {
+    const { updater, native, requestQuit, report } = harness();
+    updater.start();
+    native.emit('update-downloaded');
+    updater.restartAndInstall();
+    updater.stop();
+    if (failure === 'throw')
+      native.quitAndInstall.mockImplementationOnce(() => {
+        throw new Error('install failed');
+      });
+    expect(updater.installOnQuit()).toBe(true);
+    if (failure === 'event') native.emit('error', new Error('install failed'));
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(requestQuit).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(['before quit', 'during quit'])(
+    'uses an update downloaded %s for a queued Finder relaunch',
+    async (downloaded) => {
+      const { updater, native, requestQuit } = harness();
+      updater.start();
+      native.emit('update-available');
+      if (downloaded === 'before quit') native.emit('update-downloaded');
+      const drain = Promise.withResolvers<void>();
+      let activated = false;
+      const relaunch = vi.fn();
+      const finalQuit = vi.fn();
+      const quit = createQuitHandler({
+        beginShutdown: () => updater.stop(),
+        shutdown: () => drain.promise,
+        deadlineMs: 14_000,
+        installUpdate: (relaunchRequested) => updater.installOnQuit(relaunchRequested),
+        shouldRelaunch: () => activated,
+        relaunch,
+        quit: finalQuit,
+        report: vi.fn(),
+      });
+      quit({ preventDefault: vi.fn() });
+      activated = true;
+      if (downloaded === 'during quit') native.emit('update-downloaded');
+      drain.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(native.quitAndInstall).toHaveBeenCalledTimes(1);
+      expect(requestQuit).not.toHaveBeenCalled();
+      expect(relaunch).not.toHaveBeenCalled();
+      expect(finalQuit).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('minimum macOS version', () => {
+  it.each([
+    ['26.0', '26.0.0', true],
+    ['26.1', '26.0', true],
+    ['26.0', '26.1', false],
+    ['15.7', '26.0', false],
+    ['13.7.1', '13.7.2', false],
+    ['26.0', undefined, false],
+    ['26.0', 'invalid', false],
+  ] as const)('compares macOS %s against %s', (current, minimum, supported) => {
+    expect(isMacUpdateSupported(current, minimum)).toBe(supported);
+  });
+});
+
+describe('update menu', () => {
+  it('makes busy and disabled states non-actionable and offers retry and restart', () => {
+    for (const status of ['disabled', 'checking', 'downloading', 'installing'] as const) {
+      expect(presentUpdate(status).enabled).toBe(false);
+    }
+    for (const status of ['idle', 'current', 'ready', 'error'] as const) {
+      expect(presentUpdate(status).enabled).toBe(true);
+    }
+    expect(presentUpdate('ready').label).toBe('Restart to Update…');
+    expect(presentUpdate('error').label).toContain('Try Again');
+  });
+});

--- a/packages/desktop/__test__/updates.test.ts
+++ b/packages/desktop/__test__/updates.test.ts
@@ -29,7 +29,15 @@ function harness(enabled = canAutoUpdate(release)) {
   const onChange = vi.fn();
   const requestQuit = vi.fn();
   const report = vi.fn();
-  const updater = createDesktopUpdater({ enabled, systemVersion: '26.0', native, onChange, requestQuit, report });
+  const updater = createDesktopUpdater({
+    enabled,
+    systemVersion: '26.0',
+    native,
+    squirrel: native,
+    onChange,
+    requestQuit,
+    report,
+  });
   return { native, updater, onChange, requestQuit, report };
 }
 
@@ -121,7 +129,7 @@ describe('desktop updates', () => {
     updater.start();
     native.emit('update-downloaded');
     updater.stop();
-    expect(updater.installOnQuit()).toBe(true);
+    expect(updater.installOnQuit(false, vi.fn())).toBe(true);
     expect(native.autoRunAppAfterInstall).toBe(false);
     expect(native.quitAndInstall).toHaveBeenCalledTimes(1);
   });
@@ -231,7 +239,7 @@ describe('desktop updates', () => {
       beginShutdown: () => updater.stop(),
       shutdown,
       deadlineMs: 14_000,
-      installUpdate: (relaunchRequested) => updater.installOnQuit(relaunchRequested),
+      installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
       shouldRelaunch: () => true,
       relaunch,
       quit: finalQuit,
@@ -256,7 +264,7 @@ describe('desktop updates', () => {
     expect(relaunch).not.toHaveBeenCalled();
     expect(finalQuit).not.toHaveBeenCalled();
     expect(vi.getTimerCount()).toBe(0);
-    updater.installOnQuit();
+    updater.installOnQuit(false, vi.fn());
     expect(native.quitAndInstall).toHaveBeenCalledTimes(1);
     quit({ preventDefault: prevented }); // Squirrel's final app.quit().
     expect(prevented).toHaveBeenCalledTimes(2);
@@ -272,7 +280,7 @@ describe('desktop updates', () => {
       native.quitAndInstall.mockImplementationOnce(() => {
         throw new Error('install failed');
       });
-    expect(updater.installOnQuit()).toBe(true);
+    expect(updater.installOnQuit(false, vi.fn())).toBe(true);
     if (failure === 'event') native.emit('error', new Error('install failed'));
     expect(report).toHaveBeenCalledTimes(1);
     expect(requestQuit).toHaveBeenCalledTimes(2);
@@ -293,7 +301,7 @@ describe('desktop updates', () => {
         beginShutdown: () => updater.stop(),
         shutdown: () => drain.promise,
         deadlineMs: 14_000,
-        installUpdate: (relaunchRequested) => updater.installOnQuit(relaunchRequested),
+        installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
         shouldRelaunch: () => activated,
         relaunch,
         quit: finalQuit,

--- a/packages/desktop/__test__/updates.test.ts
+++ b/packages/desktop/__test__/updates.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
-import { createQuitHandler } from '../src/main/quit.js';
+import { createQuitHandler, type CompleteQuit } from '../src/main/quit.js';
 import {
   canAutoUpdate,
   createDesktopUpdater,
@@ -129,7 +129,7 @@ describe('desktop updates', () => {
     updater.start();
     native.emit('update-downloaded');
     updater.stop();
-    expect(updater.installOnQuit(false, vi.fn())).toBe(true);
+    expect(updater.installOnQuit((install) => install?.(false))).toBe(true);
     expect(native.autoRunAppAfterInstall).toBe(false);
     expect(native.quitAndInstall).toHaveBeenCalledTimes(1);
   });
@@ -239,7 +239,7 @@ describe('desktop updates', () => {
       beginShutdown: () => updater.stop(),
       shutdown,
       deadlineMs: 14_000,
-      installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
+      installUpdate: (completeQuit) => updater.installOnQuit(completeQuit),
       shouldRelaunch: () => true,
       relaunch,
       quit: finalQuit,
@@ -264,7 +264,7 @@ describe('desktop updates', () => {
     expect(relaunch).not.toHaveBeenCalled();
     expect(finalQuit).not.toHaveBeenCalled();
     expect(vi.getTimerCount()).toBe(0);
-    updater.installOnQuit(false, vi.fn());
+    updater.installOnQuit((install) => install?.(false));
     expect(native.quitAndInstall).toHaveBeenCalledTimes(1);
     quit({ preventDefault: prevented }); // Squirrel's final app.quit().
     expect(prevented).toHaveBeenCalledTimes(2);
@@ -280,10 +280,12 @@ describe('desktop updates', () => {
       native.quitAndInstall.mockImplementationOnce(() => {
         throw new Error('install failed');
       });
-    expect(updater.installOnQuit(false, vi.fn())).toBe(true);
+    const completeQuit = vi.fn<CompleteQuit>((install) => install?.(false));
+    expect(updater.installOnQuit(completeQuit)).toBe(true);
     if (failure === 'event') native.emit('error', new Error('install failed'));
     expect(report).toHaveBeenCalledTimes(1);
-    expect(requestQuit).toHaveBeenCalledTimes(2);
+    expect(requestQuit).toHaveBeenCalledTimes(1);
+    expect(completeQuit).toHaveBeenLastCalledWith();
   });
 
   it.each(['before quit', 'during quit'])(
@@ -301,7 +303,7 @@ describe('desktop updates', () => {
         beginShutdown: () => updater.stop(),
         shutdown: () => drain.promise,
         deadlineMs: 14_000,
-        installUpdate: (relaunchRequested, allowQuit) => updater.installOnQuit(relaunchRequested, allowQuit),
+        installUpdate: (completeQuit) => updater.installOnQuit(completeQuit),
         shouldRelaunch: () => activated,
         relaunch,
         quit: finalQuit,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -2,7 +2,6 @@
   "name": "@mlx-node/desktop",
   "version": "0.0.13",
   "private": true,
-  "productName": "mlx-node",
   "description": "mlx-node macOS desktop app (Electron shell: tray, control panel window, supervised inference sidecar)",
   "homepage": "https://github.com/mlx-node/mlx-node",
   "bugs": {
@@ -16,9 +15,6 @@
   },
   "type": "module",
   "main": "dist/main/index.js",
-  "engines": {
-    "node": ">= 22.19.0"
-  },
   "scripts": {
     "build": "tsc -b",
     "icons": "oxnode build/make-icons.ts",
@@ -30,7 +26,8 @@
   "dependencies": {
     "@mlx-node/dashboard": "workspace:*",
     "@mlx-node/lm": "workspace:*",
-    "@mlx-node/server": "workspace:*"
+    "@mlx-node/server": "workspace:*",
+    "electron-updater": "6.8.9"
   },
   "devDependencies": {
     "@electron/notarize": "3.1.1",
@@ -38,7 +35,12 @@
     "@electron/packager": "20.3.0",
     "@napi-rs/image": "1.14.0",
     "@types/node": "catalog:",
+    "app-builder-lib": "26.15.3",
     "electron": "44.0.0",
     "vite-plus": "catalog:"
-  }
+  },
+  "engines": {
+    "node": ">= 22.19.0"
+  },
+  "productName": "mlx-node"
 }

--- a/packages/desktop/scripts/check-release.ts
+++ b/packages/desktop/scripts/check-release.ts
@@ -2,14 +2,14 @@
  * The release gate for versions. Run from `.github/workflows/desktop-release.yml`.
  *
  *   check-release.ts resolve --tag <tag> --manifest <package.json>
- *   check-release.ts verify  --tag <tag> --manifest <package.json> --app <.app> [--dmg <dmg>]
+ *   check-release.ts verify  --tag <tag> --manifest <package.json> --app <.app> [--dmg <dmg>] [--zip <zip>]
  *
  * `resolve` runs BEFORE the ~16-minute build so a stale manifest costs a minute
- * instead of a full release cycle, and emits `version` + `dmg_name` to
+ * instead of a full release cycle, and emits `version`, `dmg_name`, and `zip_name` to
  * `$GITHUB_OUTPUT` so every later step reads one value rather than re-deriving it.
  *
  * `verify` runs after the artifacts exist and re-checks the same thing against
- * what was actually produced — the plist inside the `.app` and the DMG's filename.
+ * what was actually produced — the plist inside the `.app` and the archive filenames.
  * Two checks, because `resolve` only proves the inputs agreed.
  *
  * `--tag` may be empty (`workflow_dispatch` has no tag); the manifest is then the
@@ -27,6 +27,8 @@ import {
   ReleaseVersionError,
   versionFromDmgPath,
   versionFromTag,
+  updateZipFileName,
+  versionFromUpdateZipPath,
 } from './release-version.js';
 
 const { positionals, values } = parseArgs({
@@ -36,13 +38,14 @@ const { positionals, values } = parseArgs({
     manifest: { type: 'string' },
     app: { type: 'string' },
     dmg: { type: 'string', default: '' },
+    zip: { type: 'string', default: '' },
   },
 });
 
 const command = positionals[0];
 if (command !== 'resolve' && command !== 'verify') {
   console.error(
-    'usage: check-release.ts <resolve|verify> --tag <tag> --manifest <package.json> [--app <.app>] [--dmg <dmg>]',
+    'usage: check-release.ts <resolve|verify> --tag <tag> --manifest <package.json> [--app <.app>] [--dmg <dmg>] [--zip <zip>]',
   );
   process.exit(2);
 }
@@ -78,7 +81,7 @@ try {
 }
 
 function resolve(): string {
-  // The bundle and DMG do not exist yet; passing the expected version for both
+  // The bundle and archives do not exist yet; passing the expected version for them
   // would assert nothing, so they are declared absent and `verify` covers them.
   const version = assertVersionsAgree({
     tag,
@@ -86,10 +89,14 @@ function resolve(): string {
     bundleShort: tag ?? manifest,
     bundleVersion: tag ?? manifest,
     dmg: null,
+    zip: null,
   });
   const output = process.env.GITHUB_OUTPUT;
   if (output !== undefined && output !== '') {
-    appendFileSync(output, `version=${version}\ndmg_name=${dmgFileName(version)}\n`);
+    appendFileSync(
+      output,
+      `version=${version}\ndmg_name=${dmgFileName(version)}\nzip_name=${updateZipFileName(version)}\n`,
+    );
   }
   return version;
 }
@@ -111,12 +118,19 @@ function verify(): string {
     process.exit(1);
   }
 
+  const zip = values.zip.trim();
+  if (zip !== '' && (versionFromUpdateZipPath(zip) === null || !existsSync(zip))) {
+    console.error(`::error::update ZIP ${zip} must exist and be named mlx-node-<version>-darwin-arm64.zip`);
+    process.exit(1);
+  }
+
   return assertVersionsAgree({
     tag,
     manifest,
     bundleShort: plistString(plist, 'CFBundleShortVersionString'),
     bundleVersion: plistString(plist, 'CFBundleVersion'),
     dmg: dmg === '' ? null : versionFromDmgPath(dmg),
+    zip: zip === '' ? null : versionFromUpdateZipPath(zip),
   });
 }
 

--- a/packages/desktop/scripts/generate-update.ts
+++ b/packages/desktop/scripts/generate-update.ts
@@ -1,0 +1,32 @@
+/** Create electron-updater metadata from the actual packaged app and final ZIP. */
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { createUpdateArtifacts } from './update-artifacts.js';
+
+const { values } = parseArgs({
+  options: {
+    app: { type: 'string' },
+    zip: { type: 'string' },
+    'staging-percentage': { type: 'string', default: '100' },
+  },
+});
+if (!values.app || !values.zip) {
+  throw new Error('usage: generate-update.ts --app <app> --zip <zip> [--staging-percentage <0-100>]');
+}
+const readPlist = (key: string): string =>
+  execFileSync('plutil', ['-extract', key, 'raw', '-o', '-', join(values.app!, 'Contents', 'Info.plist')], {
+    encoding: 'utf-8',
+  }).trim();
+const result = await createUpdateArtifacts({
+  zipPath: values.zip,
+  version: readPlist('CFBundleShortVersionString'),
+  minimumSystemVersion: readPlist('LSMinimumSystemVersion'),
+  stagingPercentage: Number(values['staging-percentage']),
+});
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `manifest=${result.manifestPath}\nblockmap=${result.blockmapPath}\n`);
+}
+console.log(`Created ${result.manifestPath} and ${result.blockmapPath}`);

--- a/packages/desktop/scripts/package.ts
+++ b/packages/desktop/scripts/package.ts
@@ -25,6 +25,7 @@ import { maxOsVersion, parseMinOs } from './min-os.js';
 import { bundledAddonPath, codesignArgs, NATIVE_FILES, PayloadError, resolvePayload } from './payload.js';
 import { assertSemver } from './release-version.js';
 import { stageApp } from './stage-app.js';
+import { writeUpdaterConfig } from './update-artifacts.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const APP_DIR = resolve(HERE, '..');
@@ -38,7 +39,7 @@ const STAGE_APP = join(STAGE, 'app');
  * list rather than `packages/desktop/package.json` dependencies: that manifest
  * also carries `@mlx-node/lm` for the Phase 0 spike, which MAIN must never load.
  */
-const RUNTIME_ROOTS = ['@mlx-node/server', '@mlx-node/dashboard'];
+const RUNTIME_ROOTS = ['@mlx-node/server', '@mlx-node/dashboard', 'electron-updater'];
 const BUNDLE_ID = 'ai.mlxnode.desktop';
 const PRODUCT_NAME = 'mlx-node';
 const RESULT_FILE = join(OUT, 'package-result.json');
@@ -98,7 +99,13 @@ for (const file of NATIVE_FILES) {
 const stagedAddon = join(stagedNative, 'mlx-core.darwin-arm64.node');
 run('install_name_tool', ['-id', `@rpath/${NATIVE_FILES[0]}`, stagedAddon]);
 
-const staged = stageApp({ repoRoot: REPO_ROOT, desktopDir: APP_DIR, stageDir: STAGE_APP, roots: RUNTIME_ROOTS });
+const staged = stageApp({
+  repoRoot: REPO_ROOT,
+  desktopDir: APP_DIR,
+  stageDir: STAGE_APP,
+  roots: RUNTIME_ROOTS,
+  autoUpdates: sign,
+});
 console.log(`staged ${staged.externalCount} external + ${staged.workspaceCount} workspace packages`);
 console.log(`  pruned ${staged.prunedDirs} examples/docs/test dirs from staged packages`);
 console.log(`  pruned ${staged.prunedFiles} .d.ts / source-map / tsbuildinfo files`);
@@ -170,6 +177,7 @@ if (!existsSync(join(appPath, 'Contents', 'Info.plist'))) {
 
 // extraResource keeps the source directory name; the app expects `www`.
 const resources = join(appPath, 'Contents', 'Resources');
+if (sign) writeUpdaterConfig(resources);
 rmSync(join(resources, 'www'), { recursive: true, force: true });
 cpSync(join(resources, 'web'), join(resources, 'www'), { recursive: true });
 rmSync(join(resources, 'web'), { recursive: true, force: true });

--- a/packages/desktop/scripts/publish-release.ts
+++ b/packages/desktop/scripts/publish-release.ts
@@ -1,0 +1,37 @@
+/** Draft-first release lifecycle, invoked only by the desktop release workflow. */
+import { execFileSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+
+import { prepareDraftRelease, publishDesktopRelease } from './release-publication.js';
+import { versionFromTag } from './release-version.js';
+
+const { positionals, values } = parseArgs({
+  allowPositionals: true,
+  options: {
+    tag: { type: 'string' },
+    dmg: { type: 'string' },
+    zip: { type: 'string' },
+    blockmap: { type: 'string' },
+    manifest: { type: 'string' },
+  },
+});
+const tag = values.tag;
+if (!tag) throw new Error('A release tag is required for publication');
+versionFromTag(tag);
+// A manual dispatch must build the tag, not whatever branch was selected in
+// the Actions UI. --verify-tag below also requires it to exist on GitHub.
+const revision = (ref: string): string =>
+  execFileSync('git', ['rev-parse', '--verify', ref], { encoding: 'utf8' }).trim();
+if (revision(`refs/tags/${tag}^{commit}`) !== revision('HEAD')) {
+  throw new Error(`The checkout does not match release tag ${tag}`);
+}
+const github = (args: string[]): string => execFileSync('gh', args, { encoding: 'utf8' });
+if (positionals[0] === 'prepare') {
+  prepareDraftRelease(tag, github);
+} else if (positionals[0] === 'publish' && values.dmg && values.zip && values.blockmap && values.manifest) {
+  publishDesktopRelease(tag, [values.dmg, values.zip, values.blockmap, values.manifest], github);
+} else {
+  throw new Error(
+    'usage: publish-release.ts <prepare|publish> --tag <tag> [--dmg <dmg> --zip <zip> --blockmap <blockmap> --manifest <manifest>]',
+  );
+}

--- a/packages/desktop/scripts/publish-release.ts
+++ b/packages/desktop/scripts/publish-release.ts
@@ -22,14 +22,15 @@ versionFromTag(tag);
 // the Actions UI. --verify-tag below also requires it to exist on GitHub.
 const revision = (ref: string): string =>
   execFileSync('git', ['rev-parse', '--verify', ref], { encoding: 'utf8' }).trim();
-if (revision(`refs/tags/${tag}^{commit}`) !== revision('HEAD')) {
+const commit = revision('HEAD');
+if (revision(`refs/tags/${tag}^{commit}`) !== commit) {
   throw new Error(`The checkout does not match release tag ${tag}`);
 }
 const github = (args: string[]): string => execFileSync('gh', args, { encoding: 'utf8' });
 if (positionals[0] === 'prepare') {
   prepareDraftRelease(tag, github);
 } else if (positionals[0] === 'publish' && values.dmg && values.zip && values.blockmap && values.manifest) {
-  publishDesktopRelease(tag, [values.dmg, values.zip, values.blockmap, values.manifest], github);
+  await publishDesktopRelease(tag, commit, [values.dmg, values.zip, values.blockmap, values.manifest], github);
 } else {
   throw new Error(
     'usage: publish-release.ts <prepare|publish> --tag <tag> [--dmg <dmg> --zip <zip> --blockmap <blockmap> --manifest <manifest>]',

--- a/packages/desktop/scripts/release-ci.ts
+++ b/packages/desktop/scripts/release-ci.ts
@@ -1,0 +1,53 @@
+export const CI_WAIT_TIMEOUT_MS = 3 * 60 * 60 * 1_000;
+export const CI_POLL_INTERVAL_MS = 30_000;
+
+interface WorkflowRun {
+  id: number;
+  head_sha: string;
+  head_branch: string;
+  event: string;
+  path: string;
+  status: string;
+  conclusion: string | null;
+  html_url: string;
+}
+
+/** Only a completed main-push CI run for this exact commit can expose an update. */
+export async function waitForReleaseCI(commit: string, github: (args: string[]) => string): Promise<void> {
+  if (!/^[a-f0-9]{40}$/.test(commit)) throw new Error('Release CI requires a full commit SHA');
+  const deadline = Date.now() + CI_WAIT_TIMEOUT_MS;
+  const endpoint = `repos/{owner}/{repo}/actions/workflows/ci.yml/runs?head_sha=${commit}&branch=main&event=push&per_page=100`;
+  let lastStatus = '';
+  while (true) {
+    // Do not filter for success in the API: an older successful run must not
+    // hide a newer failed run or an in-progress rerun of the tagged commit.
+    const response = JSON.parse(github(['api', endpoint])) as { workflow_runs: WorkflowRun[] };
+    const run = response.workflow_runs
+      .filter(
+        (run) =>
+          run.head_sha === commit &&
+          run.head_branch === 'main' &&
+          run.event === 'push' &&
+          run.path === '.github/workflows/ci.yml',
+      )
+      .sort((a, b) => b.id - a.id)[0];
+    if (run?.status === 'completed') {
+      if (run.conclusion !== 'success') {
+        throw new Error(
+          `Release blocked: CI for ${commit} concluded ${run.conclusion ?? 'without a result'} (${run.html_url})`,
+        );
+      }
+      console.log(`Release CI passed: ${run.html_url}`);
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for successful main-branch CI for ${commit}; the release remains a draft`);
+    }
+    const status = run ? `${run.id}: ${run.status}` : 'waiting for the main-push run to appear';
+    if (status !== lastStatus) {
+      console.log(`Release CI: ${status}`);
+      lastStatus = status;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, CI_POLL_INTERVAL_MS));
+  }
+}

--- a/packages/desktop/scripts/release-publication.ts
+++ b/packages/desktop/scripts/release-publication.ts
@@ -1,6 +1,7 @@
 import { statSync } from 'node:fs';
 import { basename } from 'node:path';
 
+import { waitForReleaseCI } from './release-ci.js';
 import { dmgFileName, updateZipFileName, versionFromTag } from './release-version.js';
 
 type GitHub = (args: string[]) => string;
@@ -50,7 +51,12 @@ export function prepareDraftRelease(tag: string, github: GitHub): void {
 }
 
 /** Upload and verify the complete asset set while private, then publish once. */
-export function publishDesktopRelease(tag: string, files: string[], github: GitHub): void {
+export async function publishDesktopRelease(
+  tag: string,
+  commit: string,
+  files: string[],
+  github: GitHub,
+): Promise<void> {
   const version = versionFromTag(tag);
   const zip = updateZipFileName(version);
   const expected = [dmgFileName(version), zip, `${zip}.blockmap`, 'latest-mac.yml'];
@@ -67,6 +73,9 @@ export function publishDesktopRelease(tag: string, files: string[], github: GitH
   });
   assertDraft(tag, readRelease(tag, github));
   github(['release', 'upload', tag, ...files, '--clobber']);
+  // The tag build can overlap main CI, but the public update feed cannot.
+  // Check after uploads, then re-read the draft/assets after any CI wait.
+  await waitForReleaseCI(commit, github);
   // Re-read after upload. A failed/partial upload must never expose a release
   // lacking latest-mac.yml, and reruns may only replace files on a draft.
   const release = readRelease(tag, github);

--- a/packages/desktop/scripts/release-publication.ts
+++ b/packages/desktop/scripts/release-publication.ts
@@ -1,0 +1,81 @@
+import { statSync } from 'node:fs';
+import { basename } from 'node:path';
+
+import { dmgFileName, updateZipFileName, versionFromTag } from './release-version.js';
+
+type GitHub = (args: string[]) => string;
+interface Release {
+  tagName: string;
+  isDraft: boolean;
+  isPrerelease: boolean;
+  assets: { name: string; state: string; size: number }[];
+}
+
+function readRelease(tag: string, github: GitHub): Release {
+  return JSON.parse(github(['release', 'view', tag, '--json', 'tagName,isDraft,isPrerelease,assets'])) as Release;
+}
+
+function assertDraft(tag: string, release: Release): void {
+  if (release.tagName !== tag || release.isDraft !== true) {
+    throw new Error(
+      `${tag} must remain a draft until all desktop artifacts are uploaded; refusing to modify a public release`,
+    );
+  }
+  if (release.isPrerelease !== versionFromTag(tag).includes('-')) {
+    throw new Error(`${tag} has an incorrect prerelease setting`);
+  }
+}
+
+/** A failed build leaves this draft hidden from the public GitHub update feed. */
+export function prepareDraftRelease(tag: string, github: GitHub): void {
+  const version = versionFromTag(tag);
+  let release: Release;
+  try {
+    release = readRelease(tag, github);
+  } catch {
+    // Creation is draft-only and verifies the remote tag. A duplicate tag,
+    // authentication failure, or network failure still aborts publication.
+    github([
+      'release',
+      'create',
+      tag,
+      '--draft',
+      '--verify-tag',
+      '--generate-notes',
+      `--prerelease=${version.includes('-')}`,
+    ]);
+    release = readRelease(tag, github);
+  }
+  assertDraft(tag, release);
+}
+
+/** Upload and verify the complete asset set while private, then publish once. */
+export function publishDesktopRelease(tag: string, files: string[], github: GitHub): void {
+  const version = versionFromTag(tag);
+  const zip = updateZipFileName(version);
+  const expected = [dmgFileName(version), zip, `${zip}.blockmap`, 'latest-mac.yml'];
+  if (
+    files.length !== expected.length ||
+    expected.some((name) => files.filter((file) => basename(file) === name).length !== 1)
+  ) {
+    throw new Error('Publication requires the matching DMG, update ZIP, blockmap, and latest-mac.yml');
+  }
+  const assets = files.map((file) => {
+    const stat = statSync(file);
+    if (!stat.isFile() || stat.size === 0) throw new Error(`Missing or empty release artifact: ${file}`);
+    return { name: basename(file), size: stat.size };
+  });
+  assertDraft(tag, readRelease(tag, github));
+  github(['release', 'upload', tag, ...files, '--clobber']);
+  // Re-read after upload. A failed/partial upload must never expose a release
+  // lacking latest-mac.yml, and reruns may only replace files on a draft.
+  const release = readRelease(tag, github);
+  assertDraft(tag, release);
+  for (const expected of assets) {
+    const matches = release.assets.filter((asset) => asset.name === expected.name);
+    if (matches.length !== 1 || matches[0].state !== 'uploaded' || matches[0].size !== expected.size) {
+      throw new Error(`Release artifact is not fully uploaded: ${expected.name}`);
+    }
+  }
+  github(['release', 'edit', tag, '--draft=false', '--verify-tag']);
+}

--- a/packages/desktop/scripts/release-version.ts
+++ b/packages/desktop/scripts/release-version.ts
@@ -80,6 +80,17 @@ export function versionFromDmgPath(path: string): string | null {
   return SEMVER.test(match[1]) ? match[1] : null;
 }
 
+/** Include architecture for electron-updater and versions for blockmap lookup. */
+export function updateZipFileName(version: string): string {
+  return `mlx-node-${assertSemver('version', version)}-darwin-arm64.zip`;
+}
+
+export function versionFromUpdateZipPath(path: string): string | null {
+  const base = path.split('/').pop() ?? path;
+  const match = /^mlx-node-(.+)-darwin-arm64\.zip$/.exec(base);
+  return match !== null && SEMVER.test(match[1]) ? match[1] : null;
+}
+
 export interface ReleaseVersions {
   /** From the release tag. `null` on `workflow_dispatch`, where there is no tag. */
   tag: string | null;
@@ -91,13 +102,15 @@ export interface ReleaseVersions {
   bundleVersion: string;
   /** Parsed out of the DMG filename. `null` before the DMG exists. */
   dmg: string | null;
+  /** Parsed out of the Squirrel.Mac update archive filename. */
+  zip: string | null;
 }
 
 /**
- * Fail unless the tag, the manifest, the bundle's own metadata and the DMG name
+ * Fail unless the tag, manifest, bundle metadata, and DMG/update ZIP names
  * are all the same version. Returns that version.
  *
- * The tag wins when present because it is the only one of the four that reliably
+ * The tag wins when present because it is the only one that reliably
  * advances; the manifest is still required to match rather than being silently
  * overridden, since an artifact that disagrees with the repo it was built from is
  * a provenance bug even when the artifact is the correct one.
@@ -128,6 +141,7 @@ export function assertVersionsAgree(versions: ReleaseVersions): string {
       remedy: 'the packaged bundle was not stamped — check `package --app-version`',
     },
     { label: 'DMG filename', value: versions.dmg, remedy: 'the DMG was named from a different version than it holds' },
+    { label: 'ZIP filename', value: versions.zip, remedy: 'the update ZIP must match the version of the app it holds' },
   ];
 
   for (const check of checks) {

--- a/packages/desktop/scripts/stage-app.ts
+++ b/packages/desktop/scripts/stage-app.ts
@@ -390,6 +390,8 @@ export function stageApp(opts: {
   desktopDir: string;
   stageDir: string;
   roots: string[];
+  /** Set only by the packaging command when it will Developer ID sign the app. */
+  autoUpdates?: boolean;
 }): StageResult {
   const { repoRoot, desktopDir, stageDir } = opts;
   rmSync(stageDir, { recursive: true, force: true });
@@ -413,6 +415,7 @@ export function stageApp(opts: {
         private: true,
         type: 'module',
         main: 'dist/main/index.js',
+        autoUpdates: opts.autoUpdates === true,
       },
       null,
       2,

--- a/packages/desktop/scripts/update-artifacts.ts
+++ b/packages/desktop/scripts/update-artifacts.ts
@@ -1,0 +1,67 @@
+import { writeFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+
+import { buildBlockMap } from 'app-builder-lib/out/targets/blockmap/blockmap.js';
+
+import { assertSemver, versionFromUpdateZipPath } from './release-version.js';
+
+export const UPDATE_MANIFEST_NAME = 'latest-mac.yml';
+
+/** This file is part of the signed bundle, including its stable cache identity. */
+export function writeUpdaterConfig(resources: string): void {
+  writeFileSync(
+    join(resources, 'app-update.yml'),
+    'provider: github\nowner: mlx-node\nrepo: mlx-node\nupdaterCacheDirName: ai.mlxnode.desktop-updater\n',
+  );
+}
+
+export function assertStagingPercentage(value: number): number {
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new Error('Update staging percentage must be an integer from 0 to 100');
+  }
+  return value;
+}
+
+/** Run on the final ZIP, after notarization/stapling and before publication. */
+export async function createUpdateArtifacts(options: {
+  zipPath: string;
+  version: string;
+  minimumSystemVersion: string;
+  stagingPercentage?: number;
+  releaseDate?: Date;
+}): Promise<{ manifestPath: string; blockmapPath: string }> {
+  const version = assertSemver('update version', options.version);
+  if (versionFromUpdateZipPath(options.zipPath) !== version) {
+    throw new Error('Update ZIP filename must match the bundled app version');
+  }
+  if (!/^\d+(?:\.\d+){0,2}$/.test(options.minimumSystemVersion)) {
+    throw new Error('The update must declare a valid minimum macOS version');
+  }
+  const stagingPercentage = assertStagingPercentage(options.stagingPercentage ?? 100);
+  const releaseDate = (options.releaseDate ?? new Date()).toISOString();
+  const blockmapPath = `${options.zipPath}.blockmap`;
+  // Use the upstream generator in sidecar mode: never append bytes to our ZIP.
+  // It streams the archive and returns its size and SHA-512 alongside the map.
+  const { size, sha512 } = await buildBlockMap(options.zipPath, 'gzip', blockmapPath);
+  if (size === 0) throw new Error('Cannot publish an empty update ZIP');
+  const file = JSON.stringify(basename(options.zipPath));
+  const manifestPath = join(dirname(options.zipPath), UPDATE_MANIFEST_NAME);
+  await writeFile(
+    manifestPath,
+    [
+      `version: ${JSON.stringify(version)}`,
+      'files:',
+      `  - url: ${file}`,
+      `    sha512: ${JSON.stringify(sha512)}`,
+      `    size: ${size}`,
+      `path: ${file}`,
+      `sha512: ${JSON.stringify(sha512)}`,
+      `releaseDate: ${JSON.stringify(releaseDate)}`,
+      `minimumSystemVersion: ${JSON.stringify(options.minimumSystemVersion)}`,
+      `stagingPercentage: ${stagingPercentage}`,
+      '',
+    ].join('\n'),
+  );
+  return { manifestPath, blockmapPath };
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -16,8 +16,12 @@
  * debounced.
  */
 
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import { engineEnvFor, LAUNCHER_ENGINE_POLICY } from '@mlx-node/server/host/env-policy';
 import { app, clipboard, Menu, screen, type MenuItemConstructorOptions, type WebContents } from 'electron';
+import electronUpdater from 'electron-updater';
 
 import { DESKTOP_QUIT_DEADLINE_MS } from '../control-panel/shutdown-timings.js';
 import { createControlPanelBroker, type ControlPanelBroker } from './broker.js';
@@ -26,6 +30,7 @@ import { electronBrokerDeps } from './control-panel-child.js';
 import { createLaunchVisibility } from './launch-visibility.js';
 import { resolveAppPaths, type AppPaths } from './paths.js';
 import { installAppProtocol, registerAppScheme } from './protocol.js';
+import { createQuitHandler } from './quit.js';
 import {
   DEFAULT_SETTINGS,
   loadSettings,
@@ -38,6 +43,7 @@ import { utilityChildTransport } from './supervisor/child-utility.js';
 import { createSupervisor, type Supervisor } from './supervisor/index.js';
 import { claudeConnectCommand, codexConnectCommand } from './tray-view.js';
 import { createTray, type TrayController } from './tray.js';
+import { canAutoUpdate, createDesktopUpdater, presentUpdate, type DesktopUpdater } from './updates.js';
 import { createControlPanelWindowManager, type ControlPanelWindowManager } from './window.js';
 
 /** Coalescing window for settings writes. Long enough that a drag is one write. */
@@ -54,6 +60,7 @@ let supervisor: Supervisor | null = null;
 let tray: TrayController | null = null;
 let controlPanel: ControlPanelWindowManager | null = null;
 let broker: ControlPanelBroker<WebContents> | null = null;
+let updates: DesktopUpdater | null = null;
 const launchVisibility = createLaunchVisibility();
 
 /**
@@ -63,7 +70,6 @@ const launchVisibility = createLaunchVisibility();
  * force-quit from.
  */
 let quitting = false;
-let shuttingDown = false;
 
 /**
  * MUST run before `app.whenReady()`. Chromium reads the privileged-scheme table
@@ -129,25 +135,24 @@ function wire(): void {
     launchVisibility.activate();
   });
 
-  app.on('before-quit', (event) => {
-    // The second pass, after `shutdown()` calls `app.quit()` again. Letting it
-    // through is what actually exits.
-    if (shuttingDown) return;
-    shuttingDown = true;
-    launchVisibility.beginShutdown();
-    // Set BEFORE any window is asked to close, so the Control Panel window's close
-    // handler knows this one is real.
-    quitting = true;
-    event.preventDefault();
-    void withDeadline(shutdown(), DESKTOP_QUIT_DEADLINE_MS)
-      .catch((error: unknown) => {
-        console.error('[mlx] shutdown failed:', error);
-      })
-      .finally(() => {
-        if (launchVisibility.takeRelaunchRequest()) app.relaunch();
-        app.quit();
-      });
-  });
+  app.on(
+    'before-quit',
+    createQuitHandler({
+      beginShutdown: () => {
+        // Set before closing windows so their close handler allows a real exit.
+        quitting = true;
+        updates?.stop();
+        launchVisibility.beginShutdown();
+      },
+      shutdown,
+      deadlineMs: DESKTOP_QUIT_DEADLINE_MS,
+      installUpdate: (relaunchRequested) => updates?.installOnQuit(relaunchRequested) ?? false,
+      shouldRelaunch: () => launchVisibility.takeRelaunchRequest(),
+      relaunch: () => app.relaunch(),
+      quit: () => app.quit(),
+      report: (error) => console.error('[mlx] shutdown:', error),
+    }),
+  );
 }
 
 async function bootstrap(): Promise<void> {
@@ -169,13 +174,28 @@ async function bootstrap(): Promise<void> {
   // a real application menu instead of Electron's default.
   Menu.setApplicationMenu(
     Menu.buildFromTemplate([
-      { role: 'appMenu' },
+      {
+        label: app.name,
+        submenu: [
+          { role: 'about' },
+          { id: 'app-update', ...presentUpdate('disabled'), click: updateApp },
+          { type: 'separator' },
+          { role: 'services' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
+      },
       { role: 'editMenu' },
       { role: 'windowMenu' },
     ] as MenuItemConstructorOptions[]),
   );
 
   const loaded = await loadSettings(paths.settingsFile);
+  if (quitting) return;
   settings = loaded.settings;
   if (loaded.problem !== null) {
     console.warn(
@@ -188,6 +208,35 @@ async function bootstrap(): Promise<void> {
   }
 
   applyDockPolicy(settings.showInDock);
+
+  // Packaging stamps this flag before signing. app.isPackaged alone also
+  // accepts local unsigned bundles, which Squirrel cannot safely update.
+  let autoUpdates = false;
+  if (app.isPackaged) {
+    try {
+      const manifest = JSON.parse(await readFile(join(app.getAppPath(), 'package.json'), 'utf-8')) as {
+        autoUpdates?: unknown;
+      };
+      autoUpdates = manifest.autoUpdates === true;
+    } catch (error) {
+      console.error('[mlx] could not read update configuration:', error);
+    }
+  }
+  if (quitting) return;
+  updates = createDesktopUpdater({
+    enabled: canAutoUpdate({
+      packaged: app.isPackaged,
+      enabled: autoUpdates,
+      platform: process.platform,
+      arch: process.arch,
+      version: app.getVersion(),
+    }),
+    native: new electronUpdater.MacUpdater(),
+    systemVersion: process.getSystemVersion(),
+    onChange: refreshUpdates,
+    requestQuit: () => app.quit(),
+    report: (error) => console.error('[mlx] update:', error),
+  });
 
   supervisor = createSupervisor({
     entry: paths.sidecarEntry,
@@ -285,6 +334,7 @@ async function bootstrap(): Promise<void> {
   tray = createTray({
     iconPath: paths.trayIcon,
     showInDock: () => settings.showInDock,
+    appUpdate: () => presentUpdate(updates?.status() ?? 'disabled', updates?.progress()),
     actions: {
       openControlPanel: () => controlPanel?.show(),
       startInference: () => {
@@ -307,9 +357,11 @@ async function bootstrap(): Promise<void> {
       quit: () => {
         app.quit();
       },
+      updateApp,
     },
   });
   refreshTray();
+  updates.start();
 
   if (settings.autoStartInference) {
     void supervisor.start().catch(reportInferenceFailure);
@@ -325,6 +377,22 @@ async function bootstrap(): Promise<void> {
 function refreshTray(): void {
   if (supervisor === null) return;
   tray?.update(supervisor.snapshot());
+}
+
+function updateApp(): void {
+  if (quitting) return;
+  if (updates?.status() === 'ready') updates.restartAndInstall();
+  else updates?.check();
+}
+
+function refreshUpdates(): void {
+  const item = Menu.getApplicationMenu()?.getMenuItemById('app-update');
+  if (item !== null && item !== undefined) {
+    const presentation = presentUpdate(updates?.status() ?? 'disabled', updates?.progress());
+    item.label = presentation.label;
+    item.enabled = presentation.enabled;
+  }
+  refreshTray();
 }
 
 /**
@@ -402,20 +470,4 @@ async function shutdown(): Promise<void> {
   // its temp root. Serialising them would spend two kill-grace periods against
   // one whole-app quit deadline.
   await Promise.all([broker?.dispose(), supervisor?.dispose()]);
-}
-
-async function withDeadline(work: Promise<void>, ms: number): Promise<void> {
-  let timer: NodeJS.Timeout | undefined;
-  const capped = new Promise<void>((resolve) => {
-    timer = setTimeout(() => {
-      console.error(`[mlx] shutdown did not finish within ${ms}ms; exiting anyway`);
-      resolve();
-    }, ms);
-    timer.unref();
-  });
-  try {
-    await Promise.race([work, capped]);
-  } finally {
-    if (timer !== undefined) clearTimeout(timer);
-  }
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -146,7 +146,7 @@ function wire(): void {
       },
       shutdown,
       deadlineMs: DESKTOP_QUIT_DEADLINE_MS,
-      installUpdate: (relaunchRequested, allowQuit) => updates?.installOnQuit(relaunchRequested, allowQuit) ?? false,
+      installUpdate: (completeQuit) => updates?.installOnQuit(completeQuit) ?? false,
       shouldRelaunch: () => launchVisibility.takeRelaunchRequest(),
       relaunch: () => app.relaunch(),
       quit: () => app.quit(),

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -20,7 +20,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { engineEnvFor, LAUNCHER_ENGINE_POLICY } from '@mlx-node/server/host/env-policy';
-import { app, clipboard, Menu, screen, type MenuItemConstructorOptions, type WebContents } from 'electron';
+import { app, autoUpdater, clipboard, Menu, screen, type MenuItemConstructorOptions, type WebContents } from 'electron';
 import electronUpdater from 'electron-updater';
 
 import { DESKTOP_QUIT_DEADLINE_MS } from '../control-panel/shutdown-timings.js';
@@ -146,7 +146,7 @@ function wire(): void {
       },
       shutdown,
       deadlineMs: DESKTOP_QUIT_DEADLINE_MS,
-      installUpdate: (relaunchRequested) => updates?.installOnQuit(relaunchRequested) ?? false,
+      installUpdate: (relaunchRequested, allowQuit) => updates?.installOnQuit(relaunchRequested, allowQuit) ?? false,
       shouldRelaunch: () => launchVisibility.takeRelaunchRequest(),
       relaunch: () => app.relaunch(),
       quit: () => app.quit(),
@@ -232,6 +232,7 @@ async function bootstrap(): Promise<void> {
       version: app.getVersion(),
     }),
     native: new electronUpdater.MacUpdater(),
+    squirrel: autoUpdater,
     systemVersion: process.getSystemVersion(),
     onChange: refreshUpdates,
     requestQuit: () => app.quit(),

--- a/packages/desktop/src/main/quit.ts
+++ b/packages/desktop/src/main/quit.ts
@@ -1,9 +1,12 @@
+/** Finish quitting, optionally letting the updater own installation and relaunch. */
+export type CompleteQuit = (install?: (relaunchRequested: boolean) => void) => void;
+
 /** Drain app resources before either a normal exit or Squirrel's install/relaunch. */
 export function createQuitHandler(options: {
   beginShutdown(): void;
   shutdown(): Promise<void>;
   deadlineMs: number;
-  installUpdate(relaunchRequested: boolean, allowQuit: () => void): boolean;
+  installUpdate(completeQuit: CompleteQuit): boolean;
   shouldRelaunch(): boolean;
   relaunch(): void;
   quit(): void;
@@ -11,6 +14,20 @@ export function createQuitHandler(options: {
 }): (event: { preventDefault(): void }) => void {
   let started = false;
   let completed = false;
+  let relaunchRequested = false;
+
+  const completeQuit: CompleteQuit = (install) => {
+    // This runs after native staging, not just after the child/settings drain.
+    // Retain consumed intent if installation later fails and falls back to quit.
+    relaunchRequested = options.shouldRelaunch() || relaunchRequested;
+    completed = true;
+    if (install) {
+      install(relaunchRequested);
+    } else {
+      if (relaunchRequested) options.relaunch();
+      options.quit();
+    }
+  };
 
   async function finish(): Promise<void> {
     let timer: NodeJS.Timeout | undefined;
@@ -29,14 +46,8 @@ export function createQuitHandler(options: {
       options.report(error);
     } finally {
       if (timer !== undefined) clearTimeout(timer);
-      // Squirrel owns the relaunch after installation. A separate app.relaunch()
-      // races the old executable against replacement of its bundle.
-      const relaunchRequested = options.shouldRelaunch();
-      if (!options.installUpdate(relaunchRequested, () => (completed = true))) {
-        completed = true;
-        if (relaunchRequested) options.relaunch();
-        options.quit();
-      }
+      // Keep the completion decision live while the updater finishes staging.
+      if (!options.installUpdate(completeQuit)) completeQuit();
     }
   }
 

--- a/packages/desktop/src/main/quit.ts
+++ b/packages/desktop/src/main/quit.ts
@@ -1,0 +1,53 @@
+/** Drain app resources before either a normal exit or Squirrel's install/relaunch. */
+export function createQuitHandler(options: {
+  beginShutdown(): void;
+  shutdown(): Promise<void>;
+  deadlineMs: number;
+  installUpdate(relaunchRequested: boolean): boolean;
+  shouldRelaunch(): boolean;
+  relaunch(): void;
+  quit(): void;
+  report(error: unknown): void;
+}): (event: { preventDefault(): void }) => void {
+  let started = false;
+  let completed = false;
+
+  async function finish(): Promise<void> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        options.shutdown(),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(() => {
+            options.report(new Error(`shutdown did not finish within ${options.deadlineMs}ms; exiting anyway`));
+            resolve();
+          }, options.deadlineMs);
+          timer.unref();
+        }),
+      ]);
+    } catch (error) {
+      options.report(error);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+      completed = true;
+      // Squirrel owns the relaunch after installation. A separate app.relaunch()
+      // races the old executable against replacement of its bundle.
+      const relaunchRequested = options.shouldRelaunch();
+      if (!options.installUpdate(relaunchRequested)) {
+        if (relaunchRequested) options.relaunch();
+        options.quit();
+      }
+    }
+  }
+
+  return (event): void => {
+    // Repeated Cmd+Q / tray quit requests must not bypass an in-flight drain.
+    // Only the final quit initiated below (or by Squirrel) can proceed.
+    if (completed) return;
+    event.preventDefault();
+    if (started) return;
+    started = true;
+    options.beginShutdown();
+    void finish();
+  };
+}

--- a/packages/desktop/src/main/quit.ts
+++ b/packages/desktop/src/main/quit.ts
@@ -3,7 +3,7 @@ export function createQuitHandler(options: {
   beginShutdown(): void;
   shutdown(): Promise<void>;
   deadlineMs: number;
-  installUpdate(relaunchRequested: boolean): boolean;
+  installUpdate(relaunchRequested: boolean, allowQuit: () => void): boolean;
   shouldRelaunch(): boolean;
   relaunch(): void;
   quit(): void;
@@ -29,11 +29,11 @@ export function createQuitHandler(options: {
       options.report(error);
     } finally {
       if (timer !== undefined) clearTimeout(timer);
-      completed = true;
       // Squirrel owns the relaunch after installation. A separate app.relaunch()
       // races the old executable against replacement of its bundle.
       const relaunchRequested = options.shouldRelaunch();
-      if (!options.installUpdate(relaunchRequested)) {
+      if (!options.installUpdate(relaunchRequested, () => (completed = true))) {
+        completed = true;
         if (relaunchRequested) options.relaunch();
         options.quit();
       }
@@ -41,8 +41,8 @@ export function createQuitHandler(options: {
   }
 
   return (event): void => {
-    // Repeated Cmd+Q / tray quit requests must not bypass an in-flight drain.
-    // Only the final quit initiated below (or by Squirrel) can proceed.
+    // Repeated Cmd+Q / tray quit requests must not bypass either the resource
+    // drain or native staging. The updater releases this gate before final quit.
     if (completed) return;
     event.preventDefault();
     if (started) return;

--- a/packages/desktop/src/main/tray.ts
+++ b/packages/desktop/src/main/tray.ts
@@ -12,6 +12,7 @@ import { Menu, nativeImage, Tray, type MenuItemConstructorOptions } from 'electr
 
 import type { SupervisorSnapshot } from './supervisor/types.js';
 import { presentTray, type TrayPresentation } from './tray-view.js';
+import type { UpdatePresentation } from './updates.js';
 
 export interface TrayActions {
   openControlPanel(): void;
@@ -23,6 +24,7 @@ export interface TrayActions {
   /** Put a ready-to-paste Codex command carrying the URL and token on the clipboard. */
   copyCodexConnectCommand(): void;
   setShowInDock(next: boolean): void;
+  updateApp(): void;
   quit(): void;
 }
 
@@ -37,6 +39,7 @@ export interface TrayOptions {
    */
   iconPath: string;
   showInDock(): boolean;
+  appUpdate(): UpdatePresentation;
   actions: TrayActions;
 }
 
@@ -131,6 +134,12 @@ export function createTray(options: TrayOptions): TrayController {
         },
       },
       { type: 'separator' },
+      {
+        ...options.appUpdate(),
+        click: () => {
+          options.actions.updateApp();
+        },
+      },
       // The accelerator is display-only on a tray menu, which is why an
       // application menu with the standard roles is also installed — see
       // `index.ts`.
@@ -153,7 +162,7 @@ export function createTray(options: TrayOptions): TrayController {
       // The supervisor emits a state event for every health poll and every
       // trace line. Rebuilding the menu closes it if it happens to be open, so
       // an unchanged presentation is not re-rendered.
-      const key = `${JSON.stringify(presentation)}|${String(options.showInDock())}`;
+      const key = `${JSON.stringify(presentation)}|${String(options.showInDock())}|${JSON.stringify(options.appUpdate())}`;
       if (key === rendered) return;
       rendered = key;
       render(presentation);

--- a/packages/desktop/src/main/updates.ts
+++ b/packages/desktop/src/main/updates.ts
@@ -79,7 +79,7 @@ export interface DesktopUpdater {
   /** Stop checks and UI notifications as soon as graceful shutdown starts. */
   stop(): void;
   /** Called only AFTER settings and child processes have finished shutting down. */
-  installOnQuit(relaunchRequested?: boolean): boolean;
+  installOnQuit(relaunchRequested: boolean, allowQuit: () => void): boolean;
 }
 
 interface UpdateClient extends Pick<
@@ -105,6 +105,8 @@ export function createDesktopUpdater(options: {
   enabled: boolean;
   systemVersion: string;
   native: UpdateClient;
+  /** Electron's native staging event is later than MacUpdater's download event. */
+  squirrel: { on(event: 'update-downloaded', listener: () => void): unknown };
   onChange(): void;
   requestQuit(): void;
   report(error: unknown): void;
@@ -117,6 +119,10 @@ export function createDesktopUpdater(options: {
   let lastError: unknown;
   let installRequested = false;
   let installStarted = false;
+  let installInvoked = false;
+  let installFailed = false;
+  let squirrelReady = false;
+  let allowQuit: (() => void) | undefined;
   let timer: NodeJS.Timeout | null = null;
 
   function change(next: UpdateStatus): void {
@@ -134,10 +140,26 @@ export function createDesktopUpdater(options: {
     // If Squirrel fails after our shutdown, finish quitting. Leaving the app
     // alive here would leave an invisible process with no tray or children.
     if (installStarted) {
+      if (installFailed) return;
+      installFailed = true;
+      allowQuit?.();
       options.requestQuit();
       return;
     }
     change('error');
+  }
+
+  function finishInstall(): void {
+    if (!installStarted || installInvoked || installFailed || !squirrelReady) return;
+    // Only release the quit handler once the native payload is ready. Allowing
+    // user quits while MacUpdater waits would abort Squirrel's local transfer.
+    allowQuit?.();
+    installInvoked = true;
+    try {
+      options.native.quitAndInstall();
+    } catch (error) {
+      failed(error);
+    }
   }
 
   if (options.enabled) {
@@ -149,6 +171,10 @@ export function createDesktopUpdater(options: {
     options.native.allowDowngrade = false;
     options.native.isUpdateSupported = (info) =>
       STABLE_VERSION.test(info.version) && isMacUpdateSupported(options.systemVersion, info.minimumSystemVersion);
+    options.squirrel.on('update-downloaded', () => {
+      squirrelReady = true;
+      finishInstall();
+    });
     // Keep the error listener through shutdown: an in-flight native download
     // can still fail after stop(), and an unhandled 'error' terminates MAIN.
     options.native.on('error', failed);
@@ -177,6 +203,7 @@ export function createDesktopUpdater(options: {
     change('checking');
     percent = null;
     lastError = undefined;
+    squirrelReady = false;
     inFlight = true;
     void (async () => {
       try {
@@ -216,20 +243,17 @@ export function createDesktopUpdater(options: {
       if (timer !== null) clearInterval(timer);
       timer = null;
     },
-    installOnQuit(relaunchRequested = false): boolean {
-      if (!installRequested && status !== 'ready') return false;
+    installOnQuit(relaunchRequested, releaseQuit): boolean {
+      // Staging may fail while the children are draining. In that case finish
+      // a normal quit instead of waiting for a native event that will not arrive.
+      if (status !== 'ready' && !(installRequested && status === 'installing')) return false;
       if (!installStarted) {
         installStarted = true;
-        try {
-          // Wait for Squirrel to finish staging even on an ordinary quit. Only
-          // an explicit restart (including Finder activation) should reopen us.
-          // MacUpdater honors this flag: false calls app.quit(), while true
-          // calls Electron's native quitAndInstall() to request a relaunch.
-          options.native.autoRunAppAfterInstall = installRequested || relaunchRequested;
-          options.native.quitAndInstall();
-        } catch (error) {
-          failed(error);
-        }
+        allowQuit = releaseQuit;
+        // MacUpdater honors this flag: false calls app.quit(), while true
+        // calls Electron's native quitAndInstall() to request a relaunch.
+        options.native.autoRunAppAfterInstall = installRequested || relaunchRequested;
+        finishInstall();
       }
       return true;
     },

--- a/packages/desktop/src/main/updates.ts
+++ b/packages/desktop/src/main/updates.ts
@@ -1,5 +1,7 @@
 import type { AppUpdater } from 'electron-updater';
 
+import type { CompleteQuit } from './quit.js';
+
 export const UPDATE_INTERVAL_MS = 6 * 60 * 60 * 1_000;
 const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
@@ -79,7 +81,7 @@ export interface DesktopUpdater {
   /** Stop checks and UI notifications as soon as graceful shutdown starts. */
   stop(): void;
   /** Called only AFTER settings and child processes have finished shutting down. */
-  installOnQuit(relaunchRequested: boolean, allowQuit: () => void): boolean;
+  installOnQuit(completeQuit: CompleteQuit): boolean;
 }
 
 interface UpdateClient extends Pick<
@@ -122,7 +124,7 @@ export function createDesktopUpdater(options: {
   let installInvoked = false;
   let installFailed = false;
   let squirrelReady = false;
-  let allowQuit: (() => void) | undefined;
+  let completeQuit: CompleteQuit | undefined;
   let timer: NodeJS.Timeout | null = null;
 
   function change(next: UpdateStatus): void {
@@ -142,8 +144,7 @@ export function createDesktopUpdater(options: {
     if (installStarted) {
       if (installFailed) return;
       installFailed = true;
-      allowQuit?.();
-      options.requestQuit();
+      completeQuit?.();
       return;
     }
     change('error');
@@ -153,13 +154,17 @@ export function createDesktopUpdater(options: {
     if (!installStarted || installInvoked || installFailed || !squirrelReady) return;
     // Only release the quit handler once the native payload is ready. Allowing
     // user quits while MacUpdater waits would abort Squirrel's local transfer.
-    allowQuit?.();
     installInvoked = true;
-    try {
-      options.native.quitAndInstall();
-    } catch (error) {
-      failed(error);
-    }
+    completeQuit?.((relaunchRequested) => {
+      // Read Finder/Dock intent at the last moment, after native staging.
+      // MacUpdater uses app.quit() for false and Squirrel's relaunch for true.
+      options.native.autoRunAppAfterInstall = installRequested || relaunchRequested;
+      try {
+        options.native.quitAndInstall();
+      } catch (error) {
+        failed(error);
+      }
+    });
   }
 
   if (options.enabled) {
@@ -243,16 +248,13 @@ export function createDesktopUpdater(options: {
       if (timer !== null) clearInterval(timer);
       timer = null;
     },
-    installOnQuit(relaunchRequested, releaseQuit): boolean {
+    installOnQuit(finishQuit): boolean {
       // Staging may fail while the children are draining. In that case finish
       // a normal quit instead of waiting for a native event that will not arrive.
       if (status !== 'ready' && !(installRequested && status === 'installing')) return false;
       if (!installStarted) {
         installStarted = true;
-        allowQuit = releaseQuit;
-        // MacUpdater honors this flag: false calls app.quit(), while true
-        // calls Electron's native quitAndInstall() to request a relaunch.
-        options.native.autoRunAppAfterInstall = installRequested || relaunchRequested;
+        completeQuit = finishQuit;
         finishInstall();
       }
       return true;

--- a/packages/desktop/src/main/updates.ts
+++ b/packages/desktop/src/main/updates.ts
@@ -223,6 +223,8 @@ export function createDesktopUpdater(options: {
         try {
           // Wait for Squirrel to finish staging even on an ordinary quit. Only
           // an explicit restart (including Finder activation) should reopen us.
+          // MacUpdater honors this flag: false calls app.quit(), while true
+          // calls Electron's native quitAndInstall() to request a relaunch.
           options.native.autoRunAppAfterInstall = installRequested || relaunchRequested;
           options.native.quitAndInstall();
         } catch (error) {

--- a/packages/desktop/src/main/updates.ts
+++ b/packages/desktop/src/main/updates.ts
@@ -1,0 +1,235 @@
+import type { AppUpdater } from 'electron-updater';
+
+export const UPDATE_INTERVAL_MS = 6 * 60 * 60 * 1_000;
+const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export type UpdateStatus =
+  | 'disabled'
+  | 'idle'
+  | 'checking'
+  | 'downloading'
+  | 'current'
+  | 'ready'
+  | 'installing'
+  | 'error';
+
+export interface UpdatePresentation {
+  label: string;
+  enabled: boolean;
+}
+
+export function presentUpdate(status: UpdateStatus, percent: number | null = null): UpdatePresentation {
+  switch (status) {
+    case 'disabled':
+      return { label: 'Updates Unavailable in This Build', enabled: false };
+    case 'idle':
+      return { label: 'Check for Updates…', enabled: true };
+    case 'checking':
+      return { label: 'Checking for Updates…', enabled: false };
+    case 'downloading':
+      return { label: percent === null ? 'Downloading Update…' : `Downloading Update… ${percent}%`, enabled: false };
+    case 'current':
+      return { label: 'Up to Date — Check Again…', enabled: true };
+    case 'ready':
+      return { label: 'Restart to Update…', enabled: true };
+    case 'installing':
+      return { label: 'Restarting to Update…', enabled: false };
+    case 'error':
+      return { label: 'Update Failed — Try Again…', enabled: true };
+  }
+}
+
+/** Only signed, packaged stable builds participate in the public release feed. */
+export function canAutoUpdate(options: {
+  packaged: boolean;
+  enabled: boolean;
+  platform: string;
+  arch: string;
+  version: string;
+}): boolean {
+  return (
+    options.packaged &&
+    options.enabled &&
+    options.platform === 'darwin' &&
+    options.arch === 'arm64' &&
+    STABLE_VERSION.test(options.version)
+  );
+}
+
+/** The library defaults to Darwin kernel versions; our manifest uses macOS versions. */
+export function isMacUpdateSupported(systemVersion: string, minimumSystemVersion: string | undefined): boolean {
+  const valid = /^\d+(?:\.\d+){0,2}$/;
+  if (minimumSystemVersion === undefined || !valid.test(minimumSystemVersion) || !valid.test(systemVersion))
+    return false;
+  const current = systemVersion.split('.').map(Number);
+  const minimum = minimumSystemVersion.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const difference = (current[i] ?? 0) - (minimum[i] ?? 0);
+    if (difference !== 0) return difference > 0;
+  }
+  return true;
+}
+
+export interface DesktopUpdater {
+  status(): UpdateStatus;
+  progress(): number | null;
+  start(): void;
+  check(): void;
+  restartAndInstall(): void;
+  /** Stop checks and UI notifications as soon as graceful shutdown starts. */
+  stop(): void;
+  /** Called only AFTER settings and child processes have finished shutting down. */
+  installOnQuit(relaunchRequested?: boolean): boolean;
+}
+
+interface UpdateClient extends Pick<
+  AppUpdater,
+  | 'quitAndInstall'
+  | 'autoDownload'
+  | 'autoInstallOnAppQuit'
+  | 'autoRunAppAfterInstall'
+  | 'allowDowngrade'
+  | 'allowPrerelease'
+  | 'isUpdateSupported'
+> {
+  checkForUpdates(): Promise<{ downloadPromise?: Promise<unknown> | null } | null>;
+  on(event: 'error', listener: (error: Error) => void): unknown;
+  on(event: 'update-available', listener: () => void): unknown;
+  on(event: 'update-not-available', listener: () => void): unknown;
+  on(event: 'update-downloaded', listener: () => void): unknown;
+  on(event: 'download-progress', listener: (progress: { percent: number }) => void): unknown;
+}
+
+/** Electron is injected so download and shutdown races can be tested without a GUI. */
+export function createDesktopUpdater(options: {
+  enabled: boolean;
+  systemVersion: string;
+  native: UpdateClient;
+  onChange(): void;
+  requestQuit(): void;
+  report(error: unknown): void;
+}): DesktopUpdater {
+  let status: UpdateStatus = options.enabled ? 'idle' : 'disabled';
+  let percent: number | null = null;
+  let started = false;
+  let stopped = false;
+  let inFlight = false;
+  let lastError: unknown;
+  let installRequested = false;
+  let installStarted = false;
+  let timer: NodeJS.Timeout | null = null;
+
+  function change(next: UpdateStatus): void {
+    status = next;
+    // Remember a download that finishes during the drain: a queued Finder
+    // relaunch must still go through Squirrel, even after the tray is gone.
+    if (!stopped) options.onChange();
+  }
+
+  function failed(error: unknown): void {
+    // The library emits an error AND rejects its check/download promise.
+    if (error === lastError) return;
+    lastError = error;
+    options.report(error);
+    // If Squirrel fails after our shutdown, finish quitting. Leaving the app
+    // alive here would leave an invisible process with no tray or children.
+    if (installStarted) {
+      options.requestQuit();
+      return;
+    }
+    change('error');
+  }
+
+  if (options.enabled) {
+    // Provider/cache configuration comes from Resources/app-update.yml, staged
+    // before signing. Stable clients never opt into prereleases or downgrades.
+    options.native.autoDownload = true;
+    options.native.autoInstallOnAppQuit = true;
+    options.native.allowPrerelease = false;
+    options.native.allowDowngrade = false;
+    options.native.isUpdateSupported = (info) =>
+      STABLE_VERSION.test(info.version) && isMacUpdateSupported(options.systemVersion, info.minimumSystemVersion);
+    // Keep the error listener through shutdown: an in-flight native download
+    // can still fail after stop(), and an unhandled 'error' terminates MAIN.
+    options.native.on('error', failed);
+    options.native.on('update-available', () => {
+      if (status === 'checking') change('downloading');
+    });
+    options.native.on('update-not-available', () => {
+      if (status === 'checking') change('current');
+    });
+    options.native.on('update-downloaded', () => {
+      if (status === 'checking' || status === 'downloading') change('ready');
+    });
+    options.native.on('download-progress', (progress) => {
+      if (status !== 'downloading' || !Number.isFinite(progress.percent)) return;
+      const next = Math.max(0, Math.min(100, Math.floor(progress.percent)));
+      if (next === percent) return;
+      percent = next;
+      if (!stopped) options.onChange();
+    });
+  }
+
+  function check(): void {
+    if (stopped || !options.enabled || inFlight || !['idle', 'current', 'error'].includes(status)) return;
+    // Set this before calling Electron. Overlapping checks download the same
+    // archive twice, including when a manual check races the interval timer.
+    change('checking');
+    percent = null;
+    lastError = undefined;
+    inFlight = true;
+    void (async () => {
+      try {
+        const result = await options.native.checkForUpdates();
+        // Downloads have a separate promise. Observing only the check would
+        // leave network/disk failures as unhandled rejections in MAIN.
+        await result?.downloadPromise;
+      } catch (error) {
+        failed(error);
+      } finally {
+        inFlight = false;
+      }
+    })();
+  }
+
+  return {
+    status: () => status,
+    progress: () => percent,
+    start(): void {
+      if (started || stopped || !options.enabled) return;
+      started = true;
+      timer = setInterval(check, UPDATE_INTERVAL_MS);
+      timer.unref();
+      check();
+    },
+    check,
+    restartAndInstall(): void {
+      if (stopped || status !== 'ready') return;
+      installRequested = true;
+      change('installing');
+      // Go through app.quit() first. quitAndInstall() closes windows BEFORE
+      // before-quit, which otherwise hits our window's hide-on-close policy.
+      options.requestQuit();
+    },
+    stop(): void {
+      stopped = true;
+      if (timer !== null) clearInterval(timer);
+      timer = null;
+    },
+    installOnQuit(relaunchRequested = false): boolean {
+      if (!installRequested && status !== 'ready') return false;
+      if (!installStarted) {
+        installStarted = true;
+        try {
+          // Wait for Squirrel to finish staging even on an ordinary quit. Only
+          // an explicit restart (including Finder activation) should reopen us.
+          options.native.autoRunAppAfterInstall = installRequested || relaunchRequested;
+          options.native.quitAndInstall();
+        } catch (error) {
+          failed(error);
+        }
+      }
+      return true;
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,6 +647,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron/asar@npm:3.4.1, @electron/asar@npm:^3.3.1":
+  version: 3.4.1
+  resolution: "@electron/asar@npm:3.4.1"
+  dependencies:
+    commander: "npm:^5.0.0"
+    glob: "npm:^7.1.6"
+    minimatch: "npm:^3.0.4"
+  bin:
+    asar: bin/asar.js
+  checksum: 10c0/9df7983125faaa29c266e4beec6ceb205e139ede0e8fb81dde84c73ac8114388a99aad21379412a972163d8879ca959621f4e4896214bf8d296ba217e7cf8170
+  languageName: node
+  linkType: hard
+
 "@electron/asar@npm:^4.0.0, @electron/asar@npm:^4.0.1":
   version: 4.3.0
   resolution: "@electron/asar@npm:4.3.0"
@@ -659,6 +672,38 @@ __metadata:
   bin:
     asar: bin/asar.mjs
   checksum: 10c0/a1d682e60f9e0f6280bf85f4b4ff8b0bf03828f7f795703d4662a83938f11f48615795874af2bc83a8d94bac972c2915f0bfee1aeb24b34e41853017e57d7570
+  languageName: node
+  linkType: hard
+
+"@electron/fuses@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@electron/fuses@npm:1.8.0"
+  dependencies:
+    chalk: "npm:^4.1.1"
+    fs-extra: "npm:^9.0.1"
+    minimist: "npm:^1.2.5"
+  bin:
+    electron-fuses: dist/bin.js
+  checksum: 10c0/7a2eff2a700a0dc9997346a2cbef83a852ec4a743b047ef89ce8dddfb182377c3a71e340c0cd3dc729d843cccb524253f9a9b96f37271d431f4409f3d897a200
+  languageName: node
+  linkType: hard
+
+"@electron/get@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "@electron/get@npm:3.1.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    env-paths: "npm:^2.2.0"
+    fs-extra: "npm:^8.1.0"
+    global-agent: "npm:^3.0.0"
+    got: "npm:^11.8.5"
+    progress: "npm:^2.0.3"
+    semver: "npm:^6.2.0"
+    sumchecker: "npm:^3.0.1"
+  dependenciesMeta:
+    global-agent:
+      optional: true
+  checksum: 10c0/b56b18710482912681c0497a9a8d74f934e5fcefe527bb1f2be6ec837a3853ad7f4b8849584ce4578c3fdd341cb8364cee54f14d1103862891368bbc20b7c0df
   languageName: node
   linkType: hard
 
@@ -680,6 +725,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron/notarize@npm:2.5.0":
+  version: 2.5.0
+  resolution: "@electron/notarize@npm:2.5.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    fs-extra: "npm:^9.0.1"
+    promise-retry: "npm:^2.0.1"
+  checksum: 10c0/262c6a90db4b18c82abb2a8f5349d1bf19ac34a440fe6c01b8aee302b1c886a79906693e6c3fdba2a4efa23a6519abf2113a882b438f7b6687eb2daed3da2afa
+  languageName: node
+  linkType: hard
+
 "@electron/notarize@npm:3.1.1, @electron/notarize@npm:^3.1.0":
   version: 3.1.1
   resolution: "@electron/notarize@npm:3.1.1"
@@ -687,6 +743,23 @@ __metadata:
     debug: "npm:^4.4.0"
     promise-retry: "npm:^2.0.1"
   checksum: 10c0/1e9adc0cafc1c2e79c39a41c97de912d6a899d661de506301310e17c569dc2885c9729c21840ceb70871f2e648ab983d3731149c6dc4ea354a001ad463c83e7e
+  languageName: node
+  linkType: hard
+
+"@electron/osx-sign@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@electron/osx-sign@npm:1.3.3"
+  dependencies:
+    compare-version: "npm:^0.1.2"
+    debug: "npm:^4.3.4"
+    fs-extra: "npm:^10.0.0"
+    isbinaryfile: "npm:^4.0.8"
+    minimist: "npm:^1.2.6"
+    plist: "npm:^3.0.5"
+  bin:
+    electron-osx-flat: bin/electron-osx-flat.js
+    electron-osx-sign: bin/electron-osx-sign.js
+  checksum: 10c0/f8156be879b1850465da8135398b9e58aa6db9f3310cd625c471e1080008b628846c3345a171e17509bcd3c1883cbc90f49a914e7486b1f41702cf2499c657d0
   languageName: node
   linkType: hard
 
@@ -729,6 +802,40 @@ __metadata:
   bin:
     electron-packager: bin/electron-packager.mjs
   checksum: 10c0/3c97b7b1da3f6fbc27c7d31d44a40f7bd4e8a12fa5956e370acd3416fe356c895a3df8c10df1a234334931dfeb1a811f0d705215abddaf5e22f11f4b8049fcf1
+  languageName: node
+  linkType: hard
+
+"@electron/rebuild@npm:^4.0.4":
+  version: 4.2.0
+  resolution: "@electron/rebuild@npm:4.2.0"
+  dependencies:
+    "@malept/cross-spawn-promise": "npm:^2.0.0"
+    debug: "npm:^4.1.1"
+    node-abi: "npm:^4.2.0"
+    node-api-version: "npm:^0.2.1"
+    node-gyp: "npm:^12.2.0"
+    read-binary-file-arch: "npm:^1.0.6"
+  dependenciesMeta:
+    electron:
+      built: true
+  bin:
+    electron-rebuild: lib/cli.js
+  checksum: 10c0/6d5ed8a860b70d4760de299b4e07560cf95c81974788240aea28fdfe376ca4ec3f99bfa19d1a28cac40fa747142cc32368f1f28ad555670b59355e58d05724ae
+  languageName: node
+  linkType: hard
+
+"@electron/universal@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@electron/universal@npm:2.0.3"
+  dependencies:
+    "@electron/asar": "npm:^3.3.1"
+    "@malept/cross-spawn-promise": "npm:^2.0.0"
+    debug: "npm:^4.3.1"
+    dir-compare: "npm:^4.2.0"
+    fs-extra: "npm:^11.1.1"
+    minimatch: "npm:^9.0.3"
+    plist: "npm:^3.1.0"
+  checksum: 10c0/346b23298d4f175dc50d9b91277d8e4c30017215e1a78c985ce917cd793fc0600084d62a84f485229d781ddfeb5829b6c1125c0bda131ddb9146522d305e92aa
   languageName: node
   linkType: hard
 
@@ -1292,6 +1399,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@malept/flatpak-bundler@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@malept/flatpak-bundler@npm:0.4.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    fs-extra: "npm:^9.0.0"
+    lodash: "npm:^4.17.15"
+    tmp-promise: "npm:^3.0.2"
+  checksum: 10c0/b3c87f6482b1956411af1118c771afb39cd9a0568fbb5e86015547ff6d68d2e73a7f0d74b75a57f0a156391c347c8d0adc1037e75172b92da72b96e0a05a2f4f
+  languageName: node
+  linkType: hard
+
 "@mariozechner/clipboard-darwin-arm64@npm:0.3.9":
   version: 0.3.9
   resolution: "@mariozechner/clipboard-darwin-arm64@npm:0.3.9"
@@ -1512,7 +1631,9 @@ __metadata:
     "@mlx-node/server": "workspace:*"
     "@napi-rs/image": "npm:1.14.0"
     "@types/node": "catalog:"
+    app-builder-lib: "npm:26.15.3"
     electron: "npm:44.0.0"
+    electron-updater: "npm:6.8.9"
     vite-plus: "catalog:"
   languageName: unknown
   linkType: soft
@@ -2601,6 +2722,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@noble/hashes@npm:1.4.0"
+  checksum: 10c0/8c3f005ee72e7b8f9cff756dfae1241485187254e3f743873e22073d63906863df5d4f13d441b7530ea614b7a093f0d889309f28b59850f33b66cb26a779a4a5
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^2.2.0":
+  version: 2.4.0
+  resolution: "@noble/hashes@npm:2.4.0"
+  checksum: 10c0/f5820a38c52886073a69722a030688ad188bbacb822d01554545371259961c2b916266c57c013c2ce5a0d78aec977142fc68fd2a79be4c97b0644fcee9bb35f6
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -3640,6 +3775,48 @@ __metadata:
   version: 1.79.0
   resolution: "@oxlint/plugins@npm:1.79.0"
   checksum: 10c0/ecd7a7a5c1b4acf7a8671a3e08acf317a843c445030880726c13509669cabe8d689a90a89f2c8c1f3a800e3a603f446b2f90bd2bb34854feaf76ccdece21c558
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-schema@npm:^2.7.0":
+  version: 2.9.4
+  resolution: "@peculiar/asn1-schema@npm:2.9.4"
+  dependencies:
+    "@peculiar/utils": "npm:^2.0.2"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/f77f76b2117bf3b97238460d0b7e865e3954f8f24beefc07339e644b2f4fbbd85a624bc2231abc04bcdb572a0be42975c00c32bb51f2c2fdbf491d9373c4d0c4
+  languageName: node
+  linkType: hard
+
+"@peculiar/json-schema@npm:^1.1.12":
+  version: 1.1.12
+  resolution: "@peculiar/json-schema@npm:1.1.12"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  checksum: 10c0/202132c66dcc6b6aca5d0af971c015be2e163da2f7f992910783c5d39c8a7db59b6ec4f4ce419459a1f954b7e1d17b6b253f0e60072c1b3d254079f4eaebc311
+  languageName: node
+  linkType: hard
+
+"@peculiar/utils@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@peculiar/utils@npm:2.0.3"
+  dependencies:
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/e111a51c83334d6ff3c96b993ed0d718210620f3ad176853a4bf229f1cf4cd14e9388075318351b188862d34d2192d80f206f6bea53aa1459df3ec638cbcdbd5
+  languageName: node
+  linkType: hard
+
+"@peculiar/webcrypto@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "@peculiar/webcrypto@npm:1.7.1"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.7.0"
+    "@peculiar/json-schema": "npm:^1.1.12"
+    "@peculiar/utils": "npm:^2.0.2"
+    tslib: "npm:^2.8.1"
+    webcrypto-core: "npm:^1.9.2"
+  checksum: 10c0/26be0e62a27d72afae2410f2f0c511765c6c09cc9265272f5767ff7049dcc7f91f1fa45b2bcb84cadd270daeb74a9d95632135a6a91919aa3f4bcbf9ddc36f77
   languageName: node
   linkType: hard
 
@@ -4694,7 +4871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.0.0":
+"@types/debug@npm:^4.0.0, @types/debug@npm:^4.1.6":
   version: 4.1.13
   resolution: "@types/debug@npm:4.1.13"
   dependencies:
@@ -4730,6 +4907,15 @@ __metadata:
   version: 1.0.9
   resolution: "@types/estree@npm:1.0.9"
   checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
+  languageName: node
+  linkType: hard
+
+"@types/fs-extra@npm:9.0.13, @types/fs-extra@npm:^9.0.11":
+  version: 9.0.13
+  resolution: "@types/fs-extra@npm:9.0.13"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/576d4e9d382393316ed815c593f7f5c157408ec5e184521d077fcb15d514b5a985245f153ef52142b9b976cb9bd8f801850d51238153ebd0dc9e96b7a7548588
   languageName: node
   linkType: hard
 
@@ -5323,6 +5509,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmldom/xmldom@npm:^0.8.8":
+  version: 0.8.15
+  resolution: "@xmldom/xmldom@npm:0.8.15"
+  checksum: 10c0/59d09b85824b684fba5a0a224d5b43abea1a0d745e8d8b8136a7013e996eb6da122fdbb3deb32ed1621923a10e1937b1f7917cea43481d9d5b976e8c1ff836c1
+  languageName: node
+  linkType: hard
+
 "@xmldom/xmldom@npm:^0.9.10":
   version: 0.9.12
   resolution: "@xmldom/xmldom@npm:0.9.12"
@@ -5575,6 +5768,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abbrev@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "abbrev@npm:4.0.0"
+  checksum: 10c0/b4cc16935235e80702fc90192e349e32f8ef0ed151ef506aa78c81a7c455ec18375c4125414b99f84b2e055199d66383e787675f0bcd87da7a4dbd59f9eac1d5
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^5.0.0":
   version: 5.0.0
   resolution: "abbrev@npm:5.0.0"
@@ -5602,6 +5802,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv@npm:^8.18.0":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -5622,6 +5834,58 @@ __metadata:
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: 10c0/9c4ca80eb3c2fb7b33841c210d2f20807f40865d27008d7c3f707b7f95cab7d67462a565e2388ac3285b71cb3d9bb2173de8da37c57692a362885ec34d6e27df
+  languageName: node
+  linkType: hard
+
+"app-builder-lib@npm:26.15.3":
+  version: 26.15.3
+  resolution: "app-builder-lib@npm:26.15.3"
+  dependencies:
+    "@electron/asar": "npm:3.4.1"
+    "@electron/fuses": "npm:^1.8.0"
+    "@electron/get": "npm:^3.0.0"
+    "@electron/notarize": "npm:2.5.0"
+    "@electron/osx-sign": "npm:1.3.3"
+    "@electron/rebuild": "npm:^4.0.4"
+    "@electron/universal": "npm:2.0.3"
+    "@malept/flatpak-bundler": "npm:^0.4.0"
+    "@noble/hashes": "npm:^2.2.0"
+    "@peculiar/webcrypto": "npm:^1.7.1"
+    "@types/fs-extra": "npm:9.0.13"
+    ajv: "npm:^8.18.0"
+    asn1js: "npm:^3.0.10"
+    async-exit-hook: "npm:^2.0.1"
+    builder-util: "npm:26.15.3"
+    builder-util-runtime: "npm:9.7.0"
+    chromium-pickle-js: "npm:^0.2.0"
+    ci-info: "npm:4.3.1"
+    debug: "npm:^4.3.4"
+    dotenv: "npm:^16.4.5"
+    dotenv-expand: "npm:^11.0.6"
+    ejs: "npm:^3.1.8"
+    electron-publish: "npm:26.15.3"
+    fs-extra: "npm:^10.1.0"
+    hosted-git-info: "npm:^4.1.0"
+    isbinaryfile: "npm:^5.0.0"
+    jiti: "npm:^2.4.2"
+    js-yaml: "npm:^4.1.0"
+    json5: "npm:^2.2.3"
+    lazy-val: "npm:^1.0.5"
+    minimatch: "npm:^10.2.5"
+    pkijs: "npm:^3.4.0"
+    plist: "npm:3.1.0"
+    proper-lockfile: "npm:^4.1.2"
+    resedit: "npm:^1.7.0"
+    semver: "npm:~7.7.3"
+    tar: "npm:^7.5.7"
+    temp-file: "npm:^3.4.0"
+    tiny-async-pool: "npm:1.3.0"
+    unzipper: "npm:^0.12.3"
+    which: "npm:^5.0.0"
+  peerDependencies:
+    dmg-builder: 26.15.3
+    electron-builder-squirrel-windows: 26.15.3
+  checksum: 10c0/c3421f45df7eb69ecbd66ade2ced54fd60f452ab527c917f0613d5ce3c43172e2de677db9d3bdc4e6087d22732baf6357c3247624059a1b5a9c434243a81ff14
   languageName: node
   linkType: hard
 
@@ -5650,6 +5914,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asn1js@npm:^3.0.10, asn1js@npm:^3.0.6":
+  version: 3.0.10
+  resolution: "asn1js@npm:3.0.10"
+  dependencies:
+    pvtsutils: "npm:^1.3.6"
+    pvutils: "npm:^1.1.5"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/04056106522e4d0db4eb992299bb76d73438bfd59ffd975ac9c1f15d14e7326161dad383c54a5ccfa203b73ae7b7bf4668f42c2fed01e1f4bf79a58de71e4dc6
+  languageName: node
+  linkType: hard
+
 "assertion-error@npm:^2.0.1":
   version: 2.0.1
   resolution: "assertion-error@npm:2.0.1"
@@ -5657,10 +5932,66 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-exit-hook@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "async-exit-hook@npm:2.0.1"
+  checksum: 10c0/81407a440ef0aab328df2369f1a9d957ee53e9a5a43e3b3dcb2be05151a68de0e4ff5e927f4718c88abf85800731f5b3f69a47a6642ce135f5e7d43ca0fce41d
+  languageName: node
+  linkType: hard
+
+"async-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-function@npm:1.0.0"
+  checksum: 10c0/669a32c2cb7e45091330c680e92eaeb791bc1d4132d827591e499cd1f776ff5a873e77e5f92d0ce795a8d60f10761dec9ddfe7225a5de680f5d357f67b1aac73
+  languageName: node
+  linkType: hard
+
+"async-generator-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-generator-function@npm:1.0.0"
+  checksum: 10c0/2c50ef856c543ad500d8d8777d347e3c1ba623b93e99c9263ecc5f965c1b12d2a140e2ab6e43c3d0b85366110696f28114649411cbcd10b452a92a2318394186
+  languageName: node
+  linkType: hard
+
+"async@npm:^3.2.6":
+  version: 3.2.6
+  resolution: "async@npm:3.2.6"
+  checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
+  languageName: node
+  linkType: hard
+
+"asynckit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "asynckit@npm:0.4.0"
+  checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
+  languageName: node
+  linkType: hard
+
+"at-least-node@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "at-least-node@npm:1.0.0"
+  checksum: 10c0/4c058baf6df1bc5a1697cf182e2029c58cd99975288a13f9e70068ef5d6f4e1f1fd7c4d2c3c4912eae44797d1725be9700995736deca441b39f3e66d8dee97ef
+  languageName: node
+  linkType: hard
+
+"aws4@npm:^1.13.2":
+  version: 1.13.2
+  resolution: "aws4@npm:1.13.2"
+  checksum: 10c0/c993d0d186d699f685d73113733695d648ec7d4b301aba2e2a559d0cd9c1c902308cc52f4095e1396b23fddbc35113644e7f0a6a32753636306e41e3ed6f1e79
+  languageName: node
+  linkType: hard
+
 "bail@npm:^2.0.0":
   version: 2.0.2
   resolution: "bail@npm:2.0.2"
   checksum: 10c0/25cbea309ef6a1f56214187004e8f34014eb015713ea01fa5b9b7e9e776ca88d0fdffd64143ac42dc91966c915a4b7b683411b56e14929fad16153fc026ffb8b
+  languageName: node
+  linkType: hard
+
+"balanced-match@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "balanced-match@npm:1.0.2"
+  checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
   languageName: node
   linkType: hard
 
@@ -5692,6 +6023,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bluebird@npm:~3.7.2":
+  version: 3.7.2
+  resolution: "bluebird@npm:3.7.2"
+  checksum: 10c0/680de03adc54ff925eaa6c7bb9a47a0690e8b5de60f4792604aae8ed618c65e6b63a7893b57ca924beaf53eee69c5af4f8314148c08124c550fe1df1add897d2
+  languageName: node
+  linkType: hard
+
+"boolean@npm:^3.0.1":
+  version: 3.2.0
+  resolution: "boolean@npm:3.2.0"
+  checksum: 10c0/6a0dc9668f6f3dda42a53c181fcbdad223169c8d87b6c4011b87a8b14a21770efb2934a778f063d7ece17280f8c06d313c87f7b834bb1dd526a867ffcd00febf
+  languageName: node
+  linkType: hard
+
 "bottleneck@npm:^2.15.3":
   version: 2.19.5
   resolution: "bottleneck@npm:2.19.5"
@@ -5703,6 +6048,25 @@ __metadata:
   version: 2.14.1
   resolution: "bowser@npm:2.14.1"
   checksum: 10c0/bb69b55ba7f0456e3dc07d0cfd9467f985581f640ba8fd426b08754a6737ee0d6cf3b50607941e5255f04c83075b952ece0599f978dd4d20f1e95461104c5ffd
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^1.1.7":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+    concat-map: "npm:0.0.1"
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
@@ -5731,12 +6095,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-from@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 10c0/124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
+  languageName: node
+  linkType: hard
+
 "buffer-image-size@npm:^0.6.4":
   version: 0.6.4
   resolution: "buffer-image-size@npm:0.6.4"
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/7158205c8726caa521d3ae6ef7bc341eff211ff86f7278d122e45062e1720afef2f7ad8e845edc96c04f499b292c4ec8a74df9836a25074881260ba00b863448
+  languageName: node
+  linkType: hard
+
+"builder-util-runtime@npm:9.7.0":
+  version: 9.7.0
+  resolution: "builder-util-runtime@npm:9.7.0"
+  dependencies:
+    debug: "npm:^4.3.4"
+    sax: "npm:^1.2.4"
+  checksum: 10c0/4dac3788ce3776d268fd0cbfabe2d5168b8197fba90beda7fd2f729bfa51e689ffe0bf98b9162a1cac7f1191eb5bbcc6ca81bcbc5070df7a469fd7af511a1f31
+  languageName: node
+  linkType: hard
+
+"builder-util@npm:26.15.3":
+  version: 26.15.3
+  resolution: "builder-util@npm:26.15.3"
+  dependencies:
+    "@types/debug": "npm:^4.1.6"
+    builder-util-runtime: "npm:9.7.0"
+    chalk: "npm:^4.1.2"
+    cross-spawn: "npm:^7.0.6"
+    debug: "npm:^4.3.4"
+    fs-extra: "npm:^10.1.0"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.0"
+    js-yaml: "npm:^4.1.0"
+    sanitize-filename: "npm:^1.6.3"
+    source-map-support: "npm:^0.5.19"
+    stat-mode: "npm:^1.0.0"
+    temp-file: "npm:^3.4.0"
+    tiny-async-pool: "npm:1.3.0"
+  checksum: 10c0/e3ae624acca1b81793bfcfdeef81bbc15cc3acee67db2b00e6743138d658179f242b64a9d7111e717842ba0ca5df60620750a14ba5fdb0cee0ec58cdeeef13d4
+  languageName: node
+  linkType: hard
+
+"bytestreamjs@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "bytestreamjs@npm:2.0.1"
+  checksum: 10c0/edd66b7ca3f94aae99a1009304a42d82ca4c2085eb934192ff47a81f59215c975dc9d3cd8f23c40a2f43ef5b2fa6f01ace70b10ad247766cec6ec641b89eab48
   languageName: node
   linkType: hard
 
@@ -5759,6 +6169,16 @@ __metadata:
     normalize-url: "npm:^6.0.1"
     responselike: "npm:^2.0.0"
   checksum: 10c0/0834a7d17ae71a177bc34eab06de112a43f9b5ad05ebe929bec983d890a7d9f2bc5f1aa8bb67ea2b65e07a3bc74bea35fa62dd36dbac52876afe36fdcf83da41
+  languageName: node
+  linkType: hard
+
+"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/47bd9901d57b857590431243fea704ff18078b16890a6b3e021e12d279bbf211d039155e27d7566b374d49ee1f8189344bac9833dec7a20cdec370506361c938
   languageName: node
   linkType: hard
 
@@ -5790,7 +6210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.1.2":
+"chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -5846,6 +6266,20 @@ __metadata:
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
   checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
+  languageName: node
+  linkType: hard
+
+"chromium-pickle-js@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "chromium-pickle-js@npm:0.2.0"
+  checksum: 10c0/0a95bd280acdf05b0e08fa1a0e1db58c815dd24e92d639add8f494d23a8a49c26e4829721224d68f2f0e57a69047714db29bcff6deb5d029332321223416cb29
+  languageName: node
+  linkType: hard
+
+"ci-info@npm:4.3.1":
+  version: 4.3.1
+  resolution: "ci-info@npm:4.3.1"
+  checksum: 10c0/7dd82000f514d76ddfe7775e4cb0d66e5c638f5fa0e2a3be29557e898da0d32ac04f231217d414d07fb968b1fbc6d980ee17ddde0d2c516f23da9cfff608f6c1
   languageName: node
   linkType: hard
 
@@ -5931,6 +6365,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"combined-stream@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "combined-stream@npm:1.0.8"
+  dependencies:
+    delayed-stream: "npm:~1.0.0"
+  checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
+  languageName: node
+  linkType: hard
+
 "comma-separated-tokens@npm:^2.0.0":
   version: 2.0.3
   resolution: "comma-separated-tokens@npm:2.0.3"
@@ -5938,10 +6381,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "commander@npm:5.1.0"
+  checksum: 10c0/da9d71dbe4ce039faf1fe9eac3771dca8c11d66963341f62602f7b66e36d2a3f8883407af4f9a37b1db1a55c59c0c1325f186425764c2e963dc1d67aec2a4b6d
+  languageName: node
+  linkType: hard
+
 "commander@npm:^9.4.0":
   version: 9.5.0
   resolution: "commander@npm:9.5.0"
   checksum: 10c0/5f7784fbda2aaec39e89eb46f06a999e00224b3763dc65976e05929ec486e174fe9aac2655f03ba6a5e83875bd173be5283dc19309b7c65954701c02025b3c1d
+  languageName: node
+  linkType: hard
+
+"compare-version@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "compare-version@npm:0.1.2"
+  checksum: 10c0/f38b853cf0d244c0af5f444409abde3d2198cd97312efa1dbc4ab41b520009327c2a63db59bbaf2d69288eff6167ef22be9788dc5476157d073ecdff1a8eeb2d
+  languageName: node
+  linkType: hard
+
+"concat-map@npm:0.0.1":
+  version: 0.0.1
+  resolution: "concat-map@npm:0.0.1"
+  checksum: 10c0/c996b1cfdf95b6c90fee4dae37e332c8b6eb7d106430c17d538034c0ad9a1630cb194d2ab37293b1bdd4d779494beee7786d586a50bd9376fd6f7bcc2bd4c98f
   languageName: node
   linkType: hard
 
@@ -5966,7 +6430,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:7.0.6, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.3":
+"core-util-is@npm:~1.0.0":
+  version: 1.0.3
+  resolution: "core-util-is@npm:1.0.3"
+  checksum: 10c0/90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:7.0.6, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -6128,6 +6599,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"define-data-property@npm:^1.0.1":
+  version: 1.1.4
+  resolution: "define-data-property@npm:1.1.4"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.0.1"
+  checksum: 10c0/dea0606d1483eb9db8d930d4eac62ca0fa16738b0b3e07046cddfacf7d8c868bbe13fa0cb263eb91c7d0d527960dc3f2f2471a69ed7816210307f6744fe62e37
+  languageName: node
+  linkType: hard
+
+"define-properties@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "define-properties@npm:1.2.1"
+  dependencies:
+    define-data-property: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.0"
+    object-keys: "npm:^1.1.1"
+  checksum: 10c0/88a152319ffe1396ccc6ded510a3896e77efac7a1bfbaa174a7b00414a1747377e0bb525d303794a47cf30e805c2ec84e575758512c6e44a993076d29fd4e6c3
+  languageName: node
+  linkType: hard
+
+"delayed-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "delayed-stream@npm:1.0.0"
+  checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
+  languageName: node
+  linkType: hard
+
 "dequal@npm:^2.0.0, dequal@npm:^2.0.3":
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
@@ -6146,6 +6646,13 @@ __metadata:
   version: 1.1.0
   resolution: "detect-node-es@npm:1.1.0"
   checksum: 10c0/e562f00de23f10c27d7119e1af0e7388407eb4b06596a25f6d79a360094a109ff285de317f02b090faae093d314cf6e73ac3214f8a5bb3a0def5bece94557fbe
+  languageName: node
+  linkType: hard
+
+"detect-node@npm:^2.0.4":
+  version: 2.1.0
+  resolution: "detect-node@npm:2.1.0"
+  checksum: 10c0/f039f601790f2e9d4654e499913259a798b1f5246ae24f86ab5e8bd4aaf3bce50484234c494f11fb00aecb0c6e2733aa7b1cf3f530865640b65fbbd65b2c4e09
   languageName: node
   linkType: hard
 
@@ -6172,6 +6679,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dir-compare@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "dir-compare@npm:4.2.0"
+  dependencies:
+    minimatch: "npm:^3.0.5"
+    p-limit: "npm:^3.1.0 "
+  checksum: 10c0/615c6f6804095f912d98d49f9b56798ceebbc83612d660b7faa6bdb4894d978c02cfa1a30853a7319a269141e4f2a2034d4988a1985b58382614a3942f94e5b2
+  languageName: node
+  linkType: hard
+
 "dom-accessibility-api@npm:^0.5.9":
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
@@ -6179,7 +6696,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.3.1":
+"dotenv-expand@npm:^11.0.6":
+  version: 11.0.7
+  resolution: "dotenv-expand@npm:11.0.7"
+  dependencies:
+    dotenv: "npm:^16.4.5"
+  checksum: 10c0/d80b8a7be085edf351270b96ac0e794bc3ddd7f36157912939577cb4d33ba6492ebee349d59798b71b90e36f498d24a2a564fb4aa00073b2ef4c2a3a49c467b1
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.3.1, dotenv@npm:^16.4.5":
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
@@ -6336,12 +6862,76 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.2.0"
+  checksum: 10c0/199f2a0c1c16593ca0a145dbf76a962f8033ce3129f01284d48c45ed4e14fea9bbacd7b3610b6cdc33486cef20385ac054948fefc6272fcce645c09468f93031
+  languageName: node
+  linkType: hard
+
+"duplexer2@npm:~0.1.4":
+  version: 0.1.4
+  resolution: "duplexer2@npm:0.1.4"
+  dependencies:
+    readable-stream: "npm:^2.0.2"
+  checksum: 10c0/0765a4cc6fe6d9615d43cc6dbccff6f8412811d89a6f6aa44828ca9422a0a469625ce023bf81cee68f52930dbedf9c5716056ff264ac886612702d134b5e39b4
+  languageName: node
+  linkType: hard
+
 "ecdsa-sig-formatter@npm:1.0.11, ecdsa-sig-formatter@npm:^1.0.11":
   version: 1.0.11
   resolution: "ecdsa-sig-formatter@npm:1.0.11"
   dependencies:
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/ebfbf19d4b8be938f4dd4a83b8788385da353d63307ede301a9252f9f7f88672e76f2191618fd8edfc2f24679236064176fab0b78131b161ee73daa37125408c
+  languageName: node
+  linkType: hard
+
+"ejs@npm:^3.1.8":
+  version: 3.1.10
+  resolution: "ejs@npm:3.1.10"
+  dependencies:
+    jake: "npm:^10.8.5"
+  bin:
+    ejs: bin/cli.js
+  checksum: 10c0/52eade9e68416ed04f7f92c492183340582a36482836b11eab97b159fcdcfdedc62233a1bf0bf5e5e1851c501f2dca0e2e9afd111db2599e4e7f53ee29429ae1
+  languageName: node
+  linkType: hard
+
+"electron-publish@npm:26.15.3":
+  version: 26.15.3
+  resolution: "electron-publish@npm:26.15.3"
+  dependencies:
+    "@types/fs-extra": "npm:^9.0.11"
+    aws4: "npm:^1.13.2"
+    builder-util: "npm:26.15.3"
+    builder-util-runtime: "npm:9.7.0"
+    chalk: "npm:^4.1.2"
+    form-data: "npm:^4.0.5"
+    fs-extra: "npm:^10.1.0"
+    lazy-val: "npm:^1.0.5"
+    mime: "npm:^2.5.2"
+  checksum: 10c0/809629339769d6d45460af91de55546b1ae4e88a62d7cfe9b2b597b5aa31d190c1aea80f517f8248c08acee7e6f7327eb921b4dc9c9dd601bcde4feeedb7a87a
+  languageName: node
+  linkType: hard
+
+"electron-updater@npm:6.8.9":
+  version: 6.8.9
+  resolution: "electron-updater@npm:6.8.9"
+  dependencies:
+    builder-util-runtime: "npm:9.7.0"
+    fs-extra: "npm:^10.1.0"
+    js-yaml: "npm:^4.1.0"
+    lazy-val: "npm:^1.0.5"
+    lodash.escaperegexp: "npm:^4.1.2"
+    lodash.isequal: "npm:^4.5.0"
+    semver: "npm:~7.7.3"
+    tiny-typed-emitter: "npm:^2.1.0"
+  checksum: 10c0/a95d8ffcadc52fe289b0e44721ad78cab6bf2a4d5951f1242e0dbdf2a065e42ca64d48ee5040bd55d6320b8491ec90ae3f23eb7e343540b92e004799eb001aab
   languageName: node
   linkType: hard
 
@@ -6413,10 +7003,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-define-property@npm:^1.0.0, es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 10c0/3f54eb49c16c18707949ff25a1456728c883e81259f045003499efba399c08bad00deebf65cccde8c0e07908c1a225c9d472b7107e558f2a48e28d530e34527c
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
+  languageName: node
+  linkType: hard
+
 "es-module-lexer@npm:^2.0.0":
   version: 2.3.2
   resolution: "es-module-lexer@npm:2.3.2"
   checksum: 10c0/5e7389424c43478439f12f9a6aca1750f6f99afa384fc3de329f4a45f152ab156671055008adaafc74960877abf8cc338aeebf6bed8c21297b146fd6eb7a22f8
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "es-object-atoms@npm:1.1.2"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+  checksum: 10c0/1772861f094f739d6f41b579cfb9a18579daffeb434552a370a5fbef50a32d22227e27b63fdbb757b7ddd429d1b42fe52ccae7966d9302a2ec221b6f1b41bbc4
+  languageName: node
+  linkType: hard
+
+"es-set-tostringtag@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-set-tostringtag@npm:2.1.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.6"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
   languageName: node
   linkType: hard
 
@@ -6431,6 +7056,20 @@ __metadata:
     vitepress-plugin-sandpack@1.1.4:
       unplugged: true
   checksum: 10c0/465988c0a6b84b6d1d171287cbbe40c3247a1f94acea210ae14bc66b7d90c93e6839bd6937cbaf2a1d206669f3179eb26141a89d9125969a4b8e58cb7d86a2ca
+  languageName: node
+  linkType: hard
+
+"es6-error@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "es6-error@npm:4.1.1"
+  checksum: 10c0/357663fb1e845c047d548c3d30f86e005db71e122678f4184ced0693f634688c3f3ef2d7de7d4af732f734de01f528b05954e270f06aa7d133679fb9fe6600ef
+  languageName: node
+  linkType: hard
+
+"escape-string-regexp@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "escape-string-regexp@npm:4.0.0"
+  checksum: 10c0/9497d4dd307d845bd7f75180d8188bb17ea8c151c1edbf6b6717c100e104d629dc2dfb687686181b0f4b7d732c7dfdc4d5e7a8ff72de1b0ca283a75bbb3a9cd9
   languageName: node
   linkType: hard
 
@@ -6507,6 +7146,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-deep-equal@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "fast-deep-equal@npm:3.1.3"
+  checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
+  languageName: node
+  linkType: hard
+
 "fast-glob@npm:^3.2.2":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
@@ -6533,6 +7179,13 @@ __metadata:
   dependencies:
     fast-string-truncated-width: "npm:^3.0.2"
   checksum: 10c0/c8822d175315bb353ebe782b65214ac53b13e3bf704e03b132ea7bdfa8de6a636375b3ab7a4097545393d109381c37c4f387c72a462c90b61412dbc4632f39a7
+  languageName: node
+  linkType: hard
+
+"fast-uri@npm:^3.0.1":
+  version: 3.1.7
+  resolution: "fast-uri@npm:3.1.7"
+  checksum: 10c0/ca2baa4bde48fc7322bdc692c6636975943ebe4f6dd97e07d70b14e0ab85af2ff30de90f550f5ec2956684fe208e150d85d6cb5f3c74438c8ac1bf86bd435c13
   languageName: node
   linkType: hard
 
@@ -6576,6 +7229,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"filelist@npm:^1.0.4":
+  version: 1.0.6
+  resolution: "filelist@npm:1.0.6"
+  dependencies:
+    minimatch: "npm:^5.0.1"
+  checksum: 10c0/6ee725bec3e1936d680a45f14439b224d9f7c71658c145addcf551dd82f03d608522eb6b191aa086b392bc3e52ed4ce0ed8d78e24b203e6c5e867560a05d1121
+  languageName: node
+  linkType: hard
+
 "filename-reserved-regex@npm:^3.0.0":
   version: 3.0.0
   resolution: "filename-reserved-regex@npm:3.0.0"
@@ -6610,12 +7272,88 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data@npm:^4.0.5":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
+  languageName: node
+  linkType: hard
+
 "formdata-polyfill@npm:^4.0.10":
   version: 4.0.10
   resolution: "formdata-polyfill@npm:4.0.10"
   dependencies:
     fetch-blob: "npm:^3.1.2"
   checksum: 10c0/5392ec484f9ce0d5e0d52fb5a78e7486637d516179b0eb84d81389d7eccf9ca2f663079da56f761355c0a65792810e3b345dc24db9a8bbbcf24ef3c8c88570c6
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:11.3.1":
+  version: 11.3.1
+  resolution: "fs-extra@npm:11.3.1"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/61e5b7285b1ca72c68dfe1058b2514294a922683afac2a80aa90540f9bd85370763d675e3b408ef500077d355956fece3bd24b546790e261c3d3015967e2b2d9
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^10.0.0, fs-extra@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "fs-extra@npm:10.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/5f579466e7109719d162a9249abbeffe7f426eb133ea486e020b89bc6d67a741134076bf439983f2eb79276ceaf6bd7b7c1e43c3fd67fe889863e69072fb0a5e
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^11.1.1":
+  version: 11.4.0
+  resolution: "fs-extra@npm:11.4.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/1e311eca820a12d3d795f2043dcd5628d017f4d21e634f3f9ef314ae68bee9979758262fb9cb35ffa6f26454c3fffe8b15558733e91e8fc729b07b10bb98d8b6
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "fs-extra@npm:8.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^4.0.0"
+    universalify: "npm:^0.1.0"
+  checksum: 10c0/259f7b814d9e50d686899550c4f9ded85c46c643f7fe19be69504888e007fcbc08f306fae8ec495b8b998635e997c9e3e175ff2eeed230524ef1c1684cc96423
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^9.0.0, fs-extra@npm:^9.0.1":
+  version: 9.1.0
+  resolution: "fs-extra@npm:9.1.0"
+  dependencies:
+    at-least-node: "npm:^1.0.0"
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/9b808bd884beff5cb940773018179a6b94a966381d005479f00adda6b44e5e3d4abf765135773d849cc27efe68c349e4a7b86acd7d3306d5932c14f3a4b17a92
+  languageName: node
+  linkType: hard
+
+"fs.realpath@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fs.realpath@npm:1.0.0"
+  checksum: 10c0/444cf1291d997165dfd4c0d58b69f0e4782bfd9149fd72faa4fe299e68e0e93d6db941660b37dd29153bf7186672ececa3b50b7e7249477b03fdf850f287c948
   languageName: node
   linkType: hard
 
@@ -6635,6 +7373,13 @@ __metadata:
   dependencies:
     node-gyp: "npm:latest"
   conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
   languageName: node
   linkType: hard
 
@@ -6677,6 +7422,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generator-function@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "generator-function@npm:2.0.1"
+  checksum: 10c0/8a9f59df0f01cfefafdb3b451b80555e5cf6d76487095db91ac461a0e682e4ff7a9dbce15f4ecec191e53586d59eece01949e05a4b4492879600bbbe8e28d6b8
+  languageName: node
+  linkType: hard
+
 "get-east-asian-width@npm:1.6.0":
   version: 1.6.0
   resolution: "get-east-asian-width@npm:1.6.0"
@@ -6684,10 +7436,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.2.6":
+  version: 1.3.1
+  resolution: "get-intrinsic@npm:1.3.1"
+  dependencies:
+    async-function: "npm:^1.0.0"
+    async-generator-function: "npm:^1.0.0"
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.1.1"
+    function-bind: "npm:^1.1.2"
+    generator-function: "npm:^2.0.0"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.1.0"
+  checksum: 10c0/9f4ab0cf7efe0fd2c8185f52e6f637e708f3a112610c88869f8f041bb9ecc2ce44bf285dfdbdc6f4f7c277a5b88d8e94a432374d97cca22f3de7fc63795deb5d
+  languageName: node
+  linkType: hard
+
 "get-nonce@npm:^1.0.0":
   version: 1.0.1
   resolution: "get-nonce@npm:1.0.1"
   checksum: 10c0/2d7df55279060bf0568549e1ffc9b84bc32a32b7541675ca092dce56317cdd1a59a98dcc4072c9f6a980779440139a3221d7486f52c488e69dc0fd27b1efb162
+  languageName: node
+  linkType: hard
+
+"get-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
+  dependencies:
+    dunder-proto: "npm:^1.0.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10c0/9224acb44603c5526955e83510b9da41baf6ae73f7398875fba50edc5e944223a89c4a72b070fcd78beb5f7bdda58ecb6294adc28f7acfc0da05f76a2399643c
   languageName: node
   linkType: hard
 
@@ -6720,6 +7503,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^7.1.6":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^3.1.1"
+    once: "npm:^1.3.0"
+    path-is-absolute: "npm:^1.0.0"
+  checksum: 10c0/65676153e2b0c9095100fe7f25a778bf45608eeb32c6048cf307f579649bcc30353277b3b898a3792602c65764e5baa4f643714dfbdfd64ea271d210c7a425fe
+  languageName: node
+  linkType: hard
+
+"global-agent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "global-agent@npm:3.0.0"
+  dependencies:
+    boolean: "npm:^3.0.1"
+    es6-error: "npm:^4.1.1"
+    matcher: "npm:^3.0.0"
+    roarr: "npm:^2.15.3"
+    semver: "npm:^7.3.2"
+    serialize-error: "npm:^7.0.1"
+  checksum: 10c0/bb8750d026b25da437072762fd739098bad92ff72f66483c3929db4579e072f5523960f7e7fd70ee0d75db48898067b5dc1c9c1d17888128cff008fcc34d1bd3
+  languageName: node
+  linkType: hard
+
+"globalthis@npm:^1.0.1":
+  version: 1.0.4
+  resolution: "globalthis@npm:1.0.4"
+  dependencies:
+    define-properties: "npm:^1.2.1"
+    gopd: "npm:^1.0.1"
+  checksum: 10c0/9d156f313af79d80b1566b93e19285f481c591ad6d0d319b4be5e03750d004dde40a39a0f26f7e635f9007a3600802f53ecd85a759b86f109e80a5f705e01846
+  languageName: node
+  linkType: hard
+
 "google-auth-library@npm:^10.3.0":
   version: 10.9.1
   resolution: "google-auth-library@npm:10.9.1"
@@ -6748,7 +7569,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^11.7.0":
+"gopd@npm:^1.0.1, gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: 10c0/50fff1e04ba2b7737c097358534eacadad1e68d24cccee3272e04e007bed008e68d2614f3987788428fd192a5ae3889d08fb2331417e4fc4a9ab366b2043cead
+  languageName: node
+  linkType: hard
+
+"got@npm:^11.7.0, got@npm:^11.8.5":
   version: 11.8.6
   resolution: "got@npm:11.8.6"
   dependencies:
@@ -6767,7 +7595,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -6807,6 +7635,40 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
+  languageName: node
+  linkType: hard
+
+"has-property-descriptors@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "has-property-descriptors@npm:1.0.2"
+  dependencies:
+    es-define-property: "npm:^1.0.0"
+  checksum: 10c0/253c1f59e80bb476cf0dde8ff5284505d90c3bdb762983c3514d36414290475fe3fd6f574929d84de2a8eec00d35cf07cb6776205ff32efd7c50719125f00236
+  languageName: node
+  linkType: hard
+
+"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
+  languageName: node
+  linkType: hard
+
+"has-tostringtag@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-tostringtag@npm:1.0.2"
+  dependencies:
+    has-symbols: "npm:^1.0.3"
+  checksum: 10c0/a8b166462192bafe3d9b6e420a1d581d93dd867adb61be223a17a8d6dad147aa77a8be32c961bb2f27b3ef893cae8d36f564ab651f5e9b7938ae86f74027c48c
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.2, hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -6858,6 +7720,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hosted-git-info@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "hosted-git-info@npm:4.1.0"
+  dependencies:
+    lru-cache: "npm:^6.0.0"
+  checksum: 10c0/150fbcb001600336d17fdbae803264abed013548eea7946c2264c49ebe2ebd8c4441ba71dd23dd8e18c65de79d637f98b22d4760ba5fb2e0b15d62543d0fff07
+  languageName: node
+  linkType: hard
+
 "hpagent@npm:^1.2.0":
   version: 1.2.0
   resolution: "hpagent@npm:1.2.0"
@@ -6879,7 +7750,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:7.0.2":
+"http-proxy-agent@npm:7.0.2, http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -6899,7 +7770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:7.0.6, https-proxy-agent@npm:^7.0.1":
+"https-proxy-agent@npm:7.0.6, https-proxy-agent@npm:^7.0.0, https-proxy-agent@npm:^7.0.1":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -6929,6 +7800,23 @@ __metadata:
   version: 11.1.18
   resolution: "immer@npm:11.1.18"
   checksum: 10c0/afe02fcd154134eb2b3bea5a06051ef2e220677dbbc9c0b17ea2ce1c22bfc3690ac16f916922c12ad9c074617a02148ac5d94cbf0886d76e7ebac726806679d0
+  languageName: node
+  linkType: hard
+
+"inflight@npm:^1.0.4":
+  version: 1.0.6
+  resolution: "inflight@npm:1.0.6"
+  dependencies:
+    once: "npm:^1.3.0"
+    wrappy: "npm:1"
+  checksum: 10c0/7faca22584600a9dc5b9fca2cd5feb7135ac8c935449837b315676b4c90aa4f391ec4f42240178244b5a34e8bede1948627fda392ca3191522fc46b34e985ab2
+  languageName: node
+  linkType: hard
+
+"inherits@npm:2, inherits@npm:~2.0.3":
+  version: 2.0.4
+  resolution: "inherits@npm:2.0.4"
+  checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
   languageName: node
   linkType: hard
 
@@ -7014,10 +7902,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isarray@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "isarray@npm:1.0.0"
+  checksum: 10c0/18b5be6669be53425f0b84098732670ed4e727e3af33bc7f948aac01782110eb9a18b3b329c5323bcdd3acdaae547ee077d3951317e7f133bff7105264b3003d
+  languageName: node
+  linkType: hard
+
 "isbinaryfile@npm:^4.0.8":
   version: 4.0.10
   resolution: "isbinaryfile@npm:4.0.10"
   checksum: 10c0/0703d8cfeb69ed79e6d173120f327450011a066755150a6bbf97ffecec1069a5f2092777868315b21359098c84b54984871cad1abce877ad9141fb2caf3dcabf
+  languageName: node
+  linkType: hard
+
+"isbinaryfile@npm:^5.0.0":
+  version: 5.0.7
+  resolution: "isbinaryfile@npm:5.0.7"
+  checksum: 10c0/4cd98a91aaf969d7cae91f74d041dd1df35d9e140c522b7879180035f7eab9ba9c0c3d678e00e72a2777ee7245fd8f20b60c0787132c5fdbf6fc113492325e11
   languageName: node
   linkType: hard
 
@@ -7028,6 +7930,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isexe@npm:^3.1.1":
+  version: 3.1.5
+  resolution: "isexe@npm:3.1.5"
+  checksum: 10c0/8be2973a09f2f804ea1f34bfccfd5ea219ef48083bdb12107fe5bcf96b3e36b85084409e1b09ddaf2fae8927fdd9f6d70d90baadb78caa1ca7c530935706c8a4
+  languageName: node
+  linkType: hard
+
 "isexe@npm:^4.0.0":
   version: 4.0.0
   resolution: "isexe@npm:4.0.0"
@@ -7035,7 +7944,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:2.7.0, jiti@npm:^2.7.0":
+"jake@npm:^10.8.5":
+  version: 10.9.4
+  resolution: "jake@npm:10.9.4"
+  dependencies:
+    async: "npm:^3.2.6"
+    filelist: "npm:^1.0.4"
+    picocolors: "npm:^1.1.1"
+  bin:
+    jake: bin/cli.js
+  checksum: 10c0/bb52f000340d4a32f1a3893b9abe56ef2b77c25da4dbf2c0c874a8159d082dddda50a5ad10e26060198bd645b928ba8dba3b362710f46a247e335321188c5a9c
+  languageName: node
+  linkType: hard
+
+"jiti@npm:2.7.0, jiti@npm:^2.4.2, jiti@npm:^2.7.0":
   version: 2.7.0
   resolution: "jiti@npm:2.7.0"
   bin:
@@ -7051,7 +7973,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.2.0, js-yaml@npm:^4.3.0":
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.2.0, js-yaml@npm:^4.3.0":
   version: 4.3.2
   resolution: "js-yaml@npm:4.3.2"
   dependencies:
@@ -7088,6 +8010,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
 "json-schema@npm:^0.4.0":
   version: 0.4.0
   resolution: "json-schema@npm:0.4.0"
@@ -7095,10 +8024,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-stringify-safe@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "json-stringify-safe@npm:5.0.1"
+  checksum: 10c0/7dbf35cd0411d1d648dceb6d59ce5857ec939e52e4afc37601aa3da611f0987d5cee5b38d58329ceddf3ed48bd7215229c8d52059ab01f2444a338bf24ed0f37
+  languageName: node
+  linkType: hard
+
 "json-with-bigint@npm:^3.5.12":
   version: 3.5.12
   resolution: "json-with-bigint@npm:3.5.12"
   checksum: 10c0/3c205a445ee946bbe2409fb3e1840617eb0bac9086934ed55fefbd584c8d5bfd288bdc9a44acc8e5ca4d1ccf83b5c2ebd63add5ef4b5ca656ef4f968bf832e79
+  languageName: node
+  linkType: hard
+
+"json5@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "json5@npm:2.2.3"
+  bin:
+    json5: lib/cli.js
+  checksum: 10c0/5a04eed94810fa55c5ea138b2f7a5c12b97c3750bc63d11e511dcecbfef758003861522a070c2272764ee0f4e3e323862f386945aeb5b85b87ee43f084ba586c
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jsonfile@npm:4.0.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10c0/7dc94b628d57a66b71fb1b79510d460d662eb975b5f876d723f81549c2e9cd316d58a2ddf742b2b93a4fa6b17b2accaf1a738a0e2ea114bdfb13a32e5377e480
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^6.0.1":
+  version: 6.2.1
+  resolution: "jsonfile@npm:6.2.1"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+    universalify: "npm:^2.0.0"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10c0/e1abf000ecee9942d4d028a8e02dc752617face227d72afd1cfb2187e2433079e625bf82b807a313689db71b6472c6b2b389a2340d2798737b1199a39631c28a
   languageName: node
   linkType: hard
 
@@ -7136,6 +8106,13 @@ __metadata:
   dependencies:
     json-buffer: "npm:3.0.1"
   checksum: 10c0/aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
+  languageName: node
+  linkType: hard
+
+"lazy-val@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "lazy-val@npm:1.0.5"
+  checksum: 10c0/28ba7a0e704895a444eed47d110274090f485b991f2ea6fff2ab0878c529c53f60f2eb2d944cbbd68b91408e7455eabc62861c48289d4757fa9c818b97454f24
   languageName: node
   linkType: hard
 
@@ -7379,6 +8356,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.escaperegexp@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "lodash.escaperegexp@npm:4.1.2"
+  checksum: 10c0/484ad4067fa9119bb0f7c19a36ab143d0173a081314993fe977bd00cf2a3c6a487ce417a10f6bac598d968364f992153315f0dbe25c9e38e3eb7581dd333e087
+  languageName: node
+  linkType: hard
+
+"lodash.isequal@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.isequal@npm:4.5.0"
+  checksum: 10c0/dfdb2356db19631a4b445d5f37868a095e2402292d59539a987f134a8778c62a2810c2452d11ae9e6dcac71fc9de40a6fedcb20e2952a15b431ad8b29e50e28f
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.17.15":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
+  languageName: node
+  linkType: hard
+
 "long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
@@ -7404,6 +8402,15 @@ __metadata:
   version: 11.5.2
   resolution: "lru-cache@npm:11.5.2"
   checksum: 10c0/ece1ad731f5b655e85d67047d04bfc13823dc77aa61c5454924a9869ba600a0104e39cc33d726021feef812bc347ca34a5608a5eb1972a5dd0870b7ecd42c3f2
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "lru-cache@npm:6.0.0"
+  dependencies:
+    yallist: "npm:^4.0.0"
+  checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
   languageName: node
   linkType: hard
 
@@ -7447,6 +8454,22 @@ __metadata:
   bin:
     marked: bin/marked.js
   checksum: 10c0/22763935a0a243c41851b010a086ea85a09951e379948b6aa629b6cecdcd66e3a5e8c4acac2f6b29c183c20609d3e5102495270207dfd5f4c46ddd773a4ddb9b
+  languageName: node
+  linkType: hard
+
+"matcher@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "matcher@npm:3.0.0"
+  dependencies:
+    escape-string-regexp: "npm:^4.0.0"
+  checksum: 10c0/2edf24194a2879690bcdb29985fc6bc0d003df44e04df21ebcac721fa6ce2f6201c579866bb92f9380bffe946f11ecd8cd31f34117fb67ebf8aca604918e127e
+  languageName: node
+  linkType: hard
+
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
   languageName: node
   linkType: hard
 
@@ -8006,6 +9029,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.35":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: "npm:1.52.0"
+  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mime@npm:^2.5.2":
+  version: 2.6.0
+  resolution: "mime@npm:2.6.0"
+  bin:
+    mime: cli.js
+  checksum: 10c0/a7f2589900d9c16e3bdf7672d16a6274df903da958c1643c9c45771f0478f3846dcb1097f31eb9178452570271361e2149310931ec705c037210fc69639c8e6c
+  languageName: node
+  linkType: hard
+
 "mimic-response@npm:^1.0.0":
   version: 1.0.1
   resolution: "mimic-response@npm:1.0.1"
@@ -8029,12 +9077,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.1, minimatch@npm:^10.2.2":
+"minimatch@npm:^10.0.1, minimatch@npm:^10.2.2, minimatch@npm:^10.2.5":
   version: 10.2.6
   resolution: "minimatch@npm:10.2.6"
   dependencies:
     brace-expansion: "npm:^5.0.8"
   checksum: 10c0/4559a836243b98bd4d17ea9f7edae698717c76399eea7be374f3737f33164e4907f19e9726891ddeb122f750a5a7fa80d2ac43e851d6e5984dc4ff42ec127d3a
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
+  dependencies:
+    brace-expansion: "npm:^1.1.7"
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^5.0.1":
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^9.0.3":
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
+  dependencies:
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
+  languageName: node
+  linkType: hard
+
+"minimist@npm:^1.2.5, minimist@npm:^1.2.6":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
   languageName: node
   linkType: hard
 
@@ -8112,6 +9194,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-abi@npm:^4.2.0":
+  version: 4.35.0
+  resolution: "node-abi@npm:4.35.0"
+  dependencies:
+    semver: "npm:^7.6.3"
+  checksum: 10c0/5b83a74866888bbced1d2286551168ce006e3e1fc1ac41dc79cab213a39669bba3d67f500a1a964aab3f4b4692b8a7eda69e0a67256b307fca6c8d8f5fd1f9be
+  languageName: node
+  linkType: hard
+
+"node-api-version@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "node-api-version@npm:0.2.1"
+  dependencies:
+    semver: "npm:^7.3.5"
+  checksum: 10c0/3fe6c273e4f9dd184bb8b959ba3d8afae7eade663611d82c8538c79ac3a7b8f1d136632ceb4bf8cdc46a851fc169407746996cf7d1096de9a186e0e70fca95fa
+  languageName: node
+  linkType: hard
+
 "node-domexception@npm:^1.0.0":
   version: 1.0.0
   resolution: "node-domexception@npm:1.0.0"
@@ -8127,6 +9227,26 @@ __metadata:
     fetch-blob: "npm:^3.1.4"
     formdata-polyfill: "npm:^4.0.10"
   checksum: 10c0/f3d5e56190562221398c9f5750198b34cf6113aa304e34ee97c94fd300ec578b25b2c2906edba922050fce983338fde0d5d34fcb0fc3336ade5bd0e429ad7538
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:^12.2.0":
+  version: 12.4.0
+  resolution: "node-gyp@npm:12.4.0"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    graceful-fs: "npm:^4.2.6"
+    nopt: "npm:^9.0.0"
+    proc-log: "npm:^6.0.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^7.5.4"
+    tinyglobby: "npm:^0.2.12"
+    undici: "npm:^6.25.0"
+    which: "npm:^6.0.0"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 10c0/9acb7c798e124275a6f9c1f7eb64b5abd6196bb885a3945fb44ee0dccf435514e88cdfb0f228ee7ff76ef25107c1f39ff37a067bf92fd00b9aff9234db29ff9e
   languageName: node
   linkType: hard
 
@@ -8150,6 +9270,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-int64@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "node-int64@npm:0.4.0"
+  checksum: 10c0/a6a4d8369e2f2720e9c645255ffde909c0fbd41c92ea92a5607fc17055955daac99c1ff589d421eee12a0d24e99f7bfc2aabfeb1a4c14742f6c099a51863f31a
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^10.0.0":
   version: 10.0.1
   resolution: "nopt@npm:10.0.1"
@@ -8161,10 +9288,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nopt@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "nopt@npm:9.0.0"
+  dependencies:
+    abbrev: "npm:^4.0.0"
+  bin:
+    nopt: bin/nopt.js
+  checksum: 10c0/1822eb6f9b020ef6f7a7516d7b64a8036e09666ea55ac40416c36e4b2b343122c3cff0e2f085675f53de1d2db99a2a89a60ccea1d120bcd6a5347bf6ceb4a7fd
+  languageName: node
+  linkType: hard
+
 "normalize-url@npm:^6.0.1":
   version: 6.1.0
   resolution: "normalize-url@npm:6.1.0"
   checksum: 10c0/95d948f9bdd2cfde91aa786d1816ae40f8262946e13700bf6628105994fe0ff361662c20af3961161c38a119dc977adeb41fc0b41b1745eb77edaaf9cb22db23
+  languageName: node
+  linkType: hard
+
+"object-keys@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "object-keys@npm:1.1.1"
+  checksum: 10c0/b11f7ccdbc6d406d1f186cdadb9d54738e347b2692a14439ca5ac70c225fa6db46db809711b78589866d47b25fc3e8dee0b4c722ac751e11180f9380e3d8601d
   languageName: node
   linkType: hard
 
@@ -8194,7 +9339,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.1, once@npm:^1.4.0":
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -8483,6 +9628,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^3.1.0 ":
+  version: 3.1.0
+  resolution: "p-limit@npm:3.1.0"
+  dependencies:
+    yocto-queue: "npm:^0.1.0"
+  checksum: 10c0/9db675949dbdc9c3763c89e748d0ef8bdad0afbb24d49ceaf4c46c02c77d30db4e0652ed36d0a0a7a95154335fab810d95c86153105bb73b3a90448e2bb14e1a
+  languageName: node
+  linkType: hard
+
 "p-retry@npm:^4.6.2":
   version: 4.6.2
   resolution: "p-retry@npm:4.6.2"
@@ -8522,6 +9676,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-is-absolute@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "path-is-absolute@npm:1.0.1"
+  checksum: 10c0/127da03c82172a2a50099cddbf02510c1791fc2cc5f7713ddb613a56838db1e8168b121a920079d052e0936c23005562059756d653b7c544c53185efe53be078
+  languageName: node
+  linkType: hard
+
 "path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
@@ -8543,6 +9704,13 @@ __metadata:
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
+"pe-library@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "pe-library@npm:0.4.1"
+  checksum: 10c0/75c772e74c75d9710a2bf6b7e88fb57e4c26788422abd3b38c8100c796e311c72102ef71159b9e0b56f05f616a968e11b8ec218bcd625c896df067235af8da77
   languageName: node
   linkType: hard
 
@@ -8578,6 +9746,31 @@ __metadata:
   version: 4.0.7
   resolution: "pirates@npm:4.0.7"
   checksum: 10c0/a51f108dd811beb779d58a76864bbd49e239fa40c7984cd11596c75a121a8cc789f1c8971d8bb15f0dbf9d48b76c05bb62fcbce840f89b688c0fa64b37e8478a
+  languageName: node
+  linkType: hard
+
+"pkijs@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "pkijs@npm:3.4.0"
+  dependencies:
+    "@noble/hashes": "npm:1.4.0"
+    asn1js: "npm:^3.0.6"
+    bytestreamjs: "npm:^2.0.1"
+    pvtsutils: "npm:^1.3.6"
+    pvutils: "npm:^1.1.3"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/33cfab9283702782ae228bd2d4a51b1e9b2e0d6e2141207f29ee95716101ac4fe6e6821882da5f5eca28c74be3964b181b09e95cbbb757b2bd9dca918a5765fd
+  languageName: node
+  linkType: hard
+
+"plist@npm:3.1.0":
+  version: 3.1.0
+  resolution: "plist@npm:3.1.0"
+  dependencies:
+    "@xmldom/xmldom": "npm:^0.8.8"
+    base64-js: "npm:^1.5.1"
+    xmlbuilder: "npm:^15.1.1"
+  checksum: 10c0/db19ba50faafc4103df8e79bcd6b08004a56db2a9dd30b3e5c8b0ef30398ef44344a674e594d012c8fc39e539a2b72cb58c60a76b4b4401cbbc7c8f6b028d93d
   languageName: node
   linkType: hard
 
@@ -8641,10 +9834,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proc-log@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "proc-log@npm:6.1.0"
+  checksum: 10c0/4f178d4062733ead9d71a9b1ab24ebcecdfe2250916a5b1555f04fe2eda972a0ec76fbaa8df1ad9c02707add6749219d118a4fc46dc56bdfe4dde4b47d80bb82
+  languageName: node
+  linkType: hard
+
 "proc-log@npm:^7.0.0":
   version: 7.0.0
   resolution: "proc-log@npm:7.0.0"
   checksum: 10c0/b89c2d862604f35fec795477b0c7e376feab3ba0d4f4d291c4e959567442697cf451ac557d0623c1cc38af45a78128b983410f397a10c5d3a67f76c33de4754b
+  languageName: node
+  linkType: hard
+
+"process-nextick-args@npm:~2.0.0":
+  version: 2.0.1
+  resolution: "process-nextick-args@npm:2.0.1"
+  checksum: 10c0/bec089239487833d46b59d80327a1605e1c5287eaad770a291add7f45fda1bb5e28b38e0e061add0a1d0ee0984788ce74fa394d345eed1c420cacf392c554367
   languageName: node
   linkType: hard
 
@@ -8665,7 +9872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proper-lockfile@npm:4.1.2":
+"proper-lockfile@npm:4.1.2, proper-lockfile@npm:^4.1.2":
   version: 4.1.2
   resolution: "proper-lockfile@npm:4.1.2"
   dependencies:
@@ -8709,6 +9916,22 @@ __metadata:
     end-of-stream: "npm:^1.1.0"
     once: "npm:^1.3.1"
   checksum: 10c0/2780e66b5471c19e3e3e1063b84f3f6a3a08367f24c5ed552f98cd5901e6ada27c7ad6495d4244f553fd03b01884a4561933064f053f47c8994d84fd352768ea
+  languageName: node
+  linkType: hard
+
+"pvtsutils@npm:^1.3.6":
+  version: 1.3.6
+  resolution: "pvtsutils@npm:1.3.6"
+  dependencies:
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/b1b42646370505ccae536dcffa662303b2c553995211330c8e39dec9ab8c197585d7751c2c5b9ab2f186feda0219d9bb23c34ee1e565573be96450f79d89a13c
+  languageName: node
+  linkType: hard
+
+"pvutils@npm:^1.1.3, pvutils@npm:^1.1.5":
+  version: 1.2.0
+  resolution: "pvutils@npm:1.2.0"
+  checksum: 10c0/1206766f0b9947fd44a629e2ed7945fb5d1d8ee0f31f032ec58d60cec2165b0b3afb11bf3727215348bf19132ca34986302680b5930d45b0a0d23745fd54224b
   languageName: node
   linkType: hard
 
@@ -8878,6 +10101,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"read-binary-file-arch@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "read-binary-file-arch@npm:1.0.6"
+  dependencies:
+    debug: "npm:^4.3.4"
+  bin:
+    read-binary-file-arch: cli.js
+  checksum: 10c0/7665cb4ec61da1f4da7ba6c0fb64f53f6e739373d427dd0e1c4d19f240b3ebff0f596377c01e290a6370f611899b82df09edafa758200bf31216d855e3230058
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^2.0.2":
+  version: 2.3.8
+  resolution: "readable-stream@npm:2.3.8"
+  dependencies:
+    core-util-is: "npm:~1.0.0"
+    inherits: "npm:~2.0.3"
+    isarray: "npm:~1.0.0"
+    process-nextick-args: "npm:~2.0.0"
+    safe-buffer: "npm:~5.1.1"
+    string_decoder: "npm:~1.1.1"
+    util-deprecate: "npm:~1.0.1"
+  checksum: 10c0/7efdb01f3853bc35ac62ea25493567bf588773213f5f4a79f9c365e1ad13bab845ac0dae7bc946270dc40c3929483228415e92a3fc600cc7e4548992f41ee3fa
+  languageName: node
+  linkType: hard
+
 "recharts@npm:^3.10.1":
   version: 3.10.1
   resolution: "recharts@npm:3.10.1"
@@ -8967,6 +10216,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"require-from-string@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "require-from-string@npm:2.0.2"
+  checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
+  languageName: node
+  linkType: hard
+
+"resedit@npm:^1.7.0":
+  version: 1.7.2
+  resolution: "resedit@npm:1.7.2"
+  dependencies:
+    pe-library: "npm:^0.4.1"
+  checksum: 10c0/1d21438d22ca9010611b8db3d0b122122b9d3588fa6e608eaadca38ab86d5d1c0348f7656a9c2e7f2609c30db62d1f62ddc9184e7e11920d47d2c238b1587847
+  languageName: node
+  linkType: hard
+
 "resedit@npm:^2.0.3":
   version: 2.0.3
   resolution: "resedit@npm:2.0.3"
@@ -9027,6 +10292,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"roarr@npm:^2.15.3":
+  version: 2.15.4
+  resolution: "roarr@npm:2.15.4"
+  dependencies:
+    boolean: "npm:^3.0.1"
+    detect-node: "npm:^2.0.4"
+    globalthis: "npm:^1.0.1"
+    json-stringify-safe: "npm:^5.0.1"
+    semver-compare: "npm:^1.0.0"
+    sprintf-js: "npm:^1.1.2"
+  checksum: 10c0/7d01d4c14513c461778dd673a8f9e53255221f8d04173aafeb8e11b23d8b659bb83f1c90cfe81af7f9c213b8084b404b918108fd792bda76678f555340cc64ec
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -9043,6 +10322,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+  version: 5.1.2
+  resolution: "safe-buffer@npm:5.1.2"
+  checksum: 10c0/780ba6b5d99cc9a40f7b951d47152297d0e260f0df01472a1b99d4889679a4b94a13d644f7dbc4f022572f09ae9005fa2fbb93bbbd83643316f365a3e9a45b21
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -9050,10 +10336,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sanitize-filename@npm:^1.6.3":
+  version: 1.6.4
+  resolution: "sanitize-filename@npm:1.6.4"
+  dependencies:
+    truncate-utf8-bytes: "npm:^1.0.0"
+  checksum: 10c0/b56415a95e4f90dc992cd126b5f45c7b39d178662fbd0dc48f03203e35c58ab8e9eb3f5cebfaabc46f1438093d65a3a3cc96875e2b036a1474e19593bee9a540
+  languageName: node
+  linkType: hard
+
+"sax@npm:^1.2.4":
+  version: 1.6.1
+  resolution: "sax@npm:1.6.1"
+  checksum: 10c0/c91a71043d60da50fdf1e2cee936fc7ad4c9376afb8d1022aef5655f279433640859ec06b3b49abfcbe578fc7da2828cc1661e45aaedf835f5393496193437fa
+  languageName: node
+  linkType: hard
+
 "scheduler@npm:^0.27.0":
   version: 0.27.0
   resolution: "scheduler@npm:0.27.0"
   checksum: 10c0/4f03048cb05a3c8fddc45813052251eca00688f413a3cee236d984a161da28db28ba71bd11e7a3dd02f7af84ab28d39fb311431d3b3772fed557945beb00c452
+  languageName: node
+  linkType: hard
+
+"semver-compare@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "semver-compare@npm:1.0.0"
+  checksum: 10c0/9ef4d8b81847556f0865f46ddc4d276bace118c7cb46811867af82e837b7fc473911981d5a0abc561fa2db487065572217e5b06e18701c4281bcdd2a1affaff1
   languageName: node
   linkType: hard
 
@@ -9066,12 +10375,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.8.2, semver@npm:^7.8.5":
+"semver@npm:^5.5.0":
+  version: 5.7.2
+  resolution: "semver@npm:5.7.2"
+  bin:
+    semver: bin/semver
+  checksum: 10c0/e4cf10f86f168db772ae95d86ba65b3fd6c5967c94d97c708ccb463b778c2ee53b914cd7167620950fc07faf5a564e6efe903836639e512a1aa15fbc9667fa25
+  languageName: node
+  linkType: hard
+
+"semver@npm:^6.2.0":
+  version: 6.3.1
+  resolution: "semver@npm:6.3.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/e3d79b609071caa78bcb6ce2ad81c7966a46a7431d9d58b8800cfa9cb6a63699b3899a0e4bcce36167a284578212d9ae6942b6929ba4aa5015c079a67751d42d
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.6.3, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.8.2, semver@npm:^7.8.5":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
     semver: bin/semver.js
   checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
+  languageName: node
+  linkType: hard
+
+"semver@npm:~7.7.3":
+  version: 7.7.4
+  resolution: "semver@npm:7.7.4"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  languageName: node
+  linkType: hard
+
+"serialize-error@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "serialize-error@npm:7.0.1"
+  dependencies:
+    type-fest: "npm:^0.13.1"
+  checksum: 10c0/7982937d578cd901276c8ab3e2c6ed8a4c174137730f1fb0402d005af209a0e84d04acc874e317c936724c7b5b26c7a96ff7e4b8d11a469f4924a4b0ea814c05
   languageName: node
   linkType: hard
 
@@ -9151,6 +10496,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-support@npm:^0.5.19":
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
+  dependencies:
+    buffer-from: "npm:^1.0.0"
+    source-map: "npm:^0.6.0"
+  checksum: 10c0/9ee09942f415e0f721d6daad3917ec1516af746a8120bba7bb56278707a37f1eb8642bde456e98454b8a885023af81a16e646869975f06afc1a711fb90484e7d
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.6.0":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
+  languageName: node
+  linkType: hard
+
 "space-separated-tokens@npm:^2.0.0":
   version: 2.0.2
   resolution: "space-separated-tokens@npm:2.0.2"
@@ -9158,10 +10520,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sprintf-js@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "sprintf-js@npm:1.1.3"
+  checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
+  languageName: node
+  linkType: hard
+
 "stackback@npm:0.0.2":
   version: 0.0.2
   resolution: "stackback@npm:0.0.2"
   checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"stat-mode@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "stat-mode@npm:1.0.0"
+  checksum: 10c0/89b66a538dbfd45038fefdaf5b2104dc6e911605af1c201793e9629592ed9fdc7bdd1bca42806d0d4167c6d9cacac1f3fda41ddfe334a5c1f898113da38fae74
   languageName: node
   linkType: hard
 
@@ -9180,6 +10556,15 @@ __metadata:
     is-fullwidth-code-point: "npm:^3.0.0"
     strip-ansi: "npm:^6.0.1"
   checksum: 10c0/1e525e92e5eae0afd7454086eed9c818ee84374bb80328fc41217ae72ff5f065ef1c9d7f72da41de40c75fa8bb3dee63d92373fd492c84260a552c636392a47b
+  languageName: node
+  linkType: hard
+
+"string_decoder@npm:~1.1.1":
+  version: 1.1.1
+  resolution: "string_decoder@npm:1.1.1"
+  dependencies:
+    safe-buffer: "npm:~5.1.0"
+  checksum: 10c0/b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
   languageName: node
   linkType: hard
 
@@ -9259,7 +10644,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.3, tar@npm:^7.5.4":
+"tar@npm:^7.5.3, tar@npm:^7.5.4, tar@npm:^7.5.7":
   version: 7.5.22
   resolution: "tar@npm:7.5.22"
   dependencies:
@@ -9272,10 +10657,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"temp-file@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "temp-file@npm:3.4.0"
+  dependencies:
+    async-exit-hook: "npm:^2.0.1"
+    fs-extra: "npm:^10.0.0"
+  checksum: 10c0/70e441909097346a930ae02278df9b0133cd02dddf0b49e5ddaade735fef1410a50a448a2a812106f97c045294c99cc19f26943eb88f1d728d41fbc445a40298
+  languageName: node
+  linkType: hard
+
+"tiny-async-pool@npm:1.3.0":
+  version: 1.3.0
+  resolution: "tiny-async-pool@npm:1.3.0"
+  dependencies:
+    semver: "npm:^5.5.0"
+  checksum: 10c0/bbdece69f596f16d1a7b0df7fe451fe959c6f26af283d8919154f59abf8a853b3da1aea8d10e49e7af5b039a38a3d8b4ca0c044b59dcf19a93d63c6ee7e36507
+  languageName: node
+  linkType: hard
+
 "tiny-invariant@npm:^1.3.3":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
+  languageName: node
+  linkType: hard
+
+"tiny-typed-emitter@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "tiny-typed-emitter@npm:2.1.0"
+  checksum: 10c0/522bed4c579ee7ee16548540cb693a3d098b137496110f5a74bff970b54187e6b7343a359b703e33f77c5b4b90ec6cebc0d0ec3dbdf1bd418723c5c3ce36d8a2
   languageName: node
   linkType: hard
 
@@ -9324,6 +10735,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tmp-promise@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "tmp-promise@npm:3.0.3"
+  dependencies:
+    tmp: "npm:^0.2.0"
+  checksum: 10c0/23b47dcb2e82b14bbd8f61ed7a9d9353cdb6a6f09d7716616cfd27d0087040cd40152965a518e598d7aabe1489b9569bf1eebde0c5fadeaf3ec8098adcebea4e
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.2.0":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10c0/59eb55584f2f07210d3231b6a1f6b5c2b9794d8a7b509c8ee867ed2acad6d2245ee2448b7937b676ffbff3155a70077edde8a69f9d7cf0f90c86a62e8910c357
+  languageName: node
+  linkType: hard
+
 "to-regex-range@npm:^5.0.1":
   version: 5.0.1
   resolution: "to-regex-range@npm:5.0.1"
@@ -9368,6 +10795,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"truncate-utf8-bytes@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "truncate-utf8-bytes@npm:1.0.2"
+  dependencies:
+    utf8-byte-length: "npm:^1.0.1"
+  checksum: 10c0/af2b431fc4314f119b551e5fccfad49d4c0ef82e13ba9ca61be6567801195b08e732ce9643542e8ad1b3df44f3df2d7345b3dd34f723954b6bb43a14584d6b3c
+  languageName: node
+  linkType: hard
+
 "ts-algebra@npm:^2.0.0":
   version: 2.0.0
   resolution: "ts-algebra@npm:2.0.0"
@@ -9393,6 +10829,13 @@ __metadata:
   version: 3.14.0
   resolution: "typanion@npm:3.14.0"
   checksum: 10c0/8b03b19844e6955bfd906c31dc781bae6d7f1fb3ce4fe24b7501557013d4889ae5cefe671dafe98d87ead0adceb8afcb8bc16df7dc0bd2b7331bac96f3a7cae2
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "type-fest@npm:0.13.1"
+  checksum: 10c0/0c0fa07ae53d4e776cf4dac30d25ad799443e9eef9226f9fddbb69242db86b08584084a99885cfa5a9dfe4c063ebdc9aa7b69da348e735baede8d43f1aeae93b
   languageName: node
   linkType: hard
 
@@ -9593,6 +11036,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^6.25.0":
+  version: 6.28.1
+  resolution: "undici@npm:6.28.1"
+  checksum: 10c0/9c7c277da83972f4f506d564b1d627e3e78aadf866915eab768d96fc70daeae8ff7d87d0cdb32403ae1afdf3aef0f11715e0847d66910fda62822c33c5a7e674
+  languageName: node
+  linkType: hard
+
 "undici@npm:^7.24.4, undici@npm:^7.28.0":
   version: 7.29.0
   resolution: "undici@npm:7.29.0"
@@ -9684,6 +11134,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"universalify@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "universalify@npm:0.1.2"
+  checksum: 10c0/e70e0339f6b36f34c9816f6bf9662372bd241714dc77508d231d08386d94f2c4aa1ba1318614f92015f40d45aae1b9075cd30bd490efbe39387b60a76ca3f045
+  languageName: node
+  linkType: hard
+
+"universalify@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "universalify@npm:2.0.1"
+  checksum: 10c0/73e8ee3809041ca8b818efb141801a1004e3fc0002727f1531f4de613ea281b494a40909596dae4a042a4fb6cd385af5d4db2e137b1362e0e91384b828effd3a
+  languageName: node
+  linkType: hard
+
+"unzipper@npm:^0.12.3":
+  version: 0.12.5
+  resolution: "unzipper@npm:0.12.5"
+  dependencies:
+    bluebird: "npm:~3.7.2"
+    duplexer2: "npm:~0.1.4"
+    fs-extra: "npm:11.3.1"
+    graceful-fs: "npm:^4.2.2"
+    node-int64: "npm:^0.4.0"
+  checksum: 10c0/806e0ec3ee8f577f1ecabb0d0795b7b0e028e03db7d78d33380018be3704dd23d5f8b5c7c508766f13242daa29023c1ddc4e1174de4745a1706a705ac7aa2c94
+  languageName: node
+  linkType: hard
+
 "use-callback-ref@npm:^1.3.3":
   version: 1.3.3
   resolution: "use-callback-ref@npm:1.3.3"
@@ -9721,6 +11198,20 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10c0/35e1179f872a53227bdf8a827f7911da4c37c0f4091c29b76b1e32473d1670ebe7bcd880b808b7549ba9a5605c233350f800ffab963ee4a4ee346ee983b6019b
+  languageName: node
+  linkType: hard
+
+"utf8-byte-length@npm:^1.0.1":
+  version: 1.0.5
+  resolution: "utf8-byte-length@npm:1.0.5"
+  checksum: 10c0/e69bda3299608f4cc75976da9fb74ac94801a58b9ca29fdad03a20ec952e7477d7f226c12716b5f36bd4cff8151d1d152d02ee1df3752f017d4b2c725ce3e47a
+  languageName: node
+  linkType: hard
+
+"util-deprecate@npm:~1.0.1":
+  version: 1.0.2
+  resolution: "util-deprecate@npm:1.0.2"
+  checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
   languageName: node
   linkType: hard
 
@@ -9903,6 +11394,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webcrypto-core@npm:^1.9.2":
+  version: 1.9.2
+  resolution: "webcrypto-core@npm:1.9.2"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.7.0"
+    "@peculiar/json-schema": "npm:^1.1.12"
+    "@peculiar/utils": "npm:^2.0.2"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/83e9382af7a76546337198ab7e6c4f1bb7c230e4bab238bef5376c18573158f7e95671cfcb425f32a85fb4d01fd56abf7e99408158a3de9f60ac80b12c1fd7cc
+  languageName: node
+  linkType: hard
+
 "whatwg-mimetype@npm:^3.0.0":
   version: 3.0.0
   resolution: "whatwg-mimetype@npm:3.0.0"
@@ -9918,6 +11422,28 @@ __metadata:
   bin:
     node-which: ./bin/node-which
   checksum: 10c0/66522872a768b60c2a65a57e8ad184e5372f5b6a9ca6d5f033d4b0dc98aff63995655a7503b9c0a2598936f532120e81dd8cc155e2e92ed662a2b9377cc4374f
+  languageName: node
+  linkType: hard
+
+"which@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "which@npm:5.0.0"
+  dependencies:
+    isexe: "npm:^3.1.1"
+  bin:
+    node-which: bin/which.js
+  checksum: 10c0/e556e4cd8b7dbf5df52408c9a9dd5ac6518c8c5267c8953f5b0564073c66ed5bf9503b14d876d0e9c7844d4db9725fb0dcf45d6e911e17e26ab363dc3965ae7b
+  languageName: node
+  linkType: hard
+
+"which@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "which@npm:6.0.1"
+  dependencies:
+    isexe: "npm:^4.0.0"
+  bin:
+    node-which: bin/which.js
+  checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
   languageName: node
   linkType: hard
 
@@ -9973,6 +11499,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yallist@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "yallist@npm:4.0.0"
+  checksum: 10c0/2286b5e8dbfe22204ab66e2ef5cc9bbb1e55dfc873bbe0d568aa943eb255d131890dfd5bf243637273d31119b870f49c18fcde2c6ffbb7a7a092b870dc90625a
+  languageName: node
+  linkType: hard
+
 "yallist@npm:^5.0.0":
   version: 5.0.0
   resolution: "yallist@npm:5.0.0"
@@ -9993,6 +11526,13 @@ __metadata:
   version: 22.0.0
   resolution: "yargs-parser@npm:22.0.0"
   checksum: 10c0/cb7ef81759c4271cb1d96b9351dbbc9a9ce35d3e1122d2b739bf6c432603824fa02c67cc12dcef6ea80283379d63495686e8f41cc7b06c6576e792aba4d33e1c
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "yocto-queue@npm:0.1.0"
+  checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds automatic updates for signed, stable Apple Silicon builds using `electron-updater` and public GitHub Releases. The app checks at startup and every six hours, downloads updates in the background, and exposes progress, retry, and restart actions in the tray and application menu. Installation waits for settings, inference, download shutdown, and native staging; repeated quits cannot interrupt staging, and ordinary quit does not force a relaunch.

Keeps the existing Electron packager and signing pipeline. Releases now publish a verified update ZIP, differential blockmap, and `latest-mac.yml` after notarization/stapling, with archive hashes, minimum macOS eligibility, and a configurable rollout percentage. A version-tag push creates or resumes a draft release; the workflow publishes only after all four assets are fully uploaded and verified and the latest main-push CI run for the tagged commit completes successfully. Failed builds leave the draft hidden from updater clients, and retries refuse to overwrite public releases. Unsigned, development, and prerelease builds remain opted out.

Validation:
- All 412 desktop tests passed, including commit-specific CI publication gates, draft publication failures/retries, late Finder/Dock activation, real MacUpdater quit/relaunch behavior and native staging races, shutdown races, async download failures, OS eligibility, metadata parsing, and differential reconstruction with the upstream planner.
- Desktop/runtime/script type checks, targeted lint, formatting, workflow syntax checks, and diff checks passed.
- Packaged updater loaded and read configuration under Electron 44; a real local ZIP passed independent SHA-512, size, blockmap coverage, and release-version checks.

A Developer ID signed end-to-end upgrade still needs release validation. Existing installations without an updater need one manual installation of the first release containing this feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes release visibility timing, quit/install orchestration, and what signed clients download from GitHub—bugs could ship bad updates or strand users during shutdown.
> 
> **Overview**
> Adds **background auto-updates** for signed, stable Apple Silicon macOS builds via `electron-updater` and public GitHub Releases. The main process checks at launch and every six hours, downloads in the background, and surfaces **Check for Updates…**, progress, retry, and **Restart to Update…** in the tray and app menu. Quit/shutdown is refactored through `createQuitHandler` so installs run only after inference and settings drain, Squirrel staging can finish, and ordinary quit vs explicit restart vs Finder relaunch behave correctly. Updates are enabled only when packaging stamps `autoUpdates` and writes `app-update.yml` on signed builds—unsigned/dev/prerelease builds stay opted out.
> 
> The **desktop release workflow** now triggers on **`v*` tag push** (not `release: published`), builds a stapled update **ZIP** plus **`latest-mac.yml`** and a **blockmap** (with configurable rollout %), validates ZIP/DMG/tag/manifest alignment, and uses a **draft-first** publish path: create/resume draft, upload all four assets, wait for successful **`ci.yml` on `main` for the tagged commit**, then flip the release public—failed runs leave updaters blind. Homebrew cask bumps skip prerelease versions.
> 
> Supporting scripts extend version gates for update archives, generate updater metadata with electron-builder’s blockmap helper, and gate publication. Docs and broad tests cover publication retries, CI polling, differential-update artifacts, and MacUpdater quit races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a2f90bc3760dfef7b386d48b1940734019c108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->