### PR TITLE
fix(dashboard): close the settle window on cancel and on the updates half

### DIFF
--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -1501,6 +1501,48 @@ describe('Models page — the Install affordance', () => {
     expect(liveButtonLabels()).toContain('Update available');
   });
 
+  it('closes that window on the updates half too, when the catalog lands first', async () => {
+    // The verdict is a join of two independent responses, and the guard has to
+    // hold until BOTH have moved. `/catalog` is a worker route reading only the
+    // filesystem, while `/catalog/updates` may dial Hugging Face on a cold sha
+    // cache — so the catalog routinely wins, and on its own it lifts the guard
+    // over a remote sha resolved BEFORE the job ran. The card then offers
+    // "Update available" for the revision the job just installed, which is the
+    // pre-download verdict this mechanism exists to withhold.
+    const stale = catalogRoutes(
+      { present: false, installed: false, localRevision: null },
+      [downloadJob({ id: 'job-join', state: 'running' })],
+      { items: [{ hfRepo: REPO, remoteRevision: 'a'.repeat(40) }] },
+    );
+    // Upstream moved past what the job installed, so once BOTH bodies land there
+    // is a genuine update to offer — a suppression that never lifts fails here.
+    const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'b'.repeat(40) }, [], {
+      items: [{ hfRepo: REPO, remoteRevision: 'c'.repeat(40) }],
+    });
+    // Only the remote shas are held: the catalog arrives first, which is the
+    // whole point of the ordering under test.
+    const held = deferred(fresh['/catalog/updates']);
+    recordRequests({
+      ...stale,
+      '/models': sequence(stale['/models'], fresh['/models']),
+      '/catalog': sequence(stale['/catalog'], fresh['/catalog']),
+      '/catalog/updates': sequence(stale['/catalog/updates'], held.body),
+      '/downloads/job-join': { cancelled: true, id: 'job-join' },
+    });
+    await mountModels();
+
+    emitDownload('done', { id: 'job-join', outputDir: '/models/x' });
+    await settle();
+    // The fresh catalog HAS landed — `localRevision` is the installed one — but
+    // it is being compared against the sha from before the job.
+    expect(buttonLabels()).toContain('Update available');
+    expect(liveButtonLabels()).not.toContain('Update available');
+
+    held.release();
+    await settle();
+    expect(liveButtonLabels()).toContain('Update available');
+  });
+
   it('closes that window on a FIRST install too, where the stale body still says absent', async () => {
     // The same one render, reached from the other side: nothing was installed
     // before, so the stale body says `present: false` and the branch falls
@@ -1560,6 +1602,38 @@ describe('Models page — the Install affordance', () => {
     expect(liveButtonLabels()).toContain('Update available');
   });
 
+  it('closes the updates half for a job that settled while the page was away too', async () => {
+    // The reconcile effect records the pair from refs, not from the render, so
+    // its updates half needs its own gate. Same ordering as the live case: the
+    // filesystem catalog lands while the remote shas are still in flight.
+    const stale = catalogRoutes(
+      { present: false, installed: false, localRevision: null },
+      [downloadJob({ id: 'job-away2', state: 'done' })],
+      { items: [{ hfRepo: REPO, remoteRevision: 'a'.repeat(40) }] },
+    );
+    const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'b'.repeat(40) }, [], {
+      items: [{ hfRepo: REPO, remoteRevision: 'c'.repeat(40) }],
+    });
+    const held = deferred(fresh['/catalog/updates']);
+    recordRequests({
+      ...stale,
+      '/models': sequence(stale['/models'], fresh['/models']),
+      '/catalog': sequence(stale['/catalog'], fresh['/catalog']),
+      '/catalog/updates': sequence(stale['/catalog/updates'], held.body),
+      '/downloads/job-away2': { cancelled: true, id: 'job-away2' },
+    });
+    await mountModels();
+
+    // The installed revision is on screen, compared against the sha from before
+    // the job. That verdict must not be actionable.
+    expect(buttonLabels()).toContain('Update available');
+    expect(liveButtonLabels()).not.toContain('Update available');
+
+    held.release();
+    await settle();
+    expect(liveButtonLabels()).toContain('Update available');
+  });
+
   it('closes that window when the job settles as ERROR, which can still have installed', async () => {
     // `publish()` renames staging into place and only THEN removes the backup,
     // inside the job's try, so an `error` can name a model already on disk. That
@@ -1587,6 +1661,261 @@ describe('Models page — the Install affordance', () => {
       await settle();
       expect(buttonLabels()).toContain('Update available');
       expect(liveButtonLabels()).not.toContain('Update available');
+
+      held.release();
+      await settle();
+      expect(liveButtonLabels()).toContain('Update available');
+    } finally {
+      failed.mockRestore();
+    }
+  });
+
+  it('keeps following a job this page cancelled, so its terminal frame still lands', async () => {
+    // The server accepts a cancel while the in-flight job is still `running` and
+    // lets `processJob` emit the terminal frame as it unwinds, so the DELETE is
+    // acknowledged FIRST. Clearing `active` there unmounted `DownloadProgress`
+    // and closed its subscription before that frame arrived, so
+    // `onDownloadCancelled` never ran and nothing refreshed the snapshots — the
+    // card offered a live Install for whatever `recoverBackup` had restored,
+    // until the page was remounted.
+    //
+    // Refreshing at the acknowledgement instead does not fix it: recovery renames
+    // the crashed publish onto the final dir at `download.ts:868` and every
+    // cancel boundary comes after it, so a reload issued there can read the disk
+    // before the rename. Only the terminal frame proves the job is done with it.
+    const stale = catalogRoutes({ present: false, installed: false, localRevision: null }, [
+      downloadJob({ id: 'job-run', state: 'running' }),
+    ]);
+    const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
+      items: [{ hfRepo: REPO, remoteRevision: 'a'.repeat(40) }],
+    });
+    const calls = recordRequests({
+      ...stale,
+      '/models': sequence(stale['/models'], fresh['/models']),
+      '/catalog': sequence(stale['/catalog'], fresh['/catalog']),
+      '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
+      '/downloads/job-run': { cancelled: true, id: 'job-run' },
+    });
+    await mountModels();
+    const cancelButton = [...mounted!.container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Cancel'),
+    );
+    expect(cancelButton).toBeDefined();
+    await act(async () => {
+      cancelButton!.click();
+    });
+    await settle();
+    // Acknowledged: the Cancel is gone, because a second one answers 404 — but
+    // the card is still following the job, so nothing offers Install yet.
+    expect(dismissed(calls)).toEqual(['job-run']);
+    expect(buttonLabels()).not.toContain('Cancel');
+    expect(buttonLabels()).not.toContain('Install');
+    expect(gets(calls, '/api/catalog')).toBe(1);
+
+    // Only now does the unwinding job settle.
+    emitDownload('cancelled', { id: 'job-run' });
+    await settle();
+    expect(gets(calls, '/api/catalog')).toBe(2);
+    expect(gets(calls, '/api/models')).toBe(2);
+    expect(gets(calls, '/api/catalog/updates')).toBe(2);
+    expect(buttonLabels()).toContain('Installed');
+    expect(buttonLabels()).not.toContain('Install');
+  });
+
+  it('does not resurrect a cancelled job whose terminal frame beat the acknowledgement', async () => {
+    // The other order, and the server produces it: `cancel()` settles a QUEUED
+    // job inside itself, emitting the terminal frame BEFORE the route replies.
+    // `onDownloadCancelled` therefore clears the entry first, and the mark that
+    // follows must not put a half-built job back on the card.
+    const stale = catalogRoutes({ present: false, installed: false, localRevision: null }, [
+      downloadJob({ id: 'job-queued', state: 'running' }),
+    ]);
+    const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
+      items: [{ hfRepo: REPO, remoteRevision: 'a'.repeat(40) }],
+    });
+    const heldDelete = deferred({ cancelled: true, id: 'job-queued' });
+    recordRequests({
+      ...stale,
+      '/models': sequence(stale['/models'], fresh['/models']),
+      '/catalog': sequence(stale['/catalog'], fresh['/catalog']),
+      '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
+      '/downloads/job-queued': heldDelete.body,
+    });
+    await mountModels();
+    const cancelButton = [...mounted!.container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Cancel'),
+    );
+    await act(async () => {
+      cancelButton!.click();
+    });
+    // The frame lands while the DELETE is still in flight.
+    emitDownload('cancelled', { id: 'job-queued' });
+    await settle();
+    expect(buttonLabels()).toContain('Installed');
+
+    heldDelete.release();
+    await settle();
+    // Still settled: no progress card, no Cancel, no orphaned job.
+    expect(buttonLabels()).toContain('Installed');
+    expect(buttonLabels()).not.toContain('Cancel');
+  });
+
+  it('never marks a job the cancel did not name, when a new install beat the acknowledgement', async () => {
+    // The third order this page can produce, and the one the id guard is for.
+    // The terminal frame clears the entry, the user installs again, and only THEN
+    // does the DELETE for the FIRST job resolve. Marking whatever sits under the
+    // repo would put `cancelling` on the SECOND job — dropping the Cancel button
+    // for a job nobody cancelled, with no terminal frame coming to undo it.
+    //
+    // Hand-rolled rather than `recordRequests`, because the stub resolves a route
+    // by path alone: the POST that mints the second id and the GET that lists
+    // jobs share the `/downloads` key.
+    let releaseDelete!: () => void;
+    const heldDelete = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+    const routes = catalogRoutes({}, [downloadJob({ id: 'job-a', state: 'running' })]);
+    const subscribe = downloadSubscribeStub();
+    const { port1, port2 } = new MessageChannel();
+    port1.unref();
+    port2.unref();
+    const dispose = serveRuntimeOverPort(
+      {
+        call: async (call: ApiCall) => {
+          const path = call.path.replace(/^\/api/u, '');
+          if (call.method === 'POST' && path === '/downloads') {
+            return { ok: true as const, status: 202, body: { id: 'job-b', repo: REPO } };
+          }
+          if (call.method === 'DELETE' && path === '/downloads/job-a') {
+            await heldDelete;
+            return { ok: true as const, status: 200, body: { cancelled: true, id: 'job-a' } };
+          }
+          if (call.method === 'GET' && Object.hasOwn(routes, path)) {
+            return { ok: true as const, status: 200, body: routes[path] };
+          }
+          return { ok: false as const, status: 404, code: 'E_NOT_FOUND', message: `no stub for ${path}` };
+        },
+        subscribe,
+      },
+      bindEventTargetPort(port2),
+    );
+    connectDashboardApi(bindEventTargetPort(port1), { onUnresponsive: () => port2.close() });
+    restoreApi = () => {
+      disconnectDashboardApi();
+      dispose();
+      port1.close();
+      port2.close();
+    };
+
+    mounted = await renderPage(createElement(Models), (text) => text.includes(LABEL));
+    await settle();
+    const cancelButton = [...mounted.container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Cancel'),
+    );
+    expect(cancelButton).toBeDefined();
+    await act(async () => {
+      cancelButton!.click();
+    });
+    await settle();
+
+    // The first job settles while its own DELETE is still held.
+    emitDownload('cancelled', { id: 'job-a' });
+    await settle();
+    const install = [...mounted.container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Install'),
+    );
+    expect(install).toBeDefined();
+    // The refreshed bodies have landed, so the settle guard has already lifted.
+    expect(install!.disabled).toBe(false);
+    await act(async () => {
+      install!.click();
+    });
+    await settle();
+    expect(openedStreams.at(-1)).toBe('job-b');
+    expect(buttonLabels()).toContain('Cancel');
+
+    releaseDelete();
+    await settle();
+    // `job-b` was never cancelled, so it keeps its Cancel button.
+    expect(buttonLabels()).toContain('Cancel');
+  });
+
+  it('reloads the snapshots when a job settles as CANCELLED, which can still have installed', async () => {
+    // `cancelled` does not mean nothing reached disk. `processJob` runs
+    // `recoverBackup` BEFORE its first cancel boundary: a crashed publish left an
+    // owned backup under `.staging/<slug>.backup-<dead pid>-…`, and recovery
+    // renames it onto the final dir. Every cancel check comes after that, so a
+    // job cancelled anywhere in the fetch loop settles `cancelled` with a model
+    // installed the page's catalog body has never seen.
+    //
+    // Nothing else repairs it. No query polls, `downloads.reload` has no call
+    // site, and the reconcile effect runs only on mount and reconnect — so
+    // without a reload here the card offers Install for an installed model until
+    // the page is remounted.
+    const failed = vi.spyOn(toast, 'error');
+    try {
+      const stale = catalogRoutes({ present: false, installed: false, localRevision: null }, [
+        downloadJob({ id: 'job-run', state: 'running' }),
+      ]);
+      const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
+        items: [{ hfRepo: REPO, remoteRevision: 'a'.repeat(40) }],
+      });
+      const calls = recordRequests({
+        ...stale,
+        '/models': sequence(stale['/models'], fresh['/models']),
+        '/catalog': sequence(stale['/catalog'], fresh['/catalog']),
+        '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
+        '/downloads/job-run': { cancelled: true, id: 'job-run' },
+      });
+      await mountModels();
+      expect(buttonLabels()).toContain('Cancel');
+
+      emitDownload('cancelled', { id: 'job-run' });
+      await settle();
+      expect(gets(calls, '/api/catalog')).toBe(2);
+      expect(gets(calls, '/api/models')).toBe(2);
+      // The job resolved a fresh upstream sha at `processJob:877` and folded it
+      // into the server's cached map before it was cancelled, so this half is
+      // stale too — and it costs no new network call to move it.
+      expect(gets(calls, '/api/catalog/updates')).toBe(2);
+      expect(buttonLabels()).toContain('Installed');
+      expect(buttonLabels()).not.toContain('Install');
+      // Still silent: a cancel is not a failure, and whoever issued it already
+      // saw their own confirmation.
+      expect(failed.mock.calls).toEqual([]);
+    } finally {
+      failed.mockRestore();
+    }
+  });
+
+  it('closes that window when the job settles as CANCELLED too', async () => {
+    // The reload above opens the very window this suite exists for: `setActive`
+    // clears synchronously while the refreshed catalog is still in flight, so
+    // one committed render carries a live Install for the model `recoverBackup`
+    // just restored.
+    const failed = vi.spyOn(toast, 'error');
+    try {
+      const stale = catalogRoutes({ present: false, installed: false, localRevision: null }, [
+        downloadJob({ id: 'job-run', state: 'running' }),
+      ]);
+      // Upstream is ahead of the recovered bytes, so once the body lands there is
+      // a genuine update to offer — a suppression that never lifts kills it.
+      const fresh = catalogRoutes({ present: true, installed: true, localRevision: 'a'.repeat(40) }, [], {
+        items: [{ hfRepo: REPO, remoteRevision: 'b'.repeat(40) }],
+      });
+      const held = deferred(fresh['/catalog']);
+      recordRequests({
+        ...stale,
+        '/catalog': sequence(stale['/catalog'], held.body),
+        '/catalog/updates': sequence(stale['/catalog/updates'], fresh['/catalog/updates']),
+        '/downloads/job-run': { cancelled: true, id: 'job-run' },
+      });
+      await mountModels();
+
+      emitDownload('cancelled', { id: 'job-run' });
+      await settle();
+      expect(buttonLabels()).toContain('Install');
+      expect(liveButtonLabels()).not.toContain('Install');
 
       held.release();
       await settle();

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -69,6 +69,13 @@ function isTerminalJob(state: DownloadJob['state']): boolean {
 interface ActiveJob {
   id: string;
   committing: boolean;
+  /**
+   * This page's own cancel has been accepted, but the job has not emitted its
+   * terminal frame yet. Carried for the same reason as `committing`: the card
+   * drops its Cancel (a second one answers 404) while staying subscribed, so the
+   * frame still arrives and `onDownloadCancelled` can refresh the snapshots.
+   */
+  cancelling: boolean;
   /** Runtime generation that produced this id; ids do not survive a reconnect. */
   connection: number;
   /**
@@ -77,6 +84,16 @@ interface ActiveJob {
    * against the next authoritative snapshot.
    */
   source: 'local' | 'server';
+}
+
+/**
+ * The two response bodies a card's verdict is joined from, captured at the
+ * instant a job settled. Identity is the whole point: a reload replaces the
+ * object, so `!==` is "the refreshed body arrived".
+ */
+interface SettledBodies {
+  catalog: unknown;
+  updates: unknown;
 }
 
 function QuantBadge({ quant }: { quant: string | null }) {
@@ -206,15 +223,27 @@ export default function Models() {
    * identity no longer matching IS the refreshed catalog arriving; nothing has
    * to remember to clear it, and a reload that never returns cannot strand it
    * (a failed one renders the error card in place of the whole grid).
+   *
+   * BOTH bodies, because the verdict is a join of both and they arrive
+   * independently. `/catalog` is a worker route reading only the filesystem
+   * while `/catalog/updates` may have to dial Hugging Face on a cold sha cache,
+   * so the catalog routinely wins — and on its own it lifts the guard over a
+   * remote sha from before the job ran, which is the pre-download "Update
+   * available" this whole mechanism exists to withhold.
    */
-  const [settledOn, setSettledOn] = useState<ReadonlyMap<string, unknown>>(() => new Map());
+  const [settledOn, setSettledOn] = useState<ReadonlyMap<string, SettledBodies>>(() => new Map());
   /**
-   * The same body, reachable from the reconcile effect below. That effect cannot
-   * depend on `catalog.data`: it calls `reloadCatalog()`, so listing the body it
-   * produces would re-run the effect on arrival and reload forever.
+   * The same bodies, reachable from the reconcile effect below. That effect
+   * cannot depend on `catalog.data` or `updates.data`: it calls `reloadCatalog()`
+   * and `reloadUpdates()`, so listing the bodies they produce would re-run the
+   * effect on arrival and reload forever.
    */
   const catalogBody = useRef(catalog.data);
   catalogBody.current = catalog.data;
+  const updatesBody = useRef(updates.data);
+  updatesBody.current = updates.data;
+  /** The pair as it stands right now, for the three live settle handlers. */
+  const settledBodies = (): SettledBodies => ({ catalog: catalog.data, updates: updates.data });
 
   const [pendingDelete, setPendingDelete] = useState<LocalModel | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -258,6 +287,7 @@ export default function Models() {
         next[job.repo] = {
           id: job.id,
           committing: job.state === 'committing',
+          cancelling: false,
           connection,
           source: 'server',
         };
@@ -316,7 +346,10 @@ export default function Models() {
       // stale body offers a live button for work that has already finished.
       setSettledOn((prev) => {
         const next = new Map(prev);
-        for (const job of jobs) if (isTerminalJob(job.state)) next.set(job.repo, catalogBody.current);
+        for (const job of jobs) {
+          if (isTerminalJob(job.state))
+            next.set(job.repo, { catalog: catalogBody.current, updates: updatesBody.current });
+        }
         return next;
       });
       reloadModels();
@@ -338,7 +371,7 @@ export default function Models() {
       if (getConnectionGeneration() !== startedConnection) return;
       setActive((prev) => ({
         ...prev,
-        [repo]: { id: res.id, committing: false, connection: startedConnection, source: 'local' },
+        [repo]: { id: res.id, committing: false, cancelling: false, connection: startedConnection, source: 'local' },
       }));
     } catch (err) {
       toast.error('Failed to start download', { description: errMessage(err) });
@@ -361,7 +394,7 @@ export default function Models() {
     if (id !== undefined) {
       void mutate<CancelDownloadResponse>('DELETE', `/downloads/${encodeURIComponent(id)}`).catch(() => {});
     }
-    setSettledOn((prev) => new Map(prev).set(repo, catalog.data));
+    setSettledOn((prev) => new Map(prev).set(repo, settledBodies()));
     models.reload();
     catalog.reload();
     // The update comparison is a SEPARATE request, so it holds the pre-download
@@ -382,7 +415,7 @@ export default function Models() {
     // verdict in place would immediately re-offer "Update available" for it.
     // BOTH halves: the marker it must be compared against is `/catalog`'s
     // `localRevision`, so refreshing the remote shas alone repairs nothing.
-    setSettledOn((prev) => new Map(prev).set(repo, catalog.data));
+    setSettledOn((prev) => new Map(prev).set(repo, settledBodies()));
     catalog.reload();
     updates.reload();
     const id = active[repo]?.id;
@@ -412,6 +445,18 @@ export default function Models() {
    *
    * Silent, unlike `onDownloadError`. A cancel is not a failure, and whoever
    * issued it already got their own confirmation.
+   *
+   * It still refreshes, because `cancelled` does not mean nothing reached disk.
+   * `processJob` runs `recoverBackup` BEFORE its first cancel boundary: a
+   * crashed publish leaves an owned backup under `.staging/<slug>.backup-<pid>-…`
+   * and recovery renames it onto the final dir. Every cancel check comes after
+   * that, so a job cancelled anywhere in the fetch loop settles `cancelled` with
+   * a model installed that these snapshots have never seen — and nothing else
+   * repairs it, because the reconcile effect above runs only on mount and
+   * reconnect. All three move for the same reasons the other two settle paths
+   * give: `/models` lists the recovered checkpoint, `/catalog` carries the
+   * marker its verdict is computed from, and the job resolved a fresh upstream
+   * sha into the server's cached map before it was cancelled.
    */
   const onDownloadCancelled = (repo: string): void => {
     setActive((prev) => {
@@ -420,19 +465,41 @@ export default function Models() {
       delete next[repo];
       return next;
     });
+    setSettledOn((prev) => new Map(prev).set(repo, settledBodies()));
+    models.reload();
+    catalog.reload();
+    updates.reload();
   };
 
   const cancel = async (repo: string, id: string): Promise<void> => {
     try {
       await mutate<CancelDownloadResponse>('DELETE', `/downloads/${encodeURIComponent(id)}`);
       toast.success('Download cancelled', { description: repo });
-      // Mirror onDownloadError's reset: drop the active job so the card reverts to
-      // the Install state. Cancel only aborts the job (its staging cleans up); the
-      // shared HF cache is deliberately left intact for `mlx download` to resume.
+      // Keep following the job rather than dropping it here. The server accepts a
+      // cancel while the in-flight job is still `running` and lets `processJob`
+      // emit the terminal frame as it unwinds, so clearing `active` at this
+      // acknowledgement unmounts `DownloadProgress` and closes its subscription
+      // BEFORE that frame lands — and `onDownloadCancelled`, the one path that
+      // refreshes the snapshots, never runs at all.
+      //
+      // Refreshing here instead would not do: the unwind can still install.
+      // `recoverBackup` renames a crashed publish onto the final dir at
+      // download.ts:868 and every cancel boundary comes after it, so a reload
+      // issued now can read the disk before that rename. Only the terminal frame
+      // proves the job is done touching it.
+      //
+      // Marking rather than deleting is what keeps the stream open. It drops the
+      // Cancel button (a second cancel answers 404) and leaves the progress bar
+      // standing for the unwind, which is honest — the job is still running.
+      // Cancel only aborts the job (its staging cleans up); the shared HF cache
+      // is deliberately left intact for `mlx download` to resume.
       setActive((prev) => {
-        const next = { ...prev };
-        delete next[repo];
-        return next;
+        const job = prev[repo];
+        // A QUEUED job is settled inside `cancel()` itself, so its terminal frame
+        // can beat this acknowledgement and clear the entry first. Never put one
+        // back, and never mark a job this cancel did not name.
+        if (job === undefined || job.id !== id) return prev;
+        return { ...prev, [repo]: { ...job, cancelling: true } };
       });
     } catch (err) {
       toast.error('Failed to cancel download', { description: errMessage(err) });
@@ -641,7 +708,8 @@ export default function Models() {
               key={item.hfRepo}
               item={item}
               updateAvailable={hasUpdate(item, remoteRevisions)}
-              settling={settledOn.has(item.hfRepo) && settledOn.get(item.hfRepo) === catalog.data}
+              settling={settledOn.has(item.hfRepo) && settledOn.get(item.hfRepo)?.catalog === catalog.data}
+              updateSettling={settledOn.has(item.hfRepo) && settledOn.get(item.hfRepo)?.updates === updates.data}
               job={active[item.hfRepo]}
               onInstall={() => install(item.hfRepo)}
               onDone={() => onDownloadDone(item.hfRepo)}
@@ -733,6 +801,13 @@ interface CatalogCardProps {
    * arrived, so every field here still describes the state before the download.
    */
   settling: boolean;
+  /**
+   * The same, for the separately fetched remote shas {@link updateAvailable} is
+   * computed against. Gates only the update action: a failed `/catalog/updates`
+   * empties the sha map, so that branch is not rendered at all and this can
+   * never strand a button.
+   */
+  updateSettling: boolean;
   job: ActiveJob | undefined;
   onInstall: () => void;
   onDone: () => void;
@@ -745,6 +820,7 @@ function CatalogCard({
   item,
   updateAvailable,
   settling,
+  updateSettling,
   job,
   onInstall,
   onDone,
@@ -794,8 +870,11 @@ function CatalogCard({
             <DownloadProgress id={job.id} onDone={onDone} onError={onError} onCancelled={onCancelled} />
             {/* No Cancel while publishing: `cancel()` refuses a `committing` job
                 and the route 404s, so the button could only report a failure for
-                an install that then succeeds anyway. The progress bar stays. */}
-            {!job.committing && (
+                an install that then succeeds anyway. The progress bar stays.
+                Nor while `cancelling`: this page's cancel was already accepted
+                and the job is unwinding toward its terminal frame, so a second
+                one answers 404 too. */}
+            {!job.committing && !job.cancelling && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -811,7 +890,7 @@ function CatalogCard({
           // Same job pipeline as a first install: the runner already re-downloads
           // whenever the installed marker's revision differs from upstream, and
           // its owned-swap replaces the stale directory.
-          <Button className="w-full" onClick={onInstall} disabled={settling}>
+          <Button className="w-full" onClick={onInstall} disabled={settling || updateSettling}>
             <Download className="size-4" />
             Update available
           </Button>


### PR DESCRIPTION
Closes #137.

## What was already fixed

The issue names three settle paths. PR #136 (`92ef99aa`) landed **after** the
issue was filed and closed two of them with `settledOn` — a per-repo map holding
the `/catalog` body that was current when a job settled. The identity no longer
matching **is** the refreshed body arriving, so the guard is self-closing and
cannot strand a button.

```
              done          error         cancelled
#136 fixed:    ✅             ✅              ❌  records nothing, reloads nothing
guard covers:  /catalog      /catalog        —
missing:       /catalog/updates half on all three
```

The issue's "Testing gap" section is also stale: `deferred()` exists at
`__test__/render.ts:87`, and four `main` tests already assert inside the held
window.

## What this PR closes

**1. A cancelled job can have installed a model.**

`processJob` runs `recoverBackup` at `download.ts:867`, before its first cancel
boundary at `:942`. A crashed publish leaves an owned backup under
`.staging/<slug>.backup-<pid>-…`, and recovery renames it onto the final dir.
Every cancel check comes after that, so a job cancelled anywhere in the fetch
loop settles `cancelled` with a model on disk the page has never seen.

Nothing repaired it: no query polls, `downloads.reload` has no call site, and
the reconcile effect runs only on mount and reconnect.

**2. The page's own Cancel never reached that handler.**

The server accepts a cancel while the job is still `running` and lets
`processJob` emit the terminal frame as it unwinds (`download.ts:538-546`), so
the DELETE is acknowledged **first**. `cancel()` cleared `active` there, which
unmounted `DownloadProgress` and closed its subscription before the frame
arrived.

Refreshing at the acknowledgement instead does not work — recovery may not have
run yet. `cancel()` now marks the job `cancelling` and keeps it subscribed. The
card drops its Cancel (a second one 404s) and the terminal frame does the reset
and the refresh.

**3. `settledOn` guarded only the catalog body.**

The verdict is a join of two independent responses. `/catalog` is a worker route
reading only the filesystem; `/catalog/updates` may dial Hugging Face on a cold
sha cache. The catalog routinely wins, and on its own it lifted the guard over a
remote sha resolved before the job ran — so the card offered a **live** "Update
available" for the revision it had just installed. That is exactly the redundant
job #137 is about.

`settledOn` now holds both bodies. Only the update action is gated on both: a
failed `/catalog/updates` empties the sha map, so that branch is not rendered at
all and the guard can never strand a button.

## Verification

Every line mutation-checked. Each mutation was named and seen red:

| Mutation | Test that goes red |
| --- | --- |
| `settling={false}` | the 4 pre-existing #136 window tests |
| no `setSettledOn` on cancel | closes that window … CANCELLED too |
| no reloads on cancel | both cancelled tests |
| drop `models`/`catalog`/`updates` each | the matching GET count |
| `cancel()` deletes from `active` | keeps following a job this page cancelled |
| card keeps Cancel while `cancelling` | same |
| drop the id guard in `cancel()` | never marks a job the cancel did not name |
| update button ignores `updateSettling` | updates half, catalog lands first |
| reconcile records no updates body | updates half, settled while away |
| live handlers record no updates body | updates half, catalog lands first |

The id-guard row needed a **new** test. The third cancel order — terminal frame,
then a fresh install, then the first job's acknowledgement — had no coverage, so
dropping `job.id !== id` left the suite green while marking the **second** job
`cancelling` and dropping a Cancel nobody asked for.

- `vp test packages/dashboard --run` — 555 passed (26 files)
- `yarn typecheck` — clean
- `vp lint packages/dashboard --type-aware --type-check` — clean

## Out of scope

`onDownloadError` reloads `catalog` + `updates` but not `models`, unlike
`onDownloadDone`. That is a pre-existing stale-table defect on a different
surface, not this window. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm8vcCjeJJ28Bi7ys2utbA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes download/cancel state machines and when catalog actions are clickable; race-sensitive but scoped to the Models UI with broad new integration tests.
> 
> **Overview**
> Fixes the Models page **post-download settle window** so Install/Update actions stay disabled until both **`/catalog` and `/catalog/updates`** have refreshed, and so **user-initiated cancel** stays subscribed until the job’s terminal stream event.
> 
> **Settle guard:** `settledOn` now snapshots **both** response bodies; cards get `updateSettling` so **Update available** stays disabled if the filesystem catalog lands before stale remote SHAs. Live settle handlers and the downloads reconcile path record the same pair.
> 
> **Cancel:** `cancel()` marks the job **`cancelling`** (id-checked) instead of removing it from `active`, hides Cancel while unwinding, and **`onDownloadCancelled`** reloads models/catalog/updates and applies the same settle guard—covering cancels that may still leave a model on disk.
> 
> **Tests:** New `pages.test.ts` cases for catalog-first vs updates-first ordering, cancel acknowledgement vs terminal-frame races, and mistaken `cancelling` on a replacement job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c7f73de5ff8a918d525e40726865b162f291cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->