### PR TITLE
feat: recommend and auto-load Qwen3.8 DFlash2 companions

### DIFF
--- a/__test__/models/model-loader-registry.test.ts
+++ b/__test__/models/model-loader-registry.test.ts
@@ -201,6 +201,23 @@ describe.sequential('declarative model loader registry', () => {
     expect(loadSpy).toHaveBeenCalledWith(tempDir, { draftModelPath: '/tmp/dflash2' });
   });
 
+  it('auto-loads a Qwen draft unless discovery is disabled or an explicit path wins', async () => {
+    await writeConfig({ model_type: 'qwen3_5' });
+    const draft = join(tempDir, 'draft');
+    await mkdir(draft);
+    await writeFile(join(draft, 'config.json'), JSON.stringify({ architectures: ['DFlash2DraftModel'] }));
+    await writeFile(join(draft, 'model.safetensors'), 'weights');
+    const loadSpy = vi.spyOn(Qwen35Model, 'load').mockResolvedValue({} as never);
+    await loadModel(tempDir);
+    expect(loadSpy).toHaveBeenLastCalledWith(tempDir, { draftModelPath: draft });
+    await loadSession(tempDir);
+    expect(loadSpy).toHaveBeenLastCalledWith(tempDir, { draftModelPath: draft });
+    await loadModel(tempDir, { autoLoadDraft: false });
+    expect(loadSpy).toHaveBeenLastCalledWith(tempDir, null);
+    await loadModel(tempDir, { draftModelPath: '/explicit/draft', autoLoadDraft: false });
+    expect(loadSpy).toHaveBeenLastCalledWith(tempDir, { draftModelPath: '/explicit/draft' });
+  });
+
   it('loads Muse-Glimmer through its streaming wrapper', async () => {
     await writeConfig({ model_type: 'muse_glimmer' });
     const loadedModel = { model: 'muse_glimmer' };

--- a/__test__/server/host/discover.test.ts
+++ b/__test__/server/host/discover.test.ts
@@ -43,6 +43,12 @@ describe('discoverModels', () => {
     expect(got[0].path.endsWith('qwen3.5-demo')).toBe(true);
   });
 
+  it('keeps draft companions out of the server model picker', async () => {
+    makeModel('qwen3.8-27b-dflash2', { model_type: 'qwen3', architectures: ['DFlash2DraftModel'] });
+    makeModel('qwen3.8-27b-mxfp4-mlx', { model_type: 'qwen3_5' });
+    expect((await discoverModels(root)).map((model) => model.name)).toEqual(['qwen3.8-27b-mxfp4-mlx']);
+  });
+
   it('filters out Harrier (non-generative) model entries', async () => {
     // NOTE: two guards produce this result — the explicit NON_GENERATIVE set and
     // the no-launch-preset skip. `harrier` trips both, so this assertion cannot

--- a/__test__/server/host/inference-host.test.ts
+++ b/__test__/server/host/inference-host.test.ts
@@ -5,7 +5,7 @@ import { createServer as createNetServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { LoadableModel } from '@mlx-node/lm';
+import type { LoadableModel, LoadModelOptions } from '@mlx-node/lm';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 
 import { isServingStatus } from '../../../packages/desktop/src/main/supervisor/state.js';
@@ -502,6 +502,28 @@ describe('createInferenceHost — a tokenized host still answers the supervisor'
 });
 
 describe('createInferenceHost — out-of-band loadModel', () => {
+  it('finds a newly downloaded shared draft before applying the target config overlay', async () => {
+    const name = 'qwen3.8-27b-mxfp4-mlx';
+    const modelsDir = await makeModelsDir([name]);
+    const calls: Array<{ path: string; options?: LoadModelOptions }> = [];
+    const host = await start({
+      modelsDir,
+      loadModel: async (path, options) => {
+        calls.push({ path, options });
+        return fakeModel();
+      },
+    });
+    const draft = join(modelsDir, 'qwen3.8-27b-dflash2');
+    await mkdir(draft);
+    await writeFile(join(draft, 'config.json'), JSON.stringify({ architectures: ['DFlash2DraftModel'] }));
+    await writeFile(join(draft, 'model.safetensors'), 'weights');
+    await host.loadModel(name);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options).toEqual({ draftModelPath: draft });
+    expect(calls[0].path).not.toBe(join(modelsDir, name));
+    expect(host.health().models.resident).toEqual([name]);
+  });
+
   it('makes the model resident and records the load on /health', async () => {
     const modelsDir = await makeModelsDir(['alpha', 'beta']);
     const host = await start({ modelsDir });

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -623,7 +623,21 @@ Almost every flag belongs to pi and is forwarded verbatim; `mlx agent` only hand
 
 `mlx agent` discovers local models under the resolved models directory (`--models-dir <dir>`, else `MLX_MODELS_DIR`, else `modelsDir` in `~/.mlx-node/config.json`, else `~/.mlx-node/models`). A dash-leading path must use the `--models-dir=<dir>` form so it is not mistaken for another flag. Dense Qwen3.5/Qwen3.8 `Q<number>_K_XL.gguf` targets are also discovered when placed directly in that directory or one level inside a downloaded GGUF repository; each appears under its filename stem. Other GGUF variants and companion files such as imatrix, mmproj, draft, or DFlash2-only checkpoints are not advertised as agent models.
 
-To pair an XL GGUF target with DFlash2 automatically, use the mlx-node agent's embedded `draft/` convention:
+Qwen3.8-27B can use the separate [DFlash2 companion](https://huggingface.co/z-lab/Qwen3.8-27B-DFlash2)
+(about 3.85 GB). Install it from the desktop Models page, or download it separately:
+
+```bash
+mlx download model -m z-lab/Qwen3.8-27B-DFlash2 -o ~/.mlx-node/models/qwen3.8-27b-dflash2
+```
+
+Keep this directory beside your `Qwen3.8-27B*` target directory or GGUF repository.
+The agent, desktop server, and `loadModel` / `loadSession` detect it automatically on
+the next model load. One companion serves multiple Qwen3.8-27B quantizations;
+it is never listed as a standalone chat model. Detection checks the draft config
+and weight file before pairing; the native loader validates the tensors against
+the target. It does not attach this shared draft to Qwen3.5 or MoE targets.
+
+An embedded `draft/` takes precedence over the shared companion:
 
 ```text
 ~/.mlx-node/models/qwen38-q4xl/
@@ -637,6 +651,11 @@ To pair an XL GGUF target with DFlash2 automatically, use the mlx-node agent's e
 ```
 
 The root config and tokenizer files belong to the Qwen3.8 target. `draft/config.json` must declare `DFlash2DraftModel` in `architectures`; the draft weights stay in that directory exactly as published by z-lab. `draft/` may be a symlink to an existing local Hugging Face checkout. The agent advertises only `mlx/Qwen3.8-27B-UD-Q4_K_XL`, then passes `draft/` to the loader when that target becomes resident. mlx-vlm itself has no equivalent combined layout: it receives the same two paths explicitly through `--model` and `--draft-model`.
+
+For SDK callers, an explicit `draftModelPath` wins over discovery. Set
+`autoLoadDraft: false` to load without an automatically discovered Qwen draft.
+DFlash2 uses the flat speculative cache lane; downloading it does not promise
+a speedup for every workload, and an already resident model is not changed mid-session.
 
 On a fresh run (no explicit `--model`/`--provider`/session flag), it injects the first discovered local model — honoring a persisted `/model` pick when that model is still present — so ambient cloud credentials (e.g. a stray `GROQ_API_KEY`) never win over the local model this command promises.
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -60,8 +60,9 @@ const runtime = createDashboardRuntime({ modelsDir, dbPath });
 | Metrics        | Tokens/day (in/out/cached), tok/s + TTFT per model, MTP acceptance, model share                         | date range                                                               |
 | Cache          | Cold-tier disk usage vs quota, entry count + age histogram, hit/miss trend                              | clear all, evict older-than-N-days                                       |
 
-The Models page recommends an optional **DFlash2 for Qwen3.8-27B** download
-separately from the target. Its roughly 3.85 GB of weights install once as
+The Qwen3.8-27B download card groups an optional **DFlash2** companion beneath
+the target download, with a divider and its own install button. The roughly
+3.85 GB checkpoint is installed once as
 `qwen3.8-27b-dflash2` in the configured models directory. Compatible Qwen3.8-27B
 targets find it automatically on their next load. The companion has its own
 download progress, cancel, and update controls; it is not another chat model.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -60,6 +60,12 @@ const runtime = createDashboardRuntime({ modelsDir, dbPath });
 | Metrics        | Tokens/day (in/out/cached), tok/s + TTFT per model, MTP acceptance, model share                         | date range                                                               |
 | Cache          | Cold-tier disk usage vs quota, entry count + age histogram, hit/miss trend                              | clear all, evict older-than-N-days                                       |
 
+The Models page recommends an optional **DFlash2 for Qwen3.8-27B** download
+separately from the target. Its roughly 3.85 GB of weights install once as
+`qwen3.8-27b-dflash2` in the configured models directory. Compatible Qwen3.8-27B
+targets find it automatically on their next load. The companion has its own
+download progress, cancel, and update controls; it is not another chat model.
+
 ## Data sources
 
 All state lives on disk; SQLite is only an index.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -66,6 +66,10 @@ the target download, with a divider and its own install button. The roughly
 `qwen3.8-27b-dflash2` in the configured models directory. Compatible Qwen3.8-27B
 targets find it automatically on their next load. The companion has its own
 download progress, cancel, and update controls; it is not another chat model.
+Draft-only checkpoints are excluded from the local-model table and model counts.
+Their bytes still contribute to disk usage on Models and Overview. Expand
+**Companion weights** in the local storage panel to inspect or delete them;
+deleting a separate companion leaves the target model in place.
 
 ## Data sources
 

--- a/packages/agent/__test__/model-host.test.ts
+++ b/packages/agent/__test__/model-host.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { LoadableModel } from '@mlx-node/lm';
+import type { LoadableModel, LoadModelOptions } from '@mlx-node/lm';
 import { ChatSession } from '@mlx-node/lm';
 import { describe, expect, it, vi } from 'vite-plus/test';
 
@@ -59,7 +59,7 @@ describe('MlxModelHost', () => {
     expect(host.residentId).toBe('qwen-small');
   });
 
-  it('loads an auto-discovered DFlash2 companion with its Qwen target', async () => {
+  it('forwards a supplied DFlash2 companion with its Qwen target', async () => {
     const root = mkdtempSync(join(tmpdir(), 'mlx-host-draft-'));
     const draft = join(root, 'draft');
     mkdirSync(draft);
@@ -77,10 +77,6 @@ describe('MlxModelHost', () => {
     try {
       await getSession(host, model.name);
       expect(loader).toHaveBeenCalledWith(model.path, { draftModelPath: draft });
-      rmSync(draft, { recursive: true });
-      host.invalidateResident(model.name);
-      await getSession(host, model.name);
-      expect(loader).toHaveBeenLastCalledWith(model.path);
     } finally {
       host.invalidateResident(model.name);
       rmSync(root, { recursive: true, force: true });
@@ -109,6 +105,38 @@ describe('MlxModelHost', () => {
       host.invalidateResident(model.name);
       await getSession(host, model.name);
       expect(loader).toHaveBeenLastCalledWith('/paged/overlay', { draftModelPath: draft });
+      rmSync(draft, { recursive: true });
+      host.invalidateResident(model.name);
+      await getSession(host, model.name);
+      expect(loader).toHaveBeenLastCalledWith('/paged/overlay');
+    } finally {
+      host.invalidateResident(model.name);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves native validation errors for an explicit Qwen draft even when a shared companion exists', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'mlx-host-explicit-draft-'));
+    const shared = join(root, 'qwen3.8-27b-dflash2');
+    mkdirSync(shared);
+    writeFileSync(join(shared, 'config.json'), JSON.stringify({ architectures: ['DFlash2DraftModel'] }));
+    writeFileSync(join(shared, 'model.safetensors'), 'weights');
+    const model: DiscoveredModelLike = {
+      name: 'qwen',
+      path: join(root, 'qwen3.8-27b-mxfp4-mlx'),
+      modelType: 'qwen3_5',
+      draftModelPath: join(root, 'missing-explicit-draft'),
+    };
+    const failure = new Error('native draft validation failed');
+    const loader = vi.fn(async (_path: string, options?: LoadModelOptions) => {
+      if (options?.draftModelPath === model.draftModelPath) throw failure;
+      return {} as LoadableModel;
+    });
+    const host = new MlxModelHost([model], { loadModelFn: loader });
+    try {
+      await expect(getSession(host, model.name)).rejects.toBe(failure);
+      expect(loader).toHaveBeenCalledExactlyOnceWith(model.path, { draftModelPath: model.draftModelPath });
+      expect(host.residentId).toBeNull();
     } finally {
       host.invalidateResident(model.name);
       rmSync(root, { recursive: true, force: true });
@@ -160,22 +188,27 @@ describe('MlxModelHost', () => {
     expect(host.residentId).toBe('qwen-small');
   });
 
-  it('allows Gemma4 with an attached draft to use its flat speculative executor', async () => {
-    const loader = vi.fn(
-      async () =>
-        ({
-          hasBlockPagedCache: () => false,
-          hasMtpWeights: () => true,
-        }) as unknown as LoadableModel,
-    );
-    const host = new MlxModelHost(MODELS, {
-      loadModelFn: loader,
-      requirePagedCache: true,
-    });
+  it.each(['dspark', 'assistant'])(
+    'forwards an explicit Gemma4 %s draft to its flat speculative executor',
+    async (kind) => {
+      const loader = vi.fn(
+        async () =>
+          ({
+            hasBlockPagedCache: () => false,
+            hasMtpWeights: () => true,
+          }) as unknown as LoadableModel,
+      );
+      const model = { ...MODELS[1], draftModelPath: `/drafts/gemma4-${kind}` };
+      const host = new MlxModelHost([model], {
+        loadModelFn: loader,
+        requirePagedCache: true,
+      });
 
-    await expect(getSession(host, 'gemma-mid')).resolves.toBeInstanceOf(ChatSession);
-    expect(host.residentId).toBe('gemma-mid');
-  });
+      await expect(getSession(host, 'gemma-mid')).resolves.toBeInstanceOf(ChatSession);
+      expect(loader).toHaveBeenCalledExactlyOnceWith(model.path, { draftModelPath: model.draftModelPath });
+      expect(host.residentId).toBe('gemma-mid');
+    },
+  );
 
   it('rejects Qwen3.5 MoE MTP rather than silently routing a paged session through AR', async () => {
     const loader = vi.fn(

--- a/packages/agent/__test__/model-host.test.ts
+++ b/packages/agent/__test__/model-host.test.ts
@@ -1,3 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import type { LoadableModel } from '@mlx-node/lm';
 import { ChatSession } from '@mlx-node/lm';
 import { describe, expect, it, vi } from 'vite-plus/test';
@@ -56,18 +60,59 @@ describe('MlxModelHost', () => {
   });
 
   it('loads an auto-discovered DFlash2 companion with its Qwen target', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'mlx-host-draft-'));
+    const draft = join(root, 'draft');
+    mkdirSync(draft);
+    writeFileSync(join(draft, 'config.json'), JSON.stringify({ architectures: ['DFlash2DraftModel'] }));
+    writeFileSync(join(draft, 'model.safetensors'), 'weights');
     const loader = vi.fn(async () => ({ hasBlockPagedCache: () => true }) as unknown as LoadableModel);
     const model: DiscoveredModelLike = {
       name: 'qwen38-q4xl',
       path: '/models/qwen38-q4xl/Qwen3.8-27B-UD-Q4_K_XL.gguf',
       modelType: 'qwen3_5',
-      draftModelPath: '/models/qwen38-q4xl/draft',
+      draftModelPath: draft,
     };
     const host = new MlxModelHost([model], { loadModelFn: loader, requirePagedCache: true });
 
-    await getSession(host, model.name);
+    try {
+      await getSession(host, model.name);
+      expect(loader).toHaveBeenCalledWith(model.path, { draftModelPath: draft });
+      rmSync(draft, { recursive: true });
+      host.invalidateResident(model.name);
+      await getSession(host, model.name);
+      expect(loader).toHaveBeenLastCalledWith(model.path);
+    } finally {
+      host.invalidateResident(model.name);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 
-    expect(loader).toHaveBeenCalledWith(model.path, { draftModelPath: model.draftModelPath });
+  it('finds a newly downloaded shared draft before resolving a paged overlay', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'mlx-host-shared-draft-'));
+    const model: DiscoveredModelLike = {
+      name: 'qwen',
+      path: join(root, 'qwen3.8-27b-mxfp4-mlx'),
+      modelType: 'qwen3_5',
+    };
+    const loader = makeLoader();
+    const host = new MlxModelHost([model], {
+      loadModelFn: loader,
+      resolveModelPathFn: async () => '/paged/overlay',
+    });
+    try {
+      await getSession(host, model.name);
+      expect(loader).toHaveBeenLastCalledWith('/paged/overlay');
+      const draft = join(root, 'qwen3.8-27b-dflash2');
+      mkdirSync(draft);
+      writeFileSync(join(draft, 'config.json'), JSON.stringify({ architectures: ['DFlash2DraftModel'] }));
+      writeFileSync(join(draft, 'model.safetensors'), 'weights');
+      host.invalidateResident(model.name);
+      await getSession(host, model.name);
+      expect(loader).toHaveBeenLastCalledWith('/paged/overlay', { draftModelPath: draft });
+    } finally {
+      host.invalidateResident(model.name);
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('forwards the loaded model image capability through ChatSession', async () => {

--- a/packages/agent/__test__/models.test.ts
+++ b/packages/agent/__test__/models.test.ts
@@ -200,6 +200,29 @@ describe('discoverMlxModels', () => {
     expect(await discoverMlxModels(join(modelsDir, 'does-not-exist'))).toEqual([]);
   });
 
+  it('pairs shared draft weights with Qwen3.8 variants without exposing a draft model', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'mlx-shared-dflash-'));
+    try {
+      const target = join(root, 'qwen3.8-27b-mxfp4-mlx');
+      const draft = join(root, 'qwen3.8-27b-dflash2');
+      await mkdir(target);
+      await mkdir(draft);
+      await writeFile(join(target, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
+      await writeFile(
+        join(draft, 'config.json'),
+        JSON.stringify({ model_type: 'qwen3', architectures: ['DFlash2DraftModel'] }),
+      );
+      await writeFile(join(draft, 'model.safetensors'), 'weights');
+      await writeFile(join(root, 'Qwen3.8-27B-UD-Q4_K_XL.gguf'), minimalGguf('qwen35'));
+      const models = await discoverMlxModels(root);
+      expect(models).toHaveLength(2);
+      expect(models.every((model) => model.discovered.draftModelPath === draft)).toBe(true);
+      expect(models.some((model) => model.discovered.path === draft)).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('discovers every nested Q<number>_K_XL target by its direct GGUF path', async () => {
     const root = await mkdtemp(join(tmpdir(), 'mlx-agent-xl-gguf-'));
     try {

--- a/packages/agent/__test__/models.test.ts
+++ b/packages/agent/__test__/models.test.ts
@@ -2,8 +2,10 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+import type { LoadableModel } from '@mlx-node/lm';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
 
+import { MlxModelHost } from '../src/provider/model-host.js';
 import { discoverMlxModels, type MlxModelInfo } from '../src/provider/models.js';
 
 let modelsDir: string;
@@ -200,7 +202,7 @@ describe('discoverMlxModels', () => {
     expect(await discoverMlxModels(join(modelsDir, 'does-not-exist'))).toEqual([]);
   });
 
-  it('pairs shared draft weights with Qwen3.8 variants without exposing a draft model', async () => {
+  it('discovers Qwen3.8 variants without persisting automatic draft paths or exposing a draft model', async () => {
     const root = await mkdtemp(join(tmpdir(), 'mlx-shared-dflash-'));
     try {
       const target = join(root, 'qwen3.8-27b-mxfp4-mlx');
@@ -216,12 +218,71 @@ describe('discoverMlxModels', () => {
       await writeFile(join(root, 'Qwen3.8-27B-UD-Q4_K_XL.gguf'), minimalGguf('qwen35'));
       const models = await discoverMlxModels(root);
       expect(models).toHaveLength(2);
-      expect(models.every((model) => model.discovered.draftModelPath === draft)).toBe(true);
+      expect(models.every((model) => model.discovered.draftModelPath === undefined)).toBe(true);
       expect(models.some((model) => model.discovered.path === draft)).toBe(false);
     } finally {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it.each(['safetensors', 'top-level GGUF', 'nested GGUF', 'embedded draft'] as const)(
+    'rechecks the %s companion after discovery and on each model swap',
+    async (layout) => {
+      const root = await mkdtemp(join(tmpdir(), 'mlx-agent-draft-lifecycle-'));
+      const repo = join(root, 'qwen3.8-27b');
+      const filename = 'Qwen3.8-27B-UD-Q4_K_XL.gguf';
+      const target = layout === 'safetensors' ? repo : join(layout === 'top-level GGUF' ? root : repo, filename);
+      const draft = layout === 'embedded draft' ? join(repo, 'draft') : join(root, 'qwen3.8-27b-dflash2');
+      try {
+        if (layout !== 'top-level GGUF') {
+          await mkdir(repo);
+          await writeFile(join(repo, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
+        }
+        if (layout === 'safetensors') {
+          await writeFile(join(repo, 'model.safetensors'), 'target weights');
+        } else {
+          await writeFile(target, minimalGguf('qwen35'));
+        }
+        await mkdir(draft);
+        await writeFile(
+          join(draft, 'config.json'),
+          JSON.stringify({ model_type: 'qwen3', architectures: ['DFlash2DraftModel'] }),
+        );
+        await writeFile(join(draft, 'model.safetensors'), 'draft weights');
+        // Use the real startup discovery record: hand-built records would miss
+        // the stale automatic path that previously became authoritative here.
+        const models = await discoverMlxModels(root);
+        expect(models).toHaveLength(1);
+        const model = models[0]!.discovered;
+        const loader = vi.fn(async (path: string) => ({ fakeModelFor: path }) as unknown as LoadableModel);
+        const host = new MlxModelHost(
+          [...models.map((info) => info.discovered), { name: 'other', path: '/models/other', modelType: 'qwen3' }],
+          { loadModelFn: loader, resolveModelPathFn: async (entry) => `/paged/${entry.name}` },
+        );
+        const loadTarget = () => host.runWithResident(model.name, async () => undefined);
+        const swapAway = () => host.runWithResident('other', async () => undefined);
+
+        // A partial companion before the first load must not prevent target use.
+        await rm(join(draft, 'model.safetensors'));
+        await loadTarget();
+        expect(loader).toHaveBeenLastCalledWith(`/paged/${model.name}`);
+
+        // Restoring it is picked up from the original target, not the overlay.
+        await writeFile(join(draft, 'model.safetensors'), 'draft weights');
+        await swapAway();
+        await loadTarget();
+        expect(loader).toHaveBeenLastCalledWith(`/paged/${model.name}`, { draftModelPath: draft });
+
+        // Deleting a previously loaded companion must not poison a later swap.
+        await swapAway();
+        await rm(draft, { recursive: true });
+        await loadTarget();
+        expect(loader).toHaveBeenLastCalledWith(`/paged/${model.name}`);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('discovers every nested Q<number>_K_XL target by its direct GGUF path', async () => {
     const root = await mkdtemp(join(tmpdir(), 'mlx-agent-xl-gguf-'));
@@ -258,13 +319,11 @@ describe('discoverMlxModels', () => {
           name: 'Qwen3.8-27B-UD-Q3_K_XL',
           path: join(repo, 'Qwen3.8-27B-UD-Q3_K_XL.gguf'),
           modelType: 'qwen3_5',
-          draftModelPath: draft,
         },
         {
           name: 'Qwen3.8-27B-UD-Q4_K_XL',
           path: join(repo, 'Qwen3.8-27B-UD-Q4_K_XL.gguf'),
           modelType: 'qwen3_5',
-          draftModelPath: draft,
         },
       ]);
       expect(discovered.map((model) => model.piModel.contextWindow)).toEqual([65536, 65536]);

--- a/packages/agent/__test__/models.test.ts
+++ b/packages/agent/__test__/models.test.ts
@@ -350,6 +350,31 @@ describe('discoverMlxModels', () => {
     }
   });
 
+  it('does not attach a companion outside the store when loading a discovered top-level GGUF', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'mlx-agent-companion-boundary-'));
+    try {
+      const store = join(root, 'models');
+      await mkdir(store);
+      const gguf = join(store, 'Qwen3.8-27B-UD-Q4_K_XL.gguf');
+      await writeFile(gguf, minimalGguf('qwen35'));
+      const outside = join(root, 'qwen3.8-27b-dflash2');
+      await mkdir(outside);
+      await writeFile(join(outside, 'config.json'), JSON.stringify({ architectures: ['DFlash2DraftModel'] }));
+      await writeFile(join(outside, 'model.safetensors'), 'draft weights');
+      const models = await discoverMlxModels(store);
+      expect(models).toHaveLength(1);
+      const loader = vi.fn(async () => ({}) as LoadableModel);
+      const host = new MlxModelHost(
+        models.map((model) => model.discovered),
+        { loadModelFn: loader },
+      );
+      await host.runWithResident(models[0]!.discovered.name, async () => undefined);
+      expect(loader).toHaveBeenCalledExactlyOnceWith(gguf);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('does not advertise DFlash2 companions or XL files from unsupported direct-GGUF families', async () => {
     const root = await mkdtemp(join(tmpdir(), 'mlx-agent-nontarget-gguf-'));
     try {

--- a/packages/agent/src/catalog.ts
+++ b/packages/agent/src/catalog.ts
@@ -6,6 +6,8 @@
  * HF account — use them verbatim.
  */
 
+import { QWEN38_DFLASH2 } from '@mlx-node/lm/draft-companion';
+
 export interface CatalogEntry {
   /** Wizard display name. */
   label: string;
@@ -20,6 +22,8 @@ export interface CatalogEntry {
   hfRepoCuda?: string;
   /** Approximate download size in GB, for display. */
   sizeGb: number;
+  /** Optional companion, downloaded separately and never offered as a chat model. */
+  draft?: { label: string; hfRepo: string; sizeGb: number };
   /** One line for the wizard. */
   description: string;
   /** Exactly one entry carries this. */
@@ -50,6 +54,7 @@ export const MODEL_CATALOG: readonly CatalogEntry[] = [
     sizeGb: 23.3,
     description: 'Best tool use — recommended default',
     isDefault: true,
+    draft: QWEN38_DFLASH2,
   },
   {
     label: 'Qwen-AgentWorld-35B',
@@ -101,6 +106,17 @@ export const MODEL_CATALOG: readonly CatalogEntry[] = [
     hidden: true,
   },
 ];
+
+/** Visible target repos plus their optional companion downloads. */
+export function catalogDownloadRepos(): string[] {
+  return [
+    ...new Set(
+      MODEL_CATALOG.filter((entry) => !entry.hidden).flatMap((entry) =>
+        entry.draft === undefined ? [catalogRepo(entry)] : [catalogRepo(entry), entry.draft.hfRepo],
+      ),
+    ),
+  ];
+}
 
 /**
  * The repo THIS platform installs for `entry`. Linux is the CUDA preview

--- a/packages/agent/src/provider/model-host.ts
+++ b/packages/agent/src/provider/model-host.ts
@@ -14,7 +14,7 @@
  */
 
 import { ChatSession, loadModel, type SessionCapableModel } from '@mlx-node/lm';
-import { findDFlash2Draft, isDFlash2Companion } from '@mlx-node/lm/draft-companion';
+import { findDFlash2Draft } from '@mlx-node/lm/draft-companion';
 
 import { COLD_TIER_RESTORE_FAMILIES } from '../cold-tier.js';
 import type { DiscoveredModelLike } from '../types.js';
@@ -170,13 +170,10 @@ export class MlxModelHost {
           ? await this.resolveModelPathFn(entry, { persistPagedCache: this.persistPagedCache })
           : await this.resolveModelPathFn(entry);
         // Preserve the ordinary one-argument call for unpaired checkpoints.
-        // A discovered DFlash2 companion is an explicit load option rather
-        // than a second advertised model: target and draft become one
-        // resident session and the native loader validates their compatibility.
-        const draftModelPath =
-          entry.draftModelPath !== undefined && isDFlash2Companion(entry.draftModelPath)
-            ? entry.draftModelPath
-            : findDFlash2Draft(entry.path, entry.modelType);
+        // Supplied paths are authoritative across draft families. Let the
+        // loader validate them and report errors; only absent paths opt into
+        // Qwen DFlash2 discovery, resolved against the original target path.
+        const draftModelPath = entry.draftModelPath ?? findDFlash2Draft(entry.path, entry.modelType);
         const model =
           draftModelPath === undefined
             ? await this.loadModelFn(resolvedPath)

--- a/packages/agent/src/provider/model-host.ts
+++ b/packages/agent/src/provider/model-host.ts
@@ -14,6 +14,7 @@
  */
 
 import { ChatSession, loadModel, type SessionCapableModel } from '@mlx-node/lm';
+import { findDFlash2Draft, isDFlash2Companion } from '@mlx-node/lm/draft-companion';
 
 import { COLD_TIER_RESTORE_FAMILIES } from '../cold-tier.js';
 import type { DiscoveredModelLike } from '../types.js';
@@ -172,10 +173,14 @@ export class MlxModelHost {
         // A discovered DFlash2 companion is an explicit load option rather
         // than a second advertised model: target and draft become one
         // resident session and the native loader validates their compatibility.
+        const draftModelPath =
+          entry.draftModelPath !== undefined && isDFlash2Companion(entry.draftModelPath)
+            ? entry.draftModelPath
+            : findDFlash2Draft(entry.path, entry.modelType);
         const model =
-          entry.draftModelPath === undefined
+          draftModelPath === undefined
             ? await this.loadModelFn(resolvedPath)
-            : await this.loadModelFn(resolvedPath, { draftModelPath: entry.draftModelPath });
+            : await this.loadModelFn(resolvedPath, { draftModelPath });
         const sessionModel = model as unknown as SessionCapableModel;
         const gemmaDraftActive = entry.modelType === 'gemma4' && sessionModel.hasMtpWeights?.() === true;
         if (this.requirePagedCache && sessionModel.hasBlockPagedCache?.() !== true && !gemmaDraftActive) {

--- a/packages/agent/src/provider/models.ts
+++ b/packages/agent/src/provider/models.ts
@@ -28,7 +28,6 @@ import {
   NON_GENERATIVE_FAMILY_IDS,
   type ModelType,
 } from '@mlx-node/lm';
-import { findDFlash2Draft } from '@mlx-node/lm/draft-companion';
 
 import type { DiscoveredModelLike } from '../types.js';
 
@@ -203,12 +202,13 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
       while (usedNames.has(name)) name = `${scopeName}-${preferredName}-${suffix++}`;
     }
     usedNames.add(name);
-    const draftModelPath = findDFlash2Draft(path, modelType, modelsDir);
+    // Automatic companions can be installed or removed after this startup
+    // scan. The host resolves them on each load; draftModelPath is reserved
+    // for caller-supplied paths that the loader must treat as authoritative.
     const discovered: DiscoveredModelLike = {
       name,
       path,
       modelType,
-      ...(draftModelPath === undefined ? {} : { draftModelPath }),
     };
     out.push({
       discovered,

--- a/packages/agent/src/provider/models.ts
+++ b/packages/agent/src/provider/models.ts
@@ -28,6 +28,7 @@ import {
   NON_GENERATIVE_FAMILY_IDS,
   type ModelType,
 } from '@mlx-node/lm';
+import { findDFlash2Draft } from '@mlx-node/lm/draft-companion';
 
 import type { DiscoveredModelLike } from '../types.js';
 
@@ -57,25 +58,6 @@ function isQwen35XlGguf(name: string): boolean {
 
 function ggufModelName(name: string): string {
   return name.slice(0, -'.gguf'.length);
-}
-
-/**
- * Agent-local convention for pairing a dense Qwen3.5/Qwen3.8 target with an
- * external DFlash2 checkpoint. mlx-vlm accepts an explicit `--draft-model`
- * path and does not define a combined directory layout; the agent needs a
- * deterministic relationship it can discover without another CLI flag.
- */
-async function embeddedDFlash2Path(modelDir: string): Promise<string | undefined> {
-  const draftPath = join(modelDir, 'draft');
-  try {
-    const raw = await readFile(join(draftPath, 'config.json'), 'utf-8');
-    const config = JSON.parse(raw) as Record<string, unknown>;
-    return Array.isArray(config.architectures) && config.architectures.includes('DFlash2DraftModel')
-      ? draftPath
-      : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 interface ModelFileInventory {
@@ -191,7 +173,6 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
     metadataRoot: string,
     modelType: ModelType,
     scopeName: string,
-    draftModelPath?: string,
   ): Promise<void> => {
     if (NON_GENERATIVE_FAMILY_IDS.has(modelType)) return;
 
@@ -222,6 +203,7 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
       while (usedNames.has(name)) name = `${scopeName}-${preferredName}-${suffix++}`;
     }
     usedNames.add(name);
+    const draftModelPath = findDFlash2Draft(path, modelType, modelsDir);
     const discovered: DiscoveredModelLike = {
       name,
       path,
@@ -280,9 +262,8 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
         }
         continue;
       }
-      const draftModelPath = await embeddedDFlash2Path(full);
       for (const gguf of xlGgufs) {
-        await append(ggufModelName(gguf), join(full, gguf), full, modelType, entry.name, draftModelPath);
+        await append(ggufModelName(gguf), join(full, gguf), full, modelType, entry.name);
       }
       continue;
     }
@@ -296,8 +277,7 @@ export async function discoverMlxModels(modelsDir: string): Promise<MlxModelInfo
       continue;
     }
 
-    const draftModelPath = modelType === 'qwen3_5' ? await embeddedDFlash2Path(full) : undefined;
-    await append(basename(full), full, full, modelType, entry.name, draftModelPath);
+    await append(basename(full), full, full, modelType, entry.name);
   }
 
   out.sort((a, b) => (a.discovered.name < b.discovered.name ? -1 : a.discovered.name > b.discovered.name ? 1 : 0));

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -5,6 +5,6 @@ export interface DiscoveredModelLike {
   name: string;
   path: string;
   modelType: ModelType;
-  /** Optional external speculative drafter paired with this target checkpoint. */
+  /** External speculative drafter. When supplied, forwarded unchanged for loader validation. */
   draftModelPath?: string;
 }

--- a/packages/dashboard/__test__/api.test.ts
+++ b/packages/dashboard/__test__/api.test.ts
@@ -100,6 +100,28 @@ afterEach(async () => {
 });
 
 describe('dashboard api — models & catalog', () => {
+  it('returns draft weights separately and allows their deletion without deleting the target', async () => {
+    const name = 'qwen3.8-27b-dflash2';
+    const config = JSON.stringify({ model_type: 'qwen3', architectures: ['DFlash2DraftModel'] });
+    mkdirSync(join(modelsDir, name));
+    writeFileSync(join(modelsDir, name, 'config.json'), config);
+    writeFileSync(join(modelsDir, name, 'model.safetensors'), Buffer.alloc(128));
+    const res = await api.fetch('/api/models');
+    const body = (await res.json()) as {
+      models: Array<{ name: string }>;
+      companions: Array<{ name: string; sizeBytes: number }>;
+    };
+    expect(body.models.map((model) => model.name)).toEqual(['model-a']);
+    expect(body.companions).toMatchObject([{ name, sizeBytes: Buffer.byteLength(config) + 128 }]);
+    const removed = await api.fetch(`/api/models/${name}`, { method: 'DELETE' });
+    expect(removed.status).toBe(200);
+    expect(existsSync(join(modelsDir, name))).toBe(false);
+    expect(existsSync(join(modelsDir, 'model-a', 'model.safetensors'))).toBe(true);
+    const after = (await (await api.fetch('/api/models')).json()) as typeof body;
+    expect(after.models).toHaveLength(1);
+    expect(after.companions).toEqual([]);
+  });
+
   it('lists local models', async () => {
     const res = await api.fetch('/api/models');
     expect(res.status).toBe(200);

--- a/packages/dashboard/__test__/download.test.ts
+++ b/packages/dashboard/__test__/download.test.ts
@@ -13,7 +13,8 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-import { catalogRepo, MODEL_CATALOG } from '@mlx-node/agent/catalog';
+import { catalogDownloadRepos, catalogRepo, MODEL_CATALOG } from '@mlx-node/agent/catalog';
+import { findDFlash2Draft, QWEN38_DFLASH2 } from '@mlx-node/lm/draft-companion';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 import { catalogWithState } from '../src/catalog.js';
@@ -354,7 +355,7 @@ describe('DownloadManager.checkCatalogUpdates — the read half of the staleness
     // `hidden` entries are unpublished repos: Hugging Face answers 401 for them,
     // so dialling would spend a request to learn nothing.
     const shas = await manager().checkCatalogUpdates();
-    const visible = MODEL_CATALOG.filter((e) => !e.hidden).map((e) => catalogRepo(e));
+    const visible = catalogDownloadRepos();
     expect([...shas.keys()].sort()).toEqual([...visible].sort());
     expect(shas.get(REPO)).toBe(hub.sha);
     for (const entry of MODEL_CATALOG.filter((e) => e.hidden)) {
@@ -496,7 +497,7 @@ describe('DownloadManager.checkCatalogUpdates — the read half of the staleness
     // Upstream advances, and only THEN does the sweep ask.
     hub.sha = SHA_NEW;
     const sweep = m.checkCatalogUpdates(1000);
-    await waitFor(() => sweepAsked === MODEL_CATALOG.filter((e) => !e.hidden).length);
+    await waitFor(() => sweepAsked === catalogDownloadRepos().length);
 
     // The job's older answer lands first and writes itself through.
     releaseJob!();
@@ -560,7 +561,7 @@ describe('DownloadManager.checkCatalogUpdates — the read half of the staleness
     // OLDER sha it captured for the full six-hour TTL, with no job in the
     // interleaving for `jobResolvedShas` to repair it from. Each overlap also
     // pays a second full fan-out, the very cost the cache exists to avoid.
-    const visible = MODEL_CATALOG.filter((e) => !e.hidden).length;
+    const visible = catalogDownloadRepos().length;
     let releaseSweep: (() => void) | undefined;
     const gate = new Promise<void>((resolve) => {
       releaseSweep = resolve;
@@ -686,6 +687,37 @@ describe('DownloadManager', () => {
     expect(job.state).toBe('done');
     expect(job.totalBytes).toBe(312);
     expect(job.receivedBytes).toBe(312);
+  });
+
+  it.each([true, false])('publishes only a complete DFlash2 companion (valid architecture: %s)', async (valid) => {
+    const config = JSON.stringify({
+      model_type: 'qwen3',
+      architectures: [valid ? 'DFlash2DraftModel' : 'Qwen3ForCausalLM'],
+    });
+    hub.manifest = [
+      { type: 'file', path: 'config.json', size: Buffer.byteLength(config) },
+      { type: 'file', path: 'model.safetensors', size: 16 },
+    ];
+    const weightsFetch = makeFetchImpl({ 'model.safetensors': 16 });
+    const manager = new DownloadManager({
+      modelsDir,
+      cacheDir,
+      fetchImpl: (input, init) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        return url.endsWith('/config.json') ? Promise.resolve(new Response(config)) : weightsFetch(input, init);
+      },
+    });
+    const id = manager.start(QWEN38_DFLASH2.hfRepo);
+    await waitFor(() => manager.jobs().some((job) => job.id === id && ['done', 'error'].includes(job.state)));
+    expect(manager.jobs().find((job) => job.id === id)?.state).toBe(valid ? 'done' : 'error');
+    const draftPath = join(modelsDir, 'qwen3.8-27b-dflash2');
+    expect(existsSync(draftPath)).toBe(valid);
+    expect(findDFlash2Draft(join(modelsDir, 'qwen3.8-27b-mxfp4-mlx'), 'qwen3_5')).toBe(valid ? draftPath : undefined);
+    const target = catalogWithState(modelsDir).find((item) => item.label === 'Qwen3.8-27B')!;
+    expect(target.present).toBe(false);
+    expect(target.draft?.present).toBe(valid);
+    expect(target.draft?.installed).toBe(valid);
+    await manager.shutdown();
   });
 
   it('refuses a hidden catalog entry up front instead of failing mid-download', async () => {

--- a/packages/dashboard/__test__/loading-shape-lists.test.ts
+++ b/packages/dashboard/__test__/loading-shape-lists.test.ts
@@ -127,14 +127,15 @@ function shapeOf(container: HTMLElement): ShapeSnapshot {
 }
 
 /**
- * Cards in the recommended-models grid, found by the grid's own column class.
+ * Cards after the recommended-models heading, independent of responsive classes.
  *
  * `-1` rather than `0` when the grid is missing: two zeroes compare equal, and a
  * grid that stopped rendering would then read as a match.
  */
 function catalogCardCount(container: HTMLElement): number {
-  const grid = [...container.querySelectorAll('div')].find((div) => div.className.includes('xl:grid-cols-3'));
-  return grid === undefined ? -1 : grid.querySelectorAll('[data-slot="card"]').length;
+  const heading = [...container.querySelectorAll('h2')].find((h2) => h2.textContent === 'Recommended models');
+  const grid = heading?.parentElement?.nextElementSibling;
+  return grid == null ? -1 : grid.querySelectorAll('[data-slot="card"]').length;
 }
 
 function localModel(overrides: Partial<LocalModel>): LocalModel {

--- a/packages/dashboard/__test__/models.test.ts
+++ b/packages/dashboard/__test__/models.test.ts
@@ -53,6 +53,32 @@ afterEach(() => {
 });
 
 describe('discoverLocalModels', () => {
+  it('keeps draft-only checkpoints out of models while retaining their storage inventory', () => {
+    const config = JSON.stringify({ model_type: 'qwen3', architectures: ['DFlash2DraftModel'] });
+    writeModel(modelsDir, 'renamed-companion', config, 128);
+    writeModel(modelsDir, 'qwen3.8-27b-dflash2', config, 256);
+    // An incomplete draft still needs to be accounted for and removable.
+    rmSync(join(modelsDir, 'renamed-companion', 'model.safetensors'));
+    const inventory = discoverLocalModels(modelsDir);
+    expect(inventory.models.map((model) => model.name)).toEqual(['model-a', 'model-b']);
+    expect(inventory.companions).toEqual([
+      {
+        name: 'qwen3.8-27b-dflash2',
+        path: join(modelsDir, 'qwen3.8-27b-dflash2'),
+        sizeBytes: Buffer.byteLength(config) + 256,
+        fileCount: 2,
+      },
+      {
+        name: 'renamed-companion',
+        path: join(modelsDir, 'renamed-companion'),
+        sizeBytes: Buffer.byteLength(config),
+        fileCount: 1,
+      },
+    ]);
+    expect(inventory.warnings).toHaveLength(1);
+    expect(inventory.warnings[0]).toContain('junk');
+  });
+
   it('discovers models with correct type/quant/ctx/size and warns on junk', () => {
     const { models, warnings } = discoverLocalModels(modelsDir);
 

--- a/packages/dashboard/__test__/models.test.ts
+++ b/packages/dashboard/__test__/models.test.ts
@@ -525,6 +525,30 @@ describe('isDownloaderOwned', () => {
   });
 });
 
+describe('catalog companion state', () => {
+  it('recognizes a manual shared companion without claiming ownership or installing the target', () => {
+    writeModel(modelsDir, 'qwen3.8-27b-dflash2', JSON.stringify({ architectures: ['DFlash2DraftModel'] }), 32);
+    const target = catalogWithState(modelsDir).find((item) => item.label === 'Qwen3.8-27B')!;
+    expect(target.present).toBe(false);
+    expect(target.draft).toMatchObject({
+      present: true,
+      installed: false,
+      blockedByForeignDir: false,
+      localRevision: null,
+    });
+  });
+
+  it('blocks an incomplete manual companion directory and recognizes its completed weights', () => {
+    const draft = join(modelsDir, 'qwen3.8-27b-dflash2');
+    mkdirSync(draft);
+    writeFileSync(join(draft, 'config.json'), JSON.stringify({ architectures: ['DFlash2DraftModel'] }));
+    const state = () => catalogWithState(modelsDir).find((item) => item.label === 'Qwen3.8-27B')!.draft;
+    expect(state()).toMatchObject({ present: false, blockedByForeignDir: true });
+    writeFileSync(join(draft, 'model.safetensors'), 'weights');
+    expect(state()).toMatchObject({ present: true, installed: false, blockedByForeignDir: false });
+  });
+});
+
 describe('defaultModelsDir', () => {
   const savedEnv = process.env.MLX_MODELS_DIR;
 

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -1231,17 +1231,20 @@ describe('Models page — the Install affordance', () => {
   }
 
   it.each([false, true])(
-    'shows the companion download independently of the installed target (draft present: %s)',
+    'groups the companion download inside its installed target card (draft present: %s)',
     async (present) => {
       const draft = draftItem(present);
       await mount(createElement(Models), catalogRoutes({ present: true, installed: true, draft }), LABEL);
       const link = mounted!.container.querySelector(`a[href="https://huggingface.co/${draft.hfRepo}"]`)!;
       const card = link.closest('[data-slot="card"]')!;
-      expect(link.textContent).toContain('DFlash2 for Qwen3.8-27B');
-      expect(card.textContent).toContain('used automatically');
-      expect(card.textContent).toContain('3.85 GB');
-      const button = card.querySelector('button')!;
-      expect(button.textContent?.trim()).toBe(present ? 'Installed' : 'Install');
+      const target = mounted!.container.querySelector(`a[href="https://huggingface.co/${REPO}"]`)!;
+      expect(card).toBe(target.closest('[data-slot="card"]'));
+      expect(link.textContent).toBe('DFlash2');
+      const companion = link.closest('[role="group"]')!;
+      expect(companion.textContent).toContain('Used automatically');
+      expect(companion.textContent).toContain('3.85 GB');
+      const button = companion.querySelector('button')!;
+      expect(button.textContent?.trim()).toBe(present ? 'Installed' : 'Install DFlash2');
       expect(button.disabled).toBe(present);
     },
   );
@@ -1256,8 +1259,10 @@ describe('Models page — the Install affordance', () => {
     const card = mounted!.container
       .querySelector(`a[href="https://huggingface.co/${draft.hfRepo}"]`)!
       .closest('[data-slot="card"]')!;
-    expect(card.textContent).toContain('Cancel');
-    expect(card.textContent).not.toContain('Installed');
+    const companion = card.querySelector('[role="group"]')!;
+    expect(companion.textContent).toContain('Cancel');
+    expect(companion.textContent).not.toContain('Installed');
+    expect(card.textContent).toContain('Installed');
   });
 
   it('states the blockage instead of an Install that the runner always refuses', async () => {

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -1217,6 +1217,49 @@ describe('Models page — the Install affordance', () => {
     expect(buttonLabels()).toContain('Install');
   });
 
+  function draftItem(present = false): NonNullable<CatalogItem['draft']> {
+    return {
+      label: 'DFlash2',
+      hfRepo: 'z-lab/Qwen3.8-27B-DFlash2',
+      sizeGb: 3.85,
+      slug: 'qwen3.8-27b-dflash2',
+      present,
+      installed: present,
+      blockedByForeignDir: false,
+      localRevision: null,
+    };
+  }
+
+  it.each([false, true])(
+    'shows the companion download independently of the installed target (draft present: %s)',
+    async (present) => {
+      const draft = draftItem(present);
+      await mount(createElement(Models), catalogRoutes({ present: true, installed: true, draft }), LABEL);
+      const link = mounted!.container.querySelector(`a[href="https://huggingface.co/${draft.hfRepo}"]`)!;
+      const card = link.closest('[data-slot="card"]')!;
+      expect(link.textContent).toContain('DFlash2 for Qwen3.8-27B');
+      expect(card.textContent).toContain('used automatically');
+      expect(card.textContent).toContain('3.85 GB');
+      const button = card.querySelector('button')!;
+      expect(button.textContent?.trim()).toBe(present ? 'Installed' : 'Install');
+      expect(button.disabled).toBe(present);
+    },
+  );
+
+  it('resumes a companion download and subscribes to its own progress', async () => {
+    const draft = draftItem();
+    recordRequests(
+      catalogRoutes({ present: true, installed: true, draft }, [downloadJob({ id: 'draft-job', repo: draft.hfRepo })]),
+    );
+    await mountModels();
+    expect(openedStreams).toContain('draft-job');
+    const card = mounted!.container
+      .querySelector(`a[href="https://huggingface.co/${draft.hfRepo}"]`)!
+      .closest('[data-slot="card"]')!;
+    expect(card.textContent).toContain('Cancel');
+    expect(card.textContent).not.toContain('Installed');
+  });
+
   it('states the blockage instead of an Install that the runner always refuses', async () => {
     // `<slug>` is occupied by an unowned directory (an interrupted `mlx download`).
     // The download's ownership preflight refuses it every time, so the button would

--- a/packages/dashboard/__test__/pages.test.ts
+++ b/packages/dashboard/__test__/pages.test.ts
@@ -594,6 +594,24 @@ describe('Overview page', () => {
     };
   }
 
+  it('counts zero models when only companion weights are installed while retaining their disk usage', async () => {
+    const routes = overviewRoutes(cacheFixture());
+    routes['/models'] = {
+      models: [],
+      warnings: [],
+      dir: '/models',
+      companions: [
+        { name: 'qwen3.8-27b-dflash2', path: '/models/qwen3.8-27b-dflash2', sizeBytes: 2 * MIB, fileCount: 2 },
+      ],
+    };
+    await mount(createElement(MemoryRouter, null, createElement(Overview)), routes, 'including companions');
+    const tile = [...mounted!.container.querySelectorAll('[data-slot="card"]')].find((el) =>
+      el.textContent?.startsWith('Local models'),
+    )!;
+    expect(tile.textContent).toContain('Local models0');
+    expect(tile.textContent).toContain('2.0 MB on disk, including companions');
+  });
+
   it('never rounds the cold-cache hit rate up to 100% on the landing page', async () => {
     // F6 at its second call site. Reverting overview.tsx restores
     // `formatPercent(hits / lookups)`, which is 100% for 16189/16238.
@@ -1229,6 +1247,46 @@ describe('Models page — the Install affordance', () => {
       localRevision: null,
     };
   }
+
+  it('keeps companion storage out of the model table and count, with a separate confirmed delete action', async () => {
+    const draft = draftItem(true);
+    const companion = { name: draft.slug, path: `/models/${draft.slug}`, sizeBytes: 2 * MIB, fileCount: 2 };
+    const routes = catalogRoutes({ draft });
+    const catalog = routes['/catalog'] as CatalogResponse;
+    routes['/catalog'] = sequence(catalog, { items: [{ ...catalog.items[0], draft: draftItem(false) }] });
+    const initial: ModelsResponse = { models: [], companions: [companion], warnings: [], dir: '/models' };
+    routes['/models'] = sequence(initial, { ...initial, companions: [] });
+    routes[`/models/${draft.slug}`] = { deleted: true, name: draft.slug };
+    const calls = recordRequests(routes);
+    await mountModels();
+    const tile = [...mounted!.container.querySelectorAll('[data-slot="card"]')].find((el) =>
+      el.textContent?.startsWith('Installed'),
+    )!;
+    expect(tile.textContent).toContain('Installed0');
+    expect(tile.textContent).toContain('2.0 MB on disk, including companions');
+    expect(mounted!.container.querySelector('tbody')?.textContent ?? '').not.toContain(draft.slug);
+    const toggle = [...mounted!.container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Companion weights (1)'),
+    )!;
+    await act(async () => toggle.click());
+    const remove = mounted!.container.querySelector<HTMLButtonElement>(
+      `button[aria-label="Delete companion ${draft.slug}"]`,
+    )!;
+    await act(async () => remove.click());
+    expect(calls.filter((call) => call.method === 'DELETE')).toEqual([]);
+    const dialog = document.querySelector('[role="dialog"]')!;
+    expect(dialog.textContent).toContain('Delete companion weights?');
+    expect(dialog.textContent).toContain(draft.slug);
+    const confirm = [...dialog.querySelectorAll('button')].find((button) => button.textContent?.trim() === 'Delete')!;
+    await act(async () => confirm.click());
+    await settle();
+    expect(calls.filter((call) => call.method === 'DELETE')).toEqual([
+      { method: 'DELETE', url: `/api/models/${draft.slug}` },
+    ]);
+    expect(mounted!.container.textContent).not.toContain('Companion weights (1)');
+    expect(tile.textContent).toContain('0 B on disk');
+    expect(buttonLabels()).toContain('Install DFlash2');
+  });
 
   it.each([false, true])(
     'groups the companion download inside its installed target card (draft present: %s)',

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -26,6 +26,7 @@
     "@earendil-works/pi-coding-agent": "^0.84.4",
     "@huggingface/hub": "^2.16.1",
     "@mlx-node/agent": "workspace:*",
+    "@mlx-node/lm": "workspace:*",
     "drizzle-orm": "1.0.0-rc.4"
   },
   "devDependencies": {

--- a/packages/dashboard/src/api/handlers/models.ts
+++ b/packages/dashboard/src/api/handlers/models.ts
@@ -4,10 +4,10 @@ import type { ApiPaths, ApiRequest, MainApiContext } from '../context.js';
 import { ApiError } from '../errors.js';
 
 export function handleModels(ctx: ApiPaths): unknown {
-  const { models, warnings } = discoverLocalModels(ctx.modelsDir);
+  const { models, companions, warnings } = discoverLocalModels(ctx.modelsDir);
   // `dir` lets the UI show WHERE these checkpoints live — the directory is
   // configurable (`--models-dir`), so the count alone is ambiguous.
-  return { models, warnings, dir: ctx.modelsDir };
+  return { models, companions, warnings, dir: ctx.modelsDir };
 }
 
 export function handleDeleteModel(ctx: ApiPaths, req: ApiRequest): unknown {

--- a/packages/dashboard/src/catalog.ts
+++ b/packages/dashboard/src/catalog.ts
@@ -10,10 +10,12 @@ import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { type CatalogEntry, catalogRepo, MODEL_CATALOG } from '@mlx-node/agent/catalog';
+import { findDFlash2Draft, isDFlash2Companion } from '@mlx-node/lm/draft-companion';
 
 import { isDownloaderOwned, isModelInstalled, isModelPresent, isPathOccupied, readCompletion } from './models.js';
 
 export interface CatalogItem extends CatalogEntry {
+  draft?: CatalogDraftItem;
   /**
    * The repo THIS platform installs, already resolved by
    * {@link catalogRepo} — MXFP4 on Apple Silicon, NVFP4 on CUDA. It shadows
@@ -62,6 +64,17 @@ export interface CatalogItem extends CatalogEntry {
    *
    * A `null` here means "no update badge", never "up to date".
    */
+  localRevision: string | null;
+}
+
+export interface CatalogDraftItem {
+  label: string;
+  hfRepo: string;
+  sizeGb: number;
+  slug: string;
+  installed: boolean;
+  present: boolean;
+  blockedByForeignDir: boolean;
   localRevision: string | null;
 }
 
@@ -145,8 +158,26 @@ export function catalogWithState(modelsDir: string): CatalogItem[] {
     // Read from the canonical slug ONLY — see `localRevision` on CatalogItem for why
     // a provenance-matched renamed dir deliberately reports null.
     const completion = installed ? readCompletion(dir) : undefined;
+    let draft: CatalogDraftItem | undefined;
+    if (entry.draft !== undefined) {
+      const draftSlug = entry.draft.hfRepo.split('/')[1].toLowerCase();
+      const canonicalDraftDir = join(modelsDir, draftSlug);
+      const draftDir = findDFlash2Draft(dir, 'qwen3_5', modelsDir) ?? canonicalDraftDir;
+      const draftPresent = isModelPresent(draftDir) && isDFlash2Companion(draftDir);
+      const draftInstalled = draftPresent && draftDir === canonicalDraftDir && isModelInstalled(draftDir);
+      draft = {
+        ...entry.draft,
+        slug: draftSlug,
+        present: draftPresent,
+        installed: draftInstalled,
+        blockedByForeignDir:
+          !draftPresent && isPathOccupied(canonicalDraftDir) && !isDownloaderOwned(canonicalDraftDir),
+        localRevision: draftInstalled ? (readCompletion(draftDir)?.revision ?? null) : null,
+      };
+    }
     return {
       ...entry,
+      draft,
       hfRepo,
       slug,
       installed,

--- a/packages/dashboard/src/download.ts
+++ b/packages/dashboard/src/download.ts
@@ -43,7 +43,8 @@ import { homedir } from 'node:os';
 import { basename, dirname, join, resolve, sep } from 'node:path';
 
 import { downloadFileToCacheDir, listFiles, type ListFileEntry, modelInfo } from '@huggingface/hub';
-import { catalogRepo, MODEL_CATALOG } from '@mlx-node/agent/catalog';
+import { catalogDownloadRepos } from '@mlx-node/agent/catalog';
+import { isDFlash2Companion, QWEN38_DFLASH2 } from '@mlx-node/lm/draft-companion';
 
 /** How long a resolved set of catalog shas is reused before re-dialling HF. */
 const CATALOG_SHA_TTL_MS = 6 * 60 * 60 * 1000;
@@ -451,7 +452,7 @@ export class DownloadManager {
     // so admitting one here allocates a job that fails mid-download with a 401
     // instead of being refused up front. No UI reaches this for a hidden entry
     // (the Models page filters `!item.hidden`); a direct API POST does.
-    if (!MODEL_CATALOG.some((entry) => !entry.hidden && catalogRepo(entry) === repo)) {
+    if (!catalogDownloadRepos().includes(repo)) {
       throw new Error(`Repo "${repo}" is not in the model catalog`);
     }
     const active = this.activeJobFor(repo);
@@ -740,24 +741,22 @@ export class DownloadManager {
     const shas = new Map<string, string | null>();
     const reads = new Map<string, number>();
     await Promise.all(
-      MODEL_CATALOG.filter((entry) => !entry.hidden)
-        .map((entry) => catalogRepo(entry))
-        .map(async (repo) => {
-          const at = ++this.resolveSeq;
-          try {
-            // RAW fetch, never `wrappedFetch`. That wrapper attributes every
-            // response body to `currentFile`, so a probe running while a model
-            // downloads would inflate that file's progress past its own total;
-            // it also threads the active job's abort signal, which would make a
-            // user's cancel kill an unrelated update check.
-            shas.set(repo, await this.resolveRevision(repo, probeFetch));
-            // Only a SUCCESSFUL read claims the slot, so a job's real revision
-            // still beats this sweep's `null`.
-            reads.set(repo, at);
-          } catch {
-            shas.set(repo, null);
-          }
-        }),
+      catalogDownloadRepos().map(async (repo) => {
+        const at = ++this.resolveSeq;
+        try {
+          // RAW fetch, never `wrappedFetch`. That wrapper attributes every
+          // response body to `currentFile`, so a probe running while a model
+          // downloads would inflate that file's progress past its own total;
+          // it also threads the active job's abort signal, which would make a
+          // user's cancel kill an unrelated update check.
+          shas.set(repo, await this.resolveRevision(repo, probeFetch));
+          // Only a SUCCESSFUL read claims the slot, so a job's real revision
+          // still beats this sweep's `null`.
+          reads.set(repo, at);
+        } catch {
+          shas.set(repo, null);
+        }
+      }),
     );
     // ANY unresolved repo takes the short TTL, not only an all-failed sweep. The
     // cache is one entry for the whole sweep, so a single transient failure
@@ -809,8 +808,7 @@ export class DownloadManager {
   private async processJob(job: JobState): Promise<void> {
     // Resolved per platform, matching the allowlist gate in `start` — a job can
     // only exist for THIS platform's repo, so the lookup cannot miss.
-    const entry = MODEL_CATALOG.find((candidate) => catalogRepo(candidate) === job.repo)!;
-    const slug = catalogRepo(entry).split('/').pop()!.toLowerCase();
+    const slug = job.repo.split('/').pop()!.toLowerCase();
     const finalDir = join(this.modelsDir, slug);
     const repo = { type: 'model' as const, name: job.repo };
     this.currentJob = job;
@@ -931,7 +929,8 @@ export class DownloadManager {
         installed !== undefined &&
         installed.repo === job.repo &&
         installed.revision === revision &&
-        isModelInstalled(finalDir)
+        isModelInstalled(finalDir) &&
+        (job.repo !== QWEN38_DFLASH2.hfRepo || isDFlash2Companion(finalDir))
       ) {
         job.receivedBytes = totalBytes;
         job.state = 'done';
@@ -1013,6 +1012,9 @@ export class DownloadManager {
       // `committing`, `cancel()`'s `state !== 'running'` gate rejects it (the route
       // 404s) and publish runs to completion.
       if (job.cancelled) throw new Error('Download cancelled');
+      if (job.repo === QWEN38_DFLASH2.hfRepo && !isDFlash2Companion(stagingDir)) {
+        throw new Error('DFlash2 download requires a DFlash2DraftModel config and model.safetensors');
+      }
       job.state = 'committing';
 
       await this.publish(stagingDir, finalDir, job.repo, revision, files, job.overwrite);

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -40,6 +40,7 @@ export {
   type DownloadCompletion,
   DOWNLOAD_COMPLETE_MARKER,
   isModelInstalled,
+  type LocalCompanion,
   type LocalModel,
 } from './models.js';
 export { agentSessionsRoot, dashboardDbPath, metricsTraceDir, mlxNodeHome } from './paths.js';

--- a/packages/dashboard/src/models.ts
+++ b/packages/dashboard/src/models.ts
@@ -45,6 +45,9 @@ export interface LocalModel {
   fileCount: number;
 }
 
+/** Draft-only storage, managed on disk but excluded from standalone model lists. */
+export type LocalCompanion = Pick<LocalModel, 'name' | 'path' | 'sizeBytes' | 'fileCount'>;
+
 /**
  * Filename of the atomic-publish completion marker the download runner writes as
  * the LAST step of a download (inside the staging dir, before it is renamed onto
@@ -600,17 +603,23 @@ export function walkDirStats(
  * Scan `modelsDir` for checkpoint subdirectories. A subdirectory is a model
  * only when it carries a readable `config.json`; anything else is reported as
  * a warning and skipped (never guessed). A missing `modelsDir` yields empty
- * results with no warning.
+ * results with no warning. Draft-only checkpoints have a separate inventory
+ * for storage accounting and deletion, never contributing to model counts.
  */
-export function discoverLocalModels(modelsDir: string): { models: LocalModel[]; warnings: string[] } {
+export function discoverLocalModels(modelsDir: string): {
+  models: LocalModel[];
+  companions: LocalCompanion[];
+  warnings: string[];
+} {
   const models: LocalModel[] = [];
+  const companions: LocalCompanion[] = [];
   const warnings: string[] = [];
 
   let entries: Dirent[];
   try {
     entries = readdirSync(modelsDir, { withFileTypes: true });
   } catch {
-    return { models, warnings };
+    return { models, companions, warnings };
   }
 
   for (const entry of entries) {
@@ -647,6 +656,10 @@ export function discoverLocalModels(modelsDir: string): { models: LocalModel[]; 
     if (truncated) {
       warnings.push(`${entry.name}: directory too large to size fully; reported size is a lower bound`);
     }
+    if (Array.isArray(config.architectures) && config.architectures.includes('DFlash2DraftModel')) {
+      companions.push({ name: entry.name, path: full, sizeBytes, fileCount });
+      continue;
+    }
     models.push({
       name: entry.name,
       path: full,
@@ -659,7 +672,8 @@ export function discoverLocalModels(modelsDir: string): { models: LocalModel[]; 
   }
 
   models.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-  return { models, warnings };
+  companions.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return { models, companions, warnings };
 }
 
 /**
@@ -702,7 +716,7 @@ export function deleteLocalModel(modelsDir: string, name: string): void {
   if (stat.isSymbolicLink()) {
     throw new Error(`Refusing to delete "${name}": target is a symlink, not a model directory`);
   }
-  // Only delete a real checkpoint directory — one discovery would list (a dir
+  // Only delete a real checkpoint directory — a model or companion (a dir
   // carrying a `config.json`). The route takes an arbitrary name, so without
   // this a typo or hand-crafted request could `rmSync` an unrelated regular file
   // or non-model directory that merely happens to sit under `modelsDir`.

--- a/packages/dashboard/ui/src/lib/types.ts
+++ b/packages/dashboard/ui/src/lib/types.ts
@@ -17,6 +17,8 @@ export interface LocalModel {
 
 export interface ModelsResponse {
   models: LocalModel[];
+  /** Draft-only disk inventory, excluded from model counts and the model table. */
+  companions?: Array<Pick<LocalModel, 'name' | 'path' | 'sizeBytes' | 'fileCount'>>;
   warnings: string[];
   /** Absolute path of the models directory these checkpoints were discovered in. */
   dir: string;

--- a/packages/dashboard/ui/src/lib/types.ts
+++ b/packages/dashboard/ui/src/lib/types.ts
@@ -52,7 +52,14 @@ export interface CatalogItem {
    * `null` means staleness is unknowable, never "up to date".
    */
   localRevision: string | null;
+  /** Separate optional draft weights, never a standalone chat-model entry. */
+  draft?: CatalogDraftItem;
 }
+
+export type CatalogDraftItem = Pick<
+  CatalogItem,
+  'label' | 'hfRepo' | 'sizeGb' | 'slug' | 'installed' | 'present' | 'blockedByForeignDir' | 'localRevision'
+>;
 
 export interface CatalogResponse {
   items: CatalogItem[];

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -50,6 +50,10 @@ function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// Size columns from the content area: viewport breakpoints include the sidebar
+// and can force two cards into a space too narrow for their titles and sizes.
+const CATALOG_GRID_CLASS_NAME = 'grid grid-cols-[repeat(auto-fit,minmax(min(100%,19rem),1fr))] gap-4';
+
 /**
  * A settled job — it holds no in-flight work and the server will never move it
  * out of this state again. Mirrors `isTerminal` in `src/download.ts`, and is
@@ -193,7 +197,10 @@ function LocalModelsSkeletonRows() {
  * canonical slug carries a revision to compare AND can actually be re-installed.
  * A `null` on either side means staleness is unknowable, never "up to date".
  */
-function hasUpdate(item: CatalogItem, remoteRevisions: ReadonlyMap<string, string | null>): boolean {
+function hasUpdate(
+  item: Pick<CatalogItem, 'hfRepo' | 'installed' | 'localRevision'>,
+  remoteRevisions: ReadonlyMap<string, string | null>,
+): boolean {
   const remoteRevision = remoteRevisions.get(item.hfRepo) ?? null;
   return (
     item.installed && item.localRevision !== null && remoteRevision !== null && remoteRevision !== item.localRevision
@@ -540,6 +547,18 @@ export default function Models() {
   const remoteRevisions = new Map<string, string | null>(
     updates.error !== undefined ? [] : (updates.data?.items ?? []).map((item) => [item.hfRepo, item.remoteRevision]),
   );
+  const downloadProps = (item: CatalogDownloadProps['item']): CatalogDownloadProps => ({
+    item,
+    updateAvailable: hasUpdate(item, remoteRevisions),
+    settling: settledOn.has(item.hfRepo) && settledOn.get(item.hfRepo)?.catalog === catalog.data,
+    updateSettling: settledOn.has(item.hfRepo) && settledOn.get(item.hfRepo)?.updates === updates.data,
+    job: active[item.hfRepo],
+    onInstall: () => install(item.hfRepo),
+    onDone: () => onDownloadDone(item.hfRepo),
+    onError: (message) => onDownloadError(item.hfRepo, message),
+    onCancelled: () => onDownloadCancelled(item.hfRepo),
+    onCancel: (id) => void cancel(item.hfRepo, id),
+  });
 
   return (
     <div className="space-y-6">
@@ -696,29 +715,51 @@ export default function Models() {
           </CardContent>
         </Card>
       ) : catalog.loading ? (
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <div className={CATALOG_GRID_CLASS_NAME}>
           {Array.from({ length: 3 }).map((_, i) => (
             <CatalogCardSkeleton key={i} />
           ))}
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <div className={CATALOG_GRID_CLASS_NAME}>
           {catalogItems.map((item) => (
-            <CatalogCard
-              key={item.hfRepo}
-              item={item}
-              updateAvailable={hasUpdate(item, remoteRevisions)}
-              settling={settledOn.has(item.hfRepo) && settledOn.get(item.hfRepo)?.catalog === catalog.data}
-              updateSettling={settledOn.has(item.hfRepo) && settledOn.get(item.hfRepo)?.updates === updates.data}
-              job={active[item.hfRepo]}
-              onInstall={() => install(item.hfRepo)}
-              onDone={() => onDownloadDone(item.hfRepo)}
-              onError={(message) => onDownloadError(item.hfRepo, message)}
-              onCancelled={() => onDownloadCancelled(item.hfRepo)}
-              onCancel={(id) => void cancel(item.hfRepo, id)}
-            />
+            <CatalogCard key={item.hfRepo} {...downloadProps(item)} item={item} />
           ))}
         </div>
+      )}
+
+      {(catalog.error === undefined ? catalogItems : []).map((item) =>
+        item.draft === undefined ? null : (
+          <Card key={item.draft.hfRepo} className="gap-4">
+            <CardHeader>
+              <CardTitle className="flex flex-wrap items-center gap-2 text-base">
+                <a
+                  href={`https://huggingface.co/${item.draft.hfRepo}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="rounded-sm underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                >
+                  {item.draft.label} for {item.label}
+                </a>
+                <Badge variant="secondary" className="font-normal">
+                  Optional
+                </Badge>
+              </CardTitle>
+              <CardDescription>
+                Recommended companion weights that can speed up replies. Download separately; used automatically the
+                next time {item.label} loads.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-wrap items-center justify-between gap-3">
+              <span className="text-muted-foreground text-xs tabular-nums whitespace-nowrap">
+                ~{item.draft.sizeGb} GB
+              </span>
+              <div className="w-full sm:w-56">
+                <CatalogDownloadAction {...downloadProps(item.draft)} />
+              </div>
+            </CardContent>
+          </Card>
+        ),
       )}
 
       <Dialog open={pendingDelete !== null} onOpenChange={(open) => !open && setPendingDelete(null)}>
@@ -774,14 +815,14 @@ function CatalogCardSkeleton() {
           <CardTitle className="text-base">
             <Skeleton className="h-[1lh] w-40" />
           </CardTitle>
+          <Skeleton className="h-4 w-12 shrink-0" />
         </div>
         <CardDescription>
           <Skeleton className="h-[1lh] w-full" />
         </CardDescription>
       </CardHeader>
       <CardContent className="mt-auto space-y-3">
-        <div className="flex items-center justify-between gap-2 text-xs">
-          <Skeleton className="h-[1lh] w-48" />
+        <div className="text-xs">
           <Skeleton className="h-[1lh] w-12" />
         </div>
         {/* The button box, not a button: `h-9` is what `Button`'s default size
@@ -792,8 +833,8 @@ function CatalogCardSkeleton() {
   );
 }
 
-interface CatalogCardProps {
-  item: CatalogItem;
+interface CatalogDownloadProps {
+  item: Pick<CatalogItem, 'hfRepo' | 'installed' | 'localRevision' | 'present' | 'blockedByForeignDir' | 'slug'>;
   /** Upstream has different bytes at this repo than the local marker records. */
   updateAvailable: boolean;
   /**
@@ -816,7 +857,52 @@ interface CatalogCardProps {
   onCancel: (id: string) => void;
 }
 
-function CatalogCard({
+interface CatalogCardProps extends Omit<CatalogDownloadProps, 'item'> {
+  item: CatalogItem;
+}
+
+function CatalogCard({ item, ...download }: CatalogCardProps) {
+  // The resolved catalog repo names the build for this platform (MXFP4 or NVFP4).
+  const quantization = item.hfRepo
+    .split('/')
+    .at(-1)
+    ?.match(/(?:^|-)((?:mx|nv)fp[48]?)(?:-|$)/i)?.[1]
+    ?.toUpperCase();
+
+  return (
+    <Card className="gap-4">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-base">
+            <a
+              href={`https://huggingface.co/${item.hfRepo}`}
+              target="_blank"
+              rel="noreferrer"
+              className="focus-visible:ring-ring rounded-sm underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+            >
+              {item.label}
+            </a>
+          </CardTitle>
+          <div className="flex shrink-0 items-center gap-2">
+            {item.isDefault === true && (
+              <Badge variant="secondary" className="font-normal">
+                default
+              </Badge>
+            )}
+            <span className="text-muted-foreground text-xs tabular-nums whitespace-nowrap">~{item.sizeGb} GB</span>
+          </div>
+        </div>
+        <CardDescription>{item.description}</CardDescription>
+      </CardHeader>
+      <CardContent className="mt-auto space-y-3">
+        <div className="text-muted-foreground font-mono text-xs">{quantization ?? '—'}</div>
+        <CatalogDownloadAction item={item} {...download} />
+      </CardContent>
+    </Card>
+  );
+}
+
+function CatalogDownloadAction({
   item,
   updateAvailable,
   settling,
@@ -827,7 +913,7 @@ function CatalogCard({
   onError,
   onCancelled,
   onCancel,
-}: CatalogCardProps) {
+}: CatalogDownloadProps) {
   // Gate on `present` (loadable checkpoint on disk), not `installed` (dashboard
   // marker): a model installed via the `mlx download` CLI / wizard is present but
   // unowned, so offering Install would refuse to overwrite it and fail.
@@ -842,84 +928,62 @@ function CatalogCard({
   // mid-update would render "Installed" over a live multi-gigabyte transfer,
   // with no progress and no Cancel.
   const downloading = job !== undefined;
-
   return (
-    <Card className="gap-4">
-      <CardHeader>
-        <div className="flex items-start justify-between gap-2">
-          <CardTitle className="text-base">{item.label}</CardTitle>
-          <div className="flex shrink-0 items-center gap-2">
-            {item.isDefault === true && (
-              <Badge variant="secondary" className="font-normal">
-                default
-              </Badge>
-            )}
-            <span className="text-muted-foreground text-xs tabular-nums whitespace-nowrap">~{item.sizeGb} GB</span>
-          </div>
-        </div>
-        <CardDescription>{item.description}</CardDescription>
-      </CardHeader>
-      <CardContent className="mt-auto space-y-3">
-        {/* Full-width row of its own: the repo id truncates against the card
-            edge instead of competing with the size label for one line. */}
-        <div className="text-muted-foreground truncate font-mono text-xs" title={item.hfRepo}>
-          {item.hfRepo}
-        </div>
-        {downloading && job !== undefined ? (
-          <div className="space-y-2">
-            <DownloadProgress id={job.id} onDone={onDone} onError={onError} onCancelled={onCancelled} />
-            {/* No Cancel while publishing: `cancel()` refuses a `committing` job
+    <>
+      {downloading && job !== undefined ? (
+        <div className="space-y-2">
+          <DownloadProgress id={job.id} onDone={onDone} onError={onError} onCancelled={onCancelled} />
+          {/* No Cancel while publishing: `cancel()` refuses a `committing` job
                 and the route 404s, so the button could only report a failure for
                 an install that then succeeds anyway. The progress bar stays.
                 Nor while `cancelling`: this page's cancel was already accepted
                 and the job is unwinding toward its terminal frame, so a second
                 one answers 404 too. */}
-            {!job.committing && !job.cancelling && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="text-muted-foreground hover:text-destructive w-full"
-                onClick={() => onCancel(job.id)}
-              >
-                <X className="size-4" />
-                Cancel
-              </Button>
-            )}
-          </div>
-        ) : item.present && updateAvailable ? (
-          // Same job pipeline as a first install: the runner already re-downloads
-          // whenever the installed marker's revision differs from upstream, and
-          // its owned-swap replaces the stale directory.
-          <Button className="w-full" onClick={onInstall} disabled={settling || updateSettling}>
-            <Download className="size-4" />
-            Update available
-          </Button>
-        ) : item.present ? (
-          <Button variant="outline" className="w-full" disabled>
-            <Check className="size-4" />
-            Installed
-          </Button>
-        ) : item.blockedByForeignDir ? (
-          // The download's ownership preflight refuses an occupied directory it
-          // did not write, so an Install here can only ever raise a red toast.
-          // Name the directory in the way and the one step that clears it.
-          <div className="space-y-2">
-            <Button variant="outline" className="w-full" disabled>
-              <AlertCircle className="size-4" />
-              Needs cleanup
+          {!job.committing && !job.cancelling && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground hover:text-destructive w-full"
+              onClick={() => onCancel(job.id)}
+            >
+              <X className="size-4" />
+              Cancel
             </Button>
-            <p className="text-muted-foreground text-xs">
-              <span className="font-mono">{item.slug}</span> already exists and was not created by the dashboard. Remove
-              it (or delete it below, if it is listed) to install.
-            </p>
-          </div>
-        ) : (
-          <Button className="w-full" onClick={onInstall} disabled={settling}>
-            <Download className="size-4" />
-            Install
+          )}
+        </div>
+      ) : item.present && updateAvailable ? (
+        // Same job pipeline as a first install: the runner already re-downloads
+        // whenever the installed marker's revision differs from upstream, and
+        // its owned-swap replaces the stale directory.
+        <Button className="w-full" onClick={onInstall} disabled={settling || updateSettling}>
+          <Download className="size-4" />
+          Update available
+        </Button>
+      ) : item.present ? (
+        <Button variant="outline" className="w-full" disabled>
+          <Check className="size-4" />
+          Installed
+        </Button>
+      ) : item.blockedByForeignDir ? (
+        // The download's ownership preflight refuses an occupied directory it
+        // did not write, so an Install here can only ever raise a red toast.
+        // Name the directory in the way and the one step that clears it.
+        <div className="space-y-2">
+          <Button variant="outline" className="w-full" disabled>
+            <AlertCircle className="size-4" />
+            Needs cleanup
           </Button>
-        )}
-      </CardContent>
-    </Card>
+          <p className="text-muted-foreground text-xs">
+            <span className="font-mono">{item.slug}</span> already exists and was not created by the dashboard. Remove
+            it (or delete it below, if it is listed) to install.
+          </p>
+        </div>
+      ) : (
+        <Button className="w-full" onClick={onInstall} disabled={settling}>
+          <Download className="size-4" />
+          Install
+        </Button>
+      )}
+    </>
   );
 }

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -52,7 +52,7 @@ function errMessage(err: unknown): string {
 
 // Size columns from the content area: viewport breakpoints include the sidebar
 // and can force two cards into a space too narrow for their titles and sizes.
-const CATALOG_GRID_CLASS_NAME = 'grid grid-cols-[repeat(auto-fit,minmax(min(100%,19rem),1fr))] gap-4';
+const CATALOG_GRID_CLASS_NAME = 'grid grid-cols-[repeat(auto-fit,minmax(min(100%,19rem),1fr))] items-start gap-4';
 
 /**
  * A settled job — it holds no in-flight work and the server will never move it
@@ -717,49 +717,20 @@ export default function Models() {
       ) : catalog.loading ? (
         <div className={CATALOG_GRID_CLASS_NAME}>
           {Array.from({ length: 3 }).map((_, i) => (
-            <CatalogCardSkeleton key={i} />
+            <CatalogCardSkeleton key={i} withDraft={i === 0} />
           ))}
         </div>
       ) : (
         <div className={CATALOG_GRID_CLASS_NAME}>
           {catalogItems.map((item) => (
-            <CatalogCard key={item.hfRepo} {...downloadProps(item)} item={item} />
+            <CatalogCard
+              key={item.hfRepo}
+              {...downloadProps(item)}
+              item={item}
+              draftDownload={item.draft === undefined ? undefined : downloadProps(item.draft)}
+            />
           ))}
         </div>
-      )}
-
-      {(catalog.error === undefined ? catalogItems : []).map((item) =>
-        item.draft === undefined ? null : (
-          <Card key={item.draft.hfRepo} className="gap-4">
-            <CardHeader>
-              <CardTitle className="flex flex-wrap items-center gap-2 text-base">
-                <a
-                  href={`https://huggingface.co/${item.draft.hfRepo}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="rounded-sm underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-                >
-                  {item.draft.label} for {item.label}
-                </a>
-                <Badge variant="secondary" className="font-normal">
-                  Optional
-                </Badge>
-              </CardTitle>
-              <CardDescription>
-                Recommended companion weights that can speed up replies. Download separately; used automatically the
-                next time {item.label} loads.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="flex flex-wrap items-center justify-between gap-3">
-              <span className="text-muted-foreground text-xs tabular-nums whitespace-nowrap">
-                ~{item.draft.sizeGb} GB
-              </span>
-              <div className="w-full sm:w-56">
-                <CatalogDownloadAction {...downloadProps(item.draft)} />
-              </div>
-            </CardContent>
-          </Card>
-        ),
       )}
 
       <Dialog open={pendingDelete !== null} onOpenChange={(open) => !open && setPendingDelete(null)}>
@@ -789,25 +760,11 @@ export default function Models() {
 }
 
 /**
- * A placeholder that is a real {@link CatalogCard} with its text taken out:
- * same `Card`/`CardHeader`/`CardContent` wrappers, same `gap-4`, same padding,
- * same install button box — only the leaves are grey.
- *
- * It replaces one fixed 176px block, a height that stood for nothing in
- * particular. The card these stand in for measures 170px (24px of `py-6`, a 16px
- * `leading-none` title, `gap-1.5`, a 20px description line, `gap-4`, a 16px
- * `text-xs` meta row, `space-y-3`, the 36px button, 24px of `py-6`) and grows
- * another 20px the moment a description wraps to a second line, so no constant
- * was ever going to be right. Built from the same wrappers there is no constant
- * to get wrong: the height is whatever the loaded card computes to.
- *
- * Three of them because the served catalog holds exactly three visible entries.
- * One residual is left standing: the single `isDefault` entry carries a badge
- * that makes its title row 6px taller, and grid items stretch, so the row it
- * lands in grows by that much. Painting a badge on all three to absorb it would
- * claim a default on cards that have none.
+ * Reserve the catalog's header, metadata, and download controls while loading.
+ * The first curated entry also reserves its companion section, keeping the
+ * optional download grouped with the same target before and after data arrives.
  */
-function CatalogCardSkeleton() {
+function CatalogCardSkeleton({ withDraft = false }: { withDraft?: boolean }) {
   return (
     <Card className="gap-4">
       <CardHeader>
@@ -829,11 +786,22 @@ function CatalogCardSkeleton() {
             resolves to, and it is the tallest thing in the card's content. */}
         <Skeleton className="h-9 w-full" />
       </CardContent>
+      {withDraft && (
+        <div className="mx-6 space-y-3 border-t pt-4">
+          <div className="flex items-center justify-between gap-2">
+            <Skeleton className="h-5 w-28" />
+            <Skeleton className="h-4 w-12" />
+          </div>
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-9 w-full" />
+        </div>
+      )}
     </Card>
   );
 }
 
 interface CatalogDownloadProps {
+  installLabel?: string;
   item: Pick<CatalogItem, 'hfRepo' | 'installed' | 'localRevision' | 'present' | 'blockedByForeignDir' | 'slug'>;
   /** Upstream has different bytes at this repo than the local marker records. */
   updateAvailable: boolean;
@@ -859,9 +827,10 @@ interface CatalogDownloadProps {
 
 interface CatalogCardProps extends Omit<CatalogDownloadProps, 'item'> {
   item: CatalogItem;
+  draftDownload?: CatalogDownloadProps;
 }
 
-function CatalogCard({ item, ...download }: CatalogCardProps) {
+function CatalogCard({ item, draftDownload, ...download }: CatalogCardProps) {
   // The resolved catalog repo names the build for this platform (MXFP4 or NVFP4).
   const quantization = item.hfRepo
     .split('/')
@@ -898,12 +867,39 @@ function CatalogCard({ item, ...download }: CatalogCardProps) {
         <div className="text-muted-foreground font-mono text-xs">{quantization ?? '—'}</div>
         <CatalogDownloadAction item={item} {...download} />
       </CardContent>
+      {item.draft !== undefined && draftDownload !== undefined && (
+        <div role="group" aria-label={`${item.draft.label} companion`} className="mx-6 space-y-3 border-t pt-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <a
+                href={`https://huggingface.co/${item.draft.hfRepo}`}
+                target="_blank"
+                rel="noreferrer"
+                className="focus-visible:ring-ring rounded-sm text-sm font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+              >
+                {item.draft.label}
+              </a>
+              <Badge variant="secondary" className="font-normal">
+                Optional
+              </Badge>
+            </div>
+            <span className="text-muted-foreground text-xs tabular-nums whitespace-nowrap">
+              ~{item.draft.sizeGb} GB
+            </span>
+          </div>
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            Can speed up replies. Used automatically the next time this model loads.
+          </p>
+          <CatalogDownloadAction {...draftDownload} installLabel={`Install ${item.draft.label}`} />
+        </div>
+      )}
     </Card>
   );
 }
 
 function CatalogDownloadAction({
   item,
+  installLabel = 'Install',
   updateAvailable,
   settling,
   updateSettling,
@@ -981,7 +977,7 @@ function CatalogDownloadAction({
       ) : (
         <Button className="w-full" onClick={onInstall} disabled={settling}>
           <Download className="size-4" />
-          Install
+          {installLabel}
         </Button>
       )}
     </>

--- a/packages/dashboard/ui/src/pages/models.tsx
+++ b/packages/dashboard/ui/src/pages/models.tsx
@@ -252,7 +252,9 @@ export default function Models() {
   /** The pair as it stands right now, for the three live settle handlers. */
   const settledBodies = (): SettledBodies => ({ catalog: catalog.data, updates: updates.data });
 
-  const [pendingDelete, setPendingDelete] = useState<LocalModel | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<
+    (Pick<LocalModel, 'name' | 'path' | 'sizeBytes'> & { companion?: boolean }) | null
+  >(null);
   const [deleting, setDeleting] = useState(false);
   /** repo → active download job (seeded from the server, added on install). */
   const [active, setActive] = useState<Record<string, ActiveJob>>({});
@@ -515,11 +517,11 @@ export default function Models() {
 
   const confirmDelete = async (): Promise<void> => {
     if (pendingDelete === null) return;
-    const { name } = pendingDelete;
+    const { name, companion } = pendingDelete;
     setDeleting(true);
     try {
       await mutate<DeleteModelResponse>('DELETE', `/models/${encodeURIComponent(name)}`);
-      toast.success('Model deleted', { description: name });
+      toast.success(companion ? 'Companion deleted' : 'Model deleted', { description: name });
       setPendingDelete(null);
       models.reload();
       catalog.reload();
@@ -532,9 +534,10 @@ export default function Models() {
   };
 
   const localModels = models.data?.models ?? [];
+  const companions = models.data?.companions ?? [];
   const warnings = models.data?.warnings ?? [];
   const modelsDir = models.data?.dir ?? '';
-  const totalBytes = localModels.reduce((sum, m) => sum + m.sizeBytes, 0);
+  const totalBytes = [...localModels, ...companions].reduce((sum, m) => sum + m.sizeBytes, 0);
   const catalogItems = (catalog.data?.items ?? []).filter((item) => !item.hidden);
   // Empty whenever the update check failed or has not resolved yet, which is the
   // correct default: no badge, cards render exactly as they did before.
@@ -589,7 +592,9 @@ export default function Models() {
               </>
             ) : (
               <>
-                <span className="block">{formatBytes(totalBytes)} on disk</span>
+                <span className="block">
+                  {formatBytes(totalBytes)} on disk{companions.length > 0 ? ', including companions' : ''}
+                </span>
                 {modelsDir !== '' && (
                   // The models directory is configurable (`--models-dir`), so name
                   // it — a bare count doesn't say where these checkpoints live.
@@ -697,6 +702,42 @@ export default function Models() {
               </TableBody>
             </Table>
           )}
+          {!models.loading && models.error === undefined && companions.length > 0 && (
+            <Collapsible className="mt-4 border-t pt-4">
+              <CollapsibleTrigger className="text-muted-foreground group flex w-full items-center gap-2 text-sm">
+                <Package className="size-4 shrink-0" aria-hidden />
+                <span className="font-medium">Companion weights ({formatCount(companions.length)})</span>
+                <ChevronRight
+                  className="ml-auto size-4 shrink-0 transition-transform group-data-[state=open]:rotate-90"
+                  aria-hidden
+                />
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-3">
+                <p className="text-muted-foreground mb-2 text-xs">Optional weights used with a model.</p>
+                <ul className="space-y-2">
+                  {companions.map((companion) => (
+                    <li key={companion.name} className="flex items-center gap-3 text-sm">
+                      <span className="min-w-0 flex-1 truncate" title={companion.path}>
+                        {companion.name}
+                      </span>
+                      <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                        {formatBytes(companion.sizeBytes)}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-muted-foreground hover:text-destructive shrink-0"
+                        aria-label={`Delete companion ${companion.name}`}
+                        onClick={() => setPendingDelete({ ...companion, companion: true })}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              </CollapsibleContent>
+            </Collapsible>
+          )}
         </CardContent>
       </Card>
 
@@ -736,7 +777,7 @@ export default function Models() {
       <Dialog open={pendingDelete !== null} onOpenChange={(open) => !open && setPendingDelete(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete model?</DialogTitle>
+            <DialogTitle>{pendingDelete?.companion ? 'Delete companion weights?' : 'Delete model?'}</DialogTitle>
             <DialogDescription>
               This permanently removes <span className="text-foreground font-medium">{pendingDelete?.name}</span> (
               {pendingDelete !== null ? formatBytes(pendingDelete.sizeBytes) : ''}) from disk. This cannot be undone.

--- a/packages/dashboard/ui/src/pages/overview.tsx
+++ b/packages/dashboard/ui/src/pages/overview.tsx
@@ -40,7 +40,8 @@ export default function Overview() {
   const downloads = useJson<DownloadsResponse>('/downloads');
 
   const modelCount = models.data?.models.length ?? 0;
-  const modelBytes = models.data?.models.reduce((sum, m) => sum + m.sizeBytes, 0) ?? 0;
+  const companions = models.data?.companions ?? [];
+  const modelBytes = [...(models.data?.models ?? []), ...companions].reduce((sum, m) => sum + m.sizeBytes, 0);
 
   // Both halves of the Sessions tile come from ONE response, so they describe
   // ONE set of sessions. `total` is the true match total (not the capped page
@@ -108,7 +109,7 @@ export default function Overview() {
             ) : models.loading ? (
               <Skeleton className="h-[1lh] w-24" />
             ) : (
-              `${formatBytes(modelBytes)} on disk`
+              `${formatBytes(modelBytes)} on disk${companions.length > 0 ? ', including companions' : ''}`
             )
           }
         />

--- a/packages/desktop/__test__/child-entries.test.ts
+++ b/packages/desktop/__test__/child-entries.test.ts
@@ -9,8 +9,8 @@
  * Nothing enforces it but this file, and the regression is one stray `import`
  * away in a package nobody was editing: `@mlx-node/dashboard` depends on
  * `@mlx-node/agent`, whose MAIN entry pulls `@mlx-node/lm`. Today the dashboard
- * only reaches `@mlx-node/agent/catalog`, a leaf whose sole non-builtin edge is
- * an `import type`. Nothing but the walk below keeps it that way.
+ * only reaches native-free metadata leaves. Nothing but the walk below keeps
+ * those leaves from pulling the addon into the control panel.
  *
  * Same two halves as `__test__/server/host/addon-free-subpaths.test.ts` at the
  * repo root, which is the pattern this follows: a static import-graph walk that
@@ -38,7 +38,7 @@ const ADDON_PACKAGES = ['@mlx-node/core', '@mlx-node/lm', '@mlx-node/vlm', '@mlx
  * as offenders. `packages/agent/__test__/catalog-native-free.test.ts` proves
  * the same contract against the built output in a real process.
  */
-const ADDON_FREE_SUBPATHS = ['@mlx-node/lm/family-data'];
+const ADDON_FREE_SUBPATHS = ['@mlx-node/lm/family-data', '@mlx-node/lm/draft-companion'];
 
 /** Every `from '…'` and bare `import '…'` specifier, **type-only imports included**. */
 function specifiersOf(file: string): string[] {
@@ -187,6 +187,7 @@ describe('CONTROL PANEL never links the native addon', () => {
     // the package boundary and calling it clean.
     expect(graph.files).toContain('packages/dashboard/src/runtime.ts');
     expect(graph.files).toContain('packages/dashboard/src/download.ts');
+    expect(graph.files).toContain('packages/lm/src/draft-companion.ts');
   });
 
   it('reaches no package that maps the addon', () => {

--- a/packages/lm/__test__/draft-companion.test.ts
+++ b/packages/lm/__test__/draft-companion.test.ts
@@ -15,6 +15,7 @@ describe('DFlash2 companion discovery', () => {
     target = join(root, 'qwen3.8-27b-mxfp4-mlx');
     draft = join(root, 'Qwen3.8-27B-DFlash2');
     mkdirSync(target);
+    writeFileSync(join(target, 'config.json'), JSON.stringify({ model_type: 'qwen3_5' }));
   });
   afterEach(() => rmSync(root, { recursive: true, force: true }));
 
@@ -36,6 +37,24 @@ describe('DFlash2 companion discovery', () => {
     const embedded = join(target, 'draft');
     writeDraft(embedded);
     expect(findDFlash2Draft(target, 'qwen3_5')).toBe(embedded);
+  });
+
+  it('does not search above a standalone GGUF directory for a shared companion', () => {
+    writeDraft();
+    const store = join(root, 'models');
+    mkdirSync(store);
+    const gguf = join(store, 'Qwen3.8-27B-UD-Q4_K_XL.gguf');
+    expect(findDFlash2Draft(gguf, 'qwen3_5')).toBeUndefined();
+    const inside = join(store, 'qwen3.8-27b-dflash2');
+    writeDraft(inside);
+    expect(findDFlash2Draft(gguf, 'qwen3_5')).toBe(inside);
+  });
+
+  it('keeps a supplied model-store root authoritative for repository GGUFs', () => {
+    writeDraft();
+    const gguf = join(target, 'Qwen3.8-27B-UD-Q4_K_XL.gguf');
+    expect(findDFlash2Draft(gguf, 'qwen3_5', target)).toBeUndefined();
+    expect(findDFlash2Draft(gguf, 'qwen3_5', root)).toBe(draft);
   });
 
   it('never attaches the Qwen3.8 companion to a different model or family', () => {

--- a/packages/lm/__test__/draft-companion.test.ts
+++ b/packages/lm/__test__/draft-companion.test.ts
@@ -1,0 +1,60 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+
+import { findDFlash2Draft, isDFlash2DraftDirectory } from '../src/draft-companion.js';
+
+describe('DFlash2 companion discovery', () => {
+  let root: string;
+  let target: string;
+  let draft: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'mlx-draft-discovery-'));
+    target = join(root, 'qwen3.8-27b-mxfp4-mlx');
+    draft = join(root, 'Qwen3.8-27B-DFlash2');
+    mkdirSync(target);
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function writeDraft(path = draft): void {
+    mkdirSync(path, { recursive: true });
+    writeFileSync(join(path, 'config.json'), JSON.stringify({ architectures: ['DFlash2DraftModel'] }));
+    writeFileSync(join(path, 'model.safetensors'), 'weights');
+  }
+
+  it('pairs a separately downloaded companion with safetensors and GGUF variants', () => {
+    writeDraft();
+    expect(findDFlash2Draft(target, 'qwen3_5')).toBe(draft);
+    expect(findDFlash2Draft(join(target, 'Qwen3.8-27B-UD-Q4_K_XL.gguf'), 'qwen3_5')).toBe(draft);
+    expect(findDFlash2Draft(join(root, 'Qwen3.8-27B-UD-Q3_K_XL.gguf'), 'qwen3_5')).toBe(draft);
+  });
+
+  it('keeps explicit embedded drafts ahead of the shared recommendation', () => {
+    writeDraft();
+    const embedded = join(target, 'draft');
+    writeDraft(embedded);
+    expect(findDFlash2Draft(target, 'qwen3_5')).toBe(embedded);
+  });
+
+  it('never attaches the Qwen3.8 companion to a different model or family', () => {
+    writeDraft();
+    for (const name of ['qwen3.5-27b', 'qwen3.8-35b', 'qwen3.8-27bigger', 'other-model']) {
+      expect(findDFlash2Draft(join(root, name), 'qwen3_5')).toBeUndefined();
+    }
+    expect(findDFlash2Draft(target, 'qwen3_5_moe')).toBeUndefined();
+  });
+
+  it('ignores incomplete, empty, and wrong-architecture companion weights', () => {
+    writeDraft();
+    rmSync(join(draft, 'model.safetensors'));
+    expect(isDFlash2DraftDirectory(draft)).toBe(true);
+    expect(findDFlash2Draft(target, 'qwen3_5')).toBeUndefined();
+    writeFileSync(join(draft, 'model.safetensors'), '');
+    expect(findDFlash2Draft(target, 'qwen3_5')).toBeUndefined();
+    writeDraft();
+    writeFileSync(join(draft, 'config.json'), JSON.stringify({ architectures: ['Qwen3ForCausalLM'] }));
+    expect(findDFlash2Draft(target, 'qwen3_5')).toBeUndefined();
+  });
+});

--- a/packages/lm/__test__/model-loader-gguf.test.ts
+++ b/packages/lm/__test__/model-loader-gguf.test.ts
@@ -1,13 +1,14 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { detectModelType } from '@mlx-node/lm';
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { detectModelType, loadModel, Qwen35Model } from '@mlx-node/lm';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 const cleanups: Array<() => Promise<void>> = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   while (cleanups.length > 0) await cleanups.pop()!();
 });
 
@@ -49,6 +50,34 @@ async function writeStandaloneGguf(architecture: string): Promise<{ root: string
 }
 
 describe('standalone GGUF model detection', () => {
+  it('loads a standalone Qwen target without attaching a companion above its directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'mlx-standalone-companion-'));
+    cleanups.push(() => rm(root, { recursive: true, force: true }));
+    const store = join(root, 'models');
+    await mkdir(store);
+    const modelPath = join(store, 'Qwen3.8-27B-UD-Q4_K_XL.gguf');
+    await writeFile(modelPath, minimalGguf('qwen35'));
+    const writeDraft = async (parent: string): Promise<string> => {
+      const draft = join(parent, 'qwen3.8-27b-dflash2');
+      await mkdir(draft);
+      await writeFile(join(draft, 'config.json'), JSON.stringify({ architectures: ['DFlash2DraftModel'] }));
+      await writeFile(join(draft, 'model.safetensors'), 'draft weights');
+      return draft;
+    };
+    await writeDraft(root);
+    const loaded = {} as Qwen35Model;
+    const loadSpy = vi.spyOn(Qwen35Model, 'load').mockResolvedValue(loaded);
+    await expect(loadModel(modelPath)).resolves.toBe(loaded);
+    expect(loadSpy).toHaveBeenLastCalledWith(modelPath, null);
+
+    const inside = await writeDraft(store);
+    await loadModel(modelPath);
+    expect(loadSpy).toHaveBeenLastCalledWith(modelPath, { draftModelPath: inside });
+    await rm(inside, { recursive: true });
+    await loadModel(modelPath);
+    expect(loadSpy).toHaveBeenLastCalledWith(modelPath, null);
+  });
+
   it('maps the qwen35 header to qwen3_5 without config.json', async () => {
     const { modelPath } = await writeStandaloneGguf('qwen35');
     await expect(detectModelType(modelPath)).resolves.toBe('qwen3_5');

--- a/packages/lm/package.json
+++ b/packages/lm/package.json
@@ -22,6 +22,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./draft-companion": {
+      "types": "./dist/draft-companion.d.ts",
+      "import": "./dist/draft-companion.js"
+    },
     "./family-data": {
       "types": "./dist/family-data.d.ts",
       "import": "./dist/family-data.js"

--- a/packages/lm/src/draft-companion.ts
+++ b/packages/lm/src/draft-companion.ts
@@ -49,7 +49,14 @@ export function findDFlash2Draft(modelPath: string, modelType: string, modelsDir
   const targetName = /(?:^|[-_.])qwen3[._-]8[-_.]27b(?:[-_.]|$)/i;
   if (!targetName.test(basename(modelPath)) && !(isGguf && targetName.test(basename(modelDir)))) return undefined;
   const slug = QWEN38_DFLASH2.hfRepo.split('/')[1].toLowerCase();
-  const roots = modelsDir === undefined ? (isGguf ? [modelDir, dirname(modelDir)] : [dirname(modelDir)]) : [modelsDir];
+  const roots = modelsDir === undefined ? [isGguf ? modelDir : dirname(modelDir)] : [modelsDir];
+  // A sibling config identifies a downloaded model repository. Its parent
+  // can hold the shared companion; a standalone GGUF's containing directory
+  // is already the model store, so do not search above it. An explicit store
+  // always takes precedence over this repository inference.
+  if (modelsDir === undefined && isGguf && regularFile(join(modelDir, 'config.json'))) {
+    roots.push(dirname(modelDir));
+  }
   for (const root of roots) {
     try {
       const candidates = readdirSync(root, { withFileTypes: true })

--- a/packages/lm/src/draft-companion.ts
+++ b/packages/lm/src/draft-companion.ts
@@ -1,0 +1,67 @@
+/** Native-free metadata and discovery for optional speculative draft checkpoints. */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+
+export const QWEN38_DFLASH2 = {
+  label: 'DFlash2',
+  hfRepo: 'z-lab/Qwen3.8-27B-DFlash2',
+  sizeGb: 3.85,
+} as const;
+
+function regularFile(path: string): boolean {
+  try {
+    const stat = statSync(path);
+    return stat.isFile() && stat.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Draft-only directories must never appear in a chat-model picker. */
+export function isDFlash2DraftDirectory(path: string): boolean {
+  const configPath = join(path, 'config.json');
+  if (!regularFile(configPath)) return false;
+  try {
+    const config = JSON.parse(readFileSync(configPath, 'utf8')) as { architectures?: unknown } | null;
+    return Array.isArray(config?.architectures) && config.architectures.includes('DFlash2DraftModel');
+  } catch {
+    return false;
+  }
+}
+
+/** Cheap completeness check; the native loader validates tensor shapes and target compatibility. */
+export function isDFlash2Companion(path: string): boolean {
+  return isDFlash2DraftDirectory(path) && regularFile(join(path, 'model.safetensors'));
+}
+
+/**
+ * Prefer a target's explicit `draft/`, then the shared Qwen3.8-27B companion in
+ * its models directory. Shared pairing requires the Qwen3.8-27B target name;
+ * Qwen3.5, MoE models and unrelated renamed checkpoints must not acquire it.
+ */
+export function findDFlash2Draft(modelPath: string, modelType: string, modelsDir?: string): string | undefined {
+  if (modelType !== 'qwen3_5') return undefined;
+  const isGguf = modelPath.toLowerCase().endsWith('.gguf');
+  const modelDir = isGguf ? dirname(modelPath) : modelPath;
+  const embedded = join(modelDir, 'draft');
+  if (isDFlash2Companion(embedded)) return embedded;
+
+  const targetName = /(?:^|[-_.])qwen3[._-]8[-_.]27b(?:[-_.]|$)/i;
+  if (!targetName.test(basename(modelPath)) && !(isGguf && targetName.test(basename(modelDir)))) return undefined;
+  const slug = QWEN38_DFLASH2.hfRepo.split('/')[1].toLowerCase();
+  const roots = modelsDir === undefined ? (isGguf ? [modelDir, dirname(modelDir)] : [dirname(modelDir)]) : [modelsDir];
+  for (const root of roots) {
+    try {
+      const candidates = readdirSync(root, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && entry.name.toLowerCase() === slug)
+        .sort((a, b) => a.name.localeCompare(b.name));
+      for (const candidate of candidates) {
+        const path = join(root, candidate.name);
+        if (isDFlash2Companion(path)) return path;
+      }
+    } catch {
+      // An absent/unreadable companion leaves ordinary target loading available.
+    }
+  }
+  return undefined;
+}

--- a/packages/lm/src/models/model-loader.ts
+++ b/packages/lm/src/models/model-loader.ts
@@ -20,6 +20,7 @@ import {
 } from '@mlx-node/core';
 
 import { ChatSession, type SessionCapableModel } from '../chat-session.js';
+import { findDFlash2Draft } from '../draft-companion.js';
 import {
   familyDataFor,
   MalformedModelConfigError,
@@ -41,6 +42,8 @@ import {
 
 /** Optional settings for {@link loadModel} / {@link loadSession}. */
 export interface LoadModelOptions {
+  /** Discover a Qwen DFlash2 companion on disk (default true). Explicit draftModelPath wins. */
+  autoLoadDraft?: boolean;
   /**
    * Directory of an external draft checkpoint (config.json +
    * model.safetensors) loaded alongside the target for speculative decoding.
@@ -194,7 +197,9 @@ function dispatchLoad(
     );
   }
   const binding: LoaderBinding = LOADER_BINDINGS[modelType];
-  return binding.load(modelPath, options);
+  const draftModelPath =
+    options?.draftModelPath ?? (options?.autoLoadDraft === false ? undefined : findDFlash2Draft(modelPath, modelType));
+  return binding.load(modelPath, draftModelPath === undefined ? options : { ...options, draftModelPath });
 }
 
 /**
@@ -208,6 +213,8 @@ function dispatchLoad(
  * rejects it.
  * Without the option, Gemma4 loads `<modelPath>/draft/` automatically when
  * that embedded checkpoint is present.
+ * Qwen also discovers `draft/` or a shared `qwen3.8-27b-dflash2` directory
+ * beside a Qwen3.8-27B target. Set `autoLoadDraft: false` to disable discovery.
  */
 export async function loadModel(modelPath: string, options?: LoadModelOptions): Promise<LoadableModel> {
   const modelType = await detectModelType(modelPath);
@@ -235,6 +242,8 @@ export async function loadModel(modelPath: string, options?: LoadModelOptions): 
  * rejects it.
  * Without the option, Gemma4 loads `<modelPath>/draft/` automatically when
  * that embedded checkpoint is present.
+ * Qwen uses the same companion discovery as `loadModel()` unless
+ * `autoLoadDraft: false` is passed.
  * The resulting session auto-enables the speculative path when the model
  * reports `hasMtpWeights()` AND does not opt out of the auto-default; pass
  * `enableMtp: false` per call to suppress it, or `enableMtp: true` to force

--- a/packages/server/src/host/discover.ts
+++ b/packages/server/src/host/discover.ts
@@ -11,6 +11,7 @@ import {
   type LaunchPreset,
   type ModelType,
 } from '@mlx-node/lm';
+import { isDFlash2DraftDirectory } from '@mlx-node/lm/draft-companion';
 
 /** A locally-downloaded model paired with its sampling preset. */
 export interface DiscoveredModel {
@@ -41,6 +42,7 @@ export async function discoverModels(dir: string): Promise<DiscoveredModel[]> {
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const full = join(dir, entry.name);
+    if (isDFlash2DraftDirectory(full)) continue;
 
     let modelType: ModelType;
     try {

--- a/packages/server/src/host/index.ts
+++ b/packages/server/src/host/index.ts
@@ -45,7 +45,9 @@ import {
   PagedConfigOverrideManager,
   QWEN35_PAGED_MODEL_TYPES,
   type LoadableModel,
+  type LoadModelOptions,
 } from '@mlx-node/lm';
+import { findDFlash2Draft } from '@mlx-node/lm/draft-companion';
 
 import type { ServerHealth } from '../health.js';
 import { createServer, resolveAuthToken, type CloseOptions, type ServerInstance } from '../server.js';
@@ -167,7 +169,7 @@ export interface InferenceHostOptions {
   sweepOrphanTempRoots?: boolean;
 
   /** Test seam: replaces the native model loader. */
-  loadModel?: (path: string) => Promise<LoadableModel>;
+  loadModel?: (path: string, options?: LoadModelOptions) => Promise<LoadableModel>;
   /** Test seam: replaces the verbose request logger. */
   attachLogger?: (server: Server, logDir: string) => Logger;
 }
@@ -317,8 +319,13 @@ export async function createInferenceHost(opts: InferenceHostOptions = {}): Prom
     tempDirPrefix: hostTempDirPrefix(),
   });
   const loadModelFn = opts.loadModel ?? loadModelNative;
-  const loadModelPagedAware = async (path: string): Promise<LoadableModel> =>
-    loadModelFn(await pagedConfigOverrides.resolve(path));
+  const loadModelPagedAware = async (path: string): Promise<LoadableModel> => {
+    const entry = models.find((model) => model.path === path)!;
+    // Resolve against the source directory before creating the paged config overlay.
+    const draftModelPath = findDFlash2Draft(path, entry.modelType, modelsDir);
+    const resolvedPath = await pagedConfigOverrides.resolve(path);
+    return draftModelPath === undefined ? loadModelFn(resolvedPath) : loadModelFn(resolvedPath, { draftModelPath });
+  };
   const controller = makeSwapController(models, server.registry, loadModelPagedAware, boundEntry.name);
   ctrlRef.current = controller;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@mlx-node/core': resolve(__dirname, './packages/core/index.cjs'),
+      '@mlx-node/lm/draft-companion': resolve(__dirname, './packages/lm/src/draft-companion.ts'),
       '@mlx-node/lm/family-data': resolve(__dirname, './packages/lm/src/family-data.ts'),
       '@mlx-node/lm': resolve(__dirname, './packages/lm/src/index.ts'),
       '@mlx-node/agent/catalog': resolve(__dirname, './packages/agent/src/catalog.ts'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,7 @@ __metadata:
     "@earendil-works/pi-coding-agent": "npm:^0.84.4"
     "@huggingface/hub": "npm:^2.16.1"
     "@mlx-node/agent": "workspace:*"
+    "@mlx-node/lm": "workspace:*"
     "@radix-ui/react-dialog": "npm:^1.1.23"
     "@radix-ui/react-select": "npm:^2.3.7"
     "@radix-ui/react-slot": "npm:^1.3.3"


### PR DESCRIPTION
Qwen3.8-27B users can install the separate DFlash2 weights directly inside the Qwen3.8-27B model card and have them picked up automatically on the next target load. An optional companion section beneath the target download keeps its own Install DFlash2 button, progress, cancel, and update controls. Existing manual downloads are recognized.

Discovery supports shared `qwen3.8-27b-dflash2` directories alongside Qwen3.8-27B targets, including supported GGUF variants, while preserving embedded `draft/` and explicit path precedence. The agent, inference host, and SDK share the discovery logic. Draft-only checkpoints stay out of chat-model pickers, and SDK callers can disable discovery with `autoLoadDraft: false`.

Model cards now link the model title to Hugging Face, show the short quantization label (such as `MXFP4`), and size the grid to the available content width so repository names no longer squeeze the size label. The DFlash2 controls stay inside the Qwen card, separated by a divider, and the loading placeholder reserves that same companion section.

Validation:
- 411 focused tests passed, covering discovery, loading, download lifecycle, native-free imports, and dashboard behavior. Re-ran all 76 dashboard page and loading-shape tests after grouping the companion inside the Qwen card.
- TypeScript and dashboard builds, changed-file lint/format checks, and `git diff --check` passed.
- Electron layout checks passed at 720, 900, 1200, 1280, and 1600 px in light and dark themes with persistent scrollbars. Exercised the companion Install → progress → Installed flow using the built UI and fixture API responses.
- With the local Qwen3.8-27B UD-Q4_K_XL GGUF and real DFlash2 checkpoint, temporarily moving the companion disabled discovery; restoring it re-enabled discovery. Loading without an explicit draft path logged the external companion load and generated 32 tokens over 6 speculative cycles. This was a load/generation smoke check, not a performance comparison.

No native Rust changes are included. Local inference validation used the existing native build; remote CI will validate the PR commit separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model-load paths and discovery boundaries for dense Qwen3.8 targets; incorrect pairing could affect inference behavior, though scope is limited to optional draft discovery and UI/download flows.
> 
> **Overview**
> Adds shared **Qwen3.8-27B DFlash2** companion support end-to-end: a native-free `@mlx-node/lm/draft-companion` module discovers `draft/` or a sibling `qwen3.8-27b-dflash2` install at **load time** (not during model discovery), with embedded `draft/` and explicit `draftModelPath` taking precedence. **`loadModel` / `loadSession`** gain default auto-discovery and **`autoLoadDraft: false`** to opt out.
> 
> The **agent** and **inference host** use the same discovery; draft-only checkpoints are **excluded** from chat model lists while still counting toward disk usage. The **dashboard** catalogs an optional DFlash2 download under the Qwen3.8 card, tracks **companions** separately (install, progress, delete), and validates published companion weights.
> 
> **Docs** describe manual install and SDK behavior. Discovery no longer bakes `draftModelPath` into advertised models, so companions installed or removed after startup are picked up on the next load/swap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3115d76ee832e224751878e6b2fc175d18d1fa8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

