### PR TITLE
Pin Gemma and Qwen performance fixtures for reproducible benchmarks

### DIFF
--- a/docs/perf.md
+++ b/docs/perf.md
@@ -1,5 +1,24 @@
 # Performance & profiling
 
+## Pinned benchmark fixtures
+
+The real review inputs used in [issue #142](https://github.com/mlx-node/mlx-node/issues/142) are stored in the private R2 bucket `mlx-node-benchmarks`. Each manifest pins a versioned object, SHA-256 hashes, model identity, and the measured protocol. With Wrangler authenticated to the account in the manifest:
+
+```sh
+oxnode scripts/benchmark-fixture.ts fetch --fixture gemma4
+oxnode scripts/benchmark-fixture.ts fetch --fixture qwen38
+oxnode scripts/benchmark-fixture.ts verify --fixture qwen38 --tokenizer /path/to/prepared-model/tokenizer.json
+```
+
+| Fixture | Measured input tokens | Recorded protocol |
+| --- | --- | --- |
+| [Gemma 4 QAT Q4_0](../scripts/fixtures/gemma4-oxc-review-v1.json) | 7,733 / 40,528 / 66,904 | 256 output tokens; BF16 KV in both runtimes; 512-token prefill chunks; fresh process per sample. |
+| [Qwen3.8 UD-Q4_K_XL](../scripts/fixtures/qwen38-oxc-review-v1.json) | 6,219 / 18,754 / 32,488 | 512 output tokens; BF16 MLX / F16 llama.cpp KV; 2,048-token chunks; three requests per runtime/context process. |
+
+The default selection is `gemma4`. Downloads and existing files must match the manifest before use. `verify` is offline; the optional tokenizer check compares current rendering against every pinned token ID and prompt. Qwen verification sets `preserve_thinking=true` in a temporary tokenizer copy to match its native session; the model files are untouched. Its package contains only measured cases, with the original messages and saved rendered prompts; warmup used each same context for 16 output tokens. The unused synthetic warmup in the historical preparation file is excluded.
+
+Keep each fixture version unchanged and record runtime, cache, timing, and load conditions for new measurements. Historical messages contain tool results, but replay must not execute tools. These fixtures do not assert generated-answer parity or universal speed thresholds. See the [Gemma research reference](./research/gemma4-gguf-performance.md#pinned-fixture) and each manifest for restoration and protocol details.
+
 ## Profiling
 
 Per-generation profiling is exposed from `@mlx-node/lm`:

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -2,7 +2,7 @@
 
 ## Pinned benchmark fixtures
 
-The real review inputs used in [issue #142](https://github.com/mlx-node/mlx-node/issues/142) are stored in the private R2 bucket `mlx-node-benchmarks`. Each manifest pins a versioned object, SHA-256 hashes, model identity, and the measured protocol. With Wrangler authenticated to the account in the manifest:
+The real review inputs used in [issue #142](https://github.com/mlx-node/mlx-node/issues/142) are publicly downloadable from the R2 bucket `mlx-node-benchmarks`. Each manifest pins an HTTPS URL, SHA-256 hashes, model identity, and the measured protocol. No Cloudflare account, credentials, or Wrangler installation is needed:
 
 ```sh
 oxnode scripts/benchmark-fixture.ts fetch --fixture gemma4
@@ -15,7 +15,18 @@ oxnode scripts/benchmark-fixture.ts verify --fixture qwen38 --tokenizer /path/to
 | [Gemma 4 QAT Q4_0](../scripts/fixtures/gemma4-oxc-review-v1.json) | 7,733 / 40,528 / 66,904 | 256 output tokens; BF16 KV in both runtimes; 512-token prefill chunks; fresh process per sample. |
 | [Qwen3.8 UD-Q4_K_XL](../scripts/fixtures/qwen38-oxc-review-v1.json) | 6,219 / 18,754 / 32,488 | 512 output tokens; BF16 MLX / F16 llama.cpp KV; 2,048-token chunks; three requests per runtime/context process. |
 
-The default selection is `gemma4`. Downloads and existing files must match the manifest before use. `verify` is offline; the optional tokenizer check compares current rendering against every pinned token ID and prompt. Qwen verification sets `preserve_thinking=true` in a temporary tokenizer copy to match its native session; the model files are untouched. Its package contains only measured cases, with the original messages and saved rendered prompts; warmup used each same context for 16 output tokens. The unused synthetic warmup in the historical preparation file is excluded.
+The default selection is `gemma4`. Downloads and existing files must match the manifest before use. `fetch` and offline `verify` need no model or native addon; only the optional tokenizer check uses the addon to compare current rendering against every pinned token ID and prompt. Qwen verification sets `preserve_thinking=true` in a temporary tokenizer copy to match its native session; the model files are untouched. Its package contains only measured cases, with the original messages and saved rendered prompts; warmup used each same context for 16 output tokens. The unused synthetic warmup in the historical preparation file is excluded.
+
+In GitHub Actions, after checkout, Node.js setup, and `yarn install --immutable`, restore both fixtures with:
+
+```yaml
+- name: Download pinned benchmark fixtures
+  run: |
+    yarn oxnode scripts/benchmark-fixture.ts fetch --fixture gemma4
+    yarn oxnode scripts/benchmark-fixture.ts fetch --fixture qwen38
+```
+
+This step requires no secrets and verifies the archive, decoded payload, and all token-ID hashes before saving. The manifest's `storage.url` also supports ordinary HTTPS clients. The public `r2.dev` endpoint is [rate limited](https://developers.cloudflare.com/r2/buckets/public-buckets/); a custom domain can be added if CI download volume grows. The same payload and hashes must be retained when changing its host.
 
 Keep each fixture version unchanged and record runtime, cache, timing, and load conditions for new measurements. Historical messages contain tool results, but replay must not execute tools. These fixtures do not assert generated-answer parity or universal speed thresholds. See the [Gemma research reference](./research/gemma4-gguf-performance.md#pinned-fixture) and each manifest for restoration and protocol details.
 

--- a/docs/research/gemma4-gguf-performance.md
+++ b/docs/research/gemma4-gguf-performance.md
@@ -74,4 +74,17 @@ Projection differences stayed within one BF16 ULP (relative L2 approximately `9.
 
 Archived `gemma4-optimization-2026-09-10/results.json` holds all 18 samples, source/output hashes, and plans; runners and baseline/audit evidence share the Git-history link above. Later formatting/preflight/discovery changes leave the timed inference path unchanged; the matrix was not rerun.
 
-For reproduction, restore archived runners and use `oxnode` for TypeScript. Preserve private `.cache/benchmarks/gemma4-agent-2026-09-10/inputs.json`: rebuilding its wrapper can change dates/tools. Original llama-server flags: `-ngl 999 -fa on -ctk bf16 -ctv bf16 -c 73728 -b 2048 -ub 512 -t 6 -np 1 --no-context-shift`. Verify matching token IDs, caches, output lengths, contention, and source/binary hashes before comparing new results. Private messages, outputs, and activations stay outside Git.
+## Pinned fixture
+
+[`gemma4-oxc-review-v1`](../../scripts/fixtures/gemma4-oxc-review-v1.json) pins the exact messages, tool definitions, rendered prompts, and token IDs used above. The 362 KB compressed object is stored in the private Cloudflare R2 bucket `mlx-node-benchmarks`, under a versioned key containing the payload SHA-256. The manifest records the object and payload hashes, model/tokenizer identities, protocol, and archived runner identity. Public access is disabled; no completed-object expiration rule is configured. Private messages, outputs, and activations stay outside Git.
+
+With Wrangler authenticated to the account in the manifest, restore and verify the fixture:
+
+```sh
+oxnode scripts/benchmark-fixture.ts fetch
+oxnode scripts/benchmark-fixture.ts verify --tokenizer .cache/models/gemma-4-12b-it-qat-q4_0-gguf/tokenizer.json
+```
+
+`fetch` verifies the compressed object, decoded file, and all three token-ID hashes before saving to `.cache/benchmarks/gemma4-agent-2026-09-10/inputs.json`. An existing differing file is rejected. `verify` is offline; its optional tokenizer check detects current template/tokenizer drift. The manifest and hashes are the pin; storage administrators can still replace objects, so never bypass verification or overwrite this version. New messages, tools, or templates require a new fixture version.
+
+For inference replay, retrieve the archived runner identified by the manifest and adapt its local repository/model/llama-server paths; use `oxnode` for TypeScript. Do not rebuild the fixture wrapper, whose dates/tools can change. Keep model and token IDs, caches, output lengths, and timing policy matched; record contention and source/binary hashes. The recorded llama.cpp six-thread setting is a comparison parameter, not an optimum for every machine. A fixture pins the workload, not expected speed or generated answers.

--- a/docs/research/gemma4-gguf-performance.md
+++ b/docs/research/gemma4-gguf-performance.md
@@ -76,9 +76,9 @@ Archived `gemma4-optimization-2026-09-10/results.json` holds all 18 samples, sou
 
 ## Pinned fixture
 
-[`gemma4-oxc-review-v1`](../../scripts/fixtures/gemma4-oxc-review-v1.json) pins the exact messages, tool definitions, rendered prompts, and token IDs used above. The 362 KB compressed object is stored in the private Cloudflare R2 bucket `mlx-node-benchmarks`, under a versioned key containing the payload SHA-256. The manifest records the object and payload hashes, model/tokenizer identities, protocol, and archived runner identity. Public access is disabled; no completed-object expiration rule is configured. Private messages, outputs, and activations stay outside Git.
+[`gemma4-oxc-review-v1`](../../scripts/fixtures/gemma4-oxc-review-v1.json) pins the exact messages, tool definitions, rendered prompts, and token IDs used above. The 362 KB compressed object is publicly hosted in the Cloudflare R2 bucket `mlx-node-benchmarks`, under a versioned key containing the payload SHA-256. The manifest records its HTTPS URL, object and payload hashes, model/tokenizer identities, protocol, and archived runner identity. No completed-object expiration rule is configured. Fixture payloads live in R2 rather than Git; generated outputs and activations remain local.
 
-With Wrangler authenticated to the account in the manifest, restore and verify the fixture:
+Restore over public HTTPS and verify the fixture without Cloudflare credentials:
 
 ```sh
 oxnode scripts/benchmark-fixture.ts fetch

--- a/scripts/benchmark-fixture.ts
+++ b/scripts/benchmark-fixture.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env oxnode
+
+/// <reference types="node" />
+
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+import { gunzipSync } from 'node:zlib';
+
+interface FixtureCase {
+  name: string;
+  promptTokens: number;
+  sha256: string;
+  tokenIds: number[];
+  messages: unknown[];
+  tools: unknown[];
+  rendered: string;
+}
+
+interface Manifest {
+  id: string;
+  storage: {
+    accountId: string;
+    bucket: string;
+    key: string;
+    bytes: number;
+    sha256: string;
+  };
+  payload: { path: string; bytes: number; sha256: string };
+  cases: { name: string; promptTokens: number; tokenIdsSha256: string }[];
+}
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const hash = (data: Buffer | string) => createHash('sha256').update(data).digest('hex');
+
+function verifyBytes(data: Buffer, expected: { bytes: number; sha256: string }, label: string) {
+  if (data.length !== expected.bytes || hash(data) !== expected.sha256) {
+    throw new Error(`${label}: pinned byte length or SHA-256 mismatch`);
+  }
+}
+
+function verifyPayload(data: Buffer, manifest: Manifest): FixtureCase[] {
+  verifyBytes(data, manifest.payload, 'Fixture');
+  const cases: FixtureCase[] = JSON.parse(data.toString('utf8'));
+  if (cases.length !== manifest.cases.length) {
+    throw new Error('Fixture case count mismatch');
+  }
+  for (const [index, expected] of manifest.cases.entries()) {
+    const actual = cases[index];
+    if (
+      actual.name !== expected.name ||
+      actual.promptTokens !== expected.promptTokens ||
+      actual.tokenIds.length !== expected.promptTokens ||
+      actual.sha256 !== expected.tokenIdsSha256 ||
+      hash(JSON.stringify(actual.tokenIds)) !== expected.tokenIdsSha256
+    ) {
+      throw new Error(`${expected.name}: pinned token IDs mismatch`);
+    }
+  }
+  return cases;
+}
+
+async function fetchPayload(manifest: Manifest): Promise<Buffer> {
+  const temporary = await mkdtemp(join(tmpdir(), 'mlx-benchmark-fixture-'));
+  const compressed = join(temporary, 'inputs.json.gz');
+  try {
+    await new Promise<void>((done, reject) => {
+      const child = spawn(
+        'wrangler',
+        ['r2', 'object', 'get', `${manifest.storage.bucket}/${manifest.storage.key}`, '--remote', '--file', compressed],
+        {
+          cwd: temporary,
+          env: {
+            ...process.env,
+            CLOUDFLARE_ACCOUNT_ID: manifest.storage.accountId,
+          },
+          stdio: ['ignore', 'inherit', 'inherit'],
+        },
+      );
+      child.once('error', reject);
+      child.once('exit', (code, signal) => {
+        if (code === 0) done();
+        else reject(new Error(`Wrangler download failed: ${signal ?? code}`));
+      });
+    });
+    const archive = await readFile(compressed);
+    verifyBytes(archive, manifest.storage, 'Downloaded archive');
+    const data = gunzipSync(archive, {
+      maxOutputLength: manifest.payload.bytes,
+    });
+    verifyPayload(data, manifest);
+    return data;
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: {
+      output: { type: 'string' },
+      tokenizer: { type: 'string' },
+      help: { type: 'boolean', short: 'h' },
+    },
+  });
+  if (values.help) {
+    console.log(
+      'Usage: oxnode scripts/benchmark-fixture.ts fetch|verify [--output inputs.json] [--tokenizer tokenizer.json]\n' +
+        'fetch: authenticated R2 download, or verify an existing copy; never overwrite a different fixture.\n' +
+        'verify: offline hashes; optionally check the current native chat template against every pinned token ID.',
+    );
+    return;
+  }
+  const [mode] = positionals;
+  if (positionals.length !== 1 || !['fetch', 'verify'].includes(mode)) {
+    throw new Error('Expected fetch or verify; use --help for usage');
+  }
+  const manifest: Manifest = JSON.parse(
+    await readFile(resolve(root, 'scripts/fixtures/gemma4-oxc-review-v1.json'), 'utf8'),
+  );
+  const output = values.output ? resolve(values.output) : resolve(root, manifest.payload.path);
+  let data: Buffer;
+  try {
+    data = await readFile(output);
+  } catch (error) {
+    if (mode !== 'fetch' || (error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+    data = await fetchPayload(manifest);
+    await mkdir(dirname(output), { recursive: true });
+    await writeFile(output, data, { flag: 'wx', mode: 0o600 });
+  }
+  const cases = verifyPayload(data, manifest);
+  if (values.tokenizer) {
+    const coreUrl = pathToFileURL(resolve(root, 'packages/core/index.cjs'));
+    const { Qwen3Tokenizer } = await import(coreUrl.href);
+    const tokenizer = await Qwen3Tokenizer.fromPretrained(resolve(values.tokenizer));
+    for (const item of cases) {
+      const ids = await tokenizer.applyChatTemplate(item.messages, true, item.tools, true);
+      if (
+        hash(JSON.stringify(Array.from(ids))) !== item.sha256 ||
+        (await tokenizer.decode(ids, false)) !== item.rendered
+      ) {
+        throw new Error(`${item.name}: current tokenizer/template drifted`);
+      }
+    }
+    console.log('Current native tokenizer/template matches all pinned inputs.');
+  }
+  console.log(
+    `Verified ${manifest.id}: ${cases.map((item) => item.promptTokens.toLocaleString('en-US')).join(' / ')} tokens.\n${output}`,
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : 'Fixture check failed');
+  process.exitCode = 1;
+});

--- a/scripts/benchmark-fixture.ts
+++ b/scripts/benchmark-fixture.ts
@@ -2,7 +2,6 @@
 
 /// <reference types="node" />
 
-import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -24,9 +23,7 @@ interface FixtureCase {
 interface Manifest {
   id: string;
   storage: {
-    accountId: string;
-    bucket: string;
-    key: string;
+    url: string;
     bytes: number;
     sha256: string;
   };
@@ -70,38 +67,32 @@ function verifyPayload(data: Buffer, manifest: Manifest): FixtureCase[] {
 }
 
 async function fetchPayload(manifest: Manifest): Promise<Buffer> {
-  const temporary = await mkdtemp(join(tmpdir(), 'mlx-benchmark-fixture-'));
-  const compressed = join(temporary, 'inputs.json.gz');
-  try {
-    await new Promise<void>((done, reject) => {
-      const child = spawn(
-        'wrangler',
-        ['r2', 'object', 'get', `${manifest.storage.bucket}/${manifest.storage.key}`, '--remote', '--file', compressed],
-        {
-          cwd: temporary,
-          env: {
-            ...process.env,
-            CLOUDFLARE_ACCOUNT_ID: manifest.storage.accountId,
-          },
-          stdio: ['ignore', 'inherit', 'inherit'],
-        },
-      );
-      child.once('error', reject);
-      child.once('exit', (code, signal) => {
-        if (code === 0) done();
-        else reject(new Error(`Wrangler download failed: ${signal ?? code}`));
-      });
-    });
-    const archive = await readFile(compressed);
-    verifyBytes(archive, manifest.storage, 'Downloaded archive');
-    const data = gunzipSync(archive, {
-      maxOutputLength: manifest.payload.bytes,
-    });
-    verifyPayload(data, manifest);
-    return data;
-  } finally {
-    await rm(temporary, { recursive: true, force: true });
+  const url = new URL(manifest.storage.url);
+  if (url.protocol !== 'https:') throw new Error('Fixture URL must use HTTPS');
+  const response = await fetch(url, { signal: AbortSignal.timeout(60_000) });
+  if (!response.ok || !response.body) {
+    await response.body?.cancel();
+    throw new Error(`Fixture download failed: HTTP ${response.status}`);
   }
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > manifest.storage.bytes) throw new Error('Downloaded archive exceeds pinned byte length');
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    await reader.cancel();
+  }
+  const archive = Buffer.concat(chunks, bytes);
+  verifyBytes(archive, manifest.storage, 'Downloaded archive');
+  const data = gunzipSync(archive, { maxOutputLength: manifest.payload.bytes });
+  verifyPayload(data, manifest);
+  return data;
 }
 
 async function main() {
@@ -118,7 +109,7 @@ async function main() {
     console.log(
       'Usage: oxnode scripts/benchmark-fixture.ts fetch|verify [--fixture gemma4|qwen38] [--output inputs.json] [--tokenizer tokenizer.json]\n' +
         'The default fixture is gemma4. Qwen verification retains historical reasoning, as its session benchmark did.\n' +
-        'fetch: authenticated R2 download, or verify an existing copy; never overwrite a different fixture.\n' +
+        'fetch: public HTTPS download, or verify an existing copy; never overwrite a different fixture.\n' +
         'verify: offline hashes; optionally check the current native chat template against every pinned token ID.',
     );
     return;

--- a/scripts/benchmark-fixture.ts
+++ b/scripts/benchmark-fixture.ts
@@ -4,7 +4,7 @@
 
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -17,7 +17,7 @@ interface FixtureCase {
   sha256: string;
   tokenIds: number[];
   messages: unknown[];
-  tools: unknown[];
+  tools: unknown[] | null;
   rendered: string;
 }
 
@@ -32,9 +32,14 @@ interface Manifest {
   };
   payload: { path: string; bytes: number; sha256: string };
   cases: { name: string; promptTokens: number; tokenIdsSha256: string }[];
+  tokenizerOptions?: { preserveThinking: boolean };
 }
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const fixtures = new Map([
+  ['gemma4', 'gemma4-oxc-review-v1'],
+  ['qwen38', 'qwen38-oxc-review-v1'],
+]);
 const hash = (data: Buffer | string) => createHash('sha256').update(data).digest('hex');
 
 function verifyBytes(data: Buffer, expected: { bytes: number; sha256: string }, label: string) {
@@ -103,6 +108,7 @@ async function main() {
   const { values, positionals } = parseArgs({
     allowPositionals: true,
     options: {
+      fixture: { type: 'string', default: 'gemma4' },
       output: { type: 'string' },
       tokenizer: { type: 'string' },
       help: { type: 'boolean', short: 'h' },
@@ -110,7 +116,8 @@ async function main() {
   });
   if (values.help) {
     console.log(
-      'Usage: oxnode scripts/benchmark-fixture.ts fetch|verify [--output inputs.json] [--tokenizer tokenizer.json]\n' +
+      'Usage: oxnode scripts/benchmark-fixture.ts fetch|verify [--fixture gemma4|qwen38] [--output inputs.json] [--tokenizer tokenizer.json]\n' +
+        'The default fixture is gemma4. Qwen verification retains historical reasoning, as its session benchmark did.\n' +
         'fetch: authenticated R2 download, or verify an existing copy; never overwrite a different fixture.\n' +
         'verify: offline hashes; optionally check the current native chat template against every pinned token ID.',
     );
@@ -120,9 +127,9 @@ async function main() {
   if (positionals.length !== 1 || !['fetch', 'verify'].includes(mode)) {
     throw new Error('Expected fetch or verify; use --help for usage');
   }
-  const manifest: Manifest = JSON.parse(
-    await readFile(resolve(root, 'scripts/fixtures/gemma4-oxc-review-v1.json'), 'utf8'),
-  );
+  const fixture = fixtures.get(values.fixture);
+  if (!fixture) throw new Error(`Unknown fixture: ${values.fixture}; expected gemma4 or qwen38`);
+  const manifest: Manifest = JSON.parse(await readFile(resolve(root, `scripts/fixtures/${fixture}.json`), 'utf8'));
   const output = values.output ? resolve(values.output) : resolve(root, manifest.payload.path);
   let data: Buffer;
   try {
@@ -137,17 +144,40 @@ async function main() {
   }
   const cases = verifyPayload(data, manifest);
   if (values.tokenizer) {
-    const coreUrl = pathToFileURL(resolve(root, 'packages/core/index.cjs'));
-    const { Qwen3Tokenizer } = await import(coreUrl.href);
-    const tokenizer = await Qwen3Tokenizer.fromPretrained(resolve(values.tokenizer));
-    for (const item of cases) {
-      const ids = await tokenizer.applyChatTemplate(item.messages, true, item.tools, true);
-      if (
-        hash(JSON.stringify(Array.from(ids))) !== item.sha256 ||
-        (await tokenizer.decode(ids, false)) !== item.rendered
-      ) {
-        throw new Error(`${item.name}: current tokenizer/template drifted`);
+    const temporary = manifest.tokenizerOptions?.preserveThinking
+      ? await mkdtemp(join(tmpdir(), 'mlx-benchmark-tokenizer-'))
+      : undefined;
+    try {
+      let tokenizerPath = resolve(values.tokenizer);
+      if (temporary) {
+        const config: { chat_template?: string } = JSON.parse(
+          await readFile(join(dirname(tokenizerPath), 'tokenizer_config.json'), 'utf8'),
+        );
+        const template =
+          typeof config.chat_template === 'string'
+            ? config.chat_template
+            : await readFile(join(dirname(tokenizerPath), 'chat_template.jinja'), 'utf8');
+        // The standalone API defaults this session-only flag to false. Match
+        // the recorded Qwen session without changing the supplied model files.
+        config.chat_template = '{% set preserve_thinking = true %}' + template;
+        await copyFile(tokenizerPath, join(temporary, 'tokenizer.json'));
+        await writeFile(join(temporary, 'tokenizer_config.json'), JSON.stringify(config));
+        tokenizerPath = join(temporary, 'tokenizer.json');
       }
+      const coreUrl = pathToFileURL(resolve(root, 'packages/core/index.cjs'));
+      const { Qwen3Tokenizer } = await import(coreUrl.href);
+      const tokenizer = await Qwen3Tokenizer.fromPretrained(tokenizerPath);
+      for (const item of cases) {
+        const ids = await tokenizer.applyChatTemplate(item.messages, true, item.tools, true);
+        if (
+          hash(JSON.stringify(Array.from(ids))) !== item.sha256 ||
+          (await tokenizer.decode(ids, false)) !== item.rendered
+        ) {
+          throw new Error(`${item.name}: current tokenizer/template drifted`);
+        }
+      }
+    } finally {
+      if (temporary) await rm(temporary, { recursive: true, force: true });
     }
     console.log('Current native tokenizer/template matches all pinned inputs.');
   }

--- a/scripts/fixtures/gemma4-oxc-review-v1.json
+++ b/scripts/fixtures/gemma4-oxc-review-v1.json
@@ -7,7 +7,8 @@
     "accountId": "6db7cbc0423b5d56af93d13e4e2b469b",
     "bucket": "mlx-node-benchmarks",
     "key": "fixtures/gemma4-oxc-review/v1/812bd4adb5b10688a2c7ced9ccabf0cc43159d3b80541eb2009960ced347b697/inputs.json.gz",
-    "access": "private",
+    "access": "public",
+    "url": "https://pub-7dbe2ab7080540a39fad0219f8b247ad.r2.dev/fixtures/gemma4-oxc-review/v1/812bd4adb5b10688a2c7ced9ccabf0cc43159d3b80541eb2009960ced347b697/inputs.json.gz",
     "bytes": 361773,
     "sha256": "2caaca143a231807a574eddaef35beba7a52a4e7afea2b525eb16f49f0546fc6"
   },

--- a/scripts/fixtures/gemma4-oxc-review-v1.json
+++ b/scripts/fixtures/gemma4-oxc-review-v1.json
@@ -1,0 +1,109 @@
+{
+  "schemaVersion": 1,
+  "id": "gemma4-oxc-review-v1",
+  "measuredAt": "2026-09-10",
+  "storage": {
+    "provider": "cloudflare-r2",
+    "accountId": "6db7cbc0423b5d56af93d13e4e2b469b",
+    "bucket": "mlx-node-benchmarks",
+    "key": "fixtures/gemma4-oxc-review/v1/812bd4adb5b10688a2c7ced9ccabf0cc43159d3b80541eb2009960ced347b697/inputs.json.gz",
+    "access": "private",
+    "bytes": 361773,
+    "sha256": "2caaca143a231807a574eddaef35beba7a52a4e7afea2b525eb16f49f0546fc6"
+  },
+  "payload": {
+    "path": ".cache/benchmarks/gemma4-agent-2026-09-10/inputs.json",
+    "bytes": 2289801,
+    "sha256": "812bd4adb5b10688a2c7ced9ccabf0cc43159d3b80541eb2009960ced347b697"
+  },
+  "contents": [
+    "frozen system and historical messages",
+    "tool definitions",
+    "rendered prompts",
+    "exact input token IDs"
+  ],
+  "source": {
+    "sessionId": "01a067cf-b782-7b58-855e-8158dcb283ab",
+    "sessionSha256": "cdf4938c2ce1f37acbe87659b38782bc48dd95cabb98723c7328819d8cbc2988",
+    "originalTask": "https://github.com/oxc-project/oxc-node/pull/745",
+    "wrapper": "Pi 0.84.4; reconstructed at measurement time because the historical system prompt was absent. Use the frozen messages; do not regenerate the wrapper."
+  },
+  "model": {
+    "file": "gemma-4-12b-it-qat-q4_0.gguf",
+    "sha256": "93567e57a8fe10b23569b9d9ec38cd005deedf71e29477c421a4b83f418a538b",
+    "tokenizerSha256": "cc8d3a0ce36466ccc1278bf987df5f71db1719b9ca6b4118264f45cb627bfe0f",
+    "configSha256": "478c46e8d2c52d5c2d85bf67e3b3e8c90e7c9d91086cee27e3c267907e936bd9"
+  },
+  "cases": [
+    {
+      "name": "diff-review",
+      "promptTokens": 7733,
+      "tokenIdsSha256": "d4eec44e531cefe0f8c18c6e0bd74c2067d389bf6d1cedb01ac9e1635f92844f",
+      "historicalMessages": 8,
+      "toolResults": 4
+    },
+    {
+      "name": "test-review",
+      "promptTokens": 40528,
+      "tokenIdsSha256": "ff79c8e3f979cd26f6ff29f801f3a6110481275291a789461883a0c6c99e3efa",
+      "historicalMessages": 56,
+      "toolResults": 30
+    },
+    {
+      "name": "final-review",
+      "promptTokens": 66904,
+      "tokenIdsSha256": "806d7f48ef0224d92d8e8a575180451e0e1250c6d40df025d43ed7f459b95be3",
+      "historicalMessages": 133,
+      "toolResults": 71
+    }
+  ],
+  "protocol": {
+    "repetitions": 3,
+    "outputTokens": 256,
+    "warmupTokens": 32,
+    "warmupCase": "diff-review",
+    "freshProcessPerSample": true,
+    "cooldownSeconds": 20,
+    "runtimeOrder": "Alternate mlx-node/llama.cpp per repetition.",
+    "sampling": "Greedy autoregressive, high thinking; no speculation.",
+    "kvCache": "BF16 in both runtimes.",
+    "promptCache": "Reset before each request; assert zero cached tokens. Adaptive model-local state survives reset.",
+    "prefillChunkTokens": 512,
+    "timing": "Exclude loading and warmup; include calibration during the measured request. Native prefill-to-first-token; decode covers the subsequent 255 tokens. Record request wall time separately.",
+    "llamaServerArgs": [
+      "-ngl",
+      "999",
+      "-fa",
+      "on",
+      "-ctk",
+      "bf16",
+      "-ctv",
+      "bf16",
+      "-c",
+      "73728",
+      "-b",
+      "2048",
+      "-ub",
+      "512",
+      "-t",
+      "6",
+      "-np",
+      "1",
+      "--no-context-shift"
+    ],
+    "mlxEnv": {
+      "MLX_AGENT_METRICS": "0",
+      "MLX_PERSIST_PAGED_CACHE": "0",
+      "MLX_PAGED_PREFILL_CHUNK_SIZE": "512"
+    },
+    "llamaThreadsNote": "Six CPU threads records this matrix; record any change when benchmarking another machine, rather than treating it as a universal optimum."
+  },
+  "runner": {
+    "commit": "f193ade24e02c3ab0abba5aab74e1c916e74f454",
+    "path": "docs/research/gemma4-optimization-2026-09-10/benchmark.ts",
+    "sha256": "caaa5774984a2639c906b47d731733d815f78f3476ac2918a65e9ae4061b3e96",
+    "portability": "Historical runner has local repository/model/llama-server paths. Adapt only paths for an exact protocol replay; record any other changes."
+  },
+  "resultsUrl": "https://github.com/mlx-node/mlx-node/issues/142#issuecomment-5629164002",
+  "reuse": "Keep this version unchanged. New messages, tool definitions, tokenizer or template require a new fixture version; token IDs are model-specific. Outputs may differ and do not establish quality parity."
+}

--- a/scripts/fixtures/qwen38-oxc-review-v1.json
+++ b/scripts/fixtures/qwen38-oxc-review-v1.json
@@ -7,7 +7,8 @@
     "accountId": "6db7cbc0423b5d56af93d13e4e2b469b",
     "bucket": "mlx-node-benchmarks",
     "key": "fixtures/qwen38-oxc-review/v1/c6c1373328614919617deca668fe67301fe0df853f7780143d9690464148bf5b/inputs.json.gz",
-    "access": "private",
+    "access": "public",
+    "url": "https://pub-7dbe2ab7080540a39fad0219f8b247ad.r2.dev/fixtures/qwen38-oxc-review/v1/c6c1373328614919617deca668fe67301fe0df853f7780143d9690464148bf5b/inputs.json.gz",
     "bytes": 192794,
     "sha256": "f6232c9150080cdb18ea077f86078b34c13209f481a2ca4707932a51bcd07c1b"
   },

--- a/scripts/fixtures/qwen38-oxc-review-v1.json
+++ b/scripts/fixtures/qwen38-oxc-review-v1.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": 1,
+  "id": "qwen38-oxc-review-v1",
+  "measuredAt": "2026-09-09",
+  "storage": {
+    "provider": "cloudflare-r2",
+    "accountId": "6db7cbc0423b5d56af93d13e4e2b469b",
+    "bucket": "mlx-node-benchmarks",
+    "key": "fixtures/qwen38-oxc-review/v1/c6c1373328614919617deca668fe67301fe0df853f7780143d9690464148bf5b/inputs.json.gz",
+    "access": "private",
+    "bytes": 192794,
+    "sha256": "f6232c9150080cdb18ea077f86078b34c13209f481a2ca4707932a51bcd07c1b"
+  },
+  "payload": {
+    "path": ".cache/benchmarks/qwen38-oxc-review-v1/inputs.json",
+    "bytes": 1116207,
+    "sha256": "c6c1373328614919617deca668fe67301fe0df853f7780143d9690464148bf5b"
+  },
+  "contents": [
+    "frozen system and historical messages, including reasoning and tool results",
+    "recorded review-continuation instruction",
+    "rendered prompts",
+    "exact input token IDs"
+  ],
+  "source": {
+    "sessionId": "01a067cf-b782-7b58-855e-8158dcb283ab",
+    "originalTask": "https://github.com/oxc-project/oxc-node/pull/745",
+    "workloadSha256": "a20719fd8705b0851825320840835e6c1baf12191581dea2134d3d7a341b7426",
+    "wrapper": "Recorded system/tool definitions were absent. The measured replay used a common review system prompt and a final instruction to continue without tools; both are frozen in messages. No tool definitions were passed.",
+    "normalization": "Preserve all three measured cases with messages unchanged, rename tokens to tokenIds, and include each saved prompt text as rendered. The unused synthetic warmup entry from workload.json is excluded; actual warmup used each measured context."
+  },
+  "model": {
+    "file": "Qwen3.8-27B-UD-Q4_K_XL.gguf",
+    "bytes": 17559178144,
+    "sha256": "3f227079003add2511437e5b1e94812e363385225bf6a9b47b0054a72bc8b01e",
+    "tokenizerSha256": "eb497acada9c9bbf43bf3fba7ec911094fe4a959d929ac045f347221c30f7bd4",
+    "tokenizerConfigSha256": "52dacff44261824657e05d5176e320a8f380f3006fabbb5d87a03ccf5c208573"
+  },
+  "tokenizerOptions": {
+    "preserveThinking": true,
+    "reason": "Native Qwen sessions retain historical reasoning. For standalone-tokenizer verification only, set preserve_thinking=true in a temporary copy of the supplied chat template; do not modify model assets."
+  },
+  "cases": [
+    {
+      "name": "6k",
+      "promptTokens": 6219,
+      "tokenIdsSha256": "c301418ba1449c6fc0d252798fd5c780ef700c1b4bdbaa01b7ec570481e123ce",
+      "sourceLine": 14,
+      "renderedSha256": "268ba489100dd634215e8ef58b19e01425080c78d71e5aab83850cd4f786a153"
+    },
+    {
+      "name": "16k",
+      "promptTokens": 18754,
+      "tokenIdsSha256": "550302ea93f957e3f4a36c2f87a841d45067ecbea66e8af10e02ae3a4991ff42",
+      "sourceLine": 21,
+      "renderedSha256": "b7c3356eb087856695cef62d3c523ee1ee3ab36d1159b22a51e41a03c7fd6690"
+    },
+    {
+      "name": "32k",
+      "promptTokens": 32488,
+      "tokenIdsSha256": "9f2e3726af32c6f24cc3043b136cfd8f12f96d53262f3a108c095d02ea144e77",
+      "sourceLine": 50,
+      "renderedSha256": "fddb246ab92342628443a6b9052a7b144f068cb37f4a6c7677d41c152d3ed278"
+    }
+  ],
+  "protocol": {
+    "repetitions": 3,
+    "outputTokens": 512,
+    "warmupTokens": 16,
+    "warmup": "One excluded 16-output-token warmup from the same measured context, once per runtime/context process.",
+    "processPolicy": "Fresh process per runtime/context; three measured requests within that process, resetting prompt caches between requests.",
+    "cooldownSeconds": 60,
+    "runtimeOrder": "mlx-node then llama.cpp at 6,219 tokens; llama.cpp then mlx-node at 18,754; mlx-node then llama.cpp at 32,488.",
+    "sampling": "Greedy autoregressive, high thinking, retain historical reasoning; no MTP/DFlash/speculation.",
+    "kvCache": {
+      "mlx-node": "BF16",
+      "llama.cpp": "F16"
+    },
+    "promptCache": "Zero cached tokens. mlx-node resets caches and uses a fresh cache salt per request; llama.cpp cache_prompt=false.",
+    "prefillChunkTokens": 2048,
+    "activeRequests": 1,
+    "timing": "Exclude loading, warmup and HTTP/client overhead from native rates. Prefill-to-first-token; decode covers the subsequent 511 tokens. Record request wall time separately.",
+    "llamaServerArgs": [
+      "-ngl",
+      "99",
+      "-fa",
+      "on",
+      "-ctk",
+      "f16",
+      "-ctv",
+      "f16",
+      "-c",
+      "40960",
+      "-b",
+      "2048",
+      "-ub",
+      "2048",
+      "-t",
+      "8",
+      "-tb",
+      "8",
+      "-np",
+      "1",
+      "--no-warmup",
+      "--perf"
+    ],
+    "mlxEnv": {
+      "MLX_PAGED_PREFILL_CHUNK_SIZE": "2048"
+    },
+    "admissionPolicyByPromptTokens": {
+      "6219": "60-second cooldown plus 20 seconds at <=5% GPU utilization",
+      "18754": "60-second cooldown plus 20 seconds at <=5% GPU utilization",
+      "32488": "60-second interval; no other active local LLM; desktop graphics allowed"
+    },
+    "hardwareNote": "Recorded on M5 Max, 40 GPU cores, 128 GiB, AC power. Settings record this comparison, not universal hardware-optimal defaults. Qwen and Gemma use different workloads/protocols."
+  },
+  "measuredRevisions": {
+    "mlx-node": "c14e55847c8fa44dbb7a965b1f47af7c1d819826",
+    "llama.cpp": "a14dba686aaafba3a2d6b5eb8820b0df5c5d2d92"
+  },
+  "resultsUrl": "https://github.com/mlx-node/mlx-node/issues/142#initial-benchmark",
+  "reuse": "Use frozen messages for mlx-node session inference and frozen tokenIds for llama.cpp /completion. Same-case warmup, cache and timing rules are required for a comparable run. Keep this version unchanged; create a new version for changed messages/tools/templates. Outputs are not golden correctness assertions."
+}


### PR DESCRIPTION
Rebuilding historical benchmark wrappers can change messages, dates, tools, or token IDs, making later performance comparisons use different workloads. Pin the exact Gemma and Qwen review inputs from #142 in public R2 objects under versioned keys containing their SHA-256 hashes, so future GitHub Actions runs can restore them without Cloudflare credentials.

Add manifests with public HTTPS URLs, archive/payload/token hashes, model identities, and the measured protocols. `oxnode scripts/benchmark-fixture.ts fetch --fixture gemma4|qwen38` downloads and verifies a fixture before saving, refusing to overwrite a differing local copy. Downloads have a timeout and a size limit. Gemma remains the default. Fetch and offline verification need no model, native addon, or Wrangler installation; the performance documentation includes a GitHub Actions download step.

| Fixture | Input tokens | Compressed bytes |
| --- | --- | ---: |
| Gemma 4 QAT Q4_0 | 7,733 / 40,528 / 66,904 | 361,773 |
| Qwen3.8 UD-Q4_K_XL | 6,219 / 18,754 / 32,488 | 192,794 |

`verify --tokenizer <path>` checks current rendering against every pinned token ID and prompt. Qwen uses a temporary tokenizer copy with `preserve_thinking=true` to match its native session benchmark. Its payload preserves the original measured messages and token IDs, with saved prompt text added to the common fixture format. The unused synthetic preparation warmup is excluded; the measured warmup used each real context for 16 output tokens. Each manifest retains the original output lengths, KV types, prefill chunks, process reuse, warmup, and load policies.

Validation:

- Fresh anonymous HTTPS downloads of both fixtures pass the archive, payload, and all six token-sequence hashes. Public manifests match the repository byte for byte. Fixture payloads and hashes are unchanged by enabling public access.
- Qwen's messages, token IDs, and prompt text match the historical source cases and published fingerprints; all 18 recorded requests match those counts.
- Current native tokenizer/template matches every pinned input in both models. An altered Qwen template is rejected; supplied model files are unchanged.
- HTTP errors, network failures, oversized archives, and corrupted archives leave no output file. Differing existing files and unknown selections are rejected; selecting Qwen cannot overwrite the Gemma fixture.
- Focused TypeScript typecheck, lint, formatting, and diff checks pass. No new inference measurements or GitHub Actions benchmark runs were performed.

The public R2 development endpoint is rate limited; a custom domain can be added if download volume grows. No completed-object expiration rule is configured. Archives use immutable cache headers, but administrators can still replace objects; committed hashes detect replacement. These fixtures pin workloads and protocols, not generated answers or universal speed thresholds.
